### PR TITLE
chore(ci): publish Helm chart to gh-pages on push to main

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,0 +1,37 @@
+name: Release Helm Chart
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm-release.yml'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          charts_dir: deploy/helm
+          skip_existing: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary

Third piece of the deploy story. One workflow under `.github/workflows/helm-release.yml` mirroring `onyx-dot-app/python-sandbox`'s `helm-release.yml`:

- Triggered by `push: branches: [main]` with a path filter on `deploy/helm/**` (and the workflow file itself), plus `workflow_dispatch`.
- Uses `helm/chart-releaser-action@v1.6.0` to package every chart under `deploy/helm/*/` and publish to the `gh-pages` branch using `secrets.GITHUB_TOKEN`.
- `skip_existing: true` so re-runs and main pushes that don't bump `Chart.yaml#version` are no-ops.

Independent of PRs #1 and #2 — chart-releaser only runs when `deploy/helm/**` actually exists, so this is harmless if it lands first.

## After this lands

- First push to main that touches `deploy/helm/**` will publish chart `agent-workspace-0.1.0` to `gh-pages`.
- Once the gh-pages branch is published, GitHub Pages needs to be enabled for the repo (Settings → Pages → Source: `gh-pages`) so the chart index is reachable at `https://onyx-dot-app.github.io/agent-wiki/`. This is a one-time manual step in the repo settings.
- Downstream consumers can then run `helm repo add agent-wiki https://onyx-dot-app.github.io/agent-wiki && helm install agent-wiki agent-wiki/agent-workspace`.

## Test plan

- [x] YAML parses clean (`yaml.safe_load`)
- [ ] After merge: confirm a push to `deploy/helm/**` triggers the workflow, the run succeeds, and a `gh-pages` branch is created with `index.yaml` + `agent-workspace-0.1.0.tgz`
- [ ] Enable GitHub Pages on `gh-pages`; verify `helm repo add agent-wiki https://onyx-dot-app.github.io/agent-wiki` resolves