### PR TITLE
chore(wiki): switch to jemalloc from glibc for memory allocator

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,8 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 # git is required — the wiki is a git repo and the backend shells out to it.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends git ca-certificates \
+ && apt-get install -y --no-install-recommends git ca-certificates libjemalloc2 \
  && rm -rf /var/lib/apt/lists/*
+
+# Use jemalloc instead of glibc malloc to reduce memory fragmentation
+ENV LD_PRELOAD=libjemalloc.so.2
 
 WORKDIR /app
 


### PR DESCRIPTION
Use jemalloc instead of glibc malloc to reduce memory fragmentation


  - The backend is a long-running FastAPI service handling many requests with lots of small, short-lived Python objects — exactly the workload where glibc malloc fragments badly over time
  - The worker processes are even longer-lived and process tasks continuously

  The main benefit is RSS staying flat over time rather than slowly growing due to fragmentation. It won't reduce peak memory usage, but it prevents the  "memory leak that isn't really a leak" pattern common in Python web services.

  The downside is essentially zero — libjemalloc2 is a mature, widely-used library and the overhead is negligible.