### PR TITLE
fix(wiki): reconcile agent write drift via 3-way merge, not re-derive

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -112,7 +112,7 @@ def get_document_by_path(
         historical = wiki_git.path_at_ref(rel, ref) or rel
         try:
             body = wiki_git.read_file(historical, ref=ref)
-        except subprocess.CalledProcessError as exc:
+        except wiki_git.UnknownSha as exc:
             raise HTTPException(status_code=404, detail="not found at ref") from exc
         return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref)
     abs_path = filesystem.absolute(rel)
@@ -659,7 +659,7 @@ def merge_draft(
     require_can("write", rel, user)
     try:
         base_body = wiki_git.read_file(rel, ref=req.base_sha)
-    except subprocess.CalledProcessError as exc:
+    except wiki_git.UnknownSha as exc:
         raise HTTPException(status_code=404, detail="base revision not found") from exc
     # Fetch the most recent commit message so the LLM can reference it when
     # annotating conflicting facts (e.g. "12k from fix: update connection limit").

--- a/backend/app/llm/agents/tools/apply_patch.json
+++ b/backend/app/llm/agents/tools/apply_patch.json
@@ -18,13 +18,13 @@
       },
       "base_sha": {
         "type": "string",
-        "description": "Optional SHA the patch was authored against. If set and HEAD has moved, returns `stale_base` with the current sha and the diff since `base_sha` so you can rebase. Omit only if you've just read HEAD."
+        "description": "REQUIRED — the sha you read the doc at, which the patch's line numbers are anchored to. The patch is applied against that commit (so the anchors are exact), then 3-way merged against current HEAD, so a concurrent change is reconciled rather than clobbered. Without it, returns `base_sha_required`; if it doesn't resolve to a real commit, returns `base_sha_not_found` — re-read and pass the current sha."
       },
       "expires_in_seconds": {
         "type": "integer",
         "description": "Optional. How long (in seconds) you anticipate continuing to work on this file or feature before you're done. Sets the TTL on your row in the Active agents list, replacing the 24h default. You only have ONE row in the list at a time per (user, agent), so the latest write's value wins. Range: 60 to 604800 (7 days)."
       }
     },
-    "required": ["path", "patch", "commit_message"]
+    "required": ["path", "patch", "commit_message", "base_sha"]
   }
 }

--- a/backend/app/llm/agents/tools/apply_patch.py
+++ b/backend/app/llm/agents/tools/apply_patch.py
@@ -2,17 +2,19 @@
 
 Line-anchored unified-diff editor. Calls into ``app.wiki.patch.apply``
 which does the parsing, line-anchored match, and fuzzy fallback. This
-handler is the tool-side adapter: argument validation, optional
-``base_sha`` staleness check, commit + fan-out.
+handler is the tool-side adapter: argument validation, applying the
+patch against its base, commit + fan-out.
 """
 from __future__ import annotations
 
 from typing import Any
 
 from app.wiki import utils as wiki_utils
+from app.wiki import git as wiki_git
 from app.llm.agents.tools.errors import ToolError
+from app.llm.errors import LLMError
 from app.wiki import patch as wiki_patch
-from app.models.wiki import ChangeKind
+from app.models.wiki import ChangeKind, CommitMaxRetriesError
 
 
 def handle(args: dict[str, Any]) -> Any:
@@ -26,43 +28,68 @@ def handle(args: dict[str, Any]) -> Any:
             raise ToolError("patch is required (non-empty string)")
         if not isinstance(commit_message, str) or not commit_message.strip():
             raise ToolError("commit_message is required")
-        if base_sha is not None and not isinstance(base_sha, str):
-            raise ToolError("base_sha must be a string when provided")
+        if not isinstance(base_sha, str) or not base_sha.strip():
+            return {
+                "error": "base_sha_required",
+                "message": (
+                    "base_sha is required: the patch is applied against the "
+                    "commit it was authored on, then 3-way merged against HEAD. "
+                    "Read the doc and pass its sha as base_sha."
+                ),
+            }
 
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        stale = wiki_utils.assert_base_sha(path, base_sha)
-        if stale is not None:
-            return stale
-
-        old_body = wiki_utils.read_existing(path)
+        # base_sha is the patch's true base: applying the hunks there keeps the
+        # line anchors valid, yielding a full body that commit_and_fan_out
+        # 3-way merges against current HEAD.
         try:
-            new_body = wiki_patch.apply(old_body, patch)
+            base_body = wiki_git.read_file(path, ref=base_sha)
+        except wiki_git.UnknownSha:
+            return {
+                "error": "base_sha_not_found",
+                "message": (
+                    "base_sha does not resolve to a known commit; "
+                    "re-read the doc and pass its sha as base_sha."
+                ),
+            }
+
+        try:
+            new_body = wiki_patch.apply(base_body, patch)
         except wiki_patch.PatchError as exc:
             raise ToolError(str(exc))
 
-        if new_body == old_body:
+        if new_body == base_body:
             raise ToolError(
                 "patch produced no change (every hunk was a no-op)"
             )
 
-        # Intentionally no merge here: unified diff hunks are line-anchored, so
-        # a 3-way merge after a concurrent edit would produce wrong offsets.
-        # Callers should pass base_sha and retry on stale_base. With no
-        # base_body, commit_and_fan_out commits as-is and never returns None.
-        result = wiki_utils.commit_and_fan_out(
-            path=path, body=new_body, message=commit_message.strip(),
-            change_kind=ChangeKind.EDIT, activity_ttl=activity_ttl,
-        )
+        try:
+            result = wiki_utils.commit_and_fan_out(
+                path=path, body=new_body, message=commit_message.strip(),
+                change_kind=ChangeKind.EDIT,
+                base_body=base_body,
+                ai_merge=True,
+                activity_ttl=activity_ttl,
+            )
+        except CommitMaxRetriesError as exc:
+            return {
+                "error": "stale_base",
+                "message": "concurrent edits kept landing; max retries exceeded",
+                "current_sha": exc.current_sha,
+            }
+        except LLMError as exc:
+            return {"error": f"llm_error: {exc}"}
+
         if result is None:
-            raise RuntimeError("commit_and_fan_out returned None on a no-base commit")
+            return {"path": path, "sha": wiki_git.head_sha_for_path(path), "no_change": True}
 
         return {
             "path": path,
             "sha": result.sha,
-            "diff": wiki_utils.unified_diff(old_body, new_body, path),
-            "broken_links": wiki_utils.broken_links(path, new_body),
+            "diff": wiki_utils.unified_diff(result.old_body, result.new_body, path),
+            "broken_links": wiki_utils.broken_links(path, result.new_body),
         }
     except ToolError as exc:
         return {"error": str(exc)}

--- a/backend/app/llm/agents/tools/edit_doc.json
+++ b/backend/app/llm/agents/tools/edit_doc.json
@@ -24,10 +24,6 @@
         "type": "string",
         "description": "Short commit message summarizing the change."
       },
-      "base_sha": {
-        "type": "string",
-        "description": "Optional. The sha you last read for `path` (returned by `read_doc`). When set, the edit aborts with `stale_base` if HEAD has moved since — re-read with `read_doc` and retry. Strongly recommended over MCP; the chat agent can omit it (the loop has direct state)."
-      },
       "expires_in_seconds": {
         "type": "integer",
         "description": "Optional. How long (in seconds) you anticipate continuing to work on this file or feature before you're done. Sets the TTL on your row in the Active agents list, replacing the 24h default — use a smaller value for a focused short session, a larger one when you expect to be on the same task for hours. You only have ONE row in the list at a time per (user, agent), so the latest write's value wins. Range: 60 to 604800 (7 days)."

--- a/backend/app/llm/agents/tools/edit_doc.py
+++ b/backend/app/llm/agents/tools/edit_doc.py
@@ -32,10 +32,9 @@ def handle(args: dict[str, Any]) -> Any:
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        # No staleness bail: the replace targets current content, and any
-        # concurrent commit landing mid-flight is reconciled by the 3-way
-        # merge in commit_and_fan_out. A vanished anchor surfaces as a
-        # ReplaceError below.
+        # The replace targets current content; concurrent drift is reconciled
+        # by the 3-way merge in commit_and_fan_out, and a vanished anchor
+        # surfaces as a ReplaceError below.
         base_body = wiki_utils.read_existing(path)
         try:
             new_body = wiki_edit.replace(base_body, old_string, new_string, replace_all)

--- a/backend/app/llm/agents/tools/edit_doc.py
+++ b/backend/app/llm/agents/tools/edit_doc.py
@@ -20,7 +20,6 @@ def handle(args: dict[str, Any]) -> Any:
         old_string = args.get("old_string")
         new_string = args.get("new_string")
         commit_message = args.get("commit_message")
-        base_sha = args.get("base_sha")
         activity_ttl = wiki_utils.parse_expires_in_seconds(args.get("expires_in_seconds"))
         if not isinstance(old_string, str) or old_string == "":
             raise ToolError("old_string is required and must be non-empty")
@@ -28,17 +27,15 @@ def handle(args: dict[str, Any]) -> Any:
             raise ToolError("new_string is required (string)")
         if not isinstance(commit_message, str) or not commit_message.strip():
             raise ToolError("commit_message is required")
-        if base_sha is not None and not isinstance(base_sha, str):
-            raise ToolError("base_sha must be a string when provided")
         replace_all = bool(args.get("replace_all", False))
 
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        stale = wiki_utils.assert_base_sha(path, base_sha)
-        if stale is not None:
-            return stale
-
+        # No staleness bail: the replace targets current content, and any
+        # concurrent commit landing mid-flight is reconciled by the 3-way
+        # merge in commit_and_fan_out. A vanished anchor surfaces as a
+        # ReplaceError below.
         base_body = wiki_utils.read_existing(path)
         try:
             new_body = wiki_edit.replace(base_body, old_string, new_string, replace_all)

--- a/backend/app/llm/agents/tools/multi_edit.json
+++ b/backend/app/llm/agents/tools/multi_edit.json
@@ -35,10 +35,6 @@
         "type": "string",
         "description": "Short commit message summarizing the overall change."
       },
-      "base_sha": {
-        "type": "string",
-        "description": "Optional. The sha you last read for `path`. When set, the batch aborts with `stale_base` if HEAD has moved since."
-      },
       "expires_in_seconds": {
         "type": "integer",
         "description": "Optional. How long (in seconds) you anticipate continuing to work on this file or feature before you're done. Sets the TTL on your row in the Active agents list, replacing the 24h default. You only have ONE row in the list at a time per (user, agent), so the latest write's value wins. Range: 60 to 604800 (7 days)."

--- a/backend/app/llm/agents/tools/multi_edit.py
+++ b/backend/app/llm/agents/tools/multi_edit.py
@@ -50,9 +50,9 @@ def handle(args: dict[str, Any]) -> Any:
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        # No staleness bail: edits target current content, and any concurrent
-        # commit landing mid-flight is reconciled by the 3-way merge in
-        # commit_and_fan_out. A vanished anchor surfaces as a ReplaceError.
+        # Edits target current content; concurrent drift is reconciled by the
+        # 3-way merge in commit_and_fan_out, and a vanished anchor surfaces as
+        # a ReplaceError.
         base_body = wiki_utils.read_existing(path)
         new_body = base_body
         try:

--- a/backend/app/llm/agents/tools/multi_edit.py
+++ b/backend/app/llm/agents/tools/multi_edit.py
@@ -26,14 +26,11 @@ def handle(args: dict[str, Any]) -> Any:
         path = wiki_utils.validate_doc_path(args.get("path"))
         edits_raw = args.get("edits")
         commit_message = args.get("commit_message")
-        base_sha = args.get("base_sha")
         activity_ttl = wiki_utils.parse_expires_in_seconds(args.get("expires_in_seconds"))
         if not isinstance(edits_raw, list) or not edits_raw:
             raise ToolError("edits must be a non-empty array")
         if not isinstance(commit_message, str) or not commit_message.strip():
             raise ToolError("commit_message is required")
-        if base_sha is not None and not isinstance(base_sha, str):
-            raise ToolError("base_sha must be a string when provided")
         edits = cast(list[Any], edits_raw)
 
         # Validate edit shapes up front before touching disk.
@@ -53,10 +50,9 @@ def handle(args: dict[str, Any]) -> Any:
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        stale = wiki_utils.assert_base_sha(path, base_sha)
-        if stale is not None:
-            return stale
-
+        # No staleness bail: edits target current content, and any concurrent
+        # commit landing mid-flight is reconciled by the 3-way merge in
+        # commit_and_fan_out. A vanished anchor surfaces as a ReplaceError.
         base_body = wiki_utils.read_existing(path)
         new_body = base_body
         try:

--- a/backend/app/llm/agents/tools/read_doc.py
+++ b/backend/app/llm/agents/tools/read_doc.py
@@ -5,7 +5,6 @@ accepts an optional ``sha`` for historical reads.
 """
 from __future__ import annotations
 
-import subprocess
 from typing import Any
 
 from app.wiki import utils as wiki_utils
@@ -38,7 +37,7 @@ def handle(args: dict[str, Any]) -> Any:
     ref = sha or "HEAD"
     try:
         body = wiki_git.read_file(path, ref=ref)
-    except subprocess.CalledProcessError:
+    except wiki_git.UnknownSha:
         return {
             "error": (
                 f"sha_not_found: {path} not present at {ref}"

--- a/backend/app/llm/agents/tools/update_doc_nl.json
+++ b/backend/app/llm/agents/tools/update_doc_nl.json
@@ -12,10 +12,6 @@
         "type": "string",
         "description": "Natural-language description of the desired change. Specific is better — name the section, the value to update, what 'done' means."
       },
-      "base_sha": {
-        "type": "string",
-        "description": "Optional SHA the instruction was authored against. If set and HEAD has moved, returns `stale_base` so you can re-read and re-issue."
-      },
       "idempotency_key": {
         "type": "string",
         "description": "Optional. Over MCP this collapses retries of the same instruction onto the same `job_id` (the second call returns the existing job, `deduplicated=true`). When omitted, the server defaults to `sha256(user_id|path|instruction)` so an agent that doesn't mint its own key still gets dedupe semantics. Ignored on the in-process chat surface (which is sync)."

--- a/backend/app/llm/agents/tools/update_doc_nl.py
+++ b/backend/app/llm/agents/tools/update_doc_nl.py
@@ -32,9 +32,8 @@ def handle(args: dict[str, Any]) -> Any:
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        # No staleness bail: the sub-agent regenerates from current content, and
-        # any concurrent commit landing mid-flight is reconciled by the 3-way
-        # merge in commit_and_fan_out.
+        # The sub-agent regenerates from current content; concurrent drift is
+        # reconciled by the 3-way merge in commit_and_fan_out.
         head_sha = wiki_git.head_sha_for_path(path)
 
         old_body = wiki_utils.read_existing(path)

--- a/backend/app/llm/agents/tools/update_doc_nl.py
+++ b/backend/app/llm/agents/tools/update_doc_nl.py
@@ -25,20 +25,16 @@ def handle(args: dict[str, Any]) -> Any:
     try:
         path = wiki_utils.validate_doc_path(args.get("path"))
         instruction = args.get("instruction")
-        base_sha = args.get("base_sha")
         activity_ttl = wiki_utils.parse_expires_in_seconds(args.get("expires_in_seconds"))
         if not isinstance(instruction, str) or not instruction.strip():
             raise ToolError("instruction is required (non-empty string)")
-        if base_sha is not None and not isinstance(base_sha, str):
-            raise ToolError("base_sha must be a string when provided")
 
         if not wiki_utils.file_exists(path):
             raise ToolError(f"file not found: {path}")
 
-        stale = wiki_utils.assert_base_sha(path, base_sha)
-        if stale is not None:
-            return stale
-
+        # No staleness bail: the sub-agent regenerates from current content, and
+        # any concurrent commit landing mid-flight is reconciled by the 3-way
+        # merge in commit_and_fan_out.
         head_sha = wiki_git.head_sha_for_path(path)
 
         old_body = wiki_utils.read_existing(path)

--- a/backend/app/llm/agents/tools/write_doc.json
+++ b/backend/app/llm/agents/tools/write_doc.json
@@ -18,7 +18,7 @@
       },
       "base_sha": {
         "type": "string",
-        "description": "REQUIRED when overwriting an existing file (the sha you last read). Optional for new-file creates. Without it on an overwrite, returns `base_sha_required_for_overwrite` — full-body overwrite has no fuzzy fallback so the staleness check can't be skipped."
+        "description": "REQUIRED when overwriting an existing file (the sha you last read). Optional for new-file creates. It is the merge base: if HEAD moved since, your body is 3-way merged against the concurrent change rather than clobbering it. Without it on an overwrite, returns `base_sha_required_for_overwrite`; if it doesn't resolve to a real commit, returns `base_sha_not_found` — re-read and pass the current sha."
       },
       "expires_in_seconds": {
         "type": "integer",

--- a/backend/app/llm/agents/tools/write_doc.py
+++ b/backend/app/llm/agents/tools/write_doc.py
@@ -42,10 +42,19 @@ def handle(args: dict[str, Any]) -> Any:
                         "pass its sha as base_sha."
                     ),
                 }
-            stale = wiki_utils.assert_base_sha(path, base_sha)
-            if stale is not None:
-                return stale
-            base_body = wiki_git.read_file(path, ref=base_sha)
+            # Drift is reconciled by the 3-way merge inside commit_and_fan_out
+            # (base_sha is the merge base) rather than bailing here. base_sha
+            # must still resolve to a real commit to serve as that base.
+            try:
+                base_body = wiki_git.read_file(path, ref=base_sha)
+            except wiki_git.UnknownSha:
+                return {
+                    "error": "base_sha_not_found",
+                    "message": (
+                        "base_sha does not resolve to a known commit; "
+                        "re-read the doc and pass its sha as base_sha."
+                    ),
+                }
             try:
                 result = wiki_utils.commit_and_fan_out(
                     path=path, body=body, message=commit_message.strip(),

--- a/backend/app/llm/agents/tools/write_doc.py
+++ b/backend/app/llm/agents/tools/write_doc.py
@@ -42,9 +42,9 @@ def handle(args: dict[str, Any]) -> Any:
                         "pass its sha as base_sha."
                     ),
                 }
-            # Drift is reconciled by the 3-way merge inside commit_and_fan_out
-            # (base_sha is the merge base) rather than bailing here. base_sha
-            # must still resolve to a real commit to serve as that base.
+            # base_sha is the merge base: the 3-way merge inside
+            # commit_and_fan_out reconciles drift against it, so it must
+            # resolve to a real commit.
             try:
                 base_body = wiki_git.read_file(path, ref=base_sha)
             except wiki_git.UnknownSha:

--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -179,7 +179,6 @@ def _call_async_nl_update(
     # ---- Validate ----
     raw_path = arguments.get("path")
     instruction = arguments.get("instruction")
-    base_sha = arguments.get("base_sha")
     idempotency_key = arguments.get("idempotency_key")
 
     try:
@@ -189,12 +188,6 @@ def _call_async_nl_update(
     if not isinstance(instruction, str) or not instruction.strip():
         return (
             {"error": "instruction is required (non-empty string)",
-             "stale_paths": _compute_stale_paths(sess)},
-            True,
-        )
-    if base_sha is not None and not isinstance(base_sha, str):
-        return (
-            {"error": "base_sha must be a string when provided",
              "stale_paths": _compute_stale_paths(sess)},
             True,
         )
@@ -249,7 +242,6 @@ def _call_async_nl_update(
     payload: dict[str, Any] = {
         "path": rel,
         "instruction": instruction.strip(),
-        "base_sha": base_sha,
         "head_at_enqueue": head_sha,
         "agent_name": agent_activity.agent_name_var.get(),
     }

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -33,7 +33,6 @@ from __future__ import annotations
 
 import json
 import logging
-import subprocess
 
 from datetime import datetime, timezone
 
@@ -287,7 +286,7 @@ def _read_at(ref: str, rel_path: str) -> str:
     """Read ``rel_path`` at git ``ref``. Empty string if missing or parent-less."""
     try:
         return wiki_git.read_file(rel_path, ref=ref)
-    except subprocess.CalledProcessError:
+    except wiki_git.UnknownSha:
         log.debug("read_at miss ref=%s path=%s", ref, rel_path)
         return ""
 

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -90,16 +90,16 @@ def agent_update_document_nl(job_id: str) -> None:
       2. Reconstitute ``g.user`` from ``mcp_jobs.user_id`` so every
          downstream helper sees the right principal — same seam the
          POST handler uses.
-      3. ``base_sha`` recheck — HEAD might have moved between enqueue
-         and run. Fail with ``stale_base`` if so.
-      4. Server-side debounce — if a same-(user, path) job committed
+      3. Server-side debounce — if a same-(user, path) job committed
          within ``MCP_NL_DEBOUNCE_SECONDS``, succeed with
          ``committed=false reason=debounced``.
-      5. Run the document-updater agent.
-      6. ``NO_CHANGE`` → succeed with ``committed=false``.
+      4. Run the document-updater agent.
+      5. ``NO_CHANGE`` → succeed with ``committed=false``.
          New body → ``commit_and_fan_out`` → succeed with the sha.
+         Concurrent drift between enqueue and run is reconciled by the
+         3-way merge there, not rejected.
          Exception → fail with the error code.
-      7. Publish the terminal status to ``job://<id>`` subscribers.
+      6. Publish the terminal status to ``job://<id>`` subscribers.
     """
     job = mcp_jobs.get(job_id)
     if job is None:
@@ -109,7 +109,6 @@ def agent_update_document_nl(job_id: str) -> None:
     payload = job["payload"]
     rel = payload.get("path")
     instruction = payload.get("instruction") or ""
-    base_sha = payload.get("base_sha")
     agent_name = payload.get("agent_name")
 
     try:
@@ -118,7 +117,7 @@ def agent_update_document_nl(job_id: str) -> None:
         try:
             with set_current_user(user):
                 mcp_jobs.mark_running(job_id)
-                _run_inner(job_id, rel, instruction, base_sha)
+                _run_inner(job_id, rel, instruction)
         finally:
             agent_activity.agent_name_var.reset(agent_token)
     except UserMissingError as exc:
@@ -131,7 +130,7 @@ def agent_update_document_nl(job_id: str) -> None:
         mcp_pubsub.publish_job_update(job_id, "failed")
 
 
-def _run_inner(job_id: str, rel: str, instruction: str, base_sha: str | None) -> None:
+def _run_inner(job_id: str, rel: str, instruction: str) -> None:
     """Inside the worker's user context. Splits out so the outer
     function can wrap exceptions uniformly."""
     if not rel:
@@ -144,19 +143,10 @@ def _run_inner(job_id: str, rel: str, instruction: str, base_sha: str | None) ->
         mcp_pubsub.publish_job_update(job_id, "failed")
         return
 
+    # No stale_base recheck: the sub-agent regenerates from current content and
+    # any concurrent commit between enqueue and run is reconciled by the 3-way
+    # merge in commit_and_fan_out below (base_body + ai_merge).
     head_sha = wiki_git.head_sha_for_path(rel)
-    if base_sha and base_sha != head_sha:
-        log.info(
-            "wiki_update: stale_base %s (base=%s head=%s)",
-            rel, base_sha[:8], (head_sha or "")[:8],
-        )
-        mcp_jobs.mark_failed(
-            job_id,
-            error="stale_base",
-            result={"base_sha": base_sha, "current_sha": head_sha or ""},
-        )
-        mcp_pubsub.publish_job_update(job_id, "failed")
-        return
 
     debounced = mcp_jobs.find_recent_succeeded_for_user_path(
         user_id=_current_user_id(), path=rel, within_seconds=_DEBOUNCE_SECONDS

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -96,8 +96,8 @@ def agent_update_document_nl(job_id: str) -> None:
       4. Run the document-updater agent.
       5. ``NO_CHANGE`` → succeed with ``committed=false``.
          New body → ``commit_and_fan_out`` → succeed with the sha.
-         Concurrent drift between enqueue and run is reconciled by the
-         3-way merge there, not rejected.
+         Drift between enqueue and run is reconciled by the 3-way
+         merge there.
          Exception → fail with the error code.
       6. Publish the terminal status to ``job://<id>`` subscribers.
     """
@@ -143,9 +143,9 @@ def _run_inner(job_id: str, rel: str, instruction: str) -> None:
         mcp_pubsub.publish_job_update(job_id, "failed")
         return
 
-    # No stale_base recheck: the sub-agent regenerates from current content and
-    # any concurrent commit between enqueue and run is reconciled by the 3-way
-    # merge in commit_and_fan_out below (base_body + ai_merge).
+    # The sub-agent regenerates from current content; drift between enqueue and
+    # run is reconciled by the 3-way merge in commit_and_fan_out below
+    # (base_body + ai_merge).
     head_sha = wiki_git.head_sha_for_path(rel)
 
     debounced = mcp_jobs.find_recent_succeeded_for_user_path(

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -259,8 +259,16 @@ def delete_path(rel_path: str, message: str, author: str | None = None) -> str:
 
 
 def read_file(rel_path: str, ref: str = "HEAD") -> str:
-    """Read file contents at a given git ref. Default: working tree's last commit."""
-    return _run(["show", f"{ref}:{rel_path}"]).stdout
+    """Read file contents at a given git ref. Default: working tree's last commit.
+
+    Raises ``UnknownSha`` when ``ref`` (or the path at that ref) can't be
+    resolved, so callers get a typed error instead of a leaked
+    ``subprocess.CalledProcessError``.
+    """
+    try:
+        return _run(["show", f"{ref}:{rel_path}"]).stdout
+    except subprocess.CalledProcessError as e:
+        raise UnknownSha(ref) from e
 
 
 def path_at_ref(current_rel_path: str, ref: str) -> str | None:

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import difflib
 import logging
-import subprocess
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -401,7 +400,7 @@ def _read_head_or_empty(path: str) -> str:
     """Read ``path`` from the last git commit (HEAD), or ``""`` if not yet committed."""
     try:
         return wiki_git.read_file(path, ref="HEAD")
-    except subprocess.CalledProcessError:
+    except wiki_git.UnknownSha:
         return ""
 
 

--- a/backend/tests/test_doc_tools.py
+++ b/backend/tests/test_doc_tools.py
@@ -79,7 +79,38 @@ def test_write_doc_overwrite_without_base_sha_is_rejected(repo_with_doc):
     assert out["error"] == "base_sha_required_for_overwrite"
 
 
-def test_write_doc_overwrite_with_stale_base_sha_returns_stale_base(repo_with_doc):
+def test_write_doc_overwrite_with_stale_base_sha_merges(repo_with_doc):
+    """A stale ``base_sha`` no longer aborts: the new body is 3-way merged
+    against the concurrent change. Here the agent rewrites the Alpha section
+    while another writer appended a Gamma section — both survive."""
+    from app.llm.agents.tools.write_doc import handle
+    from app.wiki import git as wiki_git
+
+    base = wiki_git.head_sha_for_path("guide.md")
+    # Concurrent writer appends a non-overlapping section.
+    wiki_git.commit_file(
+        "guide.md",
+        "# Guide\n\nAlpha section.\n\nBeta section.\n\nGamma section.\n",
+        "concurrent",
+        author=None,
+    )
+
+    out = handle(
+        {
+            "path": "guide.md",
+            # Agent edited the Alpha line, basing off the pre-Gamma version.
+            "body": "# Guide\n\nAlpha section (revised).\n\nBeta section.\n",
+            "commit_message": "revise alpha",
+            "base_sha": base,
+        }
+    )
+    assert "error" not in out, out
+    merged = Path(repo_with_doc.wiki_dir, "guide.md").read_text()
+    assert "Alpha section (revised)." in merged  # the agent's change
+    assert "Gamma section." in merged  # the concurrent change was preserved
+
+
+def test_write_doc_overwrite_with_unknown_base_sha_returns_not_found(repo_with_doc):
     from app.llm.agents.tools.write_doc import handle
 
     out = handle(
@@ -90,9 +121,7 @@ def test_write_doc_overwrite_with_stale_base_sha_returns_stale_base(repo_with_do
             "base_sha": "deadbeef",
         }
     )
-    assert out["error"] == "stale_base"
-    assert out["base_sha"] == "deadbeef"
-    assert out["current_sha"]
+    assert out["error"] == "base_sha_not_found"
 
 
 def test_write_doc_rejects_non_md(repo_with_doc):

--- a/backend/tests/test_mcp_server_jobs.py
+++ b/backend/tests/test_mcp_server_jobs.py
@@ -303,38 +303,41 @@ def test_different_instructions_get_different_jobs(
 # --------------------------------------------------------------------------- #
 
 
-def test_update_doc_nl_stale_base_in_worker(
+def test_update_doc_nl_merges_concurrent_change_in_worker(
     client, llm_returns, immediate_documents
 ):
-    """The agent passes the base_sha it last read. Between enqueue and
-    the worker running, someone else commits — the worker's recheck
-    fails the job with stale_base."""
+    """A concurrent commit between enqueue and worker run no longer fails the
+    job. The sub-agent's regenerated body is 3-way merged against the
+    concurrent change, so the job succeeds and commits."""
     uid = seed_user(uid="u1", email="u1@x.com")
-    wiki_git.commit_file("doc.md", "# v1\n", "v1", author=None)
+    wiki_git.commit_file("doc.md", "# Doc\n\nAlpha.\n\nBeta.\n", "v1", author=None)
 
     headers, _ = _handshake(client, _mint(uid))
-    stale = _read_doc(client, headers, "doc.md")["sha"]
+    _read_doc(client, headers, "doc.md")
 
-    # Someone else commits — HEAD advances past the agent's read.
-    wiki_git.commit_file("doc.md", "# v2\n", "v2", author=None)
+    # Someone else commits a non-overlapping change — HEAD advances. The worker
+    # reads this current body and hands it to the sub-agent.
+    wiki_git.commit_file("doc.md", "# Doc\n\nAlpha.\n\nBeta.\n\nGamma.\n", "v2", author=None)
 
-    llm_returns("# v3\n")
+    # Sub-agent revises Alpha against the current (post-Gamma) body.
+    llm_returns("# Doc\n\nAlpha (revised).\n\nBeta.\n\nGamma.\n")
 
     payload, is_error = _call_tool(
         client,
         headers,
         "update_doc_nl",
-        {"path": "doc.md", "instruction": "rewrite", "base_sha": stale},
+        {"path": "doc.md", "instruction": "revise alpha"},
     )
-    # Enqueue itself succeeds — the failure happens in the worker.
     assert not is_error, payload
 
     job = mcp_jobs_repo.get(payload["job_id"])
     assert job is not None
-    assert job["status"] == "failed"
-    assert job["error"] == "stale_base"
-    assert job["result"]["base_sha"] == stale
-    assert job["result"]["current_sha"] != stale
+    assert job["status"] == "succeeded", job
+    assert job["result"]["committed"] is True
+
+    merged = wiki_git.read_file("doc.md")
+    assert "Alpha (revised)." in merged
+    assert "Gamma." in merged  # the concurrent change was preserved
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_mcp_server_writes.py
+++ b/backend/tests/test_mcp_server_writes.py
@@ -1,10 +1,10 @@
 """End-to-end tests for the Phase 4 write surface over MCP.
 
 Covers the full handshake → read → edit-with-base_sha → success flow,
-plus the staleness contract (`stale_base` rejection on drift), the
-`base_sha_required_for_overwrite` rule for ``write_doc``, ACL
-enforcement on writes, and the always-present ``stale_paths`` field
-on tool results.
+the merge-through behavior on drift (a stale ``base_sha`` reconciles
+rather than rejecting), the `base_sha_required_for_overwrite` rule for
+``write_doc``, ACL enforcement on writes, and the always-present
+``stale_paths`` field on tool results.
 """
 from __future__ import annotations
 
@@ -119,7 +119,10 @@ def test_edit_doc_with_correct_base_sha_succeeds(client):
     assert "before" not in new_body
 
 
-def test_edit_doc_with_stale_base_sha_returns_stale_base(client):
+def test_edit_doc_applies_over_concurrent_change(client):
+    """A stale ``base_sha`` no longer aborts the edit: ``edit_doc`` targets the
+    current body, so the replace lands on top of the concurrent commit and the
+    other writer's change survives."""
     uid = seed_user(uid="u1", email="u1@x.com")
     wiki_git.commit_file("guide.md", "# v1\nbefore\n", "v1", author=None)
 
@@ -141,10 +144,13 @@ def test_edit_doc_with_stale_base_sha_returns_stale_base(client):
             "base_sha": stale,
         },
     )
-    assert is_error
-    assert payload["error"] == "stale_base"
-    assert payload["base_sha"] == stale
-    assert payload["current_sha"] != stale
+    assert not is_error, payload
+    assert payload["sha"] != stale
+
+    new_body = wiki_git.read_file("guide.md")
+    assert "after" in new_body
+    assert "before" not in new_body
+    assert "# v2" in new_body  # the concurrent change was preserved
 
 
 def test_edit_doc_without_base_sha_still_works_via_mcp(client):

--- a/backend/tests/test_mcp_server_writes.py
+++ b/backend/tests/test_mcp_server_writes.py
@@ -274,6 +274,64 @@ def test_apply_patch_with_correct_base_sha(client):
     assert "second" not in body
 
 
+def test_apply_patch_merges_over_concurrent_change(client):
+    """A stale ``base_sha`` no longer aborts the patch: the hunk is applied
+    against ``base_sha`` (where its line anchors are exact) and the result is
+    3-way merged against HEAD, so a non-overlapping concurrent edit survives."""
+    uid = seed_user(uid="u1", email="u1@x.com")
+    wiki_git.commit_file("p.md", "first\nsecond\nthird\n", "seed", author=None)
+
+    headers = _handshake(client, _mint(uid))
+    stale = _read(client, headers, "p.md")["sha"]
+
+    # Someone else appends a line at the end, past the hunk's region.
+    wiki_git.commit_file("p.md", "first\nsecond\nthird\nfourth\n", "append", author=None)
+
+    diff = (
+        "--- a/p.md\n"
+        "+++ b/p.md\n"
+        "@@ -1,3 +1,3 @@\n"
+        " first\n"
+        "-second\n"
+        "+SECOND\n"
+        " third\n"
+    )
+    payload, is_error = _call(
+        client,
+        headers,
+        "apply_patch",
+        {
+            "path": "p.md",
+            "patch": diff,
+            "commit_message": "uppercase second over concurrent append",
+            "base_sha": stale,
+        },
+    )
+    assert not is_error, payload
+    assert payload["sha"] != stale
+
+    body = wiki_git.read_file("p.md")
+    assert "SECOND" in body
+    assert "second" not in body
+    assert "fourth" in body  # the concurrent append was preserved
+
+
+def test_apply_patch_without_base_sha_is_rejected(client):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    wiki_git.commit_file("p.md", "first\nsecond\nthird\n", "seed", author=None)
+
+    headers = _handshake(client, _mint(uid))
+    diff = "@@ -1,3 +1,3 @@\n first\n-second\n+SECOND\n third\n"
+    payload, is_error = _call(
+        client,
+        headers,
+        "apply_patch",
+        {"path": "p.md", "patch": diff, "commit_message": "no base"},
+    )
+    assert is_error, payload
+    assert payload["error"] == "base_sha_required"
+
+
 # --------------------------------------------------------------------------- #
 # write_doc — base_sha required on overwrite                                  #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

Agent write tools previously bailed with `stale_base` when HEAD moved past the sha the agent read, forcing it to re-read and re-derive the edit — duplicating the consolidation logic already in `commit_and_fan_out`'s 3-way merge. This drops the `assert_base_sha` re-derive gate from `write_doc`, `edit_doc`, `multi_edit`, `update_doc_nl`, and the MCP async-job worker so drift is reconciled in one place: a clean merge commits without a regenerate round-trip; an overlap goes to the AI merge. `write_doc` now uses `base_sha` purely as the merge base.

`apply_patch` is folded into the same path: it applies the patch against its true `base_sha` — where the line anchors are exact — then 3-way merges the materialized body against HEAD via `commit_and_fan_out`. You can't merge the *patch* (offsets become meaningless on drift), but you can merge the *result* of applying it at its base. `base_sha` is now **required** for `apply_patch` (a patch with no declared base can't be safely merged); missing → `base_sha_required`, unresolvable → `base_sha_not_found`. This removes the last per-tool consolidation path.

`read_file` now raises the typed `UnknownSha` instead of leaking `subprocess.CalledProcessError`.

## How Has This Been Tested?

Full backend suite passes; `ruff` and `basedpyright` clean. Rewrote the three tests that encoded the old `stale_base` contract to assert merge-through (the concurrent change is preserved). Added `test_apply_patch_merges_over_concurrent_change` (a patch on a stale base survives a concurrent append) and `test_apply_patch_without_base_sha_is_rejected`. The human `PUT /file` 409 conflict path is unchanged.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check