### PR TITLE
fix(monitoring): sum wiki_pages_total to avoid multi-instance duplicate cards

### DIFF
--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -478,7 +478,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "wiki_pages_total{job=\"agent-wiki-agent-workspace-backend\"}",
+          "expr": "sum(wiki_pages_total{job=\"agent-wiki-agent-workspace-backend\"})",
           "legendFormat": "Wiki Pages",
           "refId": "A"
         }


### PR DESCRIPTION
## Summary
- Wrap `wiki_pages_total` query in `sum()` so the stat card shows a single value instead of one card per scrape target.

## Test plan
- [ ] Wiki Pages stat card shows a single number in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)