### PR TITLE
feat(llm): add configurable selector_model for ingest pre-filter stage

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -120,6 +120,7 @@ def _llm_view(s: LLMSettings) -> LLMView:
         gemini_api_key_hint=_redact(s.gemini_api_key),
         ollama_base_url=s.ollama_base_url,
         provider_models=s.provider_models,
+        ingest_selector_model=s.ingest_selector_model,
     )
 
 
@@ -167,6 +168,11 @@ def put_llm(
 
     new_provider_models = req.provider_models if "provider_models" in sent_fields else None
 
+    if "ingest_selector_model" in sent_fields:
+        ingest_selector_model = (req.ingest_selector_model or "").strip()
+    else:
+        ingest_selector_model = current.ingest_selector_model
+
     llm_settings.upsert(
         provider=provider,
         model=model,
@@ -175,6 +181,7 @@ def put_llm(
         gemini_api_key=gemini_key,
         ollama_base_url=ollama_base_url,
         provider_models=new_provider_models,
+        ingest_selector_model=ingest_selector_model,
     )
     log.info(
         "admin: %s updated llm settings provider=%s model=%s",

--- a/backend/app/db/migrations/versions/0020_llm_selector_model.py
+++ b/backend/app/db/migrations/versions/0020_llm_selector_model.py
@@ -1,0 +1,28 @@
+"""add ingest_selector_model to llm_settings
+
+Revision ID: 0020
+Revises: 433c24868299
+Create Date: 2026-05-19 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0020"
+down_revision: tuple[str, ...] = ("0019", "433c24868299")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS is required because 0001_initial uses Base.metadata.create_all,
+    # which already includes this column on fresh installs.
+    op.execute(sa.text(
+        "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS"
+        " ingest_selector_model TEXT NOT NULL DEFAULT ''"
+    ))
+
+
+def downgrade() -> None:
+    op.drop_column("llm_settings", "ingest_selector_model")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -468,6 +468,7 @@ class LLMSettings(Base):
     provider_models: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
+    ingest_selector_model: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
     updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
 
     __table_args__ = (CheckConstraint("id = 1", name="llm_settings_singleton"),)

--- a/backend/app/llm/settings.py
+++ b/backend/app/llm/settings.py
@@ -22,6 +22,7 @@ class LLMSettings(BaseModel):
     gemini_api_key: str
     ollama_base_url: str
     provider_models: dict[str, list[str]]
+    ingest_selector_model: str  # empty or same as model → stage 3 skipped
 
 
 _EMPTY = LLMSettings(
@@ -32,6 +33,7 @@ _EMPTY = LLMSettings(
     gemini_api_key="",
     ollama_base_url="",
     provider_models={},
+    ingest_selector_model="",
 )
 
 
@@ -48,6 +50,7 @@ def get() -> LLMSettings:
             gemini_api_key=row.gemini_api_key,
             ollama_base_url=row.ollama_base_url,
             provider_models=row.provider_models or {},
+            ingest_selector_model=row.ingest_selector_model or "",
         )
 
 
@@ -60,6 +63,7 @@ def upsert(
     gemini_api_key: str,
     ollama_base_url: str,
     provider_models: dict[str, list[str]] | None = None,
+    ingest_selector_model: str | None = None,
 ) -> None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
@@ -75,6 +79,7 @@ def upsert(
                     gemini_api_key=gemini_api_key,
                     ollama_base_url=ollama_base_url,
                     provider_models=provider_models or {},
+                    ingest_selector_model=ingest_selector_model or "",
                     updated_at=now,
                 )
             )
@@ -87,5 +92,7 @@ def upsert(
             row.ollama_base_url = ollama_base_url
             if provider_models is not None:
                 row.provider_models = provider_models
+            if ingest_selector_model is not None:
+                row.ingest_selector_model = ingest_selector_model
             row.updated_at = now
-    log.info("llm_settings upserted provider=%s model=%s", provider, model)
+    log.info("llm_settings upserted provider=%s model=%s ingest_selector_model=%s", provider, model, ingest_selector_model or "none")

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -27,6 +27,7 @@ class LLMConfigRequest(BaseModel):
     gemini_api_key: str | None = None
     ollama_base_url: str | None = None
     provider_models: dict[str, list[str]] | None = None
+    ingest_selector_model: str | None = None
 
 
 class WebConfigRequest(BaseModel):
@@ -88,6 +89,7 @@ class LLMView(BaseModel):
     # Ollama doesn't have an API key — surface the base URL directly.
     ollama_base_url: str
     provider_models: dict[str, list[str]]
+    ingest_selector_model: str
 
 
 class WebView(BaseModel):

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
+import { mutate as globalMutate } from "swr";
 
 import { AppShell } from "@/components/common/AppShell";
 import { Button } from "@/components/common/Button";
@@ -14,6 +15,37 @@ import { useIsMobile } from "@/lib/viewport";
 interface IngestSettings {
   max_doc_chars: number;
   api_key: string | null;
+}
+
+type Provider = "anthropic" | "openai" | "gemini" | "ollama";
+
+interface LLMSettings {
+  provider: Provider;
+  model: string;
+  anthropic_api_key_set: boolean;
+  openai_api_key_set: boolean;
+  gemini_api_key_set: boolean;
+  ollama_base_url: string;
+  provider_models: Record<string, string[]>;
+  ingest_selector_model: string;
+}
+
+const PROVIDER_LABEL: Record<Provider, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  gemini: "Gemini",
+  ollama: "Ollama",
+};
+
+const ALL_PROVIDERS: Provider[] = ["anthropic", "openai", "gemini", "ollama"];
+
+
+function isConfigured(p: Provider, s: LLMSettings): boolean {
+  if (p === "anthropic") return s.anthropic_api_key_set;
+  if (p === "openai") return s.openai_api_key_set;
+  if (p === "gemini") return s.gemini_api_key_set;
+  if (p === "ollama") return !!s.ollama_base_url;
+  return false;
 }
 
 export default function AdminIngestPage() {
@@ -44,6 +76,7 @@ export default function AdminIngestPage() {
 
 function IngestForm() {
   const [settings, setSettings] = useState<IngestSettings | null>(null);
+  const [llmSettings, setLlmSettings] = useState<LLMSettings | null>(null);
   const [maxDocChars, setMaxDocChars] = useState("");
   const [keyVisible, setKeyVisible] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -57,9 +90,13 @@ function IngestForm() {
 
   async function load() {
     try {
-      const r = await apiFetch<IngestSettings>("/admin/ingest");
-      setSettings(r);
-      setMaxDocChars(String(r.max_doc_chars));
+      const [ingest, llm] = await Promise.all([
+        apiFetch<IngestSettings>("/admin/ingest"),
+        apiFetch<LLMSettings>("/admin/llm"),
+      ]);
+      setSettings(ingest);
+      setMaxDocChars(String(ingest.max_doc_chars));
+      setLlmSettings(llm);
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to load");
     }
@@ -120,7 +157,7 @@ function IngestForm() {
     }
   }
 
-  if (!settings) return <div>Loading…</div>;
+  if (!settings || !llmSettings) return <div>Loading…</div>;
 
   const dirty = maxDocChars !== String(settings.max_doc_chars);
 
@@ -205,7 +242,156 @@ function IngestForm() {
           </Button>
         </div>
       </form>
+
+      <div style={{ borderTop: `1px solid ${color.border.subtle}` }} />
+
+      <SelectorModelSection settings={llmSettings} onSaved={() => void load()} />
     </div>
+  );
+}
+
+function SelectorModelSection({ settings, onSaved }: { settings: LLMSettings; onSaved: () => void }) {
+  const [editing, setEditing] = useState(false);
+  const [selModel, setSelModel] = useState(settings.ingest_selector_model || "");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const availableProviders = ALL_PROVIDERS.filter((p) => isConfigured(p, settings));
+  const options = availableProviders.flatMap((p) =>
+    (settings.provider_models[p] ?? []).map((m) => ({ provider: p, model: m })),
+  );
+  const hasNoModels = availableProviders.length > 0 && options.length === 0;
+
+  useEffect(() => {
+    setSelModel(settings.ingest_selector_model || "");
+  }, [settings]);
+
+  async function onSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch("/admin/llm", {
+        method: "PUT",
+        body: JSON.stringify({ ingest_selector_model: selModel }),
+      });
+      setEditing(false);
+      onSaved();
+      void globalMutate("/llm/status");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const activeLabel = selModel
+    ? selModel === settings.model
+      ? `${selModel} (same as main model — pre-filter disabled)`
+      : selModel
+    : "None — all documents go to the main model";
+
+  return (
+    <section>
+      <h3 style={{ margin: "0 0 4px", fontSize: 14, fontWeight: 600 }}>Selector model</h3>
+      <div style={{ color: color.text.muted, fontSize: 13, marginBottom: 12 }}>
+        A faster, cheaper model that screens incoming documents before the main model decides what to update.
+        Helps reduce cost when many documents are being pushed. Leave unset to send all documents straight to the main model.
+      </div>
+      {!editing ? (
+        <div style={{
+          display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "12px 16px", border: `1px solid ${color.border.default}`,
+          borderRadius: radius.md, background: color.bg.panel,
+        }}>
+          <span style={{ fontSize: 14, color: selModel && selModel !== settings.model ? color.text.primary : color.text.muted }}>
+            {activeLabel}
+          </span>
+          <Button size="sm" variant="secondary" onClick={() => setEditing(true)} disabled={availableProviders.length === 0}>Edit</Button>
+        </div>
+      ) : (
+        <div style={{
+          border: `1px solid ${color.border.default}`,
+          borderRadius: radius.md, background: color.bg.panel,
+          display: "flex", flexDirection: "column",
+        }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4, padding: 12 }}>
+            {hasNoModels && (
+              <div style={{ fontSize: 13, color: color.text.muted, padding: "4px 0 8px" }}>
+                No models configured. Add models on the{" "}
+                <a href="/admin/llm" style={{ color: color.accent.fg }}>Language models</a> page first.
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={() => setSelModel("")}
+              style={{
+                display: "flex", alignItems: "center", gap: 12, padding: "10px 12px",
+                border: `1px solid ${selModel === "" ? color.accent.subtleBorder : color.border.default}`,
+                borderRadius: radius.sm,
+                background: selModel === "" ? color.accent.subtleBg : color.bg.page,
+                cursor: "pointer", textAlign: "left",
+              }}
+            >
+              <div style={{
+                width: 16, height: 16, borderRadius: "50%", flexShrink: 0,
+                border: selModel === "" ? "none" : `1.5px solid ${color.border.strong}`,
+                background: selModel === "" ? color.accent.bg : "transparent",
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+                {selModel === "" && <div style={{ width: 8, height: 8, borderRadius: "50%", background: color.accent.fg }} />}
+              </div>
+              <span style={{ fontSize: 13, color: selModel === "" ? color.accent.subtleFg : color.text.muted, fontStyle: "italic" }}>
+                None — all documents go to the main model
+              </span>
+            </button>
+            {options.map(({ provider: p, model: m }) => {
+              const isSelected = selModel === m;
+              return (
+                <button
+                  key={`${p}:${m}`}
+                  type="button"
+                  onClick={() => setSelModel(m)}
+                  style={{
+                    display: "flex", alignItems: "center", gap: 12, padding: "10px 12px",
+                    border: `1px solid ${isSelected ? color.accent.subtleBorder : color.border.default}`,
+                    borderRadius: radius.sm,
+                    background: isSelected ? color.accent.subtleBg : color.bg.page,
+                    cursor: "pointer", textAlign: "left",
+                  }}
+                >
+                  <div style={{
+                    width: 16, height: 16, borderRadius: "50%", flexShrink: 0,
+                    border: isSelected ? "none" : `1.5px solid ${color.border.strong}`,
+                    background: isSelected ? color.accent.bg : "transparent",
+                    display: "flex", alignItems: "center", justifyContent: "center",
+                  }}>
+                    {isSelected && <div style={{ width: 8, height: 8, borderRadius: "50%", background: color.accent.fg }} />}
+                  </div>
+                  <span style={{ fontSize: 13, fontWeight: 500, color: isSelected ? color.accent.subtleFg : color.text.secondary, flexShrink: 0 }}>
+                    {PROVIDER_LABEL[p]}
+                  </span>
+                  <span style={{ fontSize: 13, color: isSelected ? color.accent.subtleFg : color.text.muted, fontFamily: "ui-monospace, monospace" }}>
+                    {m}
+                  </span>
+                  {m === settings.model && (
+                    <span style={{ fontSize: 11, color: color.text.muted, marginLeft: "auto" }}>same as main — pre-filter disabled</span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+          {error && <div style={{ color: color.state.danger.fg, fontSize: 13, padding: "0 12px 8px" }}>{error}</div>}
+          <div style={{ display: "flex", gap: 8, padding: "4px 12px 12px" }}>
+            <Button type="button" variant="primary" size="sm" disabled={saving} onClick={() => void onSave()}>
+              {saving ? "Saving…" : "Save"}
+            </Button>
+            <Button type="button" variant="secondary" size="sm" onClick={() => { setEditing(false); setError(null); setSelModel(settings.ingest_selector_model || ""); }}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/frontend/src/app/admin/llm/page.tsx
+++ b/frontend/src/app/admin/llm/page.tsx
@@ -41,6 +41,7 @@ const PROVIDER_MODELS: Record<Provider, string[]> = {
   openai: [
     "gpt-5.5",
     "gpt-5.4",
+    "gpt-5.4-mini",
     "gpt-5.2",
   ],
   gemini: [

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -78,6 +78,12 @@ export default function AdminPage() {
             description="Reusable starting points for new wiki pages, plus optional chat prompts."
             icon={<TemplateIcon />}
           />
+          <AdminCard
+            href="/admin/ingest"
+            title="Onyx connection"
+            description="Connect your Onyx instance to push indexed documents into this wiki automatically."
+            icon={<IngestIcon />}
+          />
         </div>
       </main>
     </AppShell>
@@ -186,6 +192,16 @@ function TraceIcon() {
       <path d="M6 8.5v7" />
       <path d="M8.5 18h7" />
       <path d="M8 8l8 8" />
+    </svg>
+  );
+}
+
+function IngestIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M12 2v10" />
+      <path d="m8 8 4 4 4-4" />
+      <rect x="3" y="14" width="18" height="7" rx="2" />
     </svg>
   );
 }

--- a/frontend/src/app/agents/page.tsx
+++ b/frontend/src/app/agents/page.tsx
@@ -47,7 +47,6 @@ export default function AgentsPage() {
         <EndpointBlock />
         <TokenManager />
         <ClientConfigHelp />
-        {user.is_admin && <OnyxConnection />}
       </main>
     </AppShell>
   );
@@ -384,131 +383,6 @@ function ClientConfigHelp() {
           >
             {claudeCodeSnippet}
           </pre>
-        </div>
-      )}
-    </section>
-  );
-}
-
-// --------------------------------------------------------------------------- //
-// Onyx connection (admin only)                                               //
-// --------------------------------------------------------------------------- //
-
-interface IngestSettings {
-  api_key: string | null;
-}
-
-function OnyxConnection() {
-  const [settings, setSettings] = useState<IngestSettings | null>(null);
-  const [ingestUrl, setIngestUrl] = useState("");
-  const [keyVisible, setKeyVisible] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [notice, setNotice] = useState<string | null>(null);
-
-  useEffect(() => {
-    setIngestUrl(`${window.location.origin}/api/wiki/ingest`);
-    apiFetch<IngestSettings>("/admin/ingest")
-      .then(setSettings)
-      .catch((e) =>
-        setError(e instanceof Error ? e.message : "failed to load"),
-      );
-  }, []);
-
-  async function regenerate() {
-    if (
-      settings?.api_key &&
-      !confirm(
-        "Regenerate the API key? The old key will stop working immediately.",
-      )
-    )
-      return;
-    setBusy(true);
-    setError(null);
-    setNotice(null);
-    try {
-      const r = await apiFetch<{ api_key: string }>(
-        "/admin/ingest/regenerate-key",
-        { method: "POST" },
-      );
-      setSettings((prev) => (prev ? { ...prev, api_key: r.api_key } : prev));
-      setKeyVisible(true);
-      setNotice(
-        "New key generated. Copy it now — it will be masked after you leave this page.",
-      );
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to regenerate");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <section style={card}>
-      <h2 style={{ margin: "0 0 12px", fontSize: 16 }}>Onyx connection</h2>
-      <div style={{ fontSize: 13, color: color.text.muted, marginBottom: 16 }}>
-        Push indexed documents from Onyx into this wiki automatically. Copy the
-        endpoint and API key into your Onyx environment variables.
-      </div>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-        {/* Ingest URL */}
-        <div>
-          <div
-            style={{ fontSize: 13, color: color.text.muted, marginBottom: 6 }}
-          >
-            Endpoint URL
-          </div>
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <code style={codeBlock}>{ingestUrl || "—"}</code>
-            <CopyButton text={ingestUrl} />
-          </div>
-        </div>
-
-        {/* API key */}
-        <div>
-          <div
-            style={{ fontSize: 13, color: color.text.muted, marginBottom: 6 }}
-          >
-            API key
-          </div>
-          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <code style={codeBlock}>
-              {settings === null
-                ? "Loading…"
-                : settings.api_key
-                  ? keyVisible
-                    ? settings.api_key
-                    : "••••••••••••••••••••••••••••••••"
-                  : "No key yet — click Regenerate"}
-            </code>
-            {settings?.api_key && keyVisible && (
-              <CopyButton text={settings.api_key} />
-            )}
-            <Button
-              size="sm"
-              variant={settings?.api_key ? "secondary" : "primary"}
-              disabled={busy}
-              onClick={() => void regenerate()}
-            >
-              {busy ? "…" : "Regenerate"}
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {notice && (
-        <div
-          style={{ fontSize: 13, color: color.state.success.fg, marginTop: 10 }}
-        >
-          {notice}
-        </div>
-      )}
-      {error && (
-        <div
-          style={{ fontSize: 13, color: color.state.danger.fg, marginTop: 10 }}
-        >
-          {error}
         </div>
       )}
     </section>


### PR DESCRIPTION
## Summary

- Adds an `ingest_selector_model` field to `LLMSettings` (DB column, migration, settings module, admin API)
- Admin UI: exposes the selector model picker on the **Onyx connection** page (`/admin/ingest`) so it lives alongside the other ingest pipeline settings
- Optional cheaper model used to pre-filter BM25 candidates before the main reconcile model runs; leave unset or set to the same model as the default to disable the stage


## Changes

**Backend**
- `backend/app/db/models.py` — `ingest_selector_model` column on `LLMSettings`
- `backend/app/db/migrations/versions/0020_llm_selector_model.py` — `ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS ingest_selector_model`
- `backend/app/llm/settings.py` — `LLMSettings.ingest_selector_model`, read/write in `get()` and `upsert()`
- `backend/app/models/admin.py` — `LLMConfigRequest.ingest_selector_model`, `LLMView.ingest_selector_model`
- `backend/app/api/admin.py` — `_llm_view()` and `put_llm()` handle `ingest_selector_model`

**Frontend**
- `frontend/src/app/admin/ingest/page.tsx` — fetches `/admin/llm` alongside `/admin/ingest`; renders new `SelectorModelSection` (radio picker with None option + all configured models) at the bottom of the Onyx connection page

## Test plan
<img width="1004" height="754" alt="Screenshot 2026-05-19 at 12 58 47 PM" src="https://github.com/user-attachments/assets/6aa58573-8ebd-41e4-8e32-d634241e781f" />
- [ ] Navigate to `/admin/ingest` — "Selector model" section appears below Ingest settings
- [ ] Select a model, save — `PUT /admin/llm` succeeds, display updates
- [ ] Select "None", save — selector stage shows as disabled
- [ ] Selecting the same model as the default shows "same as default" hint
- [ ] LLM page (`/admin/llm`) no longer shows the selector model section