### PR TITLE
feat(helm): add OPENSEARCH_URL to secret + env (v0.3.4)

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/_helpers.tpl
+++ b/deploy/helm/agent-workspace/templates/_helpers.tpl
@@ -51,6 +51,11 @@ and wiki path stay in lockstep.
     secretKeyRef:
       name: {{ include "agent-workspace.fullname" . }}-secrets
       key: redis-url
+- name: OPENSEARCH_URL
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "agent-workspace.fullname" . }}-secrets
+      key: opensearch-url
 - name: WIKI_DIR
   value: /wiki
 - name: SECRET_KEY

--- a/deploy/helm/agent-workspace/templates/secret.yaml
+++ b/deploy/helm/agent-workspace/templates/secret.yaml
@@ -9,6 +9,7 @@ stringData:
   secret-key: {{ required "secretKey is required (generate with `openssl rand -hex 32`)" .Values.secretKey | quote }}
   database-url: {{ required "databaseUrl is required (PostgreSQL 17 connection string)" .Values.databaseUrl | quote }}
   redis-url: {{ required "redisUrl is required (Redis 7+ connection string, e.g. rediss://HOST:6379/0)" .Values.redisUrl | quote }}
+  opensearch-url: {{ required "opensearchUrl is required (e.g. https://admin:pass@host or http://opensearch:9200)" .Values.opensearchUrl | quote }}
   {{- if eq .Values.auth.mode "oidc" }}
   oidc-client-secret: {{ .Values.auth.oidc.clientSecret | quote }}
   {{- end }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -38,6 +38,11 @@ databaseUrl: ""
 # Form: rediss://HOST:6379/0  (rediss:// = TLS; redis:// = plaintext)
 redisUrl: ""
 
+# OpenSearch connection URL for BM25 full-text search. Required.
+# AWS OpenSearch Service: https://admin:pass@vpc-xxx.us-west-2.es.amazonaws.com
+# Self-hosted pod:        http://opensearch:9200
+opensearchUrl: ""
+
 # Comma-separated email whitelist for signup. Empty = anyone.
 allowedEmails: ""
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,12 +30,29 @@ services:
       timeout: 3s
       retries: 15
 
+  opensearch:
+    image: opensearchproject/opensearch:2.17.0
+    environment:
+      - discovery.type=single-node
+      - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
+      - plugins.security.disabled=true
+    expose:
+      - "9200"
+    ports:
+      - "127.0.0.1:9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -qv '\"status\":\"red\"'"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
   backend:
     build: ./backend
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
       - REDIS_URL=redis://redis:6379/0
+      - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
     volumes:
       - ./local_data:/data
@@ -46,6 +63,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      opensearch:
+        condition: service_healthy
 
   # Three workers, one per queue (see backend/app/tasks/queues.py).
   worker-documents:
@@ -55,6 +74,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
       - REDIS_URL=redis://redis:6379/0
+      - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
     volumes:
       - ./local_data:/data
@@ -64,6 +84,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      opensearch:
         condition: service_healthy
 
   worker-triggers:
@@ -73,6 +95,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
       - REDIS_URL=redis://redis:6379/0
+      - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
     volumes:
       - ./local_data:/data
@@ -82,6 +105,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      opensearch:
         condition: service_healthy
 
   worker-lightweight-maintenance:
@@ -91,6 +116,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
       - REDIS_URL=redis://redis:6379/0
+      - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
     volumes:
       - ./local_data:/data
@@ -100,6 +126,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      opensearch:
         condition: service_healthy
 
   frontend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,8 @@ services:
     environment:
       - discovery.type=single-node
       - OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m
-      - plugins.security.disabled=true
+      - DISABLE_INSTALL_DEMO_CONFIG=true
+      - DISABLE_SECURITY_PLUGIN=true
     expose:
       - "9200"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     expose:
       - "9200"
     ports:
-      - "127.0.0.1:9200:9200"
+      - "127.0.0.1:9201:9200"
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cluster/health | grep -qv '\"status\":\"red\"'"]
       interval: 5s


### PR DESCRIPTION
## Summary
- Adds `opensearch-url` key to the Helm secret template
- Injects `OPENSEARCH_URL` env var into backend and all worker pods via `backendEnv`
- Adds `opensearchUrl` to `values.yaml` with documentation
- Bumps chart to v0.3.4

Pairs with the Terraform PR that provisions the AWS OpenSearch domain.