### PR TITLE
prompt(reconciler): precise task rule, block new sections

### DIFF
--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -38,16 +38,17 @@ The page defines what belongs in it — not the source document. Read the
 existing page: what facts does it record, at what level of detail? Only add
 information the page's own structure clearly calls for. New or related content
 that sits at a different level of detail or serves a different purpose does
-not belong. When in doubt, use `no_change`.
+not belong. Do not create new headings or sections — only update content
+under headings that already exist. When in doubt, use `no_change`.
 
 ## Editing rules (only apply if relevant)
 
 - Surgical edits beat full rewrites. Change only what the external doc
   specifically adds or corrects.
-- Do not create new action items or checklist entries unless the source
-  explicitly describes work to be done. A data record (contact card,
-  company profile, license entry) that implies no stated action is not
-  grounds for a new task.
+- Create a new task entry only if the source explicitly assigns a concrete
+  action to a named person already tracked on the page. A source that
+  describes only an entity's state (contact info, company profile, deal
+  stage) without a stated internal assignee is not grounds for a new task.
 - Never remove information the page has that the external doc omits.
 - Don't duplicate. If a section already covers the point, refine it in place.
 - Do not copy the external document wholesale — integrate only what is


### PR DESCRIPTION
## Summary

Two targeted fixes based on analysis of 1,268 post-prompt-change eval samples:

**1. Refine task creation rule**

The previous blanket rule ("don't create tasks unless work is explicitly described") overcorrected — it was blocking legitimate commits where a call summary explicitly assigns a concrete action to a named person already tracked on the page (3 confirmed false negatives). The new rule distinguishes:
- ✅ Source explicitly assigns a concrete action to a named internal person already on the page → valid task
- ❌ Source describes only an entity's state (contact info, deal stage, company profile) without a named internal assignee → not grounds for a task

**2. Block new headings/sections in scope check**

Analysis showed the model was still creating new sections (e.g. "## Tracking OpenAI API spend") from loosely related sources. Adding "do not create new headings or sections" to the scope check prevents this class of bloat.