### PR TITLE
fix(monitoring): set default datasource in dashboard to fix stat panels showing 0

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.16
+version: 0.3.17
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -2427,7 +2427,11 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "selected": true,
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
         "hide": 0,
         "includeAll": false,
         "multi": false,


### PR DESCRIPTION
## Problem
Grafana 12 with `kubernetesDashboards=true` does not auto-populate the `$datasource` template variable before rendering stat panels. The variable had `"current": {}` (empty), leaving the datasource unresolved on load. This caused the Wiki Pages stat panel (and potentially others) to show 0 instead of the correct value, even though Prometheus was returning the correct data.

## Fix
Set an explicit `current` value on the datasource variable:
```json
"current": {
  "selected": true,
  "text": "Prometheus",
  "value": "prometheus"
}
```

This ensures `${datasource}` always resolves to the Prometheus datasource on first render.

## Test plan
- [ ] Deploy and confirm Wiki Pages panel shows correct page count (not 0)
- [ ] Confirm other stat panels continue showing correct values