### PR TITLE
feat(mcp_server): expose wiki tools to Claude Code over stdio

### DIFF
--- a/backend/app/mcp_server/README.md
+++ b/backend/app/mcp_server/README.md
@@ -1,0 +1,50 @@
+# mcp_server — wiki-as-MCP-server
+
+Exposes the agent-wiki tool surface to external coding agents (Claude Code,
+Craft, etc.) over MCP. Independent of `app/api/mcp.py`, which is the
+outbound (wiki-uses-MCP-clients) blueprint.
+
+## Run it
+
+```bash
+SECRET_KEY=... \
+WIKI_DIR=/path/to/wiki \
+APP_DB_PATH=/path/to/app.sqlite \
+QUEUE_DB_PATH=/path/to/queue.sqlite \
+python -m app.mcp_server
+```
+
+The server takes over stdio for MCP JSON-RPC. Logs route to stderr.
+
+## Register with Claude Code
+
+```bash
+cd /path/to/agent-wiki
+claude mcp add agent-wiki \
+  -e SECRET_KEY=dev-only-not-secret \
+  -e WIKI_DIR=/Users/you/agent-wiki/local_data/wiki \
+  -e APP_DB_PATH=/Users/you/agent-wiki/local_data/app.sqlite \
+  -e QUEUE_DB_PATH=/Users/you/agent-wiki/local_data/queue.sqlite \
+  -- /Users/you/agent-wiki/backend/.venv/bin/python -m app.mcp_server
+```
+
+`claude mcp list` should show `agent-wiki: ✓ Connected`.
+
+## D2 tools (4)
+
+`search_wiki`, `read_page`, `edit_doc`, `write_doc`. Specs and handlers live
+in `app/llm/agents/tools/` — the MCP server reuses them verbatim. The same
+read-before-write enforcement (`seen_doc_paths` ContextVar, set once per
+server lifetime) gates `edit_doc` / `write_doc`.
+
+## Auth (v0)
+
+Stdio transport: **process-spawn = authentication.** The parent process
+chooses what to launch and what env to pass. There's no in-band auth check.
+
+Move to a real auth bridge when adding non-stdio transport (HTTP/SSE for
+remote agents). Likely shape:
+
+- v1: per-user PAT issued from the admin UI; MCP server validates header
+  on each call against the same `users` table the Flask app uses.
+- v2: OIDC for the same flow.

--- a/backend/app/mcp_server/__init__.py
+++ b/backend/app/mcp_server/__init__.py
@@ -1,0 +1,13 @@
+"""MCP server exposing the agent-wiki tool surface to external agents.
+
+Direction: wiki-IS-MCP-server. Claude Code (or Craft, etc.) connects in over
+stdio and drives the wiki via the same tool handlers the in-app chat agent
+uses. Independent of ``app/api/mcp.py``, which is the outbound (wiki-USES-
+MCP-clients) blueprint.
+"""
+
+from __future__ import annotations
+
+from app.mcp_server.server import build_server
+
+__all__ = ["build_server"]

--- a/backend/app/mcp_server/__main__.py
+++ b/backend/app/mcp_server/__main__.py
@@ -1,0 +1,43 @@
+"""Entry point: ``python -m app.mcp_server``. Runs the stdio MCP server.
+
+Initializes the same SQLite DB + wiki git repo + FTS index that the Flask
+app touches, then takes over stdio for the MCP protocol. Logs go to stderr
+so they don't corrupt the JSON-RPC stream on stdout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from mcp.server.stdio import stdio_server
+
+from app.db.sqlite import init_db
+from app.llm.agents._session import seen_doc_paths
+from app.mcp_server.server import build_server
+from app.utils.logging import setup_logging
+from app.wiki.git import ensure_wiki_repo
+from app.wiki.search import bootstrap_index_if_empty
+
+
+async def _serve() -> None:
+    init_db()
+    ensure_wiki_repo()
+    bootstrap_index_if_empty()
+    seen_doc_paths.set(set())
+
+    server = build_server()
+    init_options = server.create_initialization_options()
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(read_stream, write_stream, init_options)
+
+
+def main() -> None:
+    setup_logging()
+    logging.getLogger().handlers[0].setStream(sys.stderr)
+    asyncio.run(_serve())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/mcp_server/server.py
+++ b/backend/app/mcp_server/server.py
@@ -1,0 +1,70 @@
+"""Build the MCP server. Reuses :mod:`app.llm.agents.tools` handlers verbatim.
+
+Tool handlers in ``app.llm.agents.tools`` already implement everything we need:
+input validation, read-before-write enforcement (via the
+``seen_doc_paths`` ContextVar), commit + reindex + trigger fan-out, and
+``{"error": str}`` envelope on failure. The MCP server is a thin adapter that
+loads a filtered subset of those specs and dispatches to the same registry.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.server import Server
+from mcp.types import TextContent, Tool
+
+from app.llm.agents import tools as tool_registry
+from app.llm.agents._session import seen_doc_paths
+
+log = logging.getLogger(__name__)
+
+D2_TOOL_NAMES: frozenset[str] = frozenset({"search_wiki", "read_page", "edit_doc", "write_doc"})
+
+
+def _exposed_specs() -> list[dict[str, Any]]:
+    return [s for s in tool_registry.TOOL_SPECS if s["name"] in D2_TOOL_NAMES]
+
+
+def _spec_to_tool(spec: dict[str, Any]) -> Tool:
+    return Tool(
+        name=spec["name"],
+        description=spec["description"],
+        inputSchema=spec["input_schema"],
+    )
+
+
+def _record_seen_path(name: str, result: Any) -> None:
+    if name != "read_page":
+        return
+    seen = seen_doc_paths.get()
+    if seen is None or not isinstance(result, dict):
+        return
+    path = result.get("path")
+    if isinstance(path, str) and path:
+        seen.add(path)
+
+
+def build_server() -> Server:
+    server: Server = Server("agent-wiki")
+
+    @server.list_tools()
+    async def list_tools() -> list[Tool]:
+        return [_spec_to_tool(s) for s in _exposed_specs()]
+
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        if name not in D2_TOOL_NAMES:
+            return [TextContent(type="text", text=json.dumps({"error": "unknown tool: %s" % name}))]
+        try:
+            result = tool_registry.dispatch(name, arguments)
+        except Exception as exc:
+            log.exception("mcp tool %s raised", name)
+            return [TextContent(type="text", text=json.dumps({"error": str(exc)}))]
+        _record_seen_path(name, result)
+        body = result if isinstance(result, str) else json.dumps(result)
+        return [TextContent(type="text", text=body)]
+
+    return server


### PR DESCRIPTION
## Description

New `backend/app/mcp_server/` runs an MCP server over stdio that exposes the existing `app/llm/agents/tools/` handlers to external coding agents (Claude Code first).

D2 tool subset: `search_wiki`, `read_page`, `edit_doc`, `write_doc`. JSON specs and Python handlers reused verbatim — same dispatch, same read-before-write enforcement via the `seen_doc_paths` ContextVar (set once for the server lifetime).

Run: `python -m app.mcp_server` with the same env as the Flask app. Register in Claude Code:

```
claude mcp add agent-wiki \
  -e SECRET_KEY=... -e WIKI_DIR=... -e APP_DB_PATH=... -e QUEUE_DB_PATH=... \
  -- /path/to/.venv/bin/python -m app.mcp_server
```

Auth model for stdio v0: process-spawn equals authentication. Real auth bridge (PAT / OIDC) deferred to the first non-stdio transport.

D3 expansion (separate PR): `multi_edit`, `create_directory`, `move_path`, `create_trigger`, `update_trigger`, `web_search`, `open_url`, `explain_functionality`.

## How Has This Been Tested?