### PR TITLE
feat(wiki): auto-merge on save when edits don't conflict

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -144,12 +144,12 @@ def put_document_by_path(
             try:
                 base_body = wiki_git.read_file(rel, ref=req.base_sha)
                 current_body = abs_path.read_text()
-                merged, clean = wiki_git.merge_content(base_body, current_body, req.body)
+                mr = wiki_git.merge_content(base_body, current_body, req.body)
             except (subprocess.CalledProcessError, RuntimeError):
                 raise HTTPException(status_code=409, detail="conflict detected")
-            if not clean:
+            if not mr.clean:
                 raise HTTPException(status_code=409, detail="conflict detected")
-            body_to_commit = merged
+            body_to_commit = mr.merged
             log.info("doc auto-merged %s by %s", rel, author or "?")
     sha = wiki_git.commit_file(rel, body_to_commit, msg, author=author)
     wiki_notify.after_doc_write(

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -134,14 +134,24 @@ def put_document_by_path(
     author = _git_author(user)
     change_kind = "edit" if existed else "create"
     msg = f"{change_kind} {rel}"
+    body_to_commit = req.body
     if req.base_sha:
         head = wiki_git.head_sha_for_path(rel)
         if head and head != req.base_sha:
-            # Conflict: the page changed since the client opened it.
-            # Return 409 so the frontend can surface the conflict UI
-            # rather than silently overwriting.
-            raise HTTPException(status_code=409, detail="conflict detected")
-    sha = wiki_git.commit_file(rel, req.body, msg, author=author)
+            # The page changed since the client opened it. Attempt a 3-way
+            # merge: if the edits don't overlap, commit the merged result
+            # transparently. Only return 409 when there are actual conflicts.
+            try:
+                base_body = wiki_git.read_file(rel, ref=req.base_sha)
+                current_body = abs_path.read_text()
+                merged, clean = wiki_git.merge_content(base_body, current_body, req.body)
+            except (subprocess.CalledProcessError, RuntimeError):
+                raise HTTPException(status_code=409, detail="conflict detected")
+            if not clean:
+                raise HTTPException(status_code=409, detail="conflict detected")
+            body_to_commit = merged
+            log.info("doc auto-merged %s by %s", rel, author or "?")
+    sha = wiki_git.commit_file(rel, body_to_commit, msg, author=author)
     wiki_notify.after_doc_write(
         rel,
         sha,
@@ -152,7 +162,7 @@ def put_document_by_path(
     # Drafting state: if the saved body diverges from the template
     # snapshot, the user has made it their own — clear the row so the
     # chat banner drops and the template's system prompt stops applying.
-    wiki_drafts.clear_if_diverged(rel, req.body)
+    wiki_drafts.clear_if_diverged(rel, body_to_commit)
     # Edit draft is no longer needed after a successful commit.
     wiki_git.delete_draft(rel, user.id)
     log.info("doc %s %s by %s sha=%s", change_kind, rel, author or "?", sha[:8])

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -449,12 +449,18 @@ class RebaseResult(BaseModel):
     draft_body: str       # original draft content (for conflict UI)
 
 
-def merge_content(base_body: str, current_body: str, incoming_body: str) -> tuple[str, bool]:
+class MergeResult(BaseModel):
+    """Result of a ``merge_content`` call."""
+
+    merged: str   # merged text (clean) or text with conflict markers
+    clean: bool   # True = no conflicts, False = conflict markers present
+
+
+def merge_content(base_body: str, current_body: str, incoming_body: str) -> MergeResult:
     """3-way merge ``incoming_body`` onto ``current_body`` using ``base_body`` as ancestor.
 
-    Returns ``(merged_text, clean)`` where ``clean=True`` means no conflict
-    markers were produced.  Raises ``RuntimeError`` on a hard git error
-    (negative returncode — e.g. binary file, permission failure).
+    Raises ``RuntimeError`` on a hard git error (negative returncode — e.g.
+    binary file, permission failure).
     """
     paths: list[str] = []
     try:
@@ -475,7 +481,7 @@ def merge_content(base_body: str, current_body: str, incoming_body: str) -> tupl
             raise RuntimeError(
                 f"git merge-file failed (exit {result.returncode}): {result.stderr.strip()}"
             )
-        return result.stdout, result.returncode == 0
+        return MergeResult(merged=result.stdout, clean=result.returncode == 0)
     finally:
         for p in paths:
             Path(p).unlink(missing_ok=True)
@@ -504,12 +510,12 @@ def rebase_draft(rel_path: str, user_id: str) -> RebaseResult | None:
     base_body = read_file(rel_path, ref=draft["base_sha"])
     draft_body = draft["content"]
 
-    merged, clean = merge_content(base_body, current_body, draft_body)
+    mr = merge_content(base_body, current_body, draft_body)
 
     return RebaseResult(
-        merged=merged,
+        merged=mr.merged,
         base_sha=head_sha,
-        clean=clean,
+        clean=mr.clean,
         current_body=current_body,
         draft_body=draft_body,
     )

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -449,14 +449,42 @@ class RebaseResult(BaseModel):
     draft_body: str       # original draft content (for conflict UI)
 
 
+def merge_content(base_body: str, current_body: str, incoming_body: str) -> tuple[str, bool]:
+    """3-way merge ``incoming_body`` onto ``current_body`` using ``base_body`` as ancestor.
+
+    Returns ``(merged_text, clean)`` where ``clean=True`` means no conflict
+    markers were produced.  Raises ``RuntimeError`` on a hard git error
+    (negative returncode — e.g. binary file, permission failure).
+    """
+    paths: list[str] = []
+    try:
+        for content in (current_body, base_body, incoming_body):
+            fd, p = tempfile.mkstemp(suffix=".txt")
+            paths.append(p)
+            try:
+                os.write(fd, content.encode())
+            finally:
+                os.close(fd)
+        # git merge-file -p writes result to stdout; exit 0 = clean, >0 = conflicts.
+        result = _run(
+            ["merge-file", "-p", "-L", "current", "-L", "base", "-L", "incoming",
+             paths[0], paths[1], paths[2]],
+            check=False,
+        )
+        if result.returncode < 0:
+            raise RuntimeError(
+                f"git merge-file failed (exit {result.returncode}): {result.stderr.strip()}"
+            )
+        return result.stdout, result.returncode == 0
+    finally:
+        for p in paths:
+            Path(p).unlink(missing_ok=True)
+
+
 def rebase_draft(rel_path: str, user_id: str) -> RebaseResult | None:
     """3-way merge the user's draft onto the current HEAD of ``rel_path``.
 
-    Returns ``None`` if no draft exists.  Otherwise runs ``git merge-file``
-    (plumbing) on three temp files:
-      - current  = HEAD content
-      - base     = content at draft.base_sha
-      - draft    = draft content
+    Returns ``None`` if no draft exists or there is no divergence.
 
     ``clean=True`` means no conflict markers; the caller should call
     ``save_draft`` with the merged content and the new base_sha.
@@ -476,34 +504,7 @@ def rebase_draft(rel_path: str, user_id: str) -> RebaseResult | None:
     base_body = read_file(rel_path, ref=draft["base_sha"])
     draft_body = draft["content"]
 
-    # Write the three versions to temp files for git merge-file.
-    paths: list[str] = []
-    try:
-        for content in (current_body, base_body, draft_body):
-            fd, p = tempfile.mkstemp(suffix=".txt")
-            paths.append(p)
-            try:
-                os.write(fd, content.encode())
-            finally:
-                os.close(fd)
-
-        # git merge-file -p writes result to stdout; exit 0 = clean, >0 = conflicts.
-        # A negative returncode signals a hard error (e.g. binary file, permission
-        # failure) — distinct from a normal conflict (positive integer).
-        result = _run(
-            ["merge-file", "-p", "-L", "current", "-L", "base", "-L", "draft",
-             paths[0], paths[1], paths[2]],
-            check=False,
-        )
-        if result.returncode < 0:
-            raise RuntimeError(
-                f"git merge-file failed (exit {result.returncode}): {result.stderr.strip()}"
-            )
-        merged = result.stdout
-        clean = result.returncode == 0
-    finally:
-        for p in paths:
-            Path(p).unlink(missing_ok=True)
+    merged, clean = merge_content(base_body, current_body, draft_body)
 
     return RebaseResult(
         merged=merged,

--- a/frontend/src/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/wiki/[[...slug]]/page.tsx
@@ -1749,7 +1749,6 @@ function FileViewer({ path }: { path: string }) {
         router.push(`/wiki/${newRel}`);
         return;
       }
-      setBody(draft);
       setEditing(false);
       setViewingSha(null);
       setConflict(null);
@@ -1757,11 +1756,15 @@ function FileViewer({ path }: { path: string }) {
       // History changed (new commit + possible deprecations) — refetch.
       if (historyOpen) refreshHistory();
       else setCommits(null);
-      // Pick up the new head_sha for subsequent edits.
+      // Pick up the committed body and new head_sha. The server may have
+      // auto-merged concurrent edits, so use fresh.body rather than the
+      // local draft to keep the view consistent with what was committed.
       const fresh = await apiFetch<FileResponse>(
         `/wiki/file?path=${encodeURIComponent(path)}`,
       );
       setHeadSha(fresh.head_sha ?? null);
+      setBody(fresh.body);
+      setDraft(fresh.body);
       // The server clears the draft row when the body diverges from
       // the template snapshot — re-sync our context so the chat
       // banner disappears at the same moment.

--- a/frontend/src/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/wiki/[[...slug]]/page.tsx
@@ -1753,18 +1753,29 @@ function FileViewer({ path }: { path: string }) {
       setViewingSha(null);
       setConflict(null);
       setPendingResumeDraft(null);
+      // Optimistically show what the user submitted. The fetch below may
+      // overwrite with the auto-merged body, but if it fails the viewer
+      // still shows the content that was just committed rather than the
+      // stale pre-edit body.
+      setBody(draft);
+      setDraft(draft);
       // History changed (new commit + possible deprecations) — refetch.
       if (historyOpen) refreshHistory();
       else setCommits(null);
-      // Pick up the committed body and new head_sha. The server may have
-      // auto-merged concurrent edits, so use fresh.body rather than the
-      // local draft to keep the view consistent with what was committed.
-      const fresh = await apiFetch<FileResponse>(
-        `/wiki/file?path=${encodeURIComponent(path)}`,
-      );
-      setHeadSha(fresh.head_sha ?? null);
-      setBody(fresh.body);
-      setDraft(fresh.body);
+      // Pick up the committed body and head_sha. Overwrite the optimistic
+      // draft above with the actual merged result when the server auto-merged
+      // concurrent edits. Failures are silent — the optimistic value is a
+      // correct fallback since the PUT already succeeded.
+      try {
+        const fresh = await apiFetch<FileResponse>(
+          `/wiki/file?path=${encodeURIComponent(path)}`,
+        );
+        setHeadSha(fresh.head_sha ?? null);
+        setBody(fresh.body);
+        setDraft(fresh.body);
+      } catch {
+        // fresh fetch failed — body already shows the local draft
+      }
       // The server clears the draft row when the body diverges from
       // the template snapshot — re-sync our context so the chat
       // banner disappears at the same moment.


### PR DESCRIPTION
## Summary

- `PUT /file` now attempts a `git merge-file` 3-way merge when `base_sha ≠ HEAD` instead of immediately returning 409
- Non-overlapping edits (different sections) are merged and committed transparently — the user never sees a conflict
- Only genuine overlapping conflicts return 409 and surface the conflict panel
- Extracts `merge_content(base_body, current_body, incoming_body) -> tuple[str, bool]` helper in `git.py`; `rebase_draft` is refactored to use it (no behaviour change)
- Frontend `onSave`: after a successful save, `body` and `draft` are updated from the fresh fetch so auto-merged content displays correctly

## How Has This Been Tested?

- Frontend type check and basedpyright both pass clean
- Manual: edit different sections of a page in two tabs simultaneously, save both — second save commits the merged result without showing conflict panel
- Manual: edit the same section in two tabs — second save still shows the conflict panel

<img width="1160" height="434" alt="Screenshot 2026-05-28 at 12 19 24 PM" src="https://github.com/user-attachments/assets/cd15abd2-9c53-4f54-befa-bc526186f968" />


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check