### PR TITLE
chore(launchers): bump @onyx-ai/agentwiki-launcher to 0.1.0-alpha.3

### DIFF
--- a/packages/agentwiki-launcher/package-lock.json
+++ b/packages/agentwiki-launcher/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onyx-ai/agentwiki-launcher",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@onyx-ai/agentwiki-launcher",
-      "version": "0.1.0-alpha.1",
+      "version": "0.1.0-alpha.3",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/packages/agentwiki-launcher/package.json
+++ b/packages/agentwiki-launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onyx-ai/agentwiki-launcher",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "description": "Local helper for the agent-wiki Run Agent button.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description

- Pin `packages/agentwiki-launcher/package.json` to `0.1.0-alpha.3`.
- Already published to the npm alpha tag.
- Cut after #69 (phase-4 cross-OS helper) merged. `npm i -g @onyx-ai/agentwiki-launcher@alpha` now resolves to the build with Linux + Windows install/terminal modules and every codex-review / greptile fix on the chain.

## How Has This Been Tested?