### PR TITLE
fix(markdown): restore heading sizes and list styles stripped by Tailwind Preflight

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -182,7 +182,19 @@ textarea::placeholder {
 .markdown h3,
 .markdown h4 {
   color: var(--color-text-primary);
+  font-weight: 600;
+  line-height: 1.3;
 }
+.markdown h1 { font-size: 1.875em; margin: 28px 0 10px; }
+.markdown h2 { font-size: 1.5em;   margin: 24px 0 8px; }
+.markdown h3 { font-size: 1.25em;  margin: 20px 0 6px; }
+.markdown h4 { font-size: 1.1em;   margin: 16px 0 4px; }
+.markdown p  { margin: 10px 0; }
+.markdown ul,
+.markdown ol { margin: 10px 0; padding-left: 24px; }
+.markdown ul { list-style: disc; }
+.markdown ol { list-style: decimal; }
+.markdown li { margin: 4px 0; }
 .markdown a {
   color: var(--color-text-primary);
   text-decoration: underline;


### PR DESCRIPTION
## Summary

- Tailwind v4's Preflight CSS reset zeroes out all heading font sizes (`h1`–`h4` inherit body size), making wiki pages render without any visual hierarchy
- Added explicit `font-size`, `font-weight`, and `margin` for `h1`–`h4` inside `.markdown`
- Also added missing `p`, `ul`, `ol`, `li` spacing rules that were similarly unstyled

## Root cause

`globals.css` had `.markdown h1–h4 { color: ... }` but no size/weight/margin. This worked before Tailwind Preflight was included; once Preflight zeroed the browser defaults, the rules needed to be explicit.

<img width="1123" height="778" alt="Screenshot 2026-05-15 at 1 09 15 PM" src="https://github.com/user-attachments/assets/82f10b2d-823c-4fa9-b65e-8dd26ca5b5cd" />

