### PR TITLE
feat(ingest): log BM25 scores and candidate filtering

### DIFF
--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -14,8 +14,12 @@ from __future__ import annotations
 
 import re
 
+import logging
+
 from app.config import CONFIG
 from app.db.fts import SearchHit, search as fts_search
+
+log = logging.getLogger(__name__)
 
 _TOKEN_RE = re.compile(r"\w+")
 
@@ -38,18 +42,28 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
     """
     hits = fts_search(content, limit=CONFIG.ingest_bm25_limit, apply_visibility=False)
     if not hits:
+        log.debug("ingest candidates: no BM25 hits for title=%r", title)
         return []
 
     query_title_tokens: set[str] = _tokens(title) if title else set()
 
     boosted: list[SearchHit] = []
     for hit in hits:
-        score = hit.score
+        raw_score = hit.score
+        score = raw_score
         if query_title_tokens and hit.title:
             sim = _jaccard(query_title_tokens, _tokens(hit.title))
             score += sim * CONFIG.ingest_bm25_title_boost
+        log.debug(
+            "ingest candidate: path=%r raw_bm25=%.3f boosted=%.3f threshold=%.3f pass=%s",
+            hit.path, raw_score, score, CONFIG.ingest_bm25_min_score, score >= CONFIG.ingest_bm25_min_score,
+        )
         if score >= CONFIG.ingest_bm25_min_score:
             boosted.append(hit.model_copy(update={"score": score}))
 
+    log.info(
+        "ingest candidates: title=%r hits=%d passed=%d threshold=%.3f",
+        title, len(hits), len(boosted), CONFIG.ingest_bm25_min_score,
+    )
     boosted.sort(key=lambda h: h.score, reverse=True)
     return boosted


### PR DESCRIPTION
## What

Adds logging to the ingest BM25 candidate search so score distribution is visible without enabling full debug traces.

**Per-push (INFO):**
```
ingest candidates: title='oncal.docx' hits=1 passed=1 threshold=1.000
```

**Per-candidate (DEBUG):**
```
ingest candidate: path='engineering/on-call-runbook.md' raw_bm25=0.423 boosted=0.423 threshold=1.000 pass=False
```

## Why

Without score visibility, it's impossible to tune `INGEST_BM25_MIN_SCORE`. The Onyx docs flood showed that completely unrelated docs were passing the threshold — but we had no data on what scores they were actually getting.

## Next

Prometheus metrics for score histograms, queue depth, and outcome rates (committed/no_change/irrelevant).