### PR TITLE
fix(wiki): fix opensearch URL parsing in prod

### DIFF
--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -50,7 +50,11 @@ def _make_client(url: str) -> object:
 
     parsed = urlparse(url)
     use_ssl = parsed.scheme == "https"
-    port = parsed.port or (443 if use_ssl else 9200)
+    try:
+        port = parsed.port or (443 if use_ssl else 9200)
+    except ValueError:
+        # URL has special chars in password that break port parsing; use default
+        port = 443 if use_ssl else 9200
     host = {"host": parsed.hostname or "localhost", "port": port}
 
     kwargs: dict[str, object] = {


### PR DESCRIPTION
 The OpenSearch URL in production has special characters in the password (s?(z-C]Ixm]]9n{9) which break URL parsing when trying to extract the port. This PR fixed it.