### PR TITLE
chore: add greptile review config (status checks + repo rules)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,44 @@
+{
+  "labels": [],
+  "comment": "",
+  "fixWithAI": true,
+  "hideFooter": false,
+  "strictness": 3,
+  "statusCheck": true,
+  "commentTypes": ["logic", "syntax", "style"],
+  "instructions": "",
+  "disabledLabels": [],
+  "excludeAuthors": ["dependabot[bot]", "renovate[bot]"],
+  "ignoreKeywords": "",
+  "ignorePatterns": "",
+  "includeAuthors": [],
+  "summarySection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": false
+  },
+  "excludeBranches": [],
+  "fileChangeLimit": 300,
+  "includeBranches": [],
+  "includeKeywords": "",
+  "triggerOnUpdates": false,
+  "updateExistingSummaryComment": true,
+  "updateSummaryOnly": false,
+  "issuesTableSection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": false
+  },
+  "statusCommentsEnabled": true,
+  "confidenceScoreSection": {
+    "included": true,
+    "collapsible": false
+  },
+  "sequenceDiagramSection": {
+    "included": true,
+    "collapsible": false,
+    "defaultOpen": false
+  },
+  "shouldUpdateDescription": false,
+  "rules": []
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,32 @@
+[
+  {
+    "scope": [],
+    "path": "CLAUDE.md",
+    "description": "Architectural seams + frontend rules + checklist for adding a feature — single source of truth for code review."
+  },
+  {
+    "scope": [],
+    "path": "README.md",
+    "description": "Repo overview and local-dev setup."
+  },
+  {
+    "scope": [],
+    "path": "docs/architecture.md",
+    "description": "High-level data flow + queue topology."
+  },
+  {
+    "scope": [],
+    "path": "docs/api.md",
+    "description": "HTTP API reference."
+  },
+  {
+    "scope": [],
+    "path": "docs/mcp-server.md",
+    "description": "MCP transport (POST JSON-RPC + GET SSE) — wire format and auth."
+  },
+  {
+    "scope": ["backend/**"],
+    "path": ".greptile/rules.md",
+    "description": "Generic review rules applied repo-wide."
+  }
+]

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -11,22 +11,7 @@
   },
   {
     "scope": [],
-    "path": "docs/architecture.md",
-    "description": "High-level data flow + queue topology."
-  },
-  {
-    "scope": [],
-    "path": "docs/api.md",
-    "description": "HTTP API reference."
-  },
-  {
-    "scope": [],
-    "path": "docs/mcp-server.md",
-    "description": "MCP transport (POST JSON-RPC + GET SSE) — wire format and auth."
-  },
-  {
-    "scope": ["backend/**"],
     "path": ".greptile/rules.md",
-    "description": "Generic review rules applied repo-wide."
+    "description": "Generic review rules applied repo-wide (architectural seams, frontend tokens, network/auth seams, comment hygiene, pre-commit discipline)."
   }
 ]

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -6,7 +6,7 @@ Use explicit type annotations for variables to enhance code clarity, especially 
 
 ## Best Practices
 
-Use the root `CLAUDE.md` "Architectural rules" and "Frontend rules" sections as core review context. Prefer consistency with existing patterns, fix issues in code you touch, avoid tacking new features onto muddy interfaces, fail loudly instead of silently swallowing errors, keep code strictly typed, preserve clear state boundaries, remove duplicate or dead logic, break up overly long functions, avoid hidden import-time side effects, respect module boundaries, and favor correctness-by-construction over relying on callers to use an API correctly.
+Prefer consistency with existing patterns, fix issues in code you touch, avoid tacking new features onto muddy interfaces, fail loudly instead of silently swallowing errors, keep code strictly typed, preserve clear state boundaries, remove duplicate or dead logic, break up overly long functions, avoid hidden import-time side effects, respect module boundaries, and favor correctness-by-construction over relying on callers to use an API correctly.
 
 ## TODOs
 
@@ -22,33 +22,33 @@ When hardcoding a boolean variable to a constant value, remove the variable enti
 
 ## Architectural Seams — Honor the Boundaries
 
-The root `CLAUDE.md` lists the interfaces that must NOT be bypassed:
+Interfaces that must NOT be bypassed:
 
-- LLM calls only through `app/llm/client.py` (no direct `anthropic` / `openai` / `google.genai` imports outside `app/llm/providers/<name>.py`).
-- Auth via `Depends(require_user)` / `current_user()`; no raw `request.session` reads outside `app/api/auth.py`.
-- Wiki ACL via `app/wiki/acl.py` + `require_can`; never read/write `acl_entries` directly.
+- LLM calls only through the central LLM client; no direct provider SDK imports outside the matching provider module.
+- Auth via the dependency-injected `require_user` / `current_user` helpers; no raw session reads in routers.
+- Wiki ACL via the ACL module + `require_can`; never read/write ACL tables directly.
 - DB: SQLAlchemy 2.0 ORM, repos return dicts. Pydantic, NOT `@dataclass`, for structured records.
-- Wiki commits via `app/wiki/git.py`; never shell out to `git` elsewhere.
-- Background work via the `pgmq`-backed queues in `app/tasks/queues.py`; no ad-hoc threading.
-- Logging via `app.utils.logging.setup_logging`; no `print()`, no `logging.basicConfig`.
-- Tracing via `app/tracing/`; never `import braintrust` outside that package.
+- Wiki commits via the git wrapper; never shell out to `git` elsewhere.
+- Background work via the `pgmq`-backed task queues; no ad-hoc threading.
+- Logging via the centralized `setup_logging`; no `print()`, no `logging.basicConfig`.
+- Tracing via the tracing module; never import provider SDKs outside that package.
 
 Flag any new code that bypasses these seams.
 
 ## No Raw SQL Outside the Allowed Sites
 
-Raw SQL is permitted only in `app/db/fts.py` (pg_textsearch operator) and `app/tasks/queue.py` (pgmq functions). Anywhere else, use the ORM session — `session.execute(text(...))` outside those files is a regression to flag.
+Raw SQL is permitted only in narrowly scoped DB-extension wrappers (FTS, task queue). Anywhere else, use the ORM session — `session.execute(text(...))` in business code is a regression to flag.
 
 ## Frontend — Design Tokens + Components
 
-- No raw hex colors, radii, or shadows in React components — they live in `frontend/src/lib/theme.ts`. If a shade isn't there, add it there first.
+- No raw hex colors, radii, or shadows in React components — pull from the centralized theme module. If a shade isn't there, add it there first.
 - No `background: "white"` (or any literal); use `color.bg.page`.
-- One `Button` component per app surface; new launcher-area components prefer `@onyx-ai/opal/components` (`Button`, `Tag`). Don't roll a new bespoke `<button style={{...}}>` for primary/secondary/danger chrome.
+- One `Button` component per app surface; prefer the OPAL primitives (`Button`, `Tag`) for new components. Don't roll a new bespoke `<button style={{...}}>` for primary/secondary/danger chrome.
 - Modal scrims use `color.overlay`; modal shadow uses `shadow.modal`. Don't introduce slate-tinted or pure-black scrims.
 
 ## Network — Only via `apiFetch`
 
-`apiFetch` from `@/lib/api` is the only allowed seam for talking to the backend from the frontend. Raw `fetch(...)` to internal endpoints loses the `credentials: "include"` + JSON parsing + `ApiError` envelope.
+The shared `apiFetch` helper is the only allowed seam for talking to the backend from the frontend. Raw `fetch(...)` to internal endpoints loses the `credentials: "include"` + JSON parsing + `ApiError` envelope.
 
 ## Auth — Only via the Provider
 

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,63 @@
+# Greptile Review Rules
+
+## Type Annotations
+
+Use explicit type annotations for variables to enhance code clarity, especially when moving type hints around in the code. Python files should be strict-typed; basedpyright runs in strict mode in CI.
+
+## Best Practices
+
+Use the root `CLAUDE.md` "Architectural rules" and "Frontend rules" sections as core review context. Prefer consistency with existing patterns, fix issues in code you touch, avoid tacking new features onto muddy interfaces, fail loudly instead of silently swallowing errors, keep code strictly typed, preserve clear state boundaries, remove duplicate or dead logic, break up overly long functions, avoid hidden import-time side effects, respect module boundaries, and favor correctness-by-construction over relying on callers to use an API correctly.
+
+## TODOs
+
+Whenever a TODO is added, there must be an associated name or ticket in the form `TODO(name): ...` or `TODO(1234): ...`.
+
+## Debugging Code
+
+Remove temporary debugging code before merging — stray `print()`, `console.log()`, dump-to-file, or scratch endpoints have no place on `main`.
+
+## Hardcoded Booleans
+
+When hardcoding a boolean variable to a constant value, remove the variable entirely and clean up all places where it's used rather than just setting it to a constant. Dead branches are noise.
+
+## Architectural Seams — Honor the Boundaries
+
+The root `CLAUDE.md` lists the interfaces that must NOT be bypassed:
+
+- LLM calls only through `app/llm/client.py` (no direct `anthropic` / `openai` / `google.genai` imports outside `app/llm/providers/<name>.py`).
+- Auth via `Depends(require_user)` / `current_user()`; no raw `request.session` reads outside `app/api/auth.py`.
+- Wiki ACL via `app/wiki/acl.py` + `require_can`; never read/write `acl_entries` directly.
+- DB: SQLAlchemy 2.0 ORM, repos return dicts. Pydantic, NOT `@dataclass`, for structured records.
+- Wiki commits via `app/wiki/git.py`; never shell out to `git` elsewhere.
+- Background work via the `pgmq`-backed queues in `app/tasks/queues.py`; no ad-hoc threading.
+- Logging via `app.utils.logging.setup_logging`; no `print()`, no `logging.basicConfig`.
+- Tracing via `app/tracing/`; never `import braintrust` outside that package.
+
+Flag any new code that bypasses these seams.
+
+## No Raw SQL Outside the Allowed Sites
+
+Raw SQL is permitted only in `app/db/fts.py` (pg_textsearch operator) and `app/tasks/queue.py` (pgmq functions). Anywhere else, use the ORM session — `session.execute(text(...))` outside those files is a regression to flag.
+
+## Frontend — Design Tokens + Components
+
+- No raw hex colors, radii, or shadows in React components — they live in `frontend/src/lib/theme.ts`. If a shade isn't there, add it there first.
+- No `background: "white"` (or any literal); use `color.bg.page`.
+- One `Button` component per app surface; new launcher-area components prefer `@onyx-ai/opal/components` (`Button`, `Tag`). Don't roll a new bespoke `<button style={{...}}>` for primary/secondary/danger chrome.
+- Modal scrims use `color.overlay`; modal shadow uses `shadow.modal`. Don't introduce slate-tinted or pure-black scrims.
+
+## Network — Only via `apiFetch`
+
+`apiFetch` from `@/lib/api` is the only allowed seam for talking to the backend from the frontend. Raw `fetch(...)` to internal endpoints loses the `credentials: "include"` + JSON parsing + `ApiError` envelope.
+
+## Auth — Only via the Provider
+
+Pages call `useRequireAuth()` to gate and `useAuth()` to read state. Don't call `/api/auth/me` from a component — the provider owns it.
+
+## Comments — Describe Current Behavior
+
+Code comments describe what the code IS, not what it replaced or used to be. No dates, no PR numbers, no audit-reference tokens (`AF#X`, `R2#7`, `P1 #3`). Migration / refactor context belongs in commit messages, not source comments.
+
+## Pre-Commit Discipline
+
+The repo's pre-commit hooks (ruff + basedpyright strict, plus frontend typecheck in CI) are the authority. Code that lints clean locally but trips them on push is a regression. Run `pre-commit run --files <changed>` before requesting review.


### PR DESCRIPTION
## Description

Mirrors onyx's `.greptile/` setup so PR reviews post as GitHub status checks (visible in `gh pr checks` and required-status-check eligible) instead of only as PR-body comments.

- `.greptile/config.json` — `statusCheck: true`, strictness 3, summary + issues + confidence sections rendered, dependabot/renovate excluded.
- `.greptile/rules.md` — generic-only review rules: type annotations, TODO authorship, debug-code removal, hardcoded booleans, architectural seams (LLM client / auth deps / wiki ACL / git wrapper / pgmq queues / logging / tracing), no raw SQL outside the allowed sites, frontend design tokens / OPAL preference, `apiFetch`-only network, `useRequireAuth`-only auth, current-behavior comments, pre-commit discipline.
- `.greptile/files.json` — points greptile at `CLAUDE.md`, `README.md`, and `docs/{architecture,api,mcp-server}.md` for repo context.

Onyx-specific rules (multi-tenant, SCIM nginx routing, `LLMFlow` registry, `SWR_KEYS` registry, Playwright POM, full-vs-lite deployments) are omitted.

## How Has This Been Tested?

- `python3 -c "import json; json.load(open('.greptile/config.json')); json.load(open('.greptile/files.json'))"` → `JSON OK`
- Config-only PR (no Python / TS changes) so pre-commit + pytest are no-ops on this diff. Greptile status check will appear on the *next* PR after this lands on main.