### PR TITLE
fix(wiki): align history panel rows + avatar sizing to Figma activity mock

### DIFF
--- a/frontend/src/components/wiki/HistoryPanel.tsx
+++ b/frontend/src/components/wiki/HistoryPanel.tsx
@@ -1,4 +1,5 @@
 import { SelectCard, Text } from "@onyx-ai/opal/components";
+import { SvgWorkflow } from "@onyx-ai/opal/icons";
 import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
 import type { IconProps } from "@onyx-ai/opal/types";
 import type { ComponentType } from "react";
@@ -195,7 +196,8 @@ function CommitRow({
         />
         {commit.triggered > 0 ? (
           <ActionLine
-            label={`⚡ Triggered ${commit.triggered} automation${
+            icon={<SvgWorkflow style={{ width: 12, height: 12 }} />}
+            label={`Triggered ${commit.triggered} automation${
               commit.triggered === 1 ? "" : "s"
             }`}
           />
@@ -211,7 +213,7 @@ function Row({ children }: { children: React.ReactNode }) {
       style={{
         display: "flex",
         flexDirection: "column",
-        gap: 4,
+        gap: 8,
         width: "100%",
         minWidth: 0,
       }}
@@ -263,11 +265,13 @@ function HeaderLine({
 }
 
 function ActionLine({
+  icon,
   label,
   stats,
   sourceUrl,
   sourceTitle,
 }: {
+  icon?: React.ReactNode;
   label: string;
   stats?: { added: number; removed: number } | null;
   sourceUrl?: string | null;
@@ -282,9 +286,22 @@ function ActionLine({
         gap: 8,
         width: "100%",
         minWidth: 0,
-        paddingLeft: 28,
+        fontSize: 12,
+        lineHeight: "16px",
       }}
     >
+      {icon ? (
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            flexShrink: 0,
+            color: color.text.muted,
+          }}
+        >
+          {icon}
+        </span>
+      ) : null}
       <div
         style={{
           flex: 1,

--- a/frontend/src/components/wiki/HistoryPanel.tsx
+++ b/frontend/src/components/wiki/HistoryPanel.tsx
@@ -397,7 +397,7 @@ function LogoAvatar({ Logo }: { Logo: ComponentType<IconProps> }) {
         border: `1px solid ${color.border.subtle}`,
       }}
     >
-      <Logo style={{ width: 12, height: 12 }} />
+      <Logo style={{ width: 16, height: 16 }} />
     </div>
   );
 }

--- a/frontend/src/components/wiki/HistoryPanel.tsx
+++ b/frontend/src/components/wiki/HistoryPanel.tsx
@@ -394,7 +394,7 @@ function LogoAvatar({ Logo }: { Logo: ComponentType<IconProps> }) {
         ...avatarBase,
         marginLeft: -6,
         background: color.bg.page,
-        border: `1px solid ${color.border.subtle}`,
+        border: "1px solid var(--diff-avatar-border)",
       }}
     >
       <Logo style={{ width: 16, height: 16 }} />

--- a/frontend/src/components/wiki/HistoryPanel.tsx
+++ b/frontend/src/components/wiki/HistoryPanel.tsx
@@ -195,12 +195,7 @@ function CommitRow({
           sourceTitle={srcTitle}
         />
         {commit.triggered > 0 ? (
-          <ActionLine
-            icon={<SvgWorkflow style={{ width: 12, height: 12 }} />}
-            label={`Triggered ${commit.triggered} automation${
-              commit.triggered === 1 ? "" : "s"
-            }`}
-          />
+          <TriggeredLine count={commit.triggered} />
         ) : null}
       </Row>
     </SelectCard>
@@ -265,13 +260,11 @@ function HeaderLine({
 }
 
 function ActionLine({
-  icon,
   label,
   stats,
   sourceUrl,
   sourceTitle,
 }: {
-  icon?: React.ReactNode;
   label: string;
   stats?: { added: number; removed: number } | null;
   sourceUrl?: string | null;
@@ -290,18 +283,6 @@ function ActionLine({
         lineHeight: "16px",
       }}
     >
-      {icon ? (
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            flexShrink: 0,
-            color: color.text.muted,
-          }}
-        >
-          {icon}
-        </span>
-      ) : null}
       <div
         style={{
           flex: 1,
@@ -345,6 +326,42 @@ function ActionLine({
           </Text>
         </a>
       ) : null}
+    </div>
+  );
+}
+
+function TriggeredLine({ count }: { count: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 4,
+        width: "100%",
+        minWidth: 0,
+        fontSize: 12,
+        lineHeight: "16px",
+      }}
+    >
+      <Text font="secondary-body" color="text-03" nowrap>
+        Triggered
+      </Text>
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          flexShrink: 0,
+          color: color.text.muted,
+        }}
+      >
+        <SvgWorkflow style={{ width: 12, height: 12 }} />
+      </span>
+      <span style={{ fontWeight: 600 }}>
+        <Text font="secondary-action" color="text-03" nowrap>
+          {`${count} automation${count === 1 ? "" : "s"}`}
+        </Text>
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Brings the wiki history/activity panel in line with the Figma activity mock (nodes `266:20732` / `266:20739`).

- **Smaller line-count rows** — description + `+x -y` stat rows now render at 12px/16 (Figma *Secondary*). OPAL `font="…"` tokens are inert in this app (no `.font-*` CSS rule is defined), so `<Text>` was inheriting the larger ambient size — set the size explicitly on the row.
- **8px gap** between activity lines (was 4px).
- **Workflow icon** — replaced the `⚡` emoji with the `SvgWorkflow` icon (12px) on the "Triggered N automations" line.
- **Removed** the left indent on the action lines.
- **Agent logo** glyph sized to 16px (was 12px) so it matches the user-initial avatar — both sit in the same 20px circle, only the glyph was undersized.

Frontend-only, single component (`HistoryPanel.tsx`). `tsc --noEmit` clean.

## How Has This Been Tested?

<img width="358" height="80" alt="Screenshot 2026-05-28 at 5 21 22 PM" src="https://github.com/user-attachments/assets/9d881079-e5ae-4ca7-953c-b4204dafe0de" />
