### PR TITLE
chore(ci): add image build/push pipeline and lint checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  helm-lint:
+    name: Helm lint
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('deploy/helm/**') != '' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.13.3
+
+      - name: helm lint
+        run: |
+          set -euo pipefail
+          for chart_dir in deploy/helm/*/; do
+            if [ -f "$chart_dir/Chart.yaml" ]; then
+              echo "Linting $chart_dir"
+              helm lint "$chart_dir" --set secretKey=ci-placeholder
+            fi
+          done
+
+  terraform-checks:
+    name: Terraform fmt + validate
+    runs-on: ubuntu-latest
+    if: ${{ hashFiles('deploy/terraform/**') != '' }}
+
+    defaults:
+      run:
+        working-directory: ./deploy/terraform
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.9.8
+
+      - name: terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: terraform init
+        run: terraform init -backend=false -input=false
+
+      - name: terraform validate
+        run: terraform validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,59 +1,32 @@
-name: CI
+name: Quality Checks PR
+
+concurrency:
+  group: Quality-Checks-PR-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
-  helm-lint:
-    name: Helm lint
+  pre-commit:
     runs-on: ubuntu-latest
-    if: ${{ hashFiles('deploy/helm/**') != '' }}
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
+      - uses: actions/checkout@v4
         with:
-          version: v3.13.3
-
-      - name: helm lint
-        run: |
-          set -euo pipefail
-          for chart_dir in deploy/helm/*/; do
-            if [ -f "$chart_dir/Chart.yaml" ]; then
-              echo "Linting $chart_dir"
-              helm lint "$chart_dir" --set secretKey=ci-placeholder
-            fi
-          done
-
-  terraform-checks:
-    name: Terraform fmt + validate
-    runs-on: ubuntu-latest
-    if: ${{ hashFiles('deploy/terraform/**') != '' }}
-
-    defaults:
-      run:
-        working-directory: ./deploy/terraform
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+          fetch-depth: 0
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.9.8
 
-      - name: terraform fmt
-        run: terraform fmt -check -recursive
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.13.3
 
-      - name: terraform init
-        run: terraform init -backend=false -input=false
-
-      - name: terraform validate
-        run: terraform validate
+      - name: Run pre-commit
+        uses: j178/prek-action@v2.0.2
+        with:
+          extra_args: ${{ github.event_name == 'pull_request' && format('--from-ref {0} --to-ref {1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) || '' }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,87 @@
+name: Build and Push Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  DOCKERHUB_USERNAME: onyxdotapp
+
+jobs:
+  build-backend:
+    name: Build and Push Backend Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-backend
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-frontend:
+    name: Build and Push Frontend Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-frontend
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/sirwart/ripsecrets
+    rev: v0.1.11
+    hooks:
+      - id: ripsecrets
+        args:
+          - --additional-pattern
+          - ^sk-[A-Za-z0-9_\-]{20,}$
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.103.0
+    hooks:
+      - id: terraform_fmt
+        files: \.tf$
+      - id: terraform_validate
+        files: \.tf$
+
+  - repo: local
+    hooks:
+      - id: helm-lint
+        name: helm lint
+        entry: bash -c 'set -euo pipefail; for d in deploy/helm/*/; do [ -f "$d/Chart.yaml" ] && helm lint "$d" --set secretKey=ci-placeholder; done'
+        language: system
+        files: ^deploy/helm/
+        pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,25 +35,9 @@ any row exists in `llm_settings`.
 
 ## Pre-commit hooks
 
-Quality checks run via `pre-commit` (or `prek`, the Rust-port drop-in) against
-`.pre-commit-config.yaml` at the repo root. CI runs the same hooks on PRs via
-`.github/workflows/ci.yml`, so what passes locally also passes in CI.
-
-```bash
-pip install pre-commit       # or: brew install prek
-pre-commit install           # one-time: install the git hook
-pre-commit run --all-files   # run every hook against the whole tree
-```
-
-Configured hooks: `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`,
-`ripsecrets` (block accidental API key commits), `terraform_fmt` +
-`terraform_validate` (gated to `*.tf` under `deploy/terraform/`), and a local
-`helm-lint` hook that runs `helm lint` against every chart in `deploy/helm/`.
-
-When adding a new tool/check, prefer adding a hook in `.pre-commit-config.yaml`
-over a one-off CI step — keeping the source of truth in one place avoids the
-"works locally but fails in CI" trap. Mirror what `onyx-dot-app/internal-tools`
-does if a precedent exists there.
+Lint config lives in `.pre-commit-config.yaml`; CI runs the same hooks on PRs.
+Run `pre-commit install` once, then `pre-commit run --all-files` ad-hoc.
+Add new checks as hooks here, not as one-off CI steps.
 
 ## Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,28 @@ App at http://localhost:8080. First account created is auto-promoted to admin
 configured at runtime in the admin UI — env vars are only the fallback before
 any row exists in `llm_settings`.
 
+## Pre-commit hooks
+
+Quality checks run via `pre-commit` (or `prek`, the Rust-port drop-in) against
+`.pre-commit-config.yaml` at the repo root. CI runs the same hooks on PRs via
+`.github/workflows/ci.yml`, so what passes locally also passes in CI.
+
+```bash
+pip install pre-commit       # or: brew install prek
+pre-commit install           # one-time: install the git hook
+pre-commit run --all-files   # run every hook against the whole tree
+```
+
+Configured hooks: `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`,
+`ripsecrets` (block accidental API key commits), `terraform_fmt` +
+`terraform_validate` (gated to `*.tf` under `deploy/terraform/`), and a local
+`helm-lint` hook that runs `helm lint` against every chart in `deploy/helm/`.
+
+When adding a new tool/check, prefer adding a hook in `.pre-commit-config.yaml`
+over a one-off CI step — keeping the source of truth in one place avoids the
+"works locally but fails in CI" trap. Mirror what `onyx-dot-app/internal-tools`
+does if a precedent exists there.
+
 ## Layout
 
 ```


### PR DESCRIPTION
## Summary

Two pieces of the deploy story:

- **`docker-build-push.yml`** — modeled on `onyx-dot-app/python-sandbox`. Triggered by `push: tags: ['v*']` (or `workflow_dispatch`), builds backend + frontend in parallel jobs, pushes multi-arch (`linux/amd64,linux/arm64`) images to `onyxdotapp/agent-wiki-backend` and `onyxdotapp/agent-wiki-frontend` on Docker Hub. Uses GHA build cache and `secrets.DOCKERHUB_TOKEN`.
- **`ci.yml` + `.pre-commit-config.yaml`** — quality checks migrated to `pre-commit`, mirroring `onyx-dot-app/internal-tools`. Single source of truth for lint config in `.pre-commit-config.yaml`; the CI workflow just runs `pre-commit` via `j178/prek-action`, so what passes locally also passes in CI. Hooks cover: `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`, `ripsecrets`, `terraform_fmt` + `terraform_validate` (gated to `*.tf`), and a local `helm-lint` hook for charts under `deploy/helm/`.
- **`CLAUDE.md`** — new "Pre-commit hooks" section documenting setup, configured hooks, and the convention to add new checks here rather than ad-hoc CI steps.

## Follow-up after this lands

- Cut a `v0.0.1` tag, watch the workflow publish to Docker Hub, verify `docker pull onyxdotapp/agent-wiki-backend:v0.0.1`.
- A few existing files (`README.md`, `local_data/wiki/difficult_separable_work.md`, `local_data/wiki/local testing/sf-trip-planning.md`) have trailing-whitespace / EOF issues. Not fixed here so the PR scope stays clean — pre-commit will catch and fix them lazily as those files get touched in future PRs.

## Test plan

- [x] `pre-commit run --files <pr-files>` passes locally
- [x] YAML parses clean (`yaml.safe_load`)
- [ ] Manual `workflow_dispatch` run from `main` after merge to verify Docker Hub auth + cache wiring
- [ ] First real release: cut `v0.0.1` tag, confirm both images push and the manifest list contains amd64 + arm64
- [ ] On a follow-up PR that touches `deploy/`, verify the pre-commit job runs and passes

## Notes

- `DOCKERHUB_TOKEN` is the same org-level secret python-sandbox uses (`onyxdotapp` namespace). No new secret to provision if this repo has access to org secrets.