### PR TITLE
fix(launchers/fe): unstack Install Helper pane CTA + helper text

### DIFF
--- a/frontend/src/components/agents/InstallHelperPane.tsx
+++ b/frontend/src/components/agents/InstallHelperPane.tsx
@@ -58,21 +58,13 @@ export function InstallHelperPane({
         <Text font="secondary-body" color="text-04" as="p">
           Launcher isn&apos;t installed on this machine.
         </Text>
-        <Section
-          flexDirection="row"
-          alignItems="center"
-          justifyContent="start"
-          gap={0.75}
-          width="full"
-        >
-          <Button size="md" variant="action" onClick={download}>
-            Download installer
-          </Button>
-          <Text font="secondary-body" color="text-04" as="span">
-            Open the downloaded zip, drag AgentWikiLauncher.app to your
-            Applications folder, then click Run Agent.
-          </Text>
-        </Section>
+        <Button size="md" variant="action" onClick={download}>
+          Download installer
+        </Button>
+        <Text font="secondary-body" color="text-04" as="p">
+          Open the downloaded zip, drag AgentWikiLauncher.app to your
+          Applications folder, then click Run Agent.
+        </Text>
         <Section
           flexDirection="row"
           alignItems="center"


### PR DESCRIPTION
## Description

OPAL \`Section flexDirection="row"\` squeezed the Download installer button — label rendered as "vnload insta" and the helper paragraph overflowed across it. Dropped the inner horizontal Section; button + helper text are now direct children of the outer column Section. Helper text is a \`<p>\` that wraps cleanly under the button at any container width.

## How Has This Been Tested?

<img width="449" height="368" alt="Screenshot 2026-05-21 at 3 25 53 PM" src="https://github.com/user-attachments/assets/59d49ea3-342c-4dcf-925b-c142b9e4e163" />


- \`npx tsc --noEmit\` clean.
- \`pre-commit run --files frontend/src/components/agents/InstallHelperPane.tsx\`: EOF / whitespace / ripsecrets Passed.

Visual verification on the next FE deploy via the SetupWizard "Set up tools" → step 2 surface.