### PR TITLE
feat(evals): add trigger-firing eval surface

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -76,6 +76,15 @@ jobs:
             --braintrust "nightly-external-agent-$(date -u +%Y%m%d)" \
             --out runs/nightly_external_agent.jsonl
 
+      - name: triggers live run
+        run: |
+          uv run python -m evals.triggers.run \
+            --cases evals/datasets/triggers/cases \
+            --models "$EVAL_MODELS" \
+            --braintrust "nightly-triggers-$(date -u +%Y%m%d)" \
+            --dataset "triggers" \
+            --out runs/nightly_triggers.jsonl
+
       - name: Upload run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/evals-smoke.yml
+++ b/.github/workflows/evals-smoke.yml
@@ -21,6 +21,7 @@ on:
       - backend/app/llm/agents/common.py
       - backend/app/llm/prompts/wiki_updater.*
       - backend/app/llm/prompts/ingest_*
+      - backend/app/triggers/natural_language.py
       - .github/workflows/evals-smoke.yml
   workflow_dispatch:
 
@@ -76,6 +77,15 @@ jobs:
             --dry-run \
             --runs 1 \
             --out runs/ci_external_agent.jsonl
+
+      - name: triggers dry-run
+        run: |
+          uv run python -m evals.triggers.run \
+            --cases evals/datasets/triggers/cases \
+            --models claude-sonnet-4-6 \
+            --dry-run \
+            --runs 1 \
+            --out runs/ci_triggers.jsonl
 
       - name: Verify dry-run produces baseline scores
         run: uv run python -m evals.ci_assert_baseline runs/

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -6,12 +6,13 @@ outside `tests/` because runs hit real LLMs and are parameterized by
 
 ## Surfaces
 
-| Module                                                   | Decides                                          | Eval target                                         |
-| -------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
-| `app.llm.agents.nl_updater.process_instruction`          | MCP path: NO_CHANGE vs new body                  | trigger class + content quality                     |
-| `app.llm.agents.ingest_batch_reconciler.batch_reconcile` | Ingest: NO_CHANGE / IRRELEVANT / new body        | trigger class + content quality                     |
-| `app.llm.agents.ingest_selector.select_candidates`       | Ingest pre-filter: which BM25 candidates survive | precision / recall / F1                             |
-| External agent (Claude Code via MCP)                     | When to call `update_doc_nl(path, instruction)`  | per-doc precision / recall + reused content scorers |
+| Module                                                        | Decides                                                                                           | Eval target                                                               |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `app.llm.agents.nl_updater.process_instruction`               | MCP path: NO_CHANGE vs new body                                                                   | trigger class + content quality                                           |
+| `app.llm.agents.ingest_batch_reconciler.batch_reconcile`      | Ingest: NO_CHANGE / IRRELEVANT / new body                                                         | trigger class + content quality                                           |
+| `app.llm.agents.ingest_selector.select_candidates`            | Ingest pre-filter: which BM25 candidates survive                                                  | precision / recall / F1                                                   |
+| External agent (Claude Code via MCP)                          | When to call `update_doc_nl(path, instruction)`                                                   | per-doc precision / recall + reused content scorers                       |
+| `app.triggers.natural_language` (delta / schedule / new-file) | Whether a wiki change/snapshot/new-file satisfies a trigger's NL "if", and what message to render | per-case match decision + no-false-fire + judge-scored reason and message |
 
 Two axes per surface: **WHEN** (trigger decision) and **HOW** (output quality).
 
@@ -35,12 +36,17 @@ backend/evals/
     wiki_updater/cases
     ingest_selector/cases.jsonl
     external_agent/scenarios/
+    triggers/cases
   wiki_updater/run.py         python -m evals.wiki_updater.run
   ingest_selector/run.py      python -m evals.ingest_selector.run
   external_agent/
     run.py                    python -m evals.external_agent.run
     _stub.py                  external-agent dry-run stub
     harness.py                in-memory wiki + tool dispatch
+  triggers/
+    run.py                    python -m evals.triggers.run
+    _stub.py                  triggers dry-run stub (payload-fingerprint routing)
+    harness.py                payload builder + per-flavor driver
 ```
 
 ## How to run

--- a/backend/evals/ci_assert_baseline.py
+++ b/backend/evals/ci_assert_baseline.py
@@ -46,6 +46,14 @@ def check_run_file(path: Path) -> list[str]:
                 "%s case %s trigger_class_match=%.2f (expected 1.0 in dry-run)"
                 % (path, r.case_id, trigger.score)
             )
+        # Trigger eval surface uses a different scorer name for the WHEN
+        # axis; same oracle invariant applies.
+        match_decision = next((s for s in r.scorers if s.name == "trigger_match_decision"), None)
+        if match_decision is not None and match_decision.score < 1.0:
+            errs.append(
+                "%s case %s trigger_match_decision=%.2f (expected 1.0 in dry-run)"
+                % (path, r.case_id, match_decision.score)
+            )
     return errs
 
 

--- a/backend/evals/datasets/triggers/cases/01-delta-status-flip-match.yaml
+++ b/backend/evals/datasets/triggers/cases/01-delta-status-flip-match.yaml
@@ -1,0 +1,42 @@
+id: trig-01-delta-status-flip-match
+flavor: delta
+nl_description: when the status of any service flips to yellow or red
+message_instruction: |
+  Post a short alert naming the service and the new status, and link the page.
+wiki_state:
+  - path: ops/status.md
+    body: |
+      # Service Status
+      - api: green
+      - worker: green
+      - billing: green
+change_path: ops/status.md
+change_kind: edit
+before: |
+  # Service Status
+  - api: green
+  - worker: green
+  - billing: green
+after: |
+  # Service Status
+  - api: yellow
+  - worker: green
+  - billing: green
+expected_matched: true
+expected_reason_facts:
+  - id: r-api-yellow
+    text: The reason mentions that the api service flipped to yellow.
+expected_message_facts_present:
+  - id: m-api
+    text: The message mentions the api service.
+  - id: m-yellow
+    text: The message indicates the service is now yellow.
+  - id: m-path
+    text: The message references ops/status.md.
+expected_message_facts_excluded:
+  - id: x-worker
+    text: The message mentions the worker service.
+  - id: x-billing
+    text: The message mentions the billing service.
+notes: Classic delta fire — clear status flip on diff.
+tags: [delta, fire, status]

--- a/backend/evals/datasets/triggers/cases/02-delta-unrelated-edit-no-fire.yaml
+++ b/backend/evals/datasets/triggers/cases/02-delta-unrelated-edit-no-fire.yaml
@@ -1,0 +1,29 @@
+id: trig-02-delta-unrelated-edit-no-fire
+flavor: delta
+nl_description: when a customer-facing pricing page changes its dollar amount
+message_instruction: |
+  Note the page and the new price.
+wiki_state:
+  - path: marketing/pricing.md
+    body: |
+      # Pricing
+      Pro: $20/seat/month
+      Team: $40/seat/month
+  - path: engineering/runbook.md
+    body: |
+      # Runbook
+      Restart steps for the api service.
+change_path: engineering/runbook.md
+change_kind: edit
+before: |
+  # Runbook
+  Restart steps for the api service.
+after: |
+  # Runbook
+  Restart steps for the api service.
+  Add a sleep 10 between worker restart and health probe.
+expected_matched: false
+notes: |
+  Restraint test — diff is on the runbook, not pricing. Trigger watches a
+  different topic. Must not fire even though the diff is real.
+tags: [delta, no-fire, restraint]

--- a/backend/evals/datasets/triggers/cases/03-delta-price-change-match.yaml
+++ b/backend/evals/datasets/triggers/cases/03-delta-price-change-match.yaml
@@ -1,0 +1,36 @@
+id: trig-03-delta-price-change-match
+flavor: delta
+nl_description: when a customer-facing pricing page changes a dollar amount
+message_instruction: |
+  Call out the page, the affected tier, and the old vs new dollar amount.
+wiki_state:
+  - path: marketing/pricing.md
+    body: |
+      # Pricing
+      Pro: $20/seat/month
+      Team: $40/seat/month
+change_path: marketing/pricing.md
+change_kind: edit
+before: |
+  # Pricing
+  Pro: $20/seat/month
+  Team: $40/seat/month
+after: |
+  # Pricing
+  Pro: $25/seat/month
+  Team: $40/seat/month
+expected_matched: true
+expected_reason_facts:
+  - id: r-pro-change
+    text: The reason mentions the Pro tier price change from $20 to $25.
+expected_message_facts_present:
+  - id: m-pro
+    text: The message mentions the Pro tier.
+  - id: m-old
+    text: The message mentions the old price $20.
+  - id: m-new
+    text: The message mentions the new price $25.
+expected_message_facts_excluded:
+  - id: x-team
+    text: The message mentions a change to the Team tier price.
+tags: [delta, fire, price]

--- a/backend/evals/datasets/triggers/cases/04-delta-typo-fix-no-fire.yaml
+++ b/backend/evals/datasets/triggers/cases/04-delta-typo-fix-no-fire.yaml
@@ -1,0 +1,29 @@
+id: trig-04-delta-typo-fix-no-fire
+flavor: delta
+nl_description: when a runbook adds a new postgres restart step
+message_instruction: |
+  Tell oncall a postgres restart step was added and link the page.
+wiki_state:
+  - path: ops/postgres-runbook.md
+    body: |
+      # Postgres Runbook
+      ## Failover
+      1. Promote the standby.
+      2. Reroute the api to the new primary.
+change_path: ops/postgres-runbook.md
+change_kind: edit
+before: |
+  # Postgres Runbook
+  ## Failover
+  1. Promote the standby.
+  2. Reroute the api to the new primary.
+after: |
+  # Postgres Runbook
+  ## Failover
+  1. Promote the standby.
+  2. Reroute the API to the new primary.
+expected_matched: false
+notes: |
+  Diff is a cosmetic capitalization fix. Trigger description is specific
+  to NEW restart steps — must not fire on a typo cleanup.
+tags: [delta, no-fire, restraint, cosmetic]

--- a/backend/evals/datasets/triggers/cases/05-delta-state-vs-update.yaml
+++ b/backend/evals/datasets/triggers/cases/05-delta-state-vs-update.yaml
@@ -1,0 +1,45 @@
+id: trig-05-delta-state-vs-update
+flavor: delta
+nl_description: |
+  when the on-call rotation lists more than 3 people for a single week
+message_instruction: |
+  Note the week and the people on rotation.
+wiki_state:
+  - path: ops/oncall.md
+    body: |
+      # On-Call Rotation
+      ## Week of 2026-04-01
+      - alice
+      - bob
+      - carol
+change_path: ops/oncall.md
+change_kind: edit
+before: |
+  # On-Call Rotation
+  ## Week of 2026-04-01
+  - alice
+  - bob
+  - carol
+after: |
+  # On-Call Rotation
+  ## Week of 2026-04-01
+  - alice
+  - bob
+  - carol
+  - dave
+  - eve
+expected_matched: true
+expected_reason_facts:
+  - id: r-week-overload
+    text: The reason mentions the week of 2026-04-01 having more than 3 people.
+expected_message_facts_present:
+  - id: m-week
+    text: The message names the week of 2026-04-01.
+  - id: m-alice
+    text: The message names alice as on rotation.
+  - id: m-dave
+    text: The message names dave as on rotation.
+notes: |
+  State-style trigger ("when X is more than N") on an edit. The model
+  must evaluate the post-edit state against the rule, not just the diff.
+tags: [delta, fire, state]

--- a/backend/evals/datasets/triggers/cases/06-schedule-state-match.yaml
+++ b/backend/evals/datasets/triggers/cases/06-schedule-state-match.yaml
@@ -1,0 +1,34 @@
+id: trig-06-schedule-state-match
+flavor: schedule
+nl_description: |
+  when there is any service whose status is currently yellow or red
+message_instruction: |
+  List the non-green services and link the status page.
+wiki_state:
+  - path: ops/status.md
+    body: |
+      # Service Status
+      - api: yellow
+      - worker: green
+      - billing: red
+  - path: marketing/index.md
+    body: |
+      # Marketing
+      Brand and launch notes.
+scope_path: ops/status.md
+when_iso: "2026-05-26T15:00:00Z"
+expected_matched: true
+expected_reason_facts:
+  - id: r-yellow-or-red
+    text: |
+      The reason notes that at least one service (api or billing) is yellow
+      or red.
+expected_message_facts_present:
+  - id: m-api-yellow
+    text: The message mentions api as yellow.
+  - id: m-billing-red
+    text: The message mentions billing as red.
+expected_message_facts_excluded:
+  - id: x-worker
+    text: The message names the worker service.
+tags: [schedule, fire, state]

--- a/backend/evals/datasets/triggers/cases/07-schedule-state-no-fire.yaml
+++ b/backend/evals/datasets/triggers/cases/07-schedule-state-no-fire.yaml
@@ -1,0 +1,18 @@
+id: trig-07-schedule-state-no-fire
+flavor: schedule
+nl_description: |
+  when there is any service whose status is currently yellow or red
+message_instruction: |
+  List the non-green services and link the status page.
+wiki_state:
+  - path: ops/status-allgreen.md
+    body: |
+      # Service Status
+      - api: green
+      - worker: green
+      - billing: green
+scope_path: ops/status-allgreen.md
+when_iso: "2026-05-26T15:00:00Z"
+expected_matched: false
+notes: All green on a state-style schedule check — must not fire.
+tags: [schedule, no-fire, restraint]

--- a/backend/evals/datasets/triggers/cases/08-new-file-incident-match.yaml
+++ b/backend/evals/datasets/triggers/cases/08-new-file-incident-match.yaml
@@ -1,0 +1,34 @@
+id: trig-08-new-file-incident-match
+flavor: new_file
+nl_description: |
+  when a new postmortem is added for a customer-impacting incident
+message_instruction: |
+  Note the incident title, the date, and link the postmortem path.
+wiki_state:
+  - path: incidents/index.md
+    body: |
+      # Incidents
+      Index of recent postmortems.
+  - path: incidents/2026-04-02-billing-outage.md
+    body: |
+      # 2026-04-02 Billing outage
+      Customer impact: billing webhooks delayed 30 min.
+new_file_path: incidents/2026-05-26-api-degradation.md
+new_file_body: |
+  # 2026-05-26 API degradation
+  Customer impact: API p95 latency exceeded 5s for 25 minutes affecting
+  external customers in the us-west region.
+
+  Root cause: connection pool exhaustion after a deploy.
+expected_matched: true
+expected_message_facts_present:
+  - id: m-title
+    text: The message mentions the API degradation incident title or summary.
+  - id: m-date
+    text: The message references the 2026-05-26 date.
+  - id: m-path
+    text: The message references incidents/2026-05-26-api-degradation.md.
+expected_message_facts_excluded:
+  - id: x-old-incident
+    text: The message mentions the 2026-04-02 billing outage.
+tags: [new_file, fire]

--- a/backend/evals/datasets/triggers/cases/09-new-file-meeting-note-no-fire.yaml
+++ b/backend/evals/datasets/triggers/cases/09-new-file-meeting-note-no-fire.yaml
@@ -1,0 +1,21 @@
+id: trig-09-new-file-meeting-note-no-fire
+flavor: new_file
+nl_description: |
+  when a new postmortem is added for a customer-impacting incident
+message_instruction: |
+  Note the incident title, the date, and link the postmortem path.
+wiki_state:
+  - path: incidents/index.md
+    body: |
+      # Incidents
+      Index of recent postmortems.
+new_file_path: incidents/2026-05-26-quarterly-review-notes.md
+new_file_body: |
+  # 2026-05-26 Quarterly Review Notes
+  Internal-only summary of this quarter's incident trends and team
+  retrospective discussion. No specific incident covered here.
+expected_matched: false
+notes: |
+  Restraint test — the new file is filed under incidents/ but it's a
+  retrospective notes doc, not a postmortem for a specific incident.
+tags: [new_file, no-fire, restraint]

--- a/backend/evals/datasets/triggers/cases/10-delta-distractor-no-fire.yaml
+++ b/backend/evals/datasets/triggers/cases/10-delta-distractor-no-fire.yaml
@@ -1,0 +1,38 @@
+id: trig-10-delta-distractor-no-fire
+flavor: delta
+nl_description: |
+  when a runbook adds a new postgres restart step
+message_instruction: |
+  Tell oncall a postgres restart step was added and link the page.
+wiki_state:
+  - path: ops/postgres-backups-runbook.md
+    body: |
+      # Postgres Runbook
+      ## Failover
+      1. Promote the standby.
+      2. Reroute the api to the new primary.
+      ## Backups
+      Snapshots run nightly at 02:00 UTC.
+change_path: ops/postgres-backups-runbook.md
+change_kind: edit
+before: |
+  # Postgres Runbook
+  ## Failover
+  1. Promote the standby.
+  2. Reroute the api to the new primary.
+  ## Backups
+  Snapshots run nightly at 02:00 UTC.
+after: |
+  # Postgres Runbook
+  ## Failover
+  1. Promote the standby.
+  2. Reroute the api to the new primary.
+  ## Backups
+  Snapshots run nightly at 02:00 UTC.
+  Verify by restoring last week's snapshot to a sandbox cluster.
+expected_matched: false
+notes: |
+  Diff is on the Backups section (restore verification), not a restart
+  step. Description mentions "restart" — distractor keyword "restore"
+  must not pull a false fire.
+tags: [delta, no-fire, restraint, distractor]

--- a/backend/evals/schema.py
+++ b/backend/evals/schema.py
@@ -24,7 +24,14 @@ Surface = Literal[
     "reconcile_document",
     "ingest_selector",
     "external_agent",
+    "triggers",
 ]
+
+
+class TriggerFlavor(str, Enum):
+    DELTA = "delta"
+    SCHEDULE = "schedule"
+    NEW_FILE = "new_file"
 
 
 class FactClaim(BaseModel):
@@ -87,6 +94,66 @@ class IngestSelectorCase(BaseModel):
     doc_content: str
     candidates: list[IngestSelectorCandidate]
     expected_kept_paths: list[str]
+    notes: str = ""
+    tags: list[str] = Field(default_factory=list)
+
+
+class TriggerWikiDoc(BaseModel):
+    """One seed doc in the synthetic wiki snapshot a trigger sees."""
+
+    model_config = ConfigDict(frozen=True)
+
+    path: str
+    body: str
+
+
+class TriggerCase(BaseModel):
+    """One trigger-firing eval case.
+
+    Covers three flavors of the natural-language trigger eval pipeline:
+
+    * ``delta`` — doc edit; runs ``matches`` (phase 1) then, when the case
+      expects a match, ``render_message`` (phase 2).
+    * ``schedule`` — snapshot tick; runs ``matches_snapshot`` + optional
+      ``render_snapshot_message``.
+    * ``new_file`` — directory-scoped new file; runs the combined
+      ``evaluate_new_file_in_dir`` (single call returns triggered + message).
+
+    Quality scoring of the rendered message reuses ``facts_present`` /
+    ``facts_preserved`` from the shared judge panel — same scorer used
+    by the wiki_updater + external_agent surfaces.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str
+    flavor: TriggerFlavor
+    nl_description: str
+    message_instruction: str = ""
+
+    wiki_state: list[TriggerWikiDoc] = Field(default_factory=list)
+
+    # delta-only
+    change_path: str | None = None
+    change_kind: str | None = None
+    before: str | None = None
+    after: str | None = None
+
+    # schedule-only
+    scope_path: str | None = None
+    when_iso: str | None = None
+
+    # new_file-only
+    new_file_path: str | None = None
+    new_file_body: str | None = None
+
+    # Ground truth
+    expected_matched: bool
+    expected_reason_facts: list[FactClaim] = Field(default_factory=list)
+    expected_message_facts_present: list[FactClaim] = Field(default_factory=list)
+    expected_message_facts_excluded: list[FactClaim] = Field(default_factory=list)
+    max_message_bloat_ratio: float = 8.0
+
     notes: str = ""
     tags: list[str] = Field(default_factory=list)
 

--- a/backend/evals/tests/test_triggers_harness.py
+++ b/backend/evals/tests/test_triggers_harness.py
@@ -1,0 +1,174 @@
+"""Unit coverage for the trigger eval harness.
+
+Exercises:
+* Case YAML loading + schema validation
+* Payload composition shape (snapshot + change/schedule/new-file block)
+* End-to-end ``run_case`` under the dry-run stub
+* Scorer wiring (decision + no-false-fire + reason / message judges short-circuit
+  when there's no message)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evals.schema import FactClaim, TriggerCase, TriggerFlavor, TriggerWikiDoc
+from evals.triggers._stub import stub_triggers
+from evals.triggers.harness import build_payload, load_cases, run_case
+from evals.triggers.run import _score_case  # pyright: ignore[reportPrivateUsage]
+
+
+CASES_DIR = Path(__file__).resolve().parent.parent / "datasets" / "triggers" / "cases"
+
+
+def test_load_seed_cases_validate() -> None:
+    cases = load_cases(CASES_DIR)
+    assert len(cases) >= 10
+    ids = {c.id for c in cases}
+    assert len(ids) == len(cases), "case ids must be unique"
+    flavors = {c.flavor for c in cases}
+    # All three flavors covered by the seed set
+    assert flavors == {
+        TriggerFlavor.DELTA,
+        TriggerFlavor.SCHEDULE,
+        TriggerFlavor.NEW_FILE,
+    }
+    # At least one fire and one no-fire per flavor → keeps the WHEN
+    # axis honest on regression.
+    for flavor in flavors:
+        flavor_cases = [c for c in cases if c.flavor is flavor]
+        assert any(c.expected_matched for c in flavor_cases), (
+            "flavor %s has no positive case" % flavor
+        )
+        assert any(not c.expected_matched for c in flavor_cases), (
+            "flavor %s has no negative case" % flavor
+        )
+
+
+def _make_delta_case(*, matched: bool) -> TriggerCase:
+    return TriggerCase(
+        id="t-delta-%s" % matched,
+        flavor=TriggerFlavor.DELTA,
+        nl_description="when status flips to yellow",
+        message_instruction="Note the service.",
+        wiki_state=[TriggerWikiDoc(path="ops/status.md", body="# Service Status")],
+        change_path="ops/status.md",
+        change_kind="edit",
+        before="api: green",
+        after="api: yellow",
+        expected_matched=matched,
+        expected_message_facts_present=[FactClaim(id="m-api", text="api is mentioned")],
+    )
+
+
+def _make_schedule_case(*, matched: bool) -> TriggerCase:
+    return TriggerCase(
+        id="t-sched-%s" % matched,
+        flavor=TriggerFlavor.SCHEDULE,
+        nl_description="when any service is yellow",
+        message_instruction="List non-green services.",
+        wiki_state=[TriggerWikiDoc(path="ops/status.md", body="api: yellow")],
+        scope_path="ops/status.md",
+        when_iso="2026-05-26T15:00:00Z",
+        expected_matched=matched,
+    )
+
+
+def _make_new_file_case(*, matched: bool) -> TriggerCase:
+    return TriggerCase(
+        id="t-newfile-%s" % matched,
+        flavor=TriggerFlavor.NEW_FILE,
+        nl_description="when a new postmortem is added",
+        message_instruction="Link the postmortem.",
+        wiki_state=[TriggerWikiDoc(path="incidents/index.md", body="# Incidents")],
+        new_file_path="incidents/2026-05-26-x.md",
+        new_file_body="# 2026-05-26 incident",
+        expected_matched=matched,
+    )
+
+
+@pytest.mark.parametrize(
+    "flavor", [TriggerFlavor.DELTA, TriggerFlavor.SCHEDULE, TriggerFlavor.NEW_FILE]
+)
+def test_build_payload_includes_snapshot_header(flavor: TriggerFlavor) -> None:
+    if flavor is TriggerFlavor.DELTA:
+        case = _make_delta_case(matched=True)
+    elif flavor is TriggerFlavor.SCHEDULE:
+        case = _make_schedule_case(matched=True)
+    else:
+        case = _make_new_file_case(matched=True)
+    payload = build_payload(case)
+    assert payload.startswith("=== WIKI (latest version) ===")
+    if flavor is TriggerFlavor.DELTA:
+        assert "=== CHANGE ===" in payload
+    elif flavor is TriggerFlavor.SCHEDULE:
+        assert "=== SCHEDULED CHECK ===" in payload
+    else:
+        assert "=== NEW FILE ===" in payload
+
+
+@pytest.mark.parametrize("matched", [True, False])
+def test_run_case_delta_via_stub(matched: bool) -> None:
+    case = _make_delta_case(matched=matched)
+    with stub_triggers([case]):
+        out = run_case(case)
+    assert out.matched is matched
+    if matched:
+        assert out.message  # phase-2 ran
+    else:
+        assert out.message == ""  # phase-2 skipped
+
+
+@pytest.mark.parametrize("matched", [True, False])
+def test_run_case_schedule_via_stub(matched: bool) -> None:
+    case = _make_schedule_case(matched=matched)
+    with stub_triggers([case]):
+        out = run_case(case)
+    assert out.matched is matched
+    if matched:
+        assert out.message
+    else:
+        assert out.message == ""
+
+
+@pytest.mark.parametrize("matched", [True, False])
+def test_run_case_new_file_via_stub(matched: bool) -> None:
+    case = _make_new_file_case(matched=matched)
+    with stub_triggers([case]):
+        out = run_case(case)
+    assert out.matched is matched
+    if matched:
+        assert out.message
+    else:
+        assert out.message == ""
+
+
+def test_score_case_decision_only_when_no_judge_facts() -> None:
+    """A case without labeled facts should still produce decision + no-false-fire
+    rows without invoking the LLM judge (so dry-run smoke stays offline)."""
+    case = _make_delta_case(matched=False)
+    with stub_triggers([case]):
+        out = run_case(case)
+    rows = _score_case(case, out, judge_models=None)
+    names = {r.name for r in rows}
+    assert "trigger_match_decision" in names
+    assert "no_false_fire_compliance" in names
+    # No reason facts on the negative case → reason scorer short-circuits.
+    assert {r.name for r in rows if r.name.startswith("reason_")} == {"reason_facts_present"}
+
+
+def test_score_case_match_axis_records_false_fire() -> None:
+    """When ground truth says no_fire but model fired, no_false_fire = 0.0."""
+    case = _make_delta_case(matched=False)
+
+    class _FakeOut:
+        matched = True
+        reason = "stub said yes anyway"
+        message = "STUB"
+
+    rows = _score_case(case, _FakeOut(), judge_models=None)  # type: ignore[arg-type]
+    by_name = {r.name: r for r in rows}
+    assert by_name["trigger_match_decision"].score == 0.0
+    assert by_name["no_false_fire_compliance"].score == 0.0

--- a/backend/evals/tests/test_triggers_harness.py
+++ b/backend/evals/tests/test_triggers_harness.py
@@ -16,7 +16,7 @@ import pytest
 
 from evals.schema import FactClaim, TriggerCase, TriggerFlavor, TriggerWikiDoc
 from evals.triggers._stub import stub_triggers
-from evals.triggers.harness import build_payload, load_cases, run_case
+from evals.triggers.harness import TriggerRunResult, build_payload, load_cases, run_case
 from evals.triggers.run import _score_case  # pyright: ignore[reportPrivateUsage]
 
 
@@ -159,16 +159,27 @@ def test_score_case_decision_only_when_no_judge_facts() -> None:
     assert {r.name for r in rows if r.name.startswith("reason_")} == {"reason_facts_present"}
 
 
+def test_build_payload_fails_loudly_on_missing_required_field() -> None:
+    """A delta case with no change_path must raise, not silently emit Path: ''."""
+    case = TriggerCase(
+        id="t-bad-delta",
+        flavor=TriggerFlavor.DELTA,
+        nl_description="whatever",
+        wiki_state=[TriggerWikiDoc(path="x.md", body="hi")],
+        change_path=None,
+        change_kind="edit",
+        after="hi there",
+        expected_matched=True,
+    )
+    with pytest.raises(ValueError, match="change_path"):
+        build_payload(case)
+
+
 def test_score_case_match_axis_records_false_fire() -> None:
     """When ground truth says no_fire but model fired, no_false_fire = 0.0."""
     case = _make_delta_case(matched=False)
-
-    class _FakeOut:
-        matched = True
-        reason = "stub said yes anyway"
-        message = "STUB"
-
-    rows = _score_case(case, _FakeOut(), judge_models=None)  # type: ignore[arg-type]
+    fake = TriggerRunResult(matched=True, reason="stub said yes anyway", message="STUB")
+    rows = _score_case(case, fake, judge_models=None)
     by_name = {r.name: r for r in rows}
     assert by_name["trigger_match_decision"].score == 0.0
     assert by_name["no_false_fire_compliance"].score == 0.0

--- a/backend/evals/triggers/__init__.py
+++ b/backend/evals/triggers/__init__.py
@@ -1,0 +1,6 @@
+"""Trigger-firing eval surface.
+
+Covers the natural-language trigger pipeline in ``app.triggers.natural_language``:
+phase-1 firing-condition check + phase-2 message render across the three
+flavors the production engine actually runs (delta / schedule / new_file).
+"""

--- a/backend/evals/triggers/_stub.py
+++ b/backend/evals/triggers/_stub.py
@@ -1,0 +1,150 @@
+"""Dry-run stub for the trigger eval.
+
+Patches ``app.llm.client.complete`` to return canned responses that
+mirror the production tool-call / JSON shape the natural_language module
+expects. Routing is by **payload fingerprint** — the union of paths in
+``wiki_state`` plus the case's change/scope/new-file path. Both phase-1
+and phase-2 calls see the full payload (wiki snapshot + change view),
+so the fingerprint resolves to the same case for both phases of one
+trial. Cases that share the exact same fingerprint collide and are
+logged + routed to the first-seen case rather than raising — keeping
+CI smoke deterministic when two cases happen to seed the same wiki.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+from app.llm import client as llm_client
+from app.llm.client import CompletionResult, ToolCall
+from app.triggers import natural_language as nl_module
+
+from evals.schema import TriggerCase, TriggerFlavor
+from evals.scorers import JUDGE_SYSTEM_MARKER as _JUDGE_MARKER
+
+
+log = logging.getLogger(__name__)
+
+
+def _fingerprint(case: TriggerCase) -> tuple[str, ...]:
+    """Stable per-case lookup key for the dry-run stub.
+
+    Uses the union of paths the payload will contain — the wiki snapshot
+    paths plus whichever flavor-specific path the case carries. Both
+    phases of a trial see the same payload, so the fingerprint resolves
+    the same case for phase-1 and phase-2 alike.
+    """
+    paths: list[str] = sorted(d.path for d in case.wiki_state)
+    extras = [p for p in (case.change_path, case.scope_path, case.new_file_path) if p is not None]
+    for p in extras:
+        if p not in paths:
+            paths.append(p)
+    return tuple(paths)
+
+
+@contextmanager
+def stub_triggers(cases: list[TriggerCase]) -> Generator[None]:
+    """Patch ``client.complete`` to canned per-case responses."""
+    original = llm_client.complete
+    case_by_fp: dict[tuple[str, ...], TriggerCase] = {}
+    for case in cases:
+        fp = _fingerprint(case)
+        if fp in case_by_fp and case_by_fp[fp].id != case.id:
+            log.warning(
+                "stub_triggers: duplicate payload fingerprint for cases %s and %s; "
+                "routing both to first",
+                case_by_fp[fp].id,
+                case.id,
+            )
+            continue
+        case_by_fp[fp] = case
+
+    # Multi-overlap routing: pick the case whose fingerprint paths are
+    # ALL present in the user text and has the most paths (most-specific
+    # wins for any future subset overlaps).
+    def _route(user_text: str) -> TriggerCase | None:
+        best: TriggerCase | None = None
+        best_size = -1
+        for fp, case in case_by_fp.items():
+            if fp and all(p in user_text for p in fp) and len(fp) > best_size:
+                best = case
+                best_size = len(fp)
+        return best
+
+    def _stub(
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = llm_client.DEFAULT_MAX_TOKENS,
+    ) -> CompletionResult:
+        del model, max_tokens
+        # Judge calls reuse the shared scorer panel — the system prompt
+        # carries _JUDGE_MARKER. Return a deterministic YES so dry-run
+        # message_facts_* scorers register vacuous pass instead of polling
+        # an unreachable model and tying to False.
+        for m in messages:
+            if m.get("role") != "system":
+                continue
+            sys_content = m.get("content", "")
+            if isinstance(sys_content, str) and _JUDGE_MARKER in sys_content:
+                return CompletionResult(text="VERDICT: YES | RATIONALE: stub")
+        user_text = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+        matched_case = _route(user_text)
+        if matched_case is None:
+            return CompletionResult(text="{}")
+
+        # Renderer call: tools=[render], regardless of flavor.
+        if tools and any(t.get("name") == "render" for t in tools):
+            msg_text = "STUB MESSAGE for %s" % matched_case.id
+            return CompletionResult(
+                tool_calls=[ToolCall(id="stub-1", name="render", arguments={"message": msg_text})]
+            )
+
+        # New-file path: no tools, JSON response body.
+        if matched_case.flavor is TriggerFlavor.NEW_FILE:
+            return CompletionResult(
+                text=json.dumps(
+                    {
+                        "triggered": matched_case.expected_matched,
+                        "trigger_message": (
+                            "STUB NEWFILE for %s" % matched_case.id
+                            if matched_case.expected_matched
+                            else ""
+                        ),
+                    }
+                )
+            )
+
+        # Otherwise it's a phase-1 matches/matches_snapshot call expecting
+        # a report tool call.
+        return CompletionResult(
+            tool_calls=[
+                ToolCall(
+                    id="stub-1",
+                    name="report",
+                    arguments={
+                        "matches": matched_case.expected_matched,
+                        "reason": "stub: %s" % matched_case.id,
+                    },
+                )
+            ]
+        )
+
+    # natural_language imports complete by name (``from app.llm.client
+    # import complete``), so monkey-patching the client module alone
+    # leaves the bound reference untouched. Patch both — client.complete
+    # for any future indirect callers, plus the bound name on the
+    # natural_language module that the trigger eval actually drives.
+    llm_client.complete = _stub  # type: ignore[assignment]
+    nl_original = nl_module.complete
+    nl_module.complete = _stub  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        llm_client.complete = original  # type: ignore[assignment]
+        nl_module.complete = nl_original  # type: ignore[assignment]

--- a/backend/evals/triggers/harness.py
+++ b/backend/evals/triggers/harness.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import yaml
 
+from pydantic import BaseModel, ConfigDict
+
 from app.triggers import natural_language as nl
 from evals.schema import TriggerCase, TriggerFlavor, TriggerWikiDoc
 
@@ -44,12 +46,30 @@ def _build_wiki_snapshot(docs: list[TriggerWikiDoc]) -> str:
     return "\n".join(chunks)
 
 
+def _require(case: TriggerCase, field: str, value: object) -> str:
+    """Fail loudly when a flavor-required field is missing.
+
+    The repo convention is "fail loudly, not silent fallbacks" — a
+    malformed YAML case must blow up at payload-build time so the
+    eval doesn't quietly run on garbage and produce a confident-looking
+    bogus score.
+    """
+    if value is None or value == "":
+        raise ValueError(
+            "trigger case %s (flavor=%s) missing required field %r"
+            % (case.id, case.flavor.value, field)
+        )
+    return str(value)
+
+
 def _build_change_view(case: TriggerCase) -> str:
     """Mirror ``app.triggers.diff.build_change_view`` for the harness."""
-    path = case.change_path or ""
-    kind = case.change_kind or "edit"
+    path = _require(case, "change_path", case.change_path)
+    kind = _require(case, "change_kind", case.change_kind)
+    after = _require(case, "after", case.after)
+    # ``before`` is allowed to be empty for ``create`` kind — that's how the
+    # production builder distinguishes a create from an edit.
     before = case.before or ""
-    after = case.after or ""
     header = "=== CHANGE ===\nPath: %s\nKind: %s\n" % (path, kind)
     if kind == "create" or not before:
         return "%s\n(new file — full body)\n%s\n" % (header, after.rstrip())
@@ -66,14 +86,14 @@ def _build_change_view(case: TriggerCase) -> str:
 
 
 def _build_schedule_block(case: TriggerCase) -> str:
-    scope = case.scope_path or "(whole wiki)"
-    when = case.when_iso or ""
+    scope = _require(case, "scope_path", case.scope_path)
+    when = _require(case, "when_iso", case.when_iso)
     return "=== SCHEDULED CHECK ===\nScope: %s\nTime: %s\n" % (scope, when)
 
 
 def _build_new_file_block(case: TriggerCase) -> str:
-    path = case.new_file_path or ""
-    body = case.new_file_body or ""
+    path = _require(case, "new_file_path", case.new_file_path)
+    body = _require(case, "new_file_body", case.new_file_body)
     return "=== NEW FILE ===\nPath: %s\n\n%s\n" % (path, body.rstrip())
 
 
@@ -87,7 +107,7 @@ def build_payload(case: TriggerCase) -> str:
     return "%s\n\n%s" % (snapshot, _build_new_file_block(case))
 
 
-class TriggerRunResult:
+class TriggerRunResult(BaseModel):
     """Outcome of running one case through the harness.
 
     Holds the actual matched bool, the rendered message (empty when not
@@ -95,12 +115,11 @@ class TriggerRunResult:
     reason from phase 1 — all three are inputs to the scorer pass.
     """
 
-    __slots__ = ("matched", "reason", "message")
+    model_config = ConfigDict(frozen=True)
 
-    def __init__(self, *, matched: bool, reason: str, message: str) -> None:
-        self.matched = matched
-        self.reason = reason
-        self.message = message
+    matched: bool
+    reason: str
+    message: str
 
 
 def run_case(case: TriggerCase) -> TriggerRunResult:

--- a/backend/evals/triggers/harness.py
+++ b/backend/evals/triggers/harness.py
@@ -1,0 +1,127 @@
+"""Synthetic-wiki driver for the trigger eval surface.
+
+Loads ``TriggerCase`` YAMLs, builds the same payload string the production
+fan-out hands to ``natural_language.matches`` / ``render_message`` /
+``matches_snapshot`` / ``render_snapshot_message`` / ``evaluate_new_file_in_dir``,
+and runs the appropriate path. No DB, no git — payload is composed inline
+from the case's ``wiki_state`` so the harness is self-contained.
+
+The payload format is identical to ``app.triggers.diff`` so any prompt
+tuning that targets the live evaluator is faithfully exercised here.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+from pathlib import Path
+
+import yaml
+
+from app.triggers import natural_language as nl
+from evals.schema import TriggerCase, TriggerFlavor, TriggerWikiDoc
+
+log = logging.getLogger(__name__)
+
+
+def load_cases(directory: Path) -> list[TriggerCase]:
+    """Load all ``.yaml`` cases under ``directory`` (one case per file)."""
+    cases: list[TriggerCase] = []
+    for path in sorted(directory.glob("*.yaml")):
+        with path.open() as fh:
+            raw = yaml.safe_load(fh)
+        cases.append(TriggerCase.model_validate(raw))
+    if not cases:
+        raise ValueError("no trigger cases found in %s" % directory)
+    return cases
+
+
+def _build_wiki_snapshot(docs: list[TriggerWikiDoc]) -> str:
+    """Mirror ``app.triggers.diff.build_wiki_snapshot`` shape for the harness."""
+    chunks: list[str] = ["=== WIKI (latest version) ==="]
+    for d in docs:
+        chunks.append("--- %s\n%s\n" % (d.path, d.body.rstrip()))
+    return "\n".join(chunks)
+
+
+def _build_change_view(case: TriggerCase) -> str:
+    """Mirror ``app.triggers.diff.build_change_view`` for the harness."""
+    path = case.change_path or ""
+    kind = case.change_kind or "edit"
+    before = case.before or ""
+    after = case.after or ""
+    header = "=== CHANGE ===\nPath: %s\nKind: %s\n" % (path, kind)
+    if kind == "create" or not before:
+        return "%s\n(new file — full body)\n%s\n" % (header, after.rstrip())
+    diff = "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile="before",
+            tofile="after",
+            n=2,
+        )
+    )
+    return "%s\n<unified diff>\n%s\n</unified diff>\n" % (header, diff.rstrip())
+
+
+def _build_schedule_block(case: TriggerCase) -> str:
+    scope = case.scope_path or "(whole wiki)"
+    when = case.when_iso or ""
+    return "=== SCHEDULED CHECK ===\nScope: %s\nTime: %s\n" % (scope, when)
+
+
+def _build_new_file_block(case: TriggerCase) -> str:
+    path = case.new_file_path or ""
+    body = case.new_file_body or ""
+    return "=== NEW FILE ===\nPath: %s\n\n%s\n" % (path, body.rstrip())
+
+
+def build_payload(case: TriggerCase) -> str:
+    """Compose the payload the natural-language evaluator will see."""
+    snapshot = _build_wiki_snapshot(list(case.wiki_state))
+    if case.flavor is TriggerFlavor.DELTA:
+        return "%s\n\n%s" % (snapshot, _build_change_view(case))
+    if case.flavor is TriggerFlavor.SCHEDULE:
+        return "%s\n\n%s" % (snapshot, _build_schedule_block(case))
+    return "%s\n\n%s" % (snapshot, _build_new_file_block(case))
+
+
+class TriggerRunResult:
+    """Outcome of running one case through the harness.
+
+    Holds the actual matched bool, the rendered message (empty when not
+    matched or the flavor has no render phase), and the model-emitted
+    reason from phase 1 — all three are inputs to the scorer pass.
+    """
+
+    __slots__ = ("matched", "reason", "message")
+
+    def __init__(self, *, matched: bool, reason: str, message: str) -> None:
+        self.matched = matched
+        self.reason = reason
+        self.message = message
+
+
+def run_case(case: TriggerCase) -> TriggerRunResult:
+    """Drive one case end-to-end through the live natural_language module.
+
+    Phase 2 is skipped when phase 1 says no_match — production never
+    renders for a non-firing trigger, so the eval doesn't either.
+    """
+    payload = build_payload(case)
+    if case.flavor is TriggerFlavor.NEW_FILE:
+        out = nl.evaluate_new_file_in_dir(case.nl_description, case.message_instruction, payload)
+        return TriggerRunResult(matched=out.triggered, reason="", message=out.message)
+    if case.flavor is TriggerFlavor.DELTA:
+        match = nl.matches(case.nl_description, payload)
+        message = ""
+        if match.matched and case.message_instruction:
+            message = nl.render_message(case.message_instruction, payload, reason=match.reason)
+        return TriggerRunResult(matched=match.matched, reason=match.reason, message=message)
+    # schedule
+    match = nl.matches_snapshot(case.nl_description, payload)
+    message = ""
+    if match.matched and case.message_instruction:
+        message = nl.render_snapshot_message(case.message_instruction, payload, reason=match.reason)
+    return TriggerRunResult(matched=match.matched, reason=match.reason, message=message)

--- a/backend/evals/triggers/run.py
+++ b/backend/evals/triggers/run.py
@@ -28,10 +28,9 @@ from pathlib import Path
 from app.utils.logging import setup_logging
 
 from evals import _cli, reporting, scorers
-from evals.schema import ScorerOutcome, Surface
+from evals.schema import ScorerOutcome, Surface, TriggerCase
 from evals.triggers._stub import stub_triggers
 from evals.triggers.harness import TriggerRunResult, load_cases, run_case
-from evals.schema import TriggerCase
 
 
 log = logging.getLogger(__name__)

--- a/backend/evals/triggers/run.py
+++ b/backend/evals/triggers/run.py
@@ -1,0 +1,248 @@
+"""CLI: run the trigger-firing eval across a model matrix.
+
+    cd backend
+    uv run python -m evals.triggers.run \\
+        --cases evals/datasets/triggers/cases \\
+        --models claude-sonnet-4-6,gpt-5
+
+The trigger eval measures two axes per case:
+
+* **WHEN** — phase-1 firing-condition decision (``trigger_match_decision``,
+  ``no_false_fire_compliance`` aggregate). False positives are louder than
+  false negatives in production, so a separate scorer tracks how often we
+  fire on cases the ground truth says should stay silent.
+* **HOW** — phase-2 rendered message quality on matched cases
+  (``message_facts_present``, ``message_facts_excluded``, ``message_bloat_ratio``,
+  ``reason_facts_present``). Reuses the shared judge panel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+from app.utils.logging import setup_logging
+
+from evals import _cli, reporting, scorers
+from evals.schema import ScorerOutcome, Surface
+from evals.triggers._stub import stub_triggers
+from evals.triggers.harness import TriggerRunResult, load_cases, run_case
+from evals.schema import TriggerCase
+
+
+log = logging.getLogger(__name__)
+
+
+def _score_case(
+    case: TriggerCase,
+    out: TriggerRunResult,
+    *,
+    judge_models: tuple[str, ...] | None = None,
+) -> list[ScorerOutcome]:
+    rows: list[ScorerOutcome] = []
+
+    match_ok = out.matched == case.expected_matched
+    rows.append(
+        ScorerOutcome(
+            name="trigger_match_decision",
+            score=1.0 if match_ok else 0.0,
+            passed=match_ok,
+            detail="expected=%s actual=%s" % (case.expected_matched, out.matched),
+        )
+    )
+
+    # no_false_fire: penalize the dangerous direction only (false positives).
+    # On cases the ground truth says should NOT fire, did we fire anyway?
+    if not case.expected_matched:
+        no_false = not out.matched
+        rows.append(
+            ScorerOutcome(
+                name="no_false_fire_compliance",
+                score=1.0 if no_false else 0.0,
+                passed=no_false,
+                detail="should_not_fire actual_matched=%s" % out.matched,
+            )
+        )
+    else:
+        rows.append(
+            ScorerOutcome(
+                name="no_false_fire_compliance",
+                score=1.0,
+                passed=True,
+                detail="n/a (case expects fire)",
+            )
+        )
+
+    # Reason quality: only meaningful when phase 1 fired and the case
+    # has labeled facts the reason should cite (delta/schedule paths).
+    if out.matched and case.expected_reason_facts and out.reason:
+        fp = scorers.facts_present(
+            out.reason, case.expected_reason_facts, judge_models=judge_models
+        )
+        rows.append(
+            ScorerOutcome(
+                name="reason_facts_present",
+                score=fp.score,
+                passed=fp.passed,
+                detail=fp.detail,
+            )
+        )
+    else:
+        rows.append(
+            ScorerOutcome(
+                name="reason_facts_present",
+                score=1.0,
+                passed=True,
+                detail="n/a",
+            )
+        )
+
+    # Message quality scorers run only when phase 1 fired AND we have a
+    # rendered message (some cases test only the WHEN axis).
+    if out.matched and out.message:
+        if case.expected_message_facts_present:
+            mp = scorers.facts_present(
+                out.message,
+                case.expected_message_facts_present,
+                judge_models=judge_models,
+            )
+            rows.append(
+                ScorerOutcome(
+                    name="message_facts_present",
+                    score=mp.score,
+                    passed=mp.passed,
+                    detail=mp.detail,
+                )
+            )
+        if case.expected_message_facts_excluded:
+            # facts_excluded uses the SAME judge — verdict YES (claim
+            # supported in the body) means we leaked something we shouldn't
+            # have, so we flip the score.
+            mx = scorers.facts_present(
+                out.message,
+                case.expected_message_facts_excluded,
+                judge_models=judge_models,
+            )
+            flipped = 1.0 - mx.score
+            rows.append(
+                ScorerOutcome(
+                    name="message_facts_excluded",
+                    score=flipped,
+                    passed=flipped >= 0.9,
+                    detail=mx.detail,
+                )
+            )
+        if case.message_instruction:
+            br = scorers.bloat_ratio(
+                case.message_instruction,
+                out.message,
+                max_ratio=case.max_message_bloat_ratio,
+            )
+            rows.append(
+                ScorerOutcome(
+                    name="message_bloat_ratio",
+                    score=br.score,
+                    passed=br.passed,
+                    detail=br.detail,
+                )
+            )
+    return rows
+
+
+def _make_run_one(
+    judge_models: tuple[str, ...] | None,
+) -> _cli.RunOne[TriggerCase]:
+    def _run_one(
+        case: TriggerCase, provider: str, model: str, run_index: int
+    ) -> tuple[Surface, str, str, str, list[ScorerOutcome]]:
+        del provider, run_index
+        out = run_case(case)
+        rows = _score_case(case, out, judge_models=judge_models)
+        expected = "matched=%s" % case.expected_matched
+        actual = "matched=%s" % out.matched
+        raw = json.dumps(
+            {
+                "matched": out.matched,
+                "reason": out.reason,
+                "message": out.message,
+                "flavor": case.flavor.value,
+            }
+        )
+        return ("triggers", expected, actual, raw, rows)
+
+    return _run_one
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run the trigger-firing eval.")
+    p.add_argument(
+        "--cases",
+        type=Path,
+        default=Path("evals/datasets/triggers/cases"),
+        help="Directory of trigger case YAML files",
+    )
+    p.add_argument(
+        "--judge-models",
+        default=",".join(scorers.DEFAULT_JUDGE_PANEL),
+        help="Comma-separated judge model panel for fact/reason scoring.",
+    )
+    _cli.add_common_args(p, default_models="claude-sonnet-4-6")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    setup_logging(args.log_level)
+    cases = load_cases(args.cases)
+    if args.case_id:
+        cases = [c for c in cases if c.id == args.case_id]
+        if not cases:
+            log.error("no case with id %s", args.case_id)
+            return 2
+    if args.limit is not None:
+        cases = cases[: args.limit]
+
+    runnable, skipped = _cli.resolve_runnable(args.models, dry_run=args.dry_run)
+    if not runnable:
+        log.error("no runnable models — set EVAL_*_API_KEY or pass --dry-run")
+        return 2
+    metadata = _cli.build_metadata(Path(__file__), args.cases)
+    judge_panel = tuple(j.strip() for j in args.judge_models.split(",") if j.strip())
+
+    log.info(
+        "running %d trigger cases × %d models × %d runs (concurrency=%d)",
+        len(cases),
+        len(runnable),
+        args.runs,
+        args.concurrency,
+    )
+    results = _cli.run_concurrent(
+        cases,
+        runnable=runnable,
+        runs=args.runs,
+        run_one=_make_run_one(judge_panel),
+        case_id=lambda c: c.id,
+        metadata=metadata,
+        judge_models=list(judge_panel),
+        concurrency=args.concurrency,
+        dry_run_ctx=stub_triggers(cases) if args.dry_run else None,
+    )
+
+    out_path = args.out or Path("runs") / ("triggers_%d.jsonl" % int(time.time()))
+    reporting.write_jsonl(out_path, results)
+    summary = reporting.summarize(results, surface="triggers")
+    reporting.print_summary(summary)
+    bt_url = ""
+    if args.braintrust:
+        bt_url = reporting.push_to_braintrust(args.braintrust, results, dataset=args.dataset)
+    reporting.write_github_summary(summary, braintrust_url=bt_url)
+    print(json.dumps({"out": str(out_path), "skipped_models": skipped, "braintrust_url": bt_url}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Closes the "Eval for triggers firing" item on the Agent Wiki TODO list.

New `triggers` surface drives `app.triggers.natural_language` end-to-end across all three production flavors — `delta`, `schedule`, `new_file` — using the same payload shape the live fan-out builds. 10 seed cases mix fire and no-fire per flavor.

Scorers:
- WHEN: `trigger_match_decision`, `no_false_fire_compliance` (penalizes the dangerous direction only — false positives are louder than false negatives)
- HOW: `reason_facts_present`, `message_facts_present`, `message_facts_excluded`, `message_bloat_ratio` (shared judge panel)

Plumbing reuses the existing skeleton: `_cli.run_concurrent`, dataset push to Braintrust per surface, GitHub-step summary. Dry-run stub routes by payload-path fingerprint (both phases of a trial see the same payload) and short-circuits judge calls via `JUDGE_SYSTEM_MARKER`.

Wired into smoke (every PR touching `evals/` or `app/triggers/natural_language.py`) and nightly (live LLM → Braintrust dataset `triggers`). `ci_assert_baseline` recognizes `trigger_match_decision` as a dry-run oracle alongside `trigger_class_match`.

## How Has This Been Tested?

## Additional Options
- [ ] [Tests added]
- [ ] [Type checked]
- [ ] [Frontend reviewed in light mode, dark mode, and responsive design]
- [ ] [I have made corresponding changes to the documentation]
- [ ] [Mobile UI Looks Good]
- [ ] [cherry-pick this PR to the latest release branch once it has been merged]