### PR TITLE
feat(monitoring): BM25 heatmap, outcomes donut, rename Traffic dashboard

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -40,7 +40,7 @@ ingest_bm25_passed = Histogram(
 ingest_bm25_score = Histogram(
     "ingest_bm25_score",
     "Raw BM25 score for each candidate before threshold filtering",
-    buckets=[1.0, 5.0, 10.0, 20.0, 30.0, 50.0, 75.0, 100.0, 150.0, 200.0],
+    buckets=[0.5, 1.0, 5.0, 10.0, 20.0, 30.0, 50.0, 75.0, 100.0, 150.0, 200.0],
 )
 
 ingest_outcomes_total = Counter(

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -55,6 +55,12 @@ ingest_llm_duration_seconds = Histogram(
     buckets=[0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0],
 )
 
+ingest_llm_calls_per_doc = Histogram(
+    "ingest_llm_calls_per_doc",
+    "Number of LLM calls made per document ingestion",
+    buckets=[0, 1, 2, 3, 5, 8, 10, 15, 20],
+)
+
 ingest_queue_depth = Gauge(
     "ingest_queue_depth",
     "Current number of pending tasks in the documents queue",

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -40,7 +40,7 @@ ingest_bm25_passed = Histogram(
 ingest_bm25_score = Histogram(
     "ingest_bm25_score",
     "Raw BM25 score for each candidate before threshold filtering",
-    buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 20.0, 50.0],
+    buckets=[1.0, 5.0, 10.0, 20.0, 30.0, 50.0, 75.0, 100.0, 150.0, 200.0],
 )
 
 ingest_outcomes_total = Counter(

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -31,6 +31,7 @@ from app.llm.agents.wiki_updater import IRRELEVANT_SENTINEL
 from app.llm.agents.tools import _doc_helpers as h
 from app.llm.errors import LLMError
 from app.metrics import (
+    ingest_llm_calls_per_doc,
     ingest_llm_duration_seconds,
     ingest_outcomes_total,
     ingest_queue_depth,
@@ -321,6 +322,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             else:
                 ingest_outcomes_total.labels(outcome="no_change").inc()
 
+    ingest_llm_calls_per_doc.observe(llm_calls)
     log.info(
         "process_pushed_document: done doc_id=%s source_type=%s candidates=%d "
         "llm_calls=%d committed=%d irrelevant=%d stopped_early=%s duration_ms=%d",

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -321,6 +321,44 @@
       ],
       "title": "BM25 Pass Rate (passed / hits)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 38},
+      "id": 13,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-purple", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Purples", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "LLM calls", "axisPlacement": "left", "unit": "short"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_llm_calls_per_doc_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "LLM Calls per Document",
+      "type": "heatmap"
     }
   ],
   "refresh": "30s",

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -270,7 +270,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 30},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 30},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -291,6 +291,35 @@
         }
       ],
       "title": "LLM Duration (p50 / p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 30},
+      "id": 12,
+      "options": {
+        "legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_bm25_passed_sum[5m])) / sum(rate(ingest_bm25_hits_sum[5m]))",
+          "legendFormat": "pass rate",
+          "refId": "A"
+        }
+      ],
+      "title": "BM25 Pass Rate (passed / hits)",
       "type": "timeseries"
     }
   ],

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -100,12 +100,40 @@
           "refId": "A"
         }
       ],
-      "title": "Ingest Outcomes",
+      "title": "Ingest Outcomes (rate)",
       "type": "timeseries"
     },
     {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "id": 9,
+      "options": {
+        "displayLabels": ["percent"],
+        "legend": {"displayMode": "table", "placement": "right", "values": ["value", "percent"]},
+        "pieType": "donut",
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(ingest_outcomes_total) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingest Outcomes (total breakdown)",
+      "type": "piechart"
+    },
+    {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 9},
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
       "id": 102,
       "title": "BM25 & LLM",
       "type": "row"
@@ -114,34 +142,39 @@
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
-          "unit": "short"
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 10},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
       "id": 6,
       "options": {
-        "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "BM25 score", "axisPlacement": "left", "unit": "short"}
       },
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.95, sum(rate(ingest_bm25_score_bucket[5m])) by (le))",
-          "legendFormat": "p95",
+          "expr": "sum(rate(ingest_bm25_score_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "refId": "A"
-        },
-        {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "histogram_quantile(0.50, sum(rate(ingest_bm25_score_bucket[5m])) by (le))",
-          "legendFormat": "p50",
-          "refId": "B"
         }
       ],
-      "title": "BM25 Score (p50 / p95)",
-      "type": "timeseries"
+      "title": "BM25 Score Distribution",
+      "type": "heatmap"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
@@ -153,7 +186,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 10},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 18},
       "id": 7,
       "options": {
         "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
@@ -186,7 +219,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 10},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 18},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -26,7 +26,7 @@
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 1},
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
       "id": 3,
       "options": {
         "colorMode": "background",

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -270,7 +270,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 30},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 30},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -305,7 +305,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 30},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 30},
       "id": 12,
       "options": {
         "legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom"},

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -26,7 +26,7 @@
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
+      "gridPos": {"h": 4, "w": 24, "x": 0, "y": 1},
       "id": 3,
       "options": {
         "colorMode": "background",
@@ -54,7 +54,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 10, "x": 4, "y": 1},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5},
       "id": 4,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -86,7 +86,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 10, "x": 14, "y": 1},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5},
       "id": 5,
       "options": {
         "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
@@ -112,7 +112,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 9},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13},
       "id": 9,
       "options": {
         "displayLabels": ["percent"],
@@ -133,7 +133,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 17},
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
       "id": 102,
       "title": "BM25 & LLM",
       "type": "row"
@@ -151,7 +151,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 9},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
       "id": 6,
       "options": {
         "calculate": false,
@@ -189,7 +189,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
       "id": 7,
       "options": {
         "calculate": false,
@@ -227,7 +227,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 22},
       "id": 10,
       "options": {
         "calculate": false,
@@ -262,7 +262,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 26},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 30},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -26,7 +26,7 @@
           "unit": "short"
         }
       },
-      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "gridPos": {"h": 4, "w": 4, "x": 0, "y": 1},
       "id": 3,
       "options": {
         "colorMode": "background",
@@ -43,6 +43,14 @@
       ],
       "title": "Ingest Queue Depth",
       "type": "stat"
+    },
+    {
+      "gridPos": {"h": 4, "w": 20, "x": 4, "y": 1},
+      "id": 11,
+      "options": {"content": "", "mode": "markdown"},
+      "title": "",
+      "transparent": true,
+      "type": "text"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${datasource}"},

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -36,7 +36,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "ingest_queue_depth{job=\"agent-wiki-agent-workspace-backend\"}",
+          "expr": "sum(ingest_queue_depth{job=\"agent-wiki-agent-workspace-backend\"})",
           "legendFormat": "Queue Depth",
           "refId": "A"
         }
@@ -180,34 +180,77 @@
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
       "fieldConfig": {
         "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
-          "unit": "short"
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 18},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 18},
       "id": 7,
       "options": {
-        "legend": {"calcs": ["mean"], "displayMode": "table", "placement": "bottom"},
-        "tooltip": {"mode": "multi", "sort": "desc"}
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-blue", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Blues", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "# docs hit", "axisPlacement": "left", "unit": "short"}
       },
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "rate(ingest_bm25_hits_sum[5m]) / rate(ingest_bm25_hits_count[5m])",
-          "legendFormat": "avg hits",
+          "expr": "sum(rate(ingest_bm25_hits_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "refId": "A"
-        },
-        {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "rate(ingest_bm25_passed_sum[5m]) / rate(ingest_bm25_passed_count[5m])",
-          "legendFormat": "avg passed",
-          "refId": "B"
         }
       ],
-      "title": "Avg BM25 Hits vs Passed",
-      "type": "timeseries"
+      "title": "BM25 Hits Distribution",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 18},
+      "id": 10,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-green", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Greens", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "# docs passed", "axisPlacement": "left", "unit": "short"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_bm25_passed_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BM25 Passed Distribution",
+      "type": "heatmap"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
@@ -219,7 +262,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 18},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 26},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -36,7 +36,7 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "ingest_queue_depth",
+          "expr": "ingest_queue_depth{job=\"agent-wiki-agent-workspace-backend\"}",
           "legendFormat": "Queue Depth",
           "refId": "A"
         }

--- a/deploy/helm/agent-workspace/files/wiki-traffic-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-traffic-dashboard.json
@@ -146,7 +146,7 @@
   "time": {"from": "now-6h", "to": "now"},
   "timepicker": {},
   "timezone": "browser",
-  "title": "Agent Wiki - HTTP",
+  "title": "Agent Wiki - Traffic",
   "uid": "agent-wiki-http",
   "version": 1
 }


### PR DESCRIPTION
## Summary
- Replaces BM25 score timeseries with a heatmap panel (exponential color scale, Oranges scheme)
- Adds ingest outcomes total breakdown as a donut/pie chart
- Fixes queue depth panel to filter to backend job only (avoids duplicate series from worker pods)
- Renames "Agent Wiki - HTTP" dashboard to "Agent Wiki - Traffic"

## Test plan
- [ ] Merge and run `ods deploy wiki` to publish chart 0.3.6
- [ ] Verify dashboards load at https://dev-wiki.onyx.app/monitoring