### PR TITLE
chore(launchers): bump @onyx-ai/agentwiki-launcher to 0.1.0-alpha.2

### DIFF
--- a/packages/agentwiki-launcher/package.json
+++ b/packages/agentwiki-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/agentwiki-launcher",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "Local helper for the agent-wiki Run Agent button.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description

- Pin `packages/agentwiki-launcher/package.json` to `0.1.0-alpha.2`.
- Already published to the npm alpha tag.
- The prior `0.1.0-alpha.1` shipped before phase-3 / phase-4 landed, so `npm i -g @onyx-ai/agentwiki-launcher` was handing users the pre-stack code (no macOS `.app` URL handler, none of the codex-review security/perm fixes).

## How Has This Been Tested?