### PR TITLE
perf(launchers/ci): content-address-cache the signed launcher build

### DIFF
--- a/.github/workflows/release-agentwiki-launcher-go.yml
+++ b/.github/workflows/release-agentwiki-launcher-go.yml
@@ -35,19 +35,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Content-addressable cache: keyed on the launcher source tree. When
-      # backend-only PRs reuse the same launcher source, the build, sign,
-      # notarize, and staple steps are skipped — only the artifact upload
-      # runs (~30s vs ~5min cold). Stapled .app tickets don't expire, so
-      # cached zips are valid until source changes evict them.
+      # Content-addressable cache: keyed on inputs that actually affect
+      # the built+signed bundle (Go source, build config, signing
+      # scripts, AppleScript stub). README and other non-build assets
+      # are intentionally excluded so doc changes don't bust the cache.
+      # Test files (*_test.go) are still hashed under the .go glob
+      # because hashFiles can't negate; small price for the simpler
+      # glob, and test changes are rare.
       - name: Restore launcher cache
         id: cache
         uses: actions/cache@v4
         with:
           path: packages/agentwiki-launcher-go/dist/
-          key: agentwiki-launcher-${{ hashFiles('packages/agentwiki-launcher-go/**') }}
+          key: |
+            agentwiki-launcher-${{ hashFiles(
+              'packages/agentwiki-launcher-go/cmd/**/*.go',
+              'packages/agentwiki-launcher-go/internal/**/*.go',
+              'packages/agentwiki-launcher-go/go.mod',
+              'packages/agentwiki-launcher-go/go.sum',
+              'packages/agentwiki-launcher-go/Makefile',
+              'packages/agentwiki-launcher-go/scripts/build-app.sh',
+              'packages/agentwiki-launcher-go/scripts/stub.applescript'
+            ) }}
 
-      - if: steps.cache.outputs.cache-hit != 'true'
+      - name: Setup Go
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: packages/agentwiki-launcher-go/go.mod

--- a/.github/workflows/release-agentwiki-launcher-go.yml
+++ b/.github/workflows/release-agentwiki-launcher-go.yml
@@ -32,24 +32,36 @@ jobs:
     timeout-minutes: 60
     outputs:
       artifact-name: ${{ steps.set-artifact.outputs.name }}
-    defaults:
-      run:
-        working-directory: packages/agentwiki-launcher-go
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      # Content-addressable cache: keyed on the launcher source tree. When
+      # backend-only PRs reuse the same launcher source, the build, sign,
+      # notarize, and staple steps are skipped — only the artifact upload
+      # runs (~30s vs ~5min cold). Stapled .app tickets don't expire, so
+      # cached zips are valid until source changes evict them.
+      - name: Restore launcher cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: packages/agentwiki-launcher-go/dist/
+          key: agentwiki-launcher-${{ hashFiles('packages/agentwiki-launcher-go/**') }}
+
+      - if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/setup-go@v5
         with:
           go-version-file: packages/agentwiki-launcher-go/go.mod
           cache: false
 
       - name: Configure AWS credentials (OIDC)
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-2
 
       - name: Pull Apple secrets
+        if: steps.cache.outputs.cache-hit != 'true'
         uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802
         with:
           # left = env var name (matches scripts/build-app.sh expectations)
@@ -62,6 +74,8 @@ jobs:
             APPLE_CERT_PASSWORD, deploy/apple-certificate-password
 
       - name: Build, sign, notarize, staple AgentWikiLauncher.app
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: packages/agentwiki-launcher-go
         run: ./scripts/build-app.sh
 
       - name: Set artifact name


### PR DESCRIPTION
## Description

Backend image builds (\`docker-build-push.yml\` + \`nightly-build.yml\`) wait ~5 min on every run for the launcher to re-sign + re-notarize, even when \`packages/agentwiki-launcher-go/**\` is byte-identical. Backend changes far outpace launcher changes; this is wasteful.

\`actions/cache@v4\` keyed on \`hashFiles('packages/agentwiki-launcher-go/**')\` restores \`dist/\` when the source hasn't changed. Setup-go + AWS OIDC + Apple secrets pull + \`build-app.sh\` are gated behind \`steps.cache.outputs.cache-hit != 'true'\`. \`upload-artifact\` still runs both paths so the chained backend builds get the artifact.

| | Cold (source changed / cache miss) | Warm (source unchanged / cache hit) |
| -- | -- | -- |
| Time | ~5 min | ~30s |

Stapled \`.app\` notarization tickets don't expire (per Apple), so serving a cached zip is valid until source evicts the cache. GH Actions cache has a 7-day eviction window.

## How Has This Been Tested?

- \`pre-commit run --files .github/workflows/release-agentwiki-launcher-go.yml\` clean.
- YAML schema OK (check-yaml hook).

Cache behavior gets exercised on the first run after merge (cold miss → fresh build → cache populated) and on the next backend deploy that doesn't touch \`packages/agentwiki-launcher-go/**\` (warm hit → artifact upload only).