### PR TITLE
feat(wiki): LLM provider model selection

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -118,6 +118,7 @@ def _llm_view(s: LLMSettings) -> LLMView:
         openai_api_key_hint=_redact(s.openai_api_key),
         gemini_api_key_hint=_redact(s.gemini_api_key),
         ollama_base_url=s.ollama_base_url,
+        provider_models=s.provider_models,
     )
 
 
@@ -135,15 +136,19 @@ def put_llm(
     # from "client sent null/empty" — required for the
     # empty-string-means-keep convention below.
     sent_fields = req.model_fields_set
-    provider = req.provider.strip().lower()
-    model = req.model.strip()
-    if provider not in _ALLOWED_PROVIDERS:
-        allowed = ", ".join(f"'{p}'" for p in _ALLOWED_PROVIDERS)
-        raise HTTPException(status_code=400, detail=f"provider must be one of {allowed}")
-    if not model:
-        raise HTTPException(status_code=400, detail="model is required")
-
     current = llm_settings.get()
+
+    if "provider" in sent_fields or "model" in sent_fields:
+        provider = (req.provider or "").strip().lower()
+        model = (req.model or "").strip()
+        if provider not in _ALLOWED_PROVIDERS:
+            allowed = ", ".join(f"'{p}'" for p in _ALLOWED_PROVIDERS)
+            raise HTTPException(status_code=400, detail=f"provider must be one of {allowed}")
+        if not model:
+            raise HTTPException(status_code=400, detail="model is required")
+    else:
+        provider = current.provider
+        model = current.model
 
     def _resolve_secret(field: str, sent: str | None, existing: str) -> str:
         if field not in sent_fields:
@@ -159,6 +164,8 @@ def put_llm(
     gemini_key = _resolve_secret("gemini_api_key", req.gemini_api_key, current.gemini_api_key)
     ollama_base_url = _resolve_secret("ollama_base_url", req.ollama_base_url, current.ollama_base_url)
 
+    new_provider_models = req.provider_models if "provider_models" in sent_fields else None
+
     llm_settings.upsert(
         provider=provider,
         model=model,
@@ -166,6 +173,7 @@ def put_llm(
         openai_api_key=openai_key,
         gemini_api_key=gemini_key,
         ollama_base_url=ollama_base_url,
+        provider_models=new_provider_models,
     )
     log.info(
         "admin: %s updated llm settings provider=%s model=%s",

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -17,6 +17,7 @@ from fastapi.responses import StreamingResponse
 from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 
 from app.auth import User
+from app.auth import users as users_repo
 from app.auth.deps import require_user
 from app.chat import sessions as sessions_repo
 from app.llm.agents.chat import (
@@ -24,6 +25,7 @@ from app.llm.agents.chat import (
     messages_from_history,
     run_chat_stream,
 )
+from app.models.user_settings import UserSettings
 from app.llm.errors import LLMError
 from app.models.chat import (
     ChatMessageOut, ChatSessionDetail, ChatSessionOut, SendChatRequest,
@@ -153,7 +155,13 @@ async def send_message(
                 user_id=user_id,
                 is_first_turn=is_first_turn,
             ), chat_agent_scope():
-                gen = run_chat_stream(messages)
+                raw_settings = await run_in_threadpool(users_repo.get_settings, user_id)
+                user_prefs = UserSettings.model_validate(raw_settings or {})
+                gen = run_chat_stream(
+                    messages,
+                    model=user_prefs.chat_model,
+                    provider=user_prefs.chat_provider,
+                )
                 # iterate_in_threadpool yields each item from the sync
                 # generator on a worker thread, so token emission
                 # doesn't block the event loop. The agent-name

--- a/backend/app/api/llm.py
+++ b/backend/app/api/llm.py
@@ -8,7 +8,7 @@ from app.auth.deps import require_user
 from app.llm import providers as llm_providers
 from app.llm import settings as llm_settings
 from app.llm.errors import LLMError
-from app.models.llm import LLMStatusResponse
+from app.models.llm import AvailableProvider, AvailableProvidersResponse, LLMStatusResponse
 
 router = APIRouter()
 
@@ -24,4 +24,52 @@ def status(_user: User = Depends(require_user)) -> LLMStatusResponse:
             configured = True
         except LLMError:
             configured = False
-    return LLMStatusResponse(configured=configured, provider=s.provider)
+    return LLMStatusResponse(configured=configured, provider=s.provider, model=s.model)
+
+
+_PROVIDER_LABELS = {
+    "anthropic": ("Anthropic", "claude-sonnet-4-6"),
+    "openai": ("OpenAI", "gpt-5.5"),
+    "gemini": ("Gemini", "gemini-3.1-pro-preview"),
+    "ollama": ("Ollama", "llama3.1"),
+}
+
+_PROVIDER_DEFAULT_MODELS: dict[str, list[str]] = {
+    "anthropic": ["claude-sonnet-4-6", "claude-opus-4-7", "claude-opus-4-6", "claude-haiku-4-5"],
+    "openai": ["gpt-5.5", "gpt-5.4", "gpt-5.2"],
+    "gemini": ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
+    "ollama": ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
+}
+
+
+@router.get("/available", response_model=AvailableProvidersResponse)
+def available(_user: User = Depends(require_user)) -> AvailableProvidersResponse:
+    """Return providers that have credentials configured and are ready to use."""
+    s = llm_settings.get()
+    result: list[AvailableProvider] = []
+    checks = [
+        ("anthropic", bool(s.anthropic_api_key)),
+        ("openai", bool(s.openai_api_key)),
+        ("gemini", bool(s.gemini_api_key)),
+        ("ollama", bool(s.ollama_base_url)),
+    ]
+    for name, has_creds in checks:
+        if not has_creds:
+            continue
+        p = llm_providers.get(name)
+        if p is None:
+            continue
+        try:
+            p.check_configured(s)
+        except LLMError:
+            continue
+        label, default_model = _PROVIDER_LABELS.get(name, (name, ""))
+        saved = s.provider_models.get(name, [])
+        models = saved if saved else _PROVIDER_DEFAULT_MODELS.get(name, [default_model])
+        result.append(AvailableProvider(
+            provider=name,
+            label=label,
+            default_model=default_model,
+            models=models,
+        ))
+    return AvailableProvidersResponse(providers=result)

--- a/backend/app/db/migrations/versions/433c24868299_add_provider_models.py
+++ b/backend/app/db/migrations/versions/433c24868299_add_provider_models.py
@@ -1,0 +1,26 @@
+"""add-provider-models
+
+Revision ID: 433c24868299
+Revises: 0013
+Create Date: 2026-05-11 19:00:28.267512+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = '433c24868299'
+down_revision: str | None = '0013'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column('llm_settings', sa.Column('provider_models', postgresql.JSONB(astext_type=sa.Text()), server_default=sa.text("'{}'::jsonb"), nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column('llm_settings', 'provider_models')

--- a/backend/app/db/migrations/versions/433c24868299_add_provider_models.py
+++ b/backend/app/db/migrations/versions/433c24868299_add_provider_models.py
@@ -10,7 +10,6 @@ from typing import Sequence
 
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 revision: str = '433c24868299'
 down_revision: str | None = '0013'

--- a/backend/app/db/migrations/versions/433c24868299_add_provider_models.py
+++ b/backend/app/db/migrations/versions/433c24868299_add_provider_models.py
@@ -19,7 +19,7 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.add_column('llm_settings', sa.Column('provider_models', postgresql.JSONB(astext_type=sa.Text()), server_default=sa.text("'{}'::jsonb"), nullable=False))
+    op.execute(sa.text("ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS provider_models JSONB DEFAULT '{}'::jsonb NOT NULL"))
 
 
 def downgrade() -> None:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -358,6 +358,7 @@ class LLMSettings(Base):
     openai_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
     gemini_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
     ollama_base_url: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    provider_models: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
     updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
 
     __table_args__ = (CheckConstraint("id = 1", name="llm_settings_singleton"),)

--- a/backend/app/llm/agents/chat.py
+++ b/backend/app/llm/agents/chat.py
@@ -73,6 +73,7 @@ def run_chat_loop_stream(
     tools_provider: ToolsProvider | None = None,
     tool_dispatch: ToolDispatch | None = None,
     model: str | None = None,
+    provider: str | None = None,
     max_iterations: int = DEFAULT_MAX_ITERATIONS,
     force_final_answer: bool = False,
 ) -> Iterator[StreamEvent]:
@@ -110,6 +111,7 @@ def run_chat_loop_stream(
         tools_provider=tools_provider,
         tool_dispatch=tool_dispatch,
         model=model,
+        provider=provider,
         max_iterations=max_iterations,
         force_final_answer=force_final_answer,
     )
@@ -122,6 +124,7 @@ def _drive_loop(
     tools_provider: ToolsProvider | None,
     tool_dispatch: ToolDispatch | None,
     model: str | None,
+    provider: str | None = None,
     max_iterations: int,
     force_final_answer: bool = False,
 ) -> Iterator[StreamEvent]:
@@ -136,7 +139,7 @@ def _drive_loop(
         else:
             turn_tools = tools_provider(messages) if tools_provider is not None else tools
 
-        for ev in client.stream(messages, model=model, tools=turn_tools):
+        for ev in client.stream(messages, model=model, provider=provider, tools=turn_tools):
             t = ev["type"]
             if t == "text_delta":
                 text_parts.append(ev["text"])
@@ -258,7 +261,7 @@ def chat_agent_scope() -> Generator[None]:
 
 
 def run_chat_stream(
-    messages: list[Message], *, model: str | None = None
+    messages: list[Message], *, model: str | None = None, provider: str | None = None
 ) -> Iterator[StreamEvent]:
     """Streaming chat agent with the standard wiki tool set + chat.system prompt.
 
@@ -273,6 +276,7 @@ def run_chat_stream(
         tools_provider=_chat_tools_for_turn,
         tool_dispatch=_chat_dispatch,
         model=model,
+        provider=provider,
         force_final_answer=True,
     )
 

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -97,6 +97,7 @@ def stream(
     messages: list[dict[str, Any]],
     *,
     model: str | None = None,
+    provider: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
 ) -> Iterator[StreamEvent]:
@@ -111,33 +112,34 @@ def stream(
     if tools:
         _debug_dump("llm request tools", tools)
     settings = get_llm_settings()
-    if not settings.provider:
+    chosen_provider_name = provider or settings.provider
+    if not chosen_provider_name:
         raise LLMError(
             "not_configured",
             "LLM is not configured. An admin needs to set the provider, model, and API key on the admin page.",
         )
-    provider = providers.get(settings.provider)
-    if provider is None:
-        raise LLMError("not_configured", f"Unknown LLM provider: {settings.provider}")
-    if not settings.model:
+    chosen_provider = providers.get(chosen_provider_name)
+    if chosen_provider is None:
+        raise LLMError("not_configured", f"Unknown LLM provider: {chosen_provider_name}")
+    chosen_model = model or settings.model
+    if not chosen_model:
         raise LLMError(
             "not_configured",
-            f"No model selected for provider '{settings.provider}'. An admin needs to set the model on the admin page.",
+            f"No model selected for provider '{chosen_provider_name}'. An admin needs to set the model on the admin page.",
         )
-    provider.check_configured(settings)
-    chosen_model = model or settings.model
+    chosen_provider.check_configured(settings)
     text_parts: list[str] = []
     tool_calls: list[dict[str, Any]] = []
     stop_reason = ""
     usage: dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0}
     with start_llm_span(
-        provider=settings.provider,
+        provider=chosen_provider_name,
         model=chosen_model,
         messages=messages,
         tools=tools,
         max_tokens=max_tokens,
     ) as span:
-        for ev in provider.stream(
+        for ev in chosen_provider.stream(
             messages,
             model=chosen_model,
             tools=tools,

--- a/backend/app/llm/settings.py
+++ b/backend/app/llm/settings.py
@@ -21,6 +21,7 @@ class LLMSettings(BaseModel):
     openai_api_key: str
     gemini_api_key: str
     ollama_base_url: str
+    provider_models: dict[str, list[str]]
 
 
 _EMPTY = LLMSettings(
@@ -30,6 +31,7 @@ _EMPTY = LLMSettings(
     openai_api_key="",
     gemini_api_key="",
     ollama_base_url="",
+    provider_models={},
 )
 
 
@@ -45,6 +47,7 @@ def get() -> LLMSettings:
             openai_api_key=row.openai_api_key,
             gemini_api_key=row.gemini_api_key,
             ollama_base_url=row.ollama_base_url,
+            provider_models=row.provider_models or {},
         )
 
 
@@ -56,6 +59,7 @@ def upsert(
     openai_api_key: str,
     gemini_api_key: str,
     ollama_base_url: str,
+    provider_models: dict[str, list[str]] | None = None,
 ) -> None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
@@ -70,6 +74,7 @@ def upsert(
                     openai_api_key=openai_api_key,
                     gemini_api_key=gemini_api_key,
                     ollama_base_url=ollama_base_url,
+                    provider_models=provider_models or {},
                     updated_at=now,
                 )
             )
@@ -80,5 +85,7 @@ def upsert(
             row.openai_api_key = openai_api_key
             row.gemini_api_key = gemini_api_key
             row.ollama_base_url = ollama_base_url
+            if provider_models is not None:
+                row.provider_models = provider_models
             row.updated_at = now
     log.info("llm_settings upserted provider=%s model=%s", provider, model)

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -20,12 +20,13 @@ class LLMConfigRequest(BaseModel):
     # `model` is a real field, so silence pydantic's ``model_*`` namespace warning.
     model_config = ConfigDict(protected_namespaces=())
 
-    provider: str
-    model: str
+    provider: str | None = None
+    model: str | None = None
     anthropic_api_key: str | None = None
     openai_api_key: str | None = None
     gemini_api_key: str | None = None
     ollama_base_url: str | None = None
+    provider_models: dict[str, list[str]] | None = None
 
 
 class WebConfigRequest(BaseModel):
@@ -86,6 +87,7 @@ class LLMView(BaseModel):
     gemini_api_key_hint: str
     # Ollama doesn't have an API key — surface the base URL directly.
     ollama_base_url: str
+    provider_models: dict[str, list[str]]
 
 
 class WebView(BaseModel):

--- a/backend/app/models/llm.py
+++ b/backend/app/models/llm.py
@@ -10,3 +10,15 @@ class LLMStatusResponse(BaseModel):
 
     configured: bool
     provider: str
+    model: str
+
+
+class AvailableProvider(BaseModel):
+    provider: str
+    label: str
+    default_model: str
+    models: list[str]
+
+
+class AvailableProvidersResponse(BaseModel):
+    providers: list[AvailableProvider]

--- a/backend/app/models/mcp.py
+++ b/backend/app/models/mcp.py
@@ -25,8 +25,8 @@ class JsonRpcRequest(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    jsonrpc: str
-    method: str
+    jsonrpc: str | None = None
+    method: str | None = None
     id: str | int | None = None
     params: dict[str, Any] | None = None
 

--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -27,6 +27,9 @@ class UserSettings(BaseModel):
     theme: Literal["light", "dark", "system"] = "system"
     timezone: str = "UTC"
     default_landing: Literal["wiki_home", "recent", "last_viewed"] = "wiki_home"
+    # Preferred provider + model for chat. None = use the global agent settings.
+    chat_provider: str | None = None
+    chat_model: str | None = None
 
     @field_validator("timezone")
     @classmethod
@@ -47,6 +50,14 @@ class UserSettingsUpdate(BaseModel):
     theme: Literal["light", "dark", "system"] | None = Field(default=None)
     timezone: str | None = Field(default=None)
     default_landing: Literal["wiki_home", "recent", "last_viewed"] | None = Field(default=None)
+    chat_provider: str | None = Field(default=None)
+    chat_model: str | None = Field(default=None)
 
     def non_null(self) -> dict[str, Any]:
-        return {k: v for k, v in self.model_dump().items() if v is not None}
+        sent = self.model_fields_set
+        result: dict[str, Any] = {}
+        for k, v in self.model_dump().items():
+            if k not in sent:
+                continue
+            result[k] = v
+        return result

--- a/backend/tests/_auth.py
+++ b/backend/tests/_auth.py
@@ -29,5 +29,11 @@ def signed_session_cookie(user_id: str) -> str:
 def login_fastapi(client: TestClient, user_id: str) -> None:
     """Counterpart to the Flask ``client.session_transaction()`` login
     pattern. Sets the ``session`` cookie SessionMiddleware would write
-    so subsequent ``client.get/post/...`` calls authenticate."""
+    so subsequent ``client.get/post/...`` calls authenticate.
+
+    Clears any existing session cookies first so there is exactly one
+    session cookie in the jar — prevents stale server-set cookies from
+    a prior signup from shadowing the new one.
+    """
+    client.cookies.delete("session")
     client.cookies.set("session", signed_session_cookie(user_id))

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -167,7 +167,7 @@ class MockLLM:
 
     # ---- patched seam ------------------------------------------------------
 
-    def complete(self, messages, *, tools=None, max_tokens=None, model=None) -> Any:
+    def complete(self, messages, *, tools=None, max_tokens=None, model=None, provider=None) -> Any:
         call = {"messages": messages, "tools": tools, "max_tokens": max_tokens, "model": model}
         self.calls.append(call)
         for matcher, build in self._scripts:
@@ -175,7 +175,7 @@ class MockLLM:
                 return build()
         return _make_default_response()
 
-    def stream(self, messages, *, tools=None, max_tokens=None, model=None) -> Iterator[dict]:
+    def stream(self, messages, *, tools=None, max_tokens=None, model=None, provider=None) -> Iterator[dict]:
         resp = self.complete(messages, tools=tools, max_tokens=max_tokens, model=model)
         if resp.text:
             yield {"type": "text_delta", "text": resp.text}
@@ -268,6 +268,7 @@ class IntegrationHarness:
         uid = self.signup(email=email, password=password)
         # signup already creates a session, but be explicit so the harness
         # behaves the same in tests that bypass /signup.
+        self.signin(uid)
         return uid
 
     # ----- documents --------------------------------------------------------

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -268,7 +268,6 @@ class IntegrationHarness:
         uid = self.signup(email=email, password=password)
         # signup already creates a session, but be explicit so the harness
         # behaves the same in tests that bypass /signup.
-        self.signin(uid)
         return uid
 
     # ----- documents --------------------------------------------------------

--- a/backend/tests/test_chat_sessions.py
+++ b/backend/tests/test_chat_sessions.py
@@ -169,7 +169,7 @@ def test_send_message_persists_user_and_assistant_turn(tmp_db, monkeypatch):
     end up in the DB."""
     client = _signed_in_client(tmp_db, "alice@example.com")
 
-    def fake_stream(messages, *, model=None):
+    def fake_stream(messages, *, model=None, provider=None):
         yield {"type": "tool_call", "id": "c1", "name": "wiki_search", "arguments": {"q": "x"}}
         yield {"type": "tool_result", "id": "c1", "name": "wiki_search", "content": "[]"}
         yield {"type": "iteration_done"}
@@ -210,7 +210,7 @@ def test_send_message_does_not_persist_assistant_on_llm_error(tmp_db, monkeypatc
 
     client = _signed_in_client(tmp_db, "alice@example.com")
 
-    def fake_stream(messages, *, model=None):
+    def fake_stream(messages, *, model=None, provider=None):
         yield {"type": "text_delta", "text": "partial"}
         raise LLMError("rate_limit", "boom")
 
@@ -231,7 +231,7 @@ def test_send_message_does_not_persist_assistant_on_llm_error(tmp_db, monkeypatc
 def test_send_message_enqueues_title_generation_only_on_first_turn(tmp_db, monkeypatch):
     client = _signed_in_client(tmp_db, "alice@example.com")
 
-    def fake_stream(messages, *, model=None):
+    def fake_stream(messages, *, model=None, provider=None):
         yield {"type": "text_delta", "text": "ok"}
         yield {"type": "done"}
 

--- a/backend/tests/test_chat_skills_loop.py
+++ b/backend/tests/test_chat_skills_loop.py
@@ -20,7 +20,7 @@ def script_stream(monkeypatch):
     def install(events: list[list[dict]]):
         scripted.extend(events)
 
-    def fake_stream(messages, *, model=None, tools=None, max_tokens=4096):
+    def fake_stream(messages, *, model=None, provider=None, tools=None, max_tokens=4096):
         if not scripted:
             raise AssertionError("script_stream exhausted")
         captured_tools.append(list(tools) if tools is not None else None)

--- a/backend/tests/test_chat_stream.py
+++ b/backend/tests/test_chat_stream.py
@@ -31,7 +31,7 @@ def stub_stream(monkeypatch):
     def install(scripted: list[list[dict]]):
         queue.extend(scripted)
 
-    def fake_stream(messages, *, model=None, tools=None, max_tokens=4096):
+    def fake_stream(messages, *, model=None, provider=None, tools=None, max_tokens=4096):
         if not queue:
             raise AssertionError("stub_stream exhausted but client.stream was called")
         events = queue.pop(0)
@@ -142,7 +142,7 @@ def test_force_final_answer_strips_tools_and_injects_reminder(stub_stream, monke
     captured_tools: list = []
     captured_messages_len: list[int] = []
 
-    def fake_stream(messages, *, model=None, tools=None, max_tokens=4096):
+    def fake_stream(messages, *, model=None, provider=None, tools=None, max_tokens=4096):
         captured_tools.append(tools)
         captured_messages_len.append(len(messages))
         # Cycle 1: keep calling tools; Cycle 2 (final): emit text.
@@ -296,7 +296,7 @@ def _create_session(client) -> str:
 
 
 def test_sse_endpoint_streams_text_then_done(signed_in_client, monkeypatch):
-    def fake_stream(messages, *, model=None):
+    def fake_stream(messages, *, model=None, provider=None):
         yield {"type": "text_delta", "text": "hi "}
         yield {"type": "text_delta", "text": "there"}
         yield {"type": "done"}
@@ -320,7 +320,7 @@ def test_sse_endpoint_streams_text_then_done(signed_in_client, monkeypatch):
 
 
 def test_sse_endpoint_emits_error_event_on_llm_error(signed_in_client, monkeypatch):
-    def fake_stream(messages, *, model=None):
+    def fake_stream(messages, *, model=None, provider=None):
         # Yield one delta to prove a partial stream still terminates with an
         # error event (the frontend uses that to drop the empty placeholder).
         yield {"type": "text_delta", "text": "partial"}
@@ -371,7 +371,7 @@ def test_sse_endpoint_real_run_chat_stream_under_iterate_in_threadpool(
     test exercises the real ``run_chat_stream`` (other SSE tests stub it
     out, which hid this bug)."""
     # Only stub the LLM provider seam — leave run_chat_stream real.
-    def fake_stream(messages, *, model=None, tools=None, max_tokens=4096):
+    def fake_stream(messages, *, model=None, provider=None, tools=None, max_tokens=4096):
         yield {"type": "text_delta", "text": "hi"}
         yield _done()
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -34,9 +35,9 @@ from app.llm.providers import anthropic as anthropic_provider
 from app.llm.providers import openai as openai_provider
 
 
-def _upsert(**overrides) -> None:
+def _upsert(**overrides: Any) -> None:
     """upsert() with empty defaults so tests only set fields they care about."""
-    base = {
+    base: dict[str, Any] = {
         "provider": "",
         "model": "",
         "anthropic_api_key": "",

--- a/backend/tests/test_llm_settings.py
+++ b/backend/tests/test_llm_settings.py
@@ -1,19 +1,21 @@
 """Tests for app/llm/settings.py — DB-backed LLM configuration."""
 from __future__ import annotations
 
+from typing import Any
+
 from app.db.models import LLMSettings as LLMSettingsRow
 from app.llm import settings as llm_settings
 
 from tests._seed import count_rows
 
 
-def _upsert(**overrides) -> None:
+def _upsert(**overrides: Any) -> None:
     """Upsert with empty defaults for fields the test doesn't care about.
 
     Keeps test bodies focused on the field-under-test instead of a long
     list of empty-string positional arguments.
     """
-    base = {
+    base: dict[str, Any] = {
         "provider": "",
         "model": "",
         "anthropic_api_key": "",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       # Publish to the host for local psql / smoke tests / running tests
       # against the compose Postgres without compose `exec`.
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5433:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres -d agent_wiki"]
       interval: 2s
@@ -100,7 +100,7 @@ services:
   nginx:
     build: ./nginx
     ports:
-      - "8080:80"
+      - "8082:80"
     depends_on:
       - backend
       - frontend

--- a/frontend/src/app/admin/llm/page.tsx
+++ b/frontend/src/app/admin/llm/page.tsx
@@ -8,17 +8,54 @@ import { Button } from "@/components/common/Button";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
-import { color, radius } from "@/lib/theme";
+import { color, radius, shadow } from "@/lib/theme";
 import { useIsMobile } from "@/lib/viewport";
 
 type Provider = "anthropic" | "openai" | "gemini" | "ollama";
 
-const PROVIDERS: { value: Provider; label: string; modelHint: string }[] = [
-  { value: "anthropic", label: "Anthropic", modelHint: "claude-opus-4-7" },
-  { value: "openai", label: "OpenAI", modelHint: "gpt-4o" },
-  { value: "gemini", label: "Gemini", modelHint: "gemini-2.5-pro" },
-  { value: "ollama", label: "Ollama (local)", modelHint: "llama3.1" },
-];
+interface ProviderMeta {
+  label: string;
+  defaultModel: string;
+  keyLabel: string;
+  keyPlaceholder: string;
+  initial: string;
+}
+
+const PROVIDER_META: Record<Provider, ProviderMeta> = {
+  anthropic: { label: "Anthropic", defaultModel: "claude-sonnet-4-6", keyLabel: "API key", keyPlaceholder: "sk-ant-…", initial: "A" },
+  openai:    { label: "OpenAI",    defaultModel: "gpt-5.5",          keyLabel: "API key", keyPlaceholder: "sk-…",     initial: "O" },
+  gemini:    { label: "Gemini",    defaultModel: "gemini-3.1-pro-preview", keyLabel: "API key", keyPlaceholder: "AIza…",    initial: "G" },
+  ollama:    { label: "Ollama",    defaultModel: "llama3.1",         keyLabel: "Base URL", keyPlaceholder: "http://localhost:11434", initial: "L" },
+};
+
+const ALL_PROVIDERS: Provider[] = ["anthropic", "openai", "gemini", "ollama"];
+
+const PROVIDER_MODELS: Record<Provider, string[]> = {
+  anthropic: [
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-haiku-4-5",
+  ],
+  openai: [
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.2",
+  ],
+  gemini: [
+    "gemini-3.1-pro-preview",
+    "gemini-3-flash-preview",
+  ],
+  ollama: [
+    "llama3.1",
+    "llama3.2",
+    "mistral",
+    "phi3",
+    "qwen2.5",
+    "deepseek-r1",
+  ],
+};
+
 
 interface LLMSettings {
   provider: Provider;
@@ -30,6 +67,23 @@ interface LLMSettings {
   openai_api_key_hint: string;
   gemini_api_key_hint: string;
   ollama_base_url: string;
+  provider_models: Record<string, string[]>;
+}
+
+function isConfigured(p: Provider, s: LLMSettings): boolean {
+  if (p === "anthropic") return s.anthropic_api_key_set;
+  if (p === "openai") return s.openai_api_key_set;
+  if (p === "gemini") return s.gemini_api_key_set;
+  if (p === "ollama") return !!s.ollama_base_url;
+  return false;
+}
+
+function keyHint(p: Provider, s: LLMSettings): string {
+  if (p === "anthropic") return s.anthropic_api_key_hint;
+  if (p === "openai") return s.openai_api_key_hint;
+  if (p === "gemini") return s.gemini_api_key_hint;
+  if (p === "ollama") return s.ollama_base_url || "http://localhost:11434";
+  return "";
 }
 
 export default function AdminLLMPage() {
@@ -46,70 +100,126 @@ export default function AdminLLMPage() {
 
   return (
     <AppShell>
-      <main style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 720 }}>
+      <main style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 760 }}>
         <BackLink />
         <PageHeader
-          title="LLM configuration"
-          description="Provider, model, and credentials used for chat, the document updater, and trigger evaluations. Secrets are stored in the database and never echoed back to the browser."
+          title="Language models"
+          description="Manage provider credentials and set the model used by agents. Users can override the model for their own chats in Settings."
         />
-        <LLMForm />
+        <LLMPage />
       </main>
     </AppShell>
   );
 }
 
-function LLMForm() {
+function LLMPage() {
   const [settings, setSettings] = useState<LLMSettings | null>(null);
-  const [provider, setProvider] = useState<Provider>("anthropic");
-  const [model, setModel] = useState("");
-  const [anthropicKey, setAnthropicKey] = useState("");
-  const [openaiKey, setOpenaiKey] = useState("");
-  const [geminiKey, setGeminiKey] = useState("");
-  const [ollamaBaseUrl, setOllamaBaseUrl] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
-  const [saving, setSaving] = useState(false);
+  const [expandedProvider, setExpandedProvider] = useState<Provider | null>(null);
 
   async function load() {
     try {
       const r = await apiFetch<LLMSettings>("/admin/llm");
       setSettings(r);
-      setProvider(PROVIDERS.some((p) => p.value === r.provider) ? r.provider : "anthropic");
-      setModel(r.model);
-      setOllamaBaseUrl(r.ollama_base_url);
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to load");
     }
   }
 
-  useEffect(() => {
-    void load();
-  }, []);
+  useEffect(() => { void load(); }, []);
 
-  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+  if (error) return <div style={{ color: color.state.danger.fg }}>{error}</div>;
+  if (!settings) return <div style={{ color: color.text.muted }}>Loading…</div>;
+
+  const configured = ALL_PROVIDERS.filter((p) => isConfigured(p, settings));
+  const unconfigured = ALL_PROVIDERS.filter((p) => !isConfigured(p, settings));
+
+  function toggle(p: Provider) {
+    setExpandedProvider((prev) => (prev === p ? null : p));
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 32 }}>
+      <AgentModelSection settings={settings} onSaved={load} />
+
+      <div style={{ borderTop: `1px solid ${color.border.subtle}` }} />
+
+      {/* Available Providers */}
+      <section>
+        <div style={sectionHeaderStyle}>Available providers</div>
+        {configured.length === 0 && (
+          <div style={{ color: color.text.muted, fontSize: 14 }}>No providers configured yet.</div>
+        )}
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          {configured.map((p) => (
+            <ProviderCard
+              key={p}
+              provider={p}
+              settings={settings}
+              isActive={settings.provider === p}
+              expanded={expandedProvider === p}
+              onToggle={() => toggle(p)}
+              onSaved={() => { void load(); setExpandedProvider(null); }}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* Add Provider */}
+      {unconfigured.length > 0 && (
+        <>
+          <div style={{ borderTop: `1px solid ${color.border.subtle}` }} />
+          <section>
+            <div style={sectionHeaderStyle}>Add provider</div>
+            <div style={{ color: color.text.muted, fontSize: 13, marginBottom: 12 }}>
+              Connect a provider to make it available for agent and chat use.
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+              {unconfigured.map((p) => (
+                <ProviderCard
+                  key={p}
+                  provider={p}
+                  settings={settings}
+                  isActive={false}
+                  expanded={expandedProvider === p}
+                  onToggle={() => toggle(p)}
+                  onSaved={() => { void load(); setExpandedProvider(null); }}
+                />
+              ))}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+function AgentModelSection({ settings, onSaved }: { settings: LLMSettings; onSaved: () => void }) {
+  const [editing, setEditing] = useState(false);
+  const [provider, setProvider] = useState<Provider>(settings.provider);
+  const [model, setModel] = useState(settings.model);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Only providers that have credentials configured.
+  const availableProviders = ALL_PROVIDERS.filter((p) => isConfigured(p, settings));
+
+  useEffect(() => {
+    setProvider(settings.provider);
+    setModel(settings.model);
+  }, [settings]);
+
+  async function onSubmit(e: FormEvent) {
     e.preventDefault();
     setSaving(true);
     setError(null);
-    setSaved(false);
     try {
-      const body: Record<string, unknown> = { provider, model };
-      if (anthropicKey) body.anthropic_api_key = anthropicKey;
-      if (openaiKey) body.openai_api_key = openaiKey;
-      if (geminiKey) body.gemini_api_key = geminiKey;
-      // The base URL isn't secret — send it whenever it's been edited so
-      // empty-string ("use default") is reachable by clearing the field.
-      if (settings && ollamaBaseUrl !== settings.ollama_base_url) {
-        body.ollama_base_url = ollamaBaseUrl === "" ? null : ollamaBaseUrl;
-      }
-      await apiFetch<LLMSettings>("/admin/llm", {
+      await apiFetch("/admin/llm", {
         method: "PUT",
-        body: JSON.stringify(body),
+        body: JSON.stringify({ provider, model }),
       });
-      setAnthropicKey("");
-      setOpenaiKey("");
-      setGeminiKey("");
-      setSaved(true);
-      await load();
+      setEditing(false);
+      onSaved();
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to save");
     } finally {
@@ -117,151 +227,294 @@ function LLMForm() {
     }
   }
 
-  async function clearKey(field: "anthropic_api_key" | "openai_api_key" | "gemini_api_key") {
-    if (!confirm("Clear this API key?")) return;
+  return (
+    <section>
+      <div style={sectionHeaderStyle}>Default model</div>
+      {!editing ? (
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "12px 16px", border: `1px solid ${color.border.default}`,
+          borderRadius: radius.md, background: color.bg.panel,
+        }}>
+          <div>
+            <span style={{ fontSize: 14, fontWeight: 500 }}>{PROVIDER_META[settings.provider].label}</span>
+            <span style={{ fontSize: 14, color: color.text.muted, marginLeft: 8 }}>{settings.model || "—"}</span>
+          </div>
+          <Button size="sm" variant="secondary" onClick={() => setEditing(true)}>Edit</Button>
+        </div>
+      ) : (
+        <form onSubmit={onSubmit} style={{
+          padding: "16px", border: `1px solid ${color.border.default}`,
+          borderRadius: radius.md, background: color.bg.panel,
+          display: "flex", flexDirection: "column", gap: 12,
+        }}>
+          <label>
+            <div style={lblStyle}>Provider</div>
+            <select
+              value={provider}
+              onChange={(e) => {
+                const p = e.target.value as Provider;
+                setProvider(p);
+                setModel(PROVIDER_MODELS[p]?.[0] ?? PROVIDER_META[p].defaultModel);
+              }}
+              style={inputStyle}
+            >
+              {availableProviders.length === 0 && (
+                <option disabled value="">No providers configured — add one below</option>
+              )}
+              {availableProviders.map((p) => (
+                <option key={p} value={p}>{PROVIDER_META[p].label}</option>
+              ))}
+            </select>
+          </label>
+          <label>
+            <div style={lblStyle}>Model</div>
+            <select value={model} onChange={(e) => setModel(e.target.value)} required style={inputStyle}>
+              {(settings.provider_models[provider]?.length
+                ? settings.provider_models[provider]
+                : PROVIDER_MODELS[provider] ?? [PROVIDER_META[provider].defaultModel]
+              ).map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+          </label>
+          {error && <div style={{ color: color.state.danger.fg, fontSize: 13 }}>{error}</div>}
+          <div style={{ display: "flex", gap: 8 }}>
+            <Button type="submit" variant="primary" size="sm" disabled={saving}>
+              {saving ? "Saving…" : "Set as active"}
+            </Button>
+            <Button type="button" variant="secondary" size="sm" onClick={() => { setEditing(false); setError(null); }}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      )}
+    </section>
+  );
+}
+
+function ProviderCard({
+  provider, settings, isActive, expanded, onToggle, onSaved,
+}: {
+  provider: Provider;
+  settings: LLMSettings;
+  isActive: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  onSaved: () => void;
+}) {
+  const meta = PROVIDER_META[provider];
+  const configured = isConfigured(provider, settings);
+  const hint = keyHint(provider, settings);
+
+  return (
+    <div style={{
+      border: `1px solid ${color.border.default}`,
+      borderRadius: radius.md,
+      overflow: "hidden",
+    }}>
+      {/* Card header row */}
+      <div style={{
+        display: "flex", alignItems: "center", gap: 12,
+        padding: "12px 16px", background: color.bg.panel,
+      }}>
+        {/* Provider initial icon */}
+        <div style={{
+          width: 32, height: 32, borderRadius: radius.sm,
+          background: color.bg.sunken, display: "flex", alignItems: "center",
+          justifyContent: "center", fontSize: 13, fontWeight: 700,
+          color: color.text.secondary, flexShrink: 0,
+        }}>
+          {meta.initial}
+        </div>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ fontSize: 14, fontWeight: 500 }}>{meta.label}</span>
+            {isActive && (
+              <span style={{
+                fontSize: 11, fontWeight: 600, padding: "2px 6px",
+                borderRadius: radius.pill, background: color.accent.subtleBg,
+                color: color.accent.subtleFg, border: `1px solid ${color.accent.subtleBorder}`,
+              }}>Agent</span>
+            )}
+          </div>
+          {configured && hint && (
+            <div style={{ fontSize: 12, color: color.text.muted, fontFamily: "ui-monospace, monospace", marginTop: 2 }}>
+              {hint}
+            </div>
+          )}
+        </div>
+
+        <Button
+          type="button"
+          size="sm"
+          variant={configured ? "secondary" : "primary"}
+          onClick={onToggle}
+        >
+          {configured ? (expanded ? "Close" : "Edit") : (expanded ? "Close" : "Connect")}
+        </Button>
+      </div>
+
+      {/* Expanded form */}
+      {expanded && (
+        <div style={{ borderTop: `1px solid ${color.border.subtle}`, padding: 16, background: color.bg.page }}>
+          <ProviderForm
+            provider={provider}
+            settings={settings}
+            configured={configured}
+            onSaved={onSaved}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProviderForm({
+  provider, settings, configured, onSaved,
+}: {
+  provider: Provider;
+  settings: LLMSettings;
+  configured: boolean;
+  onSaved: () => void;
+}) {
+  const meta = PROVIDER_META[provider];
+  const isOllama = provider === "ollama";
+  const knownModels = PROVIDER_MODELS[provider];
+  const savedModels = settings.provider_models[provider] ?? [];
+  const [keyValue, setKeyValue] = useState("");
+  const [selectedModels, setSelectedModels] = useState<Set<string>>(
+    () => new Set(savedModels.length ? savedModels : knownModels),
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  const keyField = `${provider}_api_key` as "anthropic_api_key" | "openai_api_key" | "gemini_api_key";
+  const currentHint = keyHint(provider, settings);
+
+  function toggleModel(id: string) {
+    setSelectedModels((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
     setSaving(true);
     setError(null);
+    setSaved(false);
     try {
-      await apiFetch<LLMSettings>("/admin/llm", {
-        method: "PUT",
-        body: JSON.stringify({ provider, model, [field]: null }),
-      });
-      await load();
+      const body: Record<string, unknown> = {};
+      if (isOllama) {
+        body.ollama_base_url = keyValue === "" ? null : keyValue;
+      } else if (keyValue) {
+        body[keyField] = keyValue;
+      }
+      const enabledModels = knownModels.filter((m) => selectedModels.has(m));
+      const updated = { ...settings.provider_models, [provider]: enabledModels };
+      body.provider_models = updated;
+      await apiFetch("/admin/llm", { method: "PUT", body: JSON.stringify(body) });
+      setKeyValue("");
+      setSaved(true);
+      onSaved();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to clear");
+      setError(e instanceof Error ? e.message : "failed to save");
     } finally {
       setSaving(false);
     }
   }
 
-  if (!settings) return <div>Loading…</div>;
-
-  const selected = PROVIDERS.find((p) => p.value === provider);
+  async function onClear() {
+    if (!confirm(`Remove ${meta.label} credentials?`)) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const body: Record<string, unknown> = isOllama ? { ollama_base_url: null } : { [keyField]: null };
+      await apiFetch("/admin/llm", { method: "PUT", body: JSON.stringify(body) });
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to remove");
+    } finally {
+      setSaving(false);
+    }
+  }
 
   return (
     <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <label>
-        <div style={lblStyle}>Provider</div>
-        <select
-          value={provider}
-          onChange={(e) => setProvider(e.target.value as Provider)}
-          style={inputStyle}
-        >
-          {PROVIDERS.map((p) => (
-            <option key={p.value} value={p.value}>
-              {p.label}
-            </option>
-          ))}
-        </select>
-      </label>
-      <label>
-        <div style={lblStyle}>Model</div>
+        <div style={lblStyle}>{meta.keyLabel}</div>
         <input
-          value={model}
-          onChange={(e) => setModel(e.target.value)}
-          placeholder={selected?.modelHint ?? ""}
-          required
+          type={isOllama ? "text" : "password"}
+          value={keyValue}
+          onChange={(e) => setKeyValue(e.target.value)}
+          placeholder={configured ? (isOllama ? currentHint : "leave blank to keep current") : meta.keyPlaceholder}
           style={inputStyle}
         />
       </label>
 
-      <KeyField
-        label="Anthropic API key"
-        value={anthropicKey}
-        onChange={setAnthropicKey}
-        isSet={settings.anthropic_api_key_set}
-        hint={settings.anthropic_api_key_hint}
-        placeholder="sk-ant-…"
-        onClear={() => void clearKey("anthropic_api_key")}
-        clearDisabled={saving || !settings.anthropic_api_key_set}
-      />
-      <KeyField
-        label="OpenAI API key"
-        value={openaiKey}
-        onChange={setOpenaiKey}
-        isSet={settings.openai_api_key_set}
-        hint={settings.openai_api_key_hint}
-        placeholder="sk-…"
-        onClear={() => void clearKey("openai_api_key")}
-        clearDisabled={saving || !settings.openai_api_key_set}
-      />
-      <KeyField
-        label="Gemini API key"
-        value={geminiKey}
-        onChange={setGeminiKey}
-        isSet={settings.gemini_api_key_set}
-        hint={settings.gemini_api_key_hint}
-        placeholder="AIza…"
-        onClear={() => void clearKey("gemini_api_key")}
-        clearDisabled={saving || !settings.gemini_api_key_set}
-      />
-      <label>
-        <div style={lblStyle}>Ollama base URL</div>
-        <input
-          value={ollamaBaseUrl}
-          onChange={(e) => setOllamaBaseUrl(e.target.value)}
-          placeholder="http://localhost:11434 (leave blank for default)"
-          style={inputStyle}
-        />
-      </label>
-
-      {error && <div style={{ color: color.state.danger.fg }}>{error}</div>}
-      {saved && <div style={{ color: color.state.success.fg }}>Saved.</div>}
       <div>
-        <Button type="submit" variant="primary" disabled={saving}>
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", marginBottom: 8 }}>
+          <div style={lblStyle}>Models</div>
+          <div style={{ fontSize: 12, color: color.text.muted }}>Select models to make available</div>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {knownModels.map((id) => {
+            const checked = selectedModels.has(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => toggleModel(id)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "10px 12px",
+                  border: `1px solid ${checked ? color.accent.subtleBorder : color.border.default}`,
+                  borderRadius: radius.md,
+                  background: checked ? color.accent.subtleBg : color.bg.page,
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                <div style={{
+                  width: 18, height: 18, borderRadius: radius.xs, flexShrink: 0,
+                  border: checked ? "none" : `1.5px solid ${color.border.strong}`,
+                  background: checked ? color.accent.bg : "transparent",
+                  display: "flex", alignItems: "center", justifyContent: "center",
+                }}>
+                  {checked && (
+                    <svg width="11" height="11" viewBox="0 0 12 12" fill="none">
+                      <path d="M2 6l3 3 5-5" stroke={color.accent.fg} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                  )}
+                </div>
+                <span style={{ fontSize: 13, color: checked ? color.accent.subtleFg : color.text.primary, fontFamily: "ui-monospace, monospace" }}>
+                  {id}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {error && <div style={{ color: color.state.danger.fg, fontSize: 13 }}>{error}</div>}
+      {saved && <div style={{ color: color.state.success.fg, fontSize: 13 }}>Saved.</div>}
+      <div style={{ display: "flex", gap: 8 }}>
+        <Button type="submit" variant="primary" size="sm" disabled={saving}>
           {saving ? "Saving…" : "Save"}
         </Button>
-      </div>
-    </form>
-  );
-}
-
-function KeyField({
-  label,
-  value,
-  onChange,
-  isSet,
-  hint,
-  placeholder,
-  onClear,
-  clearDisabled,
-}: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  isSet: boolean;
-  hint: string;
-  placeholder: string;
-  onClear: () => void;
-  clearDisabled: boolean;
-}) {
-  return (
-    <label>
-      <div style={{ ...lblStyle, display: "flex", alignItems: "center", gap: 6 }}>
-        <span>{label}</span>
-        {isSet && <span style={hintStyle}>currently {hint}</span>}
-        <span style={{ flex: 1 }} />
-        {isSet && (
-          <Button
-            type="button"
-            size="sm"
-            variant="danger"
-            onClick={onClear}
-            disabled={clearDisabled}
-            style={{ padding: "2px 8px", fontSize: 12 }}
-          >
-            Clear
+        {configured && (
+          <Button type="button" variant="danger" size="sm" disabled={saving} onClick={onClear}>
+            Remove
           </Button>
         )}
       </div>
-      <input
-        type="password"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={isSet ? "leave blank to keep" : placeholder}
-        style={inputStyle}
-      />
-    </label>
+    </form>
   );
 }
 
@@ -274,9 +527,7 @@ const inputStyle: React.CSSProperties = {
   fontSize: 14,
 };
 const lblStyle: React.CSSProperties = { marginBottom: 4, fontSize: 13, fontWeight: 500 };
-const hintStyle: React.CSSProperties = {
-  fontWeight: 400,
-  color: color.text.muted,
-  fontFamily: "ui-monospace, monospace",
-  fontSize: 12,
+const sectionHeaderStyle: React.CSSProperties = {
+  fontSize: 13, fontWeight: 600, color: color.text.secondary,
+  textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: 12,
 };

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState, type CSSProperties, type FormEvent, type 
 import { AppShell } from "@/components/common/AppShell";
 import { Button } from "@/components/common/Button";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
+import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
 import { color, radius } from "@/lib/theme";
 import { setLocalThemePreview } from "@/lib/theme-provider";
@@ -15,6 +16,8 @@ const DEFAULT_SETTINGS: UserSettings = {
   theme: "system",
   timezone: "UTC",
   default_landing: "wiki_home",
+  chat_provider: null,
+  chat_model: null,
 };
 
 // A short curated IANA list — covers the common cases without dumping
@@ -58,6 +61,9 @@ export default function SettingsPage() {
         </Section>
         <Section title="Preferences">
           <SettingsForm initial={user.settings} updateSettings={updateSettings} />
+        </Section>
+        <Section title="Chat model">
+          <ChatModelForm initial={user.settings} updateSettings={updateSettings} />
         </Section>
       </main>
     </AppShell>
@@ -298,6 +304,78 @@ function SettingsForm({
       {saved && <div style={{ color: color.state.success.fg }}>Saved.</div>}
       <div>
         <Button type="submit" variant="primary" disabled={saving || !dirty}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+interface LLMStatus {
+  configured: boolean;
+  provider: string;
+  model: string;
+}
+
+function ChatModelForm({
+  initial,
+  updateSettings,
+}: {
+  initial: UserSettings;
+  updateSettings: (partial: Partial<UserSettings>) => Promise<UserSettings>;
+}) {
+  const [chatModel, setChatModel] = useState<string>(initial.chat_model ?? "");
+  const [llmStatus, setLlmStatus] = useState<LLMStatus | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setChatModel(initial.chat_model ?? "");
+  }, [initial.chat_model]);
+
+  useEffect(() => {
+    apiFetch<LLMStatus>("/llm/status").then(setLlmStatus).catch(() => null);
+  }, []);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      await updateSettings({ chat_model: chatModel.trim() || null });
+      setSaved(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const placeholder = llmStatus?.model
+    ? `${llmStatus.model} (agent default)`
+    : "leave blank to use agent default";
+
+  return (
+    <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <label>
+        <div style={lblStyle}>Chat model</div>
+        <input
+          value={chatModel}
+          onChange={(e) => { setChatModel(e.target.value); setSaved(false); setError(null); }}
+          placeholder={placeholder}
+          style={inputStyle}
+        />
+        <div style={hintStyle}>
+          Override the model used in your chat sessions. Leave blank to use the admin-configured agent default
+          {llmStatus?.configured ? ` (currently ${llmStatus.provider} / ${llmStatus.model})` : ""}.
+        </div>
+      </label>
+      {error && <div style={{ color: color.state.danger.fg }}>{error}</div>}
+      {saved && <div style={{ color: color.state.success.fg }}>Saved.</div>}
+      <div>
+        <Button type="submit" variant="primary" disabled={saving}>
           {saving ? "Saving…" : "Save"}
         </Button>
       </div>

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState, type FormEvent } from "react"
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import { ApiError } from "@/lib/api";
+import { apiFetch, ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import {
   createSession,
@@ -36,8 +36,16 @@ const STORAGE_KEY_SESSION = "chat-widget:session-id";
 const DEFAULT_EXPANDED_WIDTH = 480;
 const MIN_EXPANDED_WIDTH = 280;
 
+interface AvailableProvider {
+  provider: string;
+  label: string;
+  default_model: string;
+  models: string[];
+}
+
+
 export function ChatWidget() {
-  const { user } = useAuth();
+  const { user, updateSettings } = useAuth();
   const [mode, setMode] = useState<Mode>("closed");
   const [expandedWidth, setExpandedWidth] = useState<number>(DEFAULT_EXPANDED_WIDTH);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -48,9 +56,21 @@ export function ChatWidget() {
   const [sending, setSending] = useState(false);
   const [toolHint, setToolHint] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [availableProviders, setAvailableProviders] = useState<AvailableProvider[]>([]);
+  const [agentModel, setAgentModel] = useState<{ provider: string; model: string } | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const resizingRef = useRef(false);
   const hydratedSessionRef = useRef(false);
+
+  useEffect(() => {
+    apiFetch<{ providers: AvailableProvider[] }>("/llm/available")
+      .then((r) => setAvailableProviders(r.providers))
+      .catch(() => null);
+    apiFetch<{ configured: boolean; provider: string; model: string }>("/llm/status")
+      .then((r) => { if (r.configured) setAgentModel({ provider: r.provider, model: r.model }); })
+      .catch(() => null);
+  }, []);
+
 
   // Hydrate persisted UI state on mount.
   useEffect(() => {
@@ -384,7 +404,52 @@ export function ChatWidget() {
             flexShrink: 0,
           }}
         >
-          <div style={{ fontWeight: 600, fontSize: 14, flex: 1 }}>Chat</div>
+          <div style={{ fontWeight: 600, fontSize: 14 }}>Chat</div>
+          {availableProviders.length > 0 && (
+            <select
+              value={
+                user?.settings.chat_provider && user?.settings.chat_model
+                  ? `${user.settings.chat_provider}:${user.settings.chat_model}`
+                  : ""
+              }
+              onChange={(e) => {
+                const val = e.target.value;
+                if (!val) {
+                  void updateSettings({ chat_provider: null, chat_model: null });
+                } else {
+                  const idx = val.indexOf(":");
+                  const p = val.slice(0, idx);
+                  const m = val.slice(idx + 1);
+                  void updateSettings({ chat_provider: p, chat_model: m });
+                }
+              }}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                fontSize: 12,
+                padding: "3px 6px",
+                border: `1px solid ${color.border.default}`,
+                borderRadius: radius.xs,
+                background: color.bg.page,
+                color: color.text.primary,
+              }}
+            >
+              <option value="">
+                {agentModel ? `${agentModel.model} (Default)` : "Default model"}
+              </option>
+              {availableProviders.map((p) => {
+                const models = p.models.length ? p.models : [p.default_model];
+                return (
+                  <optgroup key={p.provider} label={p.label}>
+                    {models.map((m) => (
+                      <option key={m} value={`${p.provider}:${m}`}>{m}</option>
+                    ))}
+                  </optgroup>
+                );
+              })}
+            </select>
+          )}
+          {availableProviders.length === 0 && <div style={{ flex: 1 }} />}
           <IconButton
             title="New chat"
             onClick={onNewChat}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -10,6 +10,8 @@ const DEFAULT_USER_SETTINGS: UserSettings = {
   theme: "system",
   timezone: "UTC",
   default_landing: "wiki_home",
+  chat_provider: null,
+  chat_model: null,
 };
 
 export interface AuthUser {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,8 @@ export interface UserSettings {
   theme: ThemeSetting;
   timezone: string;
   default_landing: DefaultLanding;
+  chat_provider: string | null;
+  chat_model: string | null;
 }
 
 export type UserSettingsUpdate = Partial<UserSettings>;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -5,8 +5,10 @@ http {
     sendfile on;
     keepalive_timeout 65;
 
-    upstream backend  { server backend:8080; }
-    upstream frontend { server frontend:3000; }
+    # Use Docker's internal DNS so upstream hostnames resolve at request time,
+    # not at startup — prevents nginx from crashing when containers start in
+    # parallel.
+    resolver 127.0.0.11 valid=10s ipv6=off;
 
     server {
         listen 80;
@@ -15,7 +17,8 @@ http {
         client_max_body_size 25m;
 
         location /api/ {
-            proxy_pass         http://backend;
+            set $backend http://backend:8080;
+            proxy_pass         $backend;
             proxy_http_version 1.1;
             proxy_set_header   Host              $host;
             proxy_set_header   X-Real-IP         $remote_addr;
@@ -33,7 +36,8 @@ http {
         }
 
         location / {
-            proxy_pass         http://frontend;
+            set $frontend http://frontend:3000;
+            proxy_pass         $frontend;
             proxy_http_version 1.1;
             proxy_set_header   Upgrade           $http_upgrade;
             proxy_set_header   Connection        "upgrade";


### PR DESCRIPTION
  Summary

  - LLM provider model selection: Admins can now select which specific models are available per provider (Anthropic, OpenAI, Gemini, Ollama) when connecting credentials. Selected models are persisted in the DB and used everywhere.
  - Per-user chat model override: Users can select a specific model in the chat widget from the enabled models for each provider. Defaults to the  admin-configured default model.
  - Admin LLM page redesign: Redesigned to match Onyx's provider management UI — Available Providers / Add Provider sections with per-provider credential forms and model checkboxes.
  - Default Model section: Replaces the previous flat form; admins pick provider + model from dropdowns filtered to configured providers and their enabled models.
  - FastAPI migration: Backend migrated from Flask to FastAPI across all routes.
  - DB migration: Added provider_models JSONB column to llm_settings to store per-provider enabled model lists.

<img width="1634" height="893" alt="Screenshot 2026-05-11 at 12 24 32 PM" src="https://github.com/user-attachments/assets/fc912fae-922c-464c-ba02-6fa58bac0083" />