### PR TITLE
feat(auth): real Google OIDC end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ override.tf.json
 *_override.tf.json
 *.tfvars
 !example.tfvars
+uv.lock

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -1,13 +1,14 @@
-"""Auth endpoints — signup / login / logout / me / OIDC callback."""
+"""Auth endpoints — signup / login / logout / me / OIDC login + callback."""
 from __future__ import annotations
 
 import logging
 import sqlite3
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, current_app, jsonify, redirect, request, session, url_for
 
 from app.auth import User, current_user, login_required, users as users_repo
 from app.auth.basic import authenticate
+from app.auth.oidc import CLIENT_NAME as OIDC_CLIENT_NAME, upsert_oidc_user
 from app.auth.whitelist import is_allowed, is_open
 from app.config import CONFIG
 
@@ -78,10 +79,69 @@ def logout():
     return jsonify(ok=True)
 
 
+def _oidc_client():
+    """Return the registered OIDC client, or None if OIDC isn't configured."""
+    oauth = current_app.extensions.get("authlib.integrations.flask_client")
+    if oauth is None:
+        return None
+    return oauth.create_client(OIDC_CLIENT_NAME)
+
+
+@bp.get("/oidc/login")
+def oidc_login():
+    """Kick off the OIDC authorization-code flow."""
+    if CONFIG.auth_mode != "oidc":
+        return jsonify(error="oidc disabled"), 400
+    client = _oidc_client()
+    if client is None:
+        return jsonify(error="oidc not configured"), 503
+    # Use the explicit redirect URI when set (matches what's registered with
+    # the IdP); otherwise reconstruct from the request so dev/local also works.
+    redirect_uri = CONFIG.oidc_redirect_uri or url_for("auth.oidc_callback", _external=True)
+    return client.authorize_redirect(redirect_uri)
+
+
 @bp.get("/oidc/callback")
 def oidc_callback():
-    # TODO: OIDC redirect handler (authlib).
-    raise NotImplementedError
+    """OIDC redirect handler — exchanges code for token, upserts user, starts session."""
+    if CONFIG.auth_mode != "oidc":
+        return jsonify(error="oidc disabled"), 400
+    client = _oidc_client()
+    if client is None:
+        return jsonify(error="oidc not configured"), 503
+    try:
+        token = client.authorize_access_token()
+    except Exception:
+        log.exception("oidc: failed to exchange authorization code")
+        return redirect("/login?error=oidc_exchange_failed")
+
+    userinfo = token.get("userinfo")
+    if userinfo is None:
+        try:
+            userinfo = client.userinfo(token=token)
+        except Exception:
+            log.exception("oidc: failed to fetch userinfo")
+            return redirect("/login?error=oidc_userinfo_failed")
+
+    email = (userinfo.get("email") or "").strip().lower()
+    if not email:
+        log.warning("oidc: userinfo missing email; payload keys=%s", list(userinfo.keys()))
+        return redirect("/login?error=oidc_no_email")
+    if userinfo.get("email_verified") is False:
+        log.warning("oidc: email not verified for %s", email)
+        return redirect("/login?error=oidc_email_unverified")
+    if not is_allowed(email):
+        log.info("oidc: email %s not in allow list", email)
+        return redirect("/login?error=oidc_email_not_allowed")
+
+    name = userinfo.get("name") or None
+    user_id = upsert_oidc_user(email=email, name=name)
+    row = users_repo.get_by_id(user_id)
+    assert row is not None
+    user = User(id=row["id"], email=row["email"], name=row["name"], is_admin=bool(row["is_admin"]))
+    _start_session(user)
+    log.info("oidc login: user %s (%s)", user.id, user.email)
+    return redirect("/")
 
 
 @bp.get("/me")

--- a/backend/app/auth/oidc.py
+++ b/backend/app/auth/oidc.py
@@ -1,12 +1,67 @@
-"""OIDC auth via authlib. v0 stub — issuer/client id/secret read from CONFIG."""
+"""OIDC auth via authlib's Flask integration.
+
+Wired in :func:`init_oauth` from ``app/main.py`` when ``AUTH_MODE=oidc``.
+The login + callback endpoints in ``app/api/auth.py`` use the registered
+client to drive an OIDC authorization-code flow against the configured
+issuer (Google, in practice).
+"""
 from __future__ import annotations
 
-from flask import Request
+import logging
+import secrets
 
-from app.auth import User
+from authlib.integrations.flask_client import OAuth
+from flask import Flask
+
+from app.auth import users as users_repo
+from app.config import CONFIG
+
+log = logging.getLogger(__name__)
+
+# Registered client name. Used by the API layer as ``oauth.create_client("oidc")``.
+CLIENT_NAME = "oidc"
 
 
-def authenticate_oidc(request: Request) -> User | None:
-    # TODO: validate session cookie / bearer token against the OIDC issuer
-    # (use authlib.integrations.flask_client.OAuth), upsert the user, return User.
-    raise NotImplementedError
+def init_oauth(app: Flask) -> OAuth:
+    """Create and register an OAuth client on the Flask app.
+
+    Always returns the OAuth instance so ``app.extensions["authlib.integrations.flask_client"]``
+    is populated; only registers the OIDC client when ``AUTH_MODE=oidc`` and
+    issuer/client credentials are configured.
+    """
+    oauth = OAuth(app)
+
+    if CONFIG.auth_mode != "oidc":
+        return oauth
+
+    if not (CONFIG.oidc_issuer and CONFIG.oidc_client_id and CONFIG.oidc_client_secret):
+        log.warning("AUTH_MODE=oidc but issuer/client credentials are not fully set; OIDC disabled")
+        return oauth
+
+    issuer = CONFIG.oidc_issuer.rstrip("/")
+    oauth.register(
+        name=CLIENT_NAME,
+        server_metadata_url=f"{issuer}/.well-known/openid-configuration",
+        client_id=CONFIG.oidc_client_id,
+        client_secret=CONFIG.oidc_client_secret,
+        client_kwargs={"scope": "openid email profile"},
+    )
+    log.info("OIDC client registered (issuer=%s)", issuer)
+    return oauth
+
+
+def upsert_oidc_user(email: str, name: str | None) -> str:
+    """Find or create a user by email for an OIDC sign-in.
+
+    Returns the user's id. First user created is auto-promoted to admin
+    (same convention as ``users.create``). Subsequent OIDC sign-ins for an
+    existing email are no-ops on the user row — we don't overwrite ``name``
+    or ``is_admin`` to avoid surprising downgrades.
+    """
+    existing = users_repo.get_by_email(email)
+    if existing is not None:
+        return existing["id"]
+    # Random password the user can never use; OIDC sign-in bypasses
+    # ``authenticate``. Schema requires password_hash; storing a hash of a
+    # random secret keeps the column non-null without inventing a sentinel.
+    return users_repo.create(email=email, password=secrets.token_hex(32), name=name)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,9 @@ class Config:
     oidc_client_secret: str
     oidc_redirect_uri: str
 
+    # `True` when the app is served over HTTPS — toggles SESSION_COOKIE_SECURE.
+    secure_cookies: bool
+
 
 def load_config() -> Config:
     return Config(
@@ -39,6 +42,7 @@ def load_config() -> Config:
         oidc_client_id=os.environ.get("OIDC_CLIENT_ID", ""),
         oidc_client_secret=os.environ.get("OIDC_CLIENT_SECRET", ""),
         oidc_redirect_uri=os.environ.get("OIDC_REDIRECT_URI", ""),
+        secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
     )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from flask import Flask
 
 from app.api import admin, auth, chat, documents, events, mcp, triggers, users, webhooks
+from app.auth.oidc import init_oauth
 from app.config import CONFIG
 from app.db.sqlite import init_db
 from app.utils.logging import setup_logging
@@ -20,13 +21,14 @@ def create_app() -> Flask:
         SECRET_KEY=CONFIG.secret_key,
         SESSION_COOKIE_HTTPONLY=True,
         SESSION_COOKIE_SAMESITE="Lax",
-        SESSION_COOKIE_SECURE=False,  # set True behind HTTPS in prod
+        SESSION_COOKIE_SECURE=CONFIG.secure_cookies,
         PERMANENT_SESSION_LIFETIME=timedelta(days=30),
     )
 
     init_db()
     ensure_wiki_repo()
     bootstrap_index_if_empty()
+    init_oauth(app)
 
     app.register_blueprint(auth.bp, url_prefix="/api/auth")
     app.register_blueprint(admin.bp, url_prefix="/api/admin")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -34,6 +34,7 @@ def tmp_config(tmp_path, monkeypatch):
         oidc_client_id="",
         oidc_client_secret="",
         oidc_redirect_uri="",
+        secure_cookies=False,
     )
     monkeypatch.setattr("app.config.CONFIG", cfg)
     monkeypatch.setattr("app.db.sqlite.CONFIG", cfg)

--- a/backend/tests/test_auth_oidc.py
+++ b/backend/tests/test_auth_oidc.py
@@ -1,0 +1,213 @@
+"""Tests for the OIDC auth flow (``app/auth/oidc.py`` + ``/api/auth/oidc/*``).
+
+Scope: the seam between authlib and our user/session layer. We stub the
+authlib OIDC client at ``api.auth._oidc_client`` so the tests don't make
+network calls and don't depend on a registered OAuth client. Authlib's own
+state/PKCE handling is not under test here.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+
+from app.api import auth as auth_api
+from app.auth import users as users_repo
+from app.auth.oidc import upsert_oidc_user
+
+
+@pytest.fixture
+def oidc_config(tmp_repo, monkeypatch):
+    """Flip CONFIG into oidc mode for the duration of a test.
+
+    ``tmp_repo`` already gives us a tmp DB + wiki repo; we just rebind
+    every captured CONFIG reference to one with auth_mode="oidc".
+    """
+    cfg = replace(
+        tmp_repo,
+        auth_mode="oidc",
+        oidc_issuer="https://accounts.google.com",
+        oidc_client_id="test-client-id",
+        oidc_client_secret="test-client-secret",
+    )
+    monkeypatch.setattr("app.config.CONFIG", cfg)
+    monkeypatch.setattr("app.api.auth.CONFIG", cfg)
+    monkeypatch.setattr("app.auth.oidc.CONFIG", cfg)
+    return cfg
+
+
+@pytest.fixture
+def app(oidc_config):
+    app = Flask(__name__)
+    app.config.update(SECRET_KEY="test-secret", TESTING=True)
+    app.register_blueprint(auth_api.bp, url_prefix="/api/auth")
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def stub_client(monkeypatch):
+    """Replace ``api.auth._oidc_client`` with a configurable MagicMock.
+
+    Tests set ``stub.authorize_access_token.return_value`` to control the
+    token + userinfo payload the callback handler receives.
+    """
+    stub = MagicMock(name="oidc_client")
+    monkeypatch.setattr("app.api.auth._oidc_client", lambda: stub)
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# upsert_oidc_user
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_creates_user_when_missing(tmp_repo):
+    user_id = upsert_oidc_user(email="alice@example.com", name="Alice")
+    row = users_repo.get_by_id(user_id)
+    assert row is not None
+    assert row["email"] == "alice@example.com"
+    assert row["name"] == "Alice"
+
+
+def test_upsert_first_user_is_admin(tmp_repo):
+    user_id = upsert_oidc_user(email="first@example.com", name=None)
+    row = users_repo.get_by_id(user_id)
+    assert bool(row["is_admin"]) is True
+
+
+def test_upsert_subsequent_users_not_admin(tmp_repo):
+    upsert_oidc_user(email="first@example.com", name=None)
+    second = upsert_oidc_user(email="second@example.com", name="Second")
+    row = users_repo.get_by_id(second)
+    assert bool(row["is_admin"]) is False
+
+
+def test_upsert_existing_user_returns_same_id(tmp_repo):
+    first = upsert_oidc_user(email="alice@example.com", name="Alice")
+    second = upsert_oidc_user(email="alice@example.com", name="Alice (renamed)")
+    assert first == second
+    # Existing rows aren't overwritten — name stays as originally created.
+    row = users_repo.get_by_id(first)
+    assert row["name"] == "Alice"
+
+
+# ---------------------------------------------------------------------------
+# /api/auth/oidc/login
+# ---------------------------------------------------------------------------
+
+
+def test_login_disabled_when_auth_mode_basic(tmp_repo, monkeypatch):
+    cfg = replace(tmp_repo, auth_mode="basic")
+    monkeypatch.setattr("app.api.auth.CONFIG", cfg)
+    app = Flask(__name__)
+    app.config.update(SECRET_KEY="test-secret", TESTING=True)
+    app.register_blueprint(auth_api.bp, url_prefix="/api/auth")
+    resp = app.test_client().get("/api/auth/oidc/login")
+    assert resp.status_code == 400
+    assert resp.get_json() == {"error": "oidc disabled"}
+
+
+def test_login_returns_503_when_client_not_registered(client, monkeypatch):
+    monkeypatch.setattr("app.api.auth._oidc_client", lambda: None)
+    resp = client.get("/api/auth/oidc/login")
+    assert resp.status_code == 503
+
+
+def test_login_redirects_via_authlib(client, stub_client):
+    from flask import redirect
+
+    stub_client.authorize_redirect.return_value = redirect("https://idp.example/authorize?...")
+    resp = client.get("/api/auth/oidc/login")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].startswith("https://idp.example/authorize")
+    stub_client.authorize_redirect.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# /api/auth/oidc/callback
+# ---------------------------------------------------------------------------
+
+
+def _userinfo(**overrides):
+    base = {"email": "alice@example.com", "email_verified": True, "name": "Alice"}
+    base.update(overrides)
+    return base
+
+
+def test_callback_creates_user_and_starts_session(client, stub_client):
+    stub_client.authorize_access_token.return_value = {"userinfo": _userinfo()}
+    resp = client.get("/api/auth/oidc/callback")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/"
+    row = users_repo.get_by_email("alice@example.com")
+    assert row is not None
+    assert row["name"] == "Alice"
+    # First user — should be admin per the existing convention.
+    assert bool(row["is_admin"]) is True
+    # And the response Set-Cookie should contain the Flask session cookie.
+    assert "session=" in resp.headers.get("Set-Cookie", "")
+
+
+def test_callback_normalizes_email_lowercase(client, stub_client):
+    stub_client.authorize_access_token.return_value = {
+        "userinfo": _userinfo(email="ALICE@EXAMPLE.COM")
+    }
+    client.get("/api/auth/oidc/callback")
+    assert users_repo.get_by_email("alice@example.com") is not None
+
+
+def test_callback_rejects_unverified_email(client, stub_client):
+    stub_client.authorize_access_token.return_value = {
+        "userinfo": _userinfo(email_verified=False)
+    }
+    resp = client.get("/api/auth/oidc/callback")
+    assert resp.status_code == 302
+    assert "error=oidc_email_unverified" in resp.headers["Location"]
+    # No user row should have been created.
+    assert users_repo.get_by_email("alice@example.com") is None
+
+
+def test_callback_rejects_missing_email(client, stub_client):
+    stub_client.authorize_access_token.return_value = {
+        "userinfo": {"email_verified": True, "name": "Alice"}
+    }
+    resp = client.get("/api/auth/oidc/callback")
+    assert resp.status_code == 302
+    assert "error=oidc_no_email" in resp.headers["Location"]
+
+
+def test_callback_rejects_email_not_in_allowlist(client, stub_client, monkeypatch):
+    # Tighten the allow list to a different domain than what the IdP returns.
+    monkeypatch.setenv("ALLOWED_EMAILS", "*@onyx.app")
+    monkeypatch.setattr("app.auth.whitelist.os.environ", {"ALLOWED_EMAILS": "*@onyx.app"})
+    stub_client.authorize_access_token.return_value = {
+        "userinfo": _userinfo(email="outsider@external.com")
+    }
+    resp = client.get("/api/auth/oidc/callback")
+    assert resp.status_code == 302
+    assert "error=oidc_email_not_allowed" in resp.headers["Location"]
+    assert users_repo.get_by_email("outsider@external.com") is None
+
+
+def test_callback_handles_exchange_failure(client, stub_client):
+    stub_client.authorize_access_token.side_effect = RuntimeError("boom")
+    resp = client.get("/api/auth/oidc/callback")
+    assert resp.status_code == 302
+    assert "error=oidc_exchange_failed" in resp.headers["Location"]
+
+
+def test_callback_falls_back_to_userinfo_endpoint(client, stub_client):
+    """Some IdPs put userinfo on the token; some require a separate fetch."""
+    stub_client.authorize_access_token.return_value = {}  # no userinfo on token
+    stub_client.userinfo.return_value = _userinfo(email="bob@example.com", name="Bob")
+    resp = client.get("/api/auth/oidc/callback")
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/"
+    assert users_repo.get_by_email("bob@example.com") is not None

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (Flask + SQLite + Huey + Next.js).
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/_helpers.tpl
+++ b/deploy/helm/agent-workspace/templates/_helpers.tpl
@@ -69,7 +69,7 @@ stay in lockstep.
       name: {{ include "agent-workspace.fullname" . }}-secrets
       key: oidc-client-secret
 - name: OIDC_REDIRECT_URI
-  value: {{ .Values.auth.oidc.redirectUri | quote }}
+  value: {{ default (printf "https://%s/api/auth/oidc/callback" .Values.ingress.host) .Values.auth.oidc.redirectUri | quote }}
 {{- end }}
 {{- end -}}
 

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -32,9 +32,14 @@ auth:
   # basic | oidc
   mode: basic
   oidc:
+    # Use https://accounts.google.com for Google. The /.well-known/openid-configuration
+    # path is appended automatically.
     issuer: ""
     clientId: ""
     clientSecret: ""
+    # Must match exactly what's registered with the IdP (e.g. Google Cloud Console
+    # OAuth client → Authorized redirect URIs). Defaults to
+    # `https://<ingress.host>/api/auth/oidc/callback` when left empty.
     redirectUri: ""
 
 # Set true behind HTTPS. The Ingress section below issues a cert via cert-manager.

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -16,7 +16,7 @@ output "kubeconfig_command" {
 }
 
 output "ingress_lb_hostname" {
-  description = "Public NLB hostname for the ingress-nginx LoadBalancer Service. Create a CNAME pointing your app's host (e.g. dev-wiki.onyx.app) at this. Empty string on a fresh apply if AWS hasn't finished provisioning yet — re-run `terraform refresh` or use the kubectl fallback below."
+  description = "Public NLB hostname for the ingress-nginx LoadBalancer Service. Create a CNAME pointing your app's host at this value. Empty string on a fresh apply if AWS hasn't finished provisioning yet — re-run `terraform refresh` or use the kubectl fallback below."
   value       = try(data.kubernetes_service.ingress_nginx.status[0].load_balancer[0].ingress[0].hostname, "")
 }
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -6,6 +6,14 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { useAuth } from "@/lib/auth";
 
+const OIDC_ERROR_MESSAGES: Record<string, string> = {
+  oidc_exchange_failed: "Couldn't complete sign-in. Try again.",
+  oidc_userinfo_failed: "Couldn't fetch your profile from the identity provider.",
+  oidc_no_email: "The identity provider didn't return an email address.",
+  oidc_email_unverified: "Your email isn't verified with the identity provider.",
+  oidc_email_not_allowed: "Your email isn't on the allow list for this workspace.",
+};
+
 function LoginForm() {
   const { login, config } = useAuth();
   const router = useRouter();
@@ -32,46 +40,71 @@ function LoginForm() {
 
   const next = params.get("next");
   const signupHref = next ? `/signup?next=${encodeURIComponent(next)}` : "/signup";
+  const oidcError = params.get("error");
+  const oidcErrorMessage = oidcError ? OIDC_ERROR_MESSAGES[oidcError] ?? oidcError : null;
+  const isOidc = config?.mode === "oidc";
 
   return (
     <main style={{ maxWidth: 360, margin: "10vh auto", padding: 24 }}>
       <h1 style={{ marginBottom: 24 }}>Sign in</h1>
-      <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        <label>
-          <div style={{ marginBottom: 4 }}>Email</div>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoFocus
-            style={{ width: "100%", padding: 8, boxSizing: "border-box" }}
-          />
-        </label>
-        <label>
-          <div style={{ marginBottom: 4 }}>Password</div>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            style={{ width: "100%", padding: 8, boxSizing: "border-box" }}
-          />
-        </label>
-        {error && <div style={{ color: "crimson" }}>{error}</div>}
-        <button type="submit" disabled={submitting} style={{ padding: "10px 16px", marginTop: 8 }}>
-          {submitting ? "Signing in…" : "Sign in"}
-        </button>
-      </form>
-      <p style={{ marginTop: 16, fontSize: 14, color: "#666" }}>
-        {config?.signup_open === false
-          ? "Signup is restricted — contact an admin."
-          : (
-            <>
-              Don&apos;t have an account? <Link href={signupHref}>Sign up</Link>
-            </>
-          )}
-      </p>
+      {oidcErrorMessage && (
+        <div style={{ color: "crimson", marginBottom: 16 }}>{oidcErrorMessage}</div>
+      )}
+      {isOidc ? (
+        <a
+          href="/api/auth/oidc/login"
+          style={{
+            display: "block",
+            padding: "10px 16px",
+            textAlign: "center",
+            background: "#1a73e8",
+            color: "white",
+            borderRadius: 4,
+            textDecoration: "none",
+          }}
+        >
+          Sign in with Google
+        </a>
+      ) : (
+        <>
+          <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <label>
+              <div style={{ marginBottom: 4 }}>Email</div>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoFocus
+                style={{ width: "100%", padding: 8, boxSizing: "border-box" }}
+              />
+            </label>
+            <label>
+              <div style={{ marginBottom: 4 }}>Password</div>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                style={{ width: "100%", padding: 8, boxSizing: "border-box" }}
+              />
+            </label>
+            {error && <div style={{ color: "crimson" }}>{error}</div>}
+            <button type="submit" disabled={submitting} style={{ padding: "10px 16px", marginTop: 8 }}>
+              {submitting ? "Signing in…" : "Sign in"}
+            </button>
+          </form>
+          <p style={{ marginTop: 16, fontSize: 14, color: "#666" }}>
+            {config?.signup_open === false ? (
+              "Signup is restricted — contact an admin."
+            ) : (
+              <>
+                Don&apos;t have an account? <Link href={signupHref}>Sign up</Link>
+              </>
+            )}
+          </p>
+        </>
+      )}
     </main>
   );
 }

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import Link from "next/link";
-import { Suspense, useState, type FormEvent } from "react";
+import { Suspense, useEffect, useState, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { useAuth } from "@/lib/auth";
 
 function SignupForm() {
-  const { signup } = useAuth();
+  const { signup, config } = useAuth();
   const router = useRouter();
   const params = useSearchParams();
+
+  // OIDC mode has no password; bounce to /login where the SSO button lives.
+  useEffect(() => {
+    if (config?.mode === "oidc") {
+      const next = params.get("next");
+      router.replace(next ? `/login?next=${encodeURIComponent(next)}` : "/login");
+    }
+  }, [config?.mode, params, router]);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [name, setName] = useState("");


### PR DESCRIPTION
## Summary

Replaces the OIDC stub with a working authorization-code flow via authlib's Flask integration. \`AUTH_MODE=oidc\` now actually means OIDC — no more "TODO" in the redirect handler. Plumbed end-to-end (backend + frontend + chart) and covered by 14 unit tests.

## Backend (\`backend/app/\`)

- **\`auth/oidc.py\`** — register an authlib OAuth client at app boot from \`AUTH_MODE\`/\`OIDC_ISSUER\`/\`OIDC_CLIENT_ID\`/\`OIDC_CLIENT_SECRET\`. Expose \`upsert_oidc_user(email, name)\` which finds or creates a user row (random password the user can never use; first user is auto-admin per the existing convention).
- **\`api/auth.py\`** — \`GET /api/auth/oidc/login\` redirects to the IdP's authorize URL using \`OIDC_REDIRECT_URI\` (or a request-derived fallback). \`GET /api/auth/oidc/callback\` exchanges the code, fetches userinfo, validates \`email_verified\` + the \`ALLOWED_EMAILS\` allow list, upserts the user, starts the session, redirects to \`/\`. Errors redirect to \`/login?error=<reason>\` with a friendly message.
- **\`main.py\`** — call \`init_oauth(app)\` in \`create_app()\`. Read \`SECURE_COOKIES\` from env so HTTPS deploys actually flip the secure-cookie flag (was hard-coded \`False\`).
- **\`config.py\`** — add \`secure_cookies\` field.

## Tests (\`backend/tests/test_auth_oidc.py\`)

14 tests, all green via \`pytest tests/test_auth_oidc.py\`:

- \`upsert_oidc_user\` — creates a new row on first sign-in; first user is admin; subsequent users aren't admin; existing email returns the same id without overwriting fields; emails are normalized to lowercase.
- \`/api/auth/oidc/login\` — 400 when \`AUTH_MODE=basic\`, 503 when the OAuth client isn't registered, 302 redirect to the IdP otherwise.
- \`/api/auth/oidc/callback\` — happy path creates user + starts session + redirects \`/\`; rejects \`email_verified=false\`; rejects missing email; rejects email not in \`ALLOWED_EMAILS\`; surfaces \`oidc_exchange_failed\` on token exchange errors; falls back to a separate userinfo fetch when the token doesn't carry one.

Authlib's client is stubbed at the \`api.auth._oidc_client\` seam so the suite makes no network calls and doesn't need a registered OAuth app.

## Frontend (\`frontend/src/app/\`)

- **\`login/page.tsx\`** — when \`/api/auth/config\` reports \`mode=oidc\`, hide the email/password form and show "Sign in with Google" linking to \`/api/auth/oidc/login\`. Render the \`?error=...\` bounce-back from the callback handler with a human-readable message.
- **\`signup/page.tsx\`** — redirect to \`/login\` when \`mode=oidc\` (no password to set).

## Chart (\`deploy/helm/agent-workspace/\`)

- **\`_helpers.tpl\`** — \`OIDC_REDIRECT_URI\` defaults to \`https://<ingress.host>/api/auth/oidc/callback\` when \`auth.oidc.redirectUri\` is left empty, so the typical case "just works" once the IdP client has the matching URI registered.
- **\`values.yaml\`** — comments on what each \`oidc.*\` field expects.
- **\`Chart.yaml\`** — bump 0.2.0 → 0.2.1.

## Deploy notes (Google as IdP)

1. Google Cloud Console → APIs & Services → Credentials → **Create OAuth 2.0 Client ID** (Web application).
2. Authorized redirect URI: \`https://<your-host>/api/auth/oidc/callback\`.
3. \`helm upgrade\` with:
   \`\`\`
   --set auth.mode=oidc \\
   --set auth.oidc.issuer=https://accounts.google.com \\
   --set auth.oidc.clientId=<from Google> \\
   --set auth.oidc.clientSecret=<from Google>
   \`\`\`
4. (Optional) \`--set allowedEmails="*@your-domain.com"\` to lock OIDC sign-in to a specific domain.

## Test plan

- [x] \`pytest tests/test_auth_oidc.py\` — 14 tests pass.
- [x] Full suite passes (\`pytest --ignore=tests/test_chat_stream.py\` — chat_stream failures are pre-existing, unrelated to OIDC).
- [x] \`pre-commit run\` passes (helm lint, terraform fmt clean).
- [x] Backend boots with \`AUTH_MODE=oidc\`; both \`/api/auth/oidc/login\` and \`/api/auth/oidc/callback\` are registered.
- [x] \`helm template\` with OIDC values renders \`OIDC_*\` env vars on backend + worker pods.
- [x] Frontend typecheck clean.
- [ ] After merge: cut a tag, helm upgrade with the OIDC values, complete a real Google sign-in.