### PR TITLE
feat(eval): refine judge prompt — sharpen irrelevant vs no_change, setup page relevance

### DIFF
--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -895,8 +895,13 @@ async function judgeSample(sample) {
     `- committed_moderate: source adds a concrete, focused piece of information that fits the page's scope\n` +
     `- committed_nit: source only justifies a very minor or cosmetic touch\n` +
     `- no_change_covered: wiki already covers the topic adequately — no new information in the source\n` +
-    `- no_change_extra: source has additional detail but it exceeds the page's intended scope or level of detail\n` +
-    `- irrelevant: the source document is not relevant to this wiki page\n\n` +
+    `- no_change_extra: source is on-topic but the detail it adds exceeds the page's scope or level of detail\n` +
+    `- irrelevant: the source is about a completely different topic and could never warrant a change to this page\n\n` +
+    `Important distinctions:\n` +
+    `- Use no_change_covered or no_change_extra when the source is topically related but adds nothing useful. ` +
+    `Reserve irrelevant for sources with no connection to the page's topic whatsoever.\n` +
+    `- For pages that document how to set up or connect to a service, client-side configuration and ` +
+    `troubleshooting tips are relevant — not just server-side implementation details.\n\n` +
     `When in doubt between committing and no_change, prefer no_change_extra.\n\n` +
     `Respond with JSON only: {"label":"<one of the labels>","reasoning":"<1-2 sentences>"}`,
   ].join("\n\n");

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -608,14 +608,22 @@ function judgeAll(outcome) {
 
 async function processJudgeQueue() {
   judgeQueueRunning = true;
+  let errors = 0;
   while (judgeQueue.length) {
-    document.getElementById("judge-queue-status").textContent = `${judgeQueue.length} remaining…`;
+    const statusEl = document.getElementById("judge-queue-status");
+    statusEl.textContent = `${judgeQueue.length} remaining…` + (errors ? ` (${errors} errors)` : "");
     const id = judgeQueue.shift();
     const sample = samples.find(s => s.id === id);
-    if (sample && !sample.judge_label) await judgeSample(sample);
+    if (sample && !sample.judge_label) {
+      await judgeSample(sample);
+      if (!sample.judge_label) errors++;  // judgeSample failed if label still unset
+    }
+    await new Promise(r => setTimeout(r, 300));  // avoid rate limiting
   }
   judgeQueueRunning = false;
-  document.getElementById("judge-queue-status").textContent = "";
+  const statusEl = document.getElementById("judge-queue-status");
+  statusEl.textContent = errors ? `Done — ${errors} errors (check console)` : "";
+  if (errors) setTimeout(() => { statusEl.textContent = ""; }, 5000);
 }
 
 // ── Render ────────────────────────────────────────────────────────────────────
@@ -924,6 +932,7 @@ async function judgeSample(sample) {
     await writeBack();
   } catch (e) {
     errorMsg = e.message || String(e);
+    console.error(`judgeSample failed for id=${sample.id}:`, errorMsg);
   } finally {
     judging.delete(sample.id);
     if (samples[current]?.id === sample.id) {

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -574,12 +574,20 @@ function jumpToUnlabeled(outcome) {
   }
 }
 
+const outcomeMatchesLabel = (outcome, label) => {
+  if (!outcome || !label) return true;
+  if (outcome === "committed")  return isCommit(label);
+  if (outcome === "no_change")  return label.startsWith("no_change");
+  if (outcome === "irrelevant") return label === "irrelevant";
+  return true;
+};
+
 function jumpToMismatch() {
   flushCoverage();
   for (let i = 1; i <= samples.length; i++) {
     const idx = (current + i) % samples.length;
     const s = samples[idx];
-    if (s.judge_label && s.label && s.judge_label !== s.label) {
+    if (s.label && !outcomeMatchesLabel(s.outcome, s.label)) {
       current = idx; render(); return;
     }
   }
@@ -626,7 +634,7 @@ function render() {
   document.getElementById("progress-summary").textContent =
     `${labeled} / ${samples.length} labeled  |  ${outcomeStats}`;
 
-  const mismatches = samples.filter(x => x.judge_label && x.label && x.judge_label !== x.label).length;
+  const mismatches = samples.filter(x => x.label && !outcomeMatchesLabel(x.outcome, x.label)).length;
   document.getElementById("mismatch-count").textContent =
     labeled ? `${mismatches} / ${labeled} mismatch` : "";
 

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -615,7 +615,13 @@ function render() {
 
   const labeled = samples.filter(x => x.label).length;
   document.getElementById("progress-bar").style.width = (labeled / samples.length * 100) + "%";
-  document.getElementById("progress-summary").textContent = `${labeled} / ${samples.length} labeled`;
+  const outcomeStats = ["committed", "no_change", "irrelevant"].map(o => {
+    const total = samples.filter(x => x.outcome === o).length;
+    const done  = samples.filter(x => x.outcome === o && x.label).length;
+    return `${o}: ${done}/${total}`;
+  }).join(" · ");
+  document.getElementById("progress-summary").textContent =
+    `${labeled} / ${samples.length} labeled  |  ${outcomeStats}`;
 
   const outcome = s.outcome || "";
   document.getElementById("source-title").textContent = s.source_title || "";

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -600,9 +600,14 @@ function jumpToMismatch() {
 function judgeAll(outcome) {
   if (!anthropicKey) { promptApiKey(); return; }
   const pending = samples.filter(s => s.outcome === outcome && !s.judge_label && !judging.has(s.id));
+  if (!pending.length) {
+    const statusEl = document.getElementById("judge-queue-status");
+    statusEl.textContent = `All ${outcome} already judged`;
+    setTimeout(() => { statusEl.textContent = ""; }, 3000);
+    return;
+  }
   pending.forEach(s => { if (!judgeQueue.includes(s.id)) judgeQueue.push(s.id); });
-  document.getElementById("judge-queue-status").textContent =
-    judgeQueue.length ? `${judgeQueue.length} queued…` : "";
+  document.getElementById("judge-queue-status").textContent = `${judgeQueue.length} queued…`;
   if (!judgeQueueRunning) processJudgeQueue();
 }
 

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -403,7 +403,10 @@ if(__exports != exports)module.exports = exports;return module.exports}));
       <button onclick="jumpToUnlabeled('committed')">committed</button>
       <button onclick="jumpToUnlabeled('no_change')">no_change</button>
       <button onclick="jumpToUnlabeled('irrelevant')">irrelevant</button>
+    </div>
+    <div style="display:flex;gap:6px;align-items:center;border-left:1px solid #e0e0e0;padding-left:10px;">
       <button onclick="jumpToMismatch()">⚡ mismatch</button>
+      <span id="mismatch-count" style="font-size:11px;color:#999;"></span>
     </div>
     <div style="display:flex;gap:6px;align-items:center;">
       <span style="font-size:11px;color:#999;">Judge all:</span>
@@ -622,6 +625,11 @@ function render() {
   }).join(" · ");
   document.getElementById("progress-summary").textContent =
     `${labeled} / ${samples.length} labeled  |  ${outcomeStats}`;
+
+  const mismatches = samples.filter(x => x.judge_label && x.label && x.judge_label !== x.label).length;
+  const judged     = samples.filter(x => x.judge_label && x.label).length;
+  document.getElementById("mismatch-count").textContent =
+    judged ? `${mismatches} / ${judged} mismatch` : "";
 
   const outcome = s.outcome || "";
   document.getElementById("source-title").textContent = s.source_title || "";

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -407,6 +407,8 @@ if(__exports != exports)module.exports = exports;return module.exports}));
     <div style="display:flex;gap:6px;align-items:center;border-left:1px solid #e0e0e0;padding-left:10px;">
       <button onclick="jumpToMismatch()">⚡ mismatch</button>
       <span id="mismatch-count" style="font-size:11px;color:#999;"></span>
+      <span style="color:#e0e0e0;">|</span>
+      <span id="wrong-judge-count" style="font-size:11px;color:#999;"></span>
     </div>
     <div style="display:flex;gap:6px;align-items:center;">
       <span style="font-size:11px;color:#999;">Judge all:</span>
@@ -574,6 +576,8 @@ function jumpToUnlabeled(outcome) {
   }
 }
 
+const judgeMatchesLabel = (judgeLabel, humanLabel) => judgeLabel === humanLabel;
+
 const outcomeMatchesLabel = (outcome, label) => {
   if (!outcome || !label) return true;
   if (outcome === "committed")  return isCommit(label);
@@ -634,9 +638,13 @@ function render() {
   document.getElementById("progress-summary").textContent =
     `${labeled} / ${samples.length} labeled  |  ${outcomeStats}`;
 
-  const mismatches = samples.filter(x => x.label && !outcomeMatchesLabel(x.outcome, x.label)).length;
+  const mismatches  = samples.filter(x => x.label && !outcomeMatchesLabel(x.outcome, x.label)).length;
+  const wrongJudged = samples.filter(x => x.judge_label && x.label).length;
+  const wrongJudge  = samples.filter(x => x.judge_label && x.label && !judgeMatchesLabel(x.judge_label, x.label)).length;
   document.getElementById("mismatch-count").textContent =
     labeled ? `${mismatches} / ${labeled} mismatch` : "";
+  document.getElementById("wrong-judge-count").textContent =
+    wrongJudged ? `${wrongJudge} / ${wrongJudged} wrong judge` : "";
 
   const outcome = s.outcome || "";
   document.getElementById("source-title").textContent = s.source_title || "";

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -403,6 +403,14 @@ if(__exports != exports)module.exports = exports;return module.exports}));
       <button onclick="jumpToUnlabeled('committed')">committed</button>
       <button onclick="jumpToUnlabeled('no_change')">no_change</button>
       <button onclick="jumpToUnlabeled('irrelevant')">irrelevant</button>
+      <button onclick="jumpToMismatch()">⚡ mismatch</button>
+    </div>
+    <div style="display:flex;gap:6px;align-items:center;">
+      <span style="font-size:11px;color:#999;">Judge all:</span>
+      <button onclick="judgeAll('committed')">committed</button>
+      <button onclick="judgeAll('no_change')">no_change</button>
+      <button onclick="judgeAll('irrelevant')">irrelevant</button>
+      <span id="judge-queue-status" style="font-size:11px;color:#999;"></span>
     </div>
     <div style="display:flex;gap:6px;">
       <button id="btn-judge" onclick="judgeCurrent()" style="display:none;">⚖ Judge</button>
@@ -482,6 +490,9 @@ const LABELS = [
 
 const isCommit = v => v && (v.startsWith("committed_") || v === "committed");
 
+let judgeQueue = [];
+let judgeQueueRunning = false;
+
 let samples = [];   // original rows
 let current = 0;
 let filename = "eval_samples.jsonl";
@@ -552,15 +563,44 @@ function jumpTo(val) {
 
 function jumpToUnlabeled(outcome) {
   flushCoverage();
-  // Search from current+1, wrap around
   for (let i = 1; i <= samples.length; i++) {
     const idx = (current + i) % samples.length;
     if (samples[idx].outcome === outcome && !samples[idx].label) {
-      current = idx;
-      render();
-      return;
+      current = idx; render(); return;
     }
   }
+}
+
+function jumpToMismatch() {
+  flushCoverage();
+  for (let i = 1; i <= samples.length; i++) {
+    const idx = (current + i) % samples.length;
+    const s = samples[idx];
+    if (s.judge_label && s.label && s.judge_label !== s.label) {
+      current = idx; render(); return;
+    }
+  }
+}
+
+function judgeAll(outcome) {
+  if (!anthropicKey) { promptApiKey(); return; }
+  const pending = samples.filter(s => s.outcome === outcome && !s.judge_label && !judging.has(s.id));
+  pending.forEach(s => { if (!judgeQueue.includes(s.id)) judgeQueue.push(s.id); });
+  document.getElementById("judge-queue-status").textContent =
+    judgeQueue.length ? `${judgeQueue.length} queued…` : "";
+  if (!judgeQueueRunning) processJudgeQueue();
+}
+
+async function processJudgeQueue() {
+  judgeQueueRunning = true;
+  while (judgeQueue.length) {
+    document.getElementById("judge-queue-status").textContent = `${judgeQueue.length} remaining…`;
+    const id = judgeQueue.shift();
+    const sample = samples.find(s => s.id === id);
+    if (sample && !sample.judge_label) await judgeSample(sample);
+  }
+  judgeQueueRunning = false;
+  document.getElementById("judge-queue-status").textContent = "";
 }
 
 // ── Render ────────────────────────────────────────────────────────────────────

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -627,9 +627,8 @@ function render() {
     `${labeled} / ${samples.length} labeled  |  ${outcomeStats}`;
 
   const mismatches = samples.filter(x => x.judge_label && x.label && x.judge_label !== x.label).length;
-  const judged     = samples.filter(x => x.judge_label && x.label).length;
   document.getElementById("mismatch-count").textContent =
-    judged ? `${mismatches} / ${judged} mismatch` : "";
+    labeled ? `${mismatches} / ${labeled} mismatch` : "";
 
   const outcome = s.outcome || "";
   document.getElementById("source-title").textContent = s.source_title || "";

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -576,7 +576,8 @@ function jumpToUnlabeled(outcome) {
   }
 }
 
-const judgeMatchesLabel = (judgeLabel, humanLabel) => judgeLabel === humanLabel;
+const toCategory = v => isCommit(v) ? "committed" : v?.startsWith("no_change") ? "no_change" : v;
+const judgeMatchesLabel = (judgeLabel, humanLabel) => toCategory(judgeLabel) === toCategory(humanLabel);
 
 const outcomeMatchesLabel = (outcome, label) => {
   if (!outcome || !label) return true;
@@ -616,7 +617,8 @@ async function processJudgeQueue() {
   let errors = 0;
   while (judgeQueue.length) {
     const statusEl = document.getElementById("judge-queue-status");
-    statusEl.textContent = `${judgeQueue.length} remaining…` + (errors ? ` (${errors} errors)` : "");
+    const actual = judgeQueue.filter(id => { const s = samples.find(x => x.id === id); return s && !s.judge_label; }).length;
+    statusEl.textContent = `${actual} remaining…` + (errors ? ` (${errors} errors)` : "");
     const id = judgeQueue.shift();
     const sample = samples.find(s => s.id === id);
     if (sample && !sample.judge_label) {


### PR DESCRIPTION
## Summary

Two fixes to the LLM-as-judge prompt in the eval labeler, based on analysis of mismatches in `eval_samples_prod_1626_to_2893.jsonl`:

**1. Sharpen `irrelevant` vs `no_change` distinction**

39 `no_change` outcomes were labeled `irrelevant` by the judge, inflating the mismatch count with false signal. The judge was overusing `irrelevant` for sources the reconciler correctly considered but found nothing to change. Added explicit guidance: use `no_change_covered` / `no_change_extra` when the source is topically related but adds nothing; reserve `irrelevant` for sources with no connection to the page's topic whatsoever.

**2. Setup/documentation pages**

5 Discord → MCP Server cases were labeled `irrelevant` by the judge even though the system correctly added client-side connection tips (npx PATH, Bearer token config). Added guidance that for pages documenting how to set up or connect to a service, client-side configuration and troubleshooting content is relevant.