### PR TITLE
feat(launchers): phase 3 helper — npm package, Mac URI handler, real claude verification

### DIFF
--- a/backend/app/api/launchers.py
+++ b/backend/app/api/launchers.py
@@ -105,9 +105,21 @@ def get_catalog(
                 available_for_launch=_entry_available(m),
                 setup_status={"token": has_token},
                 default_working_dir=default_workdir,
+                unscoped_workdir_warning=_unscoped_warning(m),
             )
         )
     return LauncherCatalog(launchers=entries)
+
+
+def _unscoped_warning(m: Manifest) -> str | None:
+    flags = m.launch.unscoped_workdir_argv if m.launch else []
+    if not flags:
+        return None
+    return (
+        f"No directory set — {m.name} will run in a per-session scratch "
+        f"dir (~/agent-wiki-runs/<id>/) with {' '.join(flags)}. Set a "
+        f"directory to scope it to real code."
+    )
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/launchers/manifests/claude_code.json
+++ b/backend/app/launchers/manifests/claude_code.json
@@ -13,7 +13,7 @@
   },
   "mcp_config_format": "claude_json",
   "first_turn_prompt_delivery": {
-    "method": "stdin"
+    "method": "positional_arg"
   },
   "launch": {
     "binary": "claude",
@@ -22,7 +22,8 @@
       "AGENTWIKI_SESSION_ID": "${session_id}",
       "AGENTWIKI_ENDPOINT": "${endpoint}"
     },
-    "cwd": "${working_dir}"
+    "cwd": "${working_dir}",
+    "unscoped_workdir_argv": ["--permission-mode", "bypassPermissions"]
   },
   "resume": {
     "binary": "claude",
@@ -36,7 +37,8 @@
     "env": {
       "AGENTWIKI_SESSION_ID": "${session_id}"
     },
-    "cwd": "${working_dir}"
+    "cwd": "${working_dir}",
+    "unscoped_workdir_argv": ["--permission-mode", "bypassPermissions"]
   },
   "session_id_capture": {
     "source": "file_watch",

--- a/backend/app/launchers/manifests/codex.json
+++ b/backend/app/launchers/manifests/codex.json
@@ -13,24 +13,28 @@
   },
   "mcp_config_format": "codex_toml",
   "first_turn_prompt_delivery": {
-    "method": "stdin"
+    "method": "positional_arg"
   },
   "launch": {
     "binary": "codex",
     "argv": [],
     "env": {
       "AGENTWIKI_SESSION_ID": "${session_id}",
-      "AGENTWIKI_ENDPOINT": "${endpoint}"
+      "AGENTWIKI_ENDPOINT": "${endpoint}",
+      "AGENTWIKI_MCP_TOKEN": "${token}"
     },
-    "cwd": "${working_dir}"
+    "cwd": "${working_dir}",
+    "unscoped_workdir_argv": ["--dangerously-bypass-approvals-and-sandbox"]
   },
   "resume": {
     "binary": "codex",
     "argv": ["resume", "${cli_session_id}"],
     "env": {
-      "AGENTWIKI_SESSION_ID": "${session_id}"
+      "AGENTWIKI_SESSION_ID": "${session_id}",
+      "AGENTWIKI_MCP_TOKEN": "${token}"
     },
-    "cwd": "${working_dir}"
+    "cwd": "${working_dir}",
+    "unscoped_workdir_argv": ["--dangerously-bypass-approvals-and-sandbox"]
   },
   "session_id_capture": {
     "source": "file_watch",

--- a/backend/app/launchers/registry.py
+++ b/backend/app/launchers/registry.py
@@ -77,7 +77,7 @@ class CliCheck(BaseModel):
 class FirstTurnPromptDelivery(BaseModel):
     model_config = ConfigDict(frozen=True)
 
-    method: Literal["prompt_file_flag", "stdin", "none"]
+    method: Literal["prompt_file_flag", "stdin", "positional_arg", "none"]
     flag: str | None = None
 
 
@@ -88,6 +88,12 @@ class LaunchBlock(BaseModel):
     argv: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
     cwd: str | None = None
+    # Flags appended ONLY when the user launches without setting a
+    # working directory (helper falls back to $HOME). Each entry must be
+    # a literal CLI flag — no ${var} interpolation. Surfaces to the UI
+    # as a warning so the user is told what's being applied before they
+    # click Run.
+    unscoped_workdir_argv: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
     def _validate_vars(self) -> "LaunchBlock":
@@ -103,6 +109,12 @@ class LaunchBlock(BaseModel):
                     "${first_turn_prompt} forbidden in argv — helper "
                     "materializes a tmpfile; reference ${prompt_file_path} "
                     f"instead. Offending argv[{i}]={a!r}."
+                )
+        for i, a in enumerate(self.unscoped_workdir_argv):
+            if _VAR_RE.search(a):
+                raise ValueError(
+                    "unscoped_workdir_argv entries must be literal flags — "
+                    f"no ${{var}} interpolation allowed. Offending [{i}]={a!r}."
                 )
         for k, v in self.env.items():
             _check_string(v, where=f"env.{k}")

--- a/backend/app/models/launchers.py
+++ b/backend/app/models/launchers.py
@@ -30,6 +30,10 @@ class LauncherCatalogEntry(BaseModel):
     # when caller passes ``machine_id`` + ``wiki_path``, this is
     # the resolved working-dir default for this page. Null otherwise.
     default_working_dir: str | None = None
+    # Warning to render in the Run modal when the user leaves working_dir
+    # blank — names the flags that will be applied to the unscoped launch.
+    # Null when the manifest has no ``unscoped_workdir_argv``.
+    unscoped_workdir_warning: str | None = None
 
 
 class LauncherCatalog(BaseModel):

--- a/frontend/src/components/wiki/RunAgentModal.tsx
+++ b/frontend/src/components/wiki/RunAgentModal.tsx
@@ -234,6 +234,13 @@ export function RunAgentModal({ open, onClose, wikiPath }: Props) {
               }
             />
 
+            {(() => {
+              const sel = launchers.find((c) => c.id === selectedId);
+              const warning = sel?.unscoped_workdir_warning;
+              if (!warning || workingDir.trim().length > 0) return null;
+              return <MessageCard variant="warning" title={warning} />;
+            })()}
+
             <InputVertical title="Message" withLabel="run-agent-message">
               <textarea
                 id="run-agent-message"

--- a/frontend/src/lib/launchers.ts
+++ b/frontend/src/lib/launchers.ts
@@ -20,6 +20,7 @@ export interface LauncherCatalogEntry {
   available_for_launch: boolean;
   setup_status: LauncherSetupStatus;
   default_working_dir: string | null;
+  unscoped_workdir_warning: string | null;
 }
 
 export interface LauncherCatalog {

--- a/packages/agentwiki-launcher/.gitignore
+++ b/packages/agentwiki-launcher/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+*.log

--- a/packages/agentwiki-launcher/bin/agentwiki-launcher
+++ b/packages/agentwiki-launcher/bin/agentwiki-launcher
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import("../dist/cli.js")
+  .then((m) => m.main(process.argv.slice(2)))
+  .catch((e) => {
+    console.error("[agentwiki-launcher] unhandled:", e?.stack || e?.message || e);
+    process.exit(1);
+  });

--- a/packages/agentwiki-launcher/package-lock.json
+++ b/packages/agentwiki-launcher/package-lock.json
@@ -1,0 +1,544 @@
+{
+  "name": "@onyx-ai/agentwiki-launcher",
+  "version": "0.1.0-alpha.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@onyx-ai/agentwiki-launcher",
+      "version": "0.1.0-alpha.1",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "agentwiki-launcher": "bin/agentwiki-launcher"
+      },
+      "devDependencies": {
+        "@types/node": "20.10.0",
+        "tsx": "4.7.0",
+        "typescript": "5.3.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.0.tgz",
+      "integrity": "sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/packages/agentwiki-launcher/package.json
+++ b/packages/agentwiki-launcher/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@onyx-ai/agentwiki-launcher",
+  "version": "0.1.0-alpha.1",
+  "description": "Local helper for the agent-wiki Run Agent button.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "agentwiki-launcher": "./bin/agentwiki-launcher"
+  },
+  "files": [
+    "bin",
+    "dist",
+    "install"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "node --test --import tsx 'test/**/*.test.ts'",
+    "typecheck": "tsc --noEmit",
+    "postinstall": "node ./dist/install/postinstall.js || true"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "20.10.0",
+    "tsx": "4.7.0",
+    "typescript": "5.3.3"
+  }
+}

--- a/packages/agentwiki-launcher/src/allowed_binaries.ts
+++ b/packages/agentwiki-launcher/src/allowed_binaries.ts
@@ -1,0 +1,23 @@
+/**
+ * HARDCODED allow-list of binaries the helper will spawn.
+ *
+ * Defense-in-depth against a compromised backend pushing a manifest
+ * naming `rm` / `curl` / `bash -c …`. New tools land here by appending +
+ * cutting a helper release.
+ *
+ * Path separators / parent-dir traversal rejected — binary must be an
+ * unqualified name resolved through PATH.
+ */
+const ALLOWED = new Set(["claude", "codex"]);
+
+export function isAllowed(binary: string): boolean {
+  if (binary.includes("/") || binary.includes("\\")) return false;
+  if (binary.includes("..")) return false;
+  return ALLOWED.has(binary);
+}
+
+export function assertAllowed(binary: string): void {
+  if (!isAllowed(binary)) {
+    throw new Error(`binary_not_allowed: ${binary}`);
+  }
+}

--- a/packages/agentwiki-launcher/src/claude_trust.ts
+++ b/packages/agentwiki-launcher/src/claude_trust.ts
@@ -1,0 +1,64 @@
+/**
+ * Pre-mark a directory as trusted in claude's per-project config so the
+ * launched session doesn't block on the "Do you trust the files in this
+ * folder?" dialog.
+ *
+ * Claude maintains a ``hasTrustDialogAccepted: boolean`` flag per
+ * directory inside ``~/.claude.json`` under
+ * ``projects.<absolute-path>``. ``--dangerously-skip-permissions``
+ * bypasses tool/permission gates but NOT the workspace trust dialog —
+ * that's a separate gate. When the helper launches claude in unscoped
+ * (no-workdir) mode, the agent has no human at the keyboard for the
+ * trust prompt, so we flip the flag ourselves.
+ *
+ * Atomic write: read → modify → write tmp → rename. JSON formatting is
+ * preserved as 2-space pretty-printed object (matches existing file).
+ *
+ * Best-effort: if ``~/.claude.json`` doesn't exist or isn't writable,
+ * we log and continue — claude will prompt and the user can hit "1" to
+ * proceed manually.
+ */
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+interface ClaudeConfig {
+  projects?: Record<string, Record<string, unknown> | undefined>;
+  [k: string]: unknown;
+}
+
+export function markClaudeWorkspaceTrusted(cwd: string): void {
+  const configPath = join(homedir(), ".claude.json");
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch {
+    return;
+  }
+  let parsed: ClaudeConfig;
+  try {
+    parsed = JSON.parse(raw) as ClaudeConfig;
+  } catch (e) {
+    console.error(
+      "[agentwiki-launcher] could not parse ~/.claude.json — skipping trust pre-mark:",
+      e instanceof Error ? e.message : e,
+    );
+    return;
+  }
+  parsed.projects ??= {};
+  const project = parsed.projects[cwd] ?? {};
+  if (project.hasTrustDialogAccepted === true) return;
+  project.hasTrustDialogAccepted = true;
+  parsed.projects[cwd] = project;
+  const next = JSON.stringify(parsed, null, 2);
+  const tmp = `${configPath}.agw-tmp-${process.pid}`;
+  try {
+    writeFileSync(tmp, next, { mode: 0o600 });
+    renameSync(tmp, configPath);
+  } catch (e) {
+    console.error(
+      "[agentwiki-launcher] could not write ~/.claude.json — claude will prompt:",
+      e instanceof Error ? e.message : e,
+    );
+  }
+}

--- a/packages/agentwiki-launcher/src/cli.ts
+++ b/packages/agentwiki-launcher/src/cli.ts
@@ -1,0 +1,217 @@
+import { parseLaunchUri } from "./uri.js";
+import { getOrCreateMachineId } from "./machine_id.js";
+import { exchange } from "./exchange.js";
+import { parseManifest } from "./manifest.js";
+import { writeSecureTmpfile } from "./tmpfile.js";
+import { renderClaudeJson } from "./mcp_config/claude_json.js";
+import { renderCodexToml } from "./mcp_config/codex_toml.js";
+import { buildSpawnCommand } from "./spawn.js";
+import { openInTerminalApp } from "./terminal/darwin.js";
+import { markClaudeWorkspaceTrusted } from "./claude_trust.js";
+import { writeCodexAgentWikiMcp } from "./codex_mcp_config.js";
+import { markCodexProjectTrusted } from "./codex_trust.js";
+import {
+  endpointMatchesPinned,
+  getPinnedEndpoint,
+  setPinnedEndpoint,
+} from "./endpoint_pin.js";
+
+export async function main(argv: string[]): Promise<void> {
+  const sub = argv[0];
+  if (sub === "run") {
+    await handleRun(argv[1] ?? "");
+  } else if (sub === "probe-ack") {
+    await handleProbeAck(argv[1] ?? "");
+  } else if (sub === "dispatch") {
+    // Called by the macOS .app stub. Routes by URI action so the stub
+    // doesn't need to parse.
+    const uri = argv[1] ?? "";
+    if (uri.startsWith("agentwiki://probe")) {
+      await handleProbeAck(uri);
+    } else {
+      await handleRun(uri);
+    }
+  } else if (sub === "set-endpoint") {
+    handleSetEndpoint(argv[1] ?? "");
+  } else {
+    console.error(
+      "usage: agentwiki-launcher (run <uri> | probe-ack <uri> | dispatch <uri> | set-endpoint <url>)",
+    );
+    process.exit(2);
+  }
+}
+
+function handleSetEndpoint(url: string): void {
+  if (!url) {
+    console.error("usage: agentwiki-launcher set-endpoint <wiki-url>");
+    process.exit(2);
+  }
+  setPinnedEndpoint(url);
+  console.log(`agentwiki-launcher pinned to ${url}`);
+}
+
+async function handleRun(uri: string): Promise<void> {
+  const parsed = parseLaunchUri(uri);
+  if (parsed.action !== "run") throw new Error("expected run action");
+
+  // Refuse if URI's endpoint doesn't match pinned.
+  const pinned = getPinnedEndpoint();
+  if (pinned === null) {
+    console.error(
+      "agentwiki-launcher not configured — run `agentwiki-launcher set-endpoint <wiki-url>` first.",
+    );
+    process.exit(2);
+  }
+  if (!endpointMatchesPinned(parsed.endpoint)) {
+    console.error(
+      `URI endpoint ${parsed.endpoint} does not match pinned ${pinned}; refusing.`,
+    );
+    process.exit(2);
+  }
+
+  const machineId = getOrCreateMachineId();
+  const exchanged = await exchange(pinned, parsed.code, machineId);
+  const manifest = parseManifest(exchanged.manifest);
+  if (manifest.kind !== "local_cli") {
+    throw new Error(`unsupported manifest kind ${manifest.kind}`);
+  }
+
+  const isResume = exchanged.payload.cli_session_id !== null;
+
+  // MCP config URL is the MCP-server endpoint from the exchange
+  // response (`<base>/api/mcp`), NOT the pinned wiki base URL. Using
+  // the base would make claude try to talk MCP at the wrong path
+  // and the connection would fail silently → claude exits immediately.
+  const mcpUrl = exchanged.endpoint;
+  let mcpConfigPath: string | null = null;
+  if (manifest.mcp_config_format === "claude_json") {
+    mcpConfigPath = writeSecureTmpfile(
+      renderClaudeJson({ url: mcpUrl, token: exchanged.mcp_token }),
+      ".json",
+    );
+  } else if (manifest.mcp_config_format === "codex_toml") {
+    // Codex reads MCP servers only from ``~/.codex/config.toml`` — no
+    // per-session config-file override. Write the agent-wiki block
+    // directly into that file (marked with sentinel comments; prior
+    // blocks are stripped first). ``writeSecureTmpfile`` is still kept
+    // as a no-op for symmetry with the claude path, in case a future
+    // codex version grows a ``--mcp-config`` flag.
+    writeCodexAgentWikiMcp({ url: mcpUrl, token: exchanged.mcp_token });
+    mcpConfigPath = writeSecureTmpfile(
+      renderCodexToml({ url: mcpUrl, token: exchanged.mcp_token }),
+      ".toml",
+    );
+  }
+
+  let promptFilePath: string | null = null;
+  let promptText: string | null = null;
+  if (!isResume && exchanged.payload.first_turn_prompt !== null) {
+    const method = manifest.first_turn_prompt_delivery?.method;
+    if (method === "prompt_file_flag") {
+      promptFilePath = writeSecureTmpfile(
+        exchanged.payload.first_turn_prompt,
+        ".txt",
+      );
+    } else if (method === "positional_arg") {
+      promptText = exchanged.payload.first_turn_prompt;
+    }
+  }
+
+  const cmd = buildSpawnCommand({
+    manifest,
+    token: exchanged.mcp_token,
+    endpoint: pinned,
+    sessionId: exchanged.payload.session_id,
+    cliSessionId: exchanged.payload.cli_session_id,
+    workingDir: exchanged.payload.working_dir,
+    mcpConfigPath,
+    promptFilePath,
+    promptText,
+    isResume,
+  });
+
+  // Claude's workspace-trust dialog is a separate gate from
+  // ``--dangerously-skip-permissions``. When the user launched without
+  // a working dir (and the manifest opted in via ``unscoped_workdir_argv``),
+  // we pre-mark the fallback cwd as trusted so the agent doesn't block on
+  // the prompt no one is at the keyboard to answer.
+  if (
+    exchanged.payload.working_dir === null &&
+    (manifest.launch?.unscoped_workdir_argv?.length ?? 0) > 0
+  ) {
+    if (manifest.id === "claude-code") {
+      markClaudeWorkspaceTrusted(cmd.cwd);
+    } else if (manifest.id === "codex") {
+      markCodexProjectTrusted(cmd.cwd);
+    }
+  }
+
+  const tmpfiles: string[] = [];
+  if (mcpConfigPath) tmpfiles.push(mcpConfigPath);
+  if (promptFilePath) tmpfiles.push(promptFilePath);
+
+  const closeUrl = new URL(
+    `/api/agent-sessions/${exchanged.payload.session_id}/close`,
+    pinned,
+  ).toString();
+  openInTerminalApp({
+    ...cmd,
+    tmpfilesToClean: tmpfiles,
+    closeOnExit: { url: closeUrl, token: exchanged.mcp_token },
+  });
+
+  // Best-effort spawn-OK beacon so backend's 30s sweep
+  // doesn't mark the session failed.
+  await postSpawnOk(pinned, exchanged.payload.session_id, exchanged.mcp_token);
+}
+
+async function postSpawnOk(
+  endpoint: string,
+  sessionId: string,
+  token: string,
+): Promise<void> {
+  try {
+    await fetch(
+      new URL(`/api/agent-sessions/${sessionId}/spawn-ok`, endpoint).toString(),
+      {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+  } catch {
+    // best-effort
+  }
+}
+
+async function handleProbeAck(uri: string): Promise<void> {
+  const parsed = parseLaunchUri(uri);
+  if (parsed.action !== "probe") throw new Error("expected probe action");
+
+  // Helper posts probe-ack to the **pinned** backend endpoint. URI's
+  // ``endpoint`` field carries the wiki page origin (in dev: frontend
+  // dev-server URL; in prod: same as backend). Auto-pairing to the
+  // URI's endpoint when nothing is pinned was a security hole — a
+  // crafted ``agentwiki://probe?endpoint=https://attacker.com`` URI
+  // would otherwise pin the attacker's host and POST the machine_id
+  // there before any user confirmation. Require explicit
+  // ``set-endpoint`` first.
+  const pinned = getPinnedEndpoint();
+  if (!pinned) {
+    console.error(
+      "agentwiki-launcher: no endpoint pinned. Run " +
+        "`agentwiki-launcher set-endpoint <wiki-url>` first, then click " +
+        "Test launcher manually in the wiki setup wizard again.",
+    );
+    process.exit(2);
+  }
+
+  await fetch(new URL("/api/launch/probe-ack", pinned).toString(), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      nonce: parsed.nonce,
+      helper_port: 0,
+      machine_id: getOrCreateMachineId(),
+    }),
+  });
+}

--- a/packages/agentwiki-launcher/src/cli.ts
+++ b/packages/agentwiki-launcher/src/cli.ts
@@ -205,13 +205,29 @@ async function handleProbeAck(uri: string): Promise<void> {
     process.exit(2);
   }
 
-  await fetch(new URL("/api/launch/probe-ack", pinned).toString(), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      nonce: parsed.nonce,
-      helper_port: 0,
-      machine_id: getOrCreateMachineId(),
-    }),
-  });
+  const url = new URL("/api/launch/probe-ack", pinned).toString();
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        nonce: parsed.nonce,
+        helper_port: 0,
+        machine_id: getOrCreateMachineId(),
+      }),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`agentwiki-launcher: probe-ack network error (${msg})`);
+    process.exit(3);
+  }
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    console.error(
+      `agentwiki-launcher: probe-ack ${res.status} from ${url}` +
+        (body ? ` — ${body.slice(0, 200)}` : ""),
+    );
+    process.exit(3);
+  }
 }

--- a/packages/agentwiki-launcher/src/cli.ts
+++ b/packages/agentwiki-launcher/src/cli.ts
@@ -90,12 +90,9 @@ async function handleRun(uri: string): Promise<void> {
       ".json",
     );
   } else if (manifest.mcp_config_format === "codex_toml") {
-    // Codex reads MCP servers only from ``~/.codex/config.toml`` — no
-    // per-session config-file override. Write the agent-wiki block
-    // directly into that file (marked with sentinel comments; prior
-    // blocks are stripped first). ``writeSecureTmpfile`` is still kept
-    // as a no-op for symmetry with the claude path, in case a future
-    // codex version grows a ``--mcp-config`` flag.
+    // Codex reads MCP servers only from ``~/.codex/config.toml`` —
+    // write the agent-wiki block directly into that file, replacing
+    // any block written by a prior launch.
     writeCodexAgentWikiMcp({ url: mcpUrl, token: exchanged.mcp_token });
     mcpConfigPath = writeSecureTmpfile(
       renderCodexToml({ url: mcpUrl, token: exchanged.mcp_token }),
@@ -187,14 +184,12 @@ async function handleProbeAck(uri: string): Promise<void> {
   const parsed = parseLaunchUri(uri);
   if (parsed.action !== "probe") throw new Error("expected probe action");
 
-  // Helper posts probe-ack to the **pinned** backend endpoint. URI's
-  // ``endpoint`` field carries the wiki page origin (in dev: frontend
-  // dev-server URL; in prod: same as backend). Auto-pairing to the
-  // URI's endpoint when nothing is pinned was a security hole — a
-  // crafted ``agentwiki://probe?endpoint=https://attacker.com`` URI
-  // would otherwise pin the attacker's host and POST the machine_id
-  // there before any user confirmation. Require explicit
-  // ``set-endpoint`` first.
+  // probe-ack POSTs to the pinned backend endpoint only. URI's
+  // ``endpoint`` field carries the wiki origin (frontend in dev, same
+  // host in prod) and is NOT used as the destination — a crafted
+  // ``agentwiki://probe?endpoint=https://attacker.com`` URI would
+  // otherwise pin the attacker's host and ship the machine_id there
+  // before any user confirmation. ``set-endpoint`` must run first.
   const pinned = getPinnedEndpoint();
   if (!pinned) {
     console.error(

--- a/packages/agentwiki-launcher/src/codex_mcp_config.ts
+++ b/packages/agentwiki-launcher/src/codex_mcp_config.ts
@@ -2,25 +2,17 @@
  * Inject the agent-wiki MCP server block into ``~/.codex/config.toml``.
  *
  * Codex reads its MCP server list ONLY from ``~/.codex/config.toml`` —
- * there is no ``--mcp-config`` flag and no per-session config-file
- * override. Earlier versions of the helper rendered a ``codex_toml``
- * tmpfile but never wired it; codex launched with zero knowledge of
- * agent-wiki and fell back to local-filesystem edits when asked to
- * touch a wiki page.
+ * no per-session config flag — so the helper edits that file in place:
  *
- * Approach:
- *   1. Read ``~/.codex/config.toml``.
- *   2. Strip any prior agent-wiki block our prior launches wrote (the
- *      marker comments below).
- *   3. Append a fresh marked block with the current session's URL +
- *      bearer token.
- *   4. Atomic write (tmp + rename).
+ *   1. Read ``~/.codex/config.toml`` (treat missing as empty).
+ *   2. Strip any agent-wiki block (marked or unmarked).
+ *   3. Append a fresh marked block with this session's URL + bearer.
+ *   4. Atomic tmp+rename write at mode 0600.
  *
- * Cleanup: we don't strip the block on wrapper exit — the next launch
- * overwrites it. The token is short-lived (rotates per session) and
- * lives in the user's own home dir at 0600. ``token`` validation in the
- * manifest forbids putting it in argv, which is why we go through the
- * config file instead.
+ * The block is intentionally not torn down on wrapper exit — the next
+ * launch overwrites it. The token rotates per session and the file
+ * lives in the user's own home dir; manifest validation forbids
+ * embedding the token in argv, hence the config-file detour.
  */
 import { readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -58,12 +50,10 @@ export function writeCodexAgentWikiMcp(opts: {
 }
 
 function stripManagedBlock(raw: string): string {
-  // Aggressive cleanup: remove ANY ``[mcp_servers.agent-wiki]`` table
-  // (with its keys and sub-tables) AND any orphan sentinel markers.
-  // Earlier versions only paired START_MARKER + END_MARKER but a
-  // partial write or older format could leave behind an unmarked
-  // ``[mcp_servers.agent-wiki]`` block, which TOML rejects as a
-  // duplicate key when we append our marked block at the bottom.
+  // Remove ANY ``[mcp_servers.agent-wiki]`` table (with its keys and
+  // sub-tables) and any orphan START/END markers. Catches unmarked
+  // blocks from partial writes too — TOML would otherwise reject the
+  // appended marked block as a duplicate key.
   const lines = raw.split("\n");
   const out: string[] = [];
   const agentWikiTable = /^\[mcp_servers\.agent-wiki(?:\.[^\]]+)?\]\s*$/;
@@ -90,15 +80,12 @@ function stripManagedBlock(raw: string): string {
 }
 
 function renderBlock(opts: { url: string; token: string }): string {
-  // Codex's HTTP MCP config expects ``bearer_token_env_var = "<NAME>"``
-  // — it reads the actual token from the named env var at handshake
-  // time. The earlier ``[mcp_servers.<name>.headers]`` sub-table was
-  // ignored, so codex sent the initialize request with no bearer and
-  // the backend returned 401. The matching env var name is set on the
+  // Codex's HTTP MCP config authenticates via
+  // ``bearer_token_env_var = "<NAME>"`` — it reads the token from the
+  // named env var at handshake. The matching env var is set on the
   // codex manifest's ``env`` block so the wrapper exports it before
-  // launching codex. ``opts.token`` is unused in the file (env-driven)
-  // but kept in the signature so callers stay symmetric with the
-  // claude path.
+  // launch. ``opts.token`` is unused in the file (env-driven) but kept
+  // in the signature for symmetry with the claude path.
   void opts.token;
   const url = tomlString(opts.url);
   return (

--- a/packages/agentwiki-launcher/src/codex_mcp_config.ts
+++ b/packages/agentwiki-launcher/src/codex_mcp_config.ts
@@ -1,0 +1,115 @@
+/**
+ * Inject the agent-wiki MCP server block into ``~/.codex/config.toml``.
+ *
+ * Codex reads its MCP server list ONLY from ``~/.codex/config.toml`` —
+ * there is no ``--mcp-config`` flag and no per-session config-file
+ * override. Earlier versions of the helper rendered a ``codex_toml``
+ * tmpfile but never wired it; codex launched with zero knowledge of
+ * agent-wiki and fell back to local-filesystem edits when asked to
+ * touch a wiki page.
+ *
+ * Approach:
+ *   1. Read ``~/.codex/config.toml``.
+ *   2. Strip any prior agent-wiki block our prior launches wrote (the
+ *      marker comments below).
+ *   3. Append a fresh marked block with the current session's URL +
+ *      bearer token.
+ *   4. Atomic write (tmp + rename).
+ *
+ * Cleanup: we don't strip the block on wrapper exit — the next launch
+ * overwrites it. The token is short-lived (rotates per session) and
+ * lives in the user's own home dir at 0600. ``token`` validation in the
+ * manifest forbids putting it in argv, which is why we go through the
+ * config file instead.
+ */
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const START_MARKER = "# >>> agentwiki-launcher-managed (do not edit by hand)";
+const END_MARKER = "# <<< agentwiki-launcher-managed";
+
+export function writeCodexAgentWikiMcp(opts: {
+  url: string;
+  token: string;
+}): void {
+  const configPath = join(homedir(), ".codex", "config.toml");
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch {
+    raw = "";
+  }
+  const stripped = stripManagedBlock(raw);
+  const block = renderBlock(opts);
+  const next =
+    (stripped.endsWith("\n") || stripped === "" ? stripped : stripped + "\n") +
+    block;
+  const tmp = `${configPath}.agw-tmp-${process.pid}`;
+  try {
+    writeFileSync(tmp, next, { mode: 0o600 });
+    renameSync(tmp, configPath);
+  } catch (e) {
+    console.error(
+      "[agentwiki-launcher] could not write ~/.codex/config.toml — codex won't see agent-wiki MCP:",
+      e instanceof Error ? e.message : e,
+    );
+  }
+}
+
+function stripManagedBlock(raw: string): string {
+  // Aggressive cleanup: remove ANY ``[mcp_servers.agent-wiki]`` table
+  // (with its keys and sub-tables) AND any orphan sentinel markers.
+  // Earlier versions only paired START_MARKER + END_MARKER but a
+  // partial write or older format could leave behind an unmarked
+  // ``[mcp_servers.agent-wiki]`` block, which TOML rejects as a
+  // duplicate key when we append our marked block at the bottom.
+  const lines = raw.split("\n");
+  const out: string[] = [];
+  const agentWikiTable = /^\[mcp_servers\.agent-wiki(?:\.[^\]]+)?\]\s*$/;
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line === START_MARKER || line === END_MARKER) {
+      i++;
+      continue;
+    }
+    if (agentWikiTable.test(line)) {
+      // Skip table header + all its keys until the next ``[`` (next
+      // table header) or EOF.
+      i++;
+      while (i < lines.length && !lines[i].startsWith("[")) {
+        i++;
+      }
+      continue;
+    }
+    out.push(line);
+    i++;
+  }
+  return out.join("\n");
+}
+
+function renderBlock(opts: { url: string; token: string }): string {
+  // Codex's HTTP MCP config expects ``bearer_token_env_var = "<NAME>"``
+  // — it reads the actual token from the named env var at handshake
+  // time. The earlier ``[mcp_servers.<name>.headers]`` sub-table was
+  // ignored, so codex sent the initialize request with no bearer and
+  // the backend returned 401. The matching env var name is set on the
+  // codex manifest's ``env`` block so the wrapper exports it before
+  // launching codex. ``opts.token`` is unused in the file (env-driven)
+  // but kept in the signature so callers stay symmetric with the
+  // claude path.
+  void opts.token;
+  const url = tomlString(opts.url);
+  return (
+    `${START_MARKER}\n` +
+    `[mcp_servers.agent-wiki]\n` +
+    `url = ${url}\n` +
+    `bearer_token_env_var = "AGENTWIKI_MCP_TOKEN"\n` +
+    `${END_MARKER}\n`
+  );
+}
+
+function tomlString(s: string): string {
+  return `"${s.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}

--- a/packages/agentwiki-launcher/src/codex_mcp_config.ts
+++ b/packages/agentwiki-launcher/src/codex_mcp_config.ts
@@ -14,9 +14,9 @@
  * lives in the user's own home dir; manifest validation forbids
  * embedding the token in argv, hence the config-file detour.
  */
-import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 const START_MARKER = "# >>> agentwiki-launcher-managed (do not edit by hand)";
 const END_MARKER = "# <<< agentwiki-launcher-managed";
@@ -37,6 +37,8 @@ export function writeCodexAgentWikiMcp(opts: {
   const next =
     (stripped.endsWith("\n") || stripped === "" ? stripped : stripped + "\n") +
     block;
+  const dir = dirname(configPath);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
   const tmp = `${configPath}.agw-tmp-${process.pid}`;
   try {
     writeFileSync(tmp, next, { mode: 0o600 });

--- a/packages/agentwiki-launcher/src/codex_trust.ts
+++ b/packages/agentwiki-launcher/src/codex_trust.ts
@@ -1,0 +1,52 @@
+/**
+ * Pre-mark a directory as trusted in codex's per-project config so the
+ * launched session doesn't block on the "Allow Codex to work in this
+ * folder" prompt.
+ *
+ * Codex tracks per-folder trust in ``~/.codex/config.toml`` as a
+ * top-level table per path:
+ *
+ *   [projects."/Users/nikolas/agent-wiki-runs/as_xxx"]
+ *   trust_level = "trusted"
+ *
+ * ``--dangerously-bypass-approvals-and-sandbox`` bypasses per-command
+ * approvals during execution but does NOT skip the initial folder-trust
+ * prompt — that gate runs before any sandboxing decision. We flip the
+ * trust entry ourselves before spawn.
+ *
+ * Best-effort + idempotent: if the block already exists, no-op; if the
+ * config doesn't exist or isn't writable, log and continue (codex
+ * will prompt and the user can hit "1" manually).
+ */
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function markCodexProjectTrusted(cwd: string): void {
+  const configPath = join(homedir(), ".codex", "config.toml");
+  let raw: string;
+  try {
+    raw = readFileSync(configPath, "utf-8");
+  } catch {
+    return;
+  }
+  const header = `[projects."${cwd}"]`;
+  const headerRe = new RegExp(`^${escapeRegex(header)}\\b`, "m");
+  if (headerRe.test(raw)) return;
+  const block = `\n${header}\ntrust_level = "trusted"\n`;
+  const next = raw.endsWith("\n") ? raw + block : raw + "\n" + block;
+  const tmp = `${configPath}.agw-tmp-${process.pid}`;
+  try {
+    writeFileSync(tmp, next, { mode: 0o600 });
+    renameSync(tmp, configPath);
+  } catch (e) {
+    console.error(
+      "[agentwiki-launcher] could not write ~/.codex/config.toml — codex will prompt:",
+      e instanceof Error ? e.message : e,
+    );
+  }
+}

--- a/packages/agentwiki-launcher/src/endpoint_pin.ts
+++ b/packages/agentwiki-launcher/src/endpoint_pin.ts
@@ -1,0 +1,33 @@
+/**
+ * Helper pins endpoint at install time; URI's endpoint
+ * param is IGNORED. An attacker-crafted `agentwiki://run?...&endpoint=https://attacker.com/...`
+ * is refused if it doesn't match the pinned value.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+const PIN_PATH = join(homedir(), ".agentwiki", "endpoint.url");
+
+export function getPinnedEndpoint(): string | null {
+  if (!existsSync(PIN_PATH)) return null;
+  return readFileSync(PIN_PATH, "utf-8").trim();
+}
+
+export function setPinnedEndpoint(url: string): void {
+  // Validate URL well-formedness.
+  new URL(url);
+  mkdirSync(dirname(PIN_PATH), { recursive: true, mode: 0o700 });
+  writeFileSync(PIN_PATH, url, { mode: 0o600 });
+}
+
+export function endpointMatchesPinned(candidate: string): boolean {
+  const pinned = getPinnedEndpoint();
+  if (pinned === null) return false;
+  // The URI's `endpoint` carries the wiki's MCP URL
+  // (`<base>/api/mcp`); the pin is the wiki base. Accept candidate if
+  // it starts with the pinned base (same scheme + host + port).
+  const pinnedBase = pinned.replace(/\/$/, "");
+  const candBase = candidate.replace(/\/$/, "");
+  return candBase === pinnedBase || candBase.startsWith(pinnedBase + "/");
+}

--- a/packages/agentwiki-launcher/src/exchange.ts
+++ b/packages/agentwiki-launcher/src/exchange.ts
@@ -1,0 +1,33 @@
+import type { Manifest } from "./manifest.js";
+
+export interface ExchangePayload {
+  session_id: string;
+  working_dir: string | null;
+  first_turn_prompt: string | null;
+  cli_session_id: string | null;
+}
+
+export interface ExchangeResponse {
+  mcp_token: string;
+  endpoint: string;
+  manifest: Manifest;
+  payload: ExchangePayload;
+}
+
+export async function exchange(
+  endpoint: string,
+  code: string,
+  machineId: string,
+): Promise<ExchangeResponse> {
+  const url = new URL("/api/launch/exchange", endpoint).toString();
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ code, machine_id: machineId }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`exchange failed ${res.status}: ${body}`);
+  }
+  return (await res.json()) as ExchangeResponse;
+}

--- a/packages/agentwiki-launcher/src/install/darwin.ts
+++ b/packages/agentwiki-launcher/src/install/darwin.ts
@@ -1,0 +1,119 @@
+import { execSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+// CFBundleURLTypes block we splice into the osacompile-generated Info.plist
+// so macOS routes `agentwiki://` URLs to this .app.
+const URL_TYPES_XML = `  <key>LSUIElement</key>
+  <true/>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>com.agentwiki.launcher.url</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>agentwiki</string>
+      </array>
+    </dict>
+  </array>
+`;
+
+function resolveAgentwikiLauncherPath(): string {
+  // macOS .app stub inherits a minimal PATH (~/usr/bin:/bin) that
+  // doesn't include nvm-managed Node bins. Bake the absolute path of
+  // the agentwiki-launcher executable into the stub at install time.
+  try {
+    return execSync("command -v agentwiki-launcher", {
+      encoding: "utf-8",
+    }).trim();
+  } catch {
+    // Fallback: assume it's adjacent to the node running this script
+    // (works when invoked as `node dist/install/postinstall.js`).
+    return join(process.execPath.replace(/\/node$/, ""), "agentwiki-launcher");
+  }
+}
+
+function makeAppleScript(): string {
+  const launcherPath = resolveAgentwikiLauncherPath();
+  const nodePath = process.execPath;
+  // AppleScript handles the `open location` Apple Event that macOS
+  // dispatches when a `agentwiki://` URL is opened. Plain bash stubs
+  // can't receive Apple Events.
+  return `on open location theURL
+\tset logCmd to "echo [$(date)] open location URL=" & quoted form of theURL & " >> $HOME/.agentwiki/stub.log 2>&1"
+\tdo shell script logCmd
+\ttry
+\t\tdo shell script (quoted form of "${nodePath}") & " " & (quoted form of "${launcherPath}") & " dispatch " & quoted form of theURL & " >> $HOME/.agentwiki/stub.log 2>&1"
+\ton error errMsg
+\t\tdo shell script "echo [$(date)] error: " & quoted form of errMsg & " >> $HOME/.agentwiki/stub.log 2>&1"
+\tend try
+end open location
+
+-- Also handle Finder double-click — just exit.
+on run
+\treturn
+end run
+`;
+}
+
+export function installOnDarwin(): void {
+  const dest = join(homedir(), "Applications", "AgentWiki.app");
+  const contentsDir = join(dest, "Contents");
+
+  // 1. Write AppleScript source.
+  const tmp = mkdtempSync(join(tmpdir(), "agw-applet-"));
+  const scriptPath = join(tmp, "AgentWikiLauncher.applescript");
+  writeFileSync(scriptPath, makeAppleScript());
+
+  // 2. Compile to .app bundle (replaces any existing).
+  rmSync(dest, { recursive: true, force: true });
+  mkdirSync(join(homedir(), "Applications"), { recursive: true });
+  try {
+    execSync(`osacompile -o ${shellQuote(dest)} ${shellQuote(scriptPath)}`);
+  } catch (e) {
+    console.error("[agentwiki-launcher] osacompile failed:", e);
+    rmSync(tmp, { recursive: true, force: true });
+    throw e;
+  }
+  rmSync(tmp, { recursive: true, force: true });
+
+  // 3. Patch the generated Info.plist to register the URL scheme.
+  const plistPath = join(contentsDir, "Info.plist");
+  const plist = readFileSync(plistPath, "utf-8");
+  // Insert URL_TYPES_XML right before the closing </dict>\n</plist>.
+  const patched = plist.replace(
+    /<\/dict>\s*<\/plist>/,
+    `${URL_TYPES_XML}</dict>\n</plist>`,
+  );
+  writeFileSync(plistPath, patched);
+
+  // 4. Force Launch Services to re-read the bundle.
+  try {
+    execSync(
+      `/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f ${shellQuote(
+        dest,
+      )}`,
+    );
+  } catch {
+    console.warn(
+      "[agentwiki-launcher] lsregister failed; open the .app once manually via Finder to register the URL scheme.",
+    );
+  }
+
+  // 5. Ensure log dir exists.
+  mkdirSync(join(homedir(), ".agentwiki"), { recursive: true, mode: 0o700 });
+
+  console.log(`[agentwiki-launcher] installed ${dest}`);
+}
+
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/agentwiki-launcher/src/install/postinstall.ts
+++ b/packages/agentwiki-launcher/src/install/postinstall.ts
@@ -1,0 +1,21 @@
+import { platform } from "node:process";
+
+async function main() {
+  try {
+    if (platform === "darwin") {
+      const m = await import("./darwin.js");
+      m.installOnDarwin();
+    } else if (platform === "linux") {
+      console.log("[agentwiki-launcher] Linux install — Phase 4.");
+    } else if (platform === "win32") {
+      console.log("[agentwiki-launcher] Windows install — Phase 4.");
+    }
+  } catch (e) {
+    console.warn("[agentwiki-launcher] postinstall failed:", e);
+    console.warn(
+      "Run `agentwiki-launcher set-endpoint <wiki-url>` manually after pointing it at your wiki.",
+    );
+  }
+}
+
+await main();

--- a/packages/agentwiki-launcher/src/interpolate.ts
+++ b/packages/agentwiki-launcher/src/interpolate.ts
@@ -1,0 +1,42 @@
+export interface InterpolateContext {
+  token: string;
+  endpoint: string;
+  session_id: string;
+  cli_session_id: string | null;
+  working_dir: string | null;
+  prompt_file_path: string | null;
+  mcp_config_path: string | null;
+  home: string;
+  dirhash: string;
+}
+
+const RE = /\$\{([a-z_]+)\}/g;
+
+export function interpolate(template: string, ctx: InterpolateContext): string {
+  return template.replace(RE, (_, name: string) => {
+    const value = (ctx as unknown as Record<string, string | null>)[name];
+    if (value === undefined) throw new Error(`unknown var $\{${name}\}`);
+    if (value === null) {
+      throw new Error(
+        `var $\{${name}\} unset in this context (first-turn vs resume mismatch?)`,
+      );
+    }
+    return value;
+  });
+}
+
+export function interpolateArgv(
+  argv: string[],
+  ctx: InterpolateContext,
+): string[] {
+  return argv.map((a) => interpolate(a, ctx));
+}
+
+export function interpolateEnv(
+  env: Record<string, string>,
+  ctx: InterpolateContext,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) out[k] = interpolate(v, ctx);
+  return out;
+}

--- a/packages/agentwiki-launcher/src/machine_id.ts
+++ b/packages/agentwiki-launcher/src/machine_id.ts
@@ -1,0 +1,20 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+interface Opts {
+  baseDir?: string;
+}
+
+export function getOrCreateMachineId(opts: Opts = {}): string {
+  const base = opts.baseDir ?? join(homedir(), ".agentwiki");
+  const path = join(base, "machine.id");
+  if (existsSync(path)) {
+    return readFileSync(path, "utf-8").trim();
+  }
+  mkdirSync(base, { recursive: true, mode: 0o700 });
+  const id = randomUUID();
+  writeFileSync(path, id, { mode: 0o600 });
+  return id;
+}

--- a/packages/agentwiki-launcher/src/manifest.ts
+++ b/packages/agentwiki-launcher/src/manifest.ts
@@ -126,7 +126,19 @@ function validateBlock(b: LaunchBlock, blockName: "launch" | "resume"): void {
       );
     }
   }
-  if (b.cwd) checkString(b.cwd, `${blockName}.cwd`);
+  if (b.cwd) {
+    checkString(b.cwd, `${blockName}.cwd`);
+    if (b.cwd.includes("${first_turn_prompt}")) {
+      throw new ManifestError(
+        `$\{first_turn_prompt\} forbidden in ${blockName}.cwd`,
+      );
+    }
+    if (blockName === "resume" && b.cwd.includes("${prompt_file_path}")) {
+      throw new ManifestError(
+        `$\{prompt_file_path\} forbidden in resume.cwd`,
+      );
+    }
+  }
 }
 
 export function parseManifest(raw: unknown): Manifest {

--- a/packages/agentwiki-launcher/src/manifest.ts
+++ b/packages/agentwiki-launcher/src/manifest.ts
@@ -1,0 +1,148 @@
+/**
+ * Manifest validator — TypeScript mirror of the backend pydantic model.
+ *
+ * Enforces the DSL safety rules (no ${token}/${first_turn_prompt} in
+ * argv, no ${prompt_file_path} in resume) client-side so a compromised
+ * backend can't push a malformed manifest past validation.
+ */
+export interface CliCheck {
+  binary: string;
+  version_flag?: string;
+  min_version?: string;
+  install_hint_url?: string;
+}
+
+export interface FirstTurnPromptDelivery {
+  method: "prompt_file_flag" | "stdin" | "positional_arg" | "none";
+  flag?: string;
+}
+
+export interface LaunchBlock {
+  binary: string;
+  argv: string[];
+  env: Record<string, string>;
+  cwd?: string;
+  // Appended only when the launch comes through with no working dir set
+  // (helper falls back to $HOME). Literal flags only — no ${var} allowed.
+  unscoped_workdir_argv?: string[];
+}
+
+export interface SessionIdCapture {
+  source: "file_watch" | "stdout_regex" | "none";
+  path?: string;
+  pattern?: string;
+  extract?: string;
+}
+
+export interface Manifest {
+  manifest_version: 1;
+  id: string;
+  name: string;
+  tagline: string;
+  icon_url: string;
+  kind: "local_cli" | "in_app" | "web_handoff";
+  cli_check?: CliCheck;
+  mcp_config_format?: "claude_json" | "codex_toml" | "none";
+  first_turn_prompt_delivery?: FirstTurnPromptDelivery;
+  launch?: LaunchBlock;
+  resume?: LaunchBlock;
+  session_id_capture?: SessionIdCapture;
+  task_kind?: string;
+}
+
+const ALLOWED_VARS = new Set([
+  "token",
+  "endpoint",
+  "session_id",
+  "cli_session_id",
+  "working_dir",
+  "first_turn_prompt",
+  "prompt_file_path",
+  "mcp_config_path",
+  "home",
+  "dirhash",
+]);
+
+const VAR_RE = /\$\{([a-z_]+)\}/g;
+
+export class ManifestError extends Error {}
+
+function findVars(s: string): Set<string> {
+  const found = new Set<string>();
+  let m;
+  VAR_RE.lastIndex = 0;
+  while ((m = VAR_RE.exec(s)) !== null) found.add(m[1]!);
+  return found;
+}
+
+function checkString(s: string, where: string): void {
+  for (const v of findVars(s)) {
+    if (!ALLOWED_VARS.has(v)) {
+      throw new ManifestError(
+        `unknown interpolation var $\{${v}\} in ${where}`,
+      );
+    }
+  }
+}
+
+function validateBlock(b: LaunchBlock, blockName: "launch" | "resume"): void {
+  b.argv.forEach((a, i) => {
+    checkString(a, `${blockName}.argv[${i}]`);
+    if (a.includes("${token}")) {
+      throw new ManifestError(
+        `$\{token\} forbidden in ${blockName}.argv (token must come via env)`,
+      );
+    }
+    if (a.includes("${first_turn_prompt}")) {
+      throw new ManifestError(
+        `$\{first_turn_prompt\} forbidden in ${blockName}.argv — use $\{prompt_file_path\}`,
+      );
+    }
+    if (blockName === "resume" && a.includes("${prompt_file_path}")) {
+      throw new ManifestError(
+        "${prompt_file_path} forbidden in resume.argv — first-turn-only",
+      );
+    }
+  });
+  (b.unscoped_workdir_argv ?? []).forEach((a, i) => {
+    if (VAR_RE.test(a)) {
+      VAR_RE.lastIndex = 0;
+      throw new ManifestError(
+        `${blockName}.unscoped_workdir_argv[${i}] must be a literal flag (no $\{var\})`,
+      );
+    }
+    VAR_RE.lastIndex = 0;
+  });
+  for (const [k, v] of Object.entries(b.env)) {
+    checkString(v, `${blockName}.env.${k}`);
+    if (v.includes("${first_turn_prompt}")) {
+      throw new ManifestError(
+        `$\{first_turn_prompt\} forbidden in ${blockName}.env.${k}`,
+      );
+    }
+    if (blockName === "resume" && v.includes("${prompt_file_path}")) {
+      throw new ManifestError(
+        `$\{prompt_file_path\} forbidden in resume.env.${k}`,
+      );
+    }
+  }
+  if (b.cwd) checkString(b.cwd, `${blockName}.cwd`);
+}
+
+export function parseManifest(raw: unknown): Manifest {
+  if (typeof raw !== "object" || raw === null) {
+    throw new ManifestError("manifest must be object");
+  }
+  const m = raw as Manifest;
+  if (m.manifest_version !== 1) {
+    throw new ManifestError(
+      `unsupported manifest_version ${m.manifest_version}`,
+    );
+  }
+  if (m.kind === "local_cli") {
+    if (!m.launch) throw new ManifestError("local_cli requires launch");
+    validateBlock(m.launch, "launch");
+    if (m.resume) validateBlock(m.resume, "resume");
+  }
+  return m;
+}

--- a/packages/agentwiki-launcher/src/mcp_config/claude_json.ts
+++ b/packages/agentwiki-launcher/src/mcp_config/claude_json.ts
@@ -1,0 +1,15 @@
+export function renderClaudeJson(opts: { url: string; token: string }): string {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        "agent-wiki": {
+          type: "http",
+          url: opts.url,
+          headers: { Authorization: `Bearer ${opts.token}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}

--- a/packages/agentwiki-launcher/src/mcp_config/codex_toml.ts
+++ b/packages/agentwiki-launcher/src/mcp_config/codex_toml.ts
@@ -1,0 +1,34 @@
+/**
+ * Renders the agent-wiki MCP block in codex's TOML format.
+ *
+ * Codex's current shipped version (as of phase 3) reads MCP servers
+ * only from ``~/.codex/config.toml`` and authenticates via
+ * ``bearer_token_env_var`` — the helper writes that file via
+ * ``codex_mcp_config.ts``. This module renders the same block as a
+ * standalone tmpfile for two reasons:
+ *
+ *   1. If codex ever grows a ``--mcp-config`` flag, the helper can
+ *      pass the tmpfile path and the auth shape will already match
+ *      what codex expects.
+ *   2. The cli routes ``mcp_config_format === "codex_toml"`` through
+ *      both ``writeCodexAgentWikiMcp`` (real auth via env) and
+ *      ``writeSecureTmpfile(renderCodexToml(...))`` (forward-compat
+ *      tmpfile). Keeping them in lockstep avoids a divergence where
+ *      the tmpfile would 401 if codex ever picked it up.
+ *
+ * The earlier ``[mcp_servers.agent-wiki.headers]`` sub-table was a
+ * dead end — codex ignored it and the backend returned 401 because
+ * no bearer reached the initialize call. Don't reintroduce it.
+ */
+export function renderCodexToml(opts: { url: string; token: string }): string {
+  // ``token`` isn't embedded — codex reads the actual value from the
+  // env var named below. The wrapper script exports
+  // ``AGENTWIKI_MCP_TOKEN`` from the manifest's ``env`` block.
+  void opts.token;
+  return [
+    `[mcp_servers.agent-wiki]`,
+    `url = "${opts.url}"`,
+    `bearer_token_env_var = "AGENTWIKI_MCP_TOKEN"`,
+    ``,
+  ].join("\n");
+}

--- a/packages/agentwiki-launcher/src/mcp_config/codex_toml.ts
+++ b/packages/agentwiki-launcher/src/mcp_config/codex_toml.ts
@@ -1,24 +1,12 @@
 /**
- * Renders the agent-wiki MCP block in codex's TOML format.
+ * Renders the agent-wiki MCP block in codex's TOML format as a
+ * standalone tmpfile. The live path is ``codex_mcp_config.ts``, which
+ * edits ``~/.codex/config.toml`` directly (codex reads only that
+ * file); this tmpfile renders the same block so the auth shape stays
+ * in lockstep if codex ever grows a ``--mcp-config`` flag.
  *
- * Codex's current shipped version (as of phase 3) reads MCP servers
- * only from ``~/.codex/config.toml`` and authenticates via
- * ``bearer_token_env_var`` — the helper writes that file via
- * ``codex_mcp_config.ts``. This module renders the same block as a
- * standalone tmpfile for two reasons:
- *
- *   1. If codex ever grows a ``--mcp-config`` flag, the helper can
- *      pass the tmpfile path and the auth shape will already match
- *      what codex expects.
- *   2. The cli routes ``mcp_config_format === "codex_toml"`` through
- *      both ``writeCodexAgentWikiMcp`` (real auth via env) and
- *      ``writeSecureTmpfile(renderCodexToml(...))`` (forward-compat
- *      tmpfile). Keeping them in lockstep avoids a divergence where
- *      the tmpfile would 401 if codex ever picked it up.
- *
- * The earlier ``[mcp_servers.agent-wiki.headers]`` sub-table was a
- * dead end — codex ignored it and the backend returned 401 because
- * no bearer reached the initialize call. Don't reintroduce it.
+ * Auth uses ``bearer_token_env_var`` — do not switch to a
+ * ``[mcp_servers.agent-wiki.headers]`` sub-table, codex ignores it.
  */
 export function renderCodexToml(opts: { url: string; token: string }): string {
   // ``token`` isn't embedded — codex reads the actual value from the

--- a/packages/agentwiki-launcher/src/spawn.ts
+++ b/packages/agentwiki-launcher/src/spawn.ts
@@ -1,0 +1,103 @@
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import { assertAllowed } from "./allowed_binaries.js";
+import {
+  interpolateArgv,
+  interpolateEnv,
+  type InterpolateContext,
+} from "./interpolate.js";
+import type { Manifest } from "./manifest.js";
+
+interface BuildOpts {
+  manifest: Manifest;
+  token: string;
+  endpoint: string;
+  sessionId: string;
+  cliSessionId?: string | null;
+  workingDir: string | null;
+  mcpConfigPath: string | null;
+  promptFilePath: string | null;
+  promptText: string | null;
+  isResume?: boolean;
+}
+
+export interface SpawnCommand {
+  binary: string;
+  argv: string[];
+  env: Record<string, string>;
+  cwd: string;
+}
+
+/**
+ * Note: claude's session dir uses cwd-with-slashes-replaced-by-dashes,
+ * NOT sha256. Verified by inspecting ~/.claude/projects/ on a real install.
+ */
+function claudeDirhash(cwd: string): string {
+  return cwd.replace(/\//g, "-");
+}
+
+function ensureScratchDir(sessionId: string): string {
+  const dir = join(homedir(), "agent-wiki-runs", sessionId);
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}
+
+export function buildSpawnCommand(opts: BuildOpts): SpawnCommand {
+  const block = opts.isResume ? opts.manifest.resume : opts.manifest.launch;
+  if (!block) {
+    throw new Error(
+      opts.isResume ? "manifest has no resume" : "manifest has no launch",
+    );
+  }
+  assertAllowed(block.binary);
+
+  const unscoped = opts.workingDir === null;
+  // When the user launches with no working dir, drop the agent into a
+  // per-session scratch dir instead of $HOME. Two reasons:
+  //   1. Anything under ``~/`` (e.g. ``~/.claude/``, ``~/.ssh``) is on
+  //      claude's hardcoded sensitive-file list and prompts even with
+  //      ``--permission-mode bypassPermissions`` — the agent can't write
+  //      session memory without confirmation.
+  //   2. Running from ``~/`` activates the user's global
+  //      ``~/.claude/CLAUDE.md`` (PAI rules, etc.) which the wiki agent
+  //      shouldn't inherit.
+  // ``~/agent-wiki-runs/<session-id>/`` is created on demand; cleanup is
+  // the user's call (leave for now — sessions are cheap directories).
+  const cwd = unscoped
+    ? ensureScratchDir(opts.sessionId)
+    : (opts.workingDir as string);
+  const dirhash = claudeDirhash(cwd);
+  const ctx: InterpolateContext = {
+    token: opts.token,
+    endpoint: opts.endpoint,
+    session_id: opts.sessionId,
+    cli_session_id: opts.cliSessionId ?? null,
+    working_dir: cwd,
+    prompt_file_path: opts.promptFilePath,
+    mcp_config_path: opts.mcpConfigPath,
+    home: homedir(),
+    dirhash,
+  };
+
+  let argv = interpolateArgv(block.argv, ctx);
+  if (unscoped && block.unscoped_workdir_argv?.length) {
+    argv = [...argv, ...block.unscoped_workdir_argv];
+  }
+  // First-turn-prompt delivery — three methods:
+  //   - prompt_file_flag: append `<flag> <tmpfile-path>`
+  //   - positional_arg:   append prompt text as the final argv element
+  //   - stdin / none:     no argv mutation; wrapper handles stdin if needed
+  if (!opts.isResume) {
+    const delivery = opts.manifest.first_turn_prompt_delivery;
+    if (delivery?.method === "prompt_file_flag" && opts.promptFilePath) {
+      const flag = delivery.flag ?? "--prompt-file";
+      argv = [...argv, flag, opts.promptFilePath];
+    } else if (delivery?.method === "positional_arg" && opts.promptText) {
+      argv = [...argv, opts.promptText];
+    }
+  }
+  const env = interpolateEnv(block.env, ctx);
+  return { binary: block.binary, argv, env, cwd };
+}

--- a/packages/agentwiki-launcher/src/spawn.ts
+++ b/packages/agentwiki-launcher/src/spawn.ts
@@ -30,10 +30,7 @@ export interface SpawnCommand {
   cwd: string;
 }
 
-/**
- * Note: claude's session dir uses cwd-with-slashes-replaced-by-dashes,
- * NOT sha256. Verified by inspecting ~/.claude/projects/ on a real install.
- */
+/** Claude's per-cwd session dir name: slashes become dashes. */
 function claudeDirhash(cwd: string): string {
   return cwd.replace(/\//g, "-");
 }

--- a/packages/agentwiki-launcher/src/terminal/darwin.ts
+++ b/packages/agentwiki-launcher/src/terminal/darwin.ts
@@ -1,0 +1,125 @@
+/**
+ * Open Terminal.app via a `.command` file routed through LaunchServices.
+ *
+ * Earlier version used ``osascript -e 'tell application "Terminal" to
+ * do script "..."'`` (Apple Events automation). TCC refuses to grant
+ * the AgentWiki.app stub kTCCServiceAppleEvents because the unsigned
+ * osacompile-produced bundle has no stable designated-requirement —
+ * the Apple Event is dropped silently. We switched to writing a
+ * ``run.command`` file and shelling out to ``open``, which uses
+ * LaunchServices (no AppleEvents permission needed) and Terminal.app
+ * runs the file because macOS associates the ``.command`` extension
+ * with it by default.
+ *
+ * Wrapper still holds the lifetime of the spawn tmpfiles (audit
+ * fix) via ``trap EXIT`` — cleanup fires when the launched binary
+ * exits, not when the helper does.
+ */
+import { spawn } from "node:child_process";
+import { appendFileSync, chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { SpawnCommand } from "../spawn.js";
+
+interface OpenOpts extends SpawnCommand {
+  tmpfilesToClean: string[];
+  // POST to this URL with the bearer token after the launched binary
+  // exits, so the backend's session row flips to ``closed`` immediately
+  // instead of waiting for the 65-min idle sweep.
+  closeOnExit?: { url: string; token: string };
+}
+
+export function openInTerminalApp(opts: OpenOpts): void {
+  const dir = mkdtempSync(join(tmpdir(), "agw-wrap-"));
+  const wrapper = join(dir, "run.command");
+  const envExports = Object.entries(opts.env)
+    .map(([k, v]) => `export ${k}=${shellQuote(v)}`)
+    .join("\n");
+  const argvQuoted = opts.argv.map(shellQuote).join(" ");
+  const cleanList = [...opts.tmpfilesToClean, wrapper, dir]
+    .map(shellQuote)
+    .join(" ");
+
+  // Log the full argv from node so the bash script never has to render
+  // user-controlled prompt content. Earlier version did
+  // ``echo "argv: ${argvQuoted}"`` inside double quotes; if the prompt
+  // contained backticks (e.g. markdown code spans like `onyx-cli ask`),
+  // bash treated them as command substitution and hung the wrapper.
+  const spawnLog = join(homedir(), ".agentwiki", "spawn.log");
+  try {
+    appendFileSync(
+      spawnLog,
+      `[${new Date().toString()}] queued ${opts.binary} cwd=${opts.cwd} argc=${
+        opts.argv.length
+      } mcp_config=${opts.argv[1] ?? "-"}\n`,
+    );
+  } catch {
+    // ignore — wrapper will retry the mkdir + log
+  }
+
+  // Build close-on-exit + cleanup as a bash *function* (not a single-
+  // quoted trap body). Earlier version put the curl + shellQuote'd
+  // URL/token directly INSIDE the trap's outer single-quoted body —
+  // bash's nested-quote rules made the inner ``'...'`` segments break
+  // out of the outer quoting context, so the curl never actually ran
+  // (or ran malformed) and the session row stayed ``active``. Function
+  // bodies use plain bash quoting, no collision.
+  const closeLine = opts.closeOnExit
+    ? `curl -s -o /dev/null -X POST ${shellQuote(
+        opts.closeOnExit.url,
+      )} -H ${shellQuote(
+        `Authorization: Bearer ${opts.closeOnExit.token}`,
+      )} -H 'Content-Type: application/json' -d '{"reason":"helper_exit"}' || true`
+    : "";
+
+  const script = `#!/bin/bash
+LOG="$HOME/.agentwiki/spawn.log"
+mkdir -p "$HOME/.agentwiki"
+echo "[$(date)] wrapper start cwd=${shellQuote(opts.cwd)} bin=${shellQuote(
+    opts.binary,
+  )}" >> "$LOG" 2>&1
+__agentwiki_on_exit() {
+  local rc=$?
+  echo "[$(date)] wrapper exit code=$rc" >> "$LOG"
+  ${closeLine}
+  rm -rf ${cleanList}
+}
+trap __agentwiki_on_exit EXIT
+cd ${shellQuote(opts.cwd)} 2>>"$LOG" || { echo "cd failed" >> "$LOG"; exit 1; }
+${envExports}
+# PATH note: 'open -a Terminal.app run.command' invokes the file inside
+# Terminal, which has already started a login shell and sourced the
+# user's zsh init. The bash wrapper inherits that PATH. Earlier versions
+# also did 'source ~/.zshrc' from inside bash, but some zsh init scripts
+# spawn long-running children (e.g. onyx-cli's interactive hook) that
+# hang the wrapper indefinitely — bash sourcing zsh is fragile in
+# general, so we drop it.
+echo "[$(date)] PATH=$PATH" >> "$LOG"
+echo "[$(date)] which: $(command -v ${shellQuote(
+    opts.binary,
+  )} 2>&1 || echo NOT_FOUND)" >> "$LOG"
+echo "[$(date)] launching ${opts.binary}" >> "$LOG"
+# Run binary inheriting stdin/stdout/stderr from Terminal's TTY.
+# Earlier version piped stderr through \`tee\` (process substitution)
+# which can confuse interactive CLIs about TTY state — claude detected
+# non-TTY stderr and exited clean (code=0) without showing UI.
+${shellQuote(opts.binary)} ${argvQuoted}
+echo "[$(date)] ${opts.binary} exited code=$?" >> "$LOG"
+`;
+  writeFileSync(wrapper, script);
+  chmodSync(wrapper, 0o700);
+
+  // ``open -a Terminal.app <wrapper>`` goes through LaunchServices —
+  // no AppleEvents permission required. Terminal.app receives the
+  // ``.command`` file as its open document and runs it in a new tab.
+  spawn("open", ["-a", "Terminal.app", wrapper], {
+    stdio: "ignore",
+    detached: true,
+  }).unref();
+}
+
+function shellQuote(s: string): string {
+  // Single-quote with internal single-quote escape.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/agentwiki-launcher/src/terminal/darwin.ts
+++ b/packages/agentwiki-launcher/src/terminal/darwin.ts
@@ -1,19 +1,11 @@
 /**
  * Open Terminal.app via a `.command` file routed through LaunchServices.
  *
- * Earlier version used ``osascript -e 'tell application "Terminal" to
- * do script "..."'`` (Apple Events automation). TCC refuses to grant
- * the AgentWiki.app stub kTCCServiceAppleEvents because the unsigned
- * osacompile-produced bundle has no stable designated-requirement —
- * the Apple Event is dropped silently. We switched to writing a
- * ``run.command`` file and shelling out to ``open``, which uses
- * LaunchServices (no AppleEvents permission needed) and Terminal.app
- * runs the file because macOS associates the ``.command`` extension
- * with it by default.
- *
- * Wrapper still holds the lifetime of the spawn tmpfiles (audit
- * fix) via ``trap EXIT`` — cleanup fires when the launched binary
- * exits, not when the helper does.
+ * Writes a ``run.command`` wrapper script and shells out to ``open``;
+ * macOS associates ``.command`` with Terminal.app by default, and
+ * LaunchServices needs no AppleEvents permission. The wrapper owns the
+ * lifetime of the spawn tmpfiles via ``trap EXIT`` — cleanup fires
+ * when the launched binary exits, not when this helper process does.
  */
 import { spawn } from "node:child_process";
 import { appendFileSync, chmodSync, mkdtempSync, writeFileSync } from "node:fs";
@@ -41,11 +33,9 @@ export function openInTerminalApp(opts: OpenOpts): void {
     .map(shellQuote)
     .join(" ");
 
-  // Log the full argv from node so the bash script never has to render
-  // user-controlled prompt content. Earlier version did
-  // ``echo "argv: ${argvQuoted}"`` inside double quotes; if the prompt
-  // contained backticks (e.g. markdown code spans like `onyx-cli ask`),
-  // bash treated them as command substitution and hung the wrapper.
+  // Log the full argv from node so the bash script never has to
+  // re-render user-controlled prompt content (backticks in the prompt
+  // would otherwise trigger command substitution inside double quotes).
   const spawnLog = join(homedir(), ".agentwiki", "spawn.log");
   try {
     appendFileSync(
@@ -58,13 +48,9 @@ export function openInTerminalApp(opts: OpenOpts): void {
     // ignore — wrapper will retry the mkdir + log
   }
 
-  // Build close-on-exit + cleanup as a bash *function* (not a single-
-  // quoted trap body). Earlier version put the curl + shellQuote'd
-  // URL/token directly INSIDE the trap's outer single-quoted body —
-  // bash's nested-quote rules made the inner ``'...'`` segments break
-  // out of the outer quoting context, so the curl never actually ran
-  // (or ran malformed) and the session row stayed ``active``. Function
-  // bodies use plain bash quoting, no collision.
+  // Build close-on-exit + cleanup as a bash function (not a single-
+  // quoted trap body) so the inner shellQuote'd URL/token don't have
+  // to nest inside another quoting context.
   const closeLine = opts.closeOnExit
     ? `curl -s -o /dev/null -X POST ${shellQuote(
         opts.closeOnExit.url,
@@ -88,31 +74,24 @@ __agentwiki_on_exit() {
 trap __agentwiki_on_exit EXIT
 cd ${shellQuote(opts.cwd)} 2>>"$LOG" || { echo "cd failed" >> "$LOG"; exit 1; }
 ${envExports}
-# PATH note: 'open -a Terminal.app run.command' invokes the file inside
-# Terminal, which has already started a login shell and sourced the
-# user's zsh init. The bash wrapper inherits that PATH. Earlier versions
-# also did 'source ~/.zshrc' from inside bash, but some zsh init scripts
-# spawn long-running children (e.g. onyx-cli's interactive hook) that
-# hang the wrapper indefinitely — bash sourcing zsh is fragile in
-# general, so we drop it.
+# PATH inherits from Terminal.app's login shell (zsh init has already
+# run); the bash wrapper does not source ~/.zshrc itself.
 echo "[$(date)] PATH=$PATH" >> "$LOG"
 echo "[$(date)] which: $(command -v ${shellQuote(
     opts.binary,
   )} 2>&1 || echo NOT_FOUND)" >> "$LOG"
 echo "[$(date)] launching ${opts.binary}" >> "$LOG"
-# Run binary inheriting stdin/stdout/stderr from Terminal's TTY.
-# Earlier version piped stderr through \`tee\` (process substitution)
-# which can confuse interactive CLIs about TTY state — claude detected
-# non-TTY stderr and exited clean (code=0) without showing UI.
+# Run binary inheriting stdin/stdout/stderr from Terminal's TTY so
+# interactive CLIs (claude/codex) keep TTY semantics.
 ${shellQuote(opts.binary)} ${argvQuoted}
 echo "[$(date)] ${opts.binary} exited code=$?" >> "$LOG"
 `;
   writeFileSync(wrapper, script);
   chmodSync(wrapper, 0o700);
 
-  // ``open -a Terminal.app <wrapper>`` goes through LaunchServices —
-  // no AppleEvents permission required. Terminal.app receives the
-  // ``.command`` file as its open document and runs it in a new tab.
+  // ``open -a Terminal.app <wrapper>`` routes through LaunchServices
+  // (no AppleEvents permission needed); Terminal.app opens the
+  // ``.command`` file in a new tab.
   spawn("open", ["-a", "Terminal.app", wrapper], {
     stdio: "ignore",
     detached: true,

--- a/packages/agentwiki-launcher/src/tmpfile.ts
+++ b/packages/agentwiki-launcher/src/tmpfile.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomBytes } from "node:crypto";
+
+export function writeSecureTmpfile(data: string, suffix = ""): string {
+  const dir = mkdtempSync(join(tmpdir(), "agw-"));
+  const path = join(dir, randomBytes(8).toString("hex") + suffix);
+  writeFileSync(path, data, { mode: 0o600 });
+  return path;
+}
+
+export async function withSecureTmpfiles<K extends string, R>(
+  files: Record<K, string>,
+  fn: (paths: Record<K, string>) => Promise<R> | R,
+): Promise<R> {
+  const paths = {} as Record<K, string>;
+  const dirs: string[] = [];
+  for (const [k, data] of Object.entries(files) as [K, string][]) {
+    const p = writeSecureTmpfile(data);
+    paths[k] = p;
+    const d = p.replace(/\/[^/]+$/, "");
+    dirs.push(d);
+  }
+  try {
+    return await fn(paths);
+  } finally {
+    for (const d of dirs) {
+      try {
+        rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  }
+}

--- a/packages/agentwiki-launcher/src/uri.ts
+++ b/packages/agentwiki-launcher/src/uri.ts
@@ -1,0 +1,26 @@
+type Parsed =
+  | { action: "run"; code: string; tool: string; endpoint: string }
+  | { action: "probe"; nonce: string; endpoint: string };
+
+export function parseLaunchUri(raw: string): Parsed {
+  const url = new URL(raw);
+  if (url.protocol !== "agentwiki:") {
+    throw new Error(`unknown scheme ${url.protocol}`);
+  }
+  const action = url.host || url.pathname.replace(/^\//, "");
+  const params = url.searchParams;
+  if (action === "run") {
+    const code = params.get("code") ?? "";
+    const tool = params.get("tool") ?? "";
+    const endpoint = params.get("endpoint") ?? "";
+    if (!code || !tool || !endpoint) throw new Error("missing run params");
+    return { action, code, tool, endpoint };
+  }
+  if (action === "probe") {
+    const nonce = params.get("nonce") ?? "";
+    const endpoint = params.get("endpoint") ?? "";
+    if (!nonce || !endpoint) throw new Error("missing probe params");
+    return { action, nonce, endpoint };
+  }
+  throw new Error(`unknown action ${action}`);
+}

--- a/packages/agentwiki-launcher/test/allowed_binaries.test.ts
+++ b/packages/agentwiki-launcher/test/allowed_binaries.test.ts
@@ -1,0 +1,23 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isAllowed, assertAllowed } from "../src/allowed_binaries.ts";
+
+test("claude allowed", () => {
+  assert.equal(isAllowed("claude"), true);
+});
+test("codex allowed", () => {
+  assert.equal(isAllowed("codex"), true);
+});
+test("rm not allowed", () => {
+  assert.equal(isAllowed("rm"), false);
+});
+test("absolute path rejected", () => {
+  assert.equal(isAllowed("/usr/bin/claude"), false);
+});
+test("traversal rejected", () => {
+  assert.equal(isAllowed("../claude"), false);
+});
+test("assertAllowed throws binary_not_allowed", () => {
+  assert.throws(() => assertAllowed("rm"), /binary_not_allowed/);
+});

--- a/packages/agentwiki-launcher/test/interpolate.test.ts
+++ b/packages/agentwiki-launcher/test/interpolate.test.ts
@@ -1,0 +1,35 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { interpolate, type InterpolateContext } from "../src/interpolate.ts";
+
+const CTX: InterpolateContext = {
+  token: "mcp_xyz",
+  endpoint: "https://w/api/mcp",
+  session_id: "as_1",
+  cli_session_id: null,
+  working_dir: "/home/u/p",
+  prompt_file_path: "/tmp/p.txt",
+  mcp_config_path: "/tmp/c.json",
+  home: "/home/u",
+  dirhash: "-home-u-p",
+};
+
+test("single var substitutes", () => {
+  assert.equal(interpolate("${endpoint}", CTX), "https://w/api/mcp");
+});
+
+test("multiple vars in template", () => {
+  assert.equal(interpolate("${home}/x/${dirhash}", CTX), "/home/u/x/-home-u-p");
+});
+
+test("unknown var throws", () => {
+  assert.throws(() => interpolate("${not_a_var}", CTX), /unknown var/);
+});
+
+test("null var (resume context) throws", () => {
+  assert.throws(
+    () => interpolate("${cli_session_id}", CTX),
+    /unset in this context/,
+  );
+});

--- a/packages/agentwiki-launcher/test/manifest.test.ts
+++ b/packages/agentwiki-launcher/test/manifest.test.ts
@@ -46,9 +46,23 @@ test("first_turn_prompt anywhere rejected", () => {
   assert.throws(() => parseManifest(bad), /first_turn_prompt.*forbidden/);
 });
 
+test("first_turn_prompt in cwd rejected", () => {
+  const bad = valid();
+  bad.launch!.cwd = "/tmp/${first_turn_prompt}";
+  assert.throws(
+    () => parseManifest(bad),
+    /first_turn_prompt.*forbidden in launch\.cwd/,
+  );
+});
+
 test("prompt_file_path in resume rejected", () => {
   const bad = valid() as ReturnType<typeof valid> & {
-    resume: { binary: string; argv: string[]; env: Record<string, string> };
+    resume: {
+      binary: string;
+      argv: string[];
+      env: Record<string, string>;
+      cwd?: string;
+    };
   };
   bad.resume = {
     binary: "claude",
@@ -58,6 +72,27 @@ test("prompt_file_path in resume rejected", () => {
   assert.throws(
     () => parseManifest(bad),
     /prompt_file_path.*forbidden in resume/,
+  );
+});
+
+test("prompt_file_path in resume cwd rejected", () => {
+  const bad = valid() as ReturnType<typeof valid> & {
+    resume: {
+      binary: string;
+      argv: string[];
+      env: Record<string, string>;
+      cwd?: string;
+    };
+  };
+  bad.resume = {
+    binary: "claude",
+    argv: [],
+    env: {},
+    cwd: "/tmp/${prompt_file_path}",
+  };
+  assert.throws(
+    () => parseManifest(bad),
+    /prompt_file_path.*forbidden in resume\.cwd/,
   );
 });
 

--- a/packages/agentwiki-launcher/test/manifest.test.ts
+++ b/packages/agentwiki-launcher/test/manifest.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseManifest } from "../src/manifest.ts";
+
+function valid() {
+  return {
+    manifest_version: 1 as const,
+    id: "claude-code",
+    name: "x",
+    tagline: "x",
+    icon_url: "/x.svg",
+    kind: "local_cli" as const,
+    cli_check: { binary: "claude" },
+    mcp_config_format: "claude_json" as const,
+    first_turn_prompt_delivery: { method: "stdin" as const },
+    launch: {
+      binary: "claude",
+      argv: ["--mcp-config", "${mcp_config_path}"],
+      env: { AGENTWIKI_SESSION_ID: "${session_id}" },
+      cwd: "${working_dir}",
+    },
+  };
+}
+
+test("valid manifest parses", () => {
+  const m = parseManifest(valid());
+  assert.equal(m.id, "claude-code");
+});
+
+test("unknown var rejected", () => {
+  const bad = valid();
+  bad.launch.argv.push("${not_a_var}");
+  assert.throws(() => parseManifest(bad), /unknown interpolation var/);
+});
+
+test("token in argv rejected", () => {
+  const bad = valid();
+  bad.launch.argv.push("Bearer ${token}");
+  assert.throws(() => parseManifest(bad), /token.*forbidden/);
+});
+
+test("first_turn_prompt anywhere rejected", () => {
+  const bad = valid();
+  bad.launch.argv.push("${first_turn_prompt}");
+  assert.throws(() => parseManifest(bad), /first_turn_prompt.*forbidden/);
+});
+
+test("prompt_file_path in resume rejected", () => {
+  const bad = valid() as ReturnType<typeof valid> & {
+    resume: { binary: string; argv: string[]; env: Record<string, string> };
+  };
+  bad.resume = {
+    binary: "claude",
+    argv: ["--resume", "${prompt_file_path}"],
+    env: {},
+  };
+  assert.throws(
+    () => parseManifest(bad),
+    /prompt_file_path.*forbidden in resume/,
+  );
+});
+
+test("unknown manifest version rejected", () => {
+  const bad = valid() as { manifest_version: number };
+  bad.manifest_version = 2;
+  assert.throws(() => parseManifest(bad), /unsupported manifest_version/);
+});

--- a/packages/agentwiki-launcher/test/mcp_config.test.ts
+++ b/packages/agentwiki-launcher/test/mcp_config.test.ts
@@ -1,8 +1,12 @@
-import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
 
 import { renderClaudeJson } from "../src/mcp_config/claude_json.ts";
 import { renderCodexToml } from "../src/mcp_config/codex_toml.ts";
+import { writeCodexAgentWikiMcp } from "../src/codex_mcp_config.ts";
 
 test("claude_json structure", () => {
   const s = renderClaudeJson({ url: "https://w/api/mcp", token: "mcp_xyz" });
@@ -27,3 +31,29 @@ test("codex_toml shape", () => {
   assert.match(s, /bearer_token_env_var = "AGENTWIKI_MCP_TOKEN"/);
   assert.doesNotMatch(s, /\[mcp_servers\.agent-wiki\.headers\]/);
 });
+
+test(
+  "codex config writer creates dir when missing",
+  { skip: process.platform === "win32" },
+  () => {
+    const tmpHome = mkdtempSync(join(tmpdir(), "codex-home-"));
+    const prevHome = process.env.HOME;
+    try {
+      process.env.HOME = tmpHome;
+      writeCodexAgentWikiMcp({
+        url: "https://w/api/mcp",
+        token: "mcp_xyz",
+      });
+      const configPath = join(tmpHome, ".codex", "config.toml");
+      const contents = readFileSync(configPath, "utf-8");
+      assert.match(contents, /\[mcp_servers\.agent-wiki\]/);
+    } finally {
+      if (prevHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = prevHome;
+      }
+      rmSync(tmpHome, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/agentwiki-launcher/test/mcp_config.test.ts
+++ b/packages/agentwiki-launcher/test/mcp_config.test.ts
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { renderClaudeJson } from "../src/mcp_config/claude_json.ts";
+import { renderCodexToml } from "../src/mcp_config/codex_toml.ts";
+
+test("claude_json structure", () => {
+  const s = renderClaudeJson({ url: "https://w/api/mcp", token: "mcp_xyz" });
+  const parsed = JSON.parse(s);
+  assert.deepEqual(parsed, {
+    mcpServers: {
+      "agent-wiki": {
+        type: "http",
+        url: "https://w/api/mcp",
+        headers: { Authorization: "Bearer mcp_xyz" },
+      },
+    },
+  });
+});
+
+test("codex_toml shape", () => {
+  const s = renderCodexToml({ url: "https://w/api/mcp", token: "mcp_xyz" });
+  assert.match(s, /\[mcp_servers\.agent-wiki\]/);
+  assert.match(s, /url = "https:\/\/w\/api\/mcp"/);
+  // Codex reads bearer from env var, not an inline Authorization
+  // header sub-table (that path returned 401 from the backend).
+  assert.match(s, /bearer_token_env_var = "AGENTWIKI_MCP_TOKEN"/);
+  assert.doesNotMatch(s, /\[mcp_servers\.agent-wiki\.headers\]/);
+});

--- a/packages/agentwiki-launcher/test/spawn.test.ts
+++ b/packages/agentwiki-launcher/test/spawn.test.ts
@@ -1,0 +1,84 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildSpawnCommand } from "../src/spawn.ts";
+import type { Manifest } from "../src/manifest.ts";
+
+function manifest(): Manifest {
+  return {
+    manifest_version: 1,
+    id: "claude-code",
+    name: "x",
+    tagline: "x",
+    icon_url: "/x",
+    kind: "local_cli",
+    cli_check: { binary: "claude" },
+    mcp_config_format: "claude_json",
+    first_turn_prompt_delivery: {
+      method: "prompt_file_flag",
+      flag: "--prompt-file",
+    },
+    launch: {
+      binary: "claude",
+      argv: ["--mcp-config", "${mcp_config_path}"],
+      env: { AGENTWIKI_SESSION_ID: "${session_id}" },
+      cwd: "${working_dir}",
+    },
+  };
+}
+
+test("argv interpolated + prompt-file flag appended", () => {
+  const cmd = buildSpawnCommand({
+    manifest: manifest(),
+    token: "mcp_t",
+    endpoint: "https://w",
+    sessionId: "as_1",
+    workingDir: "/home/u/p",
+    mcpConfigPath: "/tmp/c.json",
+    promptFilePath: "/tmp/p.txt",
+    promptText: null,
+  });
+  assert.deepEqual(cmd.argv, [
+    "--mcp-config",
+    "/tmp/c.json",
+    "--prompt-file",
+    "/tmp/p.txt",
+  ]);
+  assert.equal(cmd.env.AGENTWIKI_SESSION_ID, "as_1");
+  assert.equal(cmd.cwd, "/home/u/p");
+});
+
+test("disallowed binary rejected", () => {
+  const m = manifest();
+  m.launch!.binary = "rm";
+  assert.throws(
+    () =>
+      buildSpawnCommand({
+        manifest: m,
+        token: "x",
+        endpoint: "x",
+        sessionId: "x",
+        workingDir: null,
+        mcpConfigPath: null,
+        promptFilePath: null,
+        promptText: null,
+      }),
+    /binary_not_allowed/,
+  );
+});
+
+test("dirhash matches claude's slash-to-dash format", () => {
+  const m = manifest();
+  m.launch!.argv = ["--path", "${dirhash}"];
+  const cmd = buildSpawnCommand({
+    manifest: m,
+    token: "x",
+    endpoint: "x",
+    sessionId: "x",
+    workingDir: "/Users/nikolas/agent-wiki",
+    mcpConfigPath: null,
+    promptFilePath: null,
+    promptText: null,
+  });
+  assert.equal(cmd.argv[1], "-Users-nikolas-agent-wiki");
+});

--- a/packages/agentwiki-launcher/test/uri.test.ts
+++ b/packages/agentwiki-launcher/test/uri.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { parseLaunchUri } from "../src/uri.ts";
+
+test("parses run URI", () => {
+  const r = parseLaunchUri(
+    "agentwiki://run?code=lc_xyz&tool=claude-code&endpoint=https%3A%2F%2Fw%2Fapi%2Fmcp",
+  );
+  assert.equal(r.action, "run");
+  if (r.action !== "run") return;
+  assert.equal(r.code, "lc_xyz");
+  assert.equal(r.tool, "claude-code");
+  assert.equal(r.endpoint, "https://w/api/mcp");
+});
+
+test("parses probe URI", () => {
+  const r = parseLaunchUri(
+    "agentwiki://probe?nonce=n123&endpoint=https%3A%2F%2Fw",
+  );
+  assert.equal(r.action, "probe");
+  if (r.action !== "probe") return;
+  assert.equal(r.nonce, "n123");
+});
+
+test("rejects unknown scheme", () => {
+  assert.throws(() => parseLaunchUri("https://example.com"));
+});
+
+test("rejects unknown action", () => {
+  assert.throws(() => parseLaunchUri("agentwiki://destroy?x=1"));
+});
+
+test("rejects missing params", () => {
+  assert.throws(() => parseLaunchUri("agentwiki://run?code=lc"));
+});

--- a/packages/agentwiki-launcher/tsconfig.json
+++ b/packages/agentwiki-launcher/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Description

Phase 3 of coding-tool-launchers. **Stacked off PR #32** (Phase 2 frontend) — merge that first.

**New package**: `packages/agentwiki-launcher/` — Node 18+ TypeScript CLI published as `@agentwiki/launcher`. Single binary entry, four subcommands:

- `agentwiki-launcher set-endpoint <wiki-url>` — pin wiki endpoint to `~/.agentwiki/endpoint.url` (mode 0600). REQUIRED before first run.
- `agentwiki-launcher run <agentwiki://run?...>` — main flow.
- `agentwiki-launcher probe-ack <agentwiki://probe?...>` — posts ack to wiki for frontend helper detection.
- `agentwiki-launcher dispatch <agentwiki://…>` — entry from the macOS .app stub. Routes by URI action so the stub doesn't need to know the difference.

**Core modules**:

- `machine_id.ts` — uuid v4 persisted to `~/.agentwiki/machine.id` (0600).
- `allowed_binaries.ts` — hardcoded `{claude, codex}` allow-list, closes RCE hole.
- `tmpfile.ts` — secure tmpfile helper, mode 0600.
- `endpoint_pin.ts` — URI's `endpoint` param is IGNORED; refuses if doesn't match pinned (handles base/MCP-path normalization).
- `manifest.ts` — TS mirror of backend pydantic; rejects `${token}` in argv, `${first_turn_prompt}` anywhere, `${prompt_file_path}` in resume.
- `interpolate.ts` — bounded substitution; unknown vars throw.
- `mcp_config/{claude_json,codex_toml}.ts` — render MCP config files. claude JSON includes `"type": "http"` (claude rejects schema without it).
- `spawn.ts` — assembles command. `dirhash` = `cwd.replace('/', '-')` (verified against real `~/.claude/projects/`). Appends `unscoped_workdir_argv` from the manifest when `workingDir` is null. Falls back to a per-session scratch dir `~/agent-wiki-runs/<session_id>/` instead of `$HOME` so the agent doesn't touch claude's hard-coded sensitive-file list and doesn't auto-load the user's global `~/.claude/CLAUDE.md`.
- `terminal/darwin.ts` — opens Terminal.app via a `.command` wrapper + `open -a Terminal.app` (LaunchServices). Earlier osascript→Terminal call was silently dropped because TCC refuses `kTCCServiceAppleEvents` for the unsigned osacompile-produced .app; `.command` + `open` routes through LaunchServices with no AppleEvents permission needed. Wrapper trap fires a curl POST to `/api/agent-sessions/<id>/close` on exit so the session row flips to `closed` the moment the terminal tab dies (within the frontend's 5s poll window). Trap body is a named function (`__agentwiki_on_exit`) not a single-quoted inline — earlier inline form let `shellQuote`'d URL/token segments break out of the outer quote and the curl never ran.
- `exchange.ts` — POST `/api/launch/exchange` with machine_id.
- `cli.ts` — `run`: parse URI → check pinned → exchange → build spawn → openInTerminalApp → post spawn-ok beacon. `probe-ack`: send nonce + machine_id to wiki.
- `claude_trust.ts` / `codex_trust.ts` — pre-mark the launch cwd as trusted in `~/.claude.json` / `~/.codex/config.toml` so the workspace-trust dialog doesn't block an unattended agent.
- `codex_mcp_config.ts` — writes the agent-wiki MCP block into `~/.codex/config.toml` with sentinel markers (codex has no `--mcp-config` flag, so per-session block injection is the only way). Uses `bearer_token_env_var = "AGENTWIKI_MCP_TOKEN"`; the env var is exported by the wrapper before launching codex.
- `install/{postinstall,darwin}.ts` — npm postinstall creates `~/Applications/AgentWiki.app` from a compiled AppleScript (not a bash stub — bash stubs can't receive Apple Events for URL-scheme dispatch). Info.plist patched to declare the `agentwiki://` scheme + `lsregister` to register the URL handler.

**Backend additions (small)**:

- `LaunchBlock.unscoped_workdir_argv: list[str]` on the manifest pydantic model + JSON Schema. Helper appends these flags when `workingDir` is null. Literal flags only — `${var}` interpolation is rejected by the validator. claude manifest gets `--permission-mode bypassPermissions`, codex gets `--dangerously-bypass-approvals-and-sandbox`.
- `LauncherCatalogEntry.unscoped_workdir_warning: str | None` — pre-rendered warning string for the catalog response so the UI can show the user what flags will fire before they click Run with an empty workdir.
- `first_turn_prompt_delivery.method: "positional_arg"` enum value. claude + codex manifests switched from the unwired `stdin` method to `positional_arg`; helper appends `promptText` as the final argv element.
- Prompt builder gains an explicit "use the agent-wiki MCP tools (`edit_doc`, `read_doc`); the wiki repo is NOT in your cwd; `WIKI_PATH:` is the arg to those tools, not a local path" clause so launched agents don't write a local file with the wiki path's name.

**Frontend polish landing in this PR** (all small):

- Inline SVG `ToolIcons` (replaced broken `/icons/*.svg` references with React components matching the existing `WikiIcons` pattern). `ToolCard` accepts `kind` instead of `iconUrl`; in_app tools hide the launcher / CLI badges.
- Wizard Done gate loosened — CLI presence-probe isn't shipped in v1 (no localhost helper server). If `claude`/`codex` is missing at spawn time the helper exits with `cli_not_found` and the wiki UI flips the session to `failed`.
- Wiki page body polls `/api/wiki/file?path=…` every 3s while an agent session is active on the page so MCP edits land in the viewer without manual refresh. Suppressed while editing or viewing history.
- `ActiveSessionsList` chip relabelled "external agent sessions" so it doesn't visually conflict with the document-activity (24-hour history) panel.
- `RunAgentModal` busy state explicitly cleared on success path + sessionStorage bounce-back stash for browsers that navigate away on `window.location.href = uri`.

**Real CLI verification done** (claude + codex installed locally). Confirmed:

- claude session-file dir = `~/.claude/projects/<slash-to-dash-cwd>/<uuid>.jsonl`, NOT sha256.
- claude's `--strict-mcp-config` requires `"type": "http"` in the MCP block.
- codex reads MCP servers only from `~/.codex/config.toml` (no `--mcp-config` flag); helper writes a marked block.
- codex needs `bearer_token_env_var` for HTTP MCP, not a `[headers]` sub-table.
- TCC refuses AppleEvents for the unsigned osacompile .app; `.command` + LaunchServices is the workaround.
- Sourcing `~/.zshrc` from the bash wrapper hangs on `onyx-cli`'s interactive init hook → wrapper drops the source.
- Single-quoted trap body breaks on `shellQuote`'d inner segments → trap converted to a named function.
- Multi-byte prompt content with backticks (markdown code spans like `` `onyx-cli ask --json` ``) is logged via node directly, not echoed from bash, to avoid command-substitution.

26/26 unit tests green. `npm run build` produces clean dist.

## How Has This Been Tested?

- `npm test` (helper package): 26/26 green.
- `npm run build` (helper package): clean dist.
- `npm run typecheck` (frontend): clean.
- Backend launcher tests: 95 passed locally (2 pre-existing Redis-env failures unrelated).
- Live end-to-end exercise: real claude + codex launched against running backend, MCP edit_doc tool call lands in wiki repo with `agent_session_id` stamp, close-on-exit beacon flips session to `closed` within the 5s frontend poll, scratch-dir + bypass flags + workspace-trust pre-mark together avoid every prompt that previously blocked an unattended agent.
- 1 codex-driven review iteration on the rebased branch.
