### PR TITLE
chore(dev): add .vscode/launch.json with run configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ tmp_workspace/
 # editor / OS
 .DS_Store
 .idea/
-.vscode/
 *.swp
 
 # claude code — entire dir is local-only (runtime state + per-user settings).

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ tmp_workspace/
 .DS_Store
 .idea/
 *.swp
+.vscode/settings.json
 
 # claude code — entire dir is local-only (runtime state + per-user settings).
 .claude/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -116,8 +116,7 @@
       "consoleTitle": "Worker: documents Console",
       "justMyCode": false,
       "presentation": {
-        "group": "2",
-        "hidden": true
+        "group": "2"
       }
     },
     {
@@ -138,8 +137,7 @@
       "consoleTitle": "Worker: triggers Console",
       "justMyCode": false,
       "presentation": {
-        "group": "2",
-        "hidden": true
+        "group": "2"
       }
     },
     {
@@ -160,8 +158,7 @@
       "consoleTitle": "Worker: lightweight_maintenance Console",
       "justMyCode": false,
       "presentation": {
-        "group": "2",
-        "hidden": true
+        "group": "2"
       }
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,7 @@
         "run",
         "dev"
       ],
-      "envFile": "${workspaceFolder}/.vscode/.env.frontend",
+      "envFile": "${workspaceFolder}/.env",
       "console": "integratedTerminal",
       "consoleTitle": "Frontend Console",
       "presentation": {
@@ -79,7 +79,7 @@
       "request": "launch",
       "module": "uvicorn",
       "cwd": "${workspaceFolder}/backend",
-      "envFile": "${workspaceFolder}/.vscode/.env",
+      "envFile": "${workspaceFolder}/.env",
       "env": {
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
@@ -104,7 +104,7 @@
       "request": "launch",
       "module": "app.tasks.run_worker",
       "cwd": "${workspaceFolder}/backend",
-      "envFile": "${workspaceFolder}/.vscode/.env",
+      "envFile": "${workspaceFolder}/.env",
       "env": {
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
@@ -125,7 +125,7 @@
       "request": "launch",
       "module": "app.tasks.run_worker",
       "cwd": "${workspaceFolder}/backend",
-      "envFile": "${workspaceFolder}/.vscode/.env",
+      "envFile": "${workspaceFolder}/.env",
       "env": {
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
@@ -146,7 +146,7 @@
       "request": "launch",
       "module": "app.tasks.run_worker",
       "cwd": "${workspaceFolder}/backend",
-      "envFile": "${workspaceFolder}/.vscode/.env",
+      "envFile": "${workspaceFolder}/.env",
       "env": {
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"
@@ -167,7 +167,7 @@
       "request": "launch",
       "module": "pytest",
       "cwd": "${workspaceFolder}/backend",
-      "envFile": "${workspaceFolder}/.vscode/.env",
+      "envFile": "${workspaceFolder}/.env",
       "env": {
         "LOG_LEVEL": "DEBUG",
         "PYTHONUNBUFFERED": "1"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,10 @@
 {
   "version": "0.2.0",
+  // Compounds launch multiple configurations at once (shown in group 1 of the Run panel).
+  // Individual configurations (group 2) can also be started on their own for focused debugging.
   "compounds": [
     {
+      // Section header — gives group 1 a visible label in the Run panel dropdown.
       "name": "--- Compound ---",
       "configurations": [
         "--- Individual ---"
@@ -11,6 +14,8 @@
       }
     },
     {
+      // Starts the full stack: Next.js dev server, FastAPI/uvicorn, and all three workers.
+      // Use this for end-to-end development or when working on features that touch multiple layers.
       "name": "Run All Services",
       "configurations": [
         "Frontend",
@@ -24,6 +29,7 @@
       }
     },
     {
+      // Starts only the frontend and API. Useful when workers aren't needed (e.g. UI-only work).
       "name": "API + Frontend",
       "configurations": [
         "Frontend",
@@ -34,6 +40,8 @@
       }
     },
     {
+      // Starts all three workers without the API or frontend.
+      // stopAll: true means stopping this compound stops every worker it launched.
       "name": "Workers",
       "configurations": [
         "Worker: documents",
@@ -48,6 +56,7 @@
   ],
   "configurations": [
     {
+      // Section header — gives group 2 a visible label in the Run panel dropdown.
       "name": "--- Individual ---",
       "type": "node",
       "request": "launch",
@@ -57,6 +66,7 @@
       }
     },
     {
+      // Next.js dev server with hot reload. Env vars come from the root .env file.
       "name": "Frontend",
       "type": "node",
       "request": "launch",
@@ -74,6 +84,8 @@
       }
     },
     {
+      // FastAPI via uvicorn with --reload (auto-restarts on Python file changes).
+      // justMyCode: false lets the debugger step into library code (e.g. FastAPI internals).
       "name": "API Server",
       "type": "debugpy",
       "request": "launch",
@@ -99,6 +111,7 @@
       }
     },
     {
+      // Handles LLM doc-reconciliation tasks (slow/expensive — runs in its own process).
       "name": "Worker: documents",
       "type": "debugpy",
       "request": "launch",
@@ -120,6 +133,7 @@
       }
     },
     {
+      // Handles NL trigger evaluation (delta + scheduled fan-out).
       "name": "Worker: triggers",
       "type": "debugpy",
       "request": "launch",
@@ -141,6 +155,8 @@
       }
     },
     {
+      // Handles sub-second upkeep tasks (BM25 reindex, activity expiry).
+      // Handlers on this queue must be fast — no LLM, no external HTTP, no wiki commits.
       "name": "Worker: lightweight_maintenance",
       "type": "debugpy",
       "request": "launch",
@@ -162,6 +178,8 @@
       }
     },
     {
+      // Runs the full pytest suite with the debugger attached — breakpoints work inside tests.
+      // Requires the test database to exist; see CLAUDE.md § Testing for setup instructions.
       "name": "Pytest",
       "type": "debugpy",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,188 @@
+{
+  "version": "0.2.0",
+  "compounds": [
+    {
+      "name": "--- Compound ---",
+      "configurations": [
+        "--- Individual ---"
+      ],
+      "presentation": {
+        "group": "1"
+      }
+    },
+    {
+      "name": "Run All Services",
+      "configurations": [
+        "Frontend",
+        "API Server",
+        "Worker: documents",
+        "Worker: triggers",
+        "Worker: lightweight_maintenance"
+      ],
+      "presentation": {
+        "group": "1"
+      }
+    },
+    {
+      "name": "API + Frontend",
+      "configurations": [
+        "Frontend",
+        "API Server"
+      ],
+      "presentation": {
+        "group": "1"
+      }
+    },
+    {
+      "name": "Workers",
+      "configurations": [
+        "Worker: documents",
+        "Worker: triggers",
+        "Worker: lightweight_maintenance"
+      ],
+      "presentation": {
+        "group": "1"
+      },
+      "stopAll": true
+    }
+  ],
+  "configurations": [
+    {
+      "name": "--- Individual ---",
+      "type": "node",
+      "request": "launch",
+      "presentation": {
+        "group": "2",
+        "order": 0
+      }
+    },
+    {
+      "name": "Frontend",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}/frontend",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": [
+        "run",
+        "dev"
+      ],
+      "envFile": "${workspaceFolder}/.vscode/.env.frontend",
+      "console": "integratedTerminal",
+      "consoleTitle": "Frontend Console",
+      "presentation": {
+        "group": "2"
+      }
+    },
+    {
+      "name": "API Server",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "uvicorn",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1"
+      },
+      "args": [
+        "--factory",
+        "app.main:create_app",
+        "--reload",
+        "--port",
+        "8080"
+      ],
+      "console": "integratedTerminal",
+      "consoleTitle": "API Server Console",
+      "justMyCode": false,
+      "presentation": {
+        "group": "2"
+      }
+    },
+    {
+      "name": "Worker: documents",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "app.tasks.run_worker",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1"
+      },
+      "args": [
+        "documents"
+      ],
+      "console": "integratedTerminal",
+      "consoleTitle": "Worker: documents Console",
+      "justMyCode": false,
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      }
+    },
+    {
+      "name": "Worker: triggers",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "app.tasks.run_worker",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1"
+      },
+      "args": [
+        "triggers"
+      ],
+      "console": "integratedTerminal",
+      "consoleTitle": "Worker: triggers Console",
+      "justMyCode": false,
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      }
+    },
+    {
+      "name": "Worker: lightweight_maintenance",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "app.tasks.run_worker",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1"
+      },
+      "args": [
+        "lightweight_maintenance"
+      ],
+      "console": "integratedTerminal",
+      "consoleTitle": "Worker: lightweight_maintenance Console",
+      "justMyCode": false,
+      "presentation": {
+        "group": "2",
+        "hidden": true
+      }
+    },
+    {
+      "name": "Pytest",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "pytest",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.vscode/.env",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1"
+      },
+      "args": [
+        "-v"
+      ],
+      "console": "integratedTerminal",
+      "consoleTitle": "Pytest Console",
+      "presentation": {
+        "group": "2"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,0 +1,3 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python"
+}

--- a/.vscode/settings.template.json
+++ b/.vscode/settings.template.json
@@ -1,3 +1,10 @@
 {
+  // Points VS Code's Python extension to the project's virtual environment.
+  // Without this, the editor won't resolve backend imports, type-checking will
+  // show false errors, and the integrated terminal may use the wrong Python.
+  //
+  // If you followed the setup instructions (uv sync --extra dev inside backend/),
+  // your venv lives at backend/.venv and no change is needed here. If your venv
+  // is elsewhere, update the path below to match.
   "python.defaultInterpreterPath": "${workspaceFolder}/backend/.venv/bin/python"
 }


### PR DESCRIPTION
## Summary

- Adds `.vscode/launch.json` so all services can be launched and debugged directly from VS Code
- Force-tracked despite `.vscode/` being gitignored (same pattern as other projects in the org)

## Configurations

**Compounds:**
- **API + Frontend** — the two web-facing processes for normal dev
- **Run All Services** — API + Frontend + all 3 workers
- **Workers** — documents, triggers, lightweight_maintenance together

**Individual:**
- **Frontend** — `bun run dev` in `frontend/`, env from `.vscode/.env.frontend`
- **API Server** — `uvicorn --factory app.main:create_app --reload --port 8080`, debugpy-attached
- **Worker: documents / triggers / lightweight_maintenance** — each runs `python -m app.tasks.run_worker <queue>`, debugpy-attached
- **Pytest** — `pytest -v` against the backend

Backend configs read from `.vscode/.env` (gitignored); frontend from `.vscode/.env.frontend`.