### PR TITLE
feat(ingest): Onyx document ingestion with API key auth

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -19,6 +19,7 @@ from app.models.admin import (
     BraintrustView,
     IngestConfigRequest,
     IngestView,
+    RegenerateKeyResponse,
     LLMConfigRequest,
     LLMView,
     OkResponse,
@@ -242,7 +243,7 @@ _MAX_DOC_CHARS = 5_000_000
 
 
 def _ingest_view(s: IngestSettings) -> IngestView:
-    return IngestView(max_doc_chars=s.max_doc_chars)
+    return IngestView(max_doc_chars=s.max_doc_chars, api_key=s.api_key)
 
 
 @router.get("/ingest", response_model=IngestView)
@@ -265,6 +266,13 @@ def put_ingest(
         actor.id, req.max_doc_chars,
     )
     return _ingest_view(ingest_settings.get())
+
+
+@router.post("/ingest/regenerate-key", response_model=RegenerateKeyResponse)
+def regenerate_ingest_key(actor: User = Depends(require_admin)) -> RegenerateKeyResponse:
+    key = ingest_settings.regenerate_key()
+    log.info("admin: %s regenerated ingest api_key", actor.id)
+    return RegenerateKeyResponse(api_key=key)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/api/documents.py
+++ b/backend/app/api/documents.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import logging
 import re
+import secrets
 import subprocess
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 
 from app.auth import User, require_can
@@ -461,17 +462,26 @@ def set_file_draft(
     )
 
 
+def _require_ingest_key(request: Request) -> None:
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    token = auth[len("Bearer "):]
+    stored = ingest_settings.get().api_key
+    if not stored or not secrets.compare_digest(token, stored):
+        raise HTTPException(status_code=401, detail="invalid api key")
+
+
 @router.post(
     "/ingest",
     response_model=IngestResponse,
     status_code=status.HTTP_202_ACCEPTED,
     responses={413: {"model": IngestTooLargeResponse}},
 )
-def ingest_update(req: IngestRequest) -> IngestResponse | JSONResponse:
+def ingest_update(request: Request, req: IngestRequest) -> IngestResponse | JSONResponse:
     """Receive a document push from an external system. Returns 202
-    on enqueue, 413 on size overflow.
-
-    Auth: not yet implemented — matches the ``webhooks`` pattern."""
+    on enqueue, 413 on size overflow."""
+    _require_ingest_key(request)
     if not req.content.strip():
         raise RequestError("content is required and must be a non-empty string")
 

--- a/backend/app/db/migrations/versions/0018_ingest_api_key.py
+++ b/backend/app/db/migrations/versions/0018_ingest_api_key.py
@@ -1,0 +1,34 @@
+"""ingest_settings.api_key: bearer token for POST /api/documents/ingest
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-13 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0018"
+down_revision: str | None = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("ingest_settings")}
+    if "api_key" in cols:
+        return
+    op.add_column(
+        "ingest_settings",
+        sa.Column("api_key", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("ingest_settings", "api_key")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -412,6 +412,7 @@ class IngestSettings(Base):
     max_doc_chars: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("100000")
     )
+    api_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
 
     __table_args__ = (CheckConstraint("id = 1", name="ingest_settings_singleton"),)

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 from datetime import datetime, timezone
 
 from pydantic import BaseModel, ConfigDict
@@ -18,14 +19,15 @@ class IngestSettings(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     max_doc_chars: int
+    api_key: str | None
 
 
 def get() -> IngestSettings:
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            return IngestSettings(max_doc_chars=DEFAULT_MAX_DOC_CHARS)
-        return IngestSettings(max_doc_chars=row.max_doc_chars)
+            return IngestSettings(max_doc_chars=DEFAULT_MAX_DOC_CHARS, api_key=None)
+        return IngestSettings(max_doc_chars=row.max_doc_chars, api_key=row.api_key)
 
 
 def upsert(*, max_doc_chars: int) -> None:
@@ -38,3 +40,20 @@ def upsert(*, max_doc_chars: int) -> None:
             row.max_doc_chars = max_doc_chars
             row.updated_at = now
     log.info("ingest_settings upserted max_doc_chars=%d", max_doc_chars)
+
+
+def regenerate_key() -> str:
+    """Generate a new API key, persist it, and return it."""
+    key = secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        row = s.get(IngestSettingsRow, 1)
+        if row is None:
+            s.add(IngestSettingsRow(
+                id=1, max_doc_chars=DEFAULT_MAX_DOC_CHARS, api_key=key, updated_at=now,
+            ))
+        else:
+            row.api_key = key
+            row.updated_at = now
+    log.info("ingest_settings: api_key regenerated")
+    return key

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -103,6 +103,11 @@ class WebView(BaseModel):
 
 class IngestView(BaseModel):
     max_doc_chars: int
+    api_key: str | None
+
+
+class RegenerateKeyResponse(BaseModel):
+    api_key: str
 
 
 class BraintrustView(BaseModel):

--- a/backend/app/web/firecrawl.py
+++ b/backend/app/web/firecrawl.py
@@ -30,7 +30,7 @@ class FirecrawlClient(CrawlProvider):
     def __init__(self, api_key: str) -> None:
         if not api_key:
             raise ValueError("Firecrawl api_key is required")
-        self._headers = {
+        self._headers: dict[str, str | bytes] = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }

--- a/backend/app/web/serper.py
+++ b/backend/app/web/serper.py
@@ -27,7 +27,7 @@ class SerperClient(SearchProvider):
     def __init__(self, api_key: str) -> None:
         if not api_key:
             raise ValueError("Serper api_key is required")
-        self._headers = {
+        self._headers: dict[str, str | bytes] = {
             "X-API-KEY": api_key,
             "Content-Type": "application/json",
         }

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useRouter } from "next/navigation";
+
+import { AppShell } from "@/components/common/AppShell";
+import { Button } from "@/components/common/Button";
+import { BackLink, PageHeader } from "@/components/common/PageHeader";
+import { apiFetch } from "@/lib/api";
+import { useRequireAuth } from "@/lib/auth";
+import { color, radius } from "@/lib/theme";
+import { useIsMobile } from "@/lib/viewport";
+
+interface IngestSettings {
+  max_doc_chars: number;
+  api_key: string | null;
+}
+
+export default function AdminIngestPage() {
+  const { user, loading } = useRequireAuth();
+  const router = useRouter();
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    if (!loading && user && !user.is_admin) router.replace("/");
+  }, [loading, user, router]);
+
+  if (loading || !user) return <main style={{ padding: isMobile ? 16 : 32 }}>Loading…</main>;
+  if (!user.is_admin) return null;
+
+  return (
+    <AppShell>
+      <main style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 720 }}>
+        <BackLink />
+        <PageHeader
+          title="Onyx connection"
+          description="Connect your Onyx instance to automatically push indexed documents into this wiki. Copy the base URL and API key below into your Onyx environment variables."
+        />
+        <IngestForm />
+      </main>
+    </AppShell>
+  );
+}
+
+function IngestForm() {
+  const [settings, setSettings] = useState<IngestSettings | null>(null);
+  const [maxDocChars, setMaxDocChars] = useState("");
+  const [keyVisible, setKeyVisible] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [baseUrl, setBaseUrl] = useState("");
+
+  useEffect(() => {
+    setBaseUrl(window.location.origin);
+  }, []);
+
+  async function load() {
+    try {
+      const r = await apiFetch<IngestSettings>("/admin/ingest");
+      setSettings(r);
+      setMaxDocChars(String(r.max_doc_chars));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to load");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!settings) return;
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const r = await apiFetch<IngestSettings>("/admin/ingest", {
+        method: "PUT",
+        body: JSON.stringify({ max_doc_chars: Number(maxDocChars) }),
+      });
+      setSettings(r);
+      setSaved("Saved.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function regenerateKey() {
+    if (
+      settings?.api_key &&
+      !confirm("Regenerate the API key? The old key will stop working immediately.")
+    )
+      return;
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const r = await apiFetch<{ api_key: string }>("/admin/ingest/regenerate-key", {
+        method: "POST",
+      });
+      setSettings((prev) => (prev ? { ...prev, api_key: r.api_key } : prev));
+      setKeyVisible(true);
+      setSaved("New API key generated. Copy it now — it will be masked after you leave this page.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to regenerate");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function copyToClipboard(text: string) {
+    try {
+      await navigator.clipboard.writeText(text);
+    } catch {
+      // fallback: select text
+    }
+  }
+
+  if (!settings) return <div>Loading…</div>;
+
+  const dirty = maxDocChars !== String(settings.max_doc_chars);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
+      {/* Connection details */}
+      <section>
+        <h3 style={{ margin: "0 0 12px", fontSize: 14, fontWeight: 600 }}>Connection details</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {/* Base URL */}
+          <div>
+            <div style={lblStyle}>Base URL</div>
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontFamily: "ui-monospace, monospace", fontSize: 13, color: color.text.primary }}>
+                {baseUrl}/api/documents/ingest
+              </span>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => void copyToClipboard(`${baseUrl}/api/documents/ingest`)}
+              >
+                Copy
+              </Button>
+            </div>
+          </div>
+
+          {/* API Key */}
+          <div>
+            <div style={lblStyle}>API key</div>
+            <div style={{ display: "flex", gap: 8 }}>
+              <input
+                readOnly
+                type={keyVisible ? "text" : "password"}
+                value={settings.api_key ?? ""}
+                placeholder={settings.api_key ? undefined : "No key yet — click Regenerate"}
+                style={{ ...inputStyle, flex: 1, fontFamily: settings.api_key ? "ui-monospace, monospace" : undefined }}
+              />
+              {settings.api_key && keyVisible && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => void copyToClipboard(settings.api_key ?? "")}
+                >
+                  Copy
+                </Button>
+              )}
+              <Button
+                type="button"
+                variant={settings.api_key ? "secondary" : "primary"}
+                size="sm"
+                disabled={saving}
+                onClick={() => void regenerateKey()}
+              >
+                Regenerate
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Max doc size */}
+      <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>Ingest settings</h3>
+        <label>
+          <div style={lblStyle}>Max document size (characters)</div>
+          <input
+            type="number"
+            min={1000}
+            max={5000000}
+            value={maxDocChars}
+            onChange={(e) => setMaxDocChars(e.target.value)}
+            style={{ ...inputStyle, width: 160 }}
+          />
+        </label>
+        {error && <div style={{ color: color.state.danger.fg }}>{error}</div>}
+        {saved && <div style={{ color: color.state.success.fg }}>{saved}</div>}
+        <div>
+          <Button type="submit" variant="primary" disabled={saving || !dirty}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "8px 10px",
+  boxSizing: "border-box",
+  border: `1px solid ${color.border.default}`,
+  borderRadius: radius.sm,
+  fontSize: 14,
+};
+const lblStyle: React.CSSProperties = { marginBottom: 4, fontSize: 13, fontWeight: 500 };
+const hintStyle: React.CSSProperties = {
+  fontWeight: 400,
+  color: color.text.muted,
+  fontFamily: "ui-monospace, monospace",
+  fontSize: 12,
+};

--- a/frontend/src/app/agents/page.tsx
+++ b/frontend/src/app/agents/page.tsx
@@ -14,6 +14,7 @@ import {
   type CreatedToken,
   type TokenSummary,
 } from "@/lib/agents";
+import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
 import { color, radius } from "@/lib/theme";
 import { useIsMobile } from "@/lib/viewport";
@@ -35,6 +36,7 @@ export default function AgentsPage() {
         <EndpointBlock />
         <TokenManager />
         <ClientConfigHelp />
+        {user.is_admin && <OnyxConnection />}
       </main>
     </AppShell>
   );
@@ -339,6 +341,95 @@ function ClientConfigHelp() {
           </pre>
         </div>
       )}
+    </section>
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Onyx connection (admin only)                                               //
+// --------------------------------------------------------------------------- //
+
+interface IngestSettings {
+  api_key: string | null;
+}
+
+function OnyxConnection() {
+  const [settings, setSettings] = useState<IngestSettings | null>(null);
+  const [ingestUrl, setIngestUrl] = useState("");
+  const [keyVisible, setKeyVisible] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    setIngestUrl(`${window.location.origin}/api/documents/ingest`);
+    apiFetch<IngestSettings>("/admin/ingest")
+      .then(setSettings)
+      .catch((e) => setError(e instanceof Error ? e.message : "failed to load"));
+  }, []);
+
+  async function regenerate() {
+    if (
+      settings?.api_key &&
+      !confirm("Regenerate the API key? The old key will stop working immediately.")
+    )
+      return;
+    setBusy(true);
+    setError(null);
+    setNotice(null);
+    try {
+      const r = await apiFetch<{ api_key: string }>("/admin/ingest/regenerate-key", { method: "POST" });
+      setSettings((prev) => (prev ? { ...prev, api_key: r.api_key } : prev));
+      setKeyVisible(true);
+      setNotice("New key generated. Copy it now — it will be masked after you leave this page.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to regenerate");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section style={card}>
+      <h2 style={{ margin: "0 0 12px", fontSize: 16 }}>Onyx connection</h2>
+      <div style={{ fontSize: 13, color: color.text.muted, marginBottom: 16 }}>
+        Push indexed documents from Onyx into this wiki automatically. Copy the endpoint and API key
+        into your Onyx environment variables.
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+        {/* Ingest URL */}
+        <div>
+          <div style={{ fontSize: 13, color: color.text.muted, marginBottom: 6 }}>Endpoint URL</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <code style={codeBlock}>{ingestUrl || "—"}</code>
+            <CopyButton text={ingestUrl} />
+          </div>
+        </div>
+
+        {/* API key */}
+        <div>
+          <div style={{ fontSize: 13, color: color.text.muted, marginBottom: 6 }}>API key</div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <code style={codeBlock}>
+              {settings === null
+                ? "Loading…"
+                : settings.api_key
+                ? keyVisible
+                  ? settings.api_key
+                  : "••••••••••••••••••••••••••••••••"
+                : "No key yet — click Regenerate"}
+            </code>
+            {settings?.api_key && keyVisible && <CopyButton text={settings.api_key} />}
+            <Button size="sm" variant={settings?.api_key ? "secondary" : "primary"} disabled={busy} onClick={() => void regenerate()}>
+              {busy ? "…" : "Regenerate"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {notice && <div style={{ fontSize: 13, color: color.state.success.fg, marginTop: 10 }}>{notice}</div>}
+      {error && <div style={{ fontSize: 13, color: color.state.danger.fg, marginTop: 10 }}>{error}</div>}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `api_key` column to `ingest_settings` table (migration `0018`)
- `POST /admin/ingest/regenerate-key` — generates and stores a new bearer token (admin only)
- `GET /admin/ingest` — returns current key alongside `max_doc_chars`
- `POST /api/documents/ingest` — validates `Authorization: Bearer <key>`, returns 401 if missing or wrong
- Onyx connection section on the Agents page (admin only) — shows ingest endpoint URL and API key with Regenerate button
- Updates architecture docs

## Test plan
- [ ] `POST /admin/ingest/regenerate-key` returns a new key
- [ ] `POST /api/documents/ingest` with valid bearer returns 202
- [ ] `POST /api/documents/ingest` with missing/wrong token returns 401
- [ ] Onyx connection section visible on `/agents` for admin, hidden for non-admin
- [ ] API key masked on page load, visible after Regenerate
<img width="984" height="692" alt="Screenshot 2026-05-13 at 1 43 36 PM" src="https://github.com/user-attachments/assets/056ff4e7-816c-4849-bc7d-61205f93774f" />

