### PR TITLE
feat(launchers/helper-go): prompt to switch endpoint on mismatch

### DIFF
--- a/packages/agentwiki-launcher-go/cmd/agentwiki-launcher/main.go
+++ b/packages/agentwiki-launcher-go/cmd/agentwiki-launcher/main.go
@@ -184,7 +184,17 @@ func doRun(raw string) error {
 		pinned = parsed.Endpoint
 	}
 	if !endpoint.Matches(pinned, parsed.Endpoint) {
-		return fmt.Errorf("URI endpoint %s does not match pinned %s; refusing", parsed.Endpoint, pinned)
+		// Pinned-but-mismatched: ask the user before switching. Keeps
+		// anti-phishing posture (only an explicit user gesture changes
+		// the trusted endpoint) but unblocks legitimate dev → prod
+		// switches without requiring `rm ~/.agentwiki/endpoint.url`.
+		if !confirmSwitchEndpoint(pinned, parsed.Endpoint) {
+			return fmt.Errorf("URI endpoint %s does not match pinned %s; user declined to switch", parsed.Endpoint, pinned)
+		}
+		if err := endpoint.Set(parsed.Endpoint); err != nil {
+			return err
+		}
+		pinned = parsed.Endpoint
 	}
 
 	machineID, err := machine.GetOrCreate()
@@ -318,6 +328,21 @@ func confirmPinEndpoint(rawURL string) bool {
 	escaped := appleScriptEscapeLiteral(rawURL)
 	script := fmt.Sprintf(
 		"display dialog \"Pin %s as your agent-wiki endpoint?\n\nThis launcher will only accept Run Agent requests from this URL.\" buttons {\"Cancel\", \"Pin\"} default button \"Pin\" with title \"AgentWikiLauncher\" with icon note",
+		escaped,
+	)
+	return exec.Command("osascript", "-e", script).Run() == nil
+}
+
+// confirmSwitchEndpoint asks the user via a native macOS dialog whether
+// to switch the pinned endpoint from one wiki URL to another. Returns
+// true on Switch. The destructive default (Cancel) keeps a stray
+// agentwiki:// URL from silently moving the pin off a trusted host.
+func confirmSwitchEndpoint(oldURL, newURL string) bool {
+	escaped := appleScriptEscapeLiteral(
+		fmt.Sprintf("Switch your pinned wiki endpoint?\n\nCurrent: %s\nNew:     %s\n\nOnly do this if you trust the new URL.", oldURL, newURL),
+	)
+	script := fmt.Sprintf(
+		"display dialog \"%s\" buttons {\"Cancel\", \"Switch\"} default button \"Cancel\" with title \"AgentWikiLauncher\" with icon caution",
 		escaped,
 	)
 	return exec.Command("osascript", "-e", script).Run() == nil

--- a/packages/agentwiki-launcher-go/cmd/agentwiki-launcher/main.go
+++ b/packages/agentwiki-launcher-go/cmd/agentwiki-launcher/main.go
@@ -337,13 +337,21 @@ func confirmPinEndpoint(rawURL string) bool {
 // to switch the pinned endpoint from one wiki URL to another. Returns
 // true on Switch. The destructive default (Cancel) keeps a stray
 // agentwiki:// URL from silently moving the pin off a trusted host.
+//
+// Only the variable URL fragments go through appleScriptEscapeLiteral
+// (which scrubs newlines + quotes to keep an attacker from breaking the
+// dialog). The fixed scaffolding's "\n" survives so the message renders
+// across multiple lines.
 func confirmSwitchEndpoint(oldURL, newURL string) bool {
-	escaped := appleScriptEscapeLiteral(
-		fmt.Sprintf("Switch your pinned wiki endpoint?\n\nCurrent: %s\nNew:     %s\n\nOnly do this if you trust the new URL.", oldURL, newURL),
+	oldEscaped := appleScriptEscapeLiteral(oldURL)
+	newEscaped := appleScriptEscapeLiteral(newURL)
+	body := fmt.Sprintf(
+		"Switch your pinned wiki endpoint?\n\nCurrent: %s\nNew:     %s\n\nOnly do this if you trust the new URL.",
+		oldEscaped, newEscaped,
 	)
 	script := fmt.Sprintf(
 		"display dialog \"%s\" buttons {\"Cancel\", \"Switch\"} default button \"Cancel\" with title \"AgentWikiLauncher\" with icon caution",
-		escaped,
+		body,
 	)
 	return exec.Command("osascript", "-e", script).Run() == nil
 }


### PR DESCRIPTION
## Description

Launcher pinned to wiki A refuses any \`agentwiki://\` URI minted by wiki B with a terminal error — only escape today is \`rm ~/.agentwiki/endpoint.url\` from a shell. Non-power users hit a dead end; devs switching between local + prod wikis hit it constantly (e.g. local pinned to \`http://127.0.0.1:8089\`, then click Run Agent on \`https://dev-wiki.onyx.app\` → silent refuse, terminal exits).

On mismatch, now show a native macOS dialog:

\`\`\`
Switch your pinned wiki endpoint?

Current: http://127.0.0.1:8089
New:     https://dev-wiki.onyx.app

Only do this if you trust the new URL.

[ Cancel ]  [ Switch ]
\`\`\`

Anti-phishing posture preserved:
- Cancel is the default button
- Dialog uses the \`caution\` icon
- Only an explicit user gesture moves the pin off the trusted host

\`confirmPinEndpoint\` and \`confirmSwitchEndpoint\` share \`appleScriptEscapeLiteral\` so URLs with \`"\`, \`\\\`, CR, LF render cleanly.

## How Has This Been Tested?

- \`go vet ./... && go build ./...\` clean.
- \`go test ./...\` — 6 packages pass (cmd, allowed, endpoint, interpolate, manifest, uri).
- \`pre-commit run --files packages/agentwiki-launcher-go/cmd/agentwiki-launcher/main.go\` clean.

Functional verification on next signed build (the dialog UI itself can only be exercised end-to-end after notarized .app ships in a backend image; the logic is small + covered by existing endpoint-mismatch path).