### PR TITLE
fix(deploy): template + chart fixes from real-deploy bring-up

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (Flask + SQLite + Huey + Next.js).
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,53 +1,64 @@
+{{- /*
+One Deployment per Huey queue. The backend's `app.tasks.run_worker`
+requires a queue argument (`documents`, `triggers`, or `wiki_doc_index`),
+and each queue gets its own consumer process to keep slow LLM doc
+work from backpressuring fast paths like FTS reindex.
+*/ -}}
+{{- range $queue := .Values.worker.queues }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "agent-workspace.fullname" . }}-worker
+  name: {{ include "agent-workspace.fullname" $ }}-worker-{{ $queue | replace "_" "-" }}
   labels:
-    {{- include "agent-workspace.labels" . | nindent 4 }}
+    {{- include "agent-workspace.labels" $ | nindent 4 }}
     app.kubernetes.io/component: worker
+    agent-workspace.onyx.app/queue: {{ $queue }}
 spec:
-  replicas: {{ .Values.worker.replicaCount }}
+  replicas: {{ $.Values.worker.replicaCount }}
   # The worker mounts the same RWO PVCs as the backend; Recreate avoids two pods
   # holding the wiki working tree at once during rollouts.
   strategy:
     type: Recreate
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ include "agent-workspace.name" $ }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
       app.kubernetes.io/component: worker
+      agent-workspace.onyx.app/queue: {{ $queue }}
   template:
     metadata:
       labels:
-        {{- include "agent-workspace.labels" . | nindent 8 }}
+        {{- include "agent-workspace.labels" $ | nindent 8 }}
         app.kubernetes.io/component: worker
+        agent-workspace.onyx.app/queue: {{ $queue }}
     spec:
-      serviceAccountName: {{ include "agent-workspace.serviceAccountName" . }}
-      {{- with .Values.imagePullSecrets }}
+      serviceAccountName: {{ include "agent-workspace.serviceAccountName" $ }}
+      {{- with $.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.podSecurityContext }}
+      {{- with $.Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: worker
-          image: "{{ .Values.image.backend.repository }}:{{ .Values.image.backend.tag }}"
-          imagePullPolicy: {{ .Values.image.backend.pullPolicy }}
-          command: ["python", "-m", "app.tasks.run_worker"]
-          {{- with .Values.securityContext }}
+          image: "{{ $.Values.image.backend.repository }}:{{ $.Values.image.backend.tag }}"
+          imagePullPolicy: {{ $.Values.image.backend.pullPolicy }}
+          command: ["python", "-m", "app.tasks.run_worker", {{ $queue | quote }}]
+          {{- with $.Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            {{- include "agent-workspace.backendEnv" . | nindent 12 }}
+            {{- include "agent-workspace.backendEnv" $ | nindent 12 }}
           volumeMounts:
-            {{- include "agent-workspace.backendVolumeMounts" . | nindent 12 }}
+            {{- include "agent-workspace.backendVolumeMounts" $ | nindent 12 }}
           resources:
-            {{- toYaml .Values.worker.resources | nindent 12 }}
+            {{- toYaml $.Values.worker.resources | nindent 12 }}
       volumes:
-        {{- include "agent-workspace.backendVolumes" . | nindent 8 }}
+        {{- include "agent-workspace.backendVolumes" $ | nindent 8 }}
       # Co-schedule with the backend so the RWO PVCs land on the same node.
       affinity:
         podAffinity:
@@ -57,17 +68,18 @@ spec:
                   - key: app.kubernetes.io/name
                     operator: In
                     values:
-                      - {{ include "agent-workspace.name" . }}
+                      - {{ include "agent-workspace.name" $ }}
                   - key: app.kubernetes.io/component
                     operator: In
                     values:
                       - backend
               topologyKey: kubernetes.io/hostname
-      {{- with .Values.nodeSelector }}
+      {{- with $.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with $.Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -63,7 +63,16 @@ backend:
     periodSeconds: 10
 
 worker:
+  # One Deployment is created per queue; replicaCount applies per queue.
+  # Keep at 1 — backend + worker pods share RWO PVCs and must co-schedule.
   replicaCount: 1
+  # Three Huey queues, one consumer process each. Match
+  # `backend/app/tasks/huey_app.py:QUEUES`. Don't add a fourth without
+  # corresponding code.
+  queues:
+    - documents
+    - triggers
+    - wiki_doc_index
   resources:
     requests:
       cpu: 100m

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -96,7 +96,11 @@ module "eks" {
       min_size       = var.node_min_size
       max_size       = var.node_max_size
       desired_size   = var.node_desired_size
-      subnet_ids     = module.vpc.private_subnets
+      # Pin to a single AZ. EBS volumes are AZ-bound; if a node replacement
+      # lands in a different AZ than the original PVCs, the chart's RWO PVCs
+      # can't follow and the backend pod gets stuck Pending with
+      # "node(s) didn't match PersistentVolume's node affinity".
+      subnet_ids = slice(module.vpc.private_subnets, 0, 1)
     }
   }
 }
@@ -193,10 +197,25 @@ resource "helm_release" "ingress_nginx" {
     value = "LoadBalancer"
   }
 
-  # NLB is cheaper, terminates faster, and proxies arbitrary TCP — good default for an HTTP ingress.
+  # Use the AWS Load Balancer Controller (NOT the legacy in-tree NLB).
+  # `type=external` + `nlb-target-type=ip` makes the LBC manage the LB,
+  # target pods directly (bypassing NodePort), and open the necessary
+  # security-group ingress. The in-tree NLB defaults to scheme=internal AND
+  # doesn't open NodePort to the public, so the external LB ends up
+  # unreachable from the internet and cert-manager's HTTP-01 challenge fails.
   set {
     name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-type"
-    value = "nlb"
+    value = "external"
+  }
+
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-nlb-target-type"
+    value = "ip"
+  }
+
+  set {
+    name  = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-scheme"
+    value = "internet-facing"
   }
 
   depends_on = [module.eks, kubernetes_storage_class_v1.gp3]

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -24,8 +24,8 @@ variable "cluster_version" {
 
 variable "node_instance_types" {
   type        = list(string)
-  description = "EC2 instance types for the managed node group. t3.medium is a sensible default for a single-tenant lightweight workload."
-  default     = ["t3.medium"]
+  description = "EC2 instance types for the managed node group. t3.large supports 35 pods/node — t3.medium's 17-pod cap couldn't fit cluster services + the chart's backend + worker + frontend with headroom."
+  default     = ["t3.large"]
 }
 
 variable "node_min_size" {


### PR DESCRIPTION
## Summary

Three terraform fixes and one chart fix discovered while bringing up a real cluster end-to-end. The public template was structurally correct but had three latent issues that only surface when you actually try to reach the cluster from the internet, plus a chart issue that surfaces only when the worker pod tries to start. Landing the corrected patterns in the template so the next person doesn't repeat the same debug spiral.

## Terraform (`deploy/terraform/`)

- **Switch ingress-nginx to the AWS Load Balancer Controller.** Annotations: \`aws-load-balancer-type=external\` + \`nlb-target-type=ip\` + \`scheme=internet-facing\`. The legacy in-tree NLB defaults to \`scheme=internal\` AND doesn't open NodePort to \`0.0.0.0/0\` on the node SG, so the LB ends up unreachable from the public internet (and cert-manager HTTP-01 can't validate). The \`eks\` wrapper already installs the LBC via \`eks_blueprints_addons\`, so the controller is there for the using.
- **Bump default \`node_instance_types\` from \`t3.medium\` to \`t3.large\`.** \`t3.medium\` maxes at 17 pods/node; cluster services + the chart's backend + frontend exhaust the budget and the worker can't schedule.
- **Pin the main node group to a single AZ** via \`subnet_ids = slice(module.vpc.private_subnets, 0, 1)\`. EBS volumes are AZ-bound; if a node replacement lands in a different AZ than the original PV, the chart's RWO PVCs can't follow.

## Chart (\`deploy/helm/agent-workspace/\`)

- **Templatize \`worker-deployment.yaml\` to spawn one Deployment per Huey queue** (\`documents\`, \`triggers\`, \`wiki_doc_index\`). The backend's \`app.tasks.run_worker\` requires a queue argument; a single worker with no arg crashlooped on \`the following arguments are required: queue\`.
- Bump \`Chart.yaml\` version 0.1.1 → 0.2.0 so \`chart-releaser\` publishes the new chart shape (\`skip_existing\` keeps it idempotent otherwise).

## Test plan

- [x] \`terraform fmt\`, \`terraform validate\`, \`helm lint\` all clean.
- [x] \`helm template\` renders three worker Deployments named \`*-worker-{documents,triggers,wiki-doc-index}\` with correct \`command\` args.
- [x] Same fixes have been applied (and verified working) in the team's own deploy.