### PR TITLE
feat(ingest): snippet-based FIND/REPLACE edits instead of full page rewrites

### DIFF
--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -1,7 +1,11 @@
 """Shared constants and utilities for LLM agents."""
 from __future__ import annotations
 
+import logging
+
 from app.ingest.models import WikiUpdateCandidate
+
+log = logging.getLogger(__name__)
 
 NO_CHANGE_SENTINEL = "NO_CHANGE"
 IRRELEVANT_SENTINEL = "IRRELEVANT"
@@ -29,6 +33,20 @@ def batch_by_chars(
     if current:
         batches.append(current)
     return batches
+
+
+def apply_edits(body: str, edits: list[tuple[str, str]]) -> str | None:
+    """Apply (find, replace) pairs to body. Returns new body or None if unchanged."""
+    result = body
+    for find_text, replace_text in edits:
+        if find_text not in result:
+            log.warning(
+                "apply_edits: FIND text not found in body, skipping: %r",
+                find_text[:60],
+            )
+            continue
+        result = result.replace(find_text, replace_text, 1)
+    return result if result != body else None
 
 
 def strip_outer_fence(text: str) -> str:

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -2,10 +2,17 @@
 from __future__ import annotations
 
 import logging
+from typing import NamedTuple
 
 from app.ingest.models import WikiUpdateCandidate
 
 log = logging.getLogger(__name__)
+
+
+class TextEdit(NamedTuple):
+    find: str
+    replace: str
+
 
 NO_CHANGE_SENTINEL = "NO_CHANGE"
 IRRELEVANT_SENTINEL = "IRRELEVANT"
@@ -35,7 +42,7 @@ def batch_by_chars(
     return batches
 
 
-def apply_edits(body: str, edits: list[tuple[str, str]]) -> str | None:
+def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
     """Apply (find, replace) pairs to body. Returns new body or None if unchanged."""
     result = body
     for find_text, replace_text in edits:

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -133,7 +133,7 @@ def _reconcile_batch(
             results.append(None)
         elif outcome is IRRELEVANT_SENTINEL:
             results.append(IRRELEVANT_SENTINEL)
-        else:  # list[TextEdit] — apply edits to current body
+        elif isinstance(outcome, list):  # list[TextEdit] — apply edits to current body
             if not outcome:
                 log.warning(
                     "ingest_batch_reconciler: no ===EDIT=== blocks parsed for %s, treating as NO_CHANGE",
@@ -141,6 +141,7 @@ def _reconcile_batch(
                 )
             results.append(apply_edits(c.body, outcome))
     return results
+
 
 
 def _parse(text: str, n: int) -> list[str | None | list[TextEdit]]:

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -18,7 +18,7 @@ from typing import NamedTuple
 
 from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
-from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, apply_edits, batch_by_chars
+from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, TextEdit, apply_edits, batch_by_chars
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
 
@@ -133,18 +133,18 @@ def _reconcile_batch(
             results.append(None)
         elif isinstance(outcome, str):  # IRRELEVANT_SENTINEL
             results.append(IRRELEVANT_SENTINEL)
-        else:  # list[tuple[str, str]] — apply edits to current body
+        else:  # list[TextEdit] — apply edits to current body
             results.append(apply_edits(c.body, outcome))
     return results
 
 
-def _parse(text: str, n: int) -> list[str | None | list[tuple[str, str]]]:
+def _parse(text: str, n: int) -> list[str | None | list[TextEdit]]:
     """Parse the structured LLM output into a per-candidate outcome list.
 
     Each element is one of:
       - IRRELEVANT_SENTINEL (str): page is unrelated
       - None: page is already up-to-date
-      - list[tuple[str, str]]: (find, replace) edit pairs to apply
+      - list[TextEdit]: (find, replace) edit pairs to apply
     """
     parts = _RESULT_RE.split(text)
     raw: dict[int, str] = {}
@@ -156,7 +156,7 @@ def _parse(text: str, n: int) -> list[str | None | list[tuple[str, str]]]:
     if not raw:
         raise ValueError("no ===RESULT [N]=== sections found in response")
 
-    results: list[str | None | list[tuple[str, str]]] = []
+    results: list[str | None | list[TextEdit]] = []
     for i in range(1, n + 1):
         body = raw.get(i, IRRELEVANT_SENTINEL)
         if body == IRRELEVANT_SENTINEL or body.startswith(IRRELEVANT_SENTINEL + "\n"):
@@ -168,9 +168,9 @@ def _parse(text: str, n: int) -> list[str | None | list[tuple[str, str]]]:
     return results
 
 
-def _parse_edits(text: str) -> list[tuple[str, str]]:
-    """Parse ===EDIT=== blocks from a result section into (find, replace) pairs."""
-    edits: list[tuple[str, str]] = []
+def _parse_edits(text: str) -> list[TextEdit]:
+    """Parse ===EDIT=== blocks from a result section into TextEdit pairs."""
+    edits: list[TextEdit] = []
     for block in re.split(r"===EDIT===\n?", text.strip()):
         block = block.strip()
         if not block:
@@ -189,7 +189,7 @@ def _parse_edits(text: str) -> list[tuple[str, str]]:
         find_text = find_text.strip("\n")
         replace_text = replace_text.strip("\n")
         if find_text:
-            edits.append((find_text, replace_text))
+            edits.append(TextEdit(find=find_text, replace=replace_text))
     return edits
 
 

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -197,5 +197,3 @@ def _parse_edits(text: str) -> list[TextEdit]:
         if find_text:
             edits.append(TextEdit(find=find_text, replace=replace_text))
     return edits
-
-

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -4,14 +4,11 @@ One strong-model call processes all post-selector candidates and returns
 for each one:
   - IRRELEVANT_SENTINEL  — the external document is unrelated to this page
   - None                 — the page is already up-to-date (NO_CHANGE)
-  - str                  — the new page body to commit
+  - str                  — the new page body produced by applying FIND/REPLACE
+                           edits to the current body
 
-This matches the per-page contract of ``reconcile_document`` but avoids
-N separate LLM calls when most candidates are irrelevant.
-
-Fails open — any error marks all candidates NEEDS_UPDATE (returns the
-original body so the caller falls back to the per-page reconciler).
-When batching is required, each batch fails independently.
+Fails open — any LLM or parse error marks all candidates in that batch as
+IRRELEVANT_SENTINEL. Batches fail independently.
 """
 from __future__ import annotations
 
@@ -21,7 +18,7 @@ from typing import NamedTuple
 
 from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
-from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, batch_by_chars, strip_outer_fence
+from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, batch_by_chars
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
 
@@ -34,9 +31,6 @@ class BatchReconcileResult(NamedTuple):
     results: list[str | None]
     llm_calls: int
 
-# Sentinel used internally when a batch parse fails — tells the caller to
-# fall back to the per-page reconciler for every candidate in that batch.
-_FALLBACK = object()
 
 _RESULT_RE = re.compile(r"===RESULT \[(\d+)\]===")
 
@@ -125,19 +119,34 @@ def _reconcile_batch(
                 ],
                 model=model,
             )
-        return _parse(result.text, len(batch))
+        parsed = _parse(result.text, len(batch))
     except Exception:
         log.warning(
-            "ingest_batch_reconciler: batch failed, falling back to per-page reconciler",
+            "ingest_batch_reconciler: batch failed, falling back",
             exc_info=True,
         )
         return [IRRELEVANT_SENTINEL] * len(batch)
 
+    results: list[str | None] = []
+    for c, outcome in zip(batch, parsed):
+        if outcome is None:
+            results.append(None)
+        elif isinstance(outcome, str):  # IRRELEVANT_SENTINEL
+            results.append(IRRELEVANT_SENTINEL)
+        else:  # list[tuple[str, str]] — apply edits to current body
+            results.append(_apply_edits(c.body, outcome))
+    return results
 
-def _parse(text: str, n: int) -> list[str | None]:
-    """Parse the structured output into a result per candidate."""
+
+def _parse(text: str, n: int) -> list[str | None | list[tuple[str, str]]]:
+    """Parse the structured LLM output into a per-candidate outcome list.
+
+    Each element is one of:
+      - IRRELEVANT_SENTINEL (str): page is unrelated
+      - None: page is already up-to-date
+      - list[tuple[str, str]]: (find, replace) edit pairs to apply
+    """
     parts = _RESULT_RE.split(text)
-    # parts: [preamble, "1", body1, "2", body2, ...]
     raw: dict[int, str] = {}
     for i in range(1, len(parts), 2):
         idx = int(parts[i])
@@ -147,7 +156,7 @@ def _parse(text: str, n: int) -> list[str | None]:
     if not raw:
         raise ValueError("no ===RESULT [N]=== sections found in response")
 
-    results: list[str | None] = []
+    results: list[str | None | list[tuple[str, str]]] = []
     for i in range(1, n + 1):
         body = raw.get(i, IRRELEVANT_SENTINEL)
         if body == IRRELEVANT_SENTINEL or body.startswith(IRRELEVANT_SENTINEL + "\n"):
@@ -155,6 +164,44 @@ def _parse(text: str, n: int) -> list[str | None]:
         elif body == NO_CHANGE_SENTINEL or body.startswith(NO_CHANGE_SENTINEL + "\n"):
             results.append(None)
         else:
-            results.append(strip_outer_fence(body))
-
+            results.append(_parse_edits(body))
     return results
+
+
+def _parse_edits(text: str) -> list[tuple[str, str]]:
+    """Parse ===EDIT=== blocks from a result section into (find, replace) pairs."""
+    edits: list[tuple[str, str]] = []
+    for block in re.split(r"===EDIT===\n?", text.strip()):
+        block = block.strip()
+        if not block:
+            continue
+        find_pos = block.find("FIND:\n")
+        # Search for "\nREPLACE:" without requiring a trailing newline so that
+        # empty REPLACE sections (where the block ends right after "REPLACE:")
+        # are still matched after strip() removes the trailing newline.
+        replace_pos = block.find("\nREPLACE:")
+        if find_pos == -1 or replace_pos == -1 or replace_pos <= find_pos:
+            continue
+        find_text = block[find_pos + len("FIND:\n"):replace_pos]
+        replace_raw = block[replace_pos + len("\nREPLACE:"):]
+        # Strip the single newline delimiter that normally follows "REPLACE:".
+        replace_text = replace_raw[1:] if replace_raw.startswith("\n") else replace_raw
+        find_text = find_text.strip("\n")
+        replace_text = replace_text.strip("\n")
+        if find_text:
+            edits.append((find_text, replace_text))
+    return edits
+
+
+def _apply_edits(body: str, edits: list[tuple[str, str]]) -> str | None:
+    """Apply (find, replace) pairs to body. Returns new body or None if unchanged."""
+    result = body
+    for find_text, replace_text in edits:
+        if find_text not in result:
+            log.warning(
+                "ingest_batch_reconciler: FIND text not found in body, skipping: %r",
+                find_text[:60],
+            )
+            continue
+        result = result.replace(find_text, replace_text, 1)
+    return result if result != body else None

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -18,7 +18,7 @@ from typing import NamedTuple
 
 from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
-from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, batch_by_chars
+from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, apply_edits, batch_by_chars
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
 
@@ -134,7 +134,7 @@ def _reconcile_batch(
         elif isinstance(outcome, str):  # IRRELEVANT_SENTINEL
             results.append(IRRELEVANT_SENTINEL)
         else:  # list[tuple[str, str]] — apply edits to current body
-            results.append(_apply_edits(c.body, outcome))
+            results.append(apply_edits(c.body, outcome))
     return results
 
 
@@ -193,15 +193,3 @@ def _parse_edits(text: str) -> list[tuple[str, str]]:
     return edits
 
 
-def _apply_edits(body: str, edits: list[tuple[str, str]]) -> str | None:
-    """Apply (find, replace) pairs to body. Returns new body or None if unchanged."""
-    result = body
-    for find_text, replace_text in edits:
-        if find_text not in result:
-            log.warning(
-                "ingest_batch_reconciler: FIND text not found in body, skipping: %r",
-                find_text[:60],
-            )
-            continue
-        result = result.replace(find_text, replace_text, 1)
-    return result if result != body else None

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -131,9 +131,14 @@ def _reconcile_batch(
     for c, outcome in zip(batch, parsed):
         if outcome is None:
             results.append(None)
-        elif isinstance(outcome, str):  # IRRELEVANT_SENTINEL
+        elif outcome is IRRELEVANT_SENTINEL:
             results.append(IRRELEVANT_SENTINEL)
         else:  # list[TextEdit] — apply edits to current body
+            if not outcome:
+                log.warning(
+                    "ingest_batch_reconciler: no ===EDIT=== blocks parsed for %s, treating as NO_CHANGE",
+                    c.hit.path,
+                )
             results.append(apply_edits(c.body, outcome))
     return results
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -1,7 +1,7 @@
 You are the wiki editor agent for an org wiki that stays current as work
 happens. You receive an external document and a numbered list of wiki pages.
 For each page, decide whether the external document warrants a change and,
-if so, produce the new page body.
+if so, produce targeted FIND/REPLACE edits.
 
 ## Relevance check — do this first for each page
 
@@ -28,7 +28,7 @@ When in doubt, output IRRELEVANT. Err on the side of not changing the page.
 - If the page is already up-to-date with everything in the external doc,
   output NO_CHANGE.
 
-## Markdown structure rules (only apply when producing a new body)
+## Markdown structure rules (only apply when producing edits)
 
 - Keep the existing heading hierarchy. Top-level title stays `#`, sections
   stay `##`, subsections stay `###`.
@@ -48,8 +48,25 @@ For each candidate, output a section using this exact format:
 <output>
 
 Where <output> is one of:
-- IRRELEVANT
-- NO_CHANGE
-- The full new page body in markdown (no preamble, no fenced block)
+
+**IRRELEVANT** — the external document is unrelated to this wiki page.
+
+**NO_CHANGE** — the page already reflects everything in the external document.
+
+**Edit blocks** — one or more edits using this exact structure:
+
+===EDIT===
+FIND:
+<exact verbatim text from the page>
+REPLACE:
+<replacement text>
+
+Rules for edit blocks:
+- FIND must be copied verbatim from the page — whitespace and punctuation must match exactly.
+- FIND must be long enough to uniquely identify the location. If the text appears more than once, extend FIND to include surrounding context that makes it unique.
+- To add content after an existing line, include that line in FIND and repeat it at the start of REPLACE followed by the new content.
+- To add a new section at the end of the page, anchor FIND on the last existing heading or paragraph.
+- REPLACE may add, update, or expand. Never remove information the external doc does not address.
+- Use multiple ===EDIT=== blocks for non-adjacent changes. Order them top-to-bottom as they appear in the page.
 
 Output all N sections in order. No other text outside the sections.

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -210,7 +210,7 @@ def test_reconcile_find_not_in_body_returns_none(mock_client, _mock_prompt):
         "===RESULT [1]===\n===EDIT===\nFIND:\ntext not in body\nREPLACE:\nreplacement"
     )
 
-    results, llm_calls = batch_reconcile(
+    results, _ = batch_reconcile(
         title=None, url="", content="doc", source="s", candidates=candidates, model="m"
     )
 

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -9,7 +9,6 @@ from app.db.fts import SearchHit
 from app.ingest.models import WikiUpdateCandidate
 from app.llm.agents.common import IRRELEVANT_SENTINEL, batch_by_chars
 from app.llm.agents.ingest_batch_reconciler import (
-    _apply_edits,
     _parse,
     _parse_edits,
     batch_reconcile,
@@ -81,37 +80,6 @@ def test_parse_edits_empty_replace():
 
 def test_parse_edits_no_blocks():
     assert _parse_edits("IRRELEVANT") == []
-
-
-# --------------------------------------------------------------------------- #
-# _apply_edits                                                                 #
-# --------------------------------------------------------------------------- #
-
-
-def test_apply_edits_basic():
-    result = _apply_edits("The limit is unknown.", [("unknown", "20")])
-    assert result == "The limit is 20."
-
-
-def test_apply_edits_multiple():
-    body = "foo and bar"
-    result = _apply_edits(body, [("foo", "baz"), ("bar", "qux")])
-    assert result == "baz and qux"
-
-
-def test_apply_edits_no_change_when_find_missing():
-    result = _apply_edits("body text", [("not present", "replacement")])
-    assert result is None
-
-
-def test_apply_edits_returns_none_when_unchanged():
-    result = _apply_edits("body", [])
-    assert result is None
-
-
-def test_apply_edits_replaces_first_occurrence_only():
-    result = _apply_edits("x x x", [("x", "y")])
-    assert result == "y x x"
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -7,12 +7,13 @@ import pytest
 
 from app.db.fts import SearchHit
 from app.ingest.models import WikiUpdateCandidate
-from app.llm.agents.common import batch_by_chars
+from app.llm.agents.common import IRRELEVANT_SENTINEL, batch_by_chars
 from app.llm.agents.ingest_batch_reconciler import (
+    _apply_edits,
     _parse,
+    _parse_edits,
     batch_reconcile,
 )
-from app.llm.agents.common import IRRELEVANT_SENTINEL
 
 
 def _hit(path: str, score: float = 1.0) -> SearchHit:
@@ -28,7 +29,7 @@ def _llm_response(text: str) -> MagicMock:
 
 
 # --------------------------------------------------------------------------- #
-# _batch_by_chars                                                              #
+# batch_by_chars                                                               #
 # --------------------------------------------------------------------------- #
 
 
@@ -49,6 +50,71 @@ def test_batch_empty():
 
 
 # --------------------------------------------------------------------------- #
+# _parse_edits                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_edits_single():
+    text = "===EDIT===\nFIND:\nold text\nREPLACE:\nnew text"
+    assert _parse_edits(text) == [("old text", "new text")]
+
+
+def test_parse_edits_multiple():
+    text = (
+        "===EDIT===\n"
+        "FIND:\nfirst\nREPLACE:\nfirst updated\n"
+        "===EDIT===\n"
+        "FIND:\nsecond\nREPLACE:\nsecond updated"
+    )
+    assert _parse_edits(text) == [("first", "first updated"), ("second", "second updated")]
+
+
+def test_parse_edits_multiline_find():
+    text = "===EDIT===\nFIND:\nline one\nline two\nREPLACE:\nreplacement"
+    assert _parse_edits(text) == [("line one\nline two", "replacement")]
+
+
+def test_parse_edits_empty_replace():
+    text = "===EDIT===\nFIND:\nremove this\nREPLACE:\n"
+    assert _parse_edits(text) == [("remove this", "")]
+
+
+def test_parse_edits_no_blocks():
+    assert _parse_edits("IRRELEVANT") == []
+
+
+# --------------------------------------------------------------------------- #
+# _apply_edits                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_edits_basic():
+    result = _apply_edits("The limit is unknown.", [("unknown", "20")])
+    assert result == "The limit is 20."
+
+
+def test_apply_edits_multiple():
+    body = "foo and bar"
+    result = _apply_edits(body, [("foo", "baz"), ("bar", "qux")])
+    assert result == "baz and qux"
+
+
+def test_apply_edits_no_change_when_find_missing():
+    result = _apply_edits("body text", [("not present", "replacement")])
+    assert result is None
+
+
+def test_apply_edits_returns_none_when_unchanged():
+    result = _apply_edits("body", [])
+    assert result is None
+
+
+def test_apply_edits_replaces_first_occurrence_only():
+    result = _apply_edits("x x x", [("x", "y")])
+    assert result == "y x x"
+
+
+# --------------------------------------------------------------------------- #
 # _parse                                                                       #
 # --------------------------------------------------------------------------- #
 
@@ -65,22 +131,28 @@ def test_parse_no_change():
     assert results == [None]
 
 
-def test_parse_new_body():
-    text = "===RESULT [1]===\n# Updated\n\nNew content here."
+def test_parse_edit_block():
+    text = (
+        "===RESULT [1]===\n"
+        "===EDIT===\n"
+        "FIND:\nold line\n"
+        "REPLACE:\nnew line"
+    )
     results = _parse(text, 1)
-    assert results == ["# Updated\n\nNew content here."]
+    assert len(results) == 1
+    assert results[0] == [("old line", "new line")]
 
 
 def test_parse_mixed():
     text = (
         "===RESULT [1]===\nIRRELEVANT\n"
         "===RESULT [2]===\nNO_CHANGE\n"
-        "===RESULT [3]===\n# New body\n\nContent."
+        "===RESULT [3]===\n===EDIT===\nFIND:\nold\nREPLACE:\nnew"
     )
     results = _parse(text, 3)
     assert results[0] == IRRELEVANT_SENTINEL
     assert results[1] is None
-    assert results[2] == "# New body\n\nContent."
+    assert results[2] == [("old", "new")]
 
 
 def test_parse_missing_section_defaults_to_irrelevant():
@@ -103,20 +175,22 @@ def test_parse_no_sections_raises():
 @patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
 @patch("app.llm.agents.ingest_batch_reconciler.client")
 def test_reconcile_returns_results(mock_client, _mock_prompt):
-    candidates = [_candidate("a"), _candidate("b"), _candidate("c")]
+    a = _candidate("a")
+    b = _candidate("b")
+    c = _candidate("c", "current content")
     mock_client.complete.return_value = _llm_response(
         "===RESULT [1]===\nIRRELEVANT\n"
         "===RESULT [2]===\nNO_CHANGE\n"
-        "===RESULT [3]===\n# New\n\nBody."
+        "===RESULT [3]===\n===EDIT===\nFIND:\ncurrent content\nREPLACE:\nupdated content"
     )
 
     results, llm_calls = batch_reconcile(
-        title="T", url="", content="doc", source="s", candidates=candidates, model="m"
+        title="T", url="", content="doc", source="s", candidates=[a, b, c], model="m"
     )
 
     assert results[0] == IRRELEVANT_SENTINEL
     assert results[1] is None
-    assert results[2] == "# New\n\nBody."
+    assert results[2] == "updated content"
     assert llm_calls == 1
 
 
@@ -161,11 +235,27 @@ def test_reconcile_fails_open_on_parse_error(mock_client, _mock_prompt):
 
 @patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
 @patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_reconcile_find_not_in_body_returns_none(mock_client, _mock_prompt):
+    # FIND text doesn't exist in the candidate body → no edit applied → None
+    candidates = [_candidate("a", "actual body")]
+    mock_client.complete.return_value = _llm_response(
+        "===RESULT [1]===\n===EDIT===\nFIND:\ntext not in body\nREPLACE:\nreplacement"
+    )
+
+    results, llm_calls = batch_reconcile(
+        title=None, url="", content="doc", source="s", candidates=candidates, model="m"
+    )
+
+    assert results[0] is None
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
+@patch("app.llm.agents.ingest_batch_reconciler.client")
 def test_reconcile_merges_multiple_batches(mock_client, _mock_prompt):
-    a = _candidate("a", "x" * 110_000)
+    a = _candidate("a", "start " + "x" * 110_000)
     b = _candidate("b", "y" * 110_000)
     mock_client.complete.side_effect = [
-        _llm_response("===RESULT [1]===\n# Updated a\n\nBody."),
+        _llm_response("===RESULT [1]===\n===EDIT===\nFIND:\nstart\nREPLACE:\nupdated"),
         _llm_response("===RESULT [1]===\nNO_CHANGE"),
     ]
 
@@ -173,7 +263,7 @@ def test_reconcile_merges_multiple_batches(mock_client, _mock_prompt):
         title=None, url="", content="", source="s", candidates=[a, b], model="m"
     )
 
-    assert results[0] == "# Updated a\n\nBody."
+    assert results[0] == "updated " + "x" * 110_000
     assert results[1] is None
     assert llm_calls == 2
 

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -203,6 +203,25 @@ def test_reconcile_fails_open_on_parse_error(mock_client, _mock_prompt):
 
 @patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
 @patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_reconcile_empty_edit_list_warns_and_returns_none(mock_client, _mock_prompt):
+    # LLM returns a result section that is neither IRRELEVANT/NO_CHANGE nor a
+    # valid ===EDIT=== block — _parse_edits yields [] and a warning should fire.
+    candidates = [_candidate("a", "body text")]
+    mock_client.complete.return_value = _llm_response(
+        "===RESULT [1]===\nmalformed content with no edit blocks"
+    )
+
+    with patch("app.llm.agents.ingest_batch_reconciler.log") as mock_log:
+        results, _ = batch_reconcile(
+            title=None, url="", content="doc", source="s", candidates=candidates, model="m"
+        )
+
+    assert results[0] is None
+    mock_log.warning.assert_called_once()
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
+@patch("app.llm.agents.ingest_batch_reconciler.client")
 def test_reconcile_find_not_in_body_returns_none(mock_client, _mock_prompt):
     # FIND text doesn't exist in the candidate body → no edit applied → None
     candidates = [_candidate("a", "actual body")]

--- a/backend/tests/test_llm_common.py
+++ b/backend/tests/test_llm_common.py
@@ -1,0 +1,49 @@
+"""Unit tests for app.llm.agents.common."""
+from __future__ import annotations
+
+from app.llm.agents.common import apply_edits
+
+
+def test_apply_edits_basic():
+    result = apply_edits("The limit is unknown.", [("unknown", "20")])
+    assert result == "The limit is 20."
+
+
+def test_apply_edits_multiple():
+    result = apply_edits("foo and bar", [("foo", "baz"), ("bar", "qux")])
+    assert result == "baz and qux"
+
+
+def test_apply_edits_replaces_first_occurrence_only():
+    result = apply_edits("x x x", [("x", "y")])
+    assert result == "y x x"
+
+
+def test_apply_edits_find_missing_skipped():
+    result = apply_edits("body text", [("not present", "replacement")])
+    assert result is None
+
+
+def test_apply_edits_empty_edits_returns_none():
+    assert apply_edits("body", []) is None
+
+
+def test_apply_edits_all_finds_missing_returns_none():
+    result = apply_edits("body", [("x", "y"), ("z", "w")])
+    assert result is None
+
+
+def test_apply_edits_partial_match_applies_found():
+    result = apply_edits("foo bar", [("foo", "baz"), ("missing", "x")])
+    assert result == "baz bar"
+
+
+def test_apply_edits_multiline():
+    body = "## Section\n\nOld paragraph here.\n"
+    result = apply_edits(body, [("Old paragraph here.", "New paragraph with info.")])
+    assert result == "## Section\n\nNew paragraph with info.\n"
+
+
+def test_apply_edits_empty_replace_deletes_text():
+    result = apply_edits("prefix DELETE_ME suffix", [("DELETE_ME ", "")])
+    assert result == "prefix suffix"

--- a/backend/tests/test_llm_common.py
+++ b/backend/tests/test_llm_common.py
@@ -1,26 +1,30 @@
 """Unit tests for app.llm.agents.common."""
 from __future__ import annotations
 
-from app.llm.agents.common import apply_edits
+from app.llm.agents.common import TextEdit, apply_edits
+
+
+def _e(find: str, replace: str) -> TextEdit:
+    return TextEdit(find=find, replace=replace)
 
 
 def test_apply_edits_basic():
-    result = apply_edits("The limit is unknown.", [("unknown", "20")])
+    result = apply_edits("The limit is unknown.", [_e("unknown", "20")])
     assert result == "The limit is 20."
 
 
 def test_apply_edits_multiple():
-    result = apply_edits("foo and bar", [("foo", "baz"), ("bar", "qux")])
+    result = apply_edits("foo and bar", [_e("foo", "baz"), _e("bar", "qux")])
     assert result == "baz and qux"
 
 
 def test_apply_edits_replaces_first_occurrence_only():
-    result = apply_edits("x x x", [("x", "y")])
+    result = apply_edits("x x x", [_e("x", "y")])
     assert result == "y x x"
 
 
 def test_apply_edits_find_missing_skipped():
-    result = apply_edits("body text", [("not present", "replacement")])
+    result = apply_edits("body text", [_e("not present", "replacement")])
     assert result is None
 
 
@@ -29,21 +33,21 @@ def test_apply_edits_empty_edits_returns_none():
 
 
 def test_apply_edits_all_finds_missing_returns_none():
-    result = apply_edits("body", [("x", "y"), ("z", "w")])
+    result = apply_edits("body", [_e("x", "y"), _e("z", "w")])
     assert result is None
 
 
 def test_apply_edits_partial_match_applies_found():
-    result = apply_edits("foo bar", [("foo", "baz"), ("missing", "x")])
+    result = apply_edits("foo bar", [_e("foo", "baz"), _e("missing", "x")])
     assert result == "baz bar"
 
 
 def test_apply_edits_multiline():
     body = "## Section\n\nOld paragraph here.\n"
-    result = apply_edits(body, [("Old paragraph here.", "New paragraph with info.")])
+    result = apply_edits(body, [_e("Old paragraph here.", "New paragraph with info.")])
     assert result == "## Section\n\nNew paragraph with info.\n"
 
 
 def test_apply_edits_empty_replace_deletes_text():
-    result = apply_edits("prefix DELETE_ME suffix", [("DELETE_ME ", "")])
+    result = apply_edits("prefix DELETE_ME suffix", [_e("DELETE_ME ", "")])
     assert result == "prefix suffix"


### PR DESCRIPTION
## Summary

- Replaces full-page-body output from the batch reconciler with targeted `===EDIT===` blocks containing `FIND:` / `REPLACE:` pairs
- `_parse_edits()` extracts verbatim find snippets and replacement text from each result section
- `_apply_edits()` applies each pair as `str.replace(..., count=1)` — leaving unchanged content untouched
- `wiki_update.py` interface is unchanged: still receives `str | None` per candidate

## Why

Full page rewrites require the model to faithfully reproduce every unchanged line, which wastes output tokens and risks silent content loss. Unified diffs are fragile — models mis-generate context lines under pressure. Exact string matching (same mechanism as Claude Code's Edit tool) is stable as long as the FIND snippet is unique, and the system prompt instructs the model to extend the snippet with surrounding context when a short string might repeat.

## Test plan
Before the change
<img width="1158" height="643" alt="Screenshot 2026-05-20 at 11 08 53 AM" src="https://github.com/user-attachments/assets/ab0398e9-68a4-4324-a105-da86b30febe0" />
After the change
<img width="1161" height="623" alt="Screenshot 2026-05-20 at 11 08 32 AM" src="https://github.com/user-attachments/assets/43eb2693-f80f-4d20-8741-9e13a69a7044" />


- [ ] `test_parse_edits_*` — `_parse_edits()` extracts correct (find, replace) pairs including multiline and empty-replace cases
- [ ] `test_apply_edits_*` — `_apply_edits()` applies edits, replaces only first occurrence, returns `None` when nothing changes
- [ ] `test_parse_*` — `_parse()` returns edit-pair lists for new-body results, still returns `IRRELEVANT_SENTINEL` / `None` correctly
- [ ] `test_reconcile_*` — full round-trip: edits applied to candidate body, fail-open on LLM/parse errors, multi-batch merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)