### PR TITLE
feat(evals): push merge_conflict case set as Braintrust dataset

### DIFF
--- a/backend/evals/merge_conflict_update/run.py
+++ b/backend/evals/merge_conflict_update/run.py
@@ -187,6 +187,8 @@ def main(argv: list[str] | None = None) -> int:
 
     out_path = args.out or Path("runs") / ("merge_conflict_%d.jsonl" % int(time.time()))
     reporting.write_jsonl(out_path, results)
+    if args.dataset:
+        reporting.push_merge_conflict_dataset(args.dataset, cases)
     summary = reporting.summarize(results, surface="merge_conflict_update")
     reporting.print_summary(summary)
     bt_url = ""

--- a/backend/evals/reporting.py
+++ b/backend/evals/reporting.py
@@ -15,6 +15,7 @@ from app.tracing import braintrust as bt
 from evals.schema import (
     CaseResult,
     IngestSelectorCase,
+    MergeConflictCase,
     RunSummary,
     ScorerSummary,
     Surface,
@@ -337,6 +338,53 @@ def push_triggers_dataset(dataset: str, cases: list[TriggerCase]) -> int:
                 "flavor": c.flavor.value,
                 "tags": list(c.tags or []),
                 "max_message_bloat_ratio": c.max_message_bloat_ratio,
+            },
+        )
+        for c in cases
+    ]
+    pushed = bt.push_dataset(project=project, dataset=dataset, api_key=api_key, rows=rows)
+    log.info(
+        "braintrust: pushed %d/%d dataset rows to project=%s dataset=%s",
+        pushed,
+        len(cases),
+        project,
+        dataset,
+    )
+    return pushed
+
+
+def push_merge_conflict_dataset(dataset: str, cases: list[MergeConflictCase]) -> int:
+    """Push the merge-conflict eval case set as a Braintrust dataset.
+
+    Mirrors ``push_triggers_dataset`` so the runner can link experiment
+    results back to per-case dataset rows.
+    """
+    api_key = os.environ.get("BRAINTRUST_API_KEY", "")
+    project = os.environ.get("BRAINTRUST_PROJECT", "")
+    if not api_key or not project:
+        log.warning("braintrust: skip dataset push — no BRAINTRUST_API_KEY or BRAINTRUST_PROJECT")
+        return 0
+    rows = [
+        bt.DatasetRow(
+            id=c.id,
+            input={
+                "wiki_path": c.wiki_path,
+                "base_body": c.base_body,
+                "current_body": c.current_body,
+                "draft_body": c.draft_body,
+                "current_commit_message": c.current_commit_message,
+            },
+            expected={
+                "facts_from_current_present": [
+                    f.model_dump() for f in c.facts_from_current_present
+                ],
+                "facts_from_draft_present": [f.model_dump() for f in c.facts_from_draft_present],
+                "facts_must_not_appear": [f.model_dump() for f in c.facts_must_not_appear],
+                "expects_conflict_annotation": c.expects_conflict_annotation,
+            },
+            metadata={
+                "wiki_path": c.wiki_path,
+                "tags": list(c.tags or []),
             },
         )
         for c in cases

--- a/backend/evals/tests/test_reporting.py
+++ b/backend/evals/tests/test_reporting.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 from evals import reporting
-from evals.schema import CaseResult, ScorerOutcome
+from evals.schema import CaseResult, MergeConflictCase, ScorerOutcome
 
 
 def _make_result(
@@ -187,6 +187,21 @@ def test_push_to_braintrust_skips_without_creds(
     monkeypatch.delenv("BRAINTRUST_PROJECT", raising=False)
     url = reporting.push_to_braintrust("exp-1", [_make_result(case_id="a", model="m")])
     assert url == ""
+
+
+def test_push_merge_conflict_dataset_skips_without_creds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("BRAINTRUST_API_KEY", raising=False)
+    monkeypatch.delenv("BRAINTRUST_PROJECT", raising=False)
+    case = MergeConflictCase(
+        id="mc-x",
+        wiki_path="p.md",
+        base_body="base",
+        current_body="cur",
+        draft_body="draft",
+    )
+    assert reporting.push_merge_conflict_dataset("merge-conflict-update", [case]) == 0
 
 
 def test_summarize_error_rate_counts_failed_cases() -> None:


### PR DESCRIPTION
## Description

Follow-up to [#134](https://github.com/onyx-dot-app/agent-wiki/pull/134). That PR wired `--dataset merge-conflict-update` through to `push_to_braintrust`, which only **links** the experiment to a dataset name — it never uploads the case rows. The dataset object was created empty (0 rows), so per-case regression view was unavailable for the merge-conflict surface.

Same gap + fix as [#124](https://github.com/onyx-dot-app/agent-wiki/pull/124) did for triggers:
- New `reporting.push_merge_conflict_dataset(name, cases)` mirroring `push_triggers_dataset` (flavor-appropriate input/expected/metadata shape).
- `merge_conflict_update/run.py` calls it before `push_to_braintrust` when `--dataset` is set.

The 8 seed cases were already back-filled into the live `merge-conflict-update` dataset manually; this makes every nightly re-sync them automatically (id-keyed upsert).

## How Has This Been Tested?

## Additional Options
- [ ] [Tests added]
- [ ] [Type checked]
- [ ] [Frontend reviewed in light mode, dark mode, and responsive design]
- [ ] [I have made corresponding changes to the documentation]
- [ ] [Mobile UI Looks Good]
- [ ] [cherry-pick this PR to the latest release branch once it has been merged]