### PR TITLE
fix(metrics): replace wiki_pages_total gauge with on-scrape custom collector

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -152,7 +152,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     async def _refresh_wiki_pages_gauge() -> None:
         while True:
             await asyncio.sleep(60)
-            c = fts.count_documents()
+            c = await asyncio.to_thread(fts.count_documents)
             if c is not None:
                 wiki_pages_total.set(c)
 
@@ -166,6 +166,10 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     yield
 
     refresh_task.cancel()
+    try:
+        await refresh_task
+    except asyncio.CancelledError:
+        pass
     mcp_pubsub.stop_listener()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -151,7 +151,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
     async def _refresh_wiki_pages_gauge() -> None:
         while True:
-            await asyncio.sleep(60)
+            await asyncio.sleep(300)
             c = await asyncio.to_thread(fts.count_documents)
             if c is not None:
                 wiki_pages_total.set(c)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,6 @@ wiki setup.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -119,9 +118,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     without entering the context manager, so the lifespan body is
     skipped — fixtures (``tmp_db`` / ``tmp_repo``) own DB/wiki init.
     """
-    from app.db import fts
     from app.db.session import init_db
-    from app.metrics import wiki_pages_total
     from app.tasks.agent_activity import schedule_all_pending_cleanups
     from app.triggers import repo as triggers_repo
     from app.utils.logging import setup_logging
@@ -145,19 +142,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_repo.rebuild_from_filesystem()
     schedule_all_pending_cleanups()
-    count = fts.count_documents()
-    if count is not None:
-        wiki_pages_total.set(count)
-
-    async def _refresh_wiki_pages_gauge() -> None:
-        while True:
-            await asyncio.sleep(300)
-            c = await asyncio.to_thread(fts.count_documents)
-            if c is not None:
-                wiki_pages_total.set(c)
-
-    refresh_task = asyncio.create_task(_refresh_wiki_pages_gauge())
-
     # Cross-process MCP pub-sub bridge: the worker process commits docs,
     # the web process owns the SSE stream — Postgres LISTEN/NOTIFY
     # ferries update events between them.
@@ -165,11 +149,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
-    refresh_task.cancel()
-    try:
-        await refresh_task
-    except asyncio.CancelledError:
-        pass
     mcp_pubsub.stop_listener()
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ wiki setup.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -147,6 +148,16 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     count = fts.count_documents()
     if count is not None:
         wiki_pages_total.set(count)
+
+    async def _refresh_wiki_pages_gauge() -> None:
+        while True:
+            await asyncio.sleep(60)
+            c = fts.count_documents()
+            if c is not None:
+                wiki_pages_total.set(c)
+
+    refresh_task = asyncio.create_task(_refresh_wiki_pages_gauge())
+
     # Cross-process MCP pub-sub bridge: the worker process commits docs,
     # the web process owns the SSE stream — Postgres LISTEN/NOTIFY
     # ferries update events between them.
@@ -154,6 +165,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
 
     yield
 
+    refresh_task.cancel()
     mcp_pubsub.stop_listener()
 
 

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -16,6 +16,8 @@ from prometheus_client import Counter, Gauge, Histogram, REGISTRY
 from prometheus_client.core import GaugeMetricFamily  # type: ignore[import-untyped]
 from prometheus_fastapi_instrumentator import Instrumentator
 
+from app.db import fts
+
 # --------------------------------------------------------------------------- #
 # Ingest pipeline                                                              #
 # --------------------------------------------------------------------------- #
@@ -80,7 +82,6 @@ ingest_queue_depth = Gauge(
 
 class _WikiPagesCollector:
     def collect(self):
-        from app.db import fts
         count = fts.count_documents() or 0
         g = GaugeMetricFamily(
             "wiki_pages_total",

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -12,7 +12,8 @@ Ingest pipeline metrics must be updated manually at each pipeline stage.
 from __future__ import annotations
 
 from fastapi import FastAPI
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram, REGISTRY
+from prometheus_client.core import GaugeMetricFamily  # type: ignore[import-untyped]
 from prometheus_fastapi_instrumentator import Instrumentator
 
 # --------------------------------------------------------------------------- #
@@ -77,10 +78,18 @@ ingest_queue_depth = Gauge(
     "Current number of pending tasks in the documents queue",
 )
 
-wiki_pages_total = Gauge(
-    "wiki_pages_total",
-    "Total number of wiki pages currently in the search index",
-)
+class _WikiPagesCollector:
+    def collect(self):
+        from app.db import fts
+        count = fts.count_documents() or 0
+        g = GaugeMetricFamily(
+            "wiki_pages_total",
+            "Total number of wiki pages currently in the search index",
+        )
+        g.add_metric([], count)
+        yield g
+
+REGISTRY.register(_WikiPagesCollector())
 
 ingest_selector_candidates_filtered = Histogram(
     "ingest_selector_candidates_filtered",

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -21,7 +21,6 @@ import logging
 import re
 
 from app.db import fts
-from app.metrics import wiki_pages_total
 from app.tasks.queue import crontab
 from app.tasks.queues import lightweight_maintenance_queue
 from app.wiki import git as wiki_git
@@ -59,9 +58,6 @@ def index_path_inline(path: str) -> None:
         return
 
     fts.upsert_document(path, path, _extract_title(body), body)
-    count = fts.count_documents()
-    if count is not None:
-        wiki_pages_total.set(count)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -30,7 +30,6 @@ clean (``api/`` → ``wiki/`` ← ``tools/``).
 from __future__ import annotations
 
 from app.db import fts
-from app.metrics import wiki_pages_total
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
@@ -97,9 +96,6 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     acl.on_page_deleted(rel_path)
     fan_out_trigger_eval(rel_path, sha, "delete", actor)
     mcp_pubsub.publish_doc_delete(rel_path, sha)
-    count = fts.count_documents()
-    if count is not None:
-        wiki_pages_total.set(count)
     mcp_pubsub.publish_list_changed()
 
 

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.15
+version: 0.3.16
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -2277,6 +2277,7 @@
         "yAxis": {
           "axisLabel": "output tokens",
           "axisPlacement": "left",
+          "max": 16384,
           "unit": "short"
         }
       },


### PR DESCRIPTION
## Summary
- Replace the pushed `wiki_pages_total` Gauge with a custom Prometheus collector that queries OpenSearch on each scrape.
- Removes the startup initialization, background refresh task, and all manual `.set()` calls in `notify.py`, `reindex.py`, and `main.py`.
- The metric is now always accurate regardless of pod startup timing — no background tasks, no sleep loops, no wasted work between scrapes.

## Why
The previous approach relied on a `Gauge` that had to be explicitly set in the backend process. This broke because:
1. Worker processes (`lightweight-maintenance`) updated the gauge in their own registry, which Prometheus never scrapes.
2. The single startup init raced with OpenSearch availability, leaving the gauge at 0 after pod restarts.

## Test plan
- [ ] `wiki_pages_total` shows correct count in Grafana after pod restart without any warmup delay
- [ ] Gauge reflects accurate count even if OpenSearch was unavailable at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)