### PR TITLE
prompt(ingest_batch_reconciler): only mark tasks complete when explicitly confirmed

### DIFF
--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -71,10 +71,11 @@ When in doubt, use `no_change`.
 - Do not copy the external document wholesale — integrate only what is
   genuinely new or corrects something wrong.
 - Prefer one focused addition over several marginal ones.
-- Only change `- [ ]` to `- [x]` when the external document explicitly and
-  unambiguously confirms the task is fully complete. Partial progress,
-  implied completion, and related work that doesn't directly close the item
-  are not enough — leave the checkbox unchanged.
+- Only change `- [ ]` to `- [x]` when either: the external document
+  explicitly confirms the task is fully complete, or all of its sub-tasks
+  are demonstrably complete based on the available evidence. Partial
+  progress or related work that doesn't close every sub-task is not enough
+  — leave the checkbox unchanged.
 - If the page is already up-to-date with everything in the external doc,
   use action `no_change`.
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -71,6 +71,10 @@ When in doubt, use `no_change`.
 - Do not copy the external document wholesale — integrate only what is
   genuinely new or corrects something wrong.
 - Prefer one focused addition over several marginal ones.
+- Only change `- [ ]` to `- [x]` when the external document explicitly and
+  unambiguously confirms the task is fully complete. Partial progress,
+  implied completion, and related work that doesn't directly close the item
+  are not enough — leave the checkbox unchanged.
 - If the page is already up-to-date with everything in the external doc,
   use action `no_change`.
 


### PR DESCRIPTION
## Summary

Add a rule to the reconciler prompt governing markdown task checkbox updates:

- `- [ ]` may only be changed to `- [x]` when the external document explicitly and unambiguously confirms the task is fully complete
- Partial progress, implied completion, and related work that doesn't directly close the item are not sufficient

## Motivation

The reconciler was marking tasks complete based on indirect signals (e.g. a follow-up email that touched the topic, a status update on related work). Task checkboxes represent a commitment — they should only be checked when the source document explicitly closes the item.

## Test plan

- [ ] Run eval labeler against `eval_samples_prod_2894_to_5198.jsonl` and verify `committed` samples with task checkboxes are labeled correctly
- [ ] Check nightly run `bloat_ratio` and `facts_preserved` scores are unaffected