### PR TITLE
improve(ingest): switch reconciler to tool calling + fuzzy FIND matching

### DIFF
--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -43,7 +43,13 @@ def batch_by_chars(
 
 
 def rstrip_lines(text: str) -> str:
-    """Strip trailing whitespace from each line. Preserves a trailing newline if present."""
+    """Strip trailing whitespace from each line. Preserves a trailing newline if present.
+
+    Assumes LF or CRLF line endings. Bare CR (``\\r``-only, pre-OS X Mac) is treated
+    as a line separator by ``splitlines()`` and replaced with ``\\n`` on rejoin, which
+    breaks the monotone subsequence property that ``_map_norm_span_to_orig`` relies on.
+    Wiki markdown content never contains bare CR in practice.
+    """
     lines = text.splitlines()
     normalized = "\n".join(line.rstrip() for line in lines)
     if text.endswith("\n"):

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -70,9 +70,18 @@ def _map_norm_pos_to_orig(original: str, normalized: str, norm_pos: int) -> int:
 def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
     """Apply (find, replace) pairs to body. Returns new body or None if unchanged.
 
-    Falls back to trailing-whitespace-normalized matching when the exact FIND text
-    is not present — recovers from the common case where the model quotes text with
-    slightly different trailing spaces or line endings.
+    Falls back to trailing-whitespace-normalized matching (via ``rstrip_lines``)
+    when the exact FIND text is not present — recovers from the common case where
+    the model quotes text with slightly different trailing spaces or line endings.
+
+    We use this targeted normalization rather than a general fuzzy-match library
+    (e.g. diff-match-patch) deliberately: a library with a non-zero match threshold
+    can apply an edit to the wrong location, silently corrupting wiki content.
+    That false-positive failure mode is much worse than a skipped edit, which is
+    recoverable on the next ingest cycle. Trailing-whitespace variance is the
+    dominant real-world deviation; anything further off (wrong words, transposed
+    phrases) most likely indicates the model hallucinated the context, and skipping
+    is the right response.
     """
     result = body
     for find_text, replace_text in edits:

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -91,6 +91,10 @@ def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
             continue
         orig_start = _map_norm_pos_to_orig(result, norm_result, pos)
         orig_end = _map_norm_pos_to_orig(result, norm_result, pos + len(norm_find))
+        # Consume trailing whitespace on the last matched line that normalization
+        # stripped from the body but the find text didn't include.
+        while orig_end < len(result) and result[orig_end] in " \t\r":
+            orig_end += 1
         result = result[:orig_start] + replace_text + result[orig_end:]
         log.debug("apply_edits: used normalized match for FIND: %r", find_text[:60])
     return result if result != body else None

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -42,17 +42,57 @@ def batch_by_chars(
     return batches
 
 
+def _normalize_for_match(text: str) -> str:
+    """Strip trailing whitespace per line for fuzzy matching. Preserves trailing newline."""
+    lines = text.splitlines()
+    normalized = "\n".join(line.rstrip() for line in lines)
+    if text.endswith("\n"):
+        normalized += "\n"
+    return normalized
+
+
+def _map_norm_pos_to_orig(original: str, normalized: str, norm_pos: int) -> int:
+    """Map a position in a normalized string back to the corresponding position in original.
+
+    Works because normalized is derived from original by only removing characters
+    (trailing whitespace per line), so the mapping is monotone.
+    """
+    o = n = 0
+    while n < norm_pos and o < len(original):
+        if n < len(normalized) and original[o] == normalized[n]:
+            o += 1
+            n += 1
+        else:
+            o += 1  # character was stripped in normalization, skip in original
+    return o
+
+
 def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
-    """Apply (find, replace) pairs to body. Returns new body or None if unchanged."""
+    """Apply (find, replace) pairs to body. Returns new body or None if unchanged.
+
+    Falls back to trailing-whitespace-normalized matching when the exact FIND text
+    is not present — recovers from the common case where the model quotes text with
+    slightly different trailing spaces or line endings.
+    """
     result = body
     for find_text, replace_text in edits:
-        if find_text not in result:
+        if find_text in result:
+            result = result.replace(find_text, replace_text, 1)
+            continue
+        # Fuzzy fallback: match after stripping trailing whitespace per line.
+        norm_result = _normalize_for_match(result)
+        norm_find = _normalize_for_match(find_text)
+        pos = norm_result.find(norm_find)
+        if pos == -1:
             log.warning(
                 "apply_edits: FIND text not found in body, skipping: %r",
                 find_text[:60],
             )
             continue
-        result = result.replace(find_text, replace_text, 1)
+        orig_start = _map_norm_pos_to_orig(result, norm_result, pos)
+        orig_end = _map_norm_pos_to_orig(result, norm_result, pos + len(norm_find))
+        result = result[:orig_start] + replace_text + result[orig_end:]
+        log.debug("apply_edits: used normalized match for FIND: %r", find_text[:60])
     return result if result != body else None
 
 

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -51,20 +51,26 @@ def rstrip_lines(text: str) -> str:
     return normalized
 
 
-def _map_norm_pos_to_orig(original: str, normalized: str, norm_pos: int) -> int:
-    """Map a position in a normalized string back to the corresponding position in original.
+def _map_norm_span_to_orig(
+    original: str, normalized: str, norm_start: int, norm_end: int
+) -> tuple[int, int]:
+    """Map a [norm_start, norm_end) span in a normalized string back to original.
 
+    Single pass — captures both endpoints without restarting the walk.
     Works because normalized is derived from original by only removing characters
     (trailing whitespace per line), so the mapping is monotone.
     """
     o = n = 0
-    while n < norm_pos and o < len(original):
+    orig_start = 0
+    while n < norm_end and o < len(original):
+        if n == norm_start:
+            orig_start = o
         if n < len(normalized) and original[o] == normalized[n]:
             o += 1
             n += 1
         else:
             o += 1  # character was stripped in normalization, skip in original
-    return o
+    return orig_start, o
 
 
 def _fuzzy_replace(body: str, find: str, replace: str) -> str | None:
@@ -77,8 +83,7 @@ def _fuzzy_replace(body: str, find: str, replace: str) -> str | None:
     pos = norm_body.find(norm_find)
     if pos == -1:
         return None
-    orig_start = _map_norm_pos_to_orig(body, norm_body, pos)
-    orig_end = _map_norm_pos_to_orig(body, norm_body, pos + len(norm_find))
+    orig_start, orig_end = _map_norm_span_to_orig(body, norm_body, pos, pos + len(norm_find))
     # Consume trailing whitespace on the last matched line that normalization
     # stripped from the body but the find text didn't include.
     while orig_end < len(body) and body[orig_end] in " \t\r":

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -67,10 +67,29 @@ def _map_norm_pos_to_orig(original: str, normalized: str, norm_pos: int) -> int:
     return o
 
 
+def _fuzzy_replace(body: str, find: str, replace: str) -> str | None:
+    """Replace ``find`` in ``body`` using trailing-whitespace-normalized matching.
+
+    Returns the new body string, or None if no match was found.
+    """
+    norm_body = rstrip_lines(body)
+    norm_find = rstrip_lines(find)
+    pos = norm_body.find(norm_find)
+    if pos == -1:
+        return None
+    orig_start = _map_norm_pos_to_orig(body, norm_body, pos)
+    orig_end = _map_norm_pos_to_orig(body, norm_body, pos + len(norm_find))
+    # Consume trailing whitespace on the last matched line that normalization
+    # stripped from the body but the find text didn't include.
+    while orig_end < len(body) and body[orig_end] in " \t\r":
+        orig_end += 1
+    return body[:orig_start] + replace + body[orig_end:]
+
+
 def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
     """Apply (find, replace) pairs to body. Returns new body or None if unchanged.
 
-    Falls back to trailing-whitespace-normalized matching (via ``rstrip_lines``)
+    Falls back to ``_fuzzy_replace`` (trailing-whitespace-normalized matching)
     when the exact FIND text is not present — recovers from the common case where
     the model quotes text with slightly different trailing spaces or line endings.
 
@@ -88,24 +107,15 @@ def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
         if find_text in result:
             result = result.replace(find_text, replace_text, 1)
             continue
-        # Fuzzy fallback: match after stripping trailing whitespace per line.
-        norm_result = rstrip_lines(result)
-        norm_find = rstrip_lines(find_text)
-        pos = norm_result.find(norm_find)
-        if pos == -1:
+        new = _fuzzy_replace(result, find_text, replace_text)
+        if new is None:
             log.warning(
                 "apply_edits: FIND text not found in body, skipping: %r",
                 find_text[:60],
             )
             continue
-        orig_start = _map_norm_pos_to_orig(result, norm_result, pos)
-        orig_end = _map_norm_pos_to_orig(result, norm_result, pos + len(norm_find))
-        # Consume trailing whitespace on the last matched line that normalization
-        # stripped from the body but the find text didn't include.
-        while orig_end < len(result) and result[orig_end] in " \t\r":
-            orig_end += 1
-        result = result[:orig_start] + replace_text + result[orig_end:]
         log.debug("apply_edits: used normalized match for FIND: %r", find_text[:60])
+        result = new
     return result if result != body else None
 
 

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -42,8 +42,8 @@ def batch_by_chars(
     return batches
 
 
-def _normalize_for_match(text: str) -> str:
-    """Strip trailing whitespace per line for fuzzy matching. Preserves trailing newline."""
+def rstrip_lines(text: str) -> str:
+    """Strip trailing whitespace from each line. Preserves a trailing newline if present."""
     lines = text.splitlines()
     normalized = "\n".join(line.rstrip() for line in lines)
     if text.endswith("\n"):
@@ -80,8 +80,8 @@ def apply_edits(body: str, edits: list[TextEdit]) -> str | None:
             result = result.replace(find_text, replace_text, 1)
             continue
         # Fuzzy fallback: match after stripping trailing whitespace per line.
-        norm_result = _normalize_for_match(result)
-        norm_find = _normalize_for_match(find_text)
+        norm_result = rstrip_lines(result)
+        norm_find = rstrip_lines(find_text)
         pos = norm_result.find(norm_find)
         if pos == -1:
             log.warning(

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -7,9 +7,8 @@ for each one:
   - str                  — the new page body produced by applying FIND/REPLACE
                            edits to the current body
 
-The model submits decisions via the ``submit_results`` tool call — typed JSON
-rather than parsed free text, so formatting deviations cause hard errors
-instead of silent mis-parses.
+The model submits decisions via the ``submit_results`` tool call — typed JSON,
+so formatting deviations cause hard errors instead of silent mis-parses.
 
 Fails open — any error marks all candidates in that batch as IRRELEVANT_SENTINEL.
 Batches fail independently.
@@ -218,6 +217,12 @@ def _parse_tool_results(
       - None: page is already up-to-date
       - list[TextEdit]: edits to apply
     """
+    if tool_call.name != "submit_results":
+        log.warning(
+            "ingest_batch_reconciler: unexpected tool call %r, expected submit_results",
+            tool_call.name,
+        )
+        return [IRRELEVANT_SENTINEL] * len(batch)
     raw: list[Any] = tool_call.arguments.get("results") or []
     by_index: dict[int, dict[str, Any]] = {}
     for item in raw:

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -29,6 +29,7 @@ from app.tracing import trace_flow
 log = logging.getLogger(__name__)
 
 _RECONCILER_BUDGET_CHARS = 200_000
+_RECONCILER_MAX_TOKENS = 8192
 
 _SUBMIT_TOOL: dict[str, Any] = {
     "name": "submit_results",
@@ -172,7 +173,7 @@ def _reconcile_batch(
                 ],
                 model=model,
                 tools=[_SUBMIT_TOOL],
-                max_tokens=8192,
+                max_tokens=_RECONCILER_MAX_TOKENS,
             )
         if not result.tool_calls:
             raise ValueError("model returned no tool call")

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -7,18 +7,22 @@ for each one:
   - str                  — the new page body produced by applying FIND/REPLACE
                            edits to the current body
 
-Fails open — any LLM or parse error marks all candidates in that batch as
-IRRELEVANT_SENTINEL. Batches fail independently.
+The model submits decisions via the ``submit_results`` tool call — typed JSON
+rather than parsed free text, so formatting deviations cause hard errors
+instead of silent mis-parses.
+
+Fails open — any error marks all candidates in that batch as IRRELEVANT_SENTINEL.
+Batches fail independently.
 """
 from __future__ import annotations
 
 import logging
-import re
-from typing import NamedTuple
+from typing import Any, NamedTuple, cast
 
 from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
-from app.llm.agents.common import IRRELEVANT_SENTINEL, NO_CHANGE_SENTINEL, TextEdit, apply_edits, batch_by_chars
+from app.llm.client import ToolCall
+from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, apply_edits, batch_by_chars
 from app.metrics import ingest_reconciler_input_tokens, ingest_reconciler_output_tokens
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
@@ -27,13 +31,62 @@ log = logging.getLogger(__name__)
 
 _RECONCILER_BUDGET_CHARS = 200_000
 
+_SUBMIT_TOOL: dict[str, Any] = {
+    "name": "submit_results",
+    "description": "Submit your editing decisions for all candidate wiki pages.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "results": {
+                "type": "array",
+                "description": "One entry per candidate wiki page, in order.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "candidate_index": {
+                            "type": "integer",
+                            "description": "1-based index matching the candidate number.",
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["irrelevant", "no_change", "edit"],
+                            "description": (
+                                "irrelevant: page is unrelated to the external document. "
+                                "no_change: page already reflects everything in the external document. "
+                                "edit: changes are needed — provide edits."
+                            ),
+                        },
+                        "edits": {
+                            "type": "array",
+                            "description": "Required when action is 'edit'. Omit otherwise.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "find": {
+                                        "type": "string",
+                                        "description": "Exact verbatim text from the wiki page to replace.",
+                                    },
+                                    "replace": {
+                                        "type": "string",
+                                        "description": "The replacement text.",
+                                    },
+                                },
+                                "required": ["find", "replace"],
+                            },
+                        },
+                    },
+                    "required": ["candidate_index", "action"],
+                },
+            }
+        },
+        "required": ["results"],
+    },
+}
+
 
 class BatchReconcileResult(NamedTuple):
     results: list[str | None]
     llm_calls: int
-
-
-_RESULT_RE = re.compile(r"===RESULT \[(\d+)\]===")
 
 
 def batch_reconcile(
@@ -55,7 +108,7 @@ def batch_reconcile(
       - ``llm_calls`` is the number of LLM calls made (one per char-budget batch)
 
     Falls back to IRRELEVANT_SENTINEL for all candidates in a batch on any
-    LLM or parse error; batches fail independently.
+    error; batches fail independently.
     """
     if not candidates:
         return BatchReconcileResult(results=[], llm_calls=0)
@@ -119,14 +172,19 @@ def _reconcile_batch(
                     {"role": "user", "content": user},
                 ],
                 model=model,
+                tools=[_SUBMIT_TOOL],
+                max_tokens=8192,
             )
-        parsed = _parse(result.text, len(batch))
+        if not result.tool_calls:
+            raise ValueError("model returned no tool call")
+        parsed = _parse_tool_results(result.tool_calls[0], batch)
     except Exception:
         log.warning(
             "ingest_batch_reconciler: batch failed, falling back",
             exc_info=True,
         )
         return [IRRELEVANT_SENTINEL] * len(batch)
+
     try:
         ingest_reconciler_input_tokens.observe(result.usage.input_tokens)
         ingest_reconciler_output_tokens.observe(result.usage.output_tokens)
@@ -139,67 +197,67 @@ def _reconcile_batch(
             results.append(None)
         elif outcome is IRRELEVANT_SENTINEL:
             results.append(IRRELEVANT_SENTINEL)
-        elif isinstance(outcome, list):  # list[TextEdit] — apply edits to current body
+        elif isinstance(outcome, list):
             if not outcome:
                 log.warning(
-                    "ingest_batch_reconciler: no ===EDIT=== blocks parsed for %s, treating as NO_CHANGE",
+                    "ingest_batch_reconciler: no edits for %s, treating as NO_CHANGE",
                     c.hit.path,
                 )
             results.append(apply_edits(c.body, outcome))
     return results
 
 
-
-def _parse(text: str, n: int) -> list[str | None | list[TextEdit]]:
-    """Parse the structured LLM output into a per-candidate outcome list.
+def _parse_tool_results(
+    tool_call: ToolCall,
+    batch: list[WikiUpdateCandidate],
+) -> list[str | None | list[TextEdit]]:
+    """Parse a submit_results tool call into per-candidate outcomes.
 
     Each element is one of:
-      - IRRELEVANT_SENTINEL (str): page is unrelated
+      - IRRELEVANT_SENTINEL: page is unrelated
       - None: page is already up-to-date
-      - list[TextEdit]: (find, replace) edit pairs to apply
+      - list[TextEdit]: edits to apply
     """
-    parts = _RESULT_RE.split(text)
-    raw: dict[int, str] = {}
-    for i in range(1, len(parts), 2):
-        idx = int(parts[i])
-        body = parts[i + 1].strip() if i + 1 < len(parts) else ""
-        raw[idx] = body
+    raw: list[Any] = tool_call.arguments.get("results") or []
+    by_index: dict[int, dict[str, Any]] = {}
+    for item in raw:
+        if isinstance(item, dict):
+            r = cast(dict[str, Any], item)
+            idx = r.get("candidate_index")
+            if isinstance(idx, int):
+                by_index[idx] = r
 
-    if not raw:
-        raise ValueError("no ===RESULT [N]=== sections found in response")
-
-    results: list[str | None | list[TextEdit]] = []
-    for i in range(1, n + 1):
-        body = raw.get(i, IRRELEVANT_SENTINEL)
-        if body == IRRELEVANT_SENTINEL or body.startswith(IRRELEVANT_SENTINEL + "\n"):
-            results.append(IRRELEVANT_SENTINEL)
-        elif body == NO_CHANGE_SENTINEL or body.startswith(NO_CHANGE_SENTINEL + "\n"):
-            results.append(None)
+    outcomes: list[str | None | list[TextEdit]] = []
+    for i in range(1, len(batch) + 1):
+        entry = by_index.get(i)
+        if entry is None:
+            outcomes.append(IRRELEVANT_SENTINEL)
+            continue
+        action = entry.get("action", "irrelevant")
+        if action == "no_change":
+            outcomes.append(None)
+        elif action == "edit":
+            raw_edits: list[Any] = entry.get("edits") or []
+            edits: list[TextEdit] = []
+            for edit_item in raw_edits:
+                if isinstance(edit_item, dict):
+                    e = cast(dict[str, Any], edit_item)
+                    find = e.get("find")
+                    replace = e.get("replace")
+                    if isinstance(find, str) and isinstance(replace, str):
+                        edits.append(TextEdit(find=find, replace=replace))
+            if not edits:
+                log.warning(
+                    "ingest_batch_reconciler: action=edit but no valid edits for candidate %d",
+                    i,
+                )
+            outcomes.append(edits)
         else:
-            results.append(_parse_edits(body))
-    return results
-
-
-def _parse_edits(text: str) -> list[TextEdit]:
-    """Parse ===EDIT=== blocks from a result section into TextEdit pairs."""
-    edits: list[TextEdit] = []
-    for block in re.split(r"===EDIT===\n?", text.strip()):
-        block = block.strip()
-        if not block:
-            continue
-        find_pos = block.find("FIND:\n")
-        # Search for "\nREPLACE:" without requiring a trailing newline so that
-        # empty REPLACE sections (where the block ends right after "REPLACE:")
-        # are still matched after strip() removes the trailing newline.
-        replace_pos = block.find("\nREPLACE:")
-        if find_pos == -1 or replace_pos == -1 or replace_pos <= find_pos:
-            continue
-        find_text = block[find_pos + len("FIND:\n"):replace_pos]
-        replace_raw = block[replace_pos + len("\nREPLACE:"):]
-        # Strip the single newline delimiter that normally follows "REPLACE:".
-        replace_text = replace_raw[1:] if replace_raw.startswith("\n") else replace_raw
-        find_text = find_text.strip("\n")
-        replace_text = replace_text.strip("\n")
-        if find_text:
-            edits.append(TextEdit(find=find_text, replace=replace_text))
-    return edits
+            if action != "irrelevant":
+                log.warning(
+                    "ingest_batch_reconciler: unknown action %r for candidate %d, treating as irrelevant",
+                    action,
+                    i,
+                )
+            outcomes.append(IRRELEVANT_SENTINEL)
+    return outcomes

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -6,7 +6,7 @@ if so, produce targeted FIND/REPLACE edits.
 ## Relevance check — do this first for each page
 
 Ask: does the external document directly describe the same system, process,
-or operational topic that this wiki page covers? If not, output IRRELEVANT.
+or operational topic that this wiki page covers? If not, use action `irrelevant`.
 
 Being in the same product or company domain is not enough. Examples of
 irrelevant pushes:
@@ -15,7 +15,7 @@ irrelevant pushes:
 - Marketing content or general how-to guides pushed against an ops page.
 - A doc about feature X pushed against a runbook for service Y.
 
-When in doubt, output IRRELEVANT. Err on the side of not changing the page.
+When in doubt, use `irrelevant`. Err on the side of not changing the page.
 
 ## Editing rules (only apply if relevant)
 
@@ -26,7 +26,7 @@ When in doubt, output IRRELEVANT. Err on the side of not changing the page.
 - Do not copy the external document wholesale — integrate only what is
   genuinely new or corrects something wrong.
 - If the page is already up-to-date with everything in the external doc,
-  output NO_CHANGE.
+  use action `no_change`.
 
 ## Markdown structure rules (only apply when producing edits)
 
@@ -40,33 +40,19 @@ When in doubt, output IRRELEVANT. Err on the side of not changing the page.
   code snippet.
 - Do not add a trailing newline block or sign-off like "Updated by …".
 
-## Output format
+## Output
 
-For each candidate, output a section using this exact format:
+Call `submit_results` with your decisions for all N candidates.
 
-===RESULT [N]===
-<output>
-
-Where <output> is one of:
-
-**IRRELEVANT** — the external document is unrelated to this wiki page.
-
-**NO_CHANGE** — the page already reflects everything in the external document.
-
-**Edit blocks** — one or more edits using this exact structure:
-
-===EDIT===
-FIND:
-<exact verbatim text from the page>
-REPLACE:
-<replacement text>
-
-Rules for edit blocks:
-- FIND must be copied verbatim from the page — whitespace and punctuation must match exactly.
-- FIND must be long enough to uniquely identify the location. If the text appears more than once, extend FIND to include surrounding context that makes it unique.
-- To add content after an existing line, include that line in FIND and repeat it at the start of REPLACE followed by the new content.
-- To add a new section at the end of the page, anchor FIND on the last existing heading or paragraph.
-- REPLACE may add, update, or expand. Never remove information the external doc does not address.
-- Use multiple ===EDIT=== blocks for non-adjacent changes. Order them top-to-bottom as they appear in the page.
-
-Output all N sections in order. No other text outside the sections.
+Rules for `find`/`replace` edit pairs:
+- `find` must be copied verbatim from the page — whitespace and punctuation
+  must match exactly.
+- `find` must be long enough to uniquely identify the location. If the text
+  appears more than once, extend it to include surrounding context.
+- To add content after an existing line, include that line in `find` and
+  repeat it at the start of `replace` followed by the new content.
+- To add a new section at the end, anchor `find` on the last existing heading
+  or paragraph.
+- `replace` may add, update, or expand. Never remove information the external
+  doc does not address.
+- Use multiple edit objects for non-adjacent changes, ordered top-to-bottom.

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -141,6 +141,16 @@ def test_parse_tool_results_edit_with_no_edits_warns(caplog):
     assert "no valid edits" in caplog.text
 
 
+def test_parse_tool_results_wrong_tool_name_returns_all_irrelevant(caplog):
+    import logging
+    batch = [_candidate("a"), _candidate("b")]
+    tc = ToolCall(id="call_1", name="wrong_tool", arguments={"results": []})
+    with caplog.at_level(logging.WARNING, logger="app.llm.agents.ingest_batch_reconciler"):
+        results = _parse_tool_results(tc, batch)
+    assert results == [IRRELEVANT_SENTINEL, IRRELEVANT_SENTINEL]
+    assert "unexpected tool call" in caplog.text
+
+
 def test_parse_tool_results_unknown_action_defaults_to_irrelevant(caplog):
     import logging
     batch = [_candidate("a")]

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -1,6 +1,7 @@
 """Unit tests for app.llm.agents.ingest_batch_reconciler."""
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
 
 from app.db.fts import SearchHit
@@ -132,7 +133,6 @@ def test_parse_tool_results_empty_results_all_irrelevant():
 
 
 def test_parse_tool_results_edit_with_no_edits_warns(caplog):
-    import logging
     batch = [_candidate("a")]
     tc = _tool_call({"results": [{"candidate_index": 1, "action": "edit", "edits": []}]})
     with caplog.at_level(logging.WARNING, logger="app.llm.agents.ingest_batch_reconciler"):
@@ -142,7 +142,6 @@ def test_parse_tool_results_edit_with_no_edits_warns(caplog):
 
 
 def test_parse_tool_results_wrong_tool_name_returns_all_irrelevant(caplog):
-    import logging
     batch = [_candidate("a"), _candidate("b")]
     tc = ToolCall(id="call_1", name="wrong_tool", arguments={"results": []})
     with caplog.at_level(logging.WARNING, logger="app.llm.agents.ingest_batch_reconciler"):
@@ -152,7 +151,6 @@ def test_parse_tool_results_wrong_tool_name_returns_all_irrelevant(caplog):
 
 
 def test_parse_tool_results_unknown_action_defaults_to_irrelevant(caplog):
-    import logging
     batch = [_candidate("a")]
     tc = _tool_call({"results": [{"candidate_index": 1, "action": "rewrite"}]})
     with caplog.at_level(logging.WARNING, logger="app.llm.agents.ingest_batch_reconciler"):

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -7,12 +7,12 @@ import pytest
 
 from app.db.fts import SearchHit
 from app.ingest.models import WikiUpdateCandidate
-from app.llm.agents.common import IRRELEVANT_SENTINEL, batch_by_chars
+from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, batch_by_chars
 from app.llm.agents.ingest_batch_reconciler import (
-    _parse,
-    _parse_edits,
+    _parse_tool_results,
     batch_reconcile,
 )
+from app.llm.client import ToolCall
 
 
 def _hit(path: str, score: float = 1.0) -> SearchHit:
@@ -23,8 +23,23 @@ def _candidate(path: str, body: str = "body") -> WikiUpdateCandidate:
     return WikiUpdateCandidate(hit=_hit(path), body=body)
 
 
-def _llm_response(text: str) -> MagicMock:
-    m = MagicMock(text=text)
+def _tool_call(arguments: dict) -> ToolCall:
+    return ToolCall(id="call_1", name="submit_results", arguments=arguments)
+
+
+def _llm_response(arguments: dict) -> MagicMock:
+    m = MagicMock()
+    m.text = ""
+    m.tool_calls = [_tool_call(arguments)]
+    m.usage.input_tokens = 100
+    m.usage.output_tokens = 50
+    return m
+
+
+def _llm_no_tool() -> MagicMock:
+    m = MagicMock()
+    m.text = "some text the model returned instead of a tool call"
+    m.tool_calls = []
     m.usage.input_tokens = 100
     m.usage.output_tokens = 50
     return m
@@ -52,90 +67,106 @@ def test_batch_empty():
 
 
 # --------------------------------------------------------------------------- #
-# _parse_edits                                                                 #
+# _parse_tool_results                                                          #
 # --------------------------------------------------------------------------- #
 
 
-def test_parse_edits_single():
-    text = "===EDIT===\nFIND:\nold text\nREPLACE:\nnew text"
-    assert _parse_edits(text) == [("old text", "new text")]
-
-
-def test_parse_edits_multiple():
-    text = (
-        "===EDIT===\n"
-        "FIND:\nfirst\nREPLACE:\nfirst updated\n"
-        "===EDIT===\n"
-        "FIND:\nsecond\nREPLACE:\nsecond updated"
-    )
-    assert _parse_edits(text) == [("first", "first updated"), ("second", "second updated")]
-
-
-def test_parse_edits_multiline_find():
-    text = "===EDIT===\nFIND:\nline one\nline two\nREPLACE:\nreplacement"
-    assert _parse_edits(text) == [("line one\nline two", "replacement")]
-
-
-def test_parse_edits_empty_replace():
-    text = "===EDIT===\nFIND:\nremove this\nREPLACE:\n"
-    assert _parse_edits(text) == [("remove this", "")]
-
-
-def test_parse_edits_no_blocks():
-    assert _parse_edits("IRRELEVANT") == []
-
-
-# --------------------------------------------------------------------------- #
-# _parse                                                                       #
-# --------------------------------------------------------------------------- #
-
-
-def test_parse_irrelevant():
-    text = "===RESULT [1]===\nIRRELEVANT\n===RESULT [2]===\nIRRELEVANT"
-    results = _parse(text, 2)
+def test_parse_tool_results_irrelevant():
+    batch = [_candidate("a"), _candidate("b")]
+    tc = _tool_call({
+        "results": [
+            {"candidate_index": 1, "action": "irrelevant"},
+            {"candidate_index": 2, "action": "irrelevant"},
+        ]
+    })
+    results = _parse_tool_results(tc, batch)
     assert results == [IRRELEVANT_SENTINEL, IRRELEVANT_SENTINEL]
 
 
-def test_parse_no_change():
-    text = "===RESULT [1]===\nNO_CHANGE"
-    results = _parse(text, 1)
+def test_parse_tool_results_no_change():
+    batch = [_candidate("a")]
+    tc = _tool_call({"results": [{"candidate_index": 1, "action": "no_change"}]})
+    results = _parse_tool_results(tc, batch)
     assert results == [None]
 
 
-def test_parse_edit_block():
-    text = (
-        "===RESULT [1]===\n"
-        "===EDIT===\n"
-        "FIND:\nold line\n"
-        "REPLACE:\nnew line"
-    )
-    results = _parse(text, 1)
-    assert len(results) == 1
-    assert results[0] == [("old line", "new line")]
+def test_parse_tool_results_edit():
+    batch = [_candidate("a")]
+    tc = _tool_call({
+        "results": [{
+            "candidate_index": 1,
+            "action": "edit",
+            "edits": [{"find": "old text", "replace": "new text"}],
+        }]
+    })
+    results = _parse_tool_results(tc, batch)
+    assert results == [[TextEdit(find="old text", replace="new text")]]
 
 
-def test_parse_mixed():
-    text = (
-        "===RESULT [1]===\nIRRELEVANT\n"
-        "===RESULT [2]===\nNO_CHANGE\n"
-        "===RESULT [3]===\n===EDIT===\nFIND:\nold\nREPLACE:\nnew"
-    )
-    results = _parse(text, 3)
+def test_parse_tool_results_mixed():
+    batch = [_candidate("a"), _candidate("b"), _candidate("c")]
+    tc = _tool_call({
+        "results": [
+            {"candidate_index": 1, "action": "irrelevant"},
+            {"candidate_index": 2, "action": "no_change"},
+            {"candidate_index": 3, "action": "edit", "edits": [{"find": "old", "replace": "new"}]},
+        ]
+    })
+    results = _parse_tool_results(tc, batch)
     assert results[0] == IRRELEVANT_SENTINEL
     assert results[1] is None
-    assert results[2] == [("old", "new")]
+    assert results[2] == [TextEdit(find="old", replace="new")]
 
 
-def test_parse_missing_section_defaults_to_irrelevant():
-    text = "===RESULT [1]===\nNO_CHANGE"
-    results = _parse(text, 2)
+def test_parse_tool_results_missing_index_defaults_to_irrelevant():
+    batch = [_candidate("a"), _candidate("b")]
+    tc = _tool_call({"results": [{"candidate_index": 1, "action": "no_change"}]})
+    results = _parse_tool_results(tc, batch)
     assert results[0] is None
     assert results[1] == IRRELEVANT_SENTINEL
 
 
-def test_parse_no_sections_raises():
-    with pytest.raises(ValueError, match="no ===RESULT"):
-        _parse("no sections at all", 1)
+def test_parse_tool_results_empty_results_all_irrelevant():
+    batch = [_candidate("a"), _candidate("b")]
+    tc = _tool_call({"results": []})
+    results = _parse_tool_results(tc, batch)
+    assert results == [IRRELEVANT_SENTINEL, IRRELEVANT_SENTINEL]
+
+
+def test_parse_tool_results_edit_with_no_edits_warns(caplog):
+    import logging
+    batch = [_candidate("a")]
+    tc = _tool_call({"results": [{"candidate_index": 1, "action": "edit", "edits": []}]})
+    with caplog.at_level(logging.WARNING, logger="app.llm.agents.ingest_batch_reconciler"):
+        results = _parse_tool_results(tc, batch)
+    assert results == [[]]
+    assert "no valid edits" in caplog.text
+
+
+def test_parse_tool_results_unknown_action_defaults_to_irrelevant(caplog):
+    import logging
+    batch = [_candidate("a")]
+    tc = _tool_call({"results": [{"candidate_index": 1, "action": "rewrite"}]})
+    with caplog.at_level(logging.WARNING, logger="app.llm.agents.ingest_batch_reconciler"):
+        results = _parse_tool_results(tc, batch)
+    assert results == [IRRELEVANT_SENTINEL]
+    assert "unknown action" in caplog.text
+
+
+def test_parse_tool_results_multiple_edits():
+    batch = [_candidate("a")]
+    tc = _tool_call({
+        "results": [{
+            "candidate_index": 1,
+            "action": "edit",
+            "edits": [
+                {"find": "first", "replace": "FIRST"},
+                {"find": "second", "replace": "SECOND"},
+            ],
+        }]
+    })
+    results = _parse_tool_results(tc, batch)
+    assert results == [[TextEdit("first", "FIRST"), TextEdit("second", "SECOND")]]
 
 
 # --------------------------------------------------------------------------- #
@@ -149,11 +180,15 @@ def test_reconcile_returns_results(mock_client, _mock_prompt):
     a = _candidate("a")
     b = _candidate("b")
     c = _candidate("c", "current content")
-    mock_client.complete.return_value = _llm_response(
-        "===RESULT [1]===\nIRRELEVANT\n"
-        "===RESULT [2]===\nNO_CHANGE\n"
-        "===RESULT [3]===\n===EDIT===\nFIND:\ncurrent content\nREPLACE:\nupdated content"
-    )
+    mock_client.complete.return_value = _llm_response({
+        "results": [
+            {"candidate_index": 1, "action": "irrelevant"},
+            {"candidate_index": 2, "action": "no_change"},
+            {"candidate_index": 3, "action": "edit", "edits": [
+                {"find": "current content", "replace": "updated content"}
+            ]},
+        ]
+    })
 
     results, llm_calls = batch_reconcile(
         title="T", url="", content="doc", source="s", candidates=[a, b, c], model="m"
@@ -192,9 +227,9 @@ def test_reconcile_fails_open_on_llm_exception(mock_client, _mock_prompt):
 
 @patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
 @patch("app.llm.agents.ingest_batch_reconciler.client")
-def test_reconcile_fails_open_on_parse_error(mock_client, _mock_prompt):
+def test_reconcile_fails_open_when_no_tool_call(mock_client, _mock_prompt):
     candidates = [_candidate("a"), _candidate("b")]
-    mock_client.complete.return_value = _llm_response("no result sections here")
+    mock_client.complete.return_value = _llm_no_tool()
 
     results, llm_calls = batch_reconcile(
         title=None, url="", content="doc", source="s", candidates=candidates, model="m"
@@ -206,31 +241,15 @@ def test_reconcile_fails_open_on_parse_error(mock_client, _mock_prompt):
 
 @patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
 @patch("app.llm.agents.ingest_batch_reconciler.client")
-def test_reconcile_empty_edit_list_warns_and_returns_none(mock_client, _mock_prompt):
-    # LLM returns a result section that is neither IRRELEVANT/NO_CHANGE nor a
-    # valid ===EDIT=== block — _parse_edits yields [] and a warning should fire.
-    candidates = [_candidate("a", "body text")]
-    mock_client.complete.return_value = _llm_response(
-        "===RESULT [1]===\nmalformed content with no edit blocks"
-    )
-
-    with patch("app.llm.agents.ingest_batch_reconciler.log") as mock_log:
-        results, _ = batch_reconcile(
-            title=None, url="", content="doc", source="s", candidates=candidates, model="m"
-        )
-
-    assert results[0] is None
-    mock_log.warning.assert_called_once()
-
-
-@patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
-@patch("app.llm.agents.ingest_batch_reconciler.client")
 def test_reconcile_find_not_in_body_returns_none(mock_client, _mock_prompt):
-    # FIND text doesn't exist in the candidate body → no edit applied → None
     candidates = [_candidate("a", "actual body")]
-    mock_client.complete.return_value = _llm_response(
-        "===RESULT [1]===\n===EDIT===\nFIND:\ntext not in body\nREPLACE:\nreplacement"
-    )
+    mock_client.complete.return_value = _llm_response({
+        "results": [{
+            "candidate_index": 1,
+            "action": "edit",
+            "edits": [{"find": "text not in body", "replace": "replacement"}],
+        }]
+    })
 
     results, _ = batch_reconcile(
         title=None, url="", content="doc", source="s", candidates=candidates, model="m"
@@ -241,12 +260,31 @@ def test_reconcile_find_not_in_body_returns_none(mock_client, _mock_prompt):
 
 @patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
 @patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_reconcile_empty_edit_list_warns_and_returns_none(mock_client, _mock_prompt):
+    candidates = [_candidate("a", "body text")]
+    mock_client.complete.return_value = _llm_response({
+        "results": [{"candidate_index": 1, "action": "edit", "edits": []}]
+    })
+
+    with patch("app.llm.agents.ingest_batch_reconciler.log") as mock_log:
+        results, _ = batch_reconcile(
+            title=None, url="", content="doc", source="s", candidates=candidates, model="m"
+        )
+
+    assert results[0] is None
+    mock_log.warning.assert_called()
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
+@patch("app.llm.agents.ingest_batch_reconciler.client")
 def test_reconcile_merges_multiple_batches(mock_client, _mock_prompt):
     a = _candidate("a", "start " + "x" * 110_000)
     b = _candidate("b", "y" * 110_000)
     mock_client.complete.side_effect = [
-        _llm_response("===RESULT [1]===\n===EDIT===\nFIND:\nstart\nREPLACE:\nupdated"),
-        _llm_response("===RESULT [1]===\nNO_CHANGE"),
+        _llm_response({"results": [{"candidate_index": 1, "action": "edit", "edits": [
+            {"find": "start", "replace": "updated"}
+        ]}]}),
+        _llm_response({"results": [{"candidate_index": 1, "action": "no_change"}]}),
     ]
 
     results, llm_calls = batch_reconcile(
@@ -265,7 +303,7 @@ def test_reconcile_one_batch_fails_open_other_succeeds(mock_client, _mock_prompt
     b = _candidate("b", "y" * 110_000)
     mock_client.complete.side_effect = [
         RuntimeError("timeout"),
-        _llm_response("===RESULT [1]===\nNO_CHANGE"),
+        _llm_response({"results": [{"candidate_index": 1, "action": "no_change"}]}),
     ]
 
     results, llm_calls = batch_reconcile(
@@ -274,3 +312,19 @@ def test_reconcile_one_batch_fails_open_other_succeeds(mock_client, _mock_prompt
 
     assert results == [IRRELEVANT_SENTINEL, None]
     assert llm_calls == 2
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.load_prompt", return_value="p")
+@patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_reconcile_passes_tool_to_client(mock_client, _mock_prompt):
+    mock_client.complete.return_value = _llm_response({
+        "results": [{"candidate_index": 1, "action": "irrelevant"}]
+    })
+
+    batch_reconcile(
+        title=None, url="", content="doc", source="s", candidates=[_candidate("a")], model="m"
+    )
+
+    call_kwargs = mock_client.complete.call_args.kwargs
+    assert call_kwargs.get("tools") is not None
+    assert call_kwargs["tools"][0]["name"] == "submit_results"

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from app.db.fts import SearchHit
 from app.ingest.models import WikiUpdateCandidate
 from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, batch_by_chars

--- a/backend/tests/test_llm_common.py
+++ b/backend/tests/test_llm_common.py
@@ -51,3 +51,43 @@ def test_apply_edits_multiline():
 def test_apply_edits_empty_replace_deletes_text():
     result = apply_edits("prefix DELETE_ME suffix", [_e("DELETE_ME ", "")])
     assert result == "prefix suffix"
+
+
+# --------------------------------------------------------------------------- #
+# fuzzy (trailing-whitespace-normalized) matching                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_edits_fuzzy_trailing_space_on_find():
+    # Model quoted "old text " with a trailing space; body has "old text"
+    body = "line one\nold text\nline three\n"
+    result = apply_edits(body, [_e("old text ", "new text")])
+    assert result == "line one\nnew text\nline three\n"
+
+
+def test_apply_edits_fuzzy_trailing_spaces_multiline():
+    # Model quoted a multi-line block with trailing spaces on each line
+    body = "## Section\n\nfoo bar\nbaz qux\n\nend\n"
+    find = "foo bar  \nbaz qux  "  # trailing spaces the model added
+    result = apply_edits(body, [_e(find, "updated block")])
+    assert result == "## Section\n\nupdated block\n\nend\n"
+
+
+def test_apply_edits_fuzzy_preserves_body_trailing_newline():
+    body = "alpha\nbeta\n"
+    result = apply_edits(body, [_e("beta  ", "gamma")])
+    assert result == "alpha\ngamma\n"
+
+
+def test_apply_edits_fuzzy_no_match_still_skips():
+    # Text genuinely absent even after normalization — should still be skipped
+    body = "hello world"
+    result = apply_edits(body, [_e("completely different   ", "x")])
+    assert result is None
+
+
+def test_apply_edits_fuzzy_mixed_exact_and_fuzzy():
+    # First edit matches exactly, second matches only after normalization
+    body = "foo\nbar baz\nqux\n"
+    result = apply_edits(body, [_e("foo", "FOO"), _e("bar baz  ", "BAR BAZ")])
+    assert result == "FOO\nBAR BAZ\nqux\n"

--- a/backend/tests/test_llm_common.py
+++ b/backend/tests/test_llm_common.py
@@ -65,6 +65,14 @@ def test_apply_edits_fuzzy_trailing_space_on_find():
     assert result == "line one\nnew text\nline three\n"
 
 
+def test_apply_edits_fuzzy_trailing_space_on_body():
+    # Body has trailing spaces on lines; model quoted cleanly without them
+    body = "The deploy takes ~5 minutes.   \nRun the script after merging.  \n"
+    find = "The deploy takes ~5 minutes.\nRun the script after merging."
+    result = apply_edits(body, [_e(find, "The deploy takes ~2 minutes.\nRun the script after merging.")])
+    assert result == "The deploy takes ~2 minutes.\nRun the script after merging.\n"
+
+
 def test_apply_edits_fuzzy_trailing_spaces_multiline():
     # Model quoted a multi-line block with trailing spaces on each line
     body = "## Section\n\nfoo bar\nbaz qux\n\nend\n"

--- a/backend/tests/test_llm_common.py
+++ b/backend/tests/test_llm_common.py
@@ -1,7 +1,7 @@
 """Unit tests for app.llm.agents.common."""
 from __future__ import annotations
 
-from app.llm.agents.common import TextEdit, apply_edits
+from app.llm.agents.common import TextEdit, _fuzzy_replace, apply_edits
 
 
 def _e(find: str, replace: str) -> TextEdit:
@@ -54,7 +54,51 @@ def test_apply_edits_empty_replace_deletes_text():
 
 
 # --------------------------------------------------------------------------- #
-# fuzzy (trailing-whitespace-normalized) matching                              #
+# _fuzzy_replace                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_fuzzy_replace_trailing_space_on_find():
+    assert _fuzzy_replace("line\nold text\nend", "old text ", "new text") == "line\nnew text\nend"
+
+
+def test_fuzzy_replace_trailing_space_on_body():
+    body = "foo bar   \nbaz\n"
+    assert _fuzzy_replace(body, "foo bar", "updated") == "updated\nbaz\n"
+
+
+def test_fuzzy_replace_multiline_trailing_spaces():
+    body = "## Title\n\nfoo  \nbar  \n\nend\n"
+    assert _fuzzy_replace(body, "foo\nbar", "replaced") == "## Title\n\nreplaced\n\nend\n"
+
+
+def test_fuzzy_replace_no_match_returns_none():
+    assert _fuzzy_replace("hello world", "not here", "x") is None
+
+
+def test_fuzzy_replace_exact_text_also_works():
+    # _fuzzy_replace handles the case where normalization produces an exact match
+    assert _fuzzy_replace("foo\nbar\n", "foo\nbar", "baz") == "baz\n"
+
+
+def test_fuzzy_replace_preserves_content_outside_match():
+    body = "before\ntarget line  \nafter\n"
+    result = _fuzzy_replace(body, "target line", "replacement")
+    assert result == "before\nreplacement\nafter\n"
+
+
+def test_fuzzy_replace_empty_replace_removes_match():
+    body = "keep\nremove me  \nkeep\n"
+    assert _fuzzy_replace(body, "remove me", "") == "keep\n\nkeep\n"
+
+
+def test_fuzzy_replace_returns_none_when_only_whitespace_differs_midline():
+    # Spaces in the middle of a line are not normalised — not a trailing-space issue
+    assert _fuzzy_replace("foo  bar", "foo bar", "x") is None
+
+
+# --------------------------------------------------------------------------- #
+# fuzzy matching via apply_edits                                               #
 # --------------------------------------------------------------------------- #
 
 


### PR DESCRIPTION
## Description

Two reliability improvements to the ingest reconciler:

**1. Tool calling replaces text-parsed output**
Switches the batch reconciler from a free-text `===RESULT [N]===` / `===EDIT===` format (parsed with regex + string scanning) to a typed `submit_results` tool call schema. Any formatting deviation by the model now causes a hard parse error instead of silently dropping edits. `max_tokens` bumped to 8192 for the reconciler call to give large batches enough room.

**2. Fuzzy FIND matching in `apply_edits`**
Adds a trailing-whitespace-normalized fallback when exact FIND text isn't present — recovers the common case where the model quotes text with slightly different trailing spaces or line endings. Uses an in-house single-pass span mapping (`_map_norm_span_to_orig`) rather than a fuzzy-match library (e.g. diff-match-patch): a library with a non-zero threshold risks applying edits to the wrong location, silently corrupting wiki content, whereas a missed edit is safely retried on the next ingest cycle.

## How Has This Been Tested?

- Replaced `_parse` / `_parse_edits` unit tests with `_parse_tool_results` tests covering all action types, missing indices, empty edits, and unknown actions
- Added `test_reconcile_passes_tool_to_client` to verify the tool schema is wired through to `client.complete`
- Added fuzzy matching tests in `test_llm_common.py` covering trailing spaces on the find side, trailing spaces on the body side, multiline FIND blocks, and mixed exact+fuzzy edits
- Full test suite passes: 36/36

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check