### PR TITLE
feat(metrics): expose Prometheus metrics endpoint on worker pods

### DIFF
--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -17,6 +17,7 @@ import argparse
 import logging
 import time
 
+from prometheus_client import start_http_server
 from sqlalchemy import text
 
 # Importing modules registers tasks on their respective queues.
@@ -75,6 +76,7 @@ def main() -> None:
     args = parser.parse_args()
 
     setup_logging()
+    start_http_server(9091)
     _wait_for_db()
     queue = QUEUES[args.queue]
     concurrency = _CONCURRENCY[args.queue]

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.5
+version: 0.3.6
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -49,6 +49,10 @@ spec:
           image: "{{ $.Values.image.backend.repository }}:{{ $.Values.image.backend.tag }}"
           imagePullPolicy: {{ $.Values.image.backend.pullPolicy }}
           command: ["python", "-m", "app.tasks.run_worker", {{ $queue | quote }}]
+          ports:
+            - name: metrics
+              containerPort: 9091
+              protocol: TCP
           {{- with $.Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/agent-workspace/templates/worker-podmonitor.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-podmonitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "agent-workspace.fullname" . }}-worker
+  labels:
+    {{- include "agent-workspace.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "agent-workspace.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: worker
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+{{- end }}


### PR DESCRIPTION
## Summary

- `run_worker.py` — calls `start_http_server(9091)` on startup so each worker exposes `/metrics`
- `worker-deployment.yaml` — adds `metrics` port `9091` to worker containers
- `worker-podmonitor.yaml` (new) — PodMonitor that tells Prometheus to scrape all worker pods at port `metrics`
- `Chart.yaml` — bumped to `0.3.6`

## Why

Ingest pipeline metrics (`ingest_outcomes_total`, `ingest_bm25_score`, `ingest_llm_duration_seconds`) are incremented in worker processes. Without a `/metrics` endpoint on workers, Prometheus could only see zeros from the backend scrape.

## Test plan

- [ ] After deploy, worker pods expose `http://<pod-ip>:9091/metrics`
- [ ] `kubectl -n agent-wiki get podmonitor` shows `agent-wiki-agent-workspace-worker`
- [ ] Ingest dashboard panels populate after processing a document