### PR TITLE
chore(helm): bump chart to 0.3.18 to publish INGEST_EVAL_LOGGING env var

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.17
+version: 0.3.18
 appVersion: "0.1.0"


### PR DESCRIPTION
## Description

Bumps the Helm chart version from 0.3.17 → 0.3.18 so chart-releaser publishes a new package to gh-pages. The `_helpers.tpl` change adding `INGEST_EVAL_LOGGING` was merged in #93 but chart-releaser doesn't overwrite existing versions, so the 0.3.17 package in gh-pages still has the old template without that env var.

## How Has This Been Tested?

After merge, the helm-release workflow will publish 0.3.18. Re-deploying dev-wiki with the new chart will include `INGEST_EVAL_LOGGING=true` on the worker pods.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check