### PR TITLE
prompt(reconciler): block fabricated tasks and loose product-area relevance

### DIFF
--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -24,11 +24,11 @@ irrelevant pushes:
 - API reference pages pushed against an architecture decision record.
 - Marketing content or general how-to guides pushed against an ops page.
 - A doc about feature X pushed against a runbook for service Y.
-- A CRM contact or company record pushed against a task-tracking page —
-  a contact's existence is not an action item.
-- A code change pushed against a personal tracking page solely because
-  it's in the same product area — it must directly answer a specific
-  question the page explicitly poses.
+- A source that describes a state or entity (contact, record, profile)
+  without stating any action or decision, pushed against a task-tracking
+  page.
+- A source that shares the same domain but doesn't directly address a
+  fact or question the page tracks.
 
 When in doubt, use `irrelevant`. Err on the side of not changing the page.
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -24,6 +24,11 @@ irrelevant pushes:
 - API reference pages pushed against an architecture decision record.
 - Marketing content or general how-to guides pushed against an ops page.
 - A doc about feature X pushed against a runbook for service Y.
+- A CRM contact or company record pushed against a task-tracking page —
+  a contact's existence is not an action item.
+- A code change pushed against a personal tracking page solely because
+  it's in the same product area — it must directly answer a specific
+  question the page explicitly poses.
 
 When in doubt, use `irrelevant`. Err on the side of not changing the page.
 
@@ -39,6 +44,10 @@ not belong. When in doubt, use `no_change`.
 
 - Surgical edits beat full rewrites. Change only what the external doc
   specifically adds or corrects.
+- Do not create new action items or checklist entries unless the source
+  explicitly describes work to be done. A data record (contact card,
+  company profile, license entry) that implies no stated action is not
+  grounds for a new task.
 - Never remove information the page has that the external doc omits.
 - Don't duplicate. If a section already covers the point, refine it in place.
 - Do not copy the external document wholesale — integrate only what is


### PR DESCRIPTION
## Summary

Analysis of 1,092 production eval samples found 226 cases where the judge marked a committed outcome as wrong. Three patterns account for nearly all of them:

- **178 cases**: HubSpot contact/company records → `team-todos.md`. The model saw the page has a HubSpot intake section and created `- [ ] **(P1)** Confirm X next steps` tasks from bare contact cards — fabricating tasks that the source never described.
- **24 cases**: GitHub PRs → personal notes pages. The model added any PR touching the same product area (Craft, evals) even when it didn't answer the specific questions the page poses.
- **7 cases**: Slack announcements/support threads → `team-todos.md` as new task entries.

## Changes

Two targeted additions to `ingest_batch_reconciler.system.md`:

1. **Relevance check** — two new examples explicitly covering the dominant failure modes: CRM records are not action items; code changes require direct relevance to a question the page poses, not just same-area membership.

2. **Editing rules** — new rule: don't create action items or checklist entries unless the source explicitly describes work to be done.