### PR TITLE
feat(monitoring): BM25 score-by-outcome metrics + dashboard layout

### DIFF
--- a/backend/app/chat/sessions.py
+++ b/backend/app/chat/sessions.py
@@ -118,7 +118,7 @@ def update_title(session_id: str, title: str) -> None:
 
 def touch(session_id: str) -> None:
     """Bump ``updated_at`` so the session sorts to the top of the list."""
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S.%f")
     with session() as s:
         row = s.get(ChatSession, session_id)
         if row is not None:

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -43,6 +43,13 @@ ingest_bm25_score = Histogram(
     buckets=[1.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 300.0, 500.0, 750.0, 1000.0, 1500.0],
 )
 
+ingest_bm25_score_by_outcome = Histogram(
+    "ingest_bm25_score_by_outcome",
+    "BM25 score distribution broken down by ingest outcome",
+    ["outcome"],
+    buckets=[1.0, 5.0, 10.0, 20.0, 50.0, 100.0, 200.0, 300.0, 500.0, 750.0, 1000.0, 1500.0],
+)
+
 ingest_outcomes_total = Counter(
     "ingest_outcomes_total",
     "Ingest pipeline outcomes",

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -31,6 +31,7 @@ from app.llm.agents.wiki_updater import IRRELEVANT_SENTINEL
 from app.llm.agents.tools import _doc_helpers as h
 from app.llm.errors import LLMError
 from app.metrics import (
+    ingest_bm25_score_by_outcome,
     ingest_llm_calls_per_doc,
     ingest_llm_duration_seconds,
     ingest_outcomes_total,
@@ -303,6 +304,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             irrelevant += 1
             consecutive_irrelevant += 1
             ingest_outcomes_total.labels(outcome="irrelevant").inc()
+            ingest_bm25_score_by_outcome.labels(outcome="irrelevant").observe(hit.score)
             log.debug(
                 "process_pushed_document: IRRELEVANT path=%s consecutive=%d",
                 hit.path, consecutive_irrelevant,
@@ -318,9 +320,11 @@ def process_pushed_document(push: dict[str, Any]) -> None:
                 wiki_notify.after_doc_write(hit.path, sha, "edit", _INGEST_AUTHOR)
                 committed += 1
                 ingest_outcomes_total.labels(outcome="committed").inc()
+                ingest_bm25_score_by_outcome.labels(outcome="committed").observe(hit.score)
                 log.info("process_pushed_document: committed %s sha=%s", hit.path, sha)
             else:
                 ingest_outcomes_total.labels(outcome="no_change").inc()
+                ingest_bm25_score_by_outcome.labels(outcome="no_change").observe(hit.score)
 
     ingest_llm_calls_per_doc.observe(llm_calls)
     log.info(

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -140,11 +140,42 @@
       "type": "piechart"
     },
     {
-      "collapsed": false,
-      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 21},
-      "id": 102,
-      "title": "BM25 & LLM",
-      "type": "row"
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "id": 17,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-purple", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Purples", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "BM25 score", "axisPlacement": "left", "unit": "short"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_bm25_score_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BM25 Score — All Outcomes",
+      "type": "heatmap"
     },
     {
       "datasource": {"type": "prometheus", "uid": "${datasource}"},
@@ -159,7 +190,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 22},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 21},
       "id": 6,
       "options": {
         "calculate": false,
@@ -197,7 +228,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 22},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 21},
       "id": 15,
       "options": {
         "calculate": false,
@@ -235,7 +266,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 22},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 21},
       "id": 16,
       "options": {
         "calculate": false,
@@ -342,6 +373,35 @@
         "defaults": {
           "color": {"mode": "palette-classic"},
           "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 38},
+      "id": 12,
+      "options": {
+        "legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom"},
+        "tooltip": {"mode": "single"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_bm25_passed_sum[5m])) / sum(rate(ingest_bm25_hits_sum[5m]))",
+          "legendFormat": "pass rate",
+          "refId": "A"
+        }
+      ],
+      "title": "BM25 Pass Rate (passed / hits)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
           "unit": "s"
         },
         "overrides": []
@@ -367,35 +427,6 @@
         }
       ],
       "title": "LLM Duration (p50 / p95)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "${datasource}"},
-      "fieldConfig": {
-        "defaults": {
-          "color": {"mode": "palette-classic"},
-          "custom": {"drawStyle": "line", "fillOpacity": 10, "lineWidth": 2},
-          "max": 1,
-          "min": 0,
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 38},
-      "id": 12,
-      "options": {
-        "legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom"},
-        "tooltip": {"mode": "single"}
-      },
-      "targets": [
-        {
-          "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "sum(rate(ingest_bm25_passed_sum[5m])) / sum(rate(ingest_bm25_hits_sum[5m]))",
-          "legendFormat": "pass rate",
-          "refId": "A"
-        }
-      ],
-      "title": "BM25 Pass Rate (passed / hits)",
       "type": "timeseries"
     },
     {

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -159,12 +159,12 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 13},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 22},
       "id": 6,
       "options": {
         "calculate": false,
         "cellGap": 1,
-        "color": {"exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64},
+        "color": {"exponent": 0.5, "fill": "dark-green", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Greens", "steps": 64},
         "exemplars": {"color": "rgba(255,0,255,0.7)"},
         "filterValues": {"le": 1e-9},
         "legend": {"show": true},
@@ -175,13 +175,13 @@
       "targets": [
         {
           "datasource": {"type": "prometheus", "uid": "${datasource}"},
-          "expr": "sum(rate(ingest_bm25_score_bucket[5m])) by (le)",
+          "expr": "sum(rate(ingest_bm25_score_by_outcome_bucket{outcome=\"committed\"}[5m])) by (le)",
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "refId": "A"
         }
       ],
-      "title": "BM25 Score Distribution",
+      "title": "BM25 Score — Committed",
       "type": "heatmap"
     },
     {
@@ -197,7 +197,83 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 22},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 22},
+      "id": 15,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-orange", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Oranges", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "BM25 score", "axisPlacement": "left", "unit": "short"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_bm25_score_by_outcome_bucket{outcome=\"irrelevant\"}[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BM25 Score — Irrelevant",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 22},
+      "id": 16,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {"exponent": 0.5, "fill": "dark-blue", "mode": "scheme", "reverse": false, "scale": "exponential", "scheme": "Blues", "steps": 64},
+        "exemplars": {"color": "rgba(255,0,255,0.7)"},
+        "filterValues": {"le": 1e-9},
+        "legend": {"show": true},
+        "rowsFrame": {"layout": "auto"},
+        "tooltip": {"mode": "single", "showColorScale": false, "yHistogram": false},
+        "yAxis": {"axisLabel": "BM25 score", "axisPlacement": "left", "unit": "short"}
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "expr": "sum(rate(ingest_bm25_score_by_outcome_bucket{outcome=\"no_change\"}[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "BM25 Score — No Change",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${datasource}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "scheme"},
+          "custom": {
+            "fillOpacity": 80,
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "scaleDistribution": {"type": "linear"}
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 30},
       "id": 7,
       "options": {
         "calculate": false,
@@ -235,7 +311,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 22},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 30},
       "id": 10,
       "options": {
         "calculate": false,
@@ -270,7 +346,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 30},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 38},
       "id": 8,
       "options": {
         "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom"},
@@ -305,7 +381,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 30},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 38},
       "id": 12,
       "options": {
         "legend": {"calcs": ["mean", "last"], "displayMode": "table", "placement": "bottom"},
@@ -335,7 +411,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 38},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 46},
       "id": 13,
       "options": {
         "calculate": false,
@@ -370,7 +446,7 @@
         },
         "overrides": []
       },
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 38},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 46},
       "id": 14,
       "options": {
         "legend": {"calcs": ["last", "max"], "displayMode": "table", "placement": "bottom"},


### PR DESCRIPTION
## Summary

- Add `ingest_bm25_score_by_outcome` histogram (labels: committed / irrelevant / no_change) so we can correlate BM25 scores with LLM evaluation outcomes
- Add `ingest_llm_calls_per_doc` histogram
- Fix ingest pipeline reading `source` field from Onyx push payload (was `source_type`, causing "unknown" in dashboards)
- Dashboard layout: donut + All Outcomes heatmap side-by-side, then Committed / Irrelevant / No Change heatmaps in one row (w=8 each)
- Bump Helm chart to 0.3.8

## Test plan

- [ ] Merge and deploy, then confirm `ingest_bm25_score_by_outcome_bucket` appears in Prometheus
- [ ] Grafana ingestion dashboard shows data in BM25 Score — Committed / Irrelevant / No Change panels
- [ ] Source type label shows correctly (e.g. `web`) instead of `unknown`