### PR TITLE
feat(evals): push case sets to Braintrust as datasets + link experiments

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -56,6 +56,7 @@ jobs:
             --cases evals/datasets/wiki_updater/cases \
             --models "$EVAL_MODELS" \
             --braintrust "nightly-wiki-updater-$(date -u +%Y%m%d)" \
+            --dataset "wiki-updater" \
             --out runs/nightly_wiki_updater.jsonl
 
       - name: ingest_selector live run
@@ -64,6 +65,7 @@ jobs:
             --cases evals/datasets/ingest_selector/cases.jsonl \
             --models "$SELECTOR_MODELS" \
             --braintrust "nightly-ingest-selector-$(date -u +%Y%m%d)" \
+            --dataset "ingest-selector" \
             --out runs/nightly_ingest_selector.jsonl
 
       - name: external_agent live run

--- a/backend/app/tracing/braintrust.py
+++ b/backend/app/tracing/braintrust.py
@@ -228,12 +228,75 @@ class ExperimentRow(BaseModel):
     metadata: dict[str, Any]
 
 
+class DatasetRow(BaseModel):
+    """One row pushed to a Braintrust dataset.
+
+    Mirrors the BT dataset row shape: ``input`` is what the model sees,
+    ``expected`` is the ground-truth answer, ``metadata`` carries dataset-
+    level tags. The optional ``id`` lets callers anchor a row to a stable
+    identifier (e.g. a case_id) so subsequent dataset versions can update
+    the same row instead of appending a duplicate.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input: dict[str, Any]
+    expected: dict[str, Any]
+    metadata: dict[str, Any]
+    id: str | None = None
+
+
+def push_dataset(
+    *,
+    project: str,
+    dataset: str,
+    api_key: str,
+    rows: list[DatasetRow],
+) -> int:
+    """Upload ``rows`` to a Braintrust dataset (versioned, idempotent).
+
+    Each call creates or updates the named dataset. Rows with a stable
+    ``id`` are upserted — re-running with the same cases produces a new
+    dataset version rather than appending duplicates. Experiments can
+    then link results to dataset row ids for cross-run regression
+    comparison in the BT UI.
+    """
+    if not rows:
+        return 0
+    try:
+        import braintrust
+    except ImportError:
+        log.warning("braintrust SDK not installed; skipping dataset push")
+        return 0
+    try:
+        bt_dataset: Any = braintrust.init_dataset(
+            project=project,
+            name=dataset,
+            api_key=api_key,
+        )
+        for row in rows:
+            insert_kwargs: dict[str, Any] = {
+                "input": row.input,
+                "expected": row.expected,
+                "metadata": row.metadata,
+            }
+            if row.id is not None:
+                insert_kwargs["id"] = row.id
+            bt_dataset.insert(**insert_kwargs)
+        bt_dataset.flush()
+    except Exception:
+        log.exception("braintrust dataset push failed; rows not uploaded")
+        return 0
+    return len(rows)
+
+
 def push_experiment(
     *,
     project: str,
     experiment: str,
     api_key: str,
     rows: list[ExperimentRow],
+    dataset: str | None = None,
 ) -> int:
     """Upload ``rows`` to a Braintrust experiment. Returns count uploaded.
 
@@ -255,19 +318,35 @@ def push_experiment(
         log.warning("braintrust SDK not installed; skipping experiment push")
         return 0
     try:
+        # When ``dataset`` is set, link the experiment to that BT dataset so
+        # the UI can show per-row regression vs prior experiments using the
+        # same dataset. ``case_id`` in each row's metadata is also used as
+        # the dataset record id at log time.
+        bt_dataset: Any = None
+        if dataset is not None:
+            bt_dataset = braintrust.init_dataset(
+                project=project,
+                name=dataset,
+                api_key=api_key,
+            )
         bt_experiment: Any = braintrust.init(
             project=project,
             experiment=experiment,
             api_key=api_key,
+            dataset=bt_dataset,
         )
         for row in rows:
-            bt_experiment.log(
-                input=row.input,
-                output=row.output,
-                expected=row.expected,
-                scores=row.scores,
-                metadata=row.metadata,
-            )
+            log_kwargs: dict[str, Any] = {
+                "input": row.input,
+                "output": row.output,
+                "expected": row.expected,
+                "scores": row.scores,
+                "metadata": row.metadata,
+            }
+            case_id = row.metadata.get("case_id") or row.input.get("case_id")
+            if dataset is not None and case_id:
+                log_kwargs["dataset_record_id"] = case_id
+            bt_experiment.log(**log_kwargs)
         bt_experiment.flush()
     except Exception:
         log.exception("braintrust experiment push failed; results not uploaded")

--- a/backend/evals/_cli.py
+++ b/backend/evals/_cli.py
@@ -57,6 +57,15 @@ def add_common_args(parser: argparse.ArgumentParser, *, default_models: str = ""
         help="Push to a Braintrust experiment of this base name",
     )
     parser.add_argument(
+        "--dataset",
+        default=None,
+        help=(
+            "Name of a Braintrust dataset to push the case set to (and link the experiment to). "
+            "If unset, the experiment is pushed standalone. Set to enable per-row regression view "
+            "across runs in the BT UI."
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Use the surface's stub LLM (no API keys needed)",

--- a/backend/evals/external_agent/run.py
+++ b/backend/evals/external_agent/run.py
@@ -236,10 +236,7 @@ def main(argv: list[str] | None = None) -> int:
     reporting.print_summary(summary)
     bt_url = ""
     if args.braintrust:
-        # Note: external_agent doesn't push a dataset (Scenario shape is
-        # more complex than CaseResult; a scenarios-dataset helper can
-        # land in a follow-up). Experiment is pushed standalone.
-        bt_url = reporting.push_to_braintrust(args.braintrust, results)
+        bt_url = reporting.push_to_braintrust(args.braintrust, results, dataset=args.dataset)
     reporting.write_github_summary(summary, braintrust_url=bt_url)
     print(json.dumps({"out": str(out_path), "skipped_models": skipped, "braintrust_url": bt_url}))
     return 0

--- a/backend/evals/external_agent/run.py
+++ b/backend/evals/external_agent/run.py
@@ -236,6 +236,9 @@ def main(argv: list[str] | None = None) -> int:
     reporting.print_summary(summary)
     bt_url = ""
     if args.braintrust:
+        # Note: external_agent doesn't push a dataset (Scenario shape is
+        # more complex than CaseResult; a scenarios-dataset helper can
+        # land in a follow-up). Experiment is pushed standalone.
         bt_url = reporting.push_to_braintrust(args.braintrust, results)
     reporting.write_github_summary(summary, braintrust_url=bt_url)
     print(json.dumps({"out": str(out_path), "skipped_models": skipped, "braintrust_url": bt_url}))

--- a/backend/evals/ingest_selector/run.py
+++ b/backend/evals/ingest_selector/run.py
@@ -189,11 +189,13 @@ def main(argv: list[str] | None = None) -> int:
 
     out_path = args.out or Path("runs") / ("ingest_selector_%d.jsonl" % int(time.time()))
     reporting.write_jsonl(out_path, results)
+    if args.dataset:
+        reporting.push_ingest_selector_dataset(args.dataset, cases)
     summary = reporting.summarize(results, surface="ingest_selector")
     reporting.print_summary(summary)
     bt_url = ""
     if args.braintrust:
-        bt_url = reporting.push_to_braintrust(args.braintrust, results)
+        bt_url = reporting.push_to_braintrust(args.braintrust, results, dataset=args.dataset)
     reporting.write_github_summary(summary, braintrust_url=bt_url)
     print(json.dumps({"out": str(out_path), "skipped_models": skipped, "braintrust_url": bt_url}))
     return 0

--- a/backend/evals/reporting.py
+++ b/backend/evals/reporting.py
@@ -12,7 +12,14 @@ from pathlib import Path
 from typing import IO, Iterable
 
 from app.tracing import braintrust as bt
-from evals.schema import CaseResult, RunSummary, ScorerSummary, Surface
+from evals.schema import (
+    CaseResult,
+    IngestSelectorCase,
+    RunSummary,
+    ScorerSummary,
+    Surface,
+    WikiUpdaterCase,
+)
 
 
 log = logging.getLogger(__name__)
@@ -204,13 +211,102 @@ def print_summary(summary: RunSummary, *, stream: IO[str] = sys.stdout) -> None:
     print("", file=stream)
 
 
+def push_wiki_updater_dataset(dataset: str, cases: list[WikiUpdaterCase]) -> int:
+    """Push the wiki_updater case set as a Braintrust dataset.
+
+    Each case becomes one BT dataset row keyed by ``case.id`` so re-running
+    on the same case set upserts rather than appending. Subsequent
+    experiments call ``push_to_braintrust(..., dataset=<dataset>)`` to link
+    per-case results back to the dataset row for cross-run regression view.
+    """
+    api_key = os.environ.get("BRAINTRUST_API_KEY", "")
+    project = os.environ.get("BRAINTRUST_PROJECT", "")
+    if not api_key or not project:
+        log.warning("braintrust: skip dataset push — no BRAINTRUST_API_KEY or BRAINTRUST_PROJECT")
+        return 0
+    rows = [
+        bt.DatasetRow(
+            id=c.id,
+            input={
+                "surface": c.surface,
+                "wiki_path": c.wiki_path,
+                "current_body": c.current_body,
+                "doc_title": c.doc_title,
+                "doc_url": c.doc_url,
+                "doc_content": c.doc_content,
+                "source": c.source,
+                "payload": c.payload,
+            },
+            expected={
+                "expected_class": c.expected_class.value,
+                "expected_facts_present": [f.model_dump() for f in c.expected_facts_present],
+                "expected_facts_preserved": [f.model_dump() for f in c.expected_facts_preserved],
+            },
+            metadata={
+                "surface": c.surface,
+                "wiki_path": c.wiki_path,
+                "tags": list(c.tags or []),
+                "max_bloat_ratio": c.max_bloat_ratio,
+            },
+        )
+        for c in cases
+    ]
+    pushed = bt.push_dataset(project=project, dataset=dataset, api_key=api_key, rows=rows)
+    log.info(
+        "braintrust: pushed %d/%d dataset rows to project=%s dataset=%s",
+        pushed,
+        len(cases),
+        project,
+        dataset,
+    )
+    return pushed
+
+
+def push_ingest_selector_dataset(dataset: str, cases: list[IngestSelectorCase]) -> int:
+    """Push the ingest_selector case set as a Braintrust dataset."""
+    api_key = os.environ.get("BRAINTRUST_API_KEY", "")
+    project = os.environ.get("BRAINTRUST_PROJECT", "")
+    if not api_key or not project:
+        log.warning("braintrust: skip dataset push — no BRAINTRUST_API_KEY or BRAINTRUST_PROJECT")
+        return 0
+    rows = [
+        bt.DatasetRow(
+            id=c.id,
+            input={
+                "doc_title": c.doc_title,
+                "doc_content": c.doc_content,
+                "candidates": [{"path": x.path, "body": x.body} for x in c.candidates],
+            },
+            expected={"expected_kept_paths": list(c.expected_kept_paths)},
+            metadata={"tags": list(c.tags or [])},
+        )
+        for c in cases
+    ]
+    pushed = bt.push_dataset(project=project, dataset=dataset, api_key=api_key, rows=rows)
+    log.info(
+        "braintrust: pushed %d/%d dataset rows to project=%s dataset=%s",
+        pushed,
+        len(cases),
+        project,
+        dataset,
+    )
+    return pushed
+
+
 def push_to_braintrust(
     experiment: str,
     results: list[CaseResult],
     *,
     project: str | None = None,
+    dataset: str | None = None,
 ) -> str:
-    """Push results, return the experiment URL (or "" if push was skipped)."""
+    """Push results, return the experiment URL (or "" if push was skipped).
+
+    When ``dataset`` is set, the experiment is linked to that BT dataset
+    so the UI can show per-row regression vs prior experiments using the
+    same dataset. Each result row's ``case_id`` is matched to a dataset
+    row id.
+    """
     api_key = os.environ.get("BRAINTRUST_API_KEY", "")
     project_name = project or os.environ.get("BRAINTRUST_PROJECT", "")
     if not api_key or not project_name:
@@ -223,6 +319,7 @@ def push_to_braintrust(
             expected={"expected_class": r.expected_class},
             scores={s.name: s.score for s in r.scorers},
             metadata={
+                "case_id": r.case_id,
                 "provider": r.provider,
                 "model": r.model,
                 "run_index": r.run_index,
@@ -239,6 +336,7 @@ def push_to_braintrust(
         experiment=experiment,
         api_key=api_key,
         rows=rows,
+        dataset=dataset,
     )
     org = os.environ.get("BRAINTRUST_ORG", "")
     if org:

--- a/backend/evals/wiki_updater/run.py
+++ b/backend/evals/wiki_updater/run.py
@@ -231,6 +231,15 @@ def main(argv: list[str] | None = None) -> int:
 
     out_path = args.out or Path("runs") / ("wiki_updater_%d.jsonl" % int(time.time()))
     reporting.write_jsonl(out_path, results)
+    # Push the case set as a BT dataset once (per surface) before experiments,
+    # so experiments can link results to dataset rows for per-row regression view.
+    dataset_name_by_surface: dict[str, str] = {}
+    if args.dataset:
+        for surface in sorted({c.surface for c in cases}):
+            ds = "%s-%s" % (args.dataset, surface.replace("_", "-"))
+            subset_cases = [c for c in cases if c.surface == surface]
+            reporting.push_wiki_updater_dataset(ds, subset_cases)
+            dataset_name_by_surface[surface] = ds
     surface_urls: dict[str, str] = {}
     for surface in sorted({r.surface for r in results}):
         subset = [r for r in results if r.surface == surface]
@@ -239,7 +248,9 @@ def main(argv: list[str] | None = None) -> int:
         bt_url = ""
         if args.braintrust:
             experiment = "%s-%s" % (args.braintrust, surface.replace("_", "-"))
-            bt_url = reporting.push_to_braintrust(experiment, subset)
+            bt_url = reporting.push_to_braintrust(
+                experiment, subset, dataset=dataset_name_by_surface.get(surface)
+            )
             surface_urls[surface] = bt_url
         reporting.write_github_summary(sub_summary, braintrust_url=bt_url)
     print(


### PR DESCRIPTION
## Description

Follow-up to #112. Promotes the eval case set to a first-class Braintrust Dataset and links every experiment back to it. Unlocks per-case regression view across runs in the BT UI.

### What this enables in BT

- **Per-case regression view across runs** — BT recognizes `case rd-real-bulk-39ecfde34b` ran in experiment A and experiment B; clicking into the row shows side-by-side model outputs across runs. Previously only aggregate scores compared.
- **Dataset versioning** — every push of `cases/` becomes a BT dataset version; experiments link to a specific version. BT auto-detects "experiment A used dataset v3, experiment B used v4 — these 12 cases are new."
- **In-UI labeling** — humans can add golden labels / golden answers directly in BT without a separate tool. Path to filling the empty `expected_facts_*` on the 159 bulk-mined cases.
- **Smarter "Compare" tab** — BT knows which rows are shared between two experiments and highlights cross-experiment row-level deltas.

### Wiring

- `backend/app/tracing/braintrust.py` — new `DatasetRow` model + `push_dataset()` seam. `push_experiment()` gains an optional `dataset` arg that links the experiment to a named BT dataset and anchors each result row to its dataset record via `dataset_record_id`. Eval surfaces still go through `app.tracing.braintrust` — no direct `import braintrust` outside that module.
- `backend/evals/reporting.py` — typed builders `push_wiki_updater_dataset()` and `push_ingest_selector_dataset()` convert `WikiUpdaterCase` / `IngestSelectorCase` into `DatasetRow`s. `push_to_braintrust()` gains `dataset=` to thread the linkage.
- `backend/evals/_cli.py` — new `--dataset NAME` flag added to `add_common_args`. Optional; runs are standalone if unset.
- Surface runners — when `--dataset` is set, the case set is pushed as a BT dataset once before experiments. `wiki_updater` produces one dataset per surface (`<base>-process-instruction`, `<base>-reconcile-document`) matching the per-surface experiment split.
- `.github/workflows/evals-nightly.yml` — nightly runs now pass `--dataset wiki-updater` and `--dataset ingest-selector`. The production stream populates the same dataset every night; BT auto-versions.

### Out of scope

`external_agent` is left standalone for now. The `Scenario` shape is more complex than `CaseResult` (multi-doc `wiki_state`, structured `expected_updates`) and warrants a separate `push_scenarios_dataset` helper in a follow-up. The runner accepts `--dataset` for the experiment-side link but doesn't push a scenarios dataset.

## How Has This Been Tested?

- `uv run ruff format --check` over all 6 changed Python files — `6 files already formatted`
- `uv run --extra dev basedpyright` whole-project — `0 errors, 0 warnings, 0 notes`
- `pytest evals/tests` — `37 passed, 1 warning in 0.65s`
- `pre-commit run` on every changed file — every hook Passed
- Live verification end-to-end: `evals.ingest_selector.run --dataset ingest-selector --braintrust ds-verify-145318` produced two log lines confirming both pushes —
  - `braintrust: pushed 5/5 dataset rows to project=agent-wiki-evals dataset=ingest-selector`
  - `braintrust: pushed 5/5 results to project=agent-wiki-evals experiment=ds-verify-145318 url=https://www.braintrust.dev/app/Onyx%202/p/agent-wiki-evals/experiments/ds-verify-145318`
- Experiment opens in BT UI with the dataset link visible + per-row drill-down works
