### PR TITLE
feat(ingest): log reconciler decisions to ingest_examples for eval

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,7 +41,7 @@ class Config(BaseModel):
     ingest_bm25_limit: int
     ingest_irrelevant_stop_n: int
 
-    # Opt-in eval logging — captures reconciler inputs/outputs to ingest_examples
+    # Opt-in eval logging — captures reconciler inputs/outputs to ingest_eval_samples
     ingest_example_logging: bool
 
     # Coding-tool launchers (Run Agent button) — see

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -41,6 +41,9 @@ class Config(BaseModel):
     ingest_bm25_limit: int
     ingest_irrelevant_stop_n: int
 
+    # Opt-in eval logging — captures reconciler inputs/outputs to ingest_examples
+    ingest_example_logging: bool
+
     # Coding-tool launchers (Run Agent button) — see
     # local_data/wiki/Wiki Project/Specific Features/coding_tool_launchers/.
     launchers_enabled: bool
@@ -108,6 +111,8 @@ def load_config() -> Config:
         oidc_client_id=os.environ.get("OIDC_CLIENT_ID", ""),
         oidc_client_secret=os.environ.get("OIDC_CLIENT_SECRET", ""),
         oidc_redirect_uri=os.environ.get("OIDC_REDIRECT_URI", ""),
+        ingest_example_logging=os.environ.get("INGEST_EXAMPLE_LOGGING", "false").lower()
+        in {"1", "true", "yes"},
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         launchers_enabled=os.environ.get("LAUNCHERS_ENABLED", "false").lower()
         in {"1", "true", "yes"},

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,7 +42,7 @@ class Config(BaseModel):
     ingest_irrelevant_stop_n: int
 
     # Opt-in eval logging — captures reconciler inputs/outputs to ingest_eval_samples
-    ingest_example_logging: bool
+    ingest_eval_logging: bool
 
     # Coding-tool launchers (Run Agent button) — see
     # local_data/wiki/Wiki Project/Specific Features/coding_tool_launchers/.
@@ -111,7 +111,7 @@ def load_config() -> Config:
         oidc_client_id=os.environ.get("OIDC_CLIENT_ID", ""),
         oidc_client_secret=os.environ.get("OIDC_CLIENT_SECRET", ""),
         oidc_redirect_uri=os.environ.get("OIDC_REDIRECT_URI", ""),
-        ingest_example_logging=os.environ.get("INGEST_EXAMPLE_LOGGING", "false").lower()
+        ingest_eval_logging=os.environ.get("INGEST_EVAL_LOGGING", "false").lower()
         in {"1", "true", "yes"},
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         launchers_enabled=os.environ.get("LAUNCHERS_ENABLED", "false").lower()

--- a/backend/app/db/migrations/versions/0021_ingest_examples.py
+++ b/backend/app/db/migrations/versions/0021_ingest_examples.py
@@ -1,0 +1,41 @@
+"""add ingest_examples table for eval logging
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-05-21 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0021"
+down_revision: str = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ingest_examples",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "created_at",
+            sa.Text,
+            nullable=False,
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+        ),
+        sa.Column("source_type", sa.Text),
+        sa.Column("source_title", sa.Text),
+        sa.Column("source_url", sa.Text),
+        sa.Column("source_content", sa.Text, nullable=False),
+        sa.Column("wiki_path", sa.Text, nullable=False),
+        sa.Column("wiki_body_before", sa.Text, nullable=False),
+        sa.Column("diff", sa.Text),
+        sa.Column("outcome", sa.Text, nullable=False),
+        sa.Column("commit_sha", sa.Text),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("ingest_examples")

--- a/backend/app/db/migrations/versions/0021_ingest_examples.py
+++ b/backend/app/db/migrations/versions/0021_ingest_examples.py
@@ -1,4 +1,4 @@
-"""add ingest_examples table for eval logging
+"""add ingest_eval_samples table for eval logging
 
 Revision ID: 0021
 Revises: 0020
@@ -17,7 +17,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "ingest_examples",
+        "ingest_eval_samples",
         sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
         sa.Column(
             "created_at",
@@ -35,11 +35,11 @@ def upgrade() -> None:
         sa.Column("outcome", sa.Text, nullable=False),
         sa.Column("commit_sha", sa.Text),
     )
-    op.create_index("ix_ingest_examples_created_at", "ingest_examples", ["created_at"])
-    op.create_index("ix_ingest_examples_outcome", "ingest_examples", ["outcome"])
+    op.create_index("ix_ingest_eval_samples_created_at", "ingest_eval_samples", ["created_at"])
+    op.create_index("ix_ingest_eval_samples_outcome", "ingest_eval_samples", ["outcome"])
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ingest_examples_outcome", table_name="ingest_examples")
-    op.drop_index("ix_ingest_examples_created_at", table_name="ingest_examples")
-    op.drop_table("ingest_examples")
+    op.drop_index("ix_ingest_eval_samples_outcome", table_name="ingest_eval_samples")
+    op.drop_index("ix_ingest_eval_samples_created_at", table_name="ingest_eval_samples")
+    op.drop_table("ingest_eval_samples")

--- a/backend/app/db/migrations/versions/0021_ingest_examples.py
+++ b/backend/app/db/migrations/versions/0021_ingest_examples.py
@@ -16,6 +16,11 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # create_all in 0001 already materializes this table on fresh installs;
+    # skip if it exists so upgrading existing DBs and fresh installs both work.
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table("ingest_eval_samples"):
+        return
     op.create_table(
         "ingest_eval_samples",
         sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),

--- a/backend/app/db/migrations/versions/0021_ingest_examples.py
+++ b/backend/app/db/migrations/versions/0021_ingest_examples.py
@@ -30,6 +30,7 @@ def upgrade() -> None:
             nullable=False,
             server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
         ),
+        sa.Column("source_document_id", sa.Text),
         sa.Column("source_type", sa.Text),
         sa.Column("source_title", sa.Text),
         sa.Column("source_url", sa.Text),

--- a/backend/app/db/migrations/versions/0021_ingest_examples.py
+++ b/backend/app/db/migrations/versions/0021_ingest_examples.py
@@ -35,7 +35,11 @@ def upgrade() -> None:
         sa.Column("outcome", sa.Text, nullable=False),
         sa.Column("commit_sha", sa.Text),
     )
+    op.create_index("ix_ingest_examples_created_at", "ingest_examples", ["created_at"])
+    op.create_index("ix_ingest_examples_outcome", "ingest_examples", ["outcome"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_ingest_examples_outcome", table_name="ingest_examples")
+    op.drop_index("ix_ingest_examples_created_at", table_name="ingest_examples")
     op.drop_table("ingest_examples")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -714,7 +714,7 @@ class AclEntry(Base):
 
 
 # --------------------------------------------------------------------------- #
-# Ingest eval samples — opt-in eval logging (INGEST_EXAMPLE_LOGGING=true)     #
+# Ingest eval samples — opt-in eval logging (INGEST_EVAL_LOGGING=true)     #
 # --------------------------------------------------------------------------- #
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -711,3 +711,24 @@ class AclEntry(Base):
         Index("idx_acl_resource", "resource_kind", "resource_path"),
         Index("idx_acl_principal", "principal_kind", "principal_id"),
     )
+
+
+# --------------------------------------------------------------------------- #
+# Ingest examples — opt-in eval logging (INGEST_EXAMPLE_LOGGING=true)         #
+# --------------------------------------------------------------------------- #
+
+
+class IngestExample(Base):
+    __tablename__ = "ingest_examples"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    source_type: Mapped[str | None] = mapped_column(Text)
+    source_title: Mapped[str | None] = mapped_column(Text)
+    source_url: Mapped[str | None] = mapped_column(Text)
+    source_content: Mapped[str] = mapped_column(Text, nullable=False)
+    wiki_path: Mapped[str] = mapped_column(Text, nullable=False)
+    wiki_body_before: Mapped[str] = mapped_column(Text, nullable=False)
+    diff: Mapped[str | None] = mapped_column(Text)
+    outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    commit_sha: Mapped[str | None] = mapped_column(Text)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -723,6 +723,7 @@ class IngestEvalSample(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    source_document_id: Mapped[str | None] = mapped_column(Text)
     source_type: Mapped[str | None] = mapped_column(Text)
     source_title: Mapped[str | None] = mapped_column(Text)
     source_url: Mapped[str | None] = mapped_column(Text)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -714,12 +714,12 @@ class AclEntry(Base):
 
 
 # --------------------------------------------------------------------------- #
-# Ingest examples — opt-in eval logging (INGEST_EXAMPLE_LOGGING=true)         #
+# Ingest eval samples — opt-in eval logging (INGEST_EXAMPLE_LOGGING=true)     #
 # --------------------------------------------------------------------------- #
 
 
-class IngestExample(Base):
-    __tablename__ = "ingest_examples"
+class IngestEvalSample(Base):
+    __tablename__ = "ingest_eval_samples"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -1,6 +1,6 @@
 """Opt-in logging of ingest reconciler decisions to the ingest_eval_samples table.
 
-Enabled via INGEST_EXAMPLE_LOGGING=true. Each row captures the source document,
+Enabled via INGEST_EVAL_LOGGING=true. Each row captures the source document,
 the wiki page before reconciliation, the unified diff of any edit, and the outcome.
 Intended for human review and building a regression test suite.
 """

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 
 def log_sample(
     *,
+    source_document_id: str | None,
     source_type: str | None,
     source_title: str | None,
     source_url: str | None,
@@ -30,6 +31,7 @@ def log_sample(
     diff = wiki_git.diff_for_commit(commit_sha, wiki_path) if commit_sha is not None else None
     with session() as s:
         s.add(IngestEvalSample(
+            source_document_id=source_document_id,
             source_type=source_type,
             source_title=source_title,
             source_url=source_url,

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -1,4 +1,4 @@
-"""Opt-in logging of ingest reconciler decisions to the ingest_examples table.
+"""Opt-in logging of ingest reconciler decisions to the ingest_eval_samples table.
 
 Enabled via INGEST_EXAMPLE_LOGGING=true. Each row captures the source document,
 the wiki page before reconciliation, the unified diff of any edit, and the outcome.
@@ -6,29 +6,17 @@ Intended for human review and building a regression test suite.
 """
 from __future__ import annotations
 
-import difflib
 import logging
 from typing import Literal
 
-from app.db.models import IngestExample
+from app.db.models import IngestEvalSample
 from app.db.session import session
+from app.wiki import git as wiki_git
 
 log = logging.getLogger(__name__)
 
 
-def make_diff(before: str, after: str) -> str:
-    """Return a unified diff string between before and after."""
-    return "".join(
-        difflib.unified_diff(
-            before.splitlines(keepends=True),
-            after.splitlines(keepends=True),
-            fromfile="before",
-            tofile="after",
-        )
-    )
-
-
-def log_example(
+def log_sample(
     *,
     source_type: str | None,
     source_title: str | None,
@@ -36,13 +24,12 @@ def log_example(
     source_content: str,
     wiki_path: str,
     wiki_body_before: str,
-    wiki_body_after: str | None,
     outcome: Literal["committed", "no_change"],
     commit_sha: str | None,
 ) -> None:
-    diff = (make_diff(wiki_body_before, wiki_body_after) or None) if wiki_body_after is not None else None
+    diff = wiki_git.diff_for_commit(commit_sha, wiki_path) if commit_sha is not None else None
     with session() as s:
-        s.add(IngestExample(
+        s.add(IngestEvalSample(
             source_type=source_type,
             source_title=source_title,
             source_url=source_url,

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -24,7 +24,7 @@ def log_sample(
     source_content: str,
     wiki_path: str,
     wiki_body_before: str,
-    outcome: Literal["committed", "no_change"],
+    outcome: Literal["committed", "no_change", "irrelevant"],
     commit_sha: str | None,
 ) -> None:
     diff = wiki_git.diff_for_commit(commit_sha, wiki_path) if commit_sha is not None else None

--- a/backend/app/ingest/examples.py
+++ b/backend/app/ingest/examples.py
@@ -1,0 +1,54 @@
+"""Opt-in logging of ingest reconciler decisions to the ingest_examples table.
+
+Enabled via INGEST_EXAMPLE_LOGGING=true. Each row captures the source document,
+the wiki page before reconciliation, the unified diff of any edit, and the outcome.
+Intended for human review and building a regression test suite.
+"""
+from __future__ import annotations
+
+import difflib
+import logging
+
+from app.db.models import IngestExample
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+
+def make_diff(before: str, after: str) -> str:
+    """Return a unified diff string between before and after."""
+    return "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile="before",
+            tofile="after",
+        )
+    )
+
+
+def log_example(
+    *,
+    source_type: str | None,
+    source_title: str | None,
+    source_url: str | None,
+    source_content: str,
+    wiki_path: str,
+    wiki_body_before: str,
+    wiki_body_after: str | None,
+    outcome: str,
+    commit_sha: str | None,
+) -> None:
+    diff = make_diff(wiki_body_before, wiki_body_after) if wiki_body_after is not None else None
+    with session() as s:
+        s.add(IngestExample(
+            source_type=source_type,
+            source_title=source_title,
+            source_url=source_url,
+            source_content=source_content,
+            wiki_path=wiki_path,
+            wiki_body_before=wiki_body_before,
+            diff=diff,
+            outcome=outcome,
+            commit_sha=commit_sha,
+        ))

--- a/backend/app/ingest/examples.py
+++ b/backend/app/ingest/examples.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import difflib
 import logging
+from typing import Literal
 
 from app.db.models import IngestExample
 from app.db.session import session
@@ -36,10 +37,10 @@ def log_example(
     wiki_path: str,
     wiki_body_before: str,
     wiki_body_after: str | None,
-    outcome: str,
+    outcome: Literal["committed", "no_change"],
     commit_sha: str | None,
 ) -> None:
-    diff = make_diff(wiki_body_before, wiki_body_after) if wiki_body_after is not None else None
+    diff = (make_diff(wiki_body_before, wiki_body_after) or None) if wiki_body_after is not None else None
     with session() as s:
         s.add(IngestExample(
             source_type=source_type,

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -380,7 +380,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
                     ingest_examples.log_example(
                         source_type=source_type,
                         source_title=title,
-                        source_url=url or None,
+                        source_url=url if url else None,
                         source_content=content,
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,
@@ -399,7 +399,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
                     ingest_examples.log_example(
                         source_type=source_type,
                         source_title=title,
-                        source_url=url or None,
+                        source_url=url if url else None,
                         source_content=content,
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -25,6 +25,7 @@ import time
 from typing import Any
 
 from app.config import CONFIG
+from app.ingest import examples as ingest_examples
 from app.ingest import search as ingest_search
 from app.ingest.source_tiers import is_filtered
 from app.ingest.models import WikiUpdateCandidate
@@ -374,10 +375,40 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             ingest_outcomes_total.labels(outcome="committed", wiki_path=c.hit.path).inc()
             ingest_bm25_score_by_outcome.labels(outcome="committed").observe(c.hit.score)
             log.info("process_pushed_document: committed %s sha=%s", c.hit.path, sha)
+            if CONFIG.ingest_example_logging:
+                try:
+                    ingest_examples.log_example(
+                        source_type=source_type,
+                        source_title=title,
+                        source_url=url or None,
+                        source_content=content,
+                        wiki_path=c.hit.path,
+                        wiki_body_before=c.body,
+                        wiki_body_after=result,
+                        outcome="committed",
+                        commit_sha=sha,
+                    )
+                except Exception:
+                    log.warning("ingest_examples: failed to log committed example", exc_info=True)
         else:
             consecutive_irrelevant = 0
             ingest_outcomes_total.labels(outcome="no_change", wiki_path=c.hit.path).inc()
             ingest_bm25_score_by_outcome.labels(outcome="no_change").observe(c.hit.score)
+            if CONFIG.ingest_example_logging:
+                try:
+                    ingest_examples.log_example(
+                        source_type=source_type,
+                        source_title=title,
+                        source_url=url or None,
+                        source_content=content,
+                        wiki_path=c.hit.path,
+                        wiki_body_before=c.body,
+                        wiki_body_after=None,
+                        outcome="no_change",
+                        commit_sha=None,
+                    )
+                except Exception:
+                    log.warning("ingest_examples: failed to log no_change example", exc_info=True)
 
     ingest_llm_calls_per_doc.observe(llm_calls)
     log.info(

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -356,6 +356,20 @@ def process_pushed_document(push: dict[str, Any]) -> None:
                 c.hit.path,
                 consecutive_irrelevant,
             )
+            if CONFIG.ingest_eval_logging:
+                try:
+                    ingest_eval_sample.log_sample(
+                        source_type=source_type,
+                        source_title=title,
+                        source_url=url if url else None,
+                        source_content=content,
+                        wiki_path=c.hit.path,
+                        wiki_body_before=c.body,
+                        outcome="irrelevant",
+                        commit_sha=None,
+                    )
+                except Exception:
+                    log.warning("ingest_eval_sample: failed to log irrelevant sample", exc_info=True)
             if consecutive_irrelevant >= CONFIG.ingest_irrelevant_stop_n:
                 stopped_early = True
                 break

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -375,7 +375,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             ingest_outcomes_total.labels(outcome="committed", wiki_path=c.hit.path).inc()
             ingest_bm25_score_by_outcome.labels(outcome="committed").observe(c.hit.score)
             log.info("process_pushed_document: committed %s sha=%s", c.hit.path, sha)
-            if CONFIG.ingest_example_logging:
+            if CONFIG.ingest_eval_logging:
                 try:
                     ingest_eval_sample.log_sample(
                         source_type=source_type,
@@ -393,7 +393,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             consecutive_irrelevant = 0
             ingest_outcomes_total.labels(outcome="no_change", wiki_path=c.hit.path).inc()
             ingest_bm25_score_by_outcome.labels(outcome="no_change").observe(c.hit.score)
-            if CONFIG.ingest_example_logging:
+            if CONFIG.ingest_eval_logging:
                 try:
                     ingest_eval_sample.log_sample(
                         source_type=source_type,

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -359,6 +359,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             if CONFIG.ingest_eval_logging:
                 try:
                     ingest_eval_sample.log_sample(
+                        source_document_id=push.get("source_document_id"),
                         source_type=source_type,
                         source_title=title,
                         source_url=url if url else None,
@@ -392,6 +393,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             if CONFIG.ingest_eval_logging:
                 try:
                     ingest_eval_sample.log_sample(
+                        source_document_id=push.get("source_document_id"),
                         source_type=source_type,
                         source_title=title,
                         source_url=url if url else None,
@@ -410,6 +412,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             if CONFIG.ingest_eval_logging:
                 try:
                     ingest_eval_sample.log_sample(
+                        source_document_id=push.get("source_document_id"),
                         source_type=source_type,
                         source_title=title,
                         source_url=url if url else None,

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -25,7 +25,7 @@ import time
 from typing import Any
 
 from app.config import CONFIG
-from app.ingest import examples as ingest_examples
+from app.ingest import eval_sample as ingest_eval_sample
 from app.ingest import search as ingest_search
 from app.ingest.source_tiers import is_filtered
 from app.ingest.models import WikiUpdateCandidate
@@ -377,38 +377,36 @@ def process_pushed_document(push: dict[str, Any]) -> None:
             log.info("process_pushed_document: committed %s sha=%s", c.hit.path, sha)
             if CONFIG.ingest_example_logging:
                 try:
-                    ingest_examples.log_example(
+                    ingest_eval_sample.log_sample(
                         source_type=source_type,
                         source_title=title,
                         source_url=url if url else None,
                         source_content=content,
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,
-                        wiki_body_after=result,
                         outcome="committed",
                         commit_sha=sha,
                     )
                 except Exception:
-                    log.warning("ingest_examples: failed to log committed example", exc_info=True)
+                    log.warning("ingest_eval_sample: failed to log committed sample", exc_info=True)
         else:
             consecutive_irrelevant = 0
             ingest_outcomes_total.labels(outcome="no_change", wiki_path=c.hit.path).inc()
             ingest_bm25_score_by_outcome.labels(outcome="no_change").observe(c.hit.score)
             if CONFIG.ingest_example_logging:
                 try:
-                    ingest_examples.log_example(
+                    ingest_eval_sample.log_sample(
                         source_type=source_type,
                         source_title=title,
                         source_url=url if url else None,
                         source_content=content,
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,
-                        wiki_body_after=None,
                         outcome="no_change",
                         commit_sha=None,
                     )
                 except Exception:
-                    log.warning("ingest_examples: failed to log no_change example", exc_info=True)
+                    log.warning("ingest_eval_sample: failed to log no_change sample", exc_info=True)
 
     ingest_llm_calls_per_doc.observe(llm_calls)
     log.info(

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -115,6 +115,7 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_title_boost=2.0,
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
+        ingest_eval_logging=False,
         launchers_enabled=True,
         launch_code_ttl_seconds=60,
         agent_session_idle_seconds=300,

--- a/deploy/helm/agent-workspace/templates/_helpers.tpl
+++ b/deploy/helm/agent-workspace/templates/_helpers.tpl
@@ -71,6 +71,8 @@ and wiki path stay in lockstep.
   value: {{ .Values.auth.mode | quote }}
 - name: LAUNCHERS_ENABLED
   value: {{ .Values.launchersEnabled | default false | quote }}
+- name: INGEST_EVAL_LOGGING
+  value: {{ .Values.ingestEvalLogging | default false | quote }}
 - name: SECURE_COOKIES
   value: {{ .Values.secureCookies | quote }}
 {{- if eq .Values.auth.mode "oidc" }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -55,6 +55,11 @@ maxQueueSize: 1000
 # package + wiki UI are ready in your environment.
 launchersEnabled: false
 
+# Opt-in eval logging — writes one row to ingest_eval_samples per reconciler
+# decision (committed / no_change / irrelevant). Off by default; enable on
+# environments where you want to collect real traffic for eval review.
+ingestEvalLogging: false
+
 auth:
   # basic | oidc
   mode: basic


### PR DESCRIPTION
## Description

Adds opt-in logging of ingest reconciler decisions to a new `ingest_examples` table. Each row captures the source document, the wiki page before reconciliation, a unified diff of any edit made, and the outcome. Intended for human review of edit quality and building a regression test suite with real traffic.

**Why real data over mocked examples:** Synthetic eval data misses real failure modes — hallucinated FIND text, noisy source documents, BM25 false positives. Real traffic captures these naturally.

**Logging stage:** Reconciler only (not BM25 or selector). The selector is currently loose so nearly all BM25 candidates reach the reconciler anyway.

**Schema:** `ingest_examples` — `source_type`, `source_title`, `source_url`, `source_content`, `wiki_path`, `wiki_body_before`, `diff` (unified diff), `outcome` (`committed`/`no_change`), `commit_sha`

**Opt-in:** Controlled by `INGEST_EXAMPLE_LOGGING=true` env var. Off by default — zero overhead when unset.

## How Has This Been Tested?

- `basedpyright` passes on all changed files
- Verified locally: set `INGEST_EXAMPLE_LOGGING=true`, pushed a document, confirmed row inserted with correct `diff` and `commit_sha`

Tested locally

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check