### PR TITLE
chore(deploy): sync monitoring-values.yaml template with production config

### DIFF
--- a/deploy/terraform/monitoring-values.yaml
+++ b/deploy/terraform/monitoring-values.yaml
@@ -23,7 +23,7 @@ grafana:
       labelValue: "1"
       searchNamespace: agent-wiki
       folderAnnotation: grafana_folder
-      skipReload: true
+      # skipReload: true  # Set to true if the sidecar's reload call fails due to admin password mismatch
       provider:
         foldersFromFilesStructure: false
   ingress:
@@ -41,13 +41,13 @@ grafana:
   # Create with: kubectl -n agent-wiki create secret generic grafana-oauth-secret \
   #   --from-literal=GF_AUTH_GOOGLE_CLIENT_ID=<id> \
   #   --from-literal=GF_AUTH_GOOGLE_CLIENT_SECRET=<secret>
-  envFromSecret: grafana-oauth-secret
+  # envFromSecret: grafana-oauth-secret
   grafana.ini:
     server:
       root_url: https://example.com/monitoring  # Set to your public URL
       serve_from_sub_path: true
     auth:
-      disable_login_form: true
+      disable_login_form: false  # Set to true only after Google OAuth is confirmed working
       oauth_auto_login: false
     auth.basic:
       enabled: true

--- a/deploy/terraform/monitoring-values.yaml
+++ b/deploy/terraform/monitoring-values.yaml
@@ -12,6 +12,7 @@ alertmanager:
 
 grafana:
   enabled: true
+  fullnameOverride: agent-wiki-monitoring-grafana
   service:
     type: ClusterIP
     port: 80
@@ -21,34 +22,46 @@ grafana:
       label: grafana_dashboard
       labelValue: "1"
       searchNamespace: agent-wiki
+      folderAnnotation: grafana_folder
+      skipReload: true
+      provider:
+        foldersFromFilesStructure: false
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    hosts:
+      - example.com  # Set to your domain
+    path: /monitoring
+    pathType: Prefix
   persistence:
     enabled: true
     storageClassName: gp3
     size: 10Gi
-  # Optional: mount a secret with OAuth credentials.
+  # Mount a secret with OAuth credentials.
   # Create with: kubectl -n agent-wiki create secret generic grafana-oauth-secret \
   #   --from-literal=GF_AUTH_GOOGLE_CLIENT_ID=<id> \
   #   --from-literal=GF_AUTH_GOOGLE_CLIENT_SECRET=<secret>
-  # Then uncomment the line below.
-  # envFromSecret: grafana-oauth-secret
+  envFromSecret: grafana-oauth-secret
   grafana.ini:
     server:
-      # Set to the public URL where Grafana will be reachable.
-      # If served from a sub-path (e.g. /monitoring), set serve_from_sub_path: true.
-      root_url: https://example.com/monitoring
+      root_url: https://example.com/monitoring  # Set to your public URL
       serve_from_sub_path: true
     auth:
-      disable_login_form: false
-    # Uncomment to enable Google OAuth:
-    # auth.google:
-    #   enabled: true
-    #   allow_sign_up: true
-    #   scopes: openid email profile
-    #   auth_url: https://accounts.google.com/o/oauth2/v2/auth
-    #   token_url: https://oauth2.googleapis.com/token
-    #   api_url: https://openidconnect.googleapis.com/v1/userinfo
-    #   allowed_domains: example.com
-    #   use_pkce: true
+      disable_login_form: true
+      oauth_auto_login: false
+    auth.basic:
+      enabled: true
+    auth.google:
+      enabled: true
+      allow_sign_up: true
+      auto_assign_org_role: Admin  # Adjust as needed
+      scopes: openid email profile
+      auth_url: https://accounts.google.com/o/oauth2/v2/auth
+      token_url: https://oauth2.googleapis.com/token
+      api_url: https://openidconnect.googleapis.com/v1/userinfo
+      allowed_domains: example.com  # Set to your domain
+      hosted_domain: example.com    # Set to your domain
+      use_pkce: true
 
 prometheus:
   prometheusSpec:


### PR DESCRIPTION
## Summary
- Adds `fullnameOverride`, `folderAnnotation`, `provider` config, and ingress block
- Uncomments Google OAuth structure with `example.com` placeholders so new deployers know what to configure
- Adds `auth.basic.enabled: true` (needed for Grafana sidecar reload API auth)
- Adds `skipReload: true` as a commented-out escape hatch with explanation
- Keeps `envFromSecret`, `disable_login_form: true`, and `skipReload` commented/safe so a fresh install works out of the box

## Test plan
- [ ] Verify a fresh install with this template deploys without errors