### PR TITLE
chore(helm): bump chart to 0.3.11 to publish dashboard changes

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.10
+version: 0.3.11
 appVersion: "0.1.0"


### PR DESCRIPTION
Bumps the Helm chart version so chart-releaser publishes the updated dashboard JSON from PRs #75, #76, and #77 to gh-pages. Without this bump, skip_existing=true causes the deploy to keep using the old chart.