### PR TITLE
feat(wiki): Implement OpenSearch

### DIFF
--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -41,7 +41,7 @@ from app.models.document import (
 )
 from app.tasks.document_update import process_pushed_document
 from app.tasks.queues import QueueFullError
-from app.tasks.reindex import reindex_path
+from app.tasks.reindex import index_path
 from app.triggers import repo as triggers_repo
 from app.wiki import (
     agent_activity,
@@ -292,7 +292,7 @@ def reindex_document_by_path(
     if not abs_path.is_file():
         raise HTTPException(status_code=404, detail="not found")
     require_can("read", rel, user)
-    reindex_path(rel)
+    index_path(rel)
     return ReindexResponse(path=rel, queued=True)
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -21,6 +21,8 @@ class Config(BaseModel):
     wiki_dir: str
     database_url: str
     redis_url: str
+    opensearch_url: str
+    opensearch_index: str
     max_queue_size: int
 
     auth_mode: str  # "basic" | "oidc"
@@ -66,6 +68,8 @@ def load_config() -> Config:
             "postgresql://postgres:postgres@postgres:5432/agent_wiki",
         ),
         redis_url=os.environ.get("REDIS_URL", "redis://redis:6379/0"),
+        opensearch_url=os.environ.get("OPENSEARCH_URL", "http://opensearch:9200"),
+        opensearch_index=os.environ.get("OPENSEARCH_INDEX", "wiki-docs"),
         max_queue_size=_positive_int("MAX_QUEUE_SIZE", 1000),
         auth_mode=os.environ.get("AUTH_MODE", "basic"),
         oidc_issuer=os.environ.get("OIDC_ISSUER", ""),

--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -1,12 +1,35 @@
-"""BM25 search stub — returns empty results until OpenSearch lands.
+"""BM25 full-text search via OpenSearch.
 
-pg_textsearch has been removed (not available on RDS). Real search will
-be restored in the follow-up PR that wires up self-hosted OpenSearch.
-The public API is preserved so callers don't need changes.
+Index name: ``wiki-docs``.  One document per wiki page; ``_id`` = path
+(e.g. ``"docs/spec.md"``).  Stored fields: ``path`` (keyword), ``title``
+and ``body`` (text).
+
+Client is lazily initialised on first use so import-time startup
+(migrations, config load) never touches the network.  A module-level
+singleton is reused for the lifetime of the process; call
+``reset_client_for_tests()`` between tests that reconfigure CONFIG.
+
+Writes are best-effort: a failed upsert/delete logs at WARNING and
+returns without raising so a search-index glitch never aborts a doc
+commit.  Search degrades to an empty list on connection errors.
+
+Visibility filtering: uses ``acl.filter_paths_in_python`` so the check
+works regardless of whether the ``documents`` table has rows (the table
+is not populated by the current write path).
 """
 from __future__ import annotations
 
+import logging
+import threading
+from urllib.parse import urlparse
+
 from pydantic import BaseModel
+
+log = logging.getLogger(__name__)
+
+_client_lock = threading.Lock()
+_client: object | None = None
+_client_ready = False  # True once we've attempted init (even if it failed)
 
 
 class SearchHit(BaseModel):
@@ -17,6 +40,124 @@ class SearchHit(BaseModel):
     score: float
 
 
+# --------------------------------------------------------------------------- #
+# Client lifecycle                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def _make_client(url: str) -> object:
+    from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+
+    parsed = urlparse(url)
+    use_ssl = parsed.scheme == "https"
+    port = parsed.port or (443 if use_ssl else 9200)
+    host = {"host": parsed.hostname or "localhost", "port": port}
+
+    kwargs: dict[str, object] = {
+        "hosts": [host],
+        "use_ssl": use_ssl,
+        "verify_certs": use_ssl,
+        "ssl_show_warn": False,
+        "http_compress": True,
+    }
+    if parsed.username:
+        kwargs["http_auth"] = (parsed.username, parsed.password or "")
+
+    return OpenSearch(**kwargs)  # type: ignore[arg-type]
+
+
+def _get_client() -> object | None:
+    global _client, _client_ready
+    if _client_ready:
+        return _client
+    with _client_lock:
+        if _client_ready:
+            return _client
+        from app.config import CONFIG
+
+        url = CONFIG.opensearch_url
+        if not url:
+            _client_ready = True
+            return None
+        try:
+            _client = _make_client(url)
+            _ensure_index(_client)
+        except Exception:
+            log.exception("fts: failed to initialise OpenSearch client")
+            _client = None
+        _client_ready = True
+    return _client
+
+
+def reset_client_for_tests() -> None:
+    """Drop the cached client.  Call between tests that change CONFIG."""
+    global _client, _client_ready
+    with _client_lock:
+        _client = None
+        _client_ready = False
+
+
+def drop_index_for_tests() -> None:
+    """Delete the entire per-test index.  Each test gets a unique index name
+    (set in conftest via ``opensearch_index`` in Config) so deleting it is
+    safe and leaves no residue in the shared OpenSearch instance."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+
+        from opensearchpy.exceptions import NotFoundError  # type: ignore[import-untyped]
+
+        c: OpenSearch = client  # type: ignore[assignment]
+        try:
+            c.indices.delete(index=_index_name())
+        except NotFoundError:
+            pass
+    except Exception:
+        log.warning("fts: drop_index_for_tests failed", exc_info=True)
+
+
+# --------------------------------------------------------------------------- #
+# Index bootstrap                                                              #
+# --------------------------------------------------------------------------- #
+
+_MAPPING = {
+    "settings": {
+        "index": {
+            "similarity": {"default": {"type": "BM25", "b": 0.75, "k1": 1.2}},
+        },
+    },
+    "mappings": {
+        "properties": {
+            "path":  {"type": "keyword"},
+            "title": {"type": "text", "boost": 3.0},
+            "body":  {"type": "text"},
+        },
+    },
+}
+
+
+def _index_name() -> str:
+    from app.config import CONFIG
+    return CONFIG.opensearch_index
+
+
+def _ensure_index(client: object) -> None:
+    from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+
+    c: OpenSearch = client  # type: ignore[assignment]
+    idx = _index_name()
+    if not c.indices.exists(index=idx):
+        c.indices.create(index=idx, body=_MAPPING)
+        log.info("fts: created index %s", idx)
+
+
+# --------------------------------------------------------------------------- #
+# Write operations                                                             #
+# --------------------------------------------------------------------------- #
+
+
 def upsert_document(
     doc_id: str,
     path: str,
@@ -25,11 +166,52 @@ def upsert_document(
     *,
     indexed_sha: str | None = None,
 ) -> None:
-    pass
+    """Index (or re-index) a wiki page.
+
+    ``doc_id`` is accepted for API compatibility but ``path`` is used as
+    the OpenSearch ``_id`` so deletes (which always pass the path) stay
+    consistent.
+    """
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+
+        c: OpenSearch = client  # type: ignore[assignment]
+        c.index(
+            index=_index_name(),
+            id=path,  # stable _id regardless of Postgres UUID
+            body={"path": path, "title": title, "body": body},
+            refresh=True,  # type: ignore[call-arg]
+        )
+    except Exception:
+        log.warning("fts: upsert_document failed for %s", path, exc_info=True)
 
 
 def delete_document(doc_id: str) -> None:
-    pass
+    """Remove a page from the index.  ``doc_id`` is the path when called
+    from ``app.wiki.notify`` (the only callers)."""
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+
+        from opensearchpy.exceptions import NotFoundError  # type: ignore[import-untyped]
+
+        c: OpenSearch = client  # type: ignore[assignment]
+        try:
+            c.delete(index=_index_name(), id=doc_id)
+        except NotFoundError:
+            pass
+    except Exception:
+        log.warning("fts: delete_document failed for %s", doc_id, exc_info=True)
+
+
+# --------------------------------------------------------------------------- #
+# Search                                                                       #
+# --------------------------------------------------------------------------- #
 
 
 def search(
@@ -40,4 +222,78 @@ def search(
     is_admin: bool = False,
     apply_visibility: bool = True,
 ) -> list[SearchHit]:
-    return []
+    client = _get_client()
+    if client is None:
+        return []
+
+    fetch_size = min(limit * 5, 200)
+    body = {
+        "query": {
+            "multi_match": {
+                "query": query,
+                "fields": ["title^3", "body"],
+                "type": "best_fields",
+            },
+        },
+        "highlight": {
+            "fields": {
+                "body":  {"fragment_size": 200, "number_of_fragments": 1},
+                "title": {"number_of_fragments": 0},
+            },
+        },
+        "_source": ["path", "title"],
+        "size": fetch_size,
+    }
+
+    try:
+        from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+
+        c: OpenSearch = client  # type: ignore[assignment]
+        resp = c.search(index=_index_name(), body=body)
+    except Exception:
+        log.warning("fts: search failed for query %r", query, exc_info=True)
+        return []
+
+    hits = resp.get("hits", {}).get("hits", [])
+    if not hits:
+        return []
+
+    # Build (path, title, snippet, score) tuples.
+    candidates: list[tuple[str, str | None, str, float]] = []
+    for h in hits:
+        src = h.get("_source", {})
+        path: str = src.get("path", "") or h["_id"]
+        title: str | None = src.get("title") or None
+        hl: dict[str, list[str]] = h.get("highlight") or {}
+        snippet_parts: list[str] = hl.get("body") or hl.get("title") or []
+        snippet: str = snippet_parts[0] if snippet_parts else ""
+        candidates.append((path, title, snippet, float(h.get("_score", 0.0))))
+
+    if apply_visibility and candidates:
+        visible = _visible_paths(
+            {c[0] for c in candidates}, user_id=user_id, is_admin=is_admin
+        )
+        candidates = [c for c in candidates if c[0] in visible]
+
+    return [
+        SearchHit(doc_id=path, path=path, title=title, snippet=snippet, score=score)
+        for path, title, snippet, score in candidates[:limit]
+    ]
+
+
+def _visible_paths(
+    paths: set[str],
+    *,
+    user_id: str | None,
+    is_admin: bool,
+) -> set[str]:
+    """Filter ``paths`` to those the caller can read.
+
+    Uses ``acl.filter_paths_in_python`` so this works without Document
+    table rows (the current write path never populates that table).
+    """
+    if is_admin or not paths:
+        return paths
+    from app.wiki import acl
+
+    return set(acl.filter_paths_in_python(user_id, is_admin, paths))

--- a/backend/app/tasks/document_update.py
+++ b/backend/app/tasks/document_update.py
@@ -6,7 +6,7 @@ wiki page. Each task may make a full LLM call and produce a new commit, so
 we keep this work off the indexer / trigger queues to prevent provider
 slowness from cascading into search staleness or delayed trigger fires.
 
-After a successful commit, these tasks re-enqueue ``reindex_path`` (on
+After a successful commit, these tasks re-enqueue ``index_path`` (on
 ``lightweight_maintenance_queue``) and ``fan_out_trigger_eval`` (on
 ``triggers_queue``) so the side effects fan out exactly like a human edit.
 
@@ -52,7 +52,7 @@ def update_document_from_payload(doc_id: str, source: str, payload: dict[str, An
     #   1. Load current doc body from git (app.wiki.git.read_file).
     #   2. Call app.llm.agents.document_updater.run(doc_id, body, payload, source).
     #   3. If the agent produced a new body, commit it (app.wiki.git.commit_file).
-    #   4. Enqueue reindex_path on lightweight_maintenance_queue.
+    #   4. Enqueue index_path on lightweight_maintenance_queue.
     #   5. Enqueue fan_out_trigger_eval on triggers_queue for doc + parent dirs.
     raise NotImplementedError
 

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -39,8 +39,7 @@ Queues:
   here would silently starve the others. If a new task can't honor the
   rule, give it its own queue rather than co-tenanting on this one.
   Today:
-    - Search reindex stubs (``reindex_path``, ``reindex_document``) —
-      no-ops until OpenSearch lands.
+    - Search index tasks (``index_path``) — BM25 via OpenSearch.
     - Agent-activity expiration cleanup
       (``cleanup_expired_activity``) — a single ``DELETE`` enqueued
       with a delay equal to the row's ``expires_at``.

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -1,34 +1,83 @@
-"""Reindex stubs — search indexing is disabled until OpenSearch lands.
+"""Index wiki documents in OpenSearch for BM25 full-text search.
 
-pg_textsearch has been removed. The task handlers are kept registered on
-the lightweight_maintenance_queue so existing queue messages don't error
-with "no handler" — they just become silent no-ops until OpenSearch
-replaces this module.
+Three entry points:
+
+  index_path(path)        — async task on lightweight_maintenance_queue;
+                            used by after_doc_write / after_path_move.
+  index_path_inline(path) — synchronous version; tests call this directly
+                            so they can assert on search results immediately.
+  reconcile_bm25_index()    — hourly cron; re-indexes any .md files touched
+                              in the last 2 hours to heal missed events.
+
+All three swallow exceptions so a broken OpenSearch never aborts a doc
+write or hourly sweep.  Errors are logged at WARNING level.
+
+Neither function depends on the ``documents`` table — only the git
+working tree is consulted for content and path existence.
 """
 from __future__ import annotations
 
 import logging
+import re
 
+from app.db import fts
 from app.tasks.queue import crontab
 from app.tasks.queues import lightweight_maintenance_queue
 
 log = logging.getLogger(__name__)
 
+_H1_RE = re.compile(r"^#{1,2}\s+(.+)", re.MULTILINE)
+
+
+def _extract_title(body: str) -> str:
+    """Return the first # or ## heading, or empty string."""
+    m = _H1_RE.search(body)
+    return m.group(1).strip() if m else ""
+
+
+# --------------------------------------------------------------------------- #
+# Per-document reindex                                                         #
+# --------------------------------------------------------------------------- #
+
 
 @lightweight_maintenance_queue.task()
-def reindex_document(doc_id: str, path: str, title: str) -> None:
-    pass
+def index_path(path: str) -> None:
+    index_path_inline(path)
 
 
-@lightweight_maintenance_queue.task()
-def reindex_path(path: str) -> None:
-    pass
+def index_path_inline(path: str) -> None:
+    if not path.endswith(".md"):
+        return
+
+    from app.wiki import git as wiki_git
+
+    try:
+        body = wiki_git.read_file(path)
+    except Exception:
+        log.warning("index_path_inline: could not read %s, removing from index", path)
+        fts.delete_document(path)
+        return
+
+    fts.upsert_document(path, path, _extract_title(body), body)
 
 
-def reindex_path_inline(path: str) -> None:
-    pass
+# --------------------------------------------------------------------------- #
+# Hourly reconcile sweep                                                       #
+# --------------------------------------------------------------------------- #
 
 
 @lightweight_maintenance_queue.periodic_task(crontab(minute="0"))
 def reconcile_bm25_index() -> None:
-    pass
+    """Re-index any .md files touched in the last 2 hours."""
+    from app.wiki import git as wiki_git
+
+    touched = {p for p in wiki_git.paths_touched_since("2 hours ago") if p.endswith(".md")}
+    if not touched:
+        return
+
+    for path in touched:
+        try:
+            body = wiki_git.read_file(path)
+            fts.upsert_document(path, path, _extract_title(body), body)
+        except Exception:
+            log.warning("reconcile_bm25_index: failed to reindex %s", path, exc_info=True)

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from app.db import fts
 from app.mcp_server import pubsub as mcp_pubsub
-from app.tasks.reindex import reindex_path
+from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
 from app.wiki import acl
 
@@ -66,7 +66,7 @@ def after_doc_write(
         return
     if change_kind == "create":
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
-    reindex_path(rel_path)
+    index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
     mcp_pubsub.publish_doc_update(rel_path, sha, change_kind)
     if change_kind == "create":
@@ -133,7 +133,7 @@ def after_path_move(
             mcp_pubsub.publish_doc_delete(old_p, sha)
             list_changed = True
         if new_is_md:
-            reindex_path(new_p)
+            index_path(new_p)
             fan_out_trigger_eval(new_p, sha, "create", actor)
             mcp_pubsub.publish_doc_update(new_p, sha, "create")
             list_changed = True

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "ollama>=0.4",       # Local-model provider (uses Ollama HTTP API)
     "braintrust>=0.0.190", # LLM tracing — admin-configured project + key
     "pyyaml>=6.0",       # trigger files on disk
+    "opensearch-py>=2.4",  # BM25 full-text search
     "fastapi>=0.110",
     "uvicorn[standard]>=0.27",  # ASGI server — production entry via Dockerfile CMD
     "itsdangerous>=2.1", # Starlette SessionMiddleware signs the session cookie

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,10 +10,17 @@ The test database must already exist; point ``TEST_DATABASE_URL`` at it.
 Locally:
 
   createdb agent_wiki_test
+
+OpenSearch tests require a running OpenSearch instance.  Set
+``TEST_OPENSEARCH_URL`` (default ``http://localhost:9201``) and make sure
+the service is up — docker compose runs it on port 9201.  Tests that
+require OpenSearch are marked ``@needs_opensearch`` and skipped when the
+instance is not reachable.
 """
 from __future__ import annotations
 
 import os
+import urllib.request
 import uuid
 from urllib.parse import quote
 
@@ -28,6 +35,28 @@ from psycopg import sql
 from app.config import Config
 from app.mcp_server import pubsub as _mcp_pubsub
 from app.mcp_server import session as _mcp_session
+
+# --------------------------------------------------------------------------- #
+# OpenSearch availability check (runs once at collection time)                #
+# --------------------------------------------------------------------------- #
+
+_TEST_OPENSEARCH_URL = os.environ.get("TEST_OPENSEARCH_URL", "http://localhost:9201")
+
+
+def _check_opensearch() -> bool:
+    try:
+        urllib.request.urlopen(f"{_TEST_OPENSEARCH_URL}/_cluster/health", timeout=2)
+        return True
+    except Exception:
+        return False
+
+
+_opensearch_up: bool = _check_opensearch()
+
+needs_opensearch = pytest.mark.skipif(
+    not _opensearch_up,
+    reason=f"OpenSearch not reachable at {_TEST_OPENSEARCH_URL}",
+)
 
 # Suppress the cross-process Postgres LISTEN bridge in tests. ``create_app``'s
 # lifespan calls ``mcp_pubsub.start_listener`` (app/main.py), which would
@@ -72,6 +101,8 @@ def tmp_config(tmp_path, monkeypatch):
         wiki_dir=str(wiki_dir),
         database_url=_with_search_path(_BASE_URL, schema),
         redis_url=os.environ.get("TEST_REDIS_URL", "redis://localhost:6380/1"),
+        opensearch_url=_TEST_OPENSEARCH_URL,
+        opensearch_index=f"wiki-docs-test-{schema}",  # isolated per test
         max_queue_size=1000,
         auth_mode="basic",
         oidc_issuer="",
@@ -83,6 +114,10 @@ def tmp_config(tmp_path, monkeypatch):
     monkeypatch.setattr("app.config.CONFIG", cfg)
     monkeypatch.setattr("app.db.session.CONFIG", cfg)
 
+    # Reset the lazy OpenSearch client so it re-reads CONFIG on next use.
+    from app.db import fts as _fts
+    _fts.reset_client_for_tests()
+
     # Each test rebuilds the engine so the new schema's search_path takes effect.
     from app.db.session import reset_engine_for_tests
     reset_engine_for_tests()
@@ -90,6 +125,10 @@ def tmp_config(tmp_path, monkeypatch):
     yield cfg
 
     reset_engine_for_tests()
+    from app.db import fts as _fts
+    if _opensearch_up:
+        _fts.drop_index_for_tests()  # delete the per-test index
+    _fts.reset_client_for_tests()
     with psycopg.connect(_BASE_URL, autocommit=True) as conn:
         conn.execute(sql.SQL('DROP SCHEMA {} CASCADE').format(sql.Identifier(schema)))
 

--- a/backend/tests/integration/test_permissions_flow.py
+++ b/backend/tests/integration/test_permissions_flow.py
@@ -7,9 +7,8 @@ every interesting branch.
 """
 from __future__ import annotations
 
-import pytest
-
 from app.wiki import acl
+from tests.conftest import needs_opensearch
 
 
 def test_creator_becomes_owner_and_others_can_access_default_public(integration):
@@ -105,7 +104,7 @@ def test_admin_bypasses_per_page_acls(integration):
     assert resp.status_code in (200, 201)
 
 
-@pytest.mark.xfail(reason="search stubbed until OpenSearch lands", strict=True)
+@needs_opensearch
 def test_search_filters_out_unauthorized_hits(integration):
     alice = integration.signup(email="alice@x.com")
     integration.put_doc("docs/public.md", "# Public\n\nfindme keyword")
@@ -349,7 +348,7 @@ def test_delete_then_recreate_does_not_inherit_old_grants(integration):
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(reason="search stubbed until OpenSearch lands", strict=True)
+@needs_opensearch
 def test_search_returns_hits_via_group_grant(integration):
     admin = integration.signup(email="admin@x.com")
     alice = integration.signup(email="alice@x.com")
@@ -378,7 +377,7 @@ def test_search_returns_hits_via_group_grant(integration):
     assert "private/note.md" in paths
 
 
-@pytest.mark.xfail(reason="search stubbed until OpenSearch lands", strict=True)
+@needs_opensearch
 def test_search_returns_hits_via_folder_cascade(integration):
     integration.signup(email="admin@x.com")
     alice = integration.signup(email="alice@x.com")

--- a/backend/tests/test_agent_tool_permissions.py
+++ b/backend/tests/test_agent_tool_permissions.py
@@ -21,6 +21,7 @@ import pytest
 from app.auth import User
 from app.wiki import acl, git as wiki_git
 from tests._seed import seed_user
+from tests.conftest import needs_opensearch
 
 
 @pytest.fixture
@@ -207,15 +208,15 @@ def test_edit_doc_read_only_grant_still_denies_write(
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(reason="search stubbed until OpenSearch lands", strict=True)
+@needs_opensearch
 def test_search_wiki_filters_hits_per_user(repo_with_private_page, monkeypatch):
     """search_wiki should respect the calling user's visibility — Bob
     cannot see hits in Alice's private page even when the BM25 index
     has them."""
     from app.llm.agents.tools.search_wiki import handle
-    from app.tasks.reindex import reindex_path_inline
+    from app.tasks.reindex import index_path_inline
 
-    reindex_path_inline("docs/spec.md")
+    index_path_inline("docs/spec.md")
 
     # Alice (owner) finds the hit.
     with _as_user(monkeypatch, repo_with_private_page["alice"]):
@@ -230,12 +231,12 @@ def test_search_wiki_filters_hits_per_user(repo_with_private_page, monkeypatch):
     assert "docs/spec.md" not in paths
 
 
-@pytest.mark.xfail(reason="search stubbed until OpenSearch lands", strict=True)
+@needs_opensearch
 def test_search_wiki_admin_sees_everything(repo_with_private_page, monkeypatch):
     from app.llm.agents.tools.search_wiki import handle
-    from app.tasks.reindex import reindex_path_inline
+    from app.tasks.reindex import index_path_inline
 
-    reindex_path_inline("docs/spec.md")
+    index_path_inline("docs/spec.md")
     with _as_user(monkeypatch, "u_admin", is_admin=True):
         out = handle({"query": "findme"})
     paths = [r["path"] for r in out.get("results", [])]

--- a/backend/tests/test_mcp_server_tools.py
+++ b/backend/tests/test_mcp_server_tools.py
@@ -18,6 +18,7 @@ from app.main import create_app
 from app.mcp_server import session as mcp_session
 from app.mcp_server import tools as mcp_tools
 from app.wiki import acl as wiki_acl
+from tests.conftest import needs_opensearch
 from app.wiki import git as wiki_git
 
 from tests._seed import seed_user
@@ -277,17 +278,17 @@ def test_call_with_missing_name_is_invalid_params(client):
 # --------------------------------------------------------------------------- #
 
 
-@pytest.mark.xfail(reason="search stubbed until OpenSearch lands", strict=True)
+@needs_opensearch
 def test_search_wiki_returns_results_via_mcp(client):
     uid = seed_user(uid="u1", email="u1@x.com")
     # The reindex task is bound to lightweight_maintenance_queue. Run it
     # inline here so the search index sees the doc the test seeded.
     from app.tasks.queues import lightweight_maintenance_queue
-    from app.tasks.reindex import reindex_path_inline
+    from app.tasks.reindex import index_path_inline
 
     with lightweight_maintenance_queue.immediate_mode():
         wiki_git.commit_file("guide.md", "# Distributed search rocks\n", "seed", author=None)
-        reindex_path_inline("guide.md")
+        index_path_inline("guide.md")
 
     headers = _handshake(client, _mint(uid))
     rpc = _call_tool(client, headers, "search_wiki", {"query": "distributed"})


### PR DESCRIPTION
  Replaces the stub fts.py / reindex.py that returned empty results with a real OpenSearch implementation.

  What changed:
  - fts.py — lazy client init from OPENSEARCH_URL, BM25 multi_match search over title^3 / body, ACL visibility post-filter, graceful noop when OpenSearch is unavailable
  - reindex.py — reindex_path_inline reads from git and indexes on write; hourly reconcile_bm25_index cron catches missed events
  - config.py / pyproject.toml — OPENSEARCH_URL, OPENSEARCH_INDEX env vars; opensearch-py dependency
  - Tests — 6 xfail markers replaced with @needs_opensearch (skip when OpenSearch not reachable); per-test index names for parallel-safe isolation

  No vector search — pure BM25 keyword matching only.