### PR TITLE
ci(images): use AWS OIDC + Secrets Manager for DockerHub auth

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -6,8 +6,10 @@ on:
       - 'v*'
   workflow_dispatch:
 
-env:
-  DOCKERHUB_USERNAME: onyxdotapp
+# Required for OIDC authentication with AWS (matches the onyx repo pattern).
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build-backend:
@@ -18,20 +20,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            DOCKER_USERNAME, deploy/docker-username
+            DOCKER_TOKEN, deploy/docker-token
+          parse-json-secrets: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-backend
+          images: ${{ env.DOCKER_USERNAME }}/agent-wiki-backend
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
@@ -56,20 +72,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            DOCKER_USERNAME, deploy/docker-username
+            DOCKER_TOKEN, deploy/docker-token
+          parse-json-secrets: true
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_TOKEN }}
 
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-frontend
+          images: ${{ env.DOCKER_USERNAME }}/agent-wiki-frontend
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest


### PR DESCRIPTION
## Summary

Mirrors the pattern in `onyx/.github/workflows/deployment.yml`. The previous workflow tried to read `secrets.DOCKERHUB_TOKEN` directly, which isn't set on this repo (the first `v0.0.1` build failed with \`Password required\`). This switches to the org's existing setup: OIDC-assumed AWS role → Secrets Manager.

## Changes

- Drop `env.DOCKERHUB_USERNAME` (now read from Secrets Manager).
- Add `permissions: id-token: write` at the workflow level (matches onyx).
- Each job now does:
  1. `aws-actions/configure-aws-credentials@v4` with `role-to-assume: \${{ secrets.AWS_OIDC_ROLE_ARN }}` and `aws-region: us-east-2`.
  2. `aws-actions/aws-secretsmanager-get-secrets@v2` pulling `deploy/docker-username` and `deploy/docker-token`.
  3. `docker/login-action@v3` with the env-loaded creds.

## Requires (org-side, already set up for onyx)

- `AWS_OIDC_ROLE_ARN` secret accessible to this repo.
- The role's trust policy includes \`onyx-dot-app/agent-wiki\`.
- The role can read \`deploy/docker-*\` secrets in \`us-east-2\`.

## Test plan

- [x] YAML parses (pre-commit clean)
- [ ] After merge, retrigger the workflow on the existing `v0.0.1` tag:
  \`gh workflow run "Build and Push Docker Images" -R onyx-dot-app/agent-wiki --ref v0.0.1\`
- [ ] Verify both images publish: \`docker pull onyxdotapp/agent-wiki-{backend,frontend}:0.0.1\`