### PR TITLE
prompt(reconciler+judge): match detail level, fix new-deal carve-out, add bare-record rule

### DIFF
--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -55,7 +55,14 @@ not belong. Do not create new headings or sections — only update content
 under headings that already exist. If a section already contains several
 items of the same type (e.g., multiple sales follow-ups under one owner),
 adding another similar item is not clearly called for — use `no_change`.
+A deal or company not yet mentioned anywhere on the page is a new entry,
+not a similar item, and may be added if the source has concrete next steps.
 When in doubt, use `no_change`.
+
+Match the granularity already on the page. If the page covers a topic in a
+single line or brief phrase, keep the update at that same grain — do not
+expand it to a full sentence or paragraph just because the source provides
+more context.
 
 ## Editing rules (only apply if relevant)
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -62,7 +62,8 @@ When in doubt, use `no_change`.
 Match the granularity already on the page. If the page covers a topic in a
 single line or brief phrase, keep the update at that same grain — do not
 expand it to a full sentence or paragraph just because the source provides
-more context.
+more context. If the edit cannot be expressed at the existing grain, use
+`no_change`.
 
 ## Editing rules (only apply if relevant)
 

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -901,6 +901,9 @@ async function judgeSample(sample) {
     `- Use no_change_covered or no_change_extra when the source is topically related but adds nothing useful. ` +
     `Reserve irrelevant for sources with no connection to the page's topic whatsoever.\n` +
     `- A source about a different product that uses the same technology is not relevant — the page must cover the same specific system.\n` +
+    `- A HubSpot source that contains only contact info (name, email, job title, domain) or deal metadata (stage, amount, close date) ` +
+    `with no call notes, transcript, or stated next steps is irrelevant when pushed against a task-tracking page — not no_change_covered. ` +
+    `Only evaluate it as committed or no_change if the source includes a call summary or explicit action items.\n` +
     `- A conversational source (Slack, chat) that surfaces a potential issue or cc's team members tracked on the page ` +
     `implies a follow-up action and can qualify as committed_moderate.\n` +
     `- A call or meeting summary where a person tracked on the page appears in the attendee list with concrete next steps ` +
@@ -912,7 +915,10 @@ async function judgeSample(sample) {
     `- If the source contains a Stage or Status field set to a terminal value (closedlost, closed, expired, cancelled, ` +
     `resolved, churned), the work is over — do not commit action items from it even if the document also contains call notes with next steps.\n` +
     `- A short or minimal section is not a reason to refuse a new concrete entry. Scope concerns apply when a section ` +
-    `already has many similar items — not when it has room for a genuinely new one.\n\n` +
+    `already has many similar items — not when it has room for a genuinely new one.\n` +
+    `- Match the existing page's level of detail. If the page covers a topic in a single line or brief entry, the source ` +
+    `must add something at that same grain. Do not use committed when the update would expand a one-line entry into a ` +
+    `paragraph — that is no_change_extra.\n\n` +
     `When in doubt between committing and no_change, prefer no_change_extra.\n\n` +
     `Respond with JSON only: {"label":"<one of the labels>","reasoning":"<1-2 sentences>"}`,
   ].join("\n\n");

--- a/backend/scripts/eval_labeler.html
+++ b/backend/scripts/eval_labeler.html
@@ -901,7 +901,7 @@ async function judgeSample(sample) {
     `- Use no_change_covered or no_change_extra when the source is topically related but adds nothing useful. ` +
     `Reserve irrelevant for sources with no connection to the page's topic whatsoever.\n` +
     `- A source about a different product that uses the same technology is not relevant — the page must cover the same specific system.\n` +
-    `- A HubSpot source that contains only contact info (name, email, job title, domain) or deal metadata (stage, amount, close date) ` +
+    `- A source that contains only contact info (name, email, job title, domain) or deal metadata (stage, amount, close date) ` +
     `with no call notes, transcript, or stated next steps is irrelevant when pushed against a task-tracking page — not no_change_covered. ` +
     `Only evaluate it as committed or no_change if the source includes a call summary or explicit action items.\n` +
     `- A conversational source (Slack, chat) that surfaces a potential issue or cc's team members tracked on the page ` +


### PR DESCRIPTION
## Summary

Findings from mismatch analysis of 2,305 prod eval samples (IDs 2894–5198), comparing system outcome, LLM judge label, and human label.

**Reconciler (`ingest_batch_reconciler.system.md`)**

- **Detail-level matching**: if the page covers a topic in a single line or brief phrase, the edit must stay at that same grain — don't expand to a paragraph because the source has more depth. The scope check already gestured at this ("at what level of detail?") but was not actionable.
- **New-deal carve-out**: the "multiple similar items → no_change" rule was blocking 5 genuine new deals from being added to `team-todos.md` (CSEE, Lendable, CZI, Craftzing ×2 — all new companies with call summaries and concrete next steps). Added: "A deal or company not yet mentioned anywhere on the page is a new entry, not a similar item."

**Judge (`eval_labeler.html`)**

- **Bare-record rule**: the dominant judge error was labeling bare HubSpot contact/deal records (name, email, domain, no call notes) as `no_change_covered` instead of `irrelevant`. The reconciler prompt has this rule explicitly; the judge prompt did not. Fixes 19 of 22 judge-vs-label mismatches.
- **Detail-level matching**: mirror the reconciler rule — if the update would expand a one-line entry into a paragraph, use `no_change_extra`, not `committed`.

## Test plan

- [ ] Re-run judge over bare HubSpot contact samples — expect `irrelevant` instead of `no_change_covered`
- [ ] Spot-check reconciler on new-deal HubSpot call summaries — expect `committed` for new companies not yet on page
- [ ] Verify no regression on existing committed cases