### PR TITLE
fix(wiki_helm): add redis-url to secret and REDIS_URL env to workers (v0.3.3)

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "0.1.0"


### PR DESCRIPTION
## Summary
- Published chart v0.3.2 was missing `redis-url` in `secret.yaml` and `REDIS_URL` in `_helpers.tpl` — workers connected to `redis:6379` (default) instead of ElastiCache
- Bumps chart to v0.3.3; merging triggers `helm-release.yml` to auto-publish the fixed chart to gh-pages

## Test plan
- [ ] Merge triggers helm-release.yml and publishes v0.3.3
- [ ] Next `ods deploy wiki` picks up v0.3.3 and workers start without manual secret patching