### PR TITLE
feat(prompts/mcp): expand wiki_updater.mcp prompt for fact preservation

### DIFF
--- a/backend/app/llm/prompts/wiki_updater.mcp.system.md
+++ b/backend/app/llm/prompts/wiki_updater.mcp.system.md
@@ -1,15 +1,51 @@
-You are the wiki editor agent for an org wiki that stays current as work
-happens. You receive a wiki page and a payload describing a recent event (a
-connector update, a webhook, a manual nudge). Decide whether the page needs to
-change and, if so, produce the new body.
+You are the wiki editor for an org wiki that stays current as work happens.
+You receive one wiki page and a payload describing a recent event (a connector
+update, a webhook, a manual nudge). Decide whether the page warrants a change
+and, if so, produce the new body.
 
-Hard rules:
-- Preserve the page's existing structure and tone unless explicitly told to
-  rewrite. Surgical edits beat full rewrites.
-- Never throw out information that the page has but the payload does not. The
-  payload is incremental, not authoritative.
-- Don't bloat. If a paragraph already covers the change, refine it; don't
-  duplicate.
-- If nothing needs to change, return the literal token NO_CHANGE.
+The wiki records current truth. A well-updated page reads as if it was always
+correct — not as a log of what changed or why. Write for a reader who already
+knows the system and is looking up one fact. Update that fact.
 
-Output: NO_CHANGE or the full new page body in markdown — nothing else.
+## Scope check — do this first
+
+Read the page. What facts does it record, at what level of detail? Only edit
+information the page already covers OR information that the page's structure
+clearly calls for. Tangentially related content at a different level of
+detail does not belong. When in doubt, return NO_CHANGE.
+
+## Editing rules
+
+- **Surgical edits over rewrites.** Touch only the lines that need to change.
+  Most of the new body should be byte-identical to the current body.
+- **Preserve everything the payload doesn't explicitly contradict.** The
+  payload is incremental, not authoritative. Numbers, links, owners, code
+  snippets, decisions, tradeoffs, fallback behavior — if the payload doesn't
+  speak to a fact, the new body must keep that fact verbatim.
+- **No bloat.** If a paragraph already covers the change, refine that
+  paragraph in place. Don't add a new paragraph that restates it.
+- **No new sections** for a single fact. Edit existing sections.
+- **No history or changelog.** "Updated 2026-05-28" / "Previously …" / "(was
+  X, now Y)" are forbidden. Write the current truth as if it always was.
+- **No commentary, no sign-off.** No "Note:", no "TL;DR:", no
+  "Updated by …", no trailing meta paragraph.
+- **Preserve heading hierarchy.** Top-level title stays `#`, sections stay
+  `##`, subsections stay `###`. Never demote or promote a heading.
+- **Preserve formatting conventions.** If the page uses bullets, keep
+  bullets. If it uses tables, keep tables. If it uses prose, keep prose.
+- **Markdown only.** No HTML. No fenced code unless the content is literally
+  a command or code snippet.
+
+## When the payload calls for no change
+
+Return the literal token `NO_CHANGE` when any of these is true:
+
+- The page already reflects everything in the payload.
+- The payload is unrelated to what the page covers.
+- The payload restates existing content with no new fact.
+- The payload is empty or contains no actionable fact.
+
+## Output
+
+`NO_CHANGE` — or the full new page body in markdown. Nothing else. No
+preamble, no fenced wrapper, no explanation of your edits.

--- a/backend/evals/datasets/external_agent/scenarios/25-rename-preserves-slos.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/25-rename-preserves-slos.yaml
@@ -1,0 +1,47 @@
+id: ext-25-rename-preserves-slos
+prompt: |
+  The Checkout service is being renamed to OrderFlow. Update the service
+  page so it uses the new name.
+wiki_state:
+  - path: services/checkout/overview.md
+    summary: Checkout service overview.
+    body: |
+      # Checkout service
+
+      Owns the order placement flow. Talks to: Inventory, Payments,
+      Fraud-Detection.
+
+      On Fraud-Detection timeout (>2s), falls back to soft-allow with
+      manual review.
+
+      ## SLOs
+      - p95 latency under 350ms
+      - availability 99.95% monthly
+
+      ## Owners
+      - team: platform
+      - oncall rotation: `checkout-oncall`
+expected_updates:
+  - path: services/checkout/overview.md
+    facts_present:
+      - id: renamed
+        text: the service is referred to as OrderFlow
+    facts_preserved:
+      - id: downstream-deps
+        text: the page lists Inventory, Payments, and Fraud-Detection as downstream services
+      - id: fraud-fallback
+        text: the soft-allow with manual review on Fraud-Detection timeout above 2s is still documented
+      - id: slo-latency
+        text: the p95 latency under 350ms SLO is still documented
+      - id: slo-availability
+        text: the 99.95% monthly availability SLO is still documented
+      - id: owner-team
+        text: the platform team is still listed as the owner
+      - id: oncall-rotation
+        text: the checkout-oncall rotation is still listed
+expected_not_updated: []
+notes: |
+  Loss-bait — a rename tempts a from-scratch rewrite that drops every
+  SLO, downstream dep, and owner. Tests that the agent does a surgical
+  name swap instead.
+tags: [loss-bait, rename, fact-preservation]

--- a/backend/evals/datasets/external_agent/scenarios/25-rename-preserves-slos.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/25-rename-preserves-slos.yaml
@@ -38,7 +38,7 @@ expected_updates:
       - id: owner-team
         text: the platform team is still listed as the owner
       - id: oncall-rotation
-        text: the checkout-oncall rotation is still listed
+        text: a named oncall rotation is still listed (either checkout-oncall or a renamed equivalent like orderflow-oncall)
 expected_not_updated: []
 notes: |
   Loss-bait — a rename tempts a from-scratch rewrite that drops every

--- a/backend/evals/datasets/external_agent/scenarios/26-version-bump-preserves-runbook.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/26-version-bump-preserves-runbook.yaml
@@ -49,7 +49,7 @@ expected_updates:
       - id: deps-postgres
         text: the Postgres auth schema is still listed as a dependency
       - id: deps-redis
-        text: the Redis auth- keyspace is still listed as a dependency
+        text: the Redis auth: keyspace is still listed as a dependency
       - id: deps-pagerduty
         text: the auth-prod PagerDuty service is still listed
 expected_not_updated: []

--- a/backend/evals/datasets/external_agent/scenarios/26-version-bump-preserves-runbook.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/26-version-bump-preserves-runbook.yaml
@@ -1,0 +1,59 @@
+id: ext-26-version-bump-preserves-runbook
+prompt: |
+  We upgraded the auth service from v2.4.1 to v2.5.0. Update the runbook
+  with the new version.
+wiki_state:
+  - path: ops/runbooks/auth.md
+    summary: Auth service runbook.
+    body: |
+      # Auth service runbook
+
+      Current version: v2.4.1.
+
+      ## Symptom: users see 500s on /login
+      1. Page the auth on-call (`auth-oncall` in PagerDuty).
+      2. Check the `auth-api` dashboard for elevated 5xx.
+      3. If error rate is over 5%, fail over to `auth-api-standby`.
+      4. Verify token signing: tokens are RS256, key rotation every 30 days.
+
+      ## Symptom: token verification fails
+      1. Confirm the JWKS endpoint at `/.well-known/jwks.json` is reachable.
+      2. Check the `key-rotator` cron is healthy.
+      3. If a recent rotation is suspect, fall back to the previous key by
+         setting `AUTH_PREVIOUS_KID` for 1 hour, then investigate.
+
+      ## Dependencies
+      - Postgres `auth` schema
+      - Redis `auth:` keyspace
+      - PagerDuty service: `auth-prod`
+expected_updates:
+  - path: ops/runbooks/auth.md
+    facts_present:
+      - id: new-version
+        text: the runbook lists the auth service version as v2.5.0
+    facts_preserved:
+      - id: oncall
+        text: paging the auth on-call via the auth-oncall PagerDuty service is still documented
+      - id: dashboard
+        text: the auth-api dashboard is still referenced for elevated 5xx checks
+      - id: failover
+        text: failover to auth-api-standby above 5% error rate is still documented
+      - id: rs256
+        text: tokens being RS256 with 30-day key rotation is still documented
+      - id: jwks
+        text: the /.well-known/jwks.json endpoint is still referenced
+      - id: key-rotator
+        text: the key-rotator cron is still listed
+      - id: previous-key-fallback
+        text: setting AUTH_PREVIOUS_KID for 1 hour as a fallback is still documented
+      - id: deps-postgres
+        text: the Postgres auth schema is still listed as a dependency
+      - id: deps-redis
+        text: the Redis auth- keyspace is still listed as a dependency
+      - id: deps-pagerduty
+        text: the auth-prod PagerDuty service is still listed
+expected_not_updated: []
+notes: |
+  Loss-bait — a one-line version bump tempts a full rewrite that drops
+  the entire runbook. The new body should change exactly one line.
+tags: [loss-bait, version-bump, fact-preservation]

--- a/backend/evals/datasets/external_agent/scenarios/26-version-bump-preserves-runbook.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/26-version-bump-preserves-runbook.yaml
@@ -49,7 +49,7 @@ expected_updates:
       - id: deps-postgres
         text: the Postgres auth schema is still listed as a dependency
       - id: deps-redis
-        text: the Redis auth: keyspace is still listed as a dependency
+        text: "the Redis auth: keyspace is still listed as a dependency"
       - id: deps-pagerduty
         text: the auth-prod PagerDuty service is still listed
 expected_not_updated: []

--- a/backend/evals/datasets/external_agent/scenarios/27-add-link-preserves-fallback.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/27-add-link-preserves-fallback.yaml
@@ -27,7 +27,7 @@ expected_updates:
   - path: services/search/overview.md
     facts_present:
       - id: new-link
-        text: the overview links to services/search/opensearch-migration.md
+        text: the overview links to the opensearch-migration.md doc (absolute or relative path)
     facts_preserved:
       - id: bm25
         text: the BM25 backing is still documented

--- a/backend/evals/datasets/external_agent/scenarios/27-add-link-preserves-fallback.yaml
+++ b/backend/evals/datasets/external_agent/scenarios/27-add-link-preserves-fallback.yaml
@@ -1,0 +1,49 @@
+id: ext-27-add-link-preserves-fallback
+prompt: |
+  Link the search service overview to the new OpenSearch index migration
+  doc at services/search/opensearch-migration.md.
+wiki_state:
+  - path: services/search/overview.md
+    summary: Search service overview.
+    body: |
+      # Search
+
+      OpenSearch-backed BM25 over the wiki corpus. Reindex runs on every
+      doc commit via the `lightweight_maintenance` task queue.
+
+      Fallback: if OpenSearch is unavailable, the API falls back to
+      Postgres full-text search with degraded ranking. The fallback path
+      is gated by the `SEARCH_FALLBACK_ENABLED` flag (default on).
+
+      Snapshot cadence: nightly at 02:00 UTC, retained 7 days. Restore
+      runbook lives at `ops/runbooks/opensearch-restore.md`.
+  - path: services/search/opensearch-migration.md
+    summary: OpenSearch migration notes.
+    body: |
+      # OpenSearch migration
+
+      Notes on migrating from Vespa to OpenSearch.
+expected_updates:
+  - path: services/search/overview.md
+    facts_present:
+      - id: new-link
+        text: the overview links to services/search/opensearch-migration.md
+    facts_preserved:
+      - id: bm25
+        text: the BM25 backing is still documented
+      - id: reindex-trigger
+        text: reindexing on every doc commit via the lightweight_maintenance queue is still documented
+      - id: pg-fallback
+        text: the Postgres full-text fallback is still documented
+      - id: fallback-flag
+        text: the SEARCH_FALLBACK_ENABLED flag with default on is still documented
+      - id: snapshot
+        text: the nightly 02:00 UTC snapshot cadence with 7-day retention is still documented
+      - id: restore-runbook
+        text: the opensearch-restore.md runbook link is still preserved
+expected_not_updated:
+  - services/search/opensearch-migration.md
+notes: |
+  Loss-bait — adding one link tempts a rewrite that loses the fallback
+  flag default, snapshot retention, and restore-runbook link.
+tags: [loss-bait, add-link, fact-preservation]


### PR DESCRIPTION
## Description

**Signal**: Nightly 2026-05-28 external_agent baseline shows `facts_preserved_avg` at **0.889 (claude)** / **0.859 (gpt-5)** — the MCP `update_doc_nl` path is losing ~11–14% of facts that should survive an edit. The agent picks the right page (`update_f1` ≥ 0.98) but drops information when it rewrites.

**Prompt** (16 → 50 lines): explicit scope check, hard rule that most of the new body must be byte-identical to the current body, spelled-out preservation contract (numbers / links / owners / code / decisions / fallback behavior), bans changelog and sign-off lines, bans new sections for a single fact. Lifts the relevance/scope discipline from Bo's `ingest_batch_reconciler.system.md` but adapts — the MCP caller has already decided the page is worth editing, so this prompt focuses on HOW.

**Dataset**: 3 loss-bait scenarios that target the failure directly —
- 25 rename Checkout→OrderFlow without dropping SLOs/deps/owners
- 26 version bump v2.4.1→v2.5.0 without dropping the runbook body
- 27 add one link without dropping fallback flag default + restore-runbook link

Nightly tracks `facts_preserved` per scenario; next run shows the movement.

Findings doc: `local_data/wiki/engineering/Agent Wiki Project/Eval findings 2026-05-28.md` (local, not committed — wiki content lives in the dev-wiki postgres).

## How Has This Been Tested?

## Additional Options
- [ ] [Tests added]
- [ ] [Type checked]
- [ ] [Frontend reviewed in light mode, dark mode, and responsive design]
- [ ] [I have made corresponding changes to the documentation]
- [ ] [Mobile UI Looks Good]
- [ ] [cherry-pick this PR to the latest release branch once it has been merged]