### PR TITLE
prompt(ingest_batch_reconciler): tighten anti-bloat guidance

### DIFF
--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -3,6 +3,16 @@ happens. You receive an external document and a numbered list of wiki pages.
 For each page, decide whether the external document warrants a change and,
 if so, produce targeted FIND/REPLACE edits.
 
+The wiki records current truth. A well-updated page reads as if it was
+always correct — not as a log of what changed or why. Write for a reader
+who already knows the system and is looking up one fact. Update that fact.
+Change history, rationale, and context belong in the source document, not
+here.
+
+External documents are often much longer than the wiki pages they affect.
+Most of that length is rationale, history, and context that belongs in the
+source system. Extract only the fact that changed — the what, not the why.
+
 ## Relevance check — do this first for each page
 
 Ask: does the external document directly describe the same system, process,
@@ -53,6 +63,6 @@ Rules for `find`/`replace` edit pairs:
   repeat it at the start of `replace` followed by the new content.
 - To add a new section at the end, anchor `find` on the last existing heading
   or paragraph.
-- `replace` may add, update, or expand. Never remove information the external
-  doc does not address.
+- `replace` should be as short as the corrected or new fact allows. Never
+  remove information the external doc does not address.
 - Use multiple edit objects for non-adjacent changes, ordered top-to-bottom.


### PR DESCRIPTION
## Summary

- Add reader-first wiki identity framing at the top of the prompt: the wiki records current truth, not change history; write for a reader looking up one fact
- Add asymmetry rule: external documents are often much longer than wiki pages; extract only the changed fact, not rationale or context
- Tighten the `replace` rule from "`replace` may add, update, or expand" to "`replace` should be as short as the corrected or new fact allows"

## Motivation

The batch reconciler's FIND/REPLACE format prevents full-page rewrites, but the model can still bloat individual replacements by incorporating rationale and context from the source document. The existing "surgical edits" rule is a principle at the page level; these changes add the equivalent constraint at the edit level and give the model a concrete mental model of who the reader is and what they need.

## What was not changed

Relevance check, FIND/REPLACE mechanics, markdown structure rules — unchanged. This is a targeted addition, not a rewrite.

## Test plan

- [ ] Run nightly eval (`evals-nightly.yml`) against the current bloat cases and compare `bloat_ratio` on `reconcile_document` surface vs v0 baseline (0.88–0.92)
- [ ] Manually inspect a sample of reconcile outputs on long external docs to confirm replacements are tighter