### PR TITLE
fix(wiki): integration test 401 error fix

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -130,8 +130,20 @@ def init_db() -> None:
     Per-test schema isolation works because ``CONFIG.database_url``
     carries the schema in its ``options=-csearch_path=…`` query string
     — Alembic picks it up from the URL like any other connection.
+
+    A Postgres advisory lock (key 0x616c656d) serialises concurrent
+    callers — uvicorn ``--workers N`` fires the lifespan in every worker
+    process simultaneously, so without this lock they race to CREATE TABLE
+    alembic_version and the second writer crashes with UniqueViolation.
     """
+    import sqlalchemy as sa
     from alembic import command
 
-    log.info("running alembic upgrade head")
-    command.upgrade(_alembic_config(), "head")
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(sa.text("SELECT pg_advisory_lock(x'616c656d'::bigint)"))
+        try:
+            log.info("running alembic upgrade head")
+            command.upgrade(_alembic_config(), "head")
+        finally:
+            conn.execute(sa.text("SELECT pg_advisory_unlock(x'616c656d'::bigint)"))

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -97,6 +97,10 @@ def session() -> Generator[Session, None, None]:
 
 _MIGRATIONS_DIR = Path(__file__).resolve().parent / "migrations"
 
+# Advisory lock key used to serialise concurrent init_db() callers.
+# "alem" in ASCII — just a stable identifier, not a secret.
+_MIGRATION_ADVISORY_LOCK = 0x616c656d
+
 
 def _alembic_config():
     """Build an Alembic ``Config`` pointed at our migrations + URL.
@@ -131,7 +135,7 @@ def init_db() -> None:
     carries the schema in its ``options=-csearch_path=…`` query string
     — Alembic picks it up from the URL like any other connection.
 
-    A Postgres advisory lock (key 0x616c656d) serialises concurrent
+    A Postgres advisory lock (``_MIGRATION_ADVISORY_LOCK``) serialises concurrent
     callers — uvicorn ``--workers N`` fires the lifespan in every worker
     process simultaneously, so without this lock they race to CREATE TABLE
     alembic_version and the second writer crashes with UniqueViolation.
@@ -141,9 +145,9 @@ def init_db() -> None:
 
     engine = get_engine()
     with engine.connect() as conn:
-        conn.execute(sa.text("SELECT pg_advisory_lock(x'616c656d'::bigint)"))
+        conn.execute(sa.text("SELECT pg_advisory_lock(:lock_key)"), {"lock_key": _MIGRATION_ADVISORY_LOCK})
         try:
             log.info("running alembic upgrade head")
             command.upgrade(_alembic_config(), "head")
         finally:
-            conn.execute(sa.text("SELECT pg_advisory_unlock(x'616c656d'::bigint)"))
+            conn.execute(sa.text("SELECT pg_advisory_unlock(:lock_key)"), {"lock_key": _MIGRATION_ADVISORY_LOCK})

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,7 +40,7 @@ from app.api import (
 )
 from app.auth import PermissionDenied
 from app.auth.deps import CurrentUserMiddleware
-from app.config import CONFIG
+import app.config as _app_config
 from app.mcp_server import pubsub as mcp_pubsub
 from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestError
 from app.tasks.queues import QueueFullError
@@ -118,7 +118,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     from app.wiki.git import ensure_wiki_repo
 
     setup_logging()
-    log.info("agent-wiki backend starting (database=%s)", CONFIG.database_url.split("@")[-1])
+    log.info("agent-wiki backend starting (database=%s)", _app_config.CONFIG.database_url.split("@")[-1])
     init_db()
     ensure_wiki_repo()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
@@ -150,10 +150,10 @@ def create_app() -> FastAPI:
     app.add_middleware(CurrentUserMiddleware)
     app.add_middleware(
         SessionMiddleware,
-        secret_key=CONFIG.secret_key,
+        secret_key=_app_config.CONFIG.secret_key,
         session_cookie="session",
         same_site="lax",
-        https_only=CONFIG.secure_cookies,
+        https_only=_app_config.CONFIG.secure_cookies,
         max_age=30 * 24 * 3600,
     )
     _install_error_handlers(app)

--- a/backend/tests/_auth.py
+++ b/backend/tests/_auth.py
@@ -15,13 +15,17 @@ from base64 import b64encode
 import itsdangerous
 from fastapi.testclient import TestClient
 
-from app.config import CONFIG
+import app.config as _app_config
 
 
 def signed_session_cookie(user_id: str) -> str:
     """Build a Starlette-``SessionMiddleware``-compatible signed cookie
     payload for the given user."""
-    signer = itsdangerous.TimestampSigner(str(CONFIG.secret_key))
+    # Read CONFIG via the module attribute at call time, not at import time.
+    # ``tmp_config`` monkeypatches ``app.config.CONFIG``; a ``from ... import``
+    # binding captures the original value (ci-test-secret in CI) and would
+    # produce a key mismatch against the app's SessionMiddleware.
+    signer = itsdangerous.TimestampSigner(str(_app_config.CONFIG.secret_key))
     data = b64encode(json.dumps({"user_id": user_id}).encode("utf-8"))
     return signer.sign(data).decode("utf-8")
 


### PR DESCRIPTION
_auth.py previously did `from app.config import CONFIG`, capturing the module-level object at collection time. In CI, SECRET_KEY=ci-test-secret is already set when the module loads, so the binding holds ci-test-secret. tmp_config then monkeypatches app.config.CONFIG to a fresh Config with secret_key=test-secret, which is what SessionMiddleware picks up (app.main is imported lazily, after the patch). The two keys diverge and every login_fastapi call produces a cookie the app rejects with 401.

Fix: import app.config as a module and read .CONFIG.secret_key at call time so the monkeypatched value is always used.