### PR TITLE
chore(launchers/helper-go): drop stale release-mac.sh refs

### DIFF
--- a/packages/agentwiki-launcher-go/Makefile
+++ b/packages/agentwiki-launcher-go/Makefile
@@ -2,7 +2,7 @@ BIN := agentwiki-launcher
 PKG := ./cmd/agentwiki-launcher
 DIST := dist
 
-.PHONY: build clean dist test vet release
+.PHONY: build clean dist test vet
 
 build:
 	go build -o $(BIN) $(PKG)
@@ -23,9 +23,3 @@ dist: clean
 	GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o $(DIST)/$(BIN)-darwin-amd64 $(PKG)
 	@echo "Built:"
 	@ls -lh $(DIST)
-
-# Sign + notarize the darwin binaries produced by `dist`.
-# Requires APPLE_ID / APPLE_TEAM_ID / APPLE_APP_PASSWORD / APPLE_CERT_BASE64 /
-# APPLE_CERT_PASSWORD in env. Locally: `source scripts/load-secrets-aws.sh`.
-release: dist
-	./scripts/release-mac.sh

--- a/packages/agentwiki-launcher-go/README.md
+++ b/packages/agentwiki-launcher-go/README.md
@@ -78,7 +78,7 @@ the wiki endpoint, then dispatches every subsequent run silently.
 6. `xcrun stapler staple` the bundle so notarization is offline-checkable.
 7. Re-zip post-staple → `dist/AgentWikiLauncher.zip`.
 
-Required env (read by `scripts/build-app.sh` + `scripts/release-mac.sh`):
+Required env (read by `scripts/build-app.sh`):
 
 | Variable              | Purpose                                        |
 | --------------------- | ---------------------------------------------- |

--- a/packages/agentwiki-launcher-go/scripts/build-app.sh
+++ b/packages/agentwiki-launcher-go/scripts/build-app.sh
@@ -4,7 +4,7 @@
 # Outputs dist/AgentWikiLauncher.zip — stapled + notarized, drag-to-Applications
 # ready. Gatekeeper passes on first open without "Open anyway" friction.
 #
-# Required env (same as release-mac.sh):
+# Required env:
 #   APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD,
 #   APPLE_CERT_BASE64, APPLE_CERT_PASSWORD
 #

--- a/packages/agentwiki-launcher-go/scripts/load-secrets-aws.sh
+++ b/packages/agentwiki-launcher-go/scripts/load-secrets-aws.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Source this file (do not exec) to populate Apple signing env vars from
-# AWS Secrets Manager. Local-dev convenience — CI reads GitHub Actions
-# secrets directly and never calls this script.
+# AWS Secrets Manager. Local-dev convenience — CI assumes the
+# `AWS_OIDC_ROLE_ARN` role and pulls the same secrets via
+# aws-actions/aws-secretsmanager-get-secrets.
 #
 #   source scripts/load-secrets-aws.sh
-#   make release
+#   ./scripts/build-app.sh
 #
 # Overrides:
 #   AWS_PROFILE  (default: admin)


### PR DESCRIPTION
## Description

Follow-up to #80. That PR deleted \`scripts/release-mac.sh\` but a botched \`git add\` left the 4 sibling cleanup edits uncommitted, so main currently ships:

- Makefile \`release\` target pointing at a deleted script
- README env table crediting \`scripts/release-mac.sh\`
- \`build-app.sh\` header comment "(same as release-mac.sh)"
- \`load-secrets-aws.sh\` \`make release\` example

Strips all four. \`./scripts/build-app.sh\` is the only signing path now (consumed by \`.github/workflows/release-agentwiki-launcher-go.yml\`).

## How Has This Been Tested?

- \`go vet ./... && go build ./...\` clean.
- \`bash -n scripts/build-app.sh scripts/load-secrets-aws.sh\` clean.
- \`pre-commit run --files <touched>\`: end-of-files / trailing-whitespace / ripsecrets Passed.