### PR TITLE
chore(helm): bump chart to 0.3.15 to publish wiki_pages_total dashboard fix

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.14
+version: 0.3.15
 appVersion: "0.1.0"


### PR DESCRIPTION
## Summary
- Bump Helm chart to 0.3.15 to trigger release of the `sum(wiki_pages_total)` dashboard fix from #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)