### PR TITLE
feat(helm): add ServiceMonitor for Prometheus scraping

### DIFF
--- a/deploy/helm/agent-workspace/templates/servicemonitor.yaml
+++ b/deploy/helm/agent-workspace/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-backend
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: backend
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+{{- end }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -158,3 +158,11 @@ securityContext: {}
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+monitoring:
+  serviceMonitor:
+    # Set to true when kube-prometheus-stack is installed in the cluster.
+    enabled: false
+    # Extra labels added to the ServiceMonitor — must match the Prometheus
+    # Operator's serviceMonitorSelector (if set). Typically {"release": "<helm-release-name>"}.
+    labels: {}


### PR DESCRIPTION
## Summary

- Adds `ServiceMonitor` CRD template to the Helm chart — tells Prometheus Operator to scrape the backend's `/metrics` endpoint every 30s
- Gated behind `monitoring.serviceMonitor.enabled` (default `false`) so it's a no-op until kube-prometheus-stack is installed in the cluster
- Follows the same pattern as the Onyx Helm chart (`api-servicemonitor.yaml`)

## How to enable

In the deploy values (e.g. `dev-wiki-values.yaml`):
```yaml
monitoring:
  serviceMonitor:
    enabled: true
    labels:
      release: agent-wiki-monitoring
```