### PR TITLE
fix(ingest): accept top-level url field from Onyx document push hookpoint

### DIFF
--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -56,6 +56,7 @@ class IngestRequest(BaseModel):
     title: str | None = None
     source: str | None = None
     source_document_id: str | None = Field(default=None, alias="document_id")
+    url: str | None = None
     metadata: dict[str, Any] | None = None
     updated_at: str | None = None
     diff: str | None = None

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -282,7 +282,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
 
     source_label = source_type or "external"
     _meta: dict[str, Any] = push.get("metadata") or {}
-    url: str = str(_meta.get("url") or "")
+    url: str = str(push.get("url") or _meta.get("url") or "")
 
     # Read all candidate bodies upfront — needed by both the selector and the
     # main reconciler loop. Skip unreadable files early so the selector sees


### PR DESCRIPTION
## Summary

- The Onyx `DOCUMENT_PUSH` hookpoint sends `url` as a top-level field in the payload, not nested under `metadata.url`
- `IngestRequest` was silently dropping it (no `url` field defined)
- `wiki_update.py` was only reading `metadata["url"]`, so the source URL never made it into commit messages or the history panel UI

## Fix

- Add `url: str | None` to `IngestRequest`
- Prefer `push.get("url")` with fallback to `metadata["url"]` for older connectors

## How Has This Been Tested?

Verified by inspecting `DocumentPushPayload` in the Onyx hookpoint definition (`onyx/hooks/points/document_push.py`). The `url` field is top-level in that schema.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check