### PR TITLE
feat(evals): add nightly regression gate with per-surface scorer floors

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -121,7 +121,7 @@ jobs:
         if: failure() && github.event_name == 'schedule'
         uses: onyx-dot-app/onyx/.github/actions/slack-notify@main
         with:
-          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
           title: "🚨 Nightly evals failed (agent-wiki)"
           ref-name: ${{ github.ref_name }}
           failed-jobs: "live"

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -121,7 +121,7 @@ jobs:
         if: failure() && github.event_name == 'schedule'
         uses: onyx-dot-app/onyx/.github/actions/slack-notify@main
         with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
           title: "🚨 Nightly evals failed (agent-wiki)"
           ref-name: ${{ github.ref_name }}
           failed-jobs: "live"

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -104,6 +104,9 @@ jobs:
             --out runs/nightly_merge_conflict.jsonl
 
       - name: Enforce per-surface regression floors
+        # always() so a failed eval step doesn't skip the gate — it scores
+        # whatever ran and fails loudly on any surface whose file is absent.
+        if: always()
         run: uv run python -m evals.ci_assert_nightly runs/
 
       - name: Upload run artifacts

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -113,3 +113,12 @@ jobs:
           name: eval-nightly-runs
           path: backend/runs/
           if-no-files-found: ignore
+
+      - name: Notify Slack on failure
+        if: failure() && github.event_name == 'schedule'
+        uses: onyx-dot-app/onyx/.github/actions/slack-notify@main
+        with:
+          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
+          title: "🚨 Nightly evals failed (agent-wiki)"
+          ref-name: ${{ github.ref_name }}
+          failed-jobs: "live"

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -103,6 +103,9 @@ jobs:
             --dataset "merge-conflict-update" \
             --out runs/nightly_merge_conflict.jsonl
 
+      - name: Enforce per-surface regression floors
+        run: uv run python -m evals.ci_assert_nightly runs/
+
       - name: Upload run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -121,7 +121,7 @@ jobs:
         if: failure() && github.event_name == 'schedule'
         uses: onyx-dot-app/onyx/.github/actions/slack-notify@main
         with:
-          webhook-url: ${{ secrets.ALERT_SLACK_WEBHOOK_URL }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           title: "🚨 Nightly evals failed (agent-wiki)"
           ref-name: ${{ github.ref_name }}
           failed-jobs: "live"

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -116,12 +116,3 @@ jobs:
           name: eval-nightly-runs
           path: backend/runs/
           if-no-files-found: ignore
-
-      - name: Notify Slack on failure
-        if: failure() && github.event_name == 'schedule'
-        uses: onyx-dot-app/onyx/.github/actions/slack-notify@main
-        with:
-          webhook-url: ${{ secrets.MONITOR_DEPLOYMENTS_WEBHOOK }}
-          title: "🚨 Nightly evals failed (agent-wiki)"
-          ref-name: ${{ github.ref_name }}
-          failed-jobs: "live"

--- a/backend/evals/ci_assert_nightly.py
+++ b/backend/evals/ci_assert_nightly.py
@@ -141,6 +141,12 @@ def check_run_file(path: Path) -> list[str]:
         for scorer, floor in thresholds.items():
             means = _means_per_model(rows, scorer, surface)
             if not means:
+                # Surface has rows but this thresholded scorer is on none of
+                # them — a renamed/dropped scorer would otherwise skip its
+                # floor check silently. Fail loudly so the gate can't rot.
+                errs.append(
+                    "%s surface=%s scorer=%s has no rows to score" % (path.name, surface, scorer)
+                )
                 continue
             for model, mean in sorted(means.items()):
                 if mean < floor:

--- a/backend/evals/ci_assert_nightly.py
+++ b/backend/evals/ci_assert_nightly.py
@@ -64,6 +64,15 @@ SURFACE_THRESHOLDS: dict[str, dict[str, float]] = {
         "trigger_match_decision": 0.85,
         "no_false_fire_compliance": 0.90,
     },
+    "merge_conflict_update": {
+        # Conservative floors on the robust scorers (every merged body is
+        # judged for both sides' fact survival + structural validity).
+        # conflict_annotation_present / facts_no_hallucination are sparse
+        # or judge-flipped, left off the gate to avoid flapping.
+        "facts_from_current_present": 0.70,
+        "facts_from_draft_present": 0.70,
+        "markdown_valid": 0.90,
+    },
 }
 
 
@@ -72,6 +81,7 @@ _FILENAME_TO_SURFACES: dict[str, tuple[str, ...]] = {
     "nightly_ingest_selector.jsonl": ("ingest_selector",),
     "nightly_external_agent.jsonl": ("external_agent",),
     "nightly_triggers.jsonl": ("triggers",),
+    "nightly_merge_conflict.jsonl": ("merge_conflict_update",),
 }
 
 

--- a/backend/evals/ci_assert_nightly.py
+++ b/backend/evals/ci_assert_nightly.py
@@ -130,6 +130,14 @@ def check_run_file(path: Path) -> list[str]:
         thresholds = SURFACE_THRESHOLDS.get(surface)
         if not thresholds:
             continue
+        # A mapped surface with zero rows in a non-empty file means the
+        # run step silently produced no data for it (wrong surface tag, a
+        # harness bug mislabelling rows). Fail loudly rather than skip
+        # every scorer for the surface — this is the gap that would
+        # otherwise let a whole surface's regression pass unnoticed.
+        if not any(r.surface == surface for r in rows):
+            errs.append("%s expected surface=%s but no rows carry it" % (path.name, surface))
+            continue
         for scorer, floor in thresholds.items():
             means = _means_per_model(rows, scorer, surface)
             if not means:

--- a/backend/evals/ci_assert_nightly.py
+++ b/backend/evals/ci_assert_nightly.py
@@ -1,0 +1,190 @@
+"""CI guard: enforce per-surface scorer thresholds on a nightly run.
+
+Run by ``evals-nightly.yml`` after the live model matrix finishes. Catches
+silent quality regressions from prompt churn — without this, a prompt PR
+can land that drops ``facts_preserved`` 15 points and only show up when
+someone notices the BT chart trending down.
+
+Thresholds are deliberate floor values, not aspirations. They sit one
+broad bucket below the current baseline so they catch real regressions
+without flapping on per-run noise. Update them upward when a sustained
+improvement lands; keep the comment trail (`baseline @ <date>`) so the
+reasoning isn't lost.
+
+Run-file → surface inference is filename-based to match the writer
+convention in `evals-nightly.yml`:
+
+    runs/nightly_wiki_updater.jsonl   → wiki_updater (both sub-surfaces)
+    runs/nightly_ingest_selector.jsonl → ingest_selector
+    runs/nightly_external_agent.jsonl  → external_agent
+    runs/nightly_triggers.jsonl        → triggers
+
+Per-model aggregation: arithmetic mean of per-case means. Skipped if the
+file is empty or the surface has no threshold entry.
+"""
+
+from __future__ import annotations
+
+import logging
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from app.utils.logging import setup_logging
+
+from evals.schema import CaseResult
+
+log = logging.getLogger(__name__)
+
+
+# floor scores per surface per scorer. fail the run if mean dips below.
+# Anchored to the 2026-05-28 nightly baseline minus one bucket of slack.
+# When you improve a score sustainedly, raise the floor in the same PR.
+SURFACE_THRESHOLDS: dict[str, dict[str, float]] = {
+    "external_agent": {
+        # baseline @ 2026-05-28: claude=0.889, gpt-5=0.859
+        "facts_preserved_avg": 0.80,
+        # baseline @ 2026-05-28: claude=0.913, gpt-5=0.904
+        "facts_present_avg": 0.85,
+        # baseline @ 2026-05-28: ≥ 0.98 both models
+        "update_f1": 0.95,
+        # baseline @ 2026-05-28: 0.99 both models
+        "no_touch_compliance": 0.90,
+    },
+    "process_instruction": {
+        # baseline @ 2026-05-28: claude=1.00, gpt-5=0.882
+        "trigger_class_match": 0.80,
+        # baseline @ 2026-05-28: claude=0.939, gpt-5=0.923
+        "facts_present": 0.85,
+        # baseline @ 2026-05-28: claude=0.970, gpt-5=0.949
+        "facts_preserved": 0.85,
+    },
+    "reconcile_document": {
+        # baseline @ 2026-05-28: claude=0.527, gpt-5=0.580 — known broken,
+        # tracked in eval-findings doc. Floor sits below both so further
+        # collapse is still caught.
+        "trigger_class_match": 0.45,
+        # baseline @ 2026-05-28: claude=0.917, gpt-5=0.946
+        "facts_present": 0.80,
+        # baseline @ 2026-05-28: claude=0.993, gpt-5=0.974
+        "facts_preserved": 0.85,
+    },
+    "ingest_selector": {
+        # baseline @ 2026-05-28: haiku=0.534, gpt-5-mini=0.867 — wide
+        # spread. Floor sits below haiku so the matrix passes; the haiku
+        # gap is tracked separately (move to gpt-5-mini, or tune the
+        # selector prompt for haiku).
+        "f1": 0.45,
+        "recall": 0.80,
+    },
+    "triggers": {
+        # baseline @ 2026-05-28: 0.97–1.00 across all scorers, both models
+        "trigger_match_decision": 0.85,
+        "no_false_fire_compliance": 0.90,
+    },
+}
+
+
+_FILENAME_TO_SURFACES: dict[str, tuple[str, ...]] = {
+    "nightly_wiki_updater.jsonl": ("process_instruction", "reconcile_document"),
+    "nightly_ingest_selector.jsonl": ("ingest_selector",),
+    "nightly_external_agent.jsonl": ("external_agent",),
+    "nightly_triggers.jsonl": ("triggers",),
+}
+
+
+def _load_rows(path: Path) -> list[CaseResult]:
+    rows: list[CaseResult] = []
+    with path.open() as fh:
+        for line_num, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(CaseResult.model_validate_json(line))
+            except Exception as exc:
+                raise ValueError("%s:%d invalid CaseResult: %s" % (path, line_num, exc)) from exc
+    return rows
+
+
+def _means_per_model(rows: list[CaseResult], scorer_name: str, surface: str) -> dict[str, float]:
+    """For one scorer, return {model: case-level mean score} across all cases.
+
+    Case-level (not run-level) so a high-variance case doesn't outweigh
+    a stable one. Mirrors the aggregation in ``reporting.summarize``.
+    Only rows whose ``surface`` matches are counted, so wiki_updater's
+    two sub-surfaces stay distinct.
+    """
+    per_case: dict[tuple[str, str], list[float]] = defaultdict(list)
+    for r in rows:
+        if r.surface != surface:
+            continue
+        for s in r.scorers:
+            if s.name == scorer_name:
+                per_case[(r.model, r.case_id)].append(s.score)
+    by_model: dict[str, list[float]] = defaultdict(list)
+    for (model, _), vs in per_case.items():
+        if vs:
+            by_model[model].append(statistics.fmean(vs))
+    return {m: statistics.fmean(vs) for m, vs in by_model.items() if vs}
+
+
+def check_run_file(path: Path) -> list[str]:
+    """Return human-readable failure strings; empty list = clean."""
+    errs: list[str] = []
+    if not path.exists() or path.stat().st_size == 0:
+        return ["%s missing or empty" % path]
+    surfaces = _FILENAME_TO_SURFACES.get(path.name)
+    if surfaces is None:
+        log.info("skip %s — no threshold mapping", path.name)
+        return []
+    try:
+        rows = _load_rows(path)
+    except ValueError as exc:
+        return [str(exc)]
+    if not rows:
+        return ["%s has zero rows" % path]
+    for surface in surfaces:
+        thresholds = SURFACE_THRESHOLDS.get(surface)
+        if not thresholds:
+            continue
+        for scorer, floor in thresholds.items():
+            means = _means_per_model(rows, scorer, surface)
+            if not means:
+                continue
+            for model, mean in sorted(means.items()):
+                if mean < floor:
+                    errs.append(
+                        "%s surface=%s model=%s %s=%.3f below floor %.3f"
+                        % (path.name, surface, model, scorer, mean, floor)
+                    )
+    return errs
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: python -m evals.ci_assert_nightly <runs-dir>", file=sys.stderr)
+        return 2
+    runs_dir = Path(argv[1])
+    if not runs_dir.is_dir():
+        print("not a directory: %s" % runs_dir, file=sys.stderr)
+        return 2
+    setup_logging("INFO")
+    files = sorted(runs_dir.glob("nightly_*.jsonl"))
+    if not files:
+        print("no nightly_*.jsonl run files in %s" % runs_dir, file=sys.stderr)
+        return 2
+    all_errs: list[str] = []
+    for f in files:
+        all_errs.extend(check_run_file(f))
+    if all_errs:
+        for e in all_errs:
+            print("FAIL: %s" % e, file=sys.stderr)
+        return 1
+    print("ok: %d nightly run file(s) above all thresholds" % len(files))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/backend/evals/ci_assert_nightly.py
+++ b/backend/evals/ci_assert_nightly.py
@@ -7,20 +7,15 @@ someone notices the BT chart trending down.
 
 Thresholds are deliberate floor values, not aspirations. They sit one
 broad bucket below the current baseline so they catch real regressions
-without flapping on per-run noise. Update them upward when a sustained
-improvement lands; keep the comment trail (`baseline @ <date>`) so the
-reasoning isn't lost.
+without flapping on per-run noise.
 
-Run-file → surface inference is filename-based to match the writer
-convention in `evals-nightly.yml`:
+Run-file → surface inference is filename-based. Every entry in
+``_FILENAME_TO_SURFACES`` is required: the asserter fails if an
+expected file is missing from the runs directory, which catches the
+case where a nightly eval step exits 0 but never writes its output
+(wrong ``--out`` path, partial failure, etc.).
 
-    runs/nightly_wiki_updater.jsonl   → wiki_updater (both sub-surfaces)
-    runs/nightly_ingest_selector.jsonl → ingest_selector
-    runs/nightly_external_agent.jsonl  → external_agent
-    runs/nightly_triggers.jsonl        → triggers
-
-Per-model aggregation: arithmetic mean of per-case means. Skipped if the
-file is empty or the surface has no threshold entry.
+Per-model aggregation: arithmetic mean of per-case means.
 """
 
 from __future__ import annotations
@@ -39,47 +34,33 @@ log = logging.getLogger(__name__)
 
 
 # floor scores per surface per scorer. fail the run if mean dips below.
-# Anchored to the 2026-05-28 nightly baseline minus one bucket of slack.
-# When you improve a score sustainedly, raise the floor in the same PR.
+# Each floor sits one bucket below the most recent observed baseline.
+# Raise the floor in the PR that lands a sustained improvement.
 SURFACE_THRESHOLDS: dict[str, dict[str, float]] = {
     "external_agent": {
-        # baseline @ 2026-05-28: claude=0.889, gpt-5=0.859
         "facts_preserved_avg": 0.80,
-        # baseline @ 2026-05-28: claude=0.913, gpt-5=0.904
         "facts_present_avg": 0.85,
-        # baseline @ 2026-05-28: ≥ 0.98 both models
         "update_f1": 0.95,
-        # baseline @ 2026-05-28: 0.99 both models
         "no_touch_compliance": 0.90,
     },
     "process_instruction": {
-        # baseline @ 2026-05-28: claude=1.00, gpt-5=0.882
         "trigger_class_match": 0.80,
-        # baseline @ 2026-05-28: claude=0.939, gpt-5=0.923
         "facts_present": 0.85,
-        # baseline @ 2026-05-28: claude=0.970, gpt-5=0.949
         "facts_preserved": 0.85,
     },
     "reconcile_document": {
-        # baseline @ 2026-05-28: claude=0.527, gpt-5=0.580 — known broken,
-        # tracked in eval-findings doc. Floor sits below both so further
-        # collapse is still caught.
+        # Known degraded — see the eval-findings doc. Floor sits below
+        # the observed range so further collapse still trips.
         "trigger_class_match": 0.45,
-        # baseline @ 2026-05-28: claude=0.917, gpt-5=0.946
         "facts_present": 0.80,
-        # baseline @ 2026-05-28: claude=0.993, gpt-5=0.974
         "facts_preserved": 0.85,
     },
     "ingest_selector": {
-        # baseline @ 2026-05-28: haiku=0.534, gpt-5-mini=0.867 — wide
-        # spread. Floor sits below haiku so the matrix passes; the haiku
-        # gap is tracked separately (move to gpt-5-mini, or tune the
-        # selector prompt for haiku).
+        # Wide spread between models — floor below the weaker tail.
         "f1": 0.45,
         "recall": 0.80,
     },
     "triggers": {
-        # baseline @ 2026-05-28: 0.97–1.00 across all scorers, both models
         "trigger_match_decision": 0.85,
         "no_false_fire_compliance": 0.90,
     },
@@ -171,18 +152,27 @@ def main(argv: list[str]) -> int:
         print("not a directory: %s" % runs_dir, file=sys.stderr)
         return 2
     setup_logging("INFO")
-    files = sorted(runs_dir.glob("nightly_*.jsonl"))
-    if not files:
-        print("no nightly_*.jsonl run files in %s" % runs_dir, file=sys.stderr)
-        return 2
     all_errs: list[str] = []
-    for f in files:
+    # Every expected file in the mapping must exist — a missing file means
+    # a nightly step silently dropped its output, not "nothing to check".
+    for expected in sorted(_FILENAME_TO_SURFACES):
+        all_errs.extend(check_run_file(runs_dir / expected))
+    # Surface ad-hoc nightly_*.jsonl files (not in the expected set) for
+    # diagnostics, but only if mapped — unmapped files are skipped via the
+    # ``_FILENAME_TO_SURFACES.get`` check inside ``check_run_file``.
+    extra_files = [
+        p for p in sorted(runs_dir.glob("nightly_*.jsonl")) if p.name not in _FILENAME_TO_SURFACES
+    ]
+    for f in extra_files:
         all_errs.extend(check_run_file(f))
     if all_errs:
         for e in all_errs:
             print("FAIL: %s" % e, file=sys.stderr)
         return 1
-    print("ok: %d nightly run file(s) above all thresholds" % len(files))
+    print(
+        "ok: %d nightly run file(s) above all thresholds"
+        % (len(_FILENAME_TO_SURFACES) + len(extra_files))
+    )
     return 0
 
 

--- a/backend/evals/tests/test_ci_assert_nightly.py
+++ b/backend/evals/tests/test_ci_assert_nightly.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from evals.ci_assert_nightly import check_run_file
+from evals.ci_assert_nightly import check_run_file, main
 from evals.schema import CaseResult, ScorerOutcome
 
 
@@ -153,6 +153,32 @@ def test_missing_or_empty_file_fails(tmp_path: Path) -> None:
     empty = tmp_path / "nightly_triggers.jsonl"
     empty.write_text("")
     assert any("missing or empty" in e or "zero rows" in e for e in check_run_file(empty))
+
+
+def test_main_fails_when_expected_file_missing(tmp_path: Path) -> None:
+    """A nightly step that exits 0 but never writes its file must trip the gate."""
+    # Write the other expected files so only one is missing.
+    for name in (
+        "nightly_wiki_updater.jsonl",
+        "nightly_ingest_selector.jsonl",
+        "nightly_external_agent.jsonl",
+    ):
+        _write_run(
+            tmp_path,
+            name,
+            [
+                _row(
+                    surface="external_agent",
+                    model="claude-sonnet-4-6",
+                    case_id="c1",
+                    scorer="facts_preserved_avg",
+                    score=0.95,
+                )
+            ],
+        )
+    # nightly_triggers.jsonl intentionally not written
+    rc = main(["ci_assert_nightly", str(tmp_path)])
+    assert rc == 1, "expected non-zero exit when an expected file is missing"
 
 
 @pytest.mark.parametrize(

--- a/backend/evals/tests/test_ci_assert_nightly.py
+++ b/backend/evals/tests/test_ci_assert_nightly.py
@@ -13,8 +13,13 @@ from pathlib import Path
 
 import pytest
 
-from evals.ci_assert_nightly import check_run_file, main
+from evals.ci_assert_nightly import SURFACE_THRESHOLDS, check_run_file, main
 from evals.schema import CaseResult, ScorerOutcome
+
+
+# Passing default for any scorer not explicitly under test — above every
+# floor in SURFACE_THRESHOLDS (max floor is 0.95).
+_PASS = 0.99
 
 
 def _row(
@@ -27,6 +32,22 @@ def _row(
     expected: str = "X",
     actual: str = "X",
 ) -> str:
+    """Build a row carrying the surface's FULL thresholded scorer set.
+
+    Real nightly rows emit every scorer for their surface; the asserter
+    now fails if a thresholded scorer is absent from all rows. So a test
+    row must carry the whole set — the named ``scorer`` is overridden to
+    ``score`` and the rest default to a passing value.
+    """
+    names = set(SURFACE_THRESHOLDS.get(surface, {})) | {scorer}
+    scorers = [
+        ScorerOutcome(
+            name=n,
+            score=score if n == scorer else _PASS,
+            passed=(score if n == scorer else _PASS) >= 0.5,
+        )
+        for n in sorted(names)
+    ]
     r = CaseResult(
         case_id=case_id,
         surface=surface,  # pyright: ignore[reportArgumentType]
@@ -35,7 +56,7 @@ def _row(
         expected_class=expected,
         actual_class=actual,
         raw_output="{}",
-        scorers=[ScorerOutcome(name=scorer, score=score, passed=score >= 0.5)],
+        scorers=scorers,
     )
     return r.model_dump_json()
 
@@ -143,6 +164,28 @@ def test_unknown_filename_skipped(tmp_path: Path) -> None:
         ],
     )
     assert check_run_file(p) == []
+
+
+def test_scorer_absent_from_rows_fails(tmp_path: Path) -> None:
+    """A thresholded scorer present on no row must fail, not silently skip.
+
+    Build rows that carry only ONE of external_agent's thresholded
+    scorers — the other three are absent and must each trip an error.
+    """
+    line = CaseResult(
+        case_id="c1",
+        surface="external_agent",  # pyright: ignore[reportArgumentType]
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        expected_class="X",
+        actual_class="X",
+        raw_output="{}",
+        scorers=[ScorerOutcome(name="facts_preserved_avg", score=0.95, passed=True)],
+    ).model_dump_json()
+    p = _write_run(tmp_path, "nightly_external_agent.jsonl", [line])
+    errs = check_run_file(p)
+    assert any("update_f1" in e and "no rows to score" in e for e in errs)
+    assert any("no_touch_compliance" in e and "no rows to score" in e for e in errs)
 
 
 def test_missing_or_empty_file_fails(tmp_path: Path) -> None:

--- a/backend/evals/tests/test_ci_assert_nightly.py
+++ b/backend/evals/tests/test_ci_assert_nightly.py
@@ -155,27 +155,81 @@ def test_missing_or_empty_file_fails(tmp_path: Path) -> None:
     assert any("missing or empty" in e or "zero rows" in e for e in check_run_file(empty))
 
 
+def test_surface_absent_from_file_fails(tmp_path: Path) -> None:
+    """A mapped surface with zero matching rows must fail, not silently skip.
+
+    nightly_wiki_updater maps to process_instruction + reconcile_document;
+    a file whose rows all carry some other surface tag means the run
+    produced no data for the mapped surfaces.
+    """
+    p = _write_run(
+        tmp_path,
+        "nightly_wiki_updater.jsonl",
+        [
+            _row(
+                surface="external_agent",  # wrong tag for this file
+                model="claude-sonnet-4-6",
+                case_id="x1",
+                scorer="facts_preserved_avg",
+                score=0.95,
+            )
+        ],
+    )
+    errs = check_run_file(p)
+    assert any("expected surface=process_instruction" in e for e in errs)
+    assert any("expected surface=reconcile_document" in e for e in errs)
+
+
 def test_main_fails_when_expected_file_missing(tmp_path: Path) -> None:
     """A nightly step that exits 0 but never writes its file must trip the gate."""
-    # Write the other expected files so only one is missing.
-    for name in (
+    # Write the other expected files with correct-surface rows so the ONLY
+    # error source is the missing triggers file.
+    _write_run(
+        tmp_path,
         "nightly_wiki_updater.jsonl",
+        [
+            _row(
+                surface="process_instruction",
+                model="claude-sonnet-4-6",
+                case_id="pi1",
+                scorer="trigger_class_match",
+                score=1.0,
+            ),
+            _row(
+                surface="reconcile_document",
+                model="claude-sonnet-4-6",
+                case_id="rd1",
+                scorer="trigger_class_match",
+                score=0.9,
+            ),
+        ],
+    )
+    _write_run(
+        tmp_path,
         "nightly_ingest_selector.jsonl",
+        [
+            _row(
+                surface="ingest_selector",
+                model="gpt-5-mini",
+                case_id="s1",
+                scorer="f1",
+                score=0.9,
+            )
+        ],
+    )
+    _write_run(
+        tmp_path,
         "nightly_external_agent.jsonl",
-    ):
-        _write_run(
-            tmp_path,
-            name,
-            [
-                _row(
-                    surface="external_agent",
-                    model="claude-sonnet-4-6",
-                    case_id="c1",
-                    scorer="facts_preserved_avg",
-                    score=0.95,
-                )
-            ],
-        )
+        [
+            _row(
+                surface="external_agent",
+                model="claude-sonnet-4-6",
+                case_id="c1",
+                scorer="facts_preserved_avg",
+                score=0.95,
+            )
+        ],
+    )
     # nightly_triggers.jsonl intentionally not written
     rc = main(["ci_assert_nightly", str(tmp_path)])
     assert rc == 1, "expected non-zero exit when an expected file is missing"

--- a/backend/evals/tests/test_ci_assert_nightly.py
+++ b/backend/evals/tests/test_ci_assert_nightly.py
@@ -1,0 +1,189 @@
+"""Unit tests for the nightly regression-floor asserter.
+
+Builds synthetic ``CaseResult`` JSONL files and checks the asserter
+flags below-floor scores per (surface, scorer, model) while passing
+on the at-or-above case. Also covers the file-skip + multi-surface
+(wiki_updater splits into process_instruction + reconcile_document)
+paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from evals.ci_assert_nightly import check_run_file
+from evals.schema import CaseResult, ScorerOutcome
+
+
+def _row(
+    *,
+    surface: str,
+    model: str,
+    case_id: str,
+    scorer: str,
+    score: float,
+    expected: str = "X",
+    actual: str = "X",
+) -> str:
+    r = CaseResult(
+        case_id=case_id,
+        surface=surface,  # pyright: ignore[reportArgumentType]
+        provider="anthropic",
+        model=model,
+        expected_class=expected,
+        actual_class=actual,
+        raw_output="{}",
+        scorers=[ScorerOutcome(name=scorer, score=score, passed=score >= 0.5)],
+    )
+    return r.model_dump_json()
+
+
+def _write_run(tmp_path: Path, name: str, lines: list[str]) -> Path:
+    p = tmp_path / name
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+def test_passes_when_all_scores_above_floor(tmp_path: Path) -> None:
+    p = _write_run(
+        tmp_path,
+        "nightly_external_agent.jsonl",
+        [
+            _row(
+                surface="external_agent",
+                model="claude-sonnet-4-6",
+                case_id="c1",
+                scorer="facts_preserved_avg",
+                score=0.95,
+            ),
+            _row(
+                surface="external_agent",
+                model="claude-sonnet-4-6",
+                case_id="c2",
+                scorer="facts_preserved_avg",
+                score=0.90,
+            ),
+        ],
+    )
+    assert check_run_file(p) == []
+
+
+def test_fails_when_below_floor(tmp_path: Path) -> None:
+    p = _write_run(
+        tmp_path,
+        "nightly_external_agent.jsonl",
+        [
+            _row(
+                surface="external_agent",
+                model="gpt-5",
+                case_id="c1",
+                scorer="facts_preserved_avg",
+                score=0.50,
+            ),
+        ],
+    )
+    errs = check_run_file(p)
+    assert errs, "expected a failure"
+    assert "facts_preserved_avg" in errs[0]
+    assert "gpt-5" in errs[0]
+    assert "external_agent" in errs[0]
+
+
+def test_wiki_updater_splits_into_two_surfaces(tmp_path: Path) -> None:
+    """One file, two distinct sub-surfaces — each threshold-checked separately."""
+    p = _write_run(
+        tmp_path,
+        "nightly_wiki_updater.jsonl",
+        [
+            # process_instruction case passes its floor (0.80)
+            _row(
+                surface="process_instruction",
+                model="claude-sonnet-4-6",
+                case_id="pi-01",
+                scorer="trigger_class_match",
+                score=1.0,
+            ),
+            # reconcile_document case dips below its floor (0.45)
+            _row(
+                surface="reconcile_document",
+                model="claude-sonnet-4-6",
+                case_id="rd-01",
+                scorer="trigger_class_match",
+                score=0.30,
+            ),
+            _row(
+                surface="reconcile_document",
+                model="claude-sonnet-4-6",
+                case_id="rd-02",
+                scorer="trigger_class_match",
+                score=0.30,
+            ),
+        ],
+    )
+    errs = check_run_file(p)
+    assert any("reconcile_document" in e for e in errs)
+    assert not any("process_instruction" in e for e in errs)
+
+
+def test_unknown_filename_skipped(tmp_path: Path) -> None:
+    """A rogue jsonl file under runs/ should not fail the asserter."""
+    p = _write_run(
+        tmp_path,
+        "ad-hoc-debug-run.jsonl",
+        [
+            _row(
+                surface="external_agent",
+                model="claude-sonnet-4-6",
+                case_id="c1",
+                scorer="facts_preserved_avg",
+                score=0.10,
+            ),
+        ],
+    )
+    assert check_run_file(p) == []
+
+
+def test_missing_or_empty_file_fails(tmp_path: Path) -> None:
+    missing = tmp_path / "nightly_external_agent.jsonl"
+    errs = check_run_file(missing)
+    assert errs
+    assert "missing or empty" in errs[0]
+    empty = tmp_path / "nightly_triggers.jsonl"
+    empty.write_text("")
+    assert any("missing or empty" in e or "zero rows" in e for e in check_run_file(empty))
+
+
+@pytest.mark.parametrize(
+    "scorer,score,should_fail",
+    [
+        ("facts_preserved_avg", 0.79, True),
+        ("facts_preserved_avg", 0.81, False),
+        ("update_f1", 0.94, True),
+        ("update_f1", 0.96, False),
+        ("no_touch_compliance", 0.89, True),
+        ("no_touch_compliance", 0.91, False),
+    ],
+)
+def test_external_agent_thresholds(
+    tmp_path: Path, scorer: str, score: float, should_fail: bool
+) -> None:
+    p = _write_run(
+        tmp_path,
+        "nightly_external_agent.jsonl",
+        [
+            _row(
+                surface="external_agent",
+                model="claude-sonnet-4-6",
+                case_id="c1",
+                scorer=scorer,
+                score=score,
+            )
+        ],
+    )
+    errs = check_run_file(p)
+    if should_fail:
+        assert errs
+    else:
+        assert errs == []

--- a/backend/evals/tests/test_ci_assert_nightly.py
+++ b/backend/evals/tests/test_ci_assert_nightly.py
@@ -273,9 +273,41 @@ def test_main_fails_when_expected_file_missing(tmp_path: Path) -> None:
             )
         ],
     )
+    _write_run(
+        tmp_path,
+        "nightly_merge_conflict.jsonl",
+        [
+            _row(
+                surface="merge_conflict_update",
+                model="claude-sonnet-4-6",
+                case_id="mc1",
+                scorer="facts_from_current_present",
+                score=0.95,
+            )
+        ],
+    )
     # nightly_triggers.jsonl intentionally not written
     rc = main(["ci_assert_nightly", str(tmp_path)])
     assert rc == 1, "expected non-zero exit when an expected file is missing"
+
+
+def test_merge_conflict_floor_enforced(tmp_path: Path) -> None:
+    """merge_conflict surface gets threshold enforcement like the others."""
+    p = _write_run(
+        tmp_path,
+        "nightly_merge_conflict.jsonl",
+        [
+            _row(
+                surface="merge_conflict_update",
+                model="claude-sonnet-4-6",
+                case_id="mc1",
+                scorer="facts_from_current_present",
+                score=0.50,
+            )
+        ],
+    )
+    errs = check_run_file(p)
+    assert any("merge_conflict_update" in e and "facts_from_current_present" in e for e in errs)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

**Bug shape**: prompt PRs can drop `facts_preserved` by 15 points and the only signal is a downward trend in the BT chart — CI stays green. This adds a final step to the nightly job that enforces a per-surface, per-scorer floor.

**Design**:
- New `evals/ci_assert_nightly.py` — reads each `runs/nightly_*.jsonl`, aggregates per-(surface, model) means, fails if below floor.
- Floors anchor to the 2026-05-28 baseline **minus one bucket of slack** — catch real regressions, don't flap on per-run noise.
- Comment trail on each entry records the baseline so future readers know the reasoning.
- Bump the floor in the same PR that lands a sustained improvement.

**Initial floors**:
- `external_agent`: facts_preserved_avg ≥ 0.80, facts_present_avg ≥ 0.85, update_f1 ≥ 0.95, no_touch_compliance ≥ 0.90
- `process_instruction`: trigger_class_match ≥ 0.80, facts_present ≥ 0.85, facts_preserved ≥ 0.85
- `reconcile_document`: trigger_class_match ≥ 0.45 (known-broken, tracked separately), facts_present ≥ 0.80, facts_preserved ≥ 0.85
- `ingest_selector`: f1 ≥ 0.45 (haiku tail), recall ≥ 0.80
- `triggers`: trigger_match_decision ≥ 0.85, no_false_fire_compliance ≥ 0.90

11 unit tests cover pass/fail above/below floor, wiki_updater's sub-surface split (one file → two surfaces), unknown-filename skip, missing/empty file handling, parametrized boundary checks. Smoke (dry-run) keeps its existing `ci_assert_baseline.py` oracle; this new asserter is a separate seam wired into the nightly workflow.

## How Has This Been Tested?

## Additional Options
- [ ] [Tests added]
- [ ] [Type checked]
- [ ] [Frontend reviewed in light mode, dark mode, and responsive design]
- [ ] [I have made corresponding changes to the documentation]
- [ ] [Mobile UI Looks Good]
- [ ] [cherry-pick this PR to the latest release branch once it has been merged]