### PR TITLE
feat(terraform): add optional kube-prometheus-stack for self-hosted monitoring

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -288,3 +288,34 @@ resource "kubernetes_manifest" "letsencrypt_issuer" {
 
   depends_on = [helm_release.cert_manager]
 }
+
+# ----------------------------------------------------------------------------
+# Monitoring — kube-prometheus-stack (Prometheus + Grafana)
+#
+# Optional. Set monitoring_enabled = true in your tfvars to install.
+# Installs Prometheus Operator, Prometheus, and Grafana into the agent-wiki
+# namespace. Prometheus scrapes the backend via the ServiceMonitor defined in
+# the agent-workspace Helm chart (enable monitoring.serviceMonitor in values).
+#
+# Prerequisites before running `terraform apply` with monitoring_enabled = true:
+#   1. Create the grafana-oauth-secret if using OAuth:
+#      kubectl -n agent-wiki create secret generic grafana-oauth-secret \
+#        --from-literal=GF_AUTH_GOOGLE_CLIENT_ID=<id> \
+#        --from-literal=GF_AUTH_GOOGLE_CLIENT_SECRET=<secret>
+#   2. Set root_url in monitoring-values.yaml to match your domain.
+# ----------------------------------------------------------------------------
+
+resource "helm_release" "monitoring" {
+  count = var.monitoring_enabled ? 1 : 0
+
+  name             = "agent-wiki-monitoring"
+  repository       = "https://prometheus-community.github.io/helm-charts"
+  chart            = "kube-prometheus-stack"
+  version          = "82.10.5"
+  namespace        = "agent-wiki"
+  create_namespace = false
+
+  values = [file("${path.module}/monitoring-values.yaml")]
+
+  depends_on = [module.eks]
+}

--- a/deploy/terraform/monitoring-values.yaml
+++ b/deploy/terraform/monitoring-values.yaml
@@ -1,0 +1,66 @@
+kubeEtcd:
+  enabled: false
+
+kubeControllerManager:
+  enabled: false
+
+kubeScheduler:
+  enabled: false
+
+alertmanager:
+  enabled: false
+
+grafana:
+  enabled: true
+  service:
+    type: ClusterIP
+    port: 80
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: agent-wiki
+  persistence:
+    enabled: true
+    storageClassName: gp3
+    size: 10Gi
+  # Optional: mount a secret with OAuth credentials.
+  # Create with: kubectl -n agent-wiki create secret generic grafana-oauth-secret \
+  #   --from-literal=GF_AUTH_GOOGLE_CLIENT_ID=<id> \
+  #   --from-literal=GF_AUTH_GOOGLE_CLIENT_SECRET=<secret>
+  # Then uncomment the line below.
+  # envFromSecret: grafana-oauth-secret
+  grafana.ini:
+    server:
+      # Set to the public URL where Grafana will be reachable.
+      # If served from a sub-path (e.g. /monitoring), set serve_from_sub_path: true.
+      root_url: https://example.com/monitoring
+      serve_from_sub_path: true
+    auth:
+      disable_login_form: false
+    # Uncomment to enable Google OAuth:
+    # auth.google:
+    #   enabled: true
+    #   allow_sign_up: true
+    #   scopes: openid email profile
+    #   auth_url: https://accounts.google.com/o/oauth2/v2/auth
+    #   token_url: https://oauth2.googleapis.com/token
+    #   api_url: https://openidconnect.googleapis.com/v1/userinfo
+    #   allowed_domains: example.com
+    #   use_pkce: true
+
+prometheus:
+  prometheusSpec:
+    retention: 7d
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: gp3
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 30Gi

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -55,6 +55,12 @@ variable "cert_manager_email" {
   default     = ""
 }
 
+variable "monitoring_enabled" {
+  type        = bool
+  description = "Install kube-prometheus-stack (Prometheus + Grafana) into the agent-wiki namespace."
+  default     = false
+}
+
 variable "tags" {
   type        = map(string)
   description = "Default tags applied to all AWS resources."


### PR DESCRIPTION
## Summary

- Adds `monitoring_enabled` variable (default: `false`) to `deploy/terraform/variables.tf`
- Adds optional `helm_release "monitoring"` block to `deploy/terraform/main.tf` that installs kube-prometheus-stack (Prometheus + Grafana) when enabled
- Adds `deploy/terraform/monitoring-values.yaml` — a generic template with placeholder domain and commented-out OAuth config

## How to use

Set `monitoring_enabled = true` in your `tfvars`, update `monitoring-values.yaml` with your domain and optional OAuth credentials, then run `terraform apply`.

Also enable `monitoring.serviceMonitor.enabled: true` in your `agent-workspace` Helm values to have Prometheus scrape the backend's `/metrics` endpoint.

## Test plan

- [ ] `terraform plan` with `monitoring_enabled = false` shows no monitoring resources
- [ ] `terraform plan` with `monitoring_enabled = true` shows `helm_release.monitoring[0]`
- [ ] Grafana reachable at `<domain>/monitoring` after apply