### PR TITLE
fix(selector): tighten relevance bar to reduce irrelevant reconciler calls

### DIFF
--- a/backend/app/llm/prompts/ingest_selector.system.md
+++ b/backend/app/llm/prompts/ingest_selector.system.md
@@ -12,7 +12,7 @@ factual content that directly applies to what that page covers. Ask: does
 this document give the page something specific to say?
 
 Exclude when:
-- The document is a bare data record with nothing actionable or worth editing into the wiki.
+- The document is a bare data record with nothing that would change or add to this page.
 - The document describes a completely different system, product, or service,
   even if it shares the same technology or domain.
 - The document's subject is finished or inactive — the work or deal it

--- a/backend/app/llm/prompts/ingest_selector.system.md
+++ b/backend/app/llm/prompts/ingest_selector.system.md
@@ -15,8 +15,8 @@ Exclude when:
 - The document is a bare data record with nothing that would change or add to this page.
 - The document describes a completely different system, product, or service,
   even if it shares the same technology or domain.
-- The document's subject is finished or inactive — the work or deal it
-  describes is closed, cancelled, or otherwise over.
+- The document's subject is finished or inactive and the page does not
+  exist to track that kind of closed or historical content.
 
 ## Output format
 

--- a/backend/app/llm/prompts/ingest_selector.system.md
+++ b/backend/app/llm/prompts/ingest_selector.system.md
@@ -1,18 +1,24 @@
 You are a fast relevance screener for a wiki update pipeline.
 
 You receive an incoming document and a numbered list of candidate wiki pages.
-Your job is to identify which pages are plausibly worth sending to a full editor
-for review. You are the cheap first pass — the goal is to drop obviously
-unrelated candidates, not to be a strict filter.
+Your job is to pass candidates where the document has something specific
+to contribute — a concrete fact, decision, event, or action — that the page
+would need to reflect. If the signal is very weak, exclude it.
 
 ## Decision rule
 
-Include a candidate if the incoming document could plausibly add, correct, or
-update information on that page. Err on the side of inclusion.
+Include a candidate if the document clearly contains actionable or
+factual content that directly applies to what that page covers. Ask: does
+this document give the page something specific to say?
 
-Exclude a candidate only when the topics are clearly unrelated — e.g. an API
-reference pushed against an unrelated service runbook, or marketing content
-pushed against an internal architecture doc.
+Exclude when:
+- The document is a bare data record with nothing actionable or worth editing into the wiki.
+- The document describes a completely different system, product, or service,
+  even if it shares the same technology or domain.
+- The document's subject is finished or inactive — the work or deal it
+  describes is closed, cancelled, or otherwise over.
+- The document is broadly related to the topic but adds nothing the page
+  would actually record.
 
 ## Output format
 

--- a/backend/app/llm/prompts/ingest_selector.system.md
+++ b/backend/app/llm/prompts/ingest_selector.system.md
@@ -17,8 +17,6 @@ Exclude when:
   even if it shares the same technology or domain.
 - The document's subject is finished or inactive — the work or deal it
   describes is closed, cancelled, or otherwise over.
-- The document is broadly related to the topic but adds nothing the page
-  would actually record.
 
 ## Output format
 

--- a/backend/app/llm/prompts/ingest_selector.system.md
+++ b/backend/app/llm/prompts/ingest_selector.system.md
@@ -14,8 +14,7 @@ this document give the page something specific to say?
 Exclude when:
 - The document is a bare data record with nothing that would change or add to this page.
 - The document describes a completely different system, product, or service,
-  even if it shares the same technology or domain
-  (e.g. an API reference for Service B pushed against a runbook for Service A).
+  even if it shares the same technology or domain.
 - The document's subject is finished or inactive and the page does not
   exist to track that kind of closed or historical content.
 

--- a/backend/app/llm/prompts/ingest_selector.system.md
+++ b/backend/app/llm/prompts/ingest_selector.system.md
@@ -14,7 +14,8 @@ this document give the page something specific to say?
 Exclude when:
 - The document is a bare data record with nothing that would change or add to this page.
 - The document describes a completely different system, product, or service,
-  even if it shares the same technology or domain.
+  even if it shares the same technology or domain
+  (e.g. an API reference for Service B pushed against a runbook for Service A).
 - The document's subject is finished or inactive and the page does not
   exist to track that kind of closed or historical content.
 


### PR DESCRIPTION
## Summary

Raises the selector's bar from "could plausibly add or update" to "clearly has something specific to contribute." The previous prompt erred on the side of inclusion; ~92% of what reached the reconciler was irrelevant.

Changes:
- Replaced "err on the side of inclusion" with "if the signal is very weak, exclude it"
- Raised include condition from "plausibly relevant" to "clearly contains actionable or factual content that directly applies to what the page covers"
- Added three explicit exclusion conditions:
  - Bare data records with nothing that would change or add to the page
  - A different system/product that shares the same technology or domain
  - Finished or inactive work, unless the page exists to track historical or closed content
- Borderline "broadly related" cases are intentionally left to the reconciler