### PR TITLE
ci(deploy): nightly Docker Hub image build for agent-wiki

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,62 @@
+name: Nightly Image Build
+
+# Builds + pushes `onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD`
+# to Docker Hub on a daily cron. The downstream deploy job in
+# cloud-deployment-yamls picks up the tag an hour later.
+#
+# Stable `v*` releases continue to go through `docker-build-push.yml`; this
+# workflow is just the nightly cadence.
+
+on:
+  schedule:
+    - cron: "0 10 * * *" # 2 AM PST / 3 AM PDT — deploy job runs an hour later
+  workflow_dispatch:
+
+env:
+  DOCKERHUB_USERNAME: onyxdotapp
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        component: [backend, frontend]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute nightly tag
+        id: tag
+        run: echo "tag=nightly-latest-$(date -u +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./${{ matrix.component }}
+          file: ./${{ matrix.component }}/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-${{ matrix.component }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: onyx-dot-app/onyx/.github/actions/slack-notify@main
+        with:
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          title: "🚨 Nightly Image Build Failed (agent-wiki)"
+          ref-name: ${{ github.ref_name }}
+          failed-jobs: "build (${{ matrix.component }})"


### PR DESCRIPTION
## Summary

Daily cron that builds + pushes `onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD` to Docker Hub. No git tag step — the only output is the Docker Hub image tag, which is what the downstream deploy actually consumes.

- **`.github/workflows/nightly-build.yml`** (new) — cron at 10 UTC + `workflow_dispatch`. Matrix over `backend`/`frontend`, multi-arch (amd64+arm64), pulls/pushes via the existing `DOCKERHUB_TOKEN` secret. Slack notification on failure.
- Stable `v*` releases continue through the existing `docker-build-push.yml` — left untouched.

The downstream `cloud-deployment-yamls:dev-wiki-deploy.yml` (cdy PR #289) probes Docker Hub for `nightly-latest-YYYYMMDD` an hour later and `helm upgrade`s with `--set image.{backend,frontend}.tag=...`.

## Manual setup
None new. `DOCKERHUB_TOKEN` and `MONITOR_DEPLOYMENTS_WEBHOOK` are already reachable from this repo.

## Test plan
- [ ] Merge, then `gh workflow run nightly-build.yml --repo onyx-dot-app/agent-wiki` to trigger an immediate build.
- [ ] Verify `onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD` lands on Docker Hub (matrix produces both in parallel).
- [ ] Confirm `:latest` did not move (only the dated nightly tag).