### PR TITLE
rename(wiki): conflict button 'Let AI consolidate' → 'Merge with AI'

### DIFF
--- a/frontend/src/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/wiki/[[...slug]]/page.tsx
@@ -2216,7 +2216,7 @@ function FileViewer({ path }: { path: string }) {
               onClick={() => void onAiConsolidate()}
               disabled={consolidating || saving}
             >
-              {consolidating ? "Consolidating…" : "Let AI consolidate"}
+              {consolidating ? "Merging…" : "Merge with AI"}
             </Button>
             <Button
               size="sm"


### PR DESCRIPTION
## Summary

- Renames the conflict resolution button from "Let AI consolidate" to "Merge with AI"
- Also renames the in-progress label from "Consolidating…" to "Merging…"
- Consistent with the short action-verb pattern of the other conflict buttons ("Keep mine", "Use current", "Edit manually")