### PR TITLE
fix(wiki_fts): index all wiki pages inline at backend startup

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -115,7 +115,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     """
     from app.db.session import init_db
     from app.tasks.agent_activity import schedule_all_pending_cleanups
-    from app.tasks.reindex import reindex_all_inline
     from app.triggers import repo as triggers_repo
     from app.utils.logging import setup_logging
     from app.wiki.git import ensure_wiki_repo
@@ -130,7 +129,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # through the normal commit + notify path (FTS index, ACLs, MCP
     # fan-out all fire identically to a UI save).
     seed_if_empty(_app_config.CONFIG.wiki_dir)
-    reindex_all_inline()
     # Starter document templates seed once on a brand-new DB; users
     # who delete a starter will not see it re-appear after a reboot.
     seed_starter_templates_if_empty()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -115,6 +115,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     """
     from app.db.session import init_db
     from app.tasks.agent_activity import schedule_all_pending_cleanups
+    from app.tasks.reindex import reindex_all_inline
     from app.triggers import repo as triggers_repo
     from app.utils.logging import setup_logging
     from app.wiki.git import ensure_wiki_repo
@@ -129,6 +130,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # through the normal commit + notify path (FTS index, ACLs, MCP
     # fan-out all fire identically to a UI save).
     seed_if_empty(_app_config.CONFIG.wiki_dir)
+    reindex_all_inline()
     # Starter document templates seed once on a brand-new DB; users
     # who delete a starter will not see it re-appear after a reboot.
     seed_starter_templates_if_empty()

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -66,6 +66,25 @@ def index_path_inline(path: str) -> None:
 # --------------------------------------------------------------------------- #
 
 
+def reindex_all_inline() -> None:
+    """Index every .md page currently in the wiki.
+
+    Called at backend startup so freshly-seeded pages (and any pages that
+    missed indexing due to a worker race at boot) are searchable immediately
+    without waiting for the hourly reconcile or the worker queue.
+
+    Upserts are idempotent — re-indexing an already-indexed page is safe.
+    """
+    from app.wiki import git as wiki_git
+
+    paths = [p for p in wiki_git.list_paths() if p.endswith(".md")]
+    if not paths:
+        return
+    log.info("reindex: indexing %d wiki page(s) at startup", len(paths))
+    for path in paths:
+        index_path_inline(path)
+
+
 @lightweight_maintenance_queue.periodic_task(crontab(minute="0"))
 def reconcile_bm25_index() -> None:
     """Re-index any .md files touched in the last 2 hours."""

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -23,6 +23,7 @@ import re
 from app.db import fts
 from app.tasks.queue import crontab
 from app.tasks.queues import lightweight_maintenance_queue
+from app.wiki import git as wiki_git
 
 log = logging.getLogger(__name__)
 
@@ -49,8 +50,6 @@ def index_path_inline(path: str) -> None:
     if not path.endswith(".md"):
         return
 
-    from app.wiki import git as wiki_git
-
     try:
         body = wiki_git.read_file(path)
     except Exception:
@@ -75,8 +74,6 @@ def reindex_all_inline() -> None:
 
     Upserts are idempotent — re-indexing an already-indexed page is safe.
     """
-    from app.wiki import git as wiki_git
-
     paths = [p for p in wiki_git.list_paths() if p.endswith(".md")]
     if not paths:
         return
@@ -88,8 +85,6 @@ def reindex_all_inline() -> None:
 @lightweight_maintenance_queue.periodic_task(crontab(minute="0"))
 def reconcile_bm25_index() -> None:
     """Re-index any .md files touched in the last 2 hours."""
-    from app.wiki import git as wiki_git
-
     touched = {p for p in wiki_git.paths_touched_since("2 hours ago") if p.endswith(".md")}
     if not touched:
         return

--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -28,6 +28,8 @@ from pathlib import Path
 
 from sqlalchemy import text
 
+from app.tasks.reindex import reindex_all_inline
+
 log = logging.getLogger(__name__)
 
 
@@ -146,4 +148,5 @@ def seed_if_empty(target_dir: str) -> bool:
     written = write_seed_pages(Path(target_dir), overwrite_existing=False)
     if written > 0:
         _stamp_seed_marker()
+        reindex_all_inline()
     return written > 0


### PR DESCRIPTION
## Problem

After `seed_if_empty` writes pages, `after_doc_write` enqueues `index_path` tasks to the worker queue. Locally the worker often races against OpenSearch at boot — if OpenSearch isn't ready when the worker starts, the FTS client init fails and `_client_ready` gets set to `True` with `_client = None`. All subsequent indexing tasks are silently skipped, leaving seeded pages unsearchable until the hourly reconcile.

This was first reported by Yuhong — fresh local deploy, wiki has content, search returns nothing.

## Fix

Add `reindex_all_inline()` to `reindex.py` and call it from the backend lifespan after `seed_if_empty`. It indexes every `.md` page synchronously in the backend process, which by that point already has a working FTS client (or skips cleanly if OpenSearch isn't configured). Upserts are idempotent so re-indexing an already-indexed page is safe.

This also covers the production case where a node replacement left the worker with a stale FTS client — the backend's startup reconcile heals the index without needing a worker restart.