### PR TITLE
feat(deploy): add EKS + Helm scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,17 @@ local_data/wiki/.git/
 .idea/
 .vscode/
 *.swp
+
+# terraform (deploy/terraform/) — lock file is committed (matches cloud-deployment-yamls)
+*.tfstate
+*.tfstate.*
+*.tfstate.backup
+.terraform/
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+*.tfvars
+!example.tfvars

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,113 @@
+# deploy/
+
+Two-step deploy for agent-workspace:
+
+1. **`terraform/`** — provisions a small EKS cluster (VPC, EKS, EBS CSI add-on,
+   gp3 default StorageClass, ingress-nginx, cert-manager, optional
+   `letsencrypt-prod` ClusterIssuer).
+2. **`helm/agent-workspace/`** — installs the app (backend, worker, frontend,
+   two PVCs, Ingress) onto the cluster from step 1.
+
+Terraform is run once per environment; Helm is the loop you run on every app
+deploy. State is local (`terraform.tfstate` is gitignored) — fine for a single
+operator. Move it to S3 when more than one person operates the cluster.
+
+## Prereqs
+
+- AWS credentials with permission to create VPC + EKS + IAM roles.
+- `terraform >= 1.5`, `kubectl`, `helm >= 3.13`, `aws` CLI.
+- A DNS zone where you can point a record at the ingress NLB.
+
+## 1. Provision the cluster
+
+```bash
+cd deploy/terraform
+cp example.tfvars terraform.tfvars  # edit name, region, cert_manager_email
+terraform init
+terraform apply
+```
+
+Apply takes ~15 minutes (EKS control plane is the slow bit).
+
+When it's done:
+
+```bash
+$(terraform output -raw kubeconfig_command)   # writes ~/.kube/config entry
+kubectl get nodes
+```
+
+## 2. Build & push images
+
+The chart pulls from a public registry — defaults are `ghcr.io/CHANGE-ME/...`.
+Build and push:
+
+```bash
+# from repo root
+docker build -t ghcr.io/<you>/agent-workspace-backend:<tag>  ./backend
+docker build -t ghcr.io/<you>/agent-workspace-frontend:<tag> ./frontend
+docker push ghcr.io/<you>/agent-workspace-backend:<tag>
+docker push ghcr.io/<you>/agent-workspace-frontend:<tag>
+```
+
+If the repo is private, create an `imagePullSecret` and pass it via
+`--set imagePullSecrets[0].name=<secret>`.
+
+## 3. Install the chart
+
+```bash
+cd deploy/helm
+
+helm upgrade --install agent-workspace ./agent-workspace \
+  --namespace agent-workspace --create-namespace \
+  --set secretKey="$(openssl rand -hex 32)" \
+  --set image.backend.repository=ghcr.io/<you>/agent-workspace-backend \
+  --set image.backend.tag=<tag> \
+  --set image.frontend.repository=ghcr.io/<you>/agent-workspace-frontend \
+  --set image.frontend.tag=<tag> \
+  --set ingress.host=agent-workspace.example.com \
+  --set ingress.clusterIssuer=letsencrypt-prod \
+  --set ingress.tls.enabled=true
+```
+
+Or write a `values.yaml` per environment and use `-f`.
+
+## 4. Wire DNS
+
+Get the ingress NLB hostname:
+
+```bash
+$(cd deploy/terraform && terraform output -raw ingress_hostname_command)
+```
+
+Create a CNAME from `ingress.host` to that hostname. cert-manager will issue a
+Let's Encrypt cert once DNS resolves (give it a minute).
+
+## 5. Sign in
+
+Open `https://<ingress.host>`. The first account you sign up is auto-promoted
+to admin (see `app/auth/users.py`). Configure the LLM provider/keys from
+**Admin → LLM**.
+
+## Day-2
+
+- **App update** — push new images, then `helm upgrade` with the new tag.
+- **Cluster update** — `terraform apply` after bumping `cluster_version` or
+  module versions.
+- **Backups** — not wired in this scaffold. The `wiki-data` PVC is a real git
+  repo; cron a `git push --mirror` to a remote for the durable content. The
+  `app-data` PVC holds SQLite + the Huey queue; `VACUUM INTO` snapshots are
+  cheap.
+- **Tear down** — `helm uninstall agent-workspace -n agent-workspace`, then
+  `terraform destroy`. PVCs use `Retain` reclaim policy, so EBS volumes
+  survive `helm uninstall` and need to be deleted manually if you want them
+  gone.
+
+## What's deliberately not here
+
+- **No RDS / Redis / S3.** The app is SQLite-on-PVC by design — see
+  `local_data/wiki/infra/infra.md` and `CLAUDE.md`.
+- **No multi-replica backend/worker.** SQLite is single-writer; replicas would
+  fight over the wiki working tree. The chart pins both to one replica with a
+  `Recreate` strategy and a `podAffinity` rule that co-schedules them.
+- **No remote Terraform state.** Local for now (gitignored). Add an S3 backend
+  when this graduates beyond a single-operator deploy.

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: agent-workspace
+description: Self-updating wiki for AI agents (Flask + SQLite + Huey + Next.js).
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/NOTES.txt
+++ b/deploy/helm/agent-workspace/templates/NOTES.txt
@@ -1,0 +1,17 @@
+agent-workspace has been deployed.
+
+1. Find the public hostname of the ingress controller's NLB:
+   kubectl -n ingress-nginx get svc ingress-nginx-controller \
+     -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+
+2. Point a DNS record for {{ .Values.ingress.host }} at that hostname (CNAME).
+
+{{- if .Values.ingress.clusterIssuer }}
+3. cert-manager will issue a TLS cert via the "{{ .Values.ingress.clusterIssuer }}" ClusterIssuer
+   once DNS resolves to the ingress.
+{{- else }}
+3. TLS is not enabled — set .Values.ingress.clusterIssuer to a configured ClusterIssuer
+   (e.g. "letsencrypt-prod") and .Values.ingress.tls.enabled=true to add HTTPS.
+{{- end }}
+
+4. Open https://{{ .Values.ingress.host }} — the first account you sign up is auto-promoted to admin.

--- a/deploy/helm/agent-workspace/templates/_helpers.tpl
+++ b/deploy/helm/agent-workspace/templates/_helpers.tpl
@@ -1,0 +1,90 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agent-workspace.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "agent-workspace.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "agent-workspace.labels" -}}
+app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{- define "agent-workspace.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "agent-workspace.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Shared backend env. Used by both backend and worker so the SQLite + wiki paths
+stay in lockstep.
+*/}}
+{{- define "agent-workspace.backendEnv" -}}
+- name: APP_DB_PATH
+  value: /data/app.sqlite
+- name: QUEUE_DB_PATH
+  value: /data/queue.sqlite
+- name: WIKI_DIR
+  value: /wiki
+- name: SECRET_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "agent-workspace.fullname" . }}-secrets
+      key: secret-key
+- name: ALLOWED_EMAILS
+  value: {{ .Values.allowedEmails | quote }}
+- name: AUTH_MODE
+  value: {{ .Values.auth.mode | quote }}
+- name: SECURE_COOKIES
+  value: {{ .Values.secureCookies | quote }}
+{{- if eq .Values.auth.mode "oidc" }}
+- name: OIDC_ISSUER
+  value: {{ .Values.auth.oidc.issuer | quote }}
+- name: OIDC_CLIENT_ID
+  value: {{ .Values.auth.oidc.clientId | quote }}
+- name: OIDC_CLIENT_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "agent-workspace.fullname" . }}-secrets
+      key: oidc-client-secret
+- name: OIDC_REDIRECT_URI
+  value: {{ .Values.auth.oidc.redirectUri | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "agent-workspace.backendVolumeMounts" -}}
+- name: app-data
+  mountPath: /data
+- name: wiki-data
+  mountPath: /wiki
+{{- end -}}
+
+{{- define "agent-workspace.backendVolumes" -}}
+- name: app-data
+  persistentVolumeClaim:
+    claimName: {{ include "agent-workspace.fullname" . }}-app-data
+- name: wiki-data
+  persistentVolumeClaim:
+    claimName: {{ include "agent-workspace.fullname" . }}-wiki-data
+{{- end -}}

--- a/deploy/helm/agent-workspace/templates/backend-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/backend-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-backend
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicaCount }}
+  # SQLite is single-writer; Recreate so the old pod releases the PVC before the new one mounts it.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "agent-workspace.labels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      serviceAccountName: {{ include "agent-workspace.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backend
+          image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag }}"
+          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.backend.port }}
+              protocol: TCP
+          env:
+            {{- include "agent-workspace.backendEnv" . | nindent 12 }}
+          volumeMounts:
+            {{- include "agent-workspace.backendVolumeMounts" . | nindent 12 }}
+          {{- with .Values.backend.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}
+      volumes:
+        {{- include "agent-workspace.backendVolumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/agent-workspace/templates/backend-service.yaml
+++ b/deploy/helm/agent-workspace/templates/backend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-backend
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.backend.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: backend

--- a/deploy/helm/agent-workspace/templates/frontend-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/frontend-deployment.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-frontend
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "agent-workspace.labels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      serviceAccountName: {{ include "agent-workspace.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: "{{ .Values.image.frontend.repository }}:{{ .Values.image.frontend.tag }}"
+          imagePullPolicy: {{ .Values.image.frontend.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.port }}
+              protocol: TCP
+          env:
+            - name: NEXT_PUBLIC_API_BASE
+              value: /api
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/agent-workspace/templates/frontend-service.yaml
+++ b/deploy/helm/agent-workspace/templates/frontend-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-frontend
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.frontend.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: frontend

--- a/deploy/helm/agent-workspace/templates/ingress.yaml
+++ b/deploy/helm/agent-workspace/templates/ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "agent-workspace.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+  annotations:
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.ingress.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ . | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-backend
+                port:
+                  number: {{ .Values.backend.port }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-frontend
+                port:
+                  number: {{ .Values.frontend.port }}
+{{- end }}

--- a/deploy/helm/agent-workspace/templates/pvc.yaml
+++ b/deploy/helm/agent-workspace/templates/pvc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-app-data
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.appData.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.appData.size }}
+  {{- with .Values.persistence.appData.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-wiki-data
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.wikiData.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.wikiData.size }}
+  {{- with .Values.persistence.wikiData.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}

--- a/deploy/helm/agent-workspace/templates/secret.yaml
+++ b/deploy/helm/agent-workspace/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-secrets
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  secret-key: {{ required "secretKey is required (generate with `openssl rand -hex 32`)" .Values.secretKey | quote }}
+  {{- if eq .Values.auth.mode "oidc" }}
+  oidc-client-secret: {{ .Values.auth.oidc.clientSecret | quote }}
+  {{- end }}

--- a/deploy/helm/agent-workspace/templates/serviceaccount.yaml
+++ b/deploy/helm/agent-workspace/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent-workspace.serviceAccountName" . }}
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-worker
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    app.kubernetes.io/component: worker
+spec:
+  replicas: {{ .Values.worker.replicaCount }}
+  # The worker mounts the same RWO PVCs as the backend; Recreate avoids two pods
+  # holding the wiki working tree at once during rollouts.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: worker
+  template:
+    metadata:
+      labels:
+        {{- include "agent-workspace.labels" . | nindent 8 }}
+        app.kubernetes.io/component: worker
+    spec:
+      serviceAccountName: {{ include "agent-workspace.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: worker
+          image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag }}"
+          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
+          command: ["python", "-m", "app.tasks.run_worker"]
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            {{- include "agent-workspace.backendEnv" . | nindent 12 }}
+          volumeMounts:
+            {{- include "agent-workspace.backendVolumeMounts" . | nindent 12 }}
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+      volumes:
+        {{- include "agent-workspace.backendVolumes" . | nindent 8 }}
+      # Co-schedule with the backend so the RWO PVCs land on the same node.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - {{ include "agent-workspace.name" . }}
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - backend
+              topologyKey: kubernetes.io/hostname
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -1,0 +1,120 @@
+# Defaults for agent-workspace.
+#
+# Backend + worker share two PVCs (app-data, wiki-data) and run as a single
+# replica each — SQLite is single-writer and the wiki repo has no concurrent-
+# write story (see CLAUDE.md / background-tasks doc). The frontend is
+# stateless and can scale.
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  # Public registry (GHCR / Docker Hub). Override per-deploy.
+  backend:
+    repository: ghcr.io/CHANGE-ME/agent-workspace-backend
+    tag: latest
+    pullPolicy: IfNotPresent
+  frontend:
+    repository: ghcr.io/CHANGE-ME/agent-workspace-frontend
+    tag: latest
+    pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# Flask SECRET_KEY. Generate with `openssl rand -hex 32`. Required.
+secretKey: ""
+
+# Comma-separated email whitelist for signup. Empty = anyone.
+allowedEmails: ""
+
+auth:
+  # basic | oidc
+  mode: basic
+  oidc:
+    issuer: ""
+    clientId: ""
+    clientSecret: ""
+    redirectUri: ""
+
+# Set true behind HTTPS. The Ingress section below issues a cert via cert-manager.
+secureCookies: true
+
+backend:
+  replicaCount: 1
+  port: 8080
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+  livenessProbe:
+    httpGet:
+      path: /api/health
+      port: http
+    initialDelaySeconds: 20
+    periodSeconds: 30
+  readinessProbe:
+    httpGet:
+      path: /api/health
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 10
+
+worker:
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 1Gi
+
+frontend:
+  replicaCount: 1
+  port: 3000
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+
+persistence:
+  appData:
+    # SQLite app.sqlite + queue.sqlite live here. Mounted at /data on backend + worker.
+    size: 5Gi
+    storageClass: gp3
+    accessMode: ReadWriteOnce
+  wikiData:
+    # Git working tree. Mounted at /wiki on backend + worker.
+    size: 10Gi
+    storageClass: gp3
+    accessMode: ReadWriteOnce
+
+ingress:
+  enabled: true
+  className: nginx
+  host: agent-workspace.example.com
+  # Set to a configured ClusterIssuer name (e.g. "letsencrypt-prod") to enable TLS.
+  # The Terraform stack installs `letsencrypt-prod` if cert_manager_email is set.
+  clusterIssuer: ""
+  tls:
+    enabled: false
+    secretName: agent-workspace-tls
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "25m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
+podSecurityContext: {}
+securityContext: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/terraform/.terraform.lock.hcl
+++ b/deploy/terraform/.terraform.lock.hcl
@@ -1,0 +1,145 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = ">= 4.0.0, >= 4.33.0, ~> 5.0, >= 5.79.0, >= 5.95.0, < 6.0.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/cloudinit" {
+  version     = "2.3.7"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:M9TpQxKAE/hyOwytdX9MUNZw30HoD/OXqYIug5fkqH8=",
+    "zh:06f1c54e919425c3139f8aeb8fcf9bceca7e560d48c9f0c1e3bb0a8ad9d9da1e",
+    "zh:0e1e4cf6fd98b019e764c28586a386dc136129fef50af8c7165a067e7e4a31d5",
+    "zh:1871f4337c7c57287d4d67396f633d224b8938708b772abfc664d1f80bd67edd",
+    "zh:2b9269d91b742a71b2248439d5e9824f0447e6d261bfb86a8a88528609b136d1",
+    "zh:3d8ae039af21426072c66d6a59a467d51f2d9189b8198616888c1b7fc42addc7",
+    "zh:3ef4e2db5bcf3e2d915921adced43929214e0946a6fb11793085d9a48995ae01",
+    "zh:42ae54381147437c83cbb8790cc68935d71b6357728a154109d3220b1beb4dc9",
+    "zh:4496b362605ae4cbc9ef7995d102351e2fe311897586ffc7a4a262ccca0c782a",
+    "zh:652a2401257a12706d32842f66dac05a735693abcb3e6517d6b5e2573729ba13",
+    "zh:7406c30806f5979eaed5f50c548eced2ea18ea121e01801d2f0d4d87a04f6a14",
+    "zh:7848429fd5a5bcf35f6fee8487df0fb64b09ec071330f3ff240c0343fe2a5224",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.30"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
+    "zh:7b9c7b16f118fbc2b05a983817b8ce2f86df125857966ad356353baf4bff5c0a",
+    "zh:85e33ab43e0e1726e5f97a874b8e24820b6565ff8076523cc2922ba671492991",
+    "zh:9d32ac3619cfc93eb3c4f423492a8e0f79db05fec58e449dee9b2d5873d5f69f",
+    "zh:9e15c3c9dd8e0d1e3731841d44c34571b6c97f5b95e8296a45318b94e5287a6e",
+    "zh:b4c2ab35d1b7696c30b64bf2c0f3a62329107bd1a9121ce70683dec58af19615",
+    "zh:c43723e8cc65bcdf5e0c92581dcbbdcbdcf18b8d2037406a5f2033b1e22de442",
+    "zh:ceb5495d9c31bfb299d246ab333f08c7fb0d67a4f82681fbf47f2a21c3e11ab5",
+    "zh:e171026b3659305c558d9804062762d168f50ba02b88b231d20ec99578a6233f",
+    "zh:ed0fe2acdb61330b01841fa790be00ec6beaac91d41f311fb8254f74eb6a711f",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.13.1"
+  constraints = ">= 0.9.0"
+  hashes = [
+    "h1:ZT5ppCNIModqk3iOkVt5my8b8yBHmDpl663JtXAIRqM=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.2.1"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
+    "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
+    "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
+    "zh:7d0864755ba093664c4b2c07c045d3f5e3d7c799dda1a3ef33d17ed1ac563191",
+    "zh:83734f57950ab67c0d6a87babdb3f13c908cbe0a48949333f489698532e1391b",
+    "zh:951e3c285218ebca0cf20eaa4265020b4ef042fea9c6ade115ad1558cfe459e5",
+    "zh:b9543955b4297e1d93b85900854891c0e645d936d8285a190030475379c5c635",
+    "zh:bb1bd9e86c003d08c30c1b00d44118ed5bbbf6b1d2d6f7eaac4fa5c6ebea5933",
+    "zh:c9477bfe00653629cd77ddac3968475f7ad93ac3ca8bc45b56d1d9efb25e4a6e",
+    "zh:d4cfda8687f736d0cba664c22ec49dae1188289e214ef57f5afe6a7217854fed",
+    "zh:dc77ee066cf96532a48f0578c35b1eaf6dc4d8ddd0e3ae8e029a3b10676dd5d3",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/deploy/terraform/example.tfvars
+++ b/deploy/terraform/example.tfvars
@@ -1,0 +1,14 @@
+# Copy to terraform.tfvars (which is gitignored) and edit.
+name        = "agent-workspace"
+environment = "dev"
+region      = "us-west-2"
+
+# Required for the bundled letsencrypt-prod ClusterIssuer. Leave empty to skip
+# (you can install your own issuer later).
+cert_manager_email = ""
+
+# Tighten control plane access for production deploys.
+# cluster_endpoint_public_access_cidrs = ["1.2.3.4/32"]
+
+# Bigger/smaller nodes if needed.
+# node_instance_types = ["t3.large"]

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,251 @@
+locals {
+  full_name    = "${var.name}-${var.environment}"
+  vpc_name     = "${local.full_name}-vpc"
+  cluster_name = local.full_name
+
+  default_tags = merge(
+    {
+      app         = var.name
+      environment = var.environment
+      managed-by  = "terraform"
+    },
+    var.tags,
+  )
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = local.default_tags
+  }
+}
+
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+# ----------------------------------------------------------------------------
+# VPC
+# ----------------------------------------------------------------------------
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.vpc_name
+  cidr = "10.0.0.0/16"
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = "1"
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = "1"
+  }
+}
+
+# ----------------------------------------------------------------------------
+# EKS
+# ----------------------------------------------------------------------------
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = local.cluster_name
+  cluster_version = var.cluster_version
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = concat(module.vpc.private_subnets, module.vpc.public_subnets)
+
+  cluster_endpoint_public_access           = true
+  cluster_endpoint_public_access_cidrs     = var.cluster_endpoint_public_access_cidrs
+  enable_cluster_creator_admin_permissions = true
+
+  cluster_addons = {
+    coredns    = {}
+    kube-proxy = {}
+    vpc-cni    = {}
+    aws-ebs-csi-driver = {
+      service_account_role_arn = module.ebs_csi_irsa.iam_role_arn
+    }
+  }
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2023_x86_64_STANDARD"
+  }
+
+  eks_managed_node_groups = {
+    main = {
+      instance_types = var.node_instance_types
+      min_size       = var.node_min_size
+      max_size       = var.node_max_size
+      desired_size   = var.node_desired_size
+      subnet_ids     = module.vpc.private_subnets
+    }
+  }
+}
+
+# IRSA for the EBS CSI driver so PVCs (gp3) can be provisioned by the addon.
+module "ebs_csi_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.39"
+
+  role_name             = "${local.cluster_name}-ebs-csi"
+  attach_ebs_csi_policy = true
+
+  oidc_providers = {
+    eks = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:ebs-csi-controller-sa"]
+    }
+  }
+}
+
+# Make sure the cluster is fully active before any helm_release tries to talk to it.
+resource "null_resource" "wait_for_cluster" {
+  provisioner "local-exec" {
+    command = "aws eks wait cluster-active --name ${module.eks.cluster_name} --region ${var.region}"
+  }
+
+  depends_on = [module.eks]
+}
+
+data "aws_eks_cluster" "this" {
+  name       = module.eks.cluster_name
+  depends_on = [null_resource.wait_for_cluster]
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name       = module.eks.cluster_name
+  depends_on = [null_resource.wait_for_cluster]
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.this.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+    token                  = data.aws_eks_cluster_auth.this.token
+  }
+}
+
+# ----------------------------------------------------------------------------
+# Default StorageClass: gp3 (the EBS CSI add-on does not set one automatically).
+# ----------------------------------------------------------------------------
+
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Retain"
+  volume_binding_mode    = "WaitForFirstConsumer"
+  allow_volume_expansion = true
+
+  parameters = {
+    type   = "gp3"
+    fsType = "ext4"
+  }
+
+  depends_on = [module.eks]
+}
+
+# ----------------------------------------------------------------------------
+# Cluster services: ingress-nginx + cert-manager
+# ----------------------------------------------------------------------------
+
+resource "helm_release" "ingress_nginx" {
+  name             = "ingress-nginx"
+  namespace        = "ingress-nginx"
+  create_namespace = true
+
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  version    = "4.11.3"
+
+  set {
+    name  = "controller.service.type"
+    value = "LoadBalancer"
+  }
+
+  # NLB is cheaper, terminates faster, and proxies arbitrary TCP — good default for an HTTP ingress.
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
+    value = "nlb"
+  }
+
+  depends_on = [module.eks, kubernetes_storage_class_v1.gp3]
+}
+
+resource "helm_release" "cert_manager" {
+  name             = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+
+  repository = "https://charts.jetstack.io"
+  chart      = "cert-manager"
+  version    = "v1.15.3"
+
+  set {
+    name  = "crds.enabled"
+    value = "true"
+  }
+
+  depends_on = [module.eks]
+}
+
+# Optional: a Let's Encrypt ClusterIssuer wired up if cert_manager_email is set.
+# Kept inline so the user gets a working ACME issuer out of the box.
+resource "kubernetes_manifest" "letsencrypt_issuer" {
+  count = var.cert_manager_email != "" ? 1 : 0
+
+  manifest = {
+    apiVersion = "cert-manager.io/v1"
+    kind       = "ClusterIssuer"
+    metadata = {
+      name = "letsencrypt-prod"
+    }
+    spec = {
+      acme = {
+        server = "https://acme-v02.api.letsencrypt.org/directory"
+        email  = var.cert_manager_email
+        privateKeySecretRef = {
+          name = "letsencrypt-prod"
+        }
+        solvers = [
+          {
+            http01 = {
+              ingress = {
+                class = "nginx"
+              }
+            }
+          },
+        ]
+      }
+    }
+  }
+
+  depends_on = [helm_release.cert_manager]
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "region" {
+  value = var.region
+}
+
+output "kubeconfig_command" {
+  description = "Run this to point kubectl at the new cluster."
+  value       = "aws eks update-kubeconfig --name ${module.eks.cluster_name} --region ${var.region}"
+}
+
+output "ingress_hostname_command" {
+  description = "After ingress-nginx finishes provisioning the NLB, this prints its public hostname."
+  value       = "kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,62 @@
+variable "name" {
+  type        = string
+  description = "Base name used to derive cluster, VPC, and other resource names."
+  default     = "agent-workspace"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to deploy into."
+  default     = "us-west-2"
+}
+
+variable "environment" {
+  type        = string
+  description = "Environment suffix (dev, staging, prod). Appended to resource names."
+  default     = "dev"
+}
+
+variable "cluster_version" {
+  type        = string
+  description = "EKS control plane version."
+  default     = "1.30"
+}
+
+variable "node_instance_types" {
+  type        = list(string)
+  description = "EC2 instance types for the managed node group. t3.medium is a sensible default for a single-tenant lightweight workload."
+  default     = ["t3.medium"]
+}
+
+variable "node_min_size" {
+  type    = number
+  default = 1
+}
+
+variable "node_max_size" {
+  type    = number
+  default = 3
+}
+
+variable "node_desired_size" {
+  type    = number
+  default = 2
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  type        = list(string)
+  description = "CIDRs allowed to reach the EKS control plane. Defaults to the world; tighten for production."
+  default     = ["0.0.0.0/0"]
+}
+
+variable "cert_manager_email" {
+  type        = string
+  description = "Email used by Let's Encrypt for ACME certificate registration. Required if you want auto-issued TLS via the bundled ClusterIssuer."
+  default     = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Default tags applied to all AWS resources."
+  default     = {}
+}

--- a/deploy/terraform/versions.tf
+++ b/deploy/terraform/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
+  }
+}

--- a/local_data/wiki/architecture_and_progress.md
+++ b/local_data/wiki/architecture_and_progress.md
@@ -381,7 +381,7 @@ One line per area; the per-area doc has the real picture.
 | Onyx push | Not started; ingest endpoint stub | [onyx-push](onyx-push/onyx-push.md) |
 | Background tasks | Reindex live; doc-update + periodic stubs; trigger fan-out task TBD | [background-tasks](background-tasks/background-tasks.md) |
 | Exploration | Not started; parking lot for MCP-vs-skill question | [exploration](exploration/exploration.md) |
-| Infra | Compose + volumes wired; prod story TBD | [infra](infra/infra.md) |
+| Infra | Compose + volumes wired; EKS Terraform + Helm chart in `deploy/` (validated, not yet end-to-end applied) | [infra](infra/infra.md) |
 
 ---
 
@@ -496,5 +496,20 @@ area docs.
   credentials (Anthropic key, OpenAI key, Gemini key, Ollama base URL).
   Required `google-genai>=1.0` and `ollama>=0.4`; migration 0006 added
   `gemini_api_key` and `ollama_base_url` columns.
+- **2026-05-07** — **EKS + Helm deploy scaffolding landed under `deploy/`.**
+  Terraform (`deploy/terraform/`) provisions VPC + EKS via the community
+  `terraform-aws-modules/{vpc,eks}/aws` modules, wires the EBS CSI add-on
+  with IRSA, sets a `gp3` default StorageClass, and helm-installs
+  ingress-nginx (NLB) + cert-manager (with an optional `letsencrypt-prod`
+  ClusterIssuer). State is local + gitignored. Helm chart
+  (`deploy/helm/agent-workspace/`) deploys backend + worker + frontend with
+  two PVCs (`app-data` 5Gi, `wiki-data` 10Gi, both RWO `gp3`); backend and
+  worker are pinned to one replica with `Recreate` strategy and
+  `podAffinity` co-scheduling because SQLite is single-writer and the wiki
+  working tree has no concurrent-write story. The in-cluster nginx pod from
+  compose is **dropped** — the Ingress handles `/api/*` → backend, `/` →
+  frontend directly. Image registry assumed to be a public GHCR/Docker Hub
+  repo (no ECR provisioning). Two-step flow: `terraform apply` once per
+  env, then `helm upgrade --install` per app deploy. See `deploy/README.md`.
 
 _(Append new entries with a date prefix. Cross-cutting only.)_

--- a/local_data/wiki/infra/infra.md
+++ b/local_data/wiki/infra/infra.md
@@ -7,7 +7,7 @@
 > agent-wiki. Code-level architecture lives in the other per-area
 > docs (e.g. [flask-and-apis](../flask-and-apis/flask-and-apis.md)).
 
-_Last updated: 2026-05-06_
+_Last updated: 2026-05-07_
 
 ---
 
@@ -23,7 +23,8 @@ nginx :80                 reverse proxy: /api/* → backend, else → frontend
 ```
 
 All four services are defined in `docker-compose.yml` at the repo root.
-Compose is the only wiring today — no Helm chart, no k8s manifests yet.
+Compose is the canonical local path. A k8s/EKS deploy story also lives in
+`deploy/` — see "Production deploy (EKS + Helm)" below.
 
 ### Volumes
 
@@ -79,13 +80,41 @@ Not implemented. When this matters:
 - `wiki-data` — push a mirror to a remote git remote on a cron. The wiki
   *is* a git repo; this is the cleanest backup story.
 
-### Production deltas (not done yet)
-- `SESSION_COOKIE_SECURE = True` behind HTTPS (currently False; the
-  comment in `main.py` flags this).
-- Real `SECRET_KEY` from a secret store, not env.
-- Nginx terminating TLS (or a load balancer in front).
-- A health check that exercises `init_db()` having run and a sample LLM
-  ping (optional).
+### Production deploy (EKS + Helm)
+
+`deploy/` holds the production wiring. Two layers:
+
+- **`deploy/terraform/`** — provisions VPC + EKS (using
+  `terraform-aws-modules/{vpc,eks}/aws`) with the EBS CSI add-on, a `gp3`
+  default StorageClass, ingress-nginx (NLB-backed), cert-manager, and an
+  optional `letsencrypt-prod` ClusterIssuer (gated on `cert_manager_email`).
+  State is local and gitignored.
+- **`deploy/helm/agent-workspace/`** — chart with backend/worker/frontend
+  Deployments, two PVCs (`app-data` 5Gi, `wiki-data` 10Gi, both `gp3`/RWO),
+  a Secret for `SECRET_KEY` (+ optional OIDC client secret), and an Ingress
+  that routes `/api/*` → backend and `/` → frontend (replacing the
+  in-cluster nginx pod that compose uses).
+
+Constraints baked into the chart:
+- **Backend + worker pinned to 1 replica** with `strategy: Recreate` and a
+  `podAffinity` rule that co-schedules them on one node — RWO PVCs +
+  single-writer SQLite + single git working tree leave no room for HA at
+  this layer.
+- **Frontend** is stateless and free to scale.
+- **No nginx pod** — ingress-nginx replaces it. Path routing lives in the
+  Ingress resource; `proxy-body-size` matches the 25m the compose nginx had.
+
+See `deploy/README.md` for the apply/install flow.
+
+### Production deltas (still to do)
+- `SESSION_COOKIE_SECURE = True` behind HTTPS — chart wires `SECURE_COOKIES`
+  env from `values.yaml` (default `true`); backend code still needs to read
+  it (`main.py` currently hard-codes `False`).
+- Real `SECRET_KEY` from a secret store (External Secrets / AWS Secrets
+  Manager) — chart currently takes it via `--set secretKey=...`.
+- A health check that exercises `init_db()` and an LLM ping (optional).
+- Backup automation (cron `git push --mirror` for the wiki PVC, `VACUUM INTO`
+  for SQLite). Not wired.
 
 ---
 
@@ -97,6 +126,9 @@ Not implemented. When this matters:
 - Migrations run on boot; FTS5 active.
 - Wiki repo auto-initializes.
 - Worker registers tasks on import.
+- `deploy/terraform/` validates (`terraform validate` clean); `deploy/helm/`
+  lints clean and templates against representative values. Not yet
+  end-to-end applied against a real AWS account.
 
 ### Stubbed / partial
 - `nginx.conf` is minimal — fine for local, may need tuning for prod
@@ -122,10 +154,12 @@ Not implemented. When this matters:
    the wiki, `VACUUM INTO` for SQLite.
 
 ### Open questions
-- Where will this actually run for the first dogfood — a single VM, a
-  managed-container product (Fly/Render), or k8s? Affects how much we
-  invest in compose vs. moving to Helm/Kustomize. V0 brief just says
-  "deployment"; pick after the first real install.
 - Multi-worker concurrency on the wiki repo (lock strategy) — flagged
   in `background-tasks/background-tasks.md`. Becomes a real question if
-  a single worker can't keep up.
+  a single worker can't keep up; until then the helm chart pins worker
+  replicas to 1 and co-schedules with the backend.
+- First dogfood deploy: are we using the bundled `deploy/terraform` (own
+  cluster) or installing the chart into the existing Onyx EKS? The chart
+  works for either; Terraform is only needed for the former.
+- Image registry — chart defaults assume a public GHCR/Docker Hub repo
+  (no ECR provisioning). Revisit if private images become a requirement.


### PR DESCRIPTION
## Summary

First half of the production deploy story. Two layers under `deploy/`:

- **`deploy/terraform/`** — provisions VPC + EKS using the community `terraform-aws-modules/{vpc,eks}/aws` modules, wires the EBS CSI add-on with IRSA, sets a `gp3` default StorageClass, and helm-installs `ingress-nginx` (NLB) + `cert-manager`. Optional `letsencrypt-prod` `ClusterIssuer` if `cert_manager_email` is set. State is local + gitignored.
- **`deploy/helm/agent-workspace/`** — chart deploying backend, worker, frontend, two PVCs (`app-data` 5Gi, `wiki-data` 10Gi; both RWO `gp3`), a Secret for `SECRET_KEY`, and an Ingress that routes `/api/*` → backend and `/` → frontend (replacing the in-cluster nginx pod compose uses).

Constraints baked in: backend + worker pinned to one replica with `strategy: Recreate` and a `podAffinity` rule that co-schedules them on one node — SQLite is single-writer and the wiki working tree has no concurrent-write story. Frontend is stateless and free to scale.

Image refs in `values.yaml` are placeholders (`ghcr.io/CHANGE-ME/...`) for now; the build/push pipeline + image bump come in a follow-up PR.

See `deploy/README.md` for the apply/install flow. Wiki updated: production deploy section in `local_data/wiki/infra/infra.md` and a 2026-05-07 decision-log entry in `local_data/wiki/architecture_and_progress.md`.

## Test plan

- [x] `terraform fmt -check` clean
- [x] `terraform validate` passes
- [x] `helm lint deploy/helm/agent-workspace` passes
- [x] `helm template` renders cleanly across representative values (with/without TLS + ClusterIssuer)
- [ ] Real `terraform apply` against an AWS account — deferred until image pipeline is up so we can verify end-to-end