### PR TITLE
fix(chart): rename worker queue wiki_doc_index -> wiki_bm25

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (Flask + SQLite + Huey + Next.js).
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -77,7 +77,7 @@ worker:
   queues:
     - documents
     - triggers
-    - wiki_doc_index
+    - wiki_bm25
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary

\`backend/app/tasks/huey_app.py\` was renamed \`wiki_doc_index\` → \`wiki_bm25\` in main. The chart's \`worker.queues\` default still pointed at the old name, so the v0.0.2 image's worker for that queue crashlooped (\`run_worker.py: invalid choice: 'wiki_doc_index'\`).

This is the smallest possible follow-up: rename the entry in \`values.yaml\` and bump the chart version so chart-releaser publishes 0.2.2.

## Test plan

- [x] \`helm lint\` clean.
- [x] Verified live: deploying with \`--set 'worker.queues={documents,triggers,wiki_bm25}'\` brings the worker-wiki-bm25 Deployment up green; without the override it crashlooped.
- [ ] After merge: chart-releaser publishes 0.2.2; subsequent helm upgrades drop the \`--set worker.queues=...\` override.