### PR TITLE
feat(evals): merge_conflict_update eval surface

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -93,6 +93,16 @@ jobs:
             --dataset "triggers" \
             --out runs/nightly_triggers.jsonl
 
+      - name: merge_conflict_update live run
+        run: |
+          uv run python -m evals.merge_conflict_update.run \
+            --cases evals/datasets/merge_conflict_update/cases \
+            --models "$EVAL_MODELS" \
+            --concurrency 16 \
+            --braintrust "nightly-merge-conflict-$(date -u +%Y%m%d)" \
+            --dataset "merge-conflict-update" \
+            --out runs/nightly_merge_conflict.jsonl
+
       - name: Upload run artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/evals-smoke.yml
+++ b/.github/workflows/evals-smoke.yml
@@ -21,6 +21,8 @@ on:
       - backend/app/llm/agents/common.py
       - backend/app/llm/prompts/wiki_updater.*
       - backend/app/llm/prompts/ingest_*
+      - backend/app/llm/prompts/merge_conflict_update.*
+      - backend/app/llm/agents/merge_conflict_update.py
       - backend/app/triggers/natural_language.py
       - .github/workflows/evals-smoke.yml
   workflow_dispatch:
@@ -86,6 +88,15 @@ jobs:
             --dry-run \
             --runs 1 \
             --out runs/ci_triggers.jsonl
+
+      - name: merge_conflict_update dry-run
+        run: |
+          uv run python -m evals.merge_conflict_update.run \
+            --cases evals/datasets/merge_conflict_update/cases \
+            --models claude-sonnet-4-6 \
+            --dry-run \
+            --runs 1 \
+            --out runs/ci_merge_conflict.jsonl
 
       - name: Verify dry-run produces baseline scores
         run: uv run python -m evals.ci_assert_baseline runs/

--- a/backend/evals/datasets/merge_conflict_update/cases/01-disjoint-sections.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/01-disjoint-sections.yaml
@@ -1,0 +1,56 @@
+id: mc-01-disjoint-sections
+wiki_path: services/payments/overview.md
+base_body: |
+  # Payments service
+
+  Built on FastAPI + Postgres. Stripe webhooks land at /webhooks/stripe.
+
+  ## SLOs
+  - p95 latency under 200ms
+  - availability 99.95% monthly
+current_body: |
+  # Payments service
+
+  Built on FastAPI + Postgres. Stripe webhooks land at /webhooks/stripe.
+
+  ## SLOs
+  - p95 latency under 200ms
+  - availability 99.95% monthly
+
+  ## Owners
+  - team: platform
+  - oncall: payments-oncall
+draft_body: |
+  # Payments service
+
+  Built on FastAPI + Postgres. Stripe webhooks land at /webhooks/stripe.
+
+  ## SLOs
+  - p95 latency under 200ms
+  - availability 99.95% monthly
+
+  ## Dependencies
+  - Postgres `payments` schema
+  - Stripe API
+  - Fraud-Detection (soft-allow on timeout)
+current_commit_message: "feat: add Owners section"
+facts_from_current_present:
+  - id: owners-team
+    text: an Owners section names the platform team
+  - id: owners-oncall
+    text: the payments-oncall rotation is listed
+facts_from_draft_present:
+  - id: deps-postgres
+    text: a Dependencies section lists the Postgres payments schema
+  - id: deps-stripe
+    text: the Stripe API is listed as a dependency
+  - id: deps-fraud
+    text: Fraud-Detection with soft-allow on timeout is listed as a dependency
+facts_must_not_appear:
+  - id: invented-grafana
+    text: a Grafana dashboard is named
+expects_conflict_annotation: false
+notes: |
+  Clean disjoint merge. Current added Owners; Draft added Dependencies.
+  Output must contain both sections + the original SLOs.
+tags: [merge, disjoint, easy]

--- a/backend/evals/datasets/merge_conflict_update/cases/02-direct-conflict-with-msg.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/02-direct-conflict-with-msg.yaml
@@ -1,0 +1,34 @@
+id: mc-02-direct-conflict-with-msg
+wiki_path: services/auth/sla.md
+base_body: |
+  # Auth SLA
+
+  Availability target 99.9% monthly.
+  Latency p95 < 250ms.
+current_body: |
+  # Auth SLA
+
+  Availability target 99.95% monthly.
+  Latency p95 < 250ms.
+draft_body: |
+  # Auth SLA
+
+  Availability target 99.99% monthly.
+  Latency p95 < 250ms.
+current_commit_message: "raise auth availability target after Q1 reliability work"
+facts_from_current_present:
+  - id: current-availability
+    text: the 99.95% availability value or its commit-message context is referenced
+facts_from_draft_present:
+  - id: draft-availability
+    text: the 99.99% availability target is the primary value
+facts_must_not_appear:
+  - id: invented-latency
+    text: an availability target of exactly 99.5% is mentioned
+expects_conflict_annotation: true
+notes: |
+  Direct conflict on the same field — both Current and Draft moved the
+  availability number from base 99.9%. Output should keep the draft
+  value as primary and annotate the current value with the commit
+  message context.
+tags: [merge, direct-conflict, annotation]

--- a/backend/evals/datasets/merge_conflict_update/cases/03-direct-conflict-no-msg.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/03-direct-conflict-no-msg.yaml
@@ -1,0 +1,28 @@
+id: mc-03-direct-conflict-no-msg
+wiki_path: services/checkout/sla.md
+base_body: |
+  # Checkout SLA
+
+  Latency p95 < 350ms.
+current_body: |
+  # Checkout SLA
+
+  Latency p95 < 300ms.
+draft_body: |
+  # Checkout SLA
+
+  Latency p95 < 250ms.
+facts_from_current_present:
+  - id: current-300ms
+    text: the 300ms latency value is preserved (annotated or noted)
+facts_from_draft_present:
+  - id: draft-250ms
+    text: the 250ms latency value is the primary
+facts_must_not_appear:
+  - id: invented-2s
+    text: a 2 second latency value is mentioned
+expects_conflict_annotation: true
+notes: |
+  Direct conflict, no commit message — output should still annotate
+  with the fallback "from another update" wording per the agent prompt.
+tags: [merge, direct-conflict, annotation, no-commit-msg]

--- a/backend/evals/datasets/merge_conflict_update/cases/04-draft-only-change.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/04-draft-only-change.yaml
@@ -1,0 +1,41 @@
+id: mc-04-draft-only-change
+wiki_path: ops/runbooks/auth-failover.md
+base_body: |
+  # Auth Failover
+
+  ## Steps
+  1. Page auth on-call.
+  2. Check the auth-api dashboard.
+  3. Fail over to auth-api-standby.
+current_body: |
+  # Auth Failover
+
+  ## Steps
+  1. Page auth on-call.
+  2. Check the auth-api dashboard.
+  3. Fail over to auth-api-standby.
+draft_body: |
+  # Auth Failover
+
+  ## Steps
+  1. Page auth on-call.
+  2. Check the auth-api dashboard.
+  3. Fail over to auth-api-standby.
+  4. After failover, verify token signing is healthy.
+
+  ## Dependencies
+  - PagerDuty service: auth-prod
+facts_from_current_present: []
+facts_from_draft_present:
+  - id: new-step
+    text: a step about verifying token signing after failover is present
+  - id: new-deps
+    text: a Dependencies section names the auth-prod PagerDuty service
+facts_must_not_appear:
+  - id: invented-grafana
+    text: a Grafana dashboard for failover health is named
+expects_conflict_annotation: false
+notes: |
+  Current is identical to base. All edits are Draft-only. Output must
+  preserve Draft additions verbatim with no annotation.
+tags: [merge, draft-only]

--- a/backend/evals/datasets/merge_conflict_update/cases/05-current-only-change.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/05-current-only-change.yaml
@@ -1,0 +1,42 @@
+id: mc-05-current-only-change
+wiki_path: ops/runbooks/postgres-failover.md
+base_body: |
+  # Postgres Failover
+
+  ## Steps
+  1. Promote the standby.
+  2. Reroute the api to the new primary.
+current_body: |
+  # Postgres Failover
+
+  ## Steps
+  1. Promote the standby.
+  2. Reroute the api to the new primary.
+  3. Verify the replication topology is healthy.
+
+  ## Dependencies
+  - PgBouncer pool
+  - Patroni cluster manager
+draft_body: |
+  # Postgres Failover
+
+  ## Steps
+  1. Promote the standby.
+  2. Reroute the api to the new primary.
+current_commit_message: "ops: add post-failover replication check and dependencies"
+facts_from_current_present:
+  - id: new-step
+    text: a step about verifying the replication topology after failover is present
+  - id: new-deps-pgbouncer
+    text: PgBouncer pool is listed as a dependency
+  - id: new-deps-patroni
+    text: the Patroni cluster manager is listed as a dependency
+facts_from_draft_present: []
+facts_must_not_appear:
+  - id: invented-pitr
+    text: point-in-time recovery procedure is named
+expects_conflict_annotation: false
+notes: |
+  Draft is identical to base. All edits are Current-only. Output must
+  preserve Current's additions verbatim.
+tags: [merge, current-only]

--- a/backend/evals/datasets/merge_conflict_update/cases/06-same-section-both-add.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/06-same-section-both-add.yaml
@@ -1,0 +1,36 @@
+id: mc-06-same-section-both-add
+wiki_path: engineering/oncall.md
+base_body: |
+  # On-Call Rotation
+  ## This week
+  - alice
+  - bob
+current_body: |
+  # On-Call Rotation
+  ## This week
+  - alice
+  - bob
+  - carol
+draft_body: |
+  # On-Call Rotation
+  ## This week
+  - alice
+  - bob
+  - dave
+current_commit_message: "add carol to on-call rotation"
+facts_from_current_present:
+  - id: carol-added
+    text: carol is included on the this-week on-call list
+facts_from_draft_present:
+  - id: dave-added
+    text: dave is included on the this-week on-call list
+facts_must_not_appear:
+  - id: invented-eve
+    text: eve is listed on the on-call rotation
+expects_conflict_annotation: false
+notes: |
+  Both sides appended to the same list — these are not conflicting
+  values, they are independent additions. Output should contain alice,
+  bob, carol, AND dave. Conflict annotation is NOT expected (no
+  conflicting fact).
+tags: [merge, same-section, both-add, list-merge]

--- a/backend/evals/datasets/merge_conflict_update/cases/07-no-hallucination-stress.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/07-no-hallucination-stress.yaml
@@ -1,0 +1,42 @@
+id: mc-07-no-hallucination-stress
+wiki_path: architecture/data-flow.md
+base_body: |
+  # Data flow
+
+  Ingest connectors push documents to /api/ingest/push.
+current_body: |
+  # Data flow
+
+  Ingest connectors push documents to /api/ingest/push.
+
+  ## Selector pass
+  An LLM-backed selector narrows BM25 candidates before the reconciler runs.
+draft_body: |
+  # Data flow
+
+  Ingest connectors push documents to /api/ingest/push.
+
+  ## Reconciler pass
+  The reconciler decides per-page CHANGE / NO_CHANGE / IRRELEVANT.
+current_commit_message: "document the selector pre-filter"
+facts_from_current_present:
+  - id: selector
+    text: a Selector pass section describes an LLM-backed narrowing of BM25 candidates
+facts_from_draft_present:
+  - id: reconciler
+    text: a Reconciler pass section names the per-page CHANGE / NO_CHANGE / IRRELEVANT decision
+facts_must_not_appear:
+  - id: hallucinated-vespa
+    text: Vespa is named as the search backend
+  - id: hallucinated-kafka
+    text: Kafka is named as the ingest transport
+  - id: hallucinated-cost
+    text: a specific per-document cost in dollars is given
+  - id: hallucinated-latency-number
+    text: a specific p95 latency number for ingest is given
+expects_conflict_annotation: false
+notes: |
+  Stress test on no-hallucination — model has plausible-but-absent
+  related concepts it could add (Vespa, Kafka, cost numbers). Must
+  not. Both sides' real additions must be preserved.
+tags: [merge, no-hallucination, stress]

--- a/backend/evals/datasets/merge_conflict_update/cases/08-structural-preservation.yaml
+++ b/backend/evals/datasets/merge_conflict_update/cases/08-structural-preservation.yaml
@@ -1,0 +1,58 @@
+id: mc-08-structural-preservation
+wiki_path: ops/incidents/template.md
+base_body: |
+  # Incident template
+
+  ## Summary
+
+  ## Impact
+
+  ## Timeline
+
+  ## Root cause
+
+  ## Resolution
+current_body: |
+  # Incident template
+
+  ## Summary
+
+  ## Impact
+
+  ## Customer-facing impact (NEW)
+
+  ## Timeline
+
+  ## Root cause
+
+  ## Resolution
+draft_body: |
+  # Incident template
+
+  ## Summary
+
+  ## Impact
+
+  ## Timeline
+
+  ## Root cause
+
+  ## Resolution
+
+  ## Follow-ups (NEW)
+current_commit_message: "add Customer-facing impact section"
+facts_from_current_present:
+  - id: customer-impact-section
+    text: a Customer-facing impact section appears after Impact
+facts_from_draft_present:
+  - id: followups-section
+    text: a Follow-ups section appears after Resolution
+facts_must_not_appear:
+  - id: invented-postmortem-date
+    text: a specific postmortem due-date or SLA is added
+expects_conflict_annotation: false
+notes: |
+  Structural preservation — both sides added new section headings at
+  different points. Output must contain all original sections AND both
+  new ones in sensible order. Heading hierarchy stays at h2.
+tags: [merge, structural, headings]

--- a/backend/evals/merge_conflict_update/__init__.py
+++ b/backend/evals/merge_conflict_update/__init__.py
@@ -1,0 +1,6 @@
+"""3-way merge conflict resolution eval surface.
+
+Exercises ``app.llm.agents.merge_conflict_update.merge(...)`` — the
+single-shot LLM call that reconciles a user's in-progress draft with
+a concurrent HEAD edit against a common-ancestor base.
+"""

--- a/backend/evals/merge_conflict_update/_stub.py
+++ b/backend/evals/merge_conflict_update/_stub.py
@@ -79,12 +79,15 @@ def stub_merge_conflict(cases: list[MergeConflictCase]) -> Generator[None]:
         case = _route(user_text)
         if case is None:
             return CompletionResult(text="")
-        # Concatenate draft + a "merged from current:" tail so both
-        # sides' facts appear in the body. The conflict-annotation
-        # scorer reads the literal "from:" marker.
+        # Concatenate draft + a "merged from current" tail so both sides'
+        # facts appear in the body. When the case expects a conflict
+        # annotation, emit the marker the scorer recognises — mirroring
+        # the production agent, which uses the commit message when present
+        # and falls back to "another update" otherwise.
         annotation = ""
-        if case.expects_conflict_annotation and case.current_commit_message:
-            annotation = "\n\n<!-- conflict from: %s -->" % case.current_commit_message
+        if case.expects_conflict_annotation:
+            source = case.current_commit_message or "another update"
+            annotation = "\n\n<!-- conflict from: %s -->" % source
         merged = "%s%s\n\n%s" % (case.draft_body.rstrip(), annotation, case.current_body)
         return CompletionResult(text=merged)
 

--- a/backend/evals/merge_conflict_update/_stub.py
+++ b/backend/evals/merge_conflict_update/_stub.py
@@ -1,0 +1,95 @@
+"""Dry-run stub for the merge_conflict eval.
+
+Patches both ``app.llm.client.complete`` and the agent module's bound
+``complete`` reference (the agent does ``from app.llm import client``
+then ``client.complete(...)`` — patching ``llm_client.complete`` alone
+suffices, but for parity with the trigger eval stub we also patch the
+agent module). The stub returns the case's draft body concatenated with
+a marker line per current-only fact, so the eval pipeline (scorer pass +
+JSONL write) exercises end-to-end without an API key.
+
+Routing: same payload-fingerprint pattern as other stubs — uses
+``wiki_path`` + the first 200 chars of ``base_body`` because the agent's
+user message embeds both. Collisions are logged and routed to the
+first-seen case.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+from app.llm import client as llm_client
+from app.llm.client import CompletionResult
+
+from evals.scorers import JUDGE_SYSTEM_MARKER as _JUDGE_MARKER
+from evals.schema import MergeConflictCase
+
+log = logging.getLogger(__name__)
+
+
+def _fingerprint(case: MergeConflictCase) -> str:
+    # The agent's user_msg carries base_body verbatim under "## Base"; it
+    # does NOT include wiki_path, so any wiki_path-derived key wouldn't
+    # be findable in the prompt text the stub sees. base_body[:200] is
+    # the longest substring guaranteed to be uniquely present.
+    return case.base_body[:200]
+
+
+@contextmanager
+def stub_merge_conflict(cases: list[MergeConflictCase]) -> Generator[None]:
+    """Patch ``client.complete`` to return a deterministic merged body."""
+    original = llm_client.complete
+    case_by_fp: dict[str, MergeConflictCase] = {}
+    for case in cases:
+        fp = _fingerprint(case)
+        if fp in case_by_fp and case_by_fp[fp].id != case.id:
+            log.warning(
+                "stub_merge_conflict: duplicate fingerprint for cases %s and %s; routing both to first",
+                case_by_fp[fp].id,
+                case.id,
+            )
+            continue
+        case_by_fp[fp] = case
+
+    def _route(user_text: str) -> MergeConflictCase | None:
+        for fp, case in case_by_fp.items():
+            if fp and fp in user_text:
+                return case
+        return None
+
+    def _stub(
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = llm_client.DEFAULT_MAX_TOKENS,
+    ) -> CompletionResult:
+        del model, tools, max_tokens
+        # Judge calls — return YES so message_facts_* scorers pass under dry-run.
+        for m in messages:
+            if m.get("role") != "system":
+                continue
+            sys_content = m.get("content", "")
+            if isinstance(sys_content, str) and _JUDGE_MARKER in sys_content:
+                return CompletionResult(text="VERDICT: YES | RATIONALE: stub")
+        user_text = "\n".join(m.get("content", "") for m in messages if m.get("role") == "user")
+        case = _route(user_text)
+        if case is None:
+            return CompletionResult(text="")
+        # Concatenate draft + a "merged from current:" tail so both
+        # sides' facts appear in the body. The conflict-annotation
+        # scorer reads the literal "from:" marker.
+        annotation = ""
+        if case.expects_conflict_annotation and case.current_commit_message:
+            annotation = "\n\n<!-- conflict from: %s -->" % case.current_commit_message
+        merged = "%s%s\n\n%s" % (case.draft_body.rstrip(), annotation, case.current_body)
+        return CompletionResult(text=merged)
+
+    llm_client.complete = _stub  # type: ignore[assignment]
+    try:
+        yield
+    finally:
+        llm_client.complete = original  # type: ignore[assignment]

--- a/backend/evals/merge_conflict_update/harness.py
+++ b/backend/evals/merge_conflict_update/harness.py
@@ -1,0 +1,40 @@
+"""Driver for the 3-way merge eval.
+
+Loads ``MergeConflictCase`` YAMLs and runs each through the production
+``merge_conflict_update.merge`` agent. No DB or git — the case carries
+``base_body``, ``current_body``, ``draft_body`` inline.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from app.llm.agents import merge_conflict_update as agent
+from evals.schema import MergeConflictCase
+
+log = logging.getLogger(__name__)
+
+
+def load_cases(directory: Path) -> list[MergeConflictCase]:
+    cases: list[MergeConflictCase] = []
+    for path in sorted(directory.glob("*.yaml")):
+        with path.open() as fh:
+            raw = yaml.safe_load(fh)
+        cases.append(MergeConflictCase.model_validate(raw))
+    if not cases:
+        raise ValueError("no merge_conflict cases found in %s" % directory)
+    return cases
+
+
+def run_case(case: MergeConflictCase) -> str:
+    """Return the merged body the agent produced."""
+    return agent.merge(
+        wiki_path=case.wiki_path,
+        base_body=case.base_body,
+        current_body=case.current_body,
+        draft_body=case.draft_body,
+        current_commit_message=case.current_commit_message,
+    )

--- a/backend/evals/merge_conflict_update/run.py
+++ b/backend/evals/merge_conflict_update/run.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 import time
 from pathlib import Path
@@ -38,12 +39,23 @@ from evals.schema import MergeConflictCase, ScorerOutcome, Surface
 log = logging.getLogger(__name__)
 
 
-_ANNOTATION_MARKERS = ("from:", "(from ", "from another update")
+# Production agent emits the conflict annotation as a parenthesised inline
+# value: e.g. "10k (12k from: <commit message>)" when a commit message is
+# available, "10k (12k from another update)" as the fallback. The stub
+# emits an HTML comment for tests. The regex matches both production
+# forms + the stub form without tripping on bare prose ("migrated from:",
+# "inherited from BaseClass") that has no enclosing paren or HTML comment.
+_ANNOTATION_RE = re.compile(
+    r"""
+    \([^)]{1,200}\bfrom\b[^)]{0,200}\)  # paren-wrapped "(... from ...)"
+    | <!--[^>]{0,200}\bfrom\b[^>]{0,200}-->  # HTML comment fallback (stub)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
 
 def _has_annotation(body: str) -> bool:
-    low = body.lower()
-    return any(m.lower() in low for m in _ANNOTATION_MARKERS)
+    return bool(_ANNOTATION_RE.search(body))
 
 
 def _score_case(
@@ -94,7 +106,7 @@ def _score_case(
                 name="conflict_annotation_present",
                 score=1.0 if present else 0.0,
                 passed=present,
-                detail="markers=%s" % (_ANNOTATION_MARKERS,),
+                detail="pattern=%s" % _ANNOTATION_RE.pattern,
             )
         )
     rows.append(scorers.markdown_valid(merged))

--- a/backend/evals/merge_conflict_update/run.py
+++ b/backend/evals/merge_conflict_update/run.py
@@ -1,0 +1,189 @@
+"""CLI: run the merge_conflict_update eval across a model matrix.
+
+    cd backend
+    uv run python -m evals.merge_conflict_update.run \\
+        --cases evals/datasets/merge_conflict_update/cases \\
+        --models claude-sonnet-4-6,gpt-5
+
+Scores three axes per case:
+
+* **Information preservation** — facts the Current edit and the Draft
+  edit each contributed must survive into the merged body
+  (``facts_from_current_present`` + ``facts_from_draft_present``).
+* **No fabrication** — facts not present in any of base/current/draft
+  must not appear in the output (``facts_no_hallucination``).
+* **Conflict annotation** — when a case marks a direct conflict, the
+  merged body must carry an inline source marker
+  (``conflict_annotation_present``).
+
+Also reuses ``markdown_valid`` from the shared scorer suite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+from app.utils.logging import setup_logging
+
+from evals import _cli, reporting, scorers
+from evals.merge_conflict_update._stub import stub_merge_conflict
+from evals.merge_conflict_update.harness import load_cases, run_case
+from evals.schema import MergeConflictCase, ScorerOutcome, Surface
+
+log = logging.getLogger(__name__)
+
+
+_ANNOTATION_MARKERS = ("from:", "(from ", "from another update")
+
+
+def _has_annotation(body: str) -> bool:
+    low = body.lower()
+    return any(m.lower() in low for m in _ANNOTATION_MARKERS)
+
+
+def _score_case(
+    case: MergeConflictCase,
+    merged: str,
+    *,
+    judge_models: tuple[str, ...] | None = None,
+) -> list[ScorerOutcome]:
+    rows: list[ScorerOutcome] = []
+    if case.facts_from_current_present:
+        fc = scorers.facts_present(
+            merged, case.facts_from_current_present, judge_models=judge_models
+        )
+        rows.append(
+            ScorerOutcome(
+                name="facts_from_current_present",
+                score=fc.score,
+                passed=fc.passed,
+                detail=fc.detail,
+            )
+        )
+    if case.facts_from_draft_present:
+        fd = scorers.facts_present(merged, case.facts_from_draft_present, judge_models=judge_models)
+        rows.append(
+            ScorerOutcome(
+                name="facts_from_draft_present",
+                score=fd.score,
+                passed=fd.passed,
+                detail=fd.detail,
+            )
+        )
+    if case.facts_must_not_appear:
+        # Same judge — YES means the unwanted fact IS in the body, flip.
+        fh = scorers.facts_present(merged, case.facts_must_not_appear, judge_models=judge_models)
+        flipped = 1.0 - fh.score
+        rows.append(
+            ScorerOutcome(
+                name="facts_no_hallucination",
+                score=flipped,
+                passed=flipped >= 0.9,
+                detail=fh.detail,
+            )
+        )
+    if case.expects_conflict_annotation:
+        present = _has_annotation(merged)
+        rows.append(
+            ScorerOutcome(
+                name="conflict_annotation_present",
+                score=1.0 if present else 0.0,
+                passed=present,
+                detail="markers=%s" % (_ANNOTATION_MARKERS,),
+            )
+        )
+    rows.append(scorers.markdown_valid(merged))
+    return rows
+
+
+def _make_run_one(
+    judge_models: tuple[str, ...] | None,
+) -> _cli.RunOne[MergeConflictCase]:
+    def _run_one(
+        case: MergeConflictCase, provider: str, model: str, run_index: int
+    ) -> tuple[Surface, str, str, str, list[ScorerOutcome]]:
+        del provider, run_index
+        merged = run_case(case)
+        rows = _score_case(case, merged, judge_models=judge_models)
+        expected = "merged"
+        actual = "merged" if merged else "<empty>"
+        raw = json.dumps({"merged_body": merged})
+        return ("merge_conflict_update", expected, actual, raw, rows)
+
+    return _run_one
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run the merge_conflict_update eval.")
+    p.add_argument(
+        "--cases",
+        type=Path,
+        default=Path("evals/datasets/merge_conflict_update/cases"),
+        help="Directory of merge-conflict case YAML files",
+    )
+    p.add_argument(
+        "--judge-models",
+        default=",".join(scorers.DEFAULT_JUDGE_PANEL),
+        help="Comma-separated judge model panel for fact scoring.",
+    )
+    _cli.add_common_args(p, default_models="claude-sonnet-4-6")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    setup_logging(args.log_level)
+    cases = load_cases(args.cases)
+    if args.case_id:
+        cases = [c for c in cases if c.id == args.case_id]
+        if not cases:
+            log.error("no case with id %s", args.case_id)
+            return 2
+    if args.limit is not None:
+        cases = cases[: args.limit]
+
+    runnable, skipped = _cli.resolve_runnable(args.models, dry_run=args.dry_run)
+    if not runnable:
+        log.error("no runnable models — set EVAL_*_API_KEY or pass --dry-run")
+        return 2
+    metadata = _cli.build_metadata(Path(__file__), args.cases)
+    judge_panel = tuple(j.strip() for j in args.judge_models.split(",") if j.strip())
+
+    log.info(
+        "running %d merge_conflict cases × %d models × %d runs (concurrency=%d)",
+        len(cases),
+        len(runnable),
+        args.runs,
+        args.concurrency,
+    )
+    results = _cli.run_concurrent(
+        cases,
+        runnable=runnable,
+        runs=args.runs,
+        run_one=_make_run_one(judge_panel),
+        case_id=lambda c: c.id,
+        metadata=metadata,
+        judge_models=list(judge_panel),
+        concurrency=args.concurrency,
+        dry_run_ctx=stub_merge_conflict(cases) if args.dry_run else None,
+    )
+
+    out_path = args.out or Path("runs") / ("merge_conflict_%d.jsonl" % int(time.time()))
+    reporting.write_jsonl(out_path, results)
+    summary = reporting.summarize(results, surface="merge_conflict_update")
+    reporting.print_summary(summary)
+    bt_url = ""
+    if args.braintrust:
+        bt_url = reporting.push_to_braintrust(args.braintrust, results, dataset=args.dataset)
+    reporting.write_github_summary(summary, braintrust_url=bt_url)
+    print(json.dumps({"out": str(out_path), "skipped_models": skipped, "braintrust_url": bt_url}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/evals/schema.py
+++ b/backend/evals/schema.py
@@ -25,6 +25,7 @@ Surface = Literal[
     "ingest_selector",
     "external_agent",
     "triggers",
+    "merge_conflict_update",
 ]
 
 
@@ -94,6 +95,38 @@ class IngestSelectorCase(BaseModel):
     doc_content: str
     candidates: list[IngestSelectorCandidate]
     expected_kept_paths: list[str]
+    notes: str = ""
+    tags: list[str] = Field(default_factory=list)
+
+
+class MergeConflictCase(BaseModel):
+    """One case for the 3-way merge conflict resolution agent.
+
+    Exercises ``app.llm.agents.merge_conflict_update.merge(...)`` — the
+    agent reconciles a user's draft with a concurrent HEAD edit against
+    a shared ``base`` (common ancestor). The merged body should preserve
+    intentional changes from both Current and Draft, annotate direct
+    conflicts inline, and never drop or hallucinate information.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str
+    surface: Literal["merge_conflict_update"] = "merge_conflict_update"
+    wiki_path: str
+    base_body: str
+    current_body: str
+    draft_body: str
+    current_commit_message: str | None = None
+
+    # Quality scorer ground truth
+    facts_from_current_present: list[FactClaim] = Field(default_factory=list)
+    facts_from_draft_present: list[FactClaim] = Field(default_factory=list)
+    facts_must_not_appear: list[FactClaim] = Field(default_factory=list)
+    # True when current/draft change the same content directly — output
+    # should carry the conflict annotation ("draft (current from: ...)").
+    expects_conflict_annotation: bool = False
+
     notes: str = ""
     tags: list[str] = Field(default_factory=list)
 

--- a/backend/evals/tests/test_merge_conflict_harness.py
+++ b/backend/evals/tests/test_merge_conflict_harness.py
@@ -1,0 +1,103 @@
+"""Unit coverage for the merge_conflict_update eval surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from evals.merge_conflict_update._stub import stub_merge_conflict
+from evals.merge_conflict_update.harness import load_cases, run_case
+from evals.merge_conflict_update.run import _score_case  # pyright: ignore[reportPrivateUsage]
+from evals.schema import FactClaim, MergeConflictCase
+
+
+CASES_DIR = Path(__file__).resolve().parent.parent / "datasets" / "merge_conflict_update" / "cases"
+
+
+def _make_case(
+    *,
+    case_id: str = "mc-test",
+    base: str = "base body",
+    current: str = "current body",
+    draft: str = "draft body",
+    commit_msg: str | None = None,
+    expects_annotation: bool = False,
+) -> MergeConflictCase:
+    return MergeConflictCase(
+        id=case_id,
+        wiki_path="test/page.md",
+        base_body=base,
+        current_body=current,
+        draft_body=draft,
+        current_commit_message=commit_msg,
+        facts_from_current_present=[FactClaim(id="c1", text="current is present")],
+        facts_from_draft_present=[FactClaim(id="d1", text="draft is present")],
+        facts_must_not_appear=[FactClaim(id="h1", text="something invented")],
+        expects_conflict_annotation=expects_annotation,
+    )
+
+
+def test_load_seed_cases_validate() -> None:
+    cases = load_cases(CASES_DIR)
+    assert len(cases) >= 8
+    ids = {c.id for c in cases}
+    assert len(ids) == len(cases), "case ids must be unique"
+    # Both conflict-annotation modes are exercised
+    assert any(c.expects_conflict_annotation for c in cases)
+    assert any(not c.expects_conflict_annotation for c in cases)
+
+
+def test_run_case_via_stub_returns_nonempty_merge() -> None:
+    case = _make_case(
+        base="# Page\n\nBase paragraph that is unique per case",
+        current="# Page\n\nCurrent paragraph",
+        draft="# Page\n\nDraft paragraph",
+    )
+    with stub_merge_conflict([case]):
+        merged = run_case(case)
+    assert merged, "stub must produce non-empty merged body"
+    assert "Draft paragraph" in merged
+    assert "Current paragraph" in merged
+
+
+def test_score_case_records_conflict_annotation_when_expected() -> None:
+    case = _make_case(
+        base="# Page\n\nBase line unique XYZ",
+        current="# Page\n\nCurrent",
+        draft="# Page\n\nDraft",
+        commit_msg="add new fact",
+        expects_annotation=True,
+    )
+    with stub_merge_conflict([case]):
+        merged = run_case(case)
+    rows = _score_case(case, merged, judge_models=None)
+    names = {r.name for r in rows}
+    assert "conflict_annotation_present" in names
+    annotation_row = next(r for r in rows if r.name == "conflict_annotation_present")
+    # Stub injects the marker when commit_msg is set + annotation expected
+    assert annotation_row.score == 1.0
+
+
+def test_score_case_skips_annotation_when_not_expected() -> None:
+    case = _make_case(
+        base="# Page\n\nBase ABC unique",
+        current="# Page\n\nCurrent only",
+        draft="# Page\n\nDraft only",
+        expects_annotation=False,
+    )
+    with stub_merge_conflict([case]):
+        merged = run_case(case)
+    rows = _score_case(case, merged, judge_models=None)
+    names = {r.name for r in rows}
+    assert "conflict_annotation_present" not in names
+
+
+def test_score_case_always_emits_markdown_valid() -> None:
+    case = _make_case(
+        base="# Page\n\nUNIQUE-DEF",
+        current="# Page\n\nC",
+        draft="# Page\n\nD",
+    )
+    with stub_merge_conflict([case]):
+        merged = run_case(case)
+    rows = _score_case(case, merged, judge_models=None)
+    assert any(r.name == "markdown_valid" for r in rows)

--- a/backend/evals/tests/test_merge_conflict_harness.py
+++ b/backend/evals/tests/test_merge_conflict_harness.py
@@ -77,6 +77,28 @@ def test_score_case_records_conflict_annotation_when_expected() -> None:
     assert annotation_row.score == 1.0
 
 
+def test_stub_emits_annotation_without_commit_message() -> None:
+    """expects_conflict_annotation=True + no commit message must still mark.
+
+    Mirrors case 03-direct-conflict-no-msg: the stub used to gate the
+    marker on commit_message presence, which scored that case 0.0 on
+    conflict_annotation_present and tainted the smoke baseline.
+    """
+    case = _make_case(
+        case_id="mc-no-msg",
+        base="# Page\n\nUNIQUE-NOMSG base line",
+        current="# Page\n\nCurrent 300ms",
+        draft="# Page\n\nDraft 250ms",
+        commit_msg=None,
+        expects_annotation=True,
+    )
+    with stub_merge_conflict([case]):
+        merged = run_case(case)
+    rows = _score_case(case, merged, judge_models=None)
+    annotation_row = next(r for r in rows if r.name == "conflict_annotation_present")
+    assert annotation_row.score == 1.0
+
+
 def test_score_case_skips_annotation_when_not_expected() -> None:
     case = _make_case(
         base="# Page\n\nBase ABC unique",

--- a/backend/evals/tests/test_merge_conflict_harness.py
+++ b/backend/evals/tests/test_merge_conflict_harness.py
@@ -91,6 +91,28 @@ def test_score_case_skips_annotation_when_not_expected() -> None:
     assert "conflict_annotation_present" not in names
 
 
+def test_annotation_pattern_does_not_match_bare_prose() -> None:
+    """Bare 'migrated from:' / 'inherited from BaseClass' must not be a match."""
+    from evals.merge_conflict_update.run import (
+        _has_annotation,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert not _has_annotation("# Notes\n\nMigrated from: v1.\n")
+    assert not _has_annotation("class Foo inherited from BaseClass.\n")
+    assert not _has_annotation("Output from the reconciler.\n")
+
+
+def test_annotation_pattern_matches_production_forms() -> None:
+    """Match the agent prompt's parenthesised conflict annotation."""
+    from evals.merge_conflict_update.run import (
+        _has_annotation,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    assert _has_annotation("Availability target 99.99% (99.95% from: raise auth target)")
+    assert _has_annotation("Latency p95 < 250ms (300ms from another update)")
+    assert _has_annotation("body\n<!-- conflict from: some commit -->")
+
+
 def test_score_case_always_emits_markdown_valid() -> None:
     case = _make_case(
         base="# Page\n\nUNIQUE-DEF",


### PR DESCRIPTION
## Description

Adds the fifth eval surface — scores the 3-way merge agent Bo shipped in [#128](https://github.com/onyx-dot-app/agent-wiki/pull/128). Without this, prompt or model changes that break merge quality go unnoticed until a user reports a lost edit.

Scorers (per case):
- `facts_from_current_present` — Current's intentional edits survive
- `facts_from_draft_present` — Draft's intentional edits survive
- `facts_no_hallucination` — facts not in any of base/current/draft must not appear (judge-scored, flipped)
- `conflict_annotation_present` — direct-conflict cases must carry the inline `from:` marker the agent prompt specifies
- `markdown_valid` (reused)

8 seed cases: disjoint sections, direct conflict (with + without commit msg), draft-only change, current-only change, same-section both-add (list merge), no-hallucination stress (Vespa/Kafka/invented numbers must not appear), structural preservation.

Wired into smoke (every PR touching the merge agent/prompt/eval) and nightly (live LLM → BT dataset `merge-conflict-update`). 5 unit tests cover load, run-via-stub, annotation present/absent paths, markdown_valid always emitted. Smoke paths-filter extended to fire on changes to `merge_conflict_update.system.md` or `merge_conflict_update.py`.

Follow-up to [#132](https://github.com/onyx-dot-app/agent-wiki/pull/132): once both merge, raise per-surface floors in `ci_assert_nightly.py` from the merge surface's first nightly baseline.

## How Has This Been Tested?

## Additional Options
- [ ] [Tests added]
- [ ] [Type checked]
- [ ] [Frontend reviewed in light mode, dark mode, and responsive design]
- [ ] [I have made corresponding changes to the documentation]
- [ ] [Mobile UI Looks Good]
- [ ] [cherry-pick this PR to the latest release branch once it has been merged]