### PR TITLE
feat(wiki): mock-compliant share + transfer UI, folder sharing, admin groups/users

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -1,4 +1,5 @@
 """FastAPI port of ``app/api/admin.py`` (Phase 3)."""
+
 from __future__ import annotations
 
 import logging
@@ -7,6 +8,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException
 
 from app.auth import User, users as users_repo
+from app.auth import groups as groups_repo
 from app.auth.deps import require_admin
 from app.ingest import settings as ingest_settings
 from app.ingest.settings import IngestSettings
@@ -41,20 +43,22 @@ log = logging.getLogger(__name__)
 # --------------------------------------------------------------------------- #
 
 
-def _user_view(row: dict[str, Any]) -> AdminUserView:
+def _user_view(row: dict[str, Any], groups: list[str] | None = None) -> AdminUserView:
     return AdminUserView(
         id=row["id"],
         email=row["email"],
         name=row["name"],
         is_admin=bool(row["is_admin"]),
         created_at=row["created_at"],
+        groups=groups or [],
     )
 
 
 @router.get("/users", response_model=AdminUserListResponse)
 def list_users(_actor: User = Depends(require_admin)) -> AdminUserListResponse:
+    by_user = groups_repo.groups_by_user()
     return AdminUserListResponse(
-        users=[_user_view(r) for r in users_repo.list_all()],
+        users=[_user_view(r, by_user.get(r["id"], [])) for r in users_repo.list_all()],
     )
 
 
@@ -71,7 +75,10 @@ def update_user(
         raise HTTPException(status_code=400, detail="cannot demote the last admin")
     users_repo.set_admin(user_id, req.is_admin)
     log.info(
-        "admin: %s set is_admin=%s on user %s", actor.id, req.is_admin, user_id,
+        "admin: %s set is_admin=%s on user %s",
+        actor.id,
+        req.is_admin,
+        user_id,
     )
     row = users_repo.get_by_id(user_id)
     assert row is not None
@@ -161,10 +168,14 @@ def put_llm(
             return existing
         return sent
 
-    anthropic_key = _resolve_secret("anthropic_api_key", req.anthropic_api_key, current.anthropic_api_key)
+    anthropic_key = _resolve_secret(
+        "anthropic_api_key", req.anthropic_api_key, current.anthropic_api_key
+    )
     openai_key = _resolve_secret("openai_api_key", req.openai_api_key, current.openai_api_key)
     gemini_key = _resolve_secret("gemini_api_key", req.gemini_api_key, current.gemini_api_key)
-    ollama_base_url = _resolve_secret("ollama_base_url", req.ollama_base_url, current.ollama_base_url)
+    ollama_base_url = _resolve_secret(
+        "ollama_base_url", req.ollama_base_url, current.ollama_base_url
+    )
 
     new_provider_models = req.provider_models if "provider_models" in sent_fields else None
 
@@ -185,7 +196,9 @@ def put_llm(
     )
     log.info(
         "admin: %s updated llm settings provider=%s model=%s",
-        actor.id, provider, model,
+        actor.id,
+        provider,
+        model,
     )
     return _llm_view(llm_settings.get())
 
@@ -235,7 +248,9 @@ def put_web(
     )
     log.info(
         "admin: %s updated web settings serper_set=%s firecrawl_set=%s",
-        actor.id, bool(serper_key), bool(firecrawl_key),
+        actor.id,
+        bool(serper_key),
+        bool(firecrawl_key),
     )
     return _web_view(web_settings.get())
 
@@ -260,7 +275,8 @@ def get_ingest(_actor: User = Depends(require_admin)) -> IngestView:
 
 @router.put("/ingest", response_model=IngestView)
 def put_ingest(
-    req: IngestConfigRequest, actor: User = Depends(require_admin),
+    req: IngestConfigRequest,
+    actor: User = Depends(require_admin),
 ) -> IngestView:
     if req.max_doc_chars < _MIN_DOC_CHARS or req.max_doc_chars > _MAX_DOC_CHARS:
         raise HTTPException(
@@ -270,7 +286,8 @@ def put_ingest(
     ingest_settings.upsert(max_doc_chars=req.max_doc_chars)
     log.info(
         "admin: %s updated ingest settings max_doc_chars=%d",
-        actor.id, req.max_doc_chars,
+        actor.id,
+        req.max_doc_chars,
     )
     return _ingest_view(ingest_settings.get())
 
@@ -325,6 +342,9 @@ def put_braintrust(
     braintrust_settings.upsert(project=project, api_key=api_key, enabled=enabled)
     log.info(
         "admin: %s updated braintrust settings project=%s key_set=%s enabled=%s",
-        actor.id, project, bool(api_key), enabled,
+        actor.id,
+        project,
+        bool(api_key),
+        enabled,
     )
     return _braintrust_view(braintrust_settings.get())

--- a/backend/app/api/permissions.py
+++ b/backend/app/api/permissions.py
@@ -43,17 +43,20 @@ def list_groups(user: User = Depends(require_user)) -> GroupListResponse:
     Each group is enriched with member / page / folder counts for the
     groups list UI.
     """
-    rows = groups_repo.list_all() if user.is_admin else groups_repo.list_for_user(user.id)
-    counts = groups_repo.counts()
+    rows = (
+        groups_repo.list_all() if user.is_admin else groups_repo.list_for_user(user.id)
+    )
+    member_counts = groups_repo.member_counts()
+    grant_counts = acl.group_grant_counts()
     groups: list[GroupOut] = []
     for g in rows:
-        c = counts.get(g["id"], {})
+        grants = grant_counts.get(g["id"], {})
         groups.append(
             GroupOut(
                 **g,
-                member_count=c.get("members", 0),
-                page_count=c.get("pages", 0),
-                folder_count=c.get("folders", 0),
+                member_count=member_counts.get(g["id"], 0),
+                page_count=grants.get("pages", 0),
+                folder_count=grants.get("folders", 0),
             )
         )
     return GroupListResponse(groups=groups)
@@ -290,7 +293,10 @@ def transfer_ownership(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not _is_owner_or_admin(path, user):
         raise HTTPException(status_code=403, detail="forbidden")
-    if req.new_owner_user_id is not None and users_repo.get_by_id(req.new_owner_user_id) is None:
+    if (
+        req.new_owner_user_id is not None
+        and users_repo.get_by_id(req.new_owner_user_id) is None
+    ):
         raise HTTPException(status_code=404, detail="user not found")
     acl.transfer_owner(path, req.new_owner_user_id)
     log.info(

--- a/backend/app/api/permissions.py
+++ b/backend/app/api/permissions.py
@@ -1,7 +1,9 @@
 """FastAPI port of ``app/api/permissions.py`` (Phase 3)."""
+
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
@@ -36,16 +38,31 @@ log = logging.getLogger(__name__)
 
 @router.get("/groups", response_model=GroupListResponse)
 def list_groups(user: User = Depends(require_user)) -> GroupListResponse:
-    """Admin sees all groups; a regular user sees only the ones they're in."""
+    """Admin sees all groups; a regular user sees only the ones they're in.
+
+    Each group is enriched with member / page / folder counts for the
+    groups list UI.
+    """
     rows = groups_repo.list_all() if user.is_admin else groups_repo.list_for_user(user.id)
-    return GroupListResponse(groups=[GroupOut(**g) for g in rows])
+    counts = groups_repo.counts()
+    groups: list[GroupOut] = []
+    for g in rows:
+        c = counts.get(g["id"], {})
+        groups.append(
+            GroupOut(
+                **g,
+                member_count=c.get("members", 0),
+                page_count=c.get("pages", 0),
+                folder_count=c.get("folders", 0),
+            )
+        )
+    return GroupListResponse(groups=groups)
 
 
-@router.post(
-    "/groups", response_model=GroupOut, status_code=status.HTTP_201_CREATED
-)
+@router.post("/groups", response_model=GroupOut, status_code=status.HTTP_201_CREATED)
 def create_group(
-    req: GroupCreateRequest, actor: User = Depends(require_admin),
+    req: GroupCreateRequest,
+    actor: User = Depends(require_admin),
 ) -> GroupOut:
     try:
         gid = groups_repo.create(req.name, req.description, created_by_user_id=actor.id)
@@ -58,7 +75,8 @@ def create_group(
 
 @router.get("/groups/{group_id}", response_model=GroupMembersResponse)
 def get_group(
-    group_id: str, user: User = Depends(require_user),
+    group_id: str,
+    user: User = Depends(require_user),
 ) -> GroupMembersResponse:
     g = groups_repo.get(group_id)
     if g is None:
@@ -71,7 +89,8 @@ def get_group(
 
 @router.delete("/groups/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_group(
-    group_id: str, _actor: User = Depends(require_admin),
+    group_id: str,
+    _actor: User = Depends(require_admin),
 ) -> Response:
     if groups_repo.get(group_id) is None:
         raise HTTPException(status_code=404, detail="not found")
@@ -79,9 +98,7 @@ def delete_group(
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
-@router.post(
-    "/groups/{group_id}/members", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.post("/groups/{group_id}/members", status_code=status.HTTP_204_NO_CONTENT)
 def add_group_member(
     group_id: str,
     req: GroupMemberAddRequest,
@@ -100,7 +117,9 @@ def add_group_member(
     status_code=status.HTTP_204_NO_CONTENT,
 )
 def remove_group_member(
-    group_id: str, user_id: str, _actor: User = Depends(require_admin),
+    group_id: str,
+    user_id: str,
+    _actor: User = Depends(require_admin),
 ) -> Response:
     if groups_repo.get(group_id) is None:
         raise HTTPException(status_code=404, detail="not found")
@@ -131,7 +150,8 @@ def _is_owner_or_admin(path: str, user: User) -> bool:
 
 @router.get("/wiki/acl", response_model=AclListResponse)
 def list_acl(
-    path: str = Query(""), user: User = Depends(require_user),
+    path: str = Query(""),
+    user: User = Depends(require_user),
 ) -> AclListResponse:
     if not path:
         raise HTTPException(status_code=400, detail="path required")
@@ -141,11 +161,58 @@ def list_acl(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if not _can_share_path(path, user):
         raise HTTPException(status_code=403, detail="forbidden")
-    entries = [AclEntryOut(**e) for e in acl.list_for_path(path)]
+    owner_id = acl.get_owner(path)
+    rows = acl.list_for_path(path)
+    user_ids = {
+        e["principal_id"]
+        for e in rows
+        if e["principal_kind"] == "user" and e.get("principal_id") is not None
+    }
+    if owner_id is not None:
+        user_ids.add(owner_id)
+    group_ids = {
+        e["principal_id"]
+        for e in rows
+        if e["principal_kind"] == "group" and e.get("principal_id") is not None
+    }
+    users = users_repo.get_many(user_ids)
+    groups = groups_repo.get_many(group_ids)
+    entries = [_entry_out(e, users, groups) for e in rows]
+    owner_email = owner_name = None
+    if owner_id is not None:
+        owner = users.get(owner_id)
+        if owner is not None:
+            owner_email, owner_name = owner["email"], owner["name"]
     return AclListResponse(
         path=path,
-        owner_user_id=acl.get_owner(path),
+        owner_user_id=owner_id,
+        owner_email=owner_email,
+        owner_name=owner_name,
         entries=entries,
+    )
+
+
+def _entry_out(
+    e: dict[str, Any],
+    users: dict[str, dict[str, Any]],
+    groups: dict[str, dict[str, Any]],
+) -> AclEntryOut:
+    """Serialize an ACL row, resolving the principal to a display label."""
+    principal_email = principal_name = group_name = None
+    pid = e.get("principal_id")
+    if pid is not None and e["principal_kind"] == "user":
+        u = users.get(pid)
+        if u is not None:
+            principal_email, principal_name = u["email"], u["name"]
+    elif pid is not None and e["principal_kind"] == "group":
+        g = groups.get(pid)
+        if g is not None:
+            group_name = g["name"]
+    return AclEntryOut(
+        **e,
+        principal_email=principal_email,
+        principal_name=principal_name,
+        group_name=group_name,
     )
 
 
@@ -155,7 +222,8 @@ def list_acl(
     status_code=status.HTTP_201_CREATED,
 )
 def create_acl_entry(
-    req: AclGrantRequest, user: User = Depends(require_user),
+    req: AclGrantRequest,
+    user: User = Depends(require_user),
 ) -> AclGrantResponse:
     try:
         path = filesystem.safe_rel_path(req.resource_path)
@@ -187,7 +255,8 @@ def create_acl_entry(
 
 @router.delete("/wiki/acl/{entry_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_acl_entry(
-    entry_id: str, user: User = Depends(require_user),
+    entry_id: str,
+    user: User = Depends(require_user),
 ) -> Response:
     # We need the entry's resource_path to know whose owner-check to
     # apply. Fetch via the same code path the listing uses.
@@ -210,11 +279,10 @@ def delete_acl_entry(
 # --------------------------------------------------------------------------- #
 
 
-@router.post(
-    "/wiki/transfer-ownership", response_model=TransferOwnershipResponse
-)
+@router.post("/wiki/transfer-ownership", response_model=TransferOwnershipResponse)
 def transfer_ownership(
-    req: TransferOwnershipRequest, user: User = Depends(require_user),
+    req: TransferOwnershipRequest,
+    user: User = Depends(require_user),
 ) -> TransferOwnershipResponse:
     try:
         path = filesystem.safe_rel_path(req.path)
@@ -227,8 +295,10 @@ def transfer_ownership(
     acl.transfer_owner(path, req.new_owner_user_id)
     log.info(
         "ownership transferred path=%s new_owner=%s",
-        path, req.new_owner_user_id or "<cleared>",
+        path,
+        req.new_owner_user_id or "<cleared>",
     )
     return TransferOwnershipResponse(
-        path=path, owner_user_id=req.new_owner_user_id,
+        path=path,
+        owner_user_id=req.new_owner_user_id,
     )

--- a/backend/app/api/users.py
+++ b/backend/app/api/users.py
@@ -1,10 +1,13 @@
 """FastAPI port of ``app/api/users.py`` (Phase 2). All v0 stubs."""
+
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 
 from app.auth import User
+from app.auth import users as users_repo
 from app.auth.deps import require_user
+from app.models.users import UserLite, UserSearchResponse
 
 router = APIRouter()
 
@@ -12,6 +15,20 @@ router = APIRouter()
 @router.get("")
 def list_users(_user: User = Depends(require_user)) -> None:
     raise NotImplementedError
+
+
+@router.get("/search", response_model=UserSearchResponse)
+def search_users(
+    q: str = "",
+    limit: int = 20,
+    _user: User = Depends(require_user),
+) -> UserSearchResponse:
+    """Typeahead lookup for the share / transfer dialogs. Any signed-in
+    user may search so they can grant page access to colleagues by name
+    or email. Declared before ``/{user_id}`` so the literal path wins."""
+    limit = max(1, min(limit, 50))
+    rows = users_repo.search(q, limit)
+    return UserSearchResponse(users=[UserLite(**r) for r in rows])
 
 
 @router.post("")

--- a/backend/app/auth/groups.py
+++ b/backend/app/auth/groups.py
@@ -13,7 +13,7 @@ from typing import Any, Iterable
 
 from sqlalchemy import delete, func, select
 
-from app.db.models import AclEntry, Group, GroupMember, User
+from app.db.models import Group, GroupMember, User
 from app.db.session import session
 
 log = logging.getLogger(__name__)
@@ -115,7 +115,9 @@ def member_ids(group_id: str) -> list[str]:
     """User ids belonging to ``group_id``."""
     with session() as s:
         return list(
-            s.scalars(select(GroupMember.user_id).where(GroupMember.group_id == group_id)).all()
+            s.scalars(
+                select(GroupMember.user_id).where(GroupMember.group_id == group_id)
+            ).all()
         )
 
 
@@ -130,7 +132,8 @@ def members(group_id: str) -> list[dict[str, Any]]:
     with session() as s:
         rows = s.scalars(stmt).all()
         return [
-            {"id": u.id, "email": u.email, "name": u.name, "is_admin": u.is_admin} for u in rows
+            {"id": u.id, "email": u.email, "name": u.name, "is_admin": u.is_admin}
+            for u in rows
         ]
 
 
@@ -157,40 +160,28 @@ def group_ids_for_user(user_id: str) -> list[str]:
     expand a user into the set of group principals it satisfies."""
     with session() as s:
         return list(
-            s.scalars(select(GroupMember.group_id).where(GroupMember.user_id == user_id)).all()
+            s.scalars(
+                select(GroupMember.group_id).where(GroupMember.user_id == user_id)
+            ).all()
         )
 
 
-def counts() -> dict[str, dict[str, int]]:
-    """Per-group ``{members, pages, folders}`` for the groups list UI.
+def member_counts() -> dict[str, int]:
+    """Per-group member count (``group_members`` rows). One aggregate query,
+    no N+1. Groups with no members are absent (callers default to 0).
 
-    ``members`` = ``group_members`` rows; ``pages`` / ``folders`` =
-    ``acl_entries`` granted to the group, split by ``resource_kind``.
-    Two aggregate queries, no N+1. Groups with no members and no grants
-    are absent from the result (callers default missing entries to 0).
+    Page/folder grant counts live in ``app.wiki.acl.group_grant_counts`` so
+    all ACL-table reads stay inside the ACL module.
     """
-    out: dict[str, dict[str, int]] = {}
-
-    def _row(gid: str) -> dict[str, int]:
-        return out.setdefault(gid, {"members": 0, "pages": 0, "folders": 0})
-
     with session() as s:
-        for gid, n in s.execute(
-            select(GroupMember.group_id, func.count()).group_by(GroupMember.group_id)
-        ).all():
-            _row(gid)["members"] = int(n)
-        for gid, kind, n in s.execute(
-            select(AclEntry.principal_id, AclEntry.resource_kind, func.count())
-            .where(AclEntry.principal_kind == "group")
-            .group_by(AclEntry.principal_id, AclEntry.resource_kind)
-        ).all():
-            if gid is None:
-                continue
-            if kind == "page":
-                _row(gid)["pages"] = int(n)
-            elif kind == "folder":
-                _row(gid)["folders"] = int(n)
-    return out
+        return {
+            gid: int(n)
+            for gid, n in s.execute(
+                select(GroupMember.group_id, func.count()).group_by(
+                    GroupMember.group_id
+                )
+            ).all()
+        }
 
 
 def add_member(group_id: str, user_id: str) -> None:

--- a/backend/app/auth/groups.py
+++ b/backend/app/auth/groups.py
@@ -4,15 +4,16 @@ Free functions over the ``Group`` and ``GroupMember`` ORM models, same
 shape as ``app.auth.users``. All return plain dicts so callers don't
 depend on the ORM.
 """
+
 from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, Iterable
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select
 
-from app.db.models import Group, GroupMember, User
+from app.db.models import AclEntry, Group, GroupMember, User
 from app.db.session import session
 
 log = logging.getLogger(__name__)
@@ -68,6 +69,16 @@ def get(group_id: str) -> dict[str, Any] | None:
         return _to_dict(g) if g else None
 
 
+def get_many(group_ids: Iterable[str]) -> dict[str, dict[str, Any]]:
+    ids = list(dict.fromkeys(group_ids))
+    if not ids:
+        return {}
+    stmt = select(Group).where(Group.id.in_(ids))
+    with session() as s:
+        rows = s.scalars(stmt).all()
+        return {g.id: _to_dict(g) for g in rows}
+
+
 def get_by_name(name: str) -> dict[str, Any] | None:
     with session() as s:
         g = s.scalar(select(Group).where(Group.name == name.strip()))
@@ -104,9 +115,7 @@ def member_ids(group_id: str) -> list[str]:
     """User ids belonging to ``group_id``."""
     with session() as s:
         return list(
-            s.scalars(
-                select(GroupMember.user_id).where(GroupMember.group_id == group_id)
-            ).all()
+            s.scalars(select(GroupMember.user_id).where(GroupMember.group_id == group_id)).all()
         )
 
 
@@ -121,9 +130,26 @@ def members(group_id: str) -> list[dict[str, Any]]:
     with session() as s:
         rows = s.scalars(stmt).all()
         return [
-            {"id": u.id, "email": u.email, "name": u.name, "is_admin": u.is_admin}
-            for u in rows
+            {"id": u.id, "email": u.email, "name": u.name, "is_admin": u.is_admin} for u in rows
         ]
+
+
+def groups_by_user() -> dict[str, list[str]]:
+    """Map each user id to the sorted names of groups they belong to.
+
+    One join query for the whole table — used by the admin users list to
+    show each user's groups without an N+1.
+    """
+    stmt = (
+        select(GroupMember.user_id, Group.name)
+        .join(Group, Group.id == GroupMember.group_id)
+        .order_by(Group.name.asc())
+    )
+    out: dict[str, list[str]] = {}
+    with session() as s:
+        for uid, name in s.execute(stmt).all():
+            out.setdefault(uid, []).append(name)
+    return out
 
 
 def group_ids_for_user(user_id: str) -> list[str]:
@@ -131,10 +157,40 @@ def group_ids_for_user(user_id: str) -> list[str]:
     expand a user into the set of group principals it satisfies."""
     with session() as s:
         return list(
-            s.scalars(
-                select(GroupMember.group_id).where(GroupMember.user_id == user_id)
-            ).all()
+            s.scalars(select(GroupMember.group_id).where(GroupMember.user_id == user_id)).all()
         )
+
+
+def counts() -> dict[str, dict[str, int]]:
+    """Per-group ``{members, pages, folders}`` for the groups list UI.
+
+    ``members`` = ``group_members`` rows; ``pages`` / ``folders`` =
+    ``acl_entries`` granted to the group, split by ``resource_kind``.
+    Two aggregate queries, no N+1. Groups with no members and no grants
+    are absent from the result (callers default missing entries to 0).
+    """
+    out: dict[str, dict[str, int]] = {}
+
+    def _row(gid: str) -> dict[str, int]:
+        return out.setdefault(gid, {"members": 0, "pages": 0, "folders": 0})
+
+    with session() as s:
+        for gid, n in s.execute(
+            select(GroupMember.group_id, func.count()).group_by(GroupMember.group_id)
+        ).all():
+            _row(gid)["members"] = int(n)
+        for gid, kind, n in s.execute(
+            select(AclEntry.principal_id, AclEntry.resource_kind, func.count())
+            .where(AclEntry.principal_kind == "group")
+            .group_by(AclEntry.principal_id, AclEntry.resource_kind)
+        ).all():
+            if gid is None:
+                continue
+            if kind == "page":
+                _row(gid)["pages"] = int(n)
+            elif kind == "folder":
+                _row(gid)["folders"] = int(n)
+    return out
 
 
 def add_member(group_id: str, user_id: str) -> None:

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -1,11 +1,12 @@
 """User repo — SQLAlchemy ORM. Free functions over ``User`` model."""
+
 from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any
+from typing import Any, Iterable
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm.attributes import flag_modified
 
 from app.auth.passwords import hash_password
@@ -57,6 +58,40 @@ def list_all() -> list[dict[str, Any]]:
         return [_to_dict(u) for u in users]
 
 
+def get_many(user_ids: Iterable[str]) -> dict[str, dict[str, Any]]:
+    ids = list(dict.fromkeys(user_ids))
+    if not ids:
+        return {}
+    stmt = select(User).where(User.id.in_(ids))
+    with session() as s:
+        rows = s.scalars(stmt).all()
+        return {u.id: _to_dict(u) for u in rows}
+
+
+def search(query: str, limit: int = 20) -> list[dict[str, Any]]:
+    """Minimal user lookup for the share / transfer typeaheads.
+
+    Case-insensitive substring match on email or name. An empty query
+    returns the first ``limit`` users by email so the picker can show
+    suggestions before the user types. Returns only public-safe fields
+    (no password hash, settings, or admin flag) since any signed-in user
+    can call this to share a page.
+    """
+    q = (query or "").strip().lower()
+    with session() as s:
+        stmt = select(User)
+        if q:
+            like = "%" + q + "%"
+            stmt = stmt.where(
+                or_(
+                    func.lower(User.email).like(like),
+                    func.lower(User.name).like(like),
+                )
+            )
+        stmt = stmt.order_by(User.email.asc()).limit(limit)
+        return [{"id": u.id, "email": u.email, "name": u.name} for u in s.scalars(stmt).all()]
+
+
 def create(email: str, password: str, name: str | None = None) -> str:
     """Create a user. The very first user is auto-promoted to admin."""
     user_id = str(uuid.uuid4())
@@ -85,9 +120,7 @@ def set_admin(user_id: str, is_admin: bool) -> None:
 
 def admin_count() -> int:
     with session() as s:
-        return s.scalar(
-            select(func.count()).select_from(User).where(User.is_admin.is_(True))
-        ) or 0
+        return s.scalar(select(func.count()).select_from(User).where(User.is_admin.is_(True))) or 0
 
 
 def delete(user_id: str) -> None:

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -1,4 +1,5 @@
 """HTTP-shape models for the admin endpoints (request + response)."""
+
 from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict
@@ -65,6 +66,8 @@ class AdminUserView(BaseModel):
     name: str | None
     is_admin: bool
     created_at: str
+    # Names of the groups this user belongs to (for the admin users table).
+    groups: list[str] = []
 
 
 class AdminUserListResponse(BaseModel):

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 # --------------------------------------------------------------------------- #
@@ -67,7 +67,7 @@ class AdminUserView(BaseModel):
     is_admin: bool
     created_at: str
     # Names of the groups this user belongs to (for the admin users table).
-    groups: list[str] = []
+    groups: list[str] = Field(default_factory=list)
 
 
 class AdminUserListResponse(BaseModel):

--- a/backend/app/models/permissions.py
+++ b/backend/app/models/permissions.py
@@ -4,6 +4,7 @@ Routes in ``app/api/permissions.py`` and the wiki ACL endpoints in
 ``app/api/wiki.py`` parse requests and serialize responses through
 these models.
 """
+
 from __future__ import annotations
 
 from typing import Literal
@@ -27,6 +28,12 @@ class GroupOut(BaseModel):
     description: str | None
     created_by_user_id: str | None
     created_at: str
+    # Aggregate counts for the groups list UI. Default 0 so callers that
+    # build a GroupOut straight from the repo dict (group detail, create)
+    # don't have to supply them.
+    member_count: int = 0
+    page_count: int = 0
+    folder_count: int = 0
 
 
 class GroupListResponse(BaseModel):
@@ -76,11 +83,19 @@ class AclEntryOut(BaseModel):
     permission: str
     granted_by_user_id: str | None
     created_at: str
+    # Display enrichment for the share UI (resolved server-side so the
+    # client doesn't need the admin-only user list). None for principals
+    # that no longer exist or for the `everyone` principal.
+    principal_email: str | None = None
+    principal_name: str | None = None
+    group_name: str | None = None
 
 
 class AclListResponse(BaseModel):
     path: str
     owner_user_id: str | None
+    owner_email: str | None = None
+    owner_name: str | None = None
     entries: list[AclEntryOut]
 
 

--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -1,0 +1,21 @@
+"""Pydantic schemas for the public user-lookup API.
+
+Used by ``app/api/users.py:search_users`` to feed the share / transfer
+ownership typeaheads. Deliberately minimal — any signed-in user can call
+the search, so only public-safe fields are exposed (no password hash,
+settings, or admin flag).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UserLite(BaseModel):
+    id: str
+    email: str
+    name: str | None
+
+
+class UserSearchResponse(BaseModel):
+    users: list[UserLite]

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -20,6 +20,7 @@ Lifecycle hooks (:func:`on_page_created`, :func:`on_page_deleted`,
 :func:`on_path_moved`) are called from ``app.wiki.notify`` so every
 write site flows through one seam.
 """
+
 from __future__ import annotations
 
 import logging
@@ -62,9 +63,7 @@ def _ancestors(path: str) -> list[str]:
     """
     parts = [p for p in path.split("/") if p]
     parts = parts[:-1]
-    out = [
-        "/".join(parts[: i + 1]) for i in range(len(parts) - 1, -1, -1)
-    ]
+    out = ["/".join(parts[: i + 1]) for i in range(len(parts) - 1, -1, -1)]
     out.append("")
     return out
 
@@ -99,9 +98,25 @@ def set_owner(path: str, user_id: str | None) -> None:
 
 
 def transfer_owner(path: str, new_owner_id: str | None) -> None:
-    """Alias for ``set_owner`` — used by the transfer-ownership endpoint
-    so the call site reads as a transfer rather than a low-level set."""
+    """Transfer ownership, leaving the previous owner as an editor.
+
+    Moves the owner pointer to ``new_owner_id`` and, when there was a
+    distinct previous owner, grants them a ``write`` ACL on the path so
+    they keep edit access after losing ownership (Google-Docs
+    convention). Clearing the owner (``new_owner_id is None``) still
+    leaves the prior owner an editor. The grant is idempotent.
+    """
+    prev_owner = get_owner(path)
     set_owner(path, new_owner_id)
+    if prev_owner is not None and prev_owner != new_owner_id:
+        grant(
+            resource_kind="page" if _is_md_page(path) else "folder",
+            resource_path=path,
+            principal_kind="user",
+            principal_id=prev_owner,
+            permission="write",
+            granted_by_user_id=new_owner_id,
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -162,9 +177,7 @@ def grant(
     if permission not in _VALID_PERMISSIONS:
         raise ValueError(f"invalid permission: {permission!r}")
     if (principal_kind == "everyone") != (principal_id is None):
-        raise ValueError(
-            "principal_id must be NULL iff principal_kind == 'everyone'"
-        )
+        raise ValueError("principal_id must be NULL iff principal_kind == 'everyone'")
     canon = _canonicalize(resource_kind, resource_path)
 
     with session() as s:
@@ -195,7 +208,12 @@ def grant(
         )
     log.info(
         "acl grant id=%s %s:%s -> %s:%s %s",
-        eid, resource_kind, canon, principal_kind, principal_id or "*", permission,
+        eid,
+        resource_kind,
+        canon,
+        principal_kind,
+        principal_id or "*",
+        permission,
     )
     return eid
 
@@ -312,15 +330,11 @@ def effective(
     if owner is not None and user_id is not None and owner == user_id:
         return {"read", "write"}
 
-    group_ids = (
-        groups_repo.group_ids_for_user(user_id) if user_id is not None else []
-    )
+    group_ids = groups_repo.group_ids_for_user(user_id) if user_id is not None else []
 
     with session() as s:
         rows = list(
-            s.scalars(
-                _grants_for_principal(user_id, group_ids, canon_page, ancestors)
-            ).all()
+            s.scalars(_grants_for_principal(user_id, group_ids, canon_page, ancestors)).all()
         )
         if not rows and owner is None and not _path_is_managed(s, canon_page, ancestors):
             return {"read", "write"}
@@ -333,29 +347,30 @@ def effective(
     return perms
 
 
-def _path_is_managed(
-    s: Any, page_path: str, folder_paths: list[str]
-) -> bool:
+def _path_is_managed(s: Any, page_path: str, folder_paths: list[str]) -> bool:
     """True iff *any* ACL row exists at the page path or any folder
     ancestor — irrespective of principal. Used by the resolver and the
     bulk filter to detect "unconfigured" paths so the implicit-public
     fallback only kicks in when no human has ever set policy here."""
-    return s.scalar(
-        select(func.count())
-        .select_from(AclEntry)
-        .where(
-            or_(
-                and_(
-                    AclEntry.resource_kind == "page",
-                    AclEntry.resource_path == page_path,
-                ),
-                and_(
-                    AclEntry.resource_kind == "folder",
-                    AclEntry.resource_path.in_(folder_paths),
-                ),
+    return (
+        s.scalar(
+            select(func.count())
+            .select_from(AclEntry)
+            .where(
+                or_(
+                    and_(
+                        AclEntry.resource_kind == "page",
+                        AclEntry.resource_path == page_path,
+                    ),
+                    and_(
+                        AclEntry.resource_kind == "folder",
+                        AclEntry.resource_path.in_(folder_paths),
+                    ),
+                )
             )
         )
-    ) > 0
+        > 0
+    )
 
 
 def _grants_for_principal(
@@ -433,9 +448,7 @@ def visible_paths_filter(
     if is_admin:
         return literal(True)
 
-    group_ids = (
-        groups_repo.group_ids_for_user(user_id) if user_id is not None else []
-    )
+    group_ids = groups_repo.group_ids_for_user(user_id) if user_id is not None else []
 
     principal_clauses = [AclEntry.principal_kind == "everyone"]
     if user_id is not None:
@@ -464,9 +477,7 @@ def visible_paths_filter(
             path_column.like(AclEntry.resource_path + "/%"),
         ),
     )
-    acl_exists = exists(
-        select(1).where(or_(page_match, folder_match)).correlate_except(AclEntry)
-    )
+    acl_exists = exists(select(1).where(or_(page_match, folder_match)).correlate_except(AclEntry))
     # Implicit-public match: page is unconfigured (no owner, no ACL row
     # anywhere on its path). Mirrors the same fallback in ``effective``.
     any_acl_match = and_(
@@ -484,9 +495,7 @@ def visible_paths_filter(
             ),
         ),
     )
-    any_acl_exists = exists(
-        select(1).where(any_acl_match).correlate_except(AclEntry)
-    )
+    any_acl_exists = exists(select(1).where(any_acl_match).correlate_except(AclEntry))
     any_owner_exists = exists(
         select(1)
         .select_from(WikiOwner)
@@ -541,15 +550,18 @@ def on_page_created(path: str, owner_user_id: str | None) -> None:
     with session() as s:
         if s.get(WikiOwner, canon) is None:
             s.add(WikiOwner(path=canon, owner_user_id=owner_user_id))
-        existing = s.scalar(
-            select(func.count())
-            .select_from(AclEntry)
-            .where(
-                AclEntry.resource_kind == "page",
-                AclEntry.resource_path == canon,
-                AclEntry.principal_kind == "everyone",
+        existing = (
+            s.scalar(
+                select(func.count())
+                .select_from(AclEntry)
+                .where(
+                    AclEntry.resource_kind == "page",
+                    AclEntry.resource_path == canon,
+                    AclEntry.principal_kind == "everyone",
+                )
             )
-        ) or 0
+            or 0
+        )
         if existing == 0:
             for perm in ("read", "write"):
                 s.add(
@@ -596,11 +608,7 @@ def on_path_moved(moves: list[tuple[str, str]]) -> None:
                     )
                     .values(resource_path=new_p)
                 )
-                s.execute(
-                    update(WikiOwner)
-                    .where(WikiOwner.path == old_p)
-                    .values(path=new_p)
-                )
+                s.execute(update(WikiOwner).where(WikiOwner.path == old_p).values(path=new_p))
 
         # Detect a folder-level rename by looking for a common (old, new)
         # prefix shared across every moved file. ``move_path`` of a
@@ -648,13 +656,14 @@ def _common_folder_rename(
     old_prefix = first_old.rsplit("/", 1)[0]
     new_prefix = first_new.rsplit("/", 1)[0]
     while old_prefix and new_prefix:
-        suffix_old = first_old[len(old_prefix):]
-        suffix_new = first_new[len(new_prefix):]
+        suffix_old = first_old[len(old_prefix) :]
+        suffix_new = first_new[len(new_prefix) :]
         if suffix_old != suffix_new:
             return None, None
         if all(
-            o.startswith(old_prefix + "/") and n.startswith(new_prefix + "/")
-            and o[len(old_prefix):] == n[len(new_prefix):]
+            o.startswith(old_prefix + "/")
+            and n.startswith(new_prefix + "/")
+            and o[len(old_prefix) :] == n[len(new_prefix) :]
             for o, n in moves
         ):
             return old_prefix, new_prefix

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -159,8 +159,14 @@ def group_grant_counts() -> dict[str, dict[str, int]]:
     """
     out: dict[str, dict[str, int]] = {}
     with session() as s:
+        # COUNT(DISTINCT resource_path): a group can hold both a read and a
+        # write row on the same resource — count the resource once, not twice.
         for gid, kind, n in s.execute(
-            select(AclEntry.principal_id, AclEntry.resource_kind, func.count())
+            select(
+                AclEntry.principal_id,
+                AclEntry.resource_kind,
+                func.count(func.distinct(AclEntry.resource_path)),
+            )
             .where(AclEntry.principal_kind == "group")
             .group_by(AclEntry.principal_id, AclEntry.resource_kind)
         ).all():

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -29,6 +29,7 @@ import uuid
 from typing import Any, Iterable
 
 from sqlalchemy import (
+    ColumnElement,
     Select,
     and_,
     delete,
@@ -66,6 +67,13 @@ def _ancestors(path: str) -> list[str]:
     out = ["/".join(parts[: i + 1]) for i in range(len(parts) - 1, -1, -1)]
     out.append("")
     return out
+
+
+def _folder_self_and_ancestors(path: str) -> list[str]:
+    """``path`` plus every ancestor folder, deepest first, root last."""
+    if not path:
+        return [""]
+    return _ancestors(f"{path}/_")
 
 
 def _is_md_page(path: str) -> bool:
@@ -384,10 +392,18 @@ def effective(
     if is_admin:
         return {"read", "write"}
 
-    canon_page = path.strip().strip("/")
-    ancestors = _ancestors(canon_page)
+    raw_path = path.strip().strip("/")
+    is_page = _is_md_page(raw_path)
+    canon_path = (
+        _canonicalize("page", raw_path)
+        if is_page
+        else _canonicalize("folder", raw_path)
+    )
+    folder_paths = (
+        _ancestors(canon_path) if is_page else _folder_self_and_ancestors(canon_path)
+    )
 
-    owner = get_owner(canon_page)
+    owner = get_owner(canon_path)
     if owner is not None and user_id is not None and owner == user_id:
         return {"read", "write"}
 
@@ -396,13 +412,13 @@ def effective(
     with session() as s:
         rows = list(
             s.scalars(
-                _grants_for_principal(user_id, group_ids, canon_page, ancestors)
+                _grants_for_principal(user_id, group_ids, canon_path, folder_paths)
             ).all()
         )
         if (
             not rows
             and owner is None
-            and not _path_is_managed(s, canon_page, ancestors)
+            and not _path_is_managed(s, canon_path, folder_paths)
         ):
             return {"read", "write"}
 
@@ -419,24 +435,25 @@ def _path_is_managed(s: Any, page_path: str, folder_paths: list[str]) -> bool:
     ancestor — irrespective of principal. Used by the resolver and the
     bulk filter to detect "unconfigured" paths so the implicit-public
     fallback only kicks in when no human has ever set policy here."""
-    return (
-        s.scalar(
-            select(func.count())
-            .select_from(AclEntry)
-            .where(
-                or_(
-                    and_(
-                        AclEntry.resource_kind == "page",
-                        AclEntry.resource_path == page_path,
-                    ),
-                    and_(
-                        AclEntry.resource_kind == "folder",
-                        AclEntry.resource_path.in_(folder_paths),
-                    ),
-                )
+    conditions: list[ColumnElement[bool]] = []
+    if page_path and _is_md_page(page_path):
+        conditions.append(
+            and_(
+                AclEntry.resource_kind == "page",
+                AclEntry.resource_path == page_path,
             )
         )
-        > 0
+    if folder_paths:
+        conditions.append(
+            and_(
+                AclEntry.resource_kind == "folder",
+                AclEntry.resource_path.in_(folder_paths),
+            )
+        )
+    if not conditions:
+        return False
+    return (
+        s.scalar(select(func.count()).select_from(AclEntry).where(or_(*conditions))) > 0
     )
 
 
@@ -459,9 +476,11 @@ def _grants_for_principal(
                 AclEntry.principal_id.in_(group_ids),
             )
         )
-    resource_clauses = [
-        and_(AclEntry.resource_kind == "page", AclEntry.resource_path == page_path),
-    ]
+    resource_clauses: list[ColumnElement[bool]] = []
+    if page_path and _is_md_page(page_path):
+        resource_clauses.append(
+            and_(AclEntry.resource_kind == "page", AclEntry.resource_path == page_path)
+        )
     if folder_paths:
         resource_clauses.append(
             and_(
@@ -469,6 +488,11 @@ def _grants_for_principal(
                 AclEntry.resource_path.in_(folder_paths),
             )
         )
+    if not resource_clauses:
+        # Should never happen: every resource is either a page (with at least
+        # the root ancestor) or a folder (which yields the folder itself and
+        # its ancestors). Defensive fallback to avoid a pointless OR () clause.
+        resource_clauses.append(literal(False))
     return select(AclEntry).where(or_(*principal_clauses), or_(*resource_clauses))
 
 

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -106,17 +106,41 @@ def transfer_owner(path: str, new_owner_id: str | None) -> None:
     convention). Clearing the owner (``new_owner_id is None``) still
     leaves the prior owner an editor. The grant is idempotent.
     """
-    prev_owner = get_owner(path)
-    set_owner(path, new_owner_id)
-    if prev_owner is not None and prev_owner != new_owner_id:
-        grant(
-            resource_kind="page" if _is_md_page(path) else "folder",
-            resource_path=path,
-            principal_kind="user",
-            principal_id=prev_owner,
-            permission="write",
-            granted_by_user_id=new_owner_id,
-        )
+    resource_kind = "page" if _is_md_page(path) else "folder"
+    canon = _canonicalize(resource_kind, path)
+    # Single session so the owner move and the editor grant commit (or roll
+    # back) together — otherwise a failed grant after a committed owner move
+    # would strand the previous owner with no access.
+    with session() as s:
+        row = s.get(WikiOwner, path)
+        prev_owner = row.owner_user_id if row is not None else None
+        if row is None:
+            s.add(WikiOwner(path=path, owner_user_id=new_owner_id))
+        else:
+            row.owner_user_id = new_owner_id
+
+        if prev_owner is not None and prev_owner != new_owner_id:
+            already = s.scalar(
+                select(AclEntry).where(
+                    AclEntry.resource_kind == resource_kind,
+                    AclEntry.resource_path == canon,
+                    AclEntry.principal_kind == "user",
+                    AclEntry.principal_id == prev_owner,
+                    AclEntry.permission == "write",
+                )
+            )
+            if already is None:
+                s.add(
+                    AclEntry(
+                        id=f"acl_{uuid.uuid4().hex[:12]}",
+                        resource_kind=resource_kind,
+                        resource_path=canon,
+                        principal_kind="user",
+                        principal_id=prev_owner,
+                        permission="write",
+                        granted_by_user_id=new_owner_id,
+                    )
+                )
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -77,9 +77,15 @@ def _is_md_page(path: str) -> bool:
 # --------------------------------------------------------------------------- #
 
 
+def _owner_key(path: str) -> str:
+    """WikiOwner rows are keyed by the same canonical path as AclEntry rows,
+    so owner lookups and grants on the same resource always agree."""
+    return _canonicalize("page" if _is_md_page(path) else "folder", path)
+
+
 def get_owner(path: str) -> str | None:
     with session() as s:
-        row = s.get(WikiOwner, path)
+        row = s.get(WikiOwner, _owner_key(path))
         return row.owner_user_id if row is not None else None
 
 
@@ -89,10 +95,11 @@ def set_owner(path: str, user_id: str | None) -> None:
     ``None`` clears the owner (used during account deletion or as the
     default for pages backfilled at bootstrap when no owner is known).
     """
+    key = _owner_key(path)
     with session() as s:
-        row = s.get(WikiOwner, path)
+        row = s.get(WikiOwner, key)
         if row is None:
-            s.add(WikiOwner(path=path, owner_user_id=user_id))
+            s.add(WikiOwner(path=key, owner_user_id=user_id))
         else:
             row.owner_user_id = user_id
 
@@ -112,10 +119,10 @@ def transfer_owner(path: str, new_owner_id: str | None) -> None:
     # back) together — otherwise a failed grant after a committed owner move
     # would strand the previous owner with no access.
     with session() as s:
-        row = s.get(WikiOwner, path)
+        row = s.get(WikiOwner, canon)
         prev_owner = row.owner_user_id if row is not None else None
         if row is None:
-            s.add(WikiOwner(path=path, owner_user_id=new_owner_id))
+            s.add(WikiOwner(path=canon, owner_user_id=new_owner_id))
         else:
             row.owner_user_id = new_owner_id
 
@@ -141,6 +148,28 @@ def transfer_owner(path: str, new_owner_id: str | None) -> None:
                         granted_by_user_id=new_owner_id,
                     )
                 )
+
+
+def group_grant_counts() -> dict[str, dict[str, int]]:
+    """Per-group count of granted pages/folders — ACL rows whose principal is a
+    group, split by ``resource_kind``. Lives here so all ACL-table reads stay
+    inside this module. One aggregate query, no N+1.
+    """
+    out: dict[str, dict[str, int]] = {}
+    with session() as s:
+        for gid, kind, n in s.execute(
+            select(AclEntry.principal_id, AclEntry.resource_kind, func.count())
+            .where(AclEntry.principal_kind == "group")
+            .group_by(AclEntry.principal_id, AclEntry.resource_kind)
+        ).all():
+            if gid is None:
+                continue
+            row = out.setdefault(gid, {"pages": 0, "folders": 0})
+            if kind == "page":
+                row["pages"] = int(n)
+            elif kind == "folder":
+                row["folders"] = int(n)
+    return out
 
 
 # --------------------------------------------------------------------------- #
@@ -358,9 +387,15 @@ def effective(
 
     with session() as s:
         rows = list(
-            s.scalars(_grants_for_principal(user_id, group_ids, canon_page, ancestors)).all()
+            s.scalars(
+                _grants_for_principal(user_id, group_ids, canon_page, ancestors)
+            ).all()
         )
-        if not rows and owner is None and not _path_is_managed(s, canon_page, ancestors):
+        if (
+            not rows
+            and owner is None
+            and not _path_is_managed(s, canon_page, ancestors)
+        ):
             return {"read", "write"}
 
     perms: set[str] = set()
@@ -501,7 +536,9 @@ def visible_paths_filter(
             path_column.like(AclEntry.resource_path + "/%"),
         ),
     )
-    acl_exists = exists(select(1).where(or_(page_match, folder_match)).correlate_except(AclEntry))
+    acl_exists = exists(
+        select(1).where(or_(page_match, folder_match)).correlate_except(AclEntry)
+    )
     # Implicit-public match: page is unconfigured (no owner, no ACL row
     # anywhere on its path). Mirrors the same fallback in ``effective``.
     any_acl_match = and_(
@@ -632,7 +669,9 @@ def on_path_moved(moves: list[tuple[str, str]]) -> None:
                     )
                     .values(resource_path=new_p)
                 )
-                s.execute(update(WikiOwner).where(WikiOwner.path == old_p).values(path=new_p))
+                s.execute(
+                    update(WikiOwner).where(WikiOwner.path == old_p).values(path=new_p)
+                )
 
         # Detect a folder-level rename by looking for a common (old, new)
         # prefix shared across every moved file. ``move_path`` of a

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -127,27 +127,29 @@ def transfer_owner(path: str, new_owner_id: str | None) -> None:
             row.owner_user_id = new_owner_id
 
         if prev_owner is not None and prev_owner != new_owner_id:
-            already = s.scalar(
-                select(AclEntry).where(
+            # Drop any existing grant (read or write) for the previous owner on
+            # this path, then add a single write grant — otherwise a pre-existing
+            # read row would linger beside the new write row, and the UI (which
+            # collapses to the strongest grant) couldn't fully revoke them later.
+            s.execute(
+                delete(AclEntry).where(
                     AclEntry.resource_kind == resource_kind,
                     AclEntry.resource_path == canon,
                     AclEntry.principal_kind == "user",
                     AclEntry.principal_id == prev_owner,
-                    AclEntry.permission == "write",
                 )
             )
-            if already is None:
-                s.add(
-                    AclEntry(
-                        id=f"acl_{uuid.uuid4().hex[:12]}",
-                        resource_kind=resource_kind,
-                        resource_path=canon,
-                        principal_kind="user",
-                        principal_id=prev_owner,
-                        permission="write",
-                        granted_by_user_id=new_owner_id,
-                    )
+            s.add(
+                AclEntry(
+                    id=f"acl_{uuid.uuid4().hex[:12]}",
+                    resource_kind=resource_kind,
+                    resource_path=canon,
+                    principal_kind="user",
+                    principal_id=prev_owner,
+                    permission="write",
+                    granted_by_user_id=new_owner_id,
                 )
+            )
 
 
 def group_grant_counts() -> dict[str, dict[str, int]]:

--- a/backend/tests/integration/test_permissions_api.py
+++ b/backend/tests/integration/test_permissions_api.py
@@ -4,6 +4,7 @@ Phase 3 covers the *enforcement* boundary (existing wiki routes refusing
 unauthorized callers); these tests cover the new mutation surface that
 admins and owners use to manage permissions.
 """
+
 from __future__ import annotations
 
 
@@ -115,13 +116,16 @@ def test_owner_can_grant_user_access(integration):
     integration.signin(user_id=alice)
     integration.put_doc("docs/shared.md", "# Shared")
 
-    resp = integration.client.post("/api/wiki/acl", json={
-        "resource_kind": "page",
-        "resource_path": "docs/shared.md",
-        "principal_kind": "user",
-        "principal_id": bob,
-        "permission": "read",
-    })
+    resp = integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "docs/shared.md",
+            "principal_kind": "user",
+            "principal_id": bob,
+            "permission": "read",
+        },
+    )
     assert resp.status_code == 201, resp.text
     eid = resp.json()["id"]
     assert eid.startswith("acl_")
@@ -135,13 +139,16 @@ def test_owner_can_grant_user_access(integration):
 def test_grant_to_nonexistent_user_returns_404(integration):
     integration.signup(email="alice@x.com")
     integration.put_doc("docs/x.md", "x")
-    resp = integration.client.post("/api/wiki/acl", json={
-        "resource_kind": "page",
-        "resource_path": "docs/x.md",
-        "principal_kind": "user",
-        "principal_id": "u_nope",
-        "permission": "read",
-    })
+    resp = integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "docs/x.md",
+            "principal_kind": "user",
+            "principal_id": "u_nope",
+            "permission": "read",
+        },
+    )
     assert resp.status_code == 404
 
 
@@ -156,22 +163,33 @@ def test_transfer_ownership_changes_owner(integration):
     integration.put_doc("docs/spec.md", "# Spec")
     _strip_everyone(integration, "docs/spec.md")
 
-    resp = integration.client.post("/api/wiki/transfer-ownership", json={
-        "path": "docs/spec.md",
-        "new_owner_user_id": bob,
-    })
+    resp = integration.client.post(
+        "/api/wiki/transfer-ownership",
+        json={
+            "path": "docs/spec.md",
+            "new_owner_user_id": bob,
+        },
+    )
     assert resp.status_code == 200
     assert resp.json()["owner_user_id"] == bob
 
-    # Alice no longer has owner rights.
+    # Alice is no longer the owner but is left as an editor, so she keeps
+    # write access (and can still open the share dialog).
     integration.signin(user_id=alice)
     r = integration.client.get("/api/wiki/acl?path=docs/spec.md")
-    assert r.status_code == 403
+    assert r.status_code == 200
+    body = r.json()
+    assert body["owner_user_id"] == bob
+    assert any(
+        e["principal_kind"] == "user" and e["principal_id"] == alice and e["permission"] == "write"
+        for e in body["entries"]
+    )
 
-    # Bob now does.
+    # Bob now owns it.
     integration.signin(user_id=bob)
     r = integration.client.get("/api/wiki/acl?path=docs/spec.md")
     assert r.status_code == 200
+    assert r.json()["owner_user_id"] == bob
 
 
 def test_admin_can_list_and_grant_on_someone_elses_page(integration):
@@ -184,13 +202,16 @@ def test_admin_can_list_and_grant_on_someone_elses_page(integration):
     resp = integration.client.get("/api/wiki/acl?path=bob/notes.md")
     assert resp.status_code == 200
 
-    resp = integration.client.post("/api/wiki/acl", json={
-        "resource_kind": "page",
-        "resource_path": "bob/notes.md",
-        "principal_kind": "user",
-        "principal_id": admin_id,
-        "permission": "write",
-    })
+    resp = integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "bob/notes.md",
+            "principal_kind": "user",
+            "principal_id": admin_id,
+            "permission": "write",
+        },
+    )
     assert resp.status_code == 201
 
 
@@ -209,28 +230,34 @@ def test_anonymous_calls_to_permission_endpoints_return_401(integration):
     assert integration.client.get("/api/wiki/acl?path=x.md").status_code == 401
 
     # Write paths.
-    assert integration.client.post(
-        "/api/groups", json={"name": "x"}
-    ).status_code == 401
+    assert integration.client.post("/api/groups", json={"name": "x"}).status_code == 401
     assert integration.client.delete("/api/groups/grp_x").status_code == 401
-    assert integration.client.post(
-        "/api/groups/grp_x/members", json={"user_id": "u_x"}
-    ).status_code == 401
-    assert integration.client.delete(
-        "/api/groups/grp_x/members/u_x"
-    ).status_code == 401
-    assert integration.client.post(
-        "/api/wiki/acl", json={
-            "resource_kind": "page", "resource_path": "x.md",
-            "principal_kind": "everyone", "principal_id": None,
-            "permission": "read",
-        }
-    ).status_code == 401
+    assert (
+        integration.client.post("/api/groups/grp_x/members", json={"user_id": "u_x"}).status_code
+        == 401
+    )
+    assert integration.client.delete("/api/groups/grp_x/members/u_x").status_code == 401
+    assert (
+        integration.client.post(
+            "/api/wiki/acl",
+            json={
+                "resource_kind": "page",
+                "resource_path": "x.md",
+                "principal_kind": "everyone",
+                "principal_id": None,
+                "permission": "read",
+            },
+        ).status_code
+        == 401
+    )
     assert integration.client.delete("/api/wiki/acl/acl_x").status_code == 401
-    assert integration.client.post(
-        "/api/wiki/transfer-ownership",
-        json={"path": "x.md", "new_owner_user_id": "u_x"},
-    ).status_code == 401
+    assert (
+        integration.client.post(
+            "/api/wiki/transfer-ownership",
+            json={"path": "x.md", "new_owner_user_id": "u_x"},
+        ).status_code
+        == 401
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -247,21 +274,16 @@ def test_non_admin_blocked_from_every_group_mutation(integration):
     # Admin creates a group so the delete/member endpoints have a
     # target id; otherwise they'd return 404 before the auth check.
     integration.signin(email="admin@x.com")
-    gid = integration.client.post(
-        "/api/groups", json={"name": "eng"}
-    ).json()["id"]
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
 
     integration.signin(user_id=bob)
-    assert integration.client.post(
-        "/api/groups", json={"name": "rogue"}
-    ).status_code == 403
+    assert integration.client.post("/api/groups", json={"name": "rogue"}).status_code == 403
     assert integration.client.delete(f"/api/groups/{gid}").status_code == 403
-    assert integration.client.post(
-        f"/api/groups/{gid}/members", json={"user_id": bob}
-    ).status_code == 403
-    assert integration.client.delete(
-        f"/api/groups/{gid}/members/{bob}"
-    ).status_code == 403
+    assert (
+        integration.client.post(f"/api/groups/{gid}/members", json={"user_id": bob}).status_code
+        == 403
+    )
+    assert integration.client.delete(f"/api/groups/{gid}/members/{bob}").status_code == 403
 
 
 def test_non_member_cannot_view_group_detail(integration):
@@ -269,12 +291,8 @@ def test_non_member_cannot_view_group_detail(integration):
     integration.signup(email="alice@x.com")
     bob = integration.signup(email="bob@x.com")
     integration.signin(email="admin@x.com")
-    gid = integration.client.post(
-        "/api/groups", json={"name": "eng"}
-    ).json()["id"]
-    integration.client.post(
-        f"/api/groups/{gid}/members", json={"user_id": bob}
-    )
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+    integration.client.post(f"/api/groups/{gid}/members", json={"user_id": bob})
 
     # Alice is not a member, not admin.
     integration.signin(email="alice@x.com")
@@ -294,23 +312,29 @@ def test_non_member_cannot_view_group_detail(integration):
 def test_grant_to_nonexistent_group_returns_404(integration):
     integration.signup(email="alice@x.com")
     integration.put_doc("docs/x.md", "x")
-    resp = integration.client.post("/api/wiki/acl", json={
-        "resource_kind": "page",
-        "resource_path": "docs/x.md",
-        "principal_kind": "group",
-        "principal_id": "grp_nope",
-        "permission": "read",
-    })
+    resp = integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "docs/x.md",
+            "principal_kind": "group",
+            "principal_id": "grp_nope",
+            "permission": "read",
+        },
+    )
     assert resp.status_code == 404
 
 
 def test_transfer_to_nonexistent_user_returns_404(integration):
     integration.signup(email="alice@x.com")
     integration.put_doc("docs/x.md", "x")
-    resp = integration.client.post("/api/wiki/transfer-ownership", json={
-        "path": "docs/x.md",
-        "new_owner_user_id": "u_nope",
-    })
+    resp = integration.client.post(
+        "/api/wiki/transfer-ownership",
+        json={
+            "path": "docs/x.md",
+            "new_owner_user_id": "u_nope",
+        },
+    )
     assert resp.status_code == 404
 
 
@@ -323,12 +347,8 @@ def test_revoke_nonexistent_acl_entry_returns_404(integration):
 def test_member_add_with_nonexistent_user_returns_404(integration):
     integration.signup(email="admin@x.com")
     integration.signin(email="admin@x.com")
-    gid = integration.client.post(
-        "/api/groups", json={"name": "eng"}
-    ).json()["id"]
-    r = integration.client.post(
-        f"/api/groups/{gid}/members", json={"user_id": "u_nope"}
-    )
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+    r = integration.client.post(f"/api/groups/{gid}/members", json={"user_id": "u_nope"})
     assert r.status_code == 404
 
 
@@ -347,13 +367,16 @@ def test_get_or_delete_nonexistent_group_returns_404(integration):
 def test_grant_with_invalid_path_returns_400(integration):
     integration.signup(email="alice@x.com")
     # Path traversal attempt — caught by safe_rel_path.
-    resp = integration.client.post("/api/wiki/acl", json={
-        "resource_kind": "page",
-        "resource_path": "../escape.md",
-        "principal_kind": "everyone",
-        "principal_id": None,
-        "permission": "read",
-    })
+    resp = integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "../escape.md",
+            "principal_kind": "everyone",
+            "principal_id": None,
+            "permission": "read",
+        },
+    )
     assert resp.status_code == 400
 
 
@@ -361,3 +384,93 @@ def test_grant_with_missing_path_returns_400(integration):
     integration.signup(email="alice@x.com")
     resp = integration.client.get("/api/wiki/acl")
     assert resp.status_code == 400
+
+
+# --------------------------------------------------------------------------- #
+# User search (share / transfer typeahead)                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_user_search_returns_minimal_filtered_results(integration):
+    admin = integration.signup(email="admin@x.com")
+    integration.signup(email="alice@x.com")
+    integration.signup(email="bob@y.com")
+    integration.signin(user_id=admin)
+
+    resp = integration.client.get("/api/users/search?q=alice")
+    assert resp.status_code == 200, resp.text
+    users = resp.json()["users"]
+    assert [u["email"] for u in users] == ["alice@x.com"]
+    assert set(users[0].keys()) == {"id", "email", "name"}
+
+    # Empty query returns everyone, email-ordered.
+    resp = integration.client.get("/api/users/search")
+    assert [u["email"] for u in resp.json()["users"]] == [
+        "admin@x.com",
+        "alice@x.com",
+        "bob@y.com",
+    ]
+
+
+def test_groups_list_includes_counts(integration):
+    admin = integration.signup(email="admin@x.com")
+    bob = integration.signup(email="bob@x.com")
+    integration.signin(user_id=admin)
+
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+    integration.client.post(f"/api/groups/{gid}/members", json={"user_id": bob})
+
+    integration.put_doc("docs/spec.md", "# Spec")
+    r = integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "docs/spec.md",
+            "principal_kind": "group",
+            "principal_id": gid,
+            "permission": "read",
+        },
+    )
+    assert r.status_code == 201, r.text
+
+    groups = integration.client.get("/api/groups").json()["groups"]
+    g = next(x for x in groups if x["id"] == gid)
+    assert g["member_count"] == 1
+    assert g["page_count"] == 1
+    assert g["folder_count"] == 0
+
+
+def test_acl_list_includes_principal_and_owner_labels(integration):
+    admin = integration.signup(email="admin@x.com")
+    alice = integration.signup(email="alice@x.com", name="Alice")
+    integration.signin(user_id=admin)
+    integration.put_doc("docs/spec.md", "# Spec")
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+    integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "docs/spec.md",
+            "principal_kind": "user",
+            "principal_id": alice,
+            "permission": "read",
+        },
+    )
+    integration.client.post(
+        "/api/wiki/acl",
+        json={
+            "resource_kind": "page",
+            "resource_path": "docs/spec.md",
+            "principal_kind": "group",
+            "principal_id": gid,
+            "permission": "write",
+        },
+    )
+
+    body = integration.client.get("/api/wiki/acl?path=docs/spec.md").json()
+    assert body["owner_user_id"] == admin
+    assert body["owner_email"] == "admin@x.com"
+    by_kind = {e["principal_kind"]: e for e in body["entries"]}
+    assert by_kind["user"]["principal_email"] == "alice@x.com"
+    assert by_kind["user"]["principal_name"] == "Alice"
+    assert by_kind["group"]["group_name"] == "eng"

--- a/backend/tests/test_acl.py
+++ b/backend/tests/test_acl.py
@@ -5,11 +5,13 @@ every shape of grant, the bootstrap walk, and the rename/delete hooks.
 ``app.auth.groups`` is exercised end-to-end through the same tests since
 the resolver depends on group membership.
 """
+
 from __future__ import annotations
 
 import pytest
 
 from app.auth import groups as groups_repo
+from app.auth import users as users_repo
 from app.wiki import acl
 from tests._seed import seed_user
 
@@ -71,6 +73,109 @@ def test_owner_has_full_access_without_acl_rows(tmp_db):
     alice = seed_user(uid="u_alice", email="alice@x.com")
     acl.set_owner("docs/spec.md", alice)
     assert acl.effective(alice, False, "docs/spec.md") == {"read", "write"}
+
+
+def test_transfer_leaves_previous_owner_as_editor(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    bob = seed_user(uid="u_bob", email="bob@x.com")
+    acl.set_owner("docs/spec.md", alice)
+
+    acl.transfer_owner("docs/spec.md", bob)
+
+    assert acl.get_owner("docs/spec.md") == bob
+    # Previous owner keeps edit access via an explicit write grant.
+    assert acl.effective(alice, False, "docs/spec.md") == {"read", "write"}
+    entries = acl.list_for_path("docs/spec.md")
+    assert any(
+        e["principal_kind"] == "user" and e["principal_id"] == alice and e["permission"] == "write"
+        for e in entries
+    )
+
+
+def test_transfer_clearing_owner_still_leaves_editor(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    acl.set_owner("docs/spec.md", alice)
+
+    acl.transfer_owner("docs/spec.md", None)
+
+    assert acl.get_owner("docs/spec.md") is None
+    assert acl.effective(alice, False, "docs/spec.md") == {"read", "write"}
+
+
+def test_transfer_to_self_is_noop_no_grant(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    acl.set_owner("docs/spec.md", alice)
+
+    acl.transfer_owner("docs/spec.md", alice)
+
+    assert acl.get_owner("docs/spec.md") == alice
+    # No spurious self write-grant.
+    assert acl.list_for_path("docs/spec.md") == []
+
+
+def test_user_search_matches_email_and_name(tmp_db):
+    seed_user(uid="u1", email="alice@x.com", name="Alice Smith")
+    seed_user(uid="u2", email="bob@y.com", name="Bob Jones")
+    seed_user(uid="u3", email="carol@x.com", name=None)
+
+    # Email substring.
+    assert {r["id"] for r in users_repo.search("x.com")} == {"u1", "u3"}
+    # Name substring, case-insensitive.
+    assert [r["id"] for r in users_repo.search("ALICE")] == ["u1"]
+    # Empty query returns all, email-ordered, public-safe fields only.
+    res = users_repo.search("")
+    assert [r["email"] for r in res] == [
+        "alice@x.com",
+        "bob@y.com",
+        "carol@x.com",
+    ]
+    assert set(res[0].keys()) == {"id", "email", "name"}
+    # Limit respected.
+    assert len(users_repo.search("", limit=1)) == 1
+
+
+def test_group_counts(tmp_db):
+    admin = seed_user(uid="u_admin", email="admin@x.com", is_admin=True)
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    g1 = groups_repo.create("eng", None, created_by_user_id=admin)
+    g2 = groups_repo.create("growth", None, created_by_user_id=admin)
+    groups_repo.add_member(g1, admin)
+    groups_repo.add_member(g1, alice)
+    acl.grant(
+        resource_kind="page",
+        resource_path="docs/a.md",
+        principal_kind="group",
+        principal_id=g1,
+        permission="read",
+        granted_by_user_id=admin,
+    )
+    acl.grant(
+        resource_kind="folder",
+        resource_path="docs",
+        principal_kind="group",
+        principal_id=g1,
+        permission="write",
+        granted_by_user_id=admin,
+    )
+
+    c = groups_repo.counts()
+    assert c[g1] == {"members": 2, "pages": 1, "folders": 1}
+    # A group with no members and no grants is absent from the result.
+    assert g2 not in c
+
+
+def test_groups_by_user(tmp_db):
+    admin = seed_user(uid="u_admin", email="admin@x.com", is_admin=True)
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    g1 = groups_repo.create("eng", None, created_by_user_id=admin)
+    g2 = groups_repo.create("growth", None, created_by_user_id=admin)
+    groups_repo.add_member(g1, alice)
+    groups_repo.add_member(g2, alice)
+    groups_repo.add_member(g1, admin)
+
+    m = groups_repo.groups_by_user()
+    assert m[alice] == ["eng", "growth"]  # sorted by group name
+    assert m[admin] == ["eng"]
 
 
 def test_anonymous_has_no_access_when_path_is_managed(tmp_db):
@@ -408,9 +513,7 @@ def test_filter_paths_in_python(tmp_db):
     acl.on_page_created("public.md", owner_user_id=None)  # everyone read+write
     acl.set_owner("private.md", bob)  # alice has no access
     # Alice can see public, not private.
-    assert acl.filter_paths_in_python(alice, False, ["public.md", "private.md"]) == [
-        "public.md"
-    ]
+    assert acl.filter_paths_in_python(alice, False, ["public.md", "private.md"]) == ["public.md"]
     # Admin sees all.
     assert acl.filter_paths_in_python(alice, True, ["public.md", "private.md"]) == [
         "public.md",
@@ -527,23 +630,35 @@ def test_list_for_path_orders_page_then_folder_deepest_first(tmp_db):
     admin = seed_user(uid="u_admin", email="admin@x.com", is_admin=True)
     # Folder grant at root, mid, deep — plus a page grant.
     acl.grant(
-        resource_kind="folder", resource_path="",
-        principal_kind="everyone", principal_id=None, permission="read",
+        resource_kind="folder",
+        resource_path="",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
         granted_by_user_id=admin,
     )
     acl.grant(
-        resource_kind="folder", resource_path="docs",
-        principal_kind="everyone", principal_id=None, permission="read",
+        resource_kind="folder",
+        resource_path="docs",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
         granted_by_user_id=admin,
     )
     acl.grant(
-        resource_kind="folder", resource_path="docs/sub",
-        principal_kind="everyone", principal_id=None, permission="read",
+        resource_kind="folder",
+        resource_path="docs/sub",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
         granted_by_user_id=admin,
     )
     acl.grant(
-        resource_kind="page", resource_path="docs/sub/x.md",
-        principal_kind="everyone", principal_id=None, permission="read",
+        resource_kind="page",
+        resource_path="docs/sub/x.md",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
         granted_by_user_id=admin,
     )
     rows = acl.list_for_path("docs/sub/x.md")
@@ -570,8 +685,11 @@ def test_grants_to_deleted_group_become_inert(tmp_db):
     groups_repo.add_member(gid, alice)
     acl.set_owner("docs/spec.md", bob)
     acl.grant(
-        resource_kind="page", resource_path="docs/spec.md",
-        principal_kind="group", principal_id=gid, permission="read",
+        resource_kind="page",
+        resource_path="docs/spec.md",
+        principal_kind="group",
+        principal_id=gid,
+        permission="read",
         granted_by_user_id=admin,
     )
     assert acl.effective(alice, False, "docs/spec.md") == {"read"}
@@ -593,8 +711,11 @@ def test_deleting_owner_user_clears_owner_row(tmp_db):
     bob = seed_user(uid="u_bob", email="bob@x.com")
     acl.set_owner("docs/spec.md", alice)
     acl.grant(
-        resource_kind="page", resource_path="docs/spec.md",
-        principal_kind="user", principal_id=bob, permission="read",
+        resource_kind="page",
+        resource_path="docs/spec.md",
+        principal_kind="user",
+        principal_id=bob,
+        permission="read",
         granted_by_user_id=alice,
     )
     # Sanity: Alice as owner has full access.
@@ -636,15 +757,11 @@ def test_visible_paths_filter_against_db(tmp_db):
 
     pred = acl.visible_paths_filter(alice, False, Document.path)
     with session() as s:
-        rows = s.scalars(
-            sa_select(Document.path).where(pred).order_by(Document.path)
-        ).all()
+        rows = s.scalars(sa_select(Document.path).where(pred).order_by(Document.path)).all()
     assert list(rows) == ["public.md"]
 
     # Admin filter is universal-true.
     pred_admin = acl.visible_paths_filter("u_admin", True, Document.path)
     with session() as s:
-        rows = s.scalars(
-            sa_select(Document.path).where(pred_admin).order_by(Document.path)
-        ).all()
+        rows = s.scalars(sa_select(Document.path).where(pred_admin).order_by(Document.path)).all()
     assert list(rows) == ["private.md", "public.md"]

--- a/backend/tests/test_acl.py
+++ b/backend/tests/test_acl.py
@@ -158,10 +158,13 @@ def test_group_counts(tmp_db):
         granted_by_user_id=admin,
     )
 
-    c = groups_repo.counts()
-    assert c[g1] == {"members": 2, "pages": 1, "folders": 1}
-    # A group with no members and no grants is absent from the result.
-    assert g2 not in c
+    member_counts = groups_repo.member_counts()
+    grant_counts = acl.group_grant_counts()
+    assert member_counts[g1] == 2
+    assert grant_counts[g1] == {"pages": 1, "folders": 1}
+    # A group with no members and no grants is absent from both results.
+    assert g2 not in member_counts
+    assert g2 not in grant_counts
 
 
 def test_groups_by_user(tmp_db):

--- a/backend/tests/test_acl.py
+++ b/backend/tests/test_acl.py
@@ -87,7 +87,9 @@ def test_transfer_leaves_previous_owner_as_editor(tmp_db):
     assert acl.effective(alice, False, "docs/spec.md") == {"read", "write"}
     entries = acl.list_for_path("docs/spec.md")
     assert any(
-        e["principal_kind"] == "user" and e["principal_id"] == alice and e["permission"] == "write"
+        e["principal_kind"] == "user"
+        and e["principal_id"] == alice
+        and e["permission"] == "write"
         for e in entries
     )
 
@@ -312,6 +314,22 @@ def test_folder_grant_cascades_to_descendants(tmp_db):
     assert acl.effective(alice, False, "other/spec.md") == set()
 
 
+def test_folder_grant_applies_to_the_folder_itself(tmp_db):
+    # A folder-level grant must also resolve when checking access to that
+    # folder path itself (the share-a-folder flow), not only its descendants.
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    acl.grant(
+        resource_kind="folder",
+        resource_path="docs",
+        principal_kind="user",
+        principal_id=alice,
+        permission="write",
+        granted_by_user_id=None,
+    )
+    assert acl.effective(alice, False, "docs") == {"read", "write"}
+    assert acl.can(alice, False, "write", "docs") is True
+
+
 def test_root_folder_grant_matches_everything(tmp_db):
     alice = seed_user(uid="u_alice", email="alice@x.com")
     acl.grant(
@@ -389,7 +407,11 @@ def test_on_page_created_is_idempotent(tmp_db):
     alice = seed_user(uid="u_alice", email="alice@x.com")
     acl.on_page_created("docs/spec.md", owner_user_id=alice)
     acl.on_page_created("docs/spec.md", owner_user_id=alice)
-    grants = [g for g in acl.list_for_path("docs/spec.md") if g["principal_kind"] == "everyone"]
+    grants = [
+        g
+        for g in acl.list_for_path("docs/spec.md")
+        if g["principal_kind"] == "everyone"
+    ]
     assert len(grants) == 2  # one read + one write, not duplicated.
 
 
@@ -516,7 +538,9 @@ def test_filter_paths_in_python(tmp_db):
     acl.on_page_created("public.md", owner_user_id=None)  # everyone read+write
     acl.set_owner("private.md", bob)  # alice has no access
     # Alice can see public, not private.
-    assert acl.filter_paths_in_python(alice, False, ["public.md", "private.md"]) == ["public.md"]
+    assert acl.filter_paths_in_python(alice, False, ["public.md", "private.md"]) == [
+        "public.md"
+    ]
     # Admin sees all.
     assert acl.filter_paths_in_python(alice, True, ["public.md", "private.md"]) == [
         "public.md",
@@ -760,11 +784,15 @@ def test_visible_paths_filter_against_db(tmp_db):
 
     pred = acl.visible_paths_filter(alice, False, Document.path)
     with session() as s:
-        rows = s.scalars(sa_select(Document.path).where(pred).order_by(Document.path)).all()
+        rows = s.scalars(
+            sa_select(Document.path).where(pred).order_by(Document.path)
+        ).all()
     assert list(rows) == ["public.md"]
 
     # Admin filter is universal-true.
     pred_admin = acl.visible_paths_filter("u_admin", True, Document.path)
     with session() as s:
-        rows = s.scalars(sa_select(Document.path).where(pred_admin).order_by(Document.path)).all()
+        rows = s.scalars(
+            sa_select(Document.path).where(pred_admin).order_by(Document.path)
+        ).all()
     assert list(rows) == ["private.md", "public.md"]

--- a/frontend/src/app/admin/groups/groups.module.css
+++ b/frontend/src/app/admin/groups/groups.module.css
@@ -1,104 +1,14 @@
+/* Layout only — typography, inputs, menus, and buttons come from OPAL. */
+
 .toolbar {
   display: flex;
   align-items: center;
   gap: 8px;
   margin-bottom: 16px;
 }
-.search {
+.searchWrap {
   flex: 1;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  background: var(--color-bg-page);
-  color: var(--color-text-muted);
-}
-.searchInput {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  font-size: 14px;
-  color: var(--color-text-primary);
-}
-
-.cards {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.card {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  width: 100%;
-  padding: 16px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-lg);
-  background: var(--color-bg-page);
-  cursor: pointer;
-  text-align: left;
-}
-.card:hover {
-  background: var(--color-bg-hover);
-}
-.cardIcon {
-  display: inline-flex;
-  color: var(--color-text-secondary);
-  flex-shrink: 0;
-}
-.cardText {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
   min-width: 0;
-  flex: 1;
-}
-.cardName {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-.cardSub {
-  font-size: 13px;
-  color: var(--color-text-muted);
-}
-.cardRight {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-  color: var(--color-text-secondary);
-  font-size: 14px;
-}
-.delete {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-md);
-  color: var(--color-text-faint);
-  cursor: pointer;
-}
-.delete:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-state-danger-fg);
-}
-
-.empty,
-.loading {
-  font-size: 14px;
-  color: var(--color-text-muted);
-  padding: 16px 0;
-}
-.error {
-  font-size: 14px;
-  color: var(--color-state-danger-fg);
 }
 
 .createCard {
@@ -115,15 +25,17 @@
   display: flex;
   gap: 8px;
 }
-.input {
-  width: 100%;
-  padding: 8px 10px;
-  font-size: 14px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-page);
-  color: var(--color-text-primary);
-  box-sizing: border-box;
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.cardRight {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-secondary);
 }
 
 /* Detail view */
@@ -131,23 +43,21 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 4px;
+  margin: 4px 0;
+  color: var(--color-text-secondary);
 }
-.detailTitle {
-  margin: 0;
-  font-size: 20px;
-  font-weight: 600;
-}
-.detailDesc {
-  color: var(--color-text-muted);
-  margin: 0 0 16px;
-  font-size: 14px;
+.detailSpacer {
+  flex: 1;
 }
 .sectionTitle {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
   margin: 20px 0 8px;
+}
+.addRow {
+  display: flex;
+  gap: 8px;
+}
+.pickerTrigger {
+  display: inline-flex;
 }
 .memberRow {
   display: flex;
@@ -161,16 +71,4 @@
   flex-direction: column;
   min-width: 0;
   flex: 1;
-}
-.memberName {
-  font-size: 14px;
-  color: var(--color-text-primary);
-}
-.memberSub {
-  font-size: 12px;
-  color: var(--color-text-muted);
-}
-.addRow {
-  display: flex;
-  gap: 8px;
 }

--- a/frontend/src/app/admin/groups/groups.module.css
+++ b/frontend/src/app/admin/groups/groups.module.css
@@ -1,0 +1,176 @@
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-page);
+  color: var(--color-text-muted);
+}
+.searchInput {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-page);
+  cursor: pointer;
+  text-align: left;
+}
+.card:hover {
+  background: var(--color-bg-hover);
+}
+.cardIcon {
+  display: inline-flex;
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+.cardText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+.cardName {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.cardSub {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+.cardRight {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+}
+.delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-faint);
+  cursor: pointer;
+}
+.delete:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-state-danger-fg);
+}
+
+.empty,
+.loading {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  padding: 16px 0;
+}
+.error {
+  font-size: 14px;
+  color: var(--color-state-danger-fg);
+}
+
+.createCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-page);
+  margin-bottom: 16px;
+}
+.createRow {
+  display: flex;
+  gap: 8px;
+}
+.input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-page);
+  color: var(--color-text-primary);
+  box-sizing: border-box;
+}
+
+/* Detail view */
+.detailHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+.detailTitle {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+}
+.detailDesc {
+  color: var(--color-text-muted);
+  margin: 0 0 16px;
+  font-size: 14px;
+}
+.sectionTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: 20px 0 8px;
+}
+.memberRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.memberText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.memberName {
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+.memberSub {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+.addRow {
+  display: flex;
+  gap: 8px;
+}

--- a/frontend/src/app/admin/groups/groups.module.css
+++ b/frontend/src/app/admin/groups/groups.module.css
@@ -29,7 +29,13 @@
 .cards {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
+}
+.card {
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  padding: 4px;
 }
 .cardRight {
   display: inline-flex;

--- a/frontend/src/app/admin/groups/groups.module.css
+++ b/frontend/src/app/admin/groups/groups.module.css
@@ -16,9 +16,8 @@
   flex-direction: column;
   gap: 8px;
   padding: 16px;
-  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-lg);
-  background: var(--color-bg-page);
+  background: var(--color-bg-sunken);
   margin-bottom: 16px;
 }
 .createRow {
@@ -31,8 +30,9 @@
   flex-direction: column;
   gap: 10px;
 }
+/* Group rows are subtle grey-fill surfaces, not bordered cards (per mock). */
 .card {
-  border: 1px solid var(--color-border-default);
+  background: var(--color-bg-sunken);
   border-radius: var(--radius-lg);
   overflow: hidden;
   padding: 4px;

--- a/frontend/src/app/admin/groups/page.tsx
+++ b/frontend/src/app/admin/groups/page.tsx
@@ -2,13 +2,22 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { Button } from "@/components/common/Button";
-import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { Button } from "@onyx-ai/opal/components";
+import {
+  SvgChevronLeft,
+  SvgChevronRight,
+  SvgPlus,
+  SvgSearch,
+  SvgTrash,
+  SvgUserPlus,
+  SvgUsers,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+
+import { Avatar } from "@/components/common/Avatar";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
-import { ApiError, apiFetch } from "@/lib/api";
-import { color, radius } from "@/lib/theme";
-import { useIsMobile } from "@/lib/viewport";
+import { ApiError } from "@/lib/api";
 import {
   addGroupMember,
   createGroup,
@@ -18,22 +27,33 @@ import {
   useGroups,
   type Group,
 } from "@/lib/permissions";
+import { useIsMobile } from "@/lib/viewport";
+import { displayName, initials, useAdminUsers } from "@/lib/users";
 
-interface AdminUser {
-  id: string;
-  email: string;
-  name: string | null;
+import styles from "./groups.module.css";
+
+function groupSub(g: Group): string {
+  const parts: string[] = [];
+  if (g.folder_count > 0) {
+    parts.push(`${g.folder_count} ${g.folder_count === 1 ? "folder" : "folders"}`);
+  }
+  if (g.page_count > 0) {
+    parts.push(`${g.page_count} wiki ${g.page_count === 1 ? "page" : "pages"}`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : "No private pages";
 }
 
 export default function AdminGroupsPage() {
   const isMobile = useIsMobile();
   return (
     <RequireAdmin>
-      <main style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 960 }}>
+      <main
+        style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 880 }}
+      >
         <BackLink />
         <PageHeader
           title="Groups"
-          description="Groups bundle users so wiki pages can be shared with the whole group at once."
+          description="Groups bundle users so wiki pages can be shared with everyone at once."
         />
         <GroupsManager />
       </main>
@@ -42,13 +62,19 @@ export default function AdminGroupsPage() {
 }
 
 function GroupsManager() {
-  const isMobile = useIsMobile();
   const { groups, error, isLoading, refresh } = useGroups();
   const [selected, setSelected] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [creating, setCreating] = useState(false);
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [busy, setBusy] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return groups.filter((g) => !q || g.name.toLowerCase().includes(q));
+  }, [groups, query]);
 
   async function onCreate(e: React.FormEvent) {
     e.preventDefault();
@@ -59,10 +85,11 @@ function GroupsManager() {
       const g = await createGroup(name.trim(), description.trim() || undefined);
       setName("");
       setDescription("");
+      setCreating(false);
       await refresh();
       setSelected(g.id);
     } catch (err) {
-      setCreateError(err instanceof Error ? err.message : "failed");
+      setCreateError(err instanceof Error ? err.message : "Failed to create group");
     } finally {
       setBusy(false);
     }
@@ -75,97 +102,140 @@ function GroupsManager() {
     await refresh();
   }
 
-  if (error) {
-    return <div style={{ color: color.state.danger.fg }}>{error.message}</div>;
+  if (selected) {
+    return <GroupDetail groupId={selected} onBack={() => setSelected(null)} />;
   }
 
+  if (error) return <div className={styles.error}>{error.message}</div>;
+
   return (
-    <div style={{ display: "grid", gridTemplateColumns: isMobile ? "1fr" : "320px 1fr", gap: isMobile ? 16 : 24 }}>
-      <div>
-        <form onSubmit={onCreate} style={{ marginBottom: 16 }}>
-          <h3 style={{ marginTop: 0, fontSize: 14 }}>New group</h3>
+    <>
+      <div className={styles.toolbar}>
+        <span className={styles.search}>
+          <SvgSearch size={16} />
           <input
+            className={styles.searchInput}
+            placeholder="Search groups…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </span>
+        <Button
+          variant="action"
+          size="md"
+          icon={SvgPlus}
+          onClick={() => setCreating((v) => !v)}
+        >
+          New Group
+        </Button>
+      </div>
+
+      {creating && (
+        <form className={styles.createCard} onSubmit={onCreate}>
+          <input
+            className={styles.input}
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="name (e.g. eng)"
-            style={inputStyle}
+            placeholder="Group name (e.g. Engineering)"
+            autoFocus
           />
           <input
+            className={styles.input}
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            placeholder="description (optional)"
-            style={{ ...inputStyle, marginTop: 6 }}
+            placeholder="Description (optional)"
           />
-          <Button
-            type="submit"
-            variant="primary"
-            size="sm"
-            disabled={busy || !name.trim()}
-            style={{ marginTop: 8 }}
-          >
-            Create group
-          </Button>
-          {createError && (
-            <div style={{ color: color.state.danger.fg, marginTop: 8, fontSize: 13 }}>{createError}</div>
-          )}
+          <div className={styles.createRow}>
+            <Button
+              type="submit"
+              variant="action"
+              size="md"
+              disabled={busy || !name.trim()}
+            >
+              Create
+            </Button>
+            <Button
+              type="button"
+              prominence="tertiary"
+              size="md"
+              onClick={() => setCreating(false)}
+            >
+              Cancel
+            </Button>
+          </div>
+          {createError && <div className={styles.error}>{createError}</div>}
         </form>
+      )}
 
-        <h3 style={{ fontSize: 14 }}>Groups</h3>
-        {isLoading ? (
-          <LoadingSpinner />
-        ) : groups.length === 0 ? (
-          <div style={{ color: color.text.muted, fontSize: 13 }}>No groups yet.</div>
-        ) : (
-          <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-            {groups.map((g) => (
-              <li key={g.id} style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 0" }}>
-                <Button
-                  size="sm"
-                  onClick={() => setSelected(g.id)}
-                  style={{
-                    flex: 1,
-                    textAlign: "left",
-                    background: selected === g.id ? color.accent.subtleBg : color.bg.page,
-                    fontWeight: selected === g.id ? 600 : 400,
-                  }}
-                >
-                  {g.name}
-                </Button>
-                <Button size="sm" variant="danger" onClick={() => void onDelete(g)}>
-                  Delete
-                </Button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <div>
-        {selected ? <GroupDetail groupId={selected} /> : (
-          <div style={{ color: color.text.muted, fontSize: 13 }}>Select a group to manage members.</div>
-        )}
-      </div>
-    </div>
+      {isLoading ? (
+        <div className={styles.loading}>Loading…</div>
+      ) : filtered.length === 0 ? (
+        <div className={styles.empty}>
+          {query ? "No groups match your search." : "No groups yet."}
+        </div>
+      ) : (
+        <div className={styles.cards}>
+          {filtered.map((g) => (
+            <button
+              key={g.id}
+              type="button"
+              className={styles.card}
+              onClick={() => setSelected(g.id)}
+            >
+              <span className={styles.cardIcon}>
+                <SvgUsers size={22} />
+              </span>
+              <span className={styles.cardText}>
+                <span className={styles.cardName}>{g.name}</span>
+                <span className={styles.cardSub}>{groupSub(g)}</span>
+              </span>
+              <span className={styles.cardRight}>
+                {g.member_count} {g.member_count === 1 ? "Member" : "Members"}
+                <SvgChevronRight size={18} />
+              </span>
+              <span
+                className={styles.delete}
+                role="button"
+                tabIndex={0}
+                aria-label={`Delete ${g.name}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void onDelete(g);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.stopPropagation();
+                    void onDelete(g);
+                  }
+                }}
+              >
+                <SvgTrash size={16} />
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </>
   );
 }
 
-function GroupDetail({ groupId }: { groupId: string }) {
+function GroupDetail({
+  groupId,
+  onBack,
+}: {
+  groupId: string;
+  onBack: () => void;
+}) {
   const { group, members, isLoading, refresh } = useGroup(groupId);
-  const [allUsers, setAllUsers] = useState<AdminUser[]>([]);
+  const { users } = useAdminUsers();
   const [pickedId, setPickedId] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    void apiFetch<{ users: AdminUser[] }>("/admin/users")
-      .then((r) => setAllUsers(r.users))
-      .catch(() => {});
-  }, []);
-
   const candidates = useMemo(() => {
     const memberIds = new Set(members.map((m) => m.id));
-    return allUsers.filter((u) => !memberIds.has(u.id));
-  }, [allUsers, members]);
+    return users.filter((u) => !memberIds.has(u.id));
+  }, [users, members]);
 
   async function add() {
     if (!pickedId) return;
@@ -176,7 +246,7 @@ function GroupDetail({ groupId }: { groupId: string }) {
       setPickedId("");
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "failed");
+      setError(err instanceof Error ? err.message : "Failed to add member");
     } finally {
       setBusy(false);
     }
@@ -194,68 +264,77 @@ function GroupDetail({ groupId }: { groupId: string }) {
     }
   }
 
-  if (isLoading || !group) return <LoadingSpinner />;
+  if (isLoading || !group)
+    return <div className={styles.loading}>Loading…</div>;
 
   return (
     <div>
-      <h2 style={{ margin: 0 }}>{group.name}</h2>
-      {group.description && <p style={{ marginTop: 4, color: color.text.muted }}>{group.description}</p>}
+      <Button prominence="tertiary" size="sm" icon={SvgChevronLeft} onClick={onBack}>
+        All groups
+      </Button>
+      <div className={styles.detailHead}>
+        <SvgUsers size={22} />
+        <h2 className={styles.detailTitle}>{group.name}</h2>
+      </div>
+      {group.description && <p className={styles.detailDesc}>{group.description}</p>}
 
-      <h3 style={{ fontSize: 14, marginTop: 24 }}>Add member</h3>
-      <div style={{ display: "flex", gap: 8 }}>
+      <div className={styles.sectionTitle}>Add member</div>
+      <div className={styles.addRow}>
         <select
+          className={styles.input}
           value={pickedId}
           onChange={(e) => setPickedId(e.target.value)}
-          style={{ ...inputStyle, flex: 1 }}
         >
           <option value="">Choose a user…</option>
           {candidates.map((u) => (
             <option key={u.id} value={u.id}>
-              {u.email} {u.name ? `(${u.name})` : ""}
+              {u.email}
+              {u.name ? ` (${u.name})` : ""}
             </option>
           ))}
         </select>
-        <Button onClick={() => void add()} disabled={!pickedId || busy}>
+        <Button
+          variant="action"
+          size="md"
+          icon={SvgUserPlus}
+          onClick={() => void add()}
+          disabled={!pickedId || busy}
+        >
           Add
         </Button>
       </div>
-      {error && <div style={{ color: color.state.danger.fg, marginTop: 8, fontSize: 13 }}>{error}</div>}
+      {error && <div className={styles.error}>{error}</div>}
 
-      <h3 style={{ fontSize: 14, marginTop: 24 }}>Members ({members.length})</h3>
+      <div className={styles.sectionTitle}>Members ({members.length})</div>
       {members.length === 0 ? (
-        <div style={{ color: color.text.muted, fontSize: 13 }}>No members yet.</div>
+        <div className={styles.empty}>No members yet.</div>
       ) : (
-        <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-          {members.map((m) => (
-            <li
-              key={m.id}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                padding: "8px 0",
-                borderBottom: `1px solid ${color.border.subtle}`,
-              }}
-            >
-              <span>
-                {m.email} {m.name ? <span style={{ color: color.text.muted }}>({m.name})</span> : null}
+        members.map((m) => (
+          <div key={m.id} className={styles.memberRow}>
+            <Avatar
+              label={initials({ name: m.name, email: m.email })}
+              size={28}
+              title={displayName({ name: m.name, email: m.email })}
+            />
+            <span className={styles.memberText}>
+              <span className={styles.memberName}>
+                {displayName({ name: m.name, email: m.email })}
               </span>
-              <Button size="sm" variant="danger" onClick={() => void remove(m.id)} disabled={busy}>
-                Remove
-              </Button>
-            </li>
-          ))}
-        </ul>
+              <span className={styles.memberSub}>{m.email}</span>
+            </span>
+            <Button
+              prominence="tertiary"
+              size="sm"
+              variant="danger"
+              icon={SvgX}
+              onClick={() => void remove(m.id)}
+              disabled={busy}
+            >
+              Remove
+            </Button>
+          </div>
+        ))
       )}
     </div>
   );
 }
-
-const inputStyle: React.CSSProperties = {
-  width: "100%",
-  padding: "8px 10px",
-  fontSize: 14,
-  border: `1px solid ${color.border.default}`,
-  borderRadius: radius.sm,
-  boxSizing: "border-box",
-};

--- a/frontend/src/app/admin/groups/page.tsx
+++ b/frontend/src/app/admin/groups/page.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
-import { Button } from "@onyx-ai/opal/components";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  OpenButton,
+  Popover,
+  PopoverMenu,
+  Text,
+} from "@onyx-ai/opal/components";
 import {
   SvgChevronLeft,
   SvgChevronRight,
   SvgPlus,
-  SvgSearch,
   SvgTrash,
+  SvgUser,
   SvgUserPlus,
   SvgUsers,
   SvgX,
@@ -103,23 +111,34 @@ function GroupsManager() {
   }
 
   if (selected) {
-    return <GroupDetail groupId={selected} onBack={() => setSelected(null)} />;
+    const g = groups.find((x) => x.id === selected);
+    return (
+      <GroupDetail
+        groupId={selected}
+        onBack={() => setSelected(null)}
+        onDelete={g ? () => void onDelete(g) : undefined}
+      />
+    );
   }
 
-  if (error) return <div className={styles.error}>{error.message}</div>;
+  if (error)
+    return (
+      <Text font="secondary-body" color="text-02">
+        {error.message}
+      </Text>
+    );
 
   return (
     <>
       <div className={styles.toolbar}>
-        <span className={styles.search}>
-          <SvgSearch size={16} />
-          <input
-            className={styles.searchInput}
+        <div className={styles.searchWrap}>
+          <InputTypeIn
+            searchIcon
             placeholder="Search groups…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
           />
-        </span>
+        </div>
         <Button
           variant="action"
           size="md"
@@ -132,26 +151,18 @@ function GroupsManager() {
 
       {creating && (
         <form className={styles.createCard} onSubmit={onCreate}>
-          <input
-            className={styles.input}
+          <InputTypeIn
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Group name (e.g. Engineering)"
-            autoFocus
           />
-          <input
-            className={styles.input}
+          <InputTypeIn
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Description (optional)"
           />
           <div className={styles.createRow}>
-            <Button
-              type="submit"
-              variant="action"
-              size="md"
-              disabled={busy || !name.trim()}
-            >
+            <Button type="submit" variant="action" size="md" disabled={busy || !name.trim()}>
               Create
             </Button>
             <Button
@@ -163,55 +174,42 @@ function GroupsManager() {
               Cancel
             </Button>
           </div>
-          {createError && <div className={styles.error}>{createError}</div>}
+          {createError && (
+            <Text font="secondary-body" color="text-02">
+              {createError}
+            </Text>
+          )}
         </form>
       )}
 
       {isLoading ? (
-        <div className={styles.loading}>Loading…</div>
+        <Text font="secondary-body" color="text-03">
+          Loading…
+        </Text>
       ) : filtered.length === 0 ? (
-        <div className={styles.empty}>
+        <Text font="secondary-body" color="text-03">
           {query ? "No groups match your search." : "No groups yet."}
-        </div>
+        </Text>
       ) : (
         <div className={styles.cards}>
           {filtered.map((g) => (
-            <button
+            <LineItemButton
               key={g.id}
-              type="button"
-              className={styles.card}
+              icon={SvgUsers}
+              title={g.name}
+              description={groupSub(g)}
+              sizePreset="main-content"
+              variant="section"
+              rightChildren={
+                <span className={styles.cardRight}>
+                  <Text font="secondary-body" color="text-03">
+                    {`${g.member_count} ${g.member_count === 1 ? "Member" : "Members"}`}
+                  </Text>
+                  <SvgChevronRight size={18} />
+                </span>
+              }
               onClick={() => setSelected(g.id)}
-            >
-              <span className={styles.cardIcon}>
-                <SvgUsers size={22} />
-              </span>
-              <span className={styles.cardText}>
-                <span className={styles.cardName}>{g.name}</span>
-                <span className={styles.cardSub}>{groupSub(g)}</span>
-              </span>
-              <span className={styles.cardRight}>
-                {g.member_count} {g.member_count === 1 ? "Member" : "Members"}
-                <SvgChevronRight size={18} />
-              </span>
-              <span
-                className={styles.delete}
-                role="button"
-                tabIndex={0}
-                aria-label={`Delete ${g.name}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void onDelete(g);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.stopPropagation();
-                    void onDelete(g);
-                  }
-                }}
-              >
-                <SvgTrash size={16} />
-              </span>
-            </button>
+            />
           ))}
         </div>
       )}
@@ -222,13 +220,15 @@ function GroupsManager() {
 function GroupDetail({
   groupId,
   onBack,
+  onDelete,
 }: {
   groupId: string;
   onBack: () => void;
+  onDelete?: () => void;
 }) {
   const { group, members, isLoading, refresh } = useGroup(groupId);
   const { users } = useAdminUsers();
-  const [pickedId, setPickedId] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -237,13 +237,12 @@ function GroupDetail({
     return users.filter((u) => !memberIds.has(u.id));
   }, [users, members]);
 
-  async function add() {
-    if (!pickedId) return;
+  async function add(userId: string) {
     setBusy(true);
     setError(null);
     try {
-      await addGroupMember(groupId, pickedId);
-      setPickedId("");
+      await addGroupMember(groupId, userId);
+      setPickerOpen(false);
       await refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to add member");
@@ -265,7 +264,11 @@ function GroupDetail({
   }
 
   if (isLoading || !group)
-    return <div className={styles.loading}>Loading…</div>;
+    return (
+      <Text font="secondary-body" color="text-03">
+        Loading…
+      </Text>
+    );
 
   return (
     <div>
@@ -274,40 +277,74 @@ function GroupDetail({
       </Button>
       <div className={styles.detailHead}>
         <SvgUsers size={22} />
-        <h2 className={styles.detailTitle}>{group.name}</h2>
+        <Text as="h2" font="heading-h3">
+          {group.name}
+        </Text>
+        <span className={styles.detailSpacer} />
+        {onDelete && (
+          <Button
+            prominence="tertiary"
+            size="sm"
+            variant="danger"
+            icon={SvgTrash}
+            onClick={onDelete}
+          >
+            Delete group
+          </Button>
+        )}
       </div>
-      {group.description && <p className={styles.detailDesc}>{group.description}</p>}
+      {group.description && (
+        <Text font="secondary-body" color="text-03">
+          {group.description}
+        </Text>
+      )}
 
-      <div className={styles.sectionTitle}>Add member</div>
+      <div className={styles.sectionTitle}>
+        <Text font="main-ui-action" color="text-02">
+          Add member
+        </Text>
+      </div>
       <div className={styles.addRow}>
-        <select
-          className={styles.input}
-          value={pickedId}
-          onChange={(e) => setPickedId(e.target.value)}
-        >
-          <option value="">Choose a user…</option>
-          {candidates.map((u) => (
-            <option key={u.id} value={u.id}>
-              {u.email}
-              {u.name ? ` (${u.name})` : ""}
-            </option>
-          ))}
-        </select>
-        <Button
-          variant="action"
-          size="md"
-          icon={SvgUserPlus}
-          onClick={() => void add()}
-          disabled={!pickedId || busy}
-        >
-          Add
-        </Button>
+        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+          <Popover.Trigger asChild>
+            <span className={styles.pickerTrigger}>
+              <OpenButton variant="select-light" size="md" icon={SvgUserPlus}>
+                {candidates.length ? "Choose a user…" : "No users to add"}
+              </OpenButton>
+            </span>
+          </Popover.Trigger>
+          <Popover.Content width="trigger" align="start" sideOffset={4}>
+            <PopoverMenu>
+              {candidates.map((u) => (
+                <LineItemButton
+                  key={u.id}
+                  icon={SvgUser}
+                  title={displayName({ name: u.name, email: u.email })}
+                  description={u.email}
+                  sizePreset="main-ui"
+                  variant="section"
+                  onClick={() => void add(u.id)}
+                />
+              ))}
+            </PopoverMenu>
+          </Popover.Content>
+        </Popover>
       </div>
-      {error && <div className={styles.error}>{error}</div>}
+      {error && (
+        <Text font="secondary-body" color="text-02">
+          {error}
+        </Text>
+      )}
 
-      <div className={styles.sectionTitle}>Members ({members.length})</div>
+      <div className={styles.sectionTitle}>
+        <Text font="main-ui-action" color="text-02">
+          {`Members (${members.length})`}
+        </Text>
+      </div>
       {members.length === 0 ? (
-        <div className={styles.empty}>No members yet.</div>
+        <Text font="secondary-body" color="text-03">
+          No members yet.
+        </Text>
       ) : (
         members.map((m) => (
           <div key={m.id} className={styles.memberRow}>
@@ -316,12 +353,14 @@ function GroupDetail({
               size={28}
               title={displayName({ name: m.name, email: m.email })}
             />
-            <span className={styles.memberText}>
-              <span className={styles.memberName}>
+            <div className={styles.memberText}>
+              <Text font="main-ui-body" nowrap>
                 {displayName({ name: m.name, email: m.email })}
-              </span>
-              <span className={styles.memberSub}>{m.email}</span>
-            </span>
+              </Text>
+              <Text font="secondary-body" color="text-03" nowrap>
+                {m.email}
+              </Text>
+            </div>
             <Button
               prominence="tertiary"
               size="sm"

--- a/frontend/src/app/admin/groups/page.tsx
+++ b/frontend/src/app/admin/groups/page.tsx
@@ -142,7 +142,7 @@ function GroupsManager() {
         <Button
           variant="action"
           size="md"
-          icon={SvgPlus}
+          rightIcon={SvgPlus}
           onClick={() => setCreating((v) => !v)}
         >
           New Group
@@ -193,23 +193,24 @@ function GroupsManager() {
       ) : (
         <div className={styles.cards}>
           {filtered.map((g) => (
-            <LineItemButton
-              key={g.id}
-              icon={SvgUsers}
-              title={g.name}
-              description={groupSub(g)}
-              sizePreset="main-content"
-              variant="section"
-              rightChildren={
-                <span className={styles.cardRight}>
-                  <Text font="secondary-body" color="text-03">
-                    {`${g.member_count} ${g.member_count === 1 ? "Member" : "Members"}`}
-                  </Text>
-                  <SvgChevronRight size={18} />
-                </span>
-              }
-              onClick={() => setSelected(g.id)}
-            />
+            <div key={g.id} className={styles.card}>
+              <LineItemButton
+                icon={SvgUsers}
+                title={g.name}
+                description={groupSub(g)}
+                sizePreset="main-content"
+                variant="section"
+                rightChildren={
+                  <span className={styles.cardRight}>
+                    <Text font="secondary-body" color="text-03">
+                      {`${g.member_count} ${g.member_count === 1 ? "Member" : "Members"}`}
+                    </Text>
+                    <SvgChevronRight size={18} />
+                  </span>
+                }
+                onClick={() => setSelected(g.id)}
+              />
+            </div>
           ))}
         </div>
       )}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -2,14 +2,9 @@
 
 import { useMemo, useState } from "react";
 
+import { Button, Popover, SelectButton, Tag } from "@onyx-ai/opal/components";
 import {
-  Button,
-  LineItemButton,
-  Popover,
-  SelectButton,
-  Tag,
-} from "@onyx-ai/opal/components";
-import {
+  SvgCheck,
   SvgChevronDown,
   SvgSearch,
   SvgTrash,
@@ -222,30 +217,44 @@ function AccountTypeSelect({
         </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
-        <Popover.Menu>
-          {[
-            <LineItemButton
-              key="basic"
-              icon={SvgUser}
-              title="Basic"
-              state={!isAdmin ? "selected" : "empty"}
-              onClick={() => {
-                onChange(false);
-                setOpen(false);
-              }}
-            />,
-            <LineItemButton
-              key="admin"
-              icon={SvgUserShield}
-              title="Admin"
-              state={isAdmin ? "selected" : "empty"}
-              onClick={() => {
-                onChange(true);
-                setOpen(false);
-              }}
-            />,
-          ]}
-        </Popover.Menu>
+        <div className={styles.menu}>
+          <button
+            type="button"
+            className={styles.menuItem}
+            onClick={() => {
+              onChange(false);
+              setOpen(false);
+            }}
+          >
+            <span className={styles.menuItemIcon}>
+              <SvgUser size={16} />
+            </span>
+            <span className={styles.menuItemLabel}>Basic</span>
+            {!isAdmin && (
+              <span className={styles.menuItemCheck}>
+                <SvgCheck size={16} />
+              </span>
+            )}
+          </button>
+          <button
+            type="button"
+            className={styles.menuItem}
+            onClick={() => {
+              onChange(true);
+              setOpen(false);
+            }}
+          >
+            <span className={styles.menuItemIcon}>
+              <SvgUserShield size={16} />
+            </span>
+            <span className={styles.menuItemLabel}>Admin</span>
+            {isAdmin && (
+              <span className={styles.menuItemCheck}>
+                <SvgCheck size={16} />
+              </span>
+            )}
+          </button>
+        </div>
       </Popover.Content>
     </Popover>
   );

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -2,15 +2,17 @@
 
 import { useMemo, useState } from "react";
 
-import { Button, Popover, SelectButton, Tag } from "@onyx-ai/opal/components";
 import {
-  SvgCheck,
-  SvgChevronDown,
-  SvgSearch,
-  SvgTrash,
-  SvgUser,
-  SvgUserShield,
-} from "@onyx-ai/opal/icons";
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  OpenButton,
+  Popover,
+  PopoverMenu,
+  Tag,
+  Text,
+} from "@onyx-ai/opal/components";
+import { SvgTrash, SvgUser, SvgUserShield } from "@onyx-ai/opal/icons";
 
 import { Avatar } from "@/components/common/Avatar";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
@@ -102,35 +104,54 @@ function UsersTable() {
   return (
     <div>
       <div className={styles.stat}>
-        {users.length} {users.length === 1 ? "active user" : "active users"}
+        <Text font="secondary-body" color="text-03">
+          {`${users.length} ${users.length === 1 ? "active user" : "active users"}`}
+        </Text>
       </div>
-      <span className={styles.search}>
-        <SvgSearch size={16} />
-        <input
-          className={styles.searchInput}
+      <div className={styles.searchWrap}>
+        <InputTypeIn
+          searchIcon
           placeholder="Search users…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
-      </span>
+      </div>
 
       {(actionError || loadError) && (
-        <div className={styles.error}>
-          {actionError ?? loadError?.message}
+        <div className={styles.errorRow}>
+          <Text font="secondary-body" color="text-02">
+            {actionError ?? loadError?.message ?? ""}
+          </Text>
         </div>
       )}
 
       <div className={styles.table} style={{ ["--cols" as string]: cols }}>
         <div className={styles.headRow}>
-          <span className={styles.headCell}>Name</span>
-          {!isMobile && <span className={styles.headCell}>Groups</span>}
-          <span className={styles.headCell}>Account type</span>
-          {!isMobile && <span className={styles.headCell}>Created</span>}
-          <span className={styles.headCell} />
+          <Text font="secondary-action" color="text-03">
+            Name
+          </Text>
+          {!isMobile && (
+            <Text font="secondary-action" color="text-03">
+              Groups
+            </Text>
+          )}
+          <Text font="secondary-action" color="text-03">
+            Account type
+          </Text>
+          {!isMobile && (
+            <Text font="secondary-action" color="text-03">
+              Created
+            </Text>
+          )}
+          <span />
         </div>
 
         {filtered.length === 0 ? (
-          <div className={styles.empty}>No users match your search.</div>
+          <div className={styles.emptyRow}>
+            <Text font="secondary-body" color="text-03">
+              No users match your search.
+            </Text>
+          </div>
         ) : (
           filtered.map((u) => {
             const isSelf = u.id === currentUserId;
@@ -138,21 +159,23 @@ function UsersTable() {
             return (
               <div key={u.id} className={styles.row}>
                 <span className={styles.who}>
-                  <Avatar
-                    label={initials(u)}
-                    size={32}
-                    title={displayName(u)}
-                  />
+                  <Avatar label={initials(u)} size={32} title={displayName(u)} />
                   <span className={styles.whoText}>
-                    <span className={styles.whoName}>{displayName(u)}</span>
-                    <span className={styles.whoEmail}>{u.email}</span>
+                    <Text font="main-ui-body" nowrap>
+                      {displayName(u)}
+                    </Text>
+                    <Text font="secondary-body" color="text-03" nowrap>
+                      {u.email}
+                    </Text>
                   </span>
                 </span>
 
                 {!isMobile && (
                   <span className={styles.tags}>
                     {u.groups.length === 0 ? (
-                      <span className={styles.muted}>—</span>
+                      <Text font="secondary-body" color="text-05">
+                        —
+                      </Text>
                     ) : (
                       u.groups.map((g) => <Tag key={g} title={g} color="gray" />)
                     )}
@@ -166,9 +189,9 @@ function UsersTable() {
                 />
 
                 {!isMobile && (
-                  <span className={styles.created}>
+                  <Text font="secondary-body" color="text-03" nowrap>
                     {u.created_at.split(" ")[0]}
-                  </span>
+                  </Text>
                 )}
 
                 <span className={styles.actions}>
@@ -205,56 +228,41 @@ function AccountTypeSelect({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <span className={styles.menuTrigger}>
-          <SelectButton
-            size="sm"
+          <OpenButton
             variant="select-light"
+            size="sm"
             icon={isAdmin ? SvgUserShield : SvgUser}
-            rightIcon={SvgChevronDown}
             disabled={disabled}
           >
             {isAdmin ? "Admin" : "Basic"}
-          </SelectButton>
+          </OpenButton>
         </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
-        <div className={styles.menu}>
-          <button
-            type="button"
-            className={styles.menuItem}
+        <PopoverMenu>
+          <LineItemButton
+            icon={SvgUser}
+            title="Basic"
+            sizePreset="main-ui"
+            variant="section"
+            state={!isAdmin ? "selected" : "empty"}
             onClick={() => {
               onChange(false);
               setOpen(false);
             }}
-          >
-            <span className={styles.menuItemIcon}>
-              <SvgUser size={16} />
-            </span>
-            <span className={styles.menuItemLabel}>Basic</span>
-            {!isAdmin && (
-              <span className={styles.menuItemCheck}>
-                <SvgCheck size={16} />
-              </span>
-            )}
-          </button>
-          <button
-            type="button"
-            className={styles.menuItem}
+          />
+          <LineItemButton
+            icon={SvgUserShield}
+            title="Admin"
+            sizePreset="main-ui"
+            variant="section"
+            state={isAdmin ? "selected" : "empty"}
             onClick={() => {
               onChange(true);
               setOpen(false);
             }}
-          >
-            <span className={styles.menuItemIcon}>
-              <SvgUserShield size={16} />
-            </span>
-            <span className={styles.menuItemLabel}>Admin</span>
-            {isAdmin && (
-              <span className={styles.menuItemCheck}>
-                <SvgCheck size={16} />
-              </span>
-            )}
-          </button>
-        </div>
+          />
+        </PopoverMenu>
       </Popover.Content>
     </Popover>
   );

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -209,15 +209,17 @@ function AccountTypeSelect({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <SelectButton
-          size="sm"
-          variant="select-light"
-          icon={isAdmin ? SvgUserShield : SvgUser}
-          rightIcon={SvgChevronDown}
-          disabled={disabled}
-        >
-          {isAdmin ? "Admin" : "Basic"}
-        </SelectButton>
+        <span className={styles.menuTrigger}>
+          <SelectButton
+            size="sm"
+            variant="select-light"
+            icon={isAdmin ? SvgUserShield : SvgUser}
+            rightIcon={SvgChevronDown}
+            disabled={disabled}
+          >
+            {isAdmin ? "Admin" : "Basic"}
+          </SelectButton>
+        </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
         <Popover.Menu>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,28 +1,44 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo, useState } from "react";
 
-import { Button } from "@/components/common/Button";
+import {
+  Button,
+  LineItemButton,
+  Popover,
+  SelectButton,
+  Tag,
+} from "@onyx-ai/opal/components";
+import {
+  SvgChevronDown,
+  SvgSearch,
+  SvgTrash,
+  SvgUser,
+  SvgUserShield,
+} from "@onyx-ai/opal/icons";
+
+import { Avatar } from "@/components/common/Avatar";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
-import { color } from "@/lib/theme";
 import { useIsMobile } from "@/lib/viewport";
+import {
+  displayName,
+  initials,
+  useAdminUsers,
+  type AdminUser,
+} from "@/lib/users";
 
-interface AdminUser {
-  id: string;
-  email: string;
-  name: string | null;
-  is_admin: boolean;
-  created_at: string;
-}
+import styles from "./users.module.css";
 
 export default function AdminUsersPage() {
   const isMobile = useIsMobile();
   return (
     <RequireAdmin>
-      <main style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 960 }}>
+      <main
+        style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 960 }}
+      >
         <BackLink />
         <PageHeader
           title="Users"
@@ -38,34 +54,33 @@ function UsersTable() {
   const { user: currentUser } = useAuth();
   const currentUserId = currentUser?.id ?? "";
   const isMobile = useIsMobile();
-  const [users, setUsers] = useState<AdminUser[]>([]);
-  const [error, setError] = useState<string | null>(null);
+  const { users, error: loadError, refresh } = useAdminUsers();
+  const [query, setQuery] = useState("");
   const [busyId, setBusyId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  async function load() {
-    try {
-      const r = await apiFetch<{ users: AdminUser[] }>("/admin/users");
-      setUsers(r.users);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to load");
-    }
-  }
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return users;
+    return users.filter(
+      (u) =>
+        u.email.toLowerCase().includes(q) ||
+        (u.name ?? "").toLowerCase().includes(q),
+    );
+  }, [users, query]);
 
-  useEffect(() => {
-    void load();
-  }, []);
-
-  async function toggleAdmin(u: AdminUser) {
+  async function setAdmin(u: AdminUser, makeAdmin: boolean) {
+    if (u.is_admin === makeAdmin) return;
     setBusyId(u.id);
-    setError(null);
+    setActionError(null);
     try {
       await apiFetch<AdminUser>(`/admin/users/${u.id}`, {
         method: "PATCH",
-        body: JSON.stringify({ is_admin: !u.is_admin }),
+        body: JSON.stringify({ is_admin: makeAdmin }),
       });
-      await load();
+      await refresh();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to update");
+      setActionError(e instanceof Error ? e.message : "Failed to update user");
     } finally {
       setBusyId(null);
     }
@@ -74,77 +89,162 @@ function UsersTable() {
   async function remove(u: AdminUser) {
     if (!confirm(`Delete ${u.email}? This cannot be undone.`)) return;
     setBusyId(u.id);
-    setError(null);
+    setActionError(null);
     try {
       await apiFetch<void>(`/admin/users/${u.id}`, { method: "DELETE" });
-      await load();
+      await refresh();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to delete");
+      setActionError(e instanceof Error ? e.message : "Failed to delete user");
     } finally {
       setBusyId(null);
     }
   }
 
+  const cols = isMobile
+    ? "1fr auto auto"
+    : "minmax(0, 2fr) minmax(0, 1.5fr) 130px 110px 70px";
+
   return (
     <div>
-      {error && <div style={{ color: color.state.danger.fg, marginBottom: 12 }}>{error}</div>}
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <thead>
-          <tr style={{ textAlign: "left", borderBottom: `1px solid ${color.border.default}` }}>
-            <Th>Email</Th>
-            {!isMobile && <Th>Name</Th>}
-            <Th>Role</Th>
-            {!isMobile && <Th>Created</Th>}
-            <Th>Actions</Th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map((u) => {
+      <div className={styles.stat}>
+        {users.length} {users.length === 1 ? "active user" : "active users"}
+      </div>
+      <span className={styles.search}>
+        <SvgSearch size={16} />
+        <input
+          className={styles.searchInput}
+          placeholder="Search users…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </span>
+
+      {(actionError || loadError) && (
+        <div className={styles.error}>
+          {actionError ?? loadError?.message}
+        </div>
+      )}
+
+      <div className={styles.table} style={{ ["--cols" as string]: cols }}>
+        <div className={styles.headRow}>
+          <span className={styles.headCell}>Name</span>
+          {!isMobile && <span className={styles.headCell}>Groups</span>}
+          <span className={styles.headCell}>Account type</span>
+          {!isMobile && <span className={styles.headCell}>Created</span>}
+          <span className={styles.headCell} />
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className={styles.empty}>No users match your search.</div>
+        ) : (
+          filtered.map((u) => {
             const isSelf = u.id === currentUserId;
             const busy = busyId === u.id;
             return (
-              <tr key={u.id} style={{ borderBottom: `1px solid ${color.border.subtle}` }}>
-                <Td>{u.email}</Td>
-                {!isMobile && <Td>{u.name ?? "—"}</Td>}
-                <Td>
-                  {u.is_admin ? (
-                    <span style={{ color: color.text.primary, fontWeight: 600 }}>Admin</span>
-                  ) : (
-                    <span style={{ color: color.text.muted }}>User</span>
-                  )}
-                </Td>
-                {!isMobile && <Td>{u.created_at.split(" ")[0]}</Td>}
-                <Td>
+              <div key={u.id} className={styles.row}>
+                <span className={styles.who}>
+                  <Avatar
+                    label={initials(u)}
+                    size={32}
+                    title={displayName(u)}
+                  />
+                  <span className={styles.whoText}>
+                    <span className={styles.whoName}>{displayName(u)}</span>
+                    <span className={styles.whoEmail}>{u.email}</span>
+                  </span>
+                </span>
+
+                {!isMobile && (
+                  <span className={styles.tags}>
+                    {u.groups.length === 0 ? (
+                      <span className={styles.muted}>—</span>
+                    ) : (
+                      u.groups.map((g) => <Tag key={g} title={g} color="gray" />)
+                    )}
+                  </span>
+                )}
+
+                <AccountTypeSelect
+                  isAdmin={u.is_admin}
+                  disabled={busy || (u.is_admin && isSelf)}
+                  onChange={(makeAdmin) => void setAdmin(u, makeAdmin)}
+                />
+
+                {!isMobile && (
+                  <span className={styles.created}>
+                    {u.created_at.split(" ")[0]}
+                  </span>
+                )}
+
+                <span className={styles.actions}>
                   <Button
-                    size="sm"
-                    onClick={() => void toggleAdmin(u)}
-                    disabled={busy || (u.is_admin && isSelf)}
-                    title={u.is_admin && isSelf ? "Use another admin to demote yourself" : ""}
-                  >
-                    {u.is_admin ? "Demote" : "Promote"}
-                  </Button>
-                  <Button
+                    prominence="tertiary"
                     size="sm"
                     variant="danger"
+                    icon={SvgTrash}
                     onClick={() => void remove(u)}
                     disabled={busy || isSelf}
-                    style={{ marginLeft: 8 }}
-                  >
-                    Delete
-                  </Button>
-                </Td>
-              </tr>
+                    tooltip={isSelf ? "You can't delete yourself" : "Delete user"}
+                  />
+                </span>
+              </div>
             );
-          })}
-        </tbody>
-      </table>
+          })
+        )}
+      </div>
     </div>
   );
 }
 
-const Th = ({ children }: { children: React.ReactNode }) => (
-  <th style={{ padding: "10px 8px", fontSize: 13, fontWeight: 600, color: color.text.secondary }}>{children}</th>
-);
-const Td = ({ children }: { children: React.ReactNode }) => (
-  <td style={{ padding: "10px 8px", fontSize: 14 }}>{children}</td>
-);
+function AccountTypeSelect({
+  isAdmin,
+  disabled,
+  onChange,
+}: {
+  isAdmin: boolean;
+  disabled?: boolean;
+  onChange: (makeAdmin: boolean) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <SelectButton
+          size="sm"
+          variant="select-light"
+          icon={isAdmin ? SvgUserShield : SvgUser}
+          rightIcon={SvgChevronDown}
+          disabled={disabled}
+        >
+          {isAdmin ? "Admin" : "Basic"}
+        </SelectButton>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="start" sideOffset={4}>
+        <Popover.Menu>
+          {[
+            <LineItemButton
+              key="basic"
+              icon={SvgUser}
+              title="Basic"
+              state={!isAdmin ? "selected" : "empty"}
+              onClick={() => {
+                onChange(false);
+                setOpen(false);
+              }}
+            />,
+            <LineItemButton
+              key="admin"
+              icon={SvgUserShield}
+              title="Admin"
+              state={isAdmin ? "selected" : "empty"}
+              onClick={() => {
+                onChange(true);
+                setOpen(false);
+              }}
+            />,
+          ]}
+        </Popover.Menu>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -96,6 +96,49 @@
 .menuTrigger {
   display: inline-flex;
 }
+
+/* Compact dropdown menu (OPAL LineItemButton renders oversized cards). */
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 160px;
+  padding: 4px;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+}
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+.menuItem:hover {
+  background: var(--color-bg-hover);
+}
+.menuItemIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
+.menuItemLabel {
+  flex: 1;
+}
+.menuItemCheck {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
 .error {
   font-size: 14px;
   color: var(--color-state-danger-fg);

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -1,26 +1,13 @@
+/* Layout only — typography, inputs, menus, and buttons come from OPAL. */
+
 .stat {
-  font-size: 13px;
-  color: var(--color-text-muted);
   margin-bottom: 12px;
 }
-.search {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  background: var(--color-bg-page);
-  color: var(--color-text-muted);
+.searchWrap {
   margin-bottom: 16px;
 }
-.searchInput {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  font-size: 14px;
-  color: var(--color-text-primary);
+.errorRow {
+  margin-bottom: 12px;
 }
 
 .table {
@@ -33,11 +20,6 @@
   gap: 12px;
   padding: 8px;
   border-bottom: 1px solid var(--color-border-default);
-}
-.headCell {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
 }
 .row {
   display: grid;
@@ -58,94 +40,20 @@
   flex-direction: column;
   min-width: 0;
 }
-.whoName {
-  font-size: 14px;
-  color: var(--color-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.whoEmail {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 .tags {
   display: flex;
   flex-wrap: wrap;
   gap: 4px;
 }
-.muted {
-  font-size: 13px;
-  color: var(--color-text-faint);
-}
-.created {
-  font-size: 13px;
-  color: var(--color-text-muted);
-}
 .actions {
   display: flex;
   justify-content: flex-end;
-  gap: 6px;
+}
+.emptyRow {
+  padding: 16px 8px;
 }
 
-/* Wraps an OPAL SelectButton so Radix Popover can anchor to a
-   ref-forwarding DOM node (SelectButton doesn't forward its ref). */
+/* Ref-forwarding wrapper for OpenButton inside Popover.Trigger asChild. */
 .menuTrigger {
   display: inline-flex;
-}
-
-/* Compact dropdown menu (OPAL LineItemButton renders oversized cards). */
-.menu {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 160px;
-  padding: 4px;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-popover);
-}
-.menuItem {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 10px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  text-align: left;
-  font-size: 14px;
-  color: var(--color-text-primary);
-}
-.menuItem:hover {
-  background: var(--color-bg-hover);
-}
-.menuItemIcon {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--color-text-secondary);
-}
-.menuItemLabel {
-  flex: 1;
-}
-.menuItemCheck {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--color-text-secondary);
-}
-.error {
-  font-size: 14px;
-  color: var(--color-state-danger-fg);
-  margin-bottom: 12px;
-}
-.empty {
-  font-size: 14px;
-  color: var(--color-text-muted);
-  padding: 16px 0;
 }

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -90,6 +90,12 @@
   justify-content: flex-end;
   gap: 6px;
 }
+
+/* Wraps an OPAL SelectButton so Radix Popover can anchor to a
+   ref-forwarding DOM node (SelectButton doesn't forward its ref). */
+.menuTrigger {
+  display: inline-flex;
+}
 .error {
   font-size: 14px;
   color: var(--color-state-danger-fg);

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -1,0 +1,102 @@
+.stat {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  margin-bottom: 12px;
+}
+.search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-page);
+  color: var(--color-text-muted);
+  margin-bottom: 16px;
+}
+.searchInput {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+
+.table {
+  display: flex;
+  flex-direction: column;
+}
+.headRow {
+  display: grid;
+  grid-template-columns: var(--cols);
+  gap: 12px;
+  padding: 8px;
+  border-bottom: 1px solid var(--color-border-default);
+}
+.headCell {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+.row {
+  display: grid;
+  grid-template-columns: var(--cols);
+  gap: 12px;
+  align-items: center;
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+.who {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+.whoText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.whoName {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.whoEmail {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.muted {
+  font-size: 13px;
+  color: var(--color-text-faint);
+}
+.created {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.error {
+  font-size: 14px;
+  color: var(--color-state-danger-fg);
+  margin-bottom: 12px;
+}
+.empty {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  padding: 16px 0;
+}

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -14,6 +14,9 @@ import { diffLines } from "diff";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import useSWR from "swr";
+
+import { SvgShare } from "@onyx-ai/opal/icons";
+
 import { Button } from "@/components/common/Button";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
@@ -153,6 +156,7 @@ function Explorer({ dir }: { dir: string }) {
   const [renaming, setRenaming] = useState<string | null>(null);
   const [dragSource, setDragSource] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
+  const [sharePath, setSharePath] = useState<string | null>(null);
 
   const { subdirs, files } = useMemo(() => {
     const prefix = dir ? dir + "/" : "";
@@ -452,6 +456,7 @@ function Explorer({ dir }: { dir: string }) {
                 isFile={isFile}
                 busy={busyPath === childPath}
                 onDelete={() => onDelete(childPath)}
+                onShare={() => setSharePath(childPath)}
                 renaming={renaming === childPath}
                 onStartRename={() => setRenaming(childPath)}
                 onCancelRename={() => setRenaming(null)}
@@ -493,6 +498,13 @@ function Explorer({ dir }: { dir: string }) {
           });
         })()}
       </ul>
+      {sharePath && (
+        <ShareDialog
+          path={sharePath}
+          open
+          onClose={() => setSharePath(null)}
+        />
+      )}
     </main>
   );
 }
@@ -1060,6 +1072,7 @@ function Row({
   isFile,
   busy,
   onDelete,
+  onShare,
   renaming,
   onStartRename,
   onCancelRename,
@@ -1079,6 +1092,7 @@ function Row({
   isFile: boolean;
   busy: boolean;
   onDelete: () => void;
+  onShare?: () => void;
   renaming: boolean;
   onStartRename: () => void;
   onCancelRename: () => void;
@@ -1250,6 +1264,25 @@ function Row({
           >
             {updatedAt ? relativeTime(updatedAt, "short") : "—"}
           </span>
+          {onShare && (
+            <button
+              onClick={onShare}
+              disabled={busy}
+              title="Share"
+              aria-label={`Share ${label}`}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: hover ? color.text.secondary : "transparent",
+                cursor: busy ? "not-allowed" : "pointer",
+                padding: 6,
+                display: "flex",
+                alignItems: "center",
+              }}
+            >
+              <SvgShare size={16} />
+            </button>
+          )}
           <button
             onClick={onStartRename}
             disabled={busy}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -363,3 +363,24 @@ textarea::placeholder {
 [data-radix-popper-content-wrapper] {
   z-index: 1000 !important;
 }
+
+/* Primary (action) buttons follow the agent-wiki near-black accent, not
+   OPAL's default blue — matches the Figma mocks and CLAUDE.md's "accent is
+   near-black, not a hue" rule. Scoped to the action *button* so links keep
+   their own color. The accent tokens invert per theme (near-black on light,
+   near-white on dark), so the foreground is flipped to match. */
+.interactive[data-interactive-variant="action"][data-interactive-prominence="primary"]:not(
+    [data-disabled]
+  ) {
+  background-color: var(--color-accent-bg) !important;
+  --interactive-foreground: var(--color-accent-fg);
+  --interactive-foreground-icon: var(--color-accent-fg);
+}
+.interactive[data-interactive-variant="action"][data-interactive-prominence="primary"]:hover:not(
+    [data-disabled]
+  ),
+.interactive[data-interactive-variant="action"][data-interactive-prominence="primary"][data-interaction="hover"]:not(
+    [data-disabled]
+  ) {
+  background-color: var(--color-accent-bg-hover) !important;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -355,3 +355,11 @@ textarea::placeholder {
 .scroll-x-hidden::-webkit-scrollbar {
   display: none;
 }
+
+/* Radix popovers (OPAL Popover / SelectButton menus) must float above modal
+   scrims (z-index 100–110). Radix sets `z-index: auto` inline on the wrapper
+   and OPAL strips className/style from Popover.Content, so `!important` here
+   is the only way to lift the menu above the modal. */
+[data-radix-popper-content-wrapper] {
+  z-index: 1000 !important;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -384,3 +384,10 @@ textarea::placeholder {
   ) {
   background-color: var(--color-accent-bg-hover) !important;
 }
+/* Disabled primary action — neutral grey, never OPAL's default blue tint
+   (matches the mock's greyed-out Save). */
+.interactive[data-interactive-variant="action"][data-interactive-prominence="primary"][data-disabled] {
+  background-color: var(--color-bg-active) !important;
+  --interactive-foreground: var(--color-text-muted);
+  --interactive-foreground-icon: var(--color-text-muted);
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -391,3 +391,18 @@ textarea::placeholder {
   --interactive-foreground: var(--color-text-muted);
   --interactive-foreground-icon: var(--color-text-muted);
 }
+
+/* Selected menu/select items follow the near-black accent, not OPAL's default
+   action-link blue (the mocks have no blue). */
+.interactive[data-interactive-variant="select-light"][data-interactive-state="selected"],
+.interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"],
+.interactive[data-interactive-variant="select-tinted"][data-interactive-state="selected"] {
+  --interactive-foreground: var(--text-05) !important;
+  --interactive-foreground-icon: var(--text-05) !important;
+}
+
+/* Floating menus (typeahead, dropdowns) keep their shadow for depth but drop
+   the hard border — the mocks show no bordered popover surface. */
+[data-radix-popper-content-wrapper] > * {
+  border-color: transparent !important;
+}

--- a/frontend/src/components/common/Avatar.module.css
+++ b/frontend/src/components/common/Avatar.module.css
@@ -1,0 +1,12 @@
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
+  font-weight: 600;
+  line-height: 1;
+  flex-shrink: 0;
+  user-select: none;
+}

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -1,0 +1,26 @@
+import styles from "./Avatar.module.css";
+
+interface AvatarProps {
+  /** Initials (1–2 chars) shown inside the circle. */
+  label: string;
+  /** Diameter in px. Defaults to 28 (the share-row size). */
+  size?: number;
+  /** Accessible label / hover tooltip (e.g. the full name). */
+  title?: string;
+}
+
+/** Round initials avatar — near-black accent fill, inverse text. Matches
+ * the Figma share/transfer rows (no uploaded avatars exist server-side). */
+export function Avatar({ label, size = 28, title }: AvatarProps) {
+  return (
+    <span
+      className={styles.avatar}
+      style={{ width: size, height: size, fontSize: Math.round(size * 0.42) }}
+      title={title}
+      role={title ? "img" : undefined}
+      aria-label={title}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -1,17 +1,22 @@
 import styles from "./Avatar.module.css";
 
+type IconComponent = (props: { size?: number }) => React.ReactNode;
+
 interface AvatarProps {
-  /** Initials (1–2 chars) shown inside the circle. */
+  /** Initials (1–2 chars) shown inside the circle. Ignored when `icon` is set. */
   label: string;
+  /** Optional glyph rendered instead of the label (e.g. a group icon). */
+  icon?: IconComponent;
   /** Diameter in px. Defaults to 28 (the share-row size). */
   size?: number;
   /** Accessible label / hover tooltip (e.g. the full name). */
   title?: string;
 }
 
-/** Round initials avatar — near-black accent fill, inverse text. Matches
- * the Figma share/transfer rows (no uploaded avatars exist server-side). */
-export function Avatar({ label, size = 28, title }: AvatarProps) {
+/** Round avatar — near-black accent fill, inverse text/glyph. Matches the
+ * Figma share/transfer rows (no uploaded avatars exist server-side). Shows
+ * `icon` (e.g. a group glyph) when provided, otherwise the initials. */
+export function Avatar({ label, icon: Icon, size = 28, title }: AvatarProps) {
   return (
     <span
       className={styles.avatar}
@@ -20,7 +25,7 @@ export function Avatar({ label, size = 28, title }: AvatarProps) {
       role={title ? "img" : undefined}
       aria-label={title}
     >
-      {label}
+      {Icon ? <Icon size={Math.round(size * 0.55)} /> : label}
     </span>
   );
 }

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -66,14 +66,17 @@
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);
 }
-/* Scope + permission are white-fill boxes on the grey container — the
-   white-on-grey contrast is the edge, no border line. Token chrome around a
-   transparent select-light OpenButton (left label + right chevron). */
+/* Scope + permission are input-style boxes matching the search field above:
+   page fill + the same 1px border. The border (not fill contrast) is what
+   defines them — fill contrast alone fails in dark, where bg-page is darker
+   than the bg-sunken container. Token chrome around a transparent
+   select-light OpenButton (left label + right chevron). */
 .scopeBox,
 .permBox {
   display: flex;
   min-width: 0;
   background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
 }
 .scopeBox {

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -66,16 +66,14 @@
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);
 }
-/* Scope + permission are white, input-style boxes (subtle border, like the
-   search field) on the grey container. OPAL has no white-bordered select
-   variant, so the box is token chrome around a transparent select-light
-   OpenButton (which provides left label + right chevron). Scope is wider. */
+/* Scope + permission are white-fill boxes on the grey container — the
+   white-on-grey contrast is the edge, no border line. Token chrome around a
+   transparent select-light OpenButton (left label + right chevron). */
 .scopeBox,
 .permBox {
   display: flex;
   min-width: 0;
   background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
 }
 .scopeBox {

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -54,11 +54,21 @@
   flex-direction: column;
   gap: 8px;
 }
+/* General-access controls live in one subtle grey-fill container (no border),
+   with a faint vertical hairline between the scope and permission cells. */
 .generalRow {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 2px;
+  padding: 4px 8px;
+  background: var(--color-bg-sunken);
+  border-radius: var(--radius-md);
+}
+.vDivider {
+  width: 1px;
+  align-self: stretch;
+  margin: 4px 0;
+  background: var(--color-border-subtle);
 }
 /* Scope control fills the row; chevron pushes to the right via the
    OpenButton's justifyContent="between". Flat — no box, no border. */
@@ -84,11 +94,14 @@
   flex-direction: column;
   gap: 4px;
 }
+/* Each grantee/owner row is its own slightly shaded container (fill, no border). */
 .row {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 2px;
+  padding: 6px 8px;
+  background: var(--color-bg-sunken);
+  border-radius: var(--radius-md);
 }
 .rowText {
   display: flex;

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -66,18 +66,22 @@
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);
 }
-.vDivider {
-  width: 1px;
-  align-self: stretch;
-  margin: 4px 0;
-  background: var(--color-border-subtle);
-}
-/* Scope control fills the row; chevron pushes to the right via the
-   OpenButton's justifyContent="between". Flat — no box, no border. */
-.scopeBox {
-  flex: 1;
-  min-width: 0;
+/* Scope + permission are white, input-style boxes (subtle border, like the
+   search field above) sitting inside the grey general-access container. Scope
+   is the wider of the two; chevrons push to each box's right edge. */
+.scopeBox,
+.permBox {
   display: flex;
+  min-width: 0;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+}
+.scopeBox {
+  flex: 1.7 1.7 0;
+}
+.permBox {
+  flex: 1 1 0;
 }
 
 /* Ref-forwarding wrappers: OPAL InputTypeIn / OpenButton don't forward refs,

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -1,0 +1,287 @@
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: max(20px, min(80px, 5vh)) 16px;
+  z-index: 100;
+}
+
+.dialog {
+  background: var(--color-bg-panel);
+  border-radius: var(--radius-lg);
+  width: min(480px, 100%);
+  max-height: calc(100vh - 80px);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Header — white band over the panel surface, matches the Figma. */
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 16px;
+  background: var(--color-bg-page);
+}
+
+.headerIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--color-text-secondary);
+}
+
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.titleName {
+  font-style: italic;
+}
+
+.subtitle {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.closeBtn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.closeBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+/* Content */
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  overflow-y: auto;
+}
+
+.inputWrap {
+  position: relative;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-page);
+  color: var(--color-text-primary);
+}
+.input:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+}
+
+/* Typeahead results dropdown anchored to the input. */
+.results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 1;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+  padding: 4px;
+  max-height: 240px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.resultRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.resultRow:hover,
+.resultRowActive {
+  background: var(--color-bg-hover);
+}
+.resultRow:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.resultText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.resultName {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.resultSub {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.resultTag {
+  font-size: 12px;
+  color: var(--color-text-faint);
+  flex-shrink: 0;
+}
+.resultsEmpty {
+  padding: 8px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+/* General-access row */
+.generalRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 2px;
+}
+.generalIcon {
+  display: inline-flex;
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
+}
+.generalSpacer {
+  flex: 1;
+}
+
+/* Grantee list */
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 2px;
+}
+.rowText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.rowName {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rowSub {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rowRight {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.ownerTag {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+.inheritedTag {
+  font-size: 12px;
+  color: var(--color-text-faint);
+}
+.transferBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.transferBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.error {
+  font-size: 13px;
+  color: var(--color-state-danger-fg);
+  padding: 0 2px;
+}
+.loading {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  padding: 8px 2px;
+}
+
+/* Footer */
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 16px;
+  background: var(--color-bg-page);
+}
+.footerRight {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.copied {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -45,21 +45,37 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: 12px;
   padding: 12px;
   overflow-y: auto;
 }
 
+.cardStack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
 .generalRow {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 8px;
-  background: var(--color-bg-sunken);
-  border-radius: var(--radius-md);
+  padding: 2px;
 }
-.generalSpacer {
+/* General-access controls render as white, token-bordered boxes (OPAL OpenButton
+   has no white+border-at-rest variant, so the box chrome is token CSS while the
+   OpenButton stays the interactive trigger). */
+.scopeBox,
+.permBox {
+  display: flex;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+}
+.scopeBox {
   flex: 1;
+  min-width: 0;
+}
+.permBox {
+  flex-shrink: 0;
 }
 
 /* Ref-forwarding wrappers: OPAL InputTypeIn / OpenButton don't forward refs,
@@ -76,13 +92,16 @@
 .list {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
 }
+/* Each grantee row sits on its own white surface over the grey card. */
 .row {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 2px;
+  padding: 6px 8px;
+  background: var(--color-bg-page);
+  border-radius: var(--radius-md);
 }
 .rowText {
   display: flex;

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -1,3 +1,5 @@
+/* Layout only — typography, inputs, menus, and buttons come from OPAL. */
+
 .scrim {
   position: fixed;
   inset: 0;
@@ -20,7 +22,6 @@
   overflow: hidden;
 }
 
-/* Header — white band over the panel surface, matches the Figma. */
 .header {
   display: flex;
   align-items: flex-start;
@@ -28,14 +29,12 @@
   padding: 16px;
   background: var(--color-bg-page);
 }
-
 .headerIcon {
   display: inline-flex;
   flex-shrink: 0;
   margin-top: 2px;
   color: var(--color-text-secondary);
 }
-
 .headerText {
   display: flex;
   flex-direction: column;
@@ -43,42 +42,6 @@
   min-width: 0;
   flex: 1;
 }
-
-.title {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-
-.titleName {
-  font-style: italic;
-}
-
-.subtitle {
-  font-size: 12px;
-  color: var(--color-text-muted);
-}
-
-.closeBtn {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  cursor: pointer;
-}
-.closeBtn:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-text-primary);
-}
-
-/* Content */
 .content {
   display: flex;
   flex-direction: column;
@@ -87,96 +50,6 @@
   overflow-y: auto;
 }
 
-.inputWrap {
-  position: relative;
-}
-
-.input {
-  width: 100%;
-  padding: 8px 10px;
-  font-size: 14px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-page);
-  color: var(--color-text-primary);
-}
-.input:focus {
-  outline: none;
-  border-color: var(--color-border-focus);
-}
-
-/* Typeahead results dropdown anchored to the input. */
-.results {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  z-index: 1;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-popover);
-  padding: 4px;
-  max-height: 240px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.resultRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 6px 8px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  text-align: left;
-}
-.resultRow:hover,
-.resultRowActive {
-  background: var(--color-bg-hover);
-}
-.resultRow:disabled {
-  cursor: default;
-  opacity: 0.55;
-}
-
-.resultText {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-.resultName {
-  font-size: 14px;
-  color: var(--color-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.resultSub {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.resultTag {
-  font-size: 12px;
-  color: var(--color-text-faint);
-  flex-shrink: 0;
-}
-.resultsEmpty {
-  padding: 8px;
-  font-size: 13px;
-  color: var(--color-text-muted);
-}
-
-/* General-access row */
 .generalRow {
   display: flex;
   align-items: center;
@@ -187,68 +60,17 @@
   flex: 1;
 }
 
-/* Wraps an OPAL SelectButton so Radix Popover can anchor to a
-   ref-forwarding DOM node (SelectButton doesn't forward its ref). */
+/* Ref-forwarding wrappers: OPAL InputTypeIn / OpenButton don't forward refs,
+   so Popover.Anchor / Popover.Trigger asChild must wrap them in a real
+   element for Radix to anchor the floating menu. */
+.anchorWrap {
+  display: block;
+  width: 100%;
+}
 .menuTrigger {
   display: inline-flex;
 }
 
-/* Compact dropdown menu (OPAL LineItemButton renders oversized cards, so
-   the menu rows are custom). The Popover.Content positions this surface. */
-.menu {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  min-width: 180px;
-  padding: 4px;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-popover);
-}
-.menuItem {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 8px 10px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  text-align: left;
-  font-size: 14px;
-  color: var(--color-text-primary);
-}
-.menuItem:hover {
-  background: var(--color-bg-hover);
-}
-.menuItemIcon {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--color-text-secondary);
-}
-.menuItemLabel {
-  flex: 1;
-}
-.menuItemCheck {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--color-text-secondary);
-}
-.menuItemDanger {
-  color: var(--color-state-danger-fg);
-}
-.menuItemDanger .menuItemIcon {
-  color: var(--color-state-danger-fg);
-}
-.menuDivider {
-  height: 1px;
-  margin: 4px 0;
-  background: var(--color-border-subtle);
-}
-
-/* Grantee list */
 .list {
   display: flex;
   flex-direction: column;
@@ -266,64 +88,19 @@
   min-width: 0;
   flex: 1;
 }
-.rowName {
-  font-size: 14px;
-  color: var(--color-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.rowSub {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 .rowRight {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   flex-shrink: 0;
 }
-.ownerTag {
-  font-size: 13px;
-  color: var(--color-text-secondary);
-}
-.inheritedTag {
-  font-size: 12px;
-  color: var(--color-text-faint);
-}
-.transferBtn {
+.inheritedIcon {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-md);
+  flex-shrink: 0;
   color: var(--color-text-muted);
-  cursor: pointer;
-}
-.transferBtn:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-text-primary);
 }
 
-.error {
-  font-size: 13px;
-  color: var(--color-state-danger-fg);
-  padding: 0 2px;
-}
-.loading {
-  font-size: 13px;
-  color: var(--color-text-muted);
-  padding: 8px 2px;
-}
-
-/* Footer */
 .footer {
   display: flex;
   align-items: center;
@@ -336,8 +113,4 @@
   display: flex;
   align-items: center;
   gap: 8px;
-}
-.copied {
-  font-size: 13px;
-  color: var(--color-text-muted);
 }

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -60,22 +60,12 @@
   gap: 8px;
   padding: 2px;
 }
-/* General-access controls render as white, token-bordered boxes (OPAL OpenButton
-   has no white+border-at-rest variant, so the box chrome is token CSS while the
-   OpenButton stays the interactive trigger). */
-.scopeBox,
-.permBox {
-  display: flex;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-sm);
-}
+/* Scope control fills the row; chevron pushes to the right via the
+   OpenButton's justifyContent="between". Flat — no box, no border. */
 .scopeBox {
   flex: 1;
   min-width: 0;
-}
-.permBox {
-  flex-shrink: 0;
+  display: flex;
 }
 
 /* Ref-forwarding wrappers: OPAL InputTypeIn / OpenButton don't forward refs,
@@ -94,14 +84,11 @@
   flex-direction: column;
   gap: 4px;
 }
-/* Each grantee row sits on its own white surface over the grey card. */
 .row {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 8px;
-  background: var(--color-bg-page);
-  border-radius: var(--radius-md);
+  padding: 6px 2px;
 }
 .rowText {
   display: flex;

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -54,7 +54,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 2px;
+  padding: 4px 8px;
+  background: var(--color-bg-sunken);
+  border-radius: var(--radius-md);
 }
 .generalSpacer {
   flex: 1;

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -45,13 +45,18 @@
 .content {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   padding: 12px;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
+/* Input + general-access stay fixed; only the people list scrolls. */
 .cardStack {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
   gap: 8px;
 }
 /* General-access row: a subtle grey-fill container (matching the grantee
@@ -61,6 +66,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
   min-height: 48px;
   padding: 6px 8px;
   background: var(--color-bg-sunken);
@@ -88,21 +94,29 @@
 .anchorWrap {
   display: block;
   width: 100%;
+  flex-shrink: 0;
 }
 .menuTrigger {
   display: inline-flex;
 }
 
+/* The people list is the only scrollable region when the modal hits its
+   max height; rows above (input, general-access) stay pinned. */
 .list {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   gap: 4px;
+  padding-right: 2px;
 }
 /* Each grantee/owner row is its own slightly shaded container (fill, no border). */
 .row {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
   min-height: 48px;
   padding: 6px 8px;
   background: var(--color-bg-sunken);

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -55,11 +55,13 @@
   gap: 8px;
 }
 /* General-access controls live in one subtle grey-fill container (no border),
-   with a faint vertical hairline between the scope and permission cells. */
+   with a faint vertical hairline between the scope and permission cells.
+   Shares the grantee-row min-height so every section is the same height. */
 .generalRow {
   display: flex;
   align-items: center;
   gap: 8px;
+  min-height: 48px;
   padding: 4px 8px;
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);
@@ -99,6 +101,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-height: 48px;
   padding: 6px 8px;
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -66,17 +66,13 @@
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);
 }
-/* Scope + permission are input-style boxes matching the search field above:
-   page fill + the same 1px border. The border (not fill contrast) is what
-   defines them — fill contrast alone fails in dark, where bg-page is darker
-   than the bg-sunken container. Token chrome around a transparent
-   select-light OpenButton (left label + right chevron). */
+/* Scope + permission are white-fill boxes on the grey container — no border.
+   Scope is the wider of the two. */
 .scopeBox,
 .permBox {
   display: flex;
   min-width: 0;
   background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
   border-radius: var(--radius-sm);
 }
 .scopeBox {

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -54,21 +54,22 @@
   flex-direction: column;
   gap: 8px;
 }
-/* General-access controls live in one subtle grey-fill container (no border),
-   with a faint vertical hairline between the scope and permission cells.
+/* General-access row: a subtle grey-fill container (matching the grantee
+   rows) holding the lock/globe icon and the scope + permission controls.
    Shares the grantee-row min-height so every section is the same height. */
 .generalRow {
   display: flex;
   align-items: center;
   gap: 8px;
   min-height: 48px;
-  padding: 4px 8px;
+  padding: 6px 8px;
   background: var(--color-bg-sunken);
   border-radius: var(--radius-md);
 }
 /* Scope + permission are white, input-style boxes (subtle border, like the
-   search field above) sitting inside the grey general-access container. Scope
-   is the wider of the two; chevrons push to each box's right edge. */
+   search field) on the grey container. OPAL has no white-bordered select
+   variant, so the box is token chrome around a transparent select-light
+   OpenButton (which provides left label + right chevron). Scope is wider. */
 .scopeBox,
 .permBox {
   display: flex;

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -183,13 +183,14 @@
   gap: 8px;
   padding: 4px 2px;
 }
-.generalIcon {
-  display: inline-flex;
-  color: var(--color-text-secondary);
-  flex-shrink: 0;
-}
 .generalSpacer {
   flex: 1;
+}
+
+/* Wraps an OPAL SelectButton so Radix Popover can anchor to a
+   ref-forwarding DOM node (SelectButton doesn't forward its ref). */
+.menuTrigger {
+  display: inline-flex;
 }
 
 /* Grantee list */

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -193,6 +193,61 @@
   display: inline-flex;
 }
 
+/* Compact dropdown menu (OPAL LineItemButton renders oversized cards, so
+   the menu rows are custom). The Popover.Content positions this surface. */
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 180px;
+  padding: 4px;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+}
+.menuItem {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+  font-size: 14px;
+  color: var(--color-text-primary);
+}
+.menuItem:hover {
+  background: var(--color-bg-hover);
+}
+.menuItemIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
+.menuItemLabel {
+  flex: 1;
+}
+.menuItemCheck {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+}
+.menuItemDanger {
+  color: var(--color-state-danger-fg);
+}
+.menuItemDanger .menuItemIcon {
+  color: var(--color-state-danger-fg);
+}
+.menuDivider {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--color-border-subtle);
+}
+
 /* Grantee list */
 .list {
   display: flex;

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -289,6 +289,9 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
       onClose();
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : "Failed to save changes");
+      // Re-pull the ACL so the baseline reflects whatever partially applied;
+      // otherwise a retry re-issues already-committed grants/revokes and 404s.
+      await refresh();
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import {
   Button,
@@ -155,7 +155,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
   const { acl, error, isLoading, refresh } = usePageAcl(open ? path : null);
   const { groups } = useGroups();
   const { user } = useAuth();
-  const dialogRef = useRef<HTMLDivElement>(null);
 
   const baseline = useMemo(() => deriveBaseline(acl), [acl]);
 
@@ -318,7 +317,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
       }}
     >
       <div
-        ref={dialogRef}
         className={styles.dialog}
         role="dialog"
         aria-modal="true"
@@ -416,24 +414,19 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
               )}
             </div>
 
-            {/* General access */}
+            {/* General access — the scope dropdown carries the lock/globe icon */}
             <div className={styles.generalRow}>
-              <span className={styles.generalIcon}>
-                {general === "private" ? <SvgLock size={16} /> : <SvgGlobe size={16} />}
-              </span>
               <ScopeSelect
                 value={general === "private" ? "invited" : "anyone"}
                 onChange={(scope) =>
                   setGeneral(scope === "invited" ? "private" : "public-read")
                 }
-                container={dialogRef.current}
               />
               <span className={styles.generalSpacer} />
               <PermSelect
                 value={general === "public-write" ? "write" : "read"}
                 disabled={general === "private"}
                 onChange={(p) => setGeneral(p === "write" ? "public-write" : "public-read")}
-                container={dialogRef.current}
               />
             </div>
 
@@ -487,7 +480,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                         value={g.permission}
                         onChange={(p) => setPermission(k, p)}
                         onRemove={() => removeGrant(k)}
-                        container={dialogRef.current}
                       />
                     </span>
                   </div>
@@ -552,13 +544,11 @@ function PermSelect({
   onChange,
   onRemove,
   disabled,
-  container,
 }: {
   value: Permission;
   onChange: (p: Permission) => void;
   onRemove?: () => void;
   disabled?: boolean;
-  container: HTMLElement | null;
 }) {
   const [open, setOpen] = useState(false);
   const label = value === "write" ? "Edit" : "View";
@@ -566,17 +556,19 @@ function PermSelect({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <SelectButton
-          size="sm"
-          variant="select-light"
-          icon={icon}
-          rightIcon={SvgChevronDown}
-          disabled={disabled}
-        >
-          {label}
-        </SelectButton>
+        <span className={styles.menuTrigger}>
+          <SelectButton
+            size="sm"
+            variant="select-light"
+            icon={icon}
+            rightIcon={SvgChevronDown}
+            disabled={disabled}
+          >
+            {label}
+          </SelectButton>
+        </span>
       </Popover.Trigger>
-      <Popover.Content width="fit" align="end" sideOffset={4} container={container}>
+      <Popover.Content width="fit" align="end" sideOffset={4}>
         <Popover.Menu>
           {[
             <LineItemButton
@@ -624,27 +616,27 @@ function PermSelect({
 function ScopeSelect({
   value,
   onChange,
-  container,
 }: {
   value: "invited" | "anyone";
   onChange: (v: "invited" | "anyone") => void;
-  container: HTMLElement | null;
 }) {
   const [open, setOpen] = useState(false);
   const label = value === "invited" ? "Only those invited" : "Anyone signed in";
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <SelectButton
-          size="sm"
-          variant="select-light"
-          icon={value === "invited" ? SvgLock : SvgGlobe}
-          rightIcon={SvgChevronDown}
-        >
-          {label}
-        </SelectButton>
+        <span className={styles.menuTrigger}>
+          <SelectButton
+            size="sm"
+            variant="select-light"
+            icon={value === "invited" ? SvgLock : SvgGlobe}
+            rightIcon={SvgChevronDown}
+          >
+            {label}
+          </SelectButton>
+        </span>
       </Popover.Trigger>
-      <Popover.Content width="fit" align="start" sideOffset={4} container={container}>
+      <Popover.Content width="fit" align="start" sideOffset={4}>
         <Popover.Menu>
           {[
             <LineItemButton

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -4,6 +4,8 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   Button,
+  Card,
+  Divider,
   InputTypeIn,
   LineItemButton,
   OpenButton,
@@ -364,6 +366,8 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
           </div>
         ) : (
           <div className={styles.content}>
+            <Card background="heavy" border="none" rounding="lg" padding="sm">
+            <div className={styles.cardStack}>
             {/* Add people / groups — InputTypeIn anchors a portaled results menu */}
             <Popover
               open={showPicker}
@@ -445,42 +449,53 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
               </Popover.Content>
             </Popover>
 
-            {/* General access */}
-            <div className={styles.generalRow}>
-              <ScopeSelect
-                value={general === "private" ? "invited" : "anyone"}
-                onChange={(scope) =>
-                  setGeneral(scope === "invited" ? "private" : "public-read")
-                }
-              />
-              <span className={styles.generalSpacer} />
-              <PermSelect
-                value={general === "public-write" ? "write" : "read"}
-                disabled={general === "private"}
-                onChange={(p) => setGeneral(p === "write" ? "public-write" : "public-read")}
-              />
-            </div>
-
             {saveError && (
               <Text font="secondary-body" color="text-02">
                 {saveError}
               </Text>
             )}
 
-            {/* People with access */}
-            <div className={styles.list}>
-              {ownerId && (
-                <OwnerRow
-                  ownerId={ownerId}
-                  ownerEmail={acl.owner_email ?? null}
-                  ownerName={acl.owner_name ?? null}
-                  isYou={ownerId === user?.id}
-                  canTransfer={ownerId === user?.id || Boolean(user?.is_admin)}
-                  onTransfer={() => setTransferOpen(true)}
+              {/* General access */}
+              <div className={styles.generalRow}>
+                <span className={styles.inheritedIcon}>
+                  {general === "private" ? (
+                    <SvgLock size={18} />
+                  ) : (
+                    <SvgGlobe size={18} />
+                  )}
+                </span>
+                <ScopeSelect
+                  value={general === "private" ? "invited" : "anyone"}
+                  onChange={(scope) =>
+                    setGeneral(scope === "invited" ? "private" : "public-read")
+                  }
                 />
-              )}
+                <PermSelect
+                  boxed
+                  value={general === "public-write" ? "write" : "read"}
+                  disabled={general === "private"}
+                  onChange={(p) =>
+                    setGeneral(p === "write" ? "public-write" : "public-read")
+                  }
+                />
+              </div>
 
-              {[...grants.values()].map((g) => {
+              <Divider paddingParallel="fit" />
+
+              {/* People with access */}
+              <div className={styles.list}>
+                {ownerId && (
+                  <OwnerRow
+                    ownerId={ownerId}
+                    ownerEmail={acl.owner_email ?? null}
+                    ownerName={acl.owner_name ?? null}
+                    isYou={ownerId === user?.id}
+                    canTransfer={ownerId === user?.id || Boolean(user?.is_admin)}
+                    onTransfer={() => setTransferOpen(true)}
+                  />
+                )}
+
+                {[...grants.values()].map((g) => {
                 const k = keyFor(g.kind, g.id);
                 const group =
                   g.kind === "group" ? groups.find((x) => x.id === g.id) : undefined;
@@ -521,16 +536,18 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                 );
               })}
 
-              {baseline.inherited.map((e) => (
-                <InheritedRow key={e.id} entry={e} groups={groups} />
-              ))}
+                {baseline.inherited.map((e) => (
+                  <InheritedRow key={e.id} entry={e} groups={groups} />
+                ))}
+              </div>
             </div>
+            </Card>
           </div>
         )}
 
         <footer className={styles.footer}>
           <Button
-            prominence="tertiary"
+            prominence="secondary"
             size="md"
             icon={SvgLink}
             onClick={() => void copyLink()}
@@ -538,7 +555,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
             {copied ? "Copied" : "Copy Link"}
           </Button>
           <span className={styles.footerRight}>
-            <Button prominence="tertiary" size="md" onClick={onClose}>
+            <Button prominence="secondary" size="md" onClick={onClose}>
               Cancel
             </Button>
             <Button
@@ -578,11 +595,13 @@ function PermSelect({
   onChange,
   onRemove,
   disabled,
+  boxed,
 }: {
   value: Permission;
   onChange: (p: Permission) => void;
   onRemove?: () => void;
   disabled?: boolean;
+  boxed?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const label = value === "write" ? "Edit" : "View";
@@ -590,8 +609,16 @@ function PermSelect({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <span className={styles.menuTrigger}>
-          <OpenButton variant="select-light" size="sm" icon={icon} disabled={disabled}>
+        <span className={boxed ? styles.permBox : styles.menuTrigger}>
+          <OpenButton
+            variant="select-light"
+            size="sm"
+            icon={icon}
+            disabled={disabled}
+            width={boxed ? "full" : undefined}
+            justifyContent={boxed ? "between" : undefined}
+            rounding={boxed ? "sm" : undefined}
+          >
             {label}
           </OpenButton>
         </span>
@@ -653,17 +680,19 @@ function ScopeSelect({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <span className={styles.menuTrigger}>
+        <span className={styles.scopeBox}>
           <OpenButton
             variant="select-light"
             size="sm"
-            icon={value === "invited" ? SvgLock : SvgGlobe}
+            width="full"
+            justifyContent="between"
+            rounding="sm"
           >
             {label}
           </OpenButton>
         </span>
       </Popover.Trigger>
-      <Popover.Content width="fit" align="start" sideOffset={4}>
+      <Popover.Content width="trigger" align="start" sideOffset={4}>
         <PopoverMenu>
           <LineItemButton
             icon={SvgLock}

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -281,6 +281,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
   const save = async () => {
     setSaving(true);
     setSaveError(null);
+    let ok = false;
     try {
       const revokes: string[] = [];
       const adds: GrantDraft[] = [];
@@ -330,20 +331,23 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
           permission: "write",
         });
       }
+      ok = true;
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : "Failed to save changes");
       // Re-pull the ACL so the baseline reflects whatever partially applied;
       // otherwise a retry re-issues already-committed grants/revokes and 404s.
-      await refresh();
+      // Best-effort — a failing refetch must not skip the cleanup below.
+      await refresh().catch(() => undefined);
+    } finally {
       setSaving(false);
-      return;
     }
-    // All mutations committed — the save succeeded. Close immediately and
-    // refresh the cache best-effort; a failing refetch must NOT surface as a
-    // save error or keep the dialog open after the DB already changed.
-    setSaving(false);
-    onClose();
-    void refresh();
+    // All mutations committed — the save succeeded. Close and refresh the
+    // cache best-effort; a failing refetch must NOT surface as a save error
+    // or keep the dialog open after the DB already changed.
+    if (ok) {
+      onClose();
+      void refresh();
+    }
   };
 
   const forbidden = error instanceof ApiError && error.status === 403;

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -22,6 +22,7 @@ import {
   SvgShare,
   SvgUser,
   SvgUsers,
+  SvgUserShield,
   SvgX,
 } from "@onyx-ai/opal/icons";
 
@@ -494,7 +495,12 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                     : g.email ?? "";
                 return (
                   <div key={k} className={styles.row}>
-                    <Avatar label={(name[0] ?? "?").toUpperCase()} size={28} title={name} />
+                    <Avatar
+                      label={(name[0] ?? "?").toUpperCase()}
+                      icon={g.kind === "group" ? SvgUsers : undefined}
+                      size={28}
+                      title={name}
+                    />
                     <div className={styles.rowText}>
                       <Text font="main-ui-body" nowrap>
                         {name}
@@ -720,6 +726,9 @@ function OwnerRow({
         )}
       </div>
       <span className={styles.rowRight}>
+        <span className={styles.inheritedIcon}>
+          <SvgUserShield size={16} />
+        </span>
         <Text font="secondary-body" color="text-03">
           Owner
         </Text>

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -41,6 +41,7 @@ import {
   type Visibility,
 } from "@/lib/permissions";
 import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
+import { lastSegment } from "@/lib/wiki";
 import { markdown } from "@onyx-ai/opal/utils";
 
 import { TransferModal } from "./TransferModal";
@@ -83,13 +84,6 @@ const EMPTY_BASELINE: Baseline = {
 
 function keyFor(kind: PrincipalKind, id: string): string {
   return `${kind}:${id}`;
-}
-
-function lastSegment(path: string): string {
-  const clean = path.replace(/\/+$/, "");
-  if (!clean) return "Wiki";
-  const seg = clean.split("/").pop() ?? clean;
-  return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
 }
 
 function deriveBaseline(
@@ -183,13 +177,19 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
   const [copied, setCopied] = useState(false);
 
   // Reset working state to the loaded baseline whenever the ACL changes.
+  // Does NOT clear saveError — a save failure re-pulls the ACL (changing
+  // baseline), and the error must survive that refresh so the user sees it.
   useEffect(() => {
     if (!open) return;
     setGrants(new Map(baseline.grants));
     setScope(baseline.general === "private" ? "invited" : "anyone");
     setGeneralPerm(baseline.general === "public-write" ? "write" : "read");
-    setSaveError(null);
   }, [baseline, open]);
+
+  // Clear any stale save error only on (re)open, not on baseline refresh.
+  useEffect(() => {
+    if (open) setSaveError(null);
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -661,7 +661,7 @@ function PermSelect({
               setOpen(false);
             }}
           />
-          {onRemove ? null : undefined}
+          {onRemove ? <Divider paddingParallel="fit" paddingPerpendicular="2xs" /> : null}
           {onRemove ? (
             <LineItemButton
               icon={SvgX}

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -468,8 +468,8 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                     setGeneral(scope === "invited" ? "private" : "public-read")
                   }
                 />
-                <span className={styles.vDivider} />
                 <PermSelect
+                  boxed
                   value={general === "public-write" ? "write" : "read"}
                   disabled={general === "private"}
                   onChange={(p) =>
@@ -592,11 +592,13 @@ function PermSelect({
   onChange,
   onRemove,
   disabled,
+  boxed,
 }: {
   value: Permission;
   onChange: (p: Permission) => void;
   onRemove?: () => void;
   disabled?: boolean;
+  boxed?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const label = value === "write" ? "Edit" : "View";
@@ -604,8 +606,16 @@ function PermSelect({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <span className={styles.menuTrigger}>
-          <OpenButton variant="select-light" size="sm" icon={icon} disabled={disabled}>
+        <span className={boxed ? styles.permBox : styles.menuTrigger}>
+          <OpenButton
+            variant="select-light"
+            size="sm"
+            icon={icon}
+            disabled={disabled}
+            width={boxed ? "full" : undefined}
+            justifyContent={boxed ? "between" : undefined}
+            rounding={boxed ? "sm" : undefined}
+          >
             {label}
           </OpenButton>
         </span>

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -1,28 +1,45 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
-import { Button } from "@/components/common/Button";
-import { LoadingSpinner } from "@/components/common/LoadingSpinner";
-import { ApiError, apiFetch } from "@/lib/api";
+import {
+  Button,
+  LineItemButton,
+  Popover,
+  SelectButton,
+} from "@onyx-ai/opal/components";
+import {
+  SvgArrowExchange,
+  SvgCheck,
+  SvgChevronDown,
+  SvgEdit,
+  SvgEye,
+  SvgGlobe,
+  SvgLink,
+  SvgLock,
+  SvgShare,
+  SvgUser,
+  SvgUsers,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+
+import { Avatar } from "@/components/common/Avatar";
+import { ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
 import {
   grantAcl,
   revokeAcl,
-  transferOwnership,
   useGroups,
   usePageAcl,
-  visibility,
   type AclEntry,
   type Permission,
-  type PrincipalKind,
+  type ResourceKind,
+  type Visibility,
 } from "@/lib/permissions";
-import { color, radius, shadow } from "@/lib/theme";
+import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
 
-interface AdminUser {
-  id: string;
-  email: string;
-  name: string | null;
-}
+import { TransferModal } from "./TransferModal";
+import styles from "./ShareDialog.module.css";
 
 interface ShareDialogProps {
   path: string;
@@ -30,106 +47,498 @@ interface ShareDialogProps {
   onClose: () => void;
 }
 
+type PrincipalKind = "user" | "group";
+
+interface GrantDraft {
+  kind: PrincipalKind;
+  id: string;
+  permission: Permission;
+  email?: string | null;
+  name?: string | null;
+  groupName?: string | null;
+}
+
+interface Baseline {
+  grants: Map<string, GrantDraft>;
+  general: Visibility;
+  entryIdByKey: Map<string, string>;
+  everyoneReadId: string | null;
+  everyoneWriteId: string | null;
+  inherited: AclEntry[];
+}
+
+const EMPTY_BASELINE: Baseline = {
+  grants: new Map(),
+  general: "private",
+  entryIdByKey: new Map(),
+  everyoneReadId: null,
+  everyoneWriteId: null,
+  inherited: [],
+};
+
+function keyFor(kind: PrincipalKind, id: string): string {
+  return `${kind}:${id}`;
+}
+
+function lastSegment(path: string): string {
+  const clean = path.replace(/\/+$/, "");
+  if (!clean) return "Wiki";
+  const seg = clean.split("/").pop() ?? clean;
+  return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
+}
+
+function deriveBaseline(
+  acl: { path: string; entries: AclEntry[] } | null,
+): Baseline {
+  if (!acl) return EMPTY_BASELINE;
+  const grants = new Map<string, GrantDraft>();
+  const entryIdByKey = new Map<string, string>();
+  let everyoneReadId: string | null = null;
+  let everyoneWriteId: string | null = null;
+  const inherited: AclEntry[] = [];
+
+  for (const e of acl.entries) {
+    const own = e.resource_path === acl.path;
+    if (!own) {
+      inherited.push(e);
+      continue;
+    }
+    if (e.principal_kind === "everyone") {
+      if (e.permission === "write") everyoneWriteId = e.id;
+      else if (e.permission === "read") everyoneReadId = e.id;
+      continue;
+    }
+    if (e.principal_kind !== "user" && e.principal_kind !== "group") continue;
+    if (!e.principal_id) continue;
+    const k = keyFor(e.principal_kind, e.principal_id);
+    const existing = grants.get(k);
+    // Collapse a duplicate principal to its strongest grant (write > read).
+    if (existing && existing.permission === "write") continue;
+    grants.set(k, {
+      kind: e.principal_kind,
+      id: e.principal_id,
+      permission: e.permission,
+      email: e.principal_email,
+      name: e.principal_name,
+      groupName: e.group_name,
+    });
+    entryIdByKey.set(k, e.id);
+  }
+
+  const general: Visibility = everyoneWriteId
+    ? "public-write"
+    : everyoneReadId
+      ? "public-read"
+      : "private";
+
+  return {
+    grants,
+    general,
+    entryIdByKey,
+    everyoneReadId,
+    everyoneWriteId,
+    inherited,
+  };
+}
+
+function grantsEqual(a: Map<string, GrantDraft>, b: Map<string, GrantDraft>) {
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) {
+    const o = b.get(k);
+    if (!o || o.permission !== v.permission) return false;
+  }
+  return true;
+}
+
 export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
+  const resourceKind: ResourceKind = path.endsWith(".md") ? "page" : "folder";
   const { acl, error, isLoading, refresh } = usePageAcl(open ? path : null);
   const { groups } = useGroups();
+  const { user } = useAuth();
+  const dialogRef = useRef<HTMLDivElement>(null);
 
-  // Limited-scope user list — only used for principal selection in the
-  // grant form. Falls back gracefully for non-admins (the endpoint is
-  // admin-only); they can still grant to groups they're in or pick
-  // 'everyone'.
-  const [users, setUsers] = useState<AdminUser[]>([]);
+  const baseline = useMemo(() => deriveBaseline(acl), [acl]);
+
+  const [grants, setGrants] = useState<Map<string, GrantDraft>>(new Map());
+  const [general, setGeneral] = useState<Visibility>("private");
+  const [query, setQuery] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [transferOpen, setTransferOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  // Reset working state to the loaded baseline whenever the ACL changes.
+  useEffect(() => {
+    setGrants(new Map(baseline.grants));
+    setGeneral(baseline.general);
+    setSaveError(null);
+  }, [baseline]);
+
+  // Escape to close.
   useEffect(() => {
     if (!open) return;
-    void apiFetch<{ users: AdminUser[] }>("/admin/users")
-      .then((r) => setUsers(r.users))
-      .catch(() => setUsers([]));
-  }, [open]);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const userSearchEnabled = open && pickerOpen;
+  const { users: userResults } = useUserSearch(query, userSearchEnabled);
+
+  const groupResults = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return groups.filter((g) => !q || g.name.toLowerCase().includes(q));
+  }, [groups, query]);
 
   if (!open) return null;
 
+  const ownerId = acl?.owner_user_id ?? null;
+  const dirty = !grantsEqual(grants, baseline.grants) || general !== baseline.general;
+
+  const addUser = (u: UserLite) => {
+    const k = keyFor("user", u.id);
+    if (grants.has(k) || u.id === ownerId) return;
+    const next = new Map(grants);
+    next.set(k, { kind: "user", id: u.id, permission: "read", email: u.email, name: u.name });
+    setGrants(next);
+    setQuery("");
+  };
+  const addGroup = (gid: string, name: string) => {
+    const k = keyFor("group", gid);
+    if (grants.has(k)) return;
+    const next = new Map(grants);
+    next.set(k, { kind: "group", id: gid, permission: "read", groupName: name });
+    setGrants(next);
+    setQuery("");
+  };
+  const setPermission = (k: string, permission: Permission) => {
+    const cur = grants.get(k);
+    if (!cur) return;
+    const next = new Map(grants);
+    next.set(k, { ...cur, permission });
+    setGrants(next);
+  };
+  const removeGrant = (k: string) => {
+    const next = new Map(grants);
+    next.delete(k);
+    setGrants(next);
+  };
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard blocked — no-op */
+    }
+  };
+
+  const save = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const revokes: string[] = [];
+      const adds: GrantDraft[] = [];
+      const keys = new Set([...baseline.grants.keys(), ...grants.keys()]);
+      for (const k of keys) {
+        const o = baseline.grants.get(k);
+        const n = grants.get(k);
+        if (n && !o) adds.push(n);
+        else if (o && !n) {
+          const id = baseline.entryIdByKey.get(k);
+          if (id) revokes.push(id);
+        } else if (o && n && o.permission !== n.permission) {
+          const id = baseline.entryIdByKey.get(k);
+          if (id) revokes.push(id);
+          adds.push(n);
+        }
+      }
+
+      const desiredRead = general === "public-read";
+      const desiredWrite = general === "public-write";
+      if (baseline.everyoneReadId && !desiredRead) revokes.push(baseline.everyoneReadId);
+      if (baseline.everyoneWriteId && !desiredWrite) revokes.push(baseline.everyoneWriteId);
+
+      for (const id of revokes) await revokeAcl(id);
+      for (const g of adds) {
+        await grantAcl({
+          resource_kind: resourceKind,
+          resource_path: path,
+          principal_kind: g.kind,
+          principal_id: g.id,
+          permission: g.permission,
+        });
+      }
+      if (desiredRead && !baseline.everyoneReadId) {
+        await grantAcl({
+          resource_kind: resourceKind,
+          resource_path: path,
+          principal_kind: "everyone",
+          principal_id: null,
+          permission: "read",
+        });
+      }
+      if (desiredWrite && !baseline.everyoneWriteId) {
+        await grantAcl({
+          resource_kind: resourceKind,
+          resource_path: path,
+          principal_kind: "everyone",
+          principal_id: null,
+          permission: "write",
+        });
+      }
+      await refresh();
+      onClose();
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Failed to save changes");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const forbidden = error instanceof ApiError && error.status === 403;
+  const kindNoun = resourceKind === "folder" ? "folder" : "page";
+
+  // Picker candidates, excluding owner + already-granted principals (shown
+  // as "Shared" rather than addable).
+  const addedKeys = grants;
+  const pickerGroups = groupResults;
+  const pickerUsers = userResults;
+  const showPicker = pickerOpen && (pickerGroups.length > 0 || pickerUsers.length > 0);
+
   return (
-    <div style={overlayStyle} onClick={onClose}>
-      <div style={modalStyle} onClick={(e) => e.stopPropagation()}>
-        <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16 }}>
-          <div>
-            <h2 style={{ margin: 0, fontSize: 18 }}>Share</h2>
-            <code style={{ fontSize: 12, color: color.text.muted }}>{path}</code>
+    <div
+      className={styles.scrim}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        ref={dialogRef}
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Share ${lastSegment(path)}`}
+      >
+        <header className={styles.header}>
+          <span className={styles.headerIcon}>
+            <SvgShare size={20} />
+          </span>
+          <div className={styles.headerText}>
+            <h2 className={styles.title}>
+              Share <span className={styles.titleName}>{lastSegment(path)}</span>
+            </h2>
+            <span className={styles.subtitle}>
+              Share this {kindNoun} with people or groups
+            </span>
           </div>
-          <button onClick={onClose} style={iconBtnStyle}>×</button>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            <SvgX size={18} />
+          </button>
         </header>
 
-        {error && (
-          <div style={{ color: color.state.danger.fg, marginBottom: 12 }}>
-            {error instanceof ApiError && error.status === 403
-              ? "Only the owner or an admin can manage sharing for this page."
-              : error.message}
+        {forbidden ? (
+          <div className={styles.content}>
+            <div className={styles.error}>
+              Only the owner or an admin can manage sharing for this {kindNoun}.
+            </div>
+          </div>
+        ) : isLoading || !acl ? (
+          <div className={styles.content}>
+            <div className={styles.loading}>Loading…</div>
+          </div>
+        ) : (
+          <div className={styles.content}>
+            {/* Add people / groups */}
+            <div className={styles.inputWrap}>
+              <input
+                className={styles.input}
+                placeholder="Add users and groups"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onFocus={() => setPickerOpen(true)}
+                onBlur={() => window.setTimeout(() => setPickerOpen(false), 120)}
+              />
+              {showPicker && (
+                <div className={styles.results}>
+                  {pickerGroups.map((g) => {
+                    const already = addedKeys.has(keyFor("group", g.id));
+                    return (
+                      <button
+                        key={`g-${g.id}`}
+                        type="button"
+                        className={styles.resultRow}
+                        disabled={already}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          if (!already) addGroup(g.id, g.name);
+                        }}
+                      >
+                        <Avatar label={(g.name[0] ?? "?").toUpperCase()} size={28} />
+                        <span className={styles.resultText}>
+                          <span className={styles.resultName}>{g.name}</span>
+                          <span className={styles.resultSub}>
+                            {g.member_count} {g.member_count === 1 ? "member" : "members"}
+                          </span>
+                        </span>
+                        {already && <span className={styles.resultTag}>Shared</span>}
+                      </button>
+                    );
+                  })}
+                  {pickerUsers.map((u) => {
+                    const already =
+                      addedKeys.has(keyFor("user", u.id)) || u.id === ownerId;
+                    return (
+                      <button
+                        key={`u-${u.id}`}
+                        type="button"
+                        className={styles.resultRow}
+                        disabled={already}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          if (!already) addUser(u);
+                        }}
+                      >
+                        <Avatar label={initials(u)} size={28} title={displayName(u)} />
+                        <span className={styles.resultText}>
+                          <span className={styles.resultName}>{displayName(u)}</span>
+                          <span className={styles.resultSub}>{u.email}</span>
+                        </span>
+                        {already && <span className={styles.resultTag}>Shared</span>}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            {/* General access */}
+            <div className={styles.generalRow}>
+              <span className={styles.generalIcon}>
+                {general === "private" ? <SvgLock size={16} /> : <SvgGlobe size={16} />}
+              </span>
+              <ScopeSelect
+                value={general === "private" ? "invited" : "anyone"}
+                onChange={(scope) =>
+                  setGeneral(scope === "invited" ? "private" : "public-read")
+                }
+                container={dialogRef.current}
+              />
+              <span className={styles.generalSpacer} />
+              <PermSelect
+                value={general === "public-write" ? "write" : "read"}
+                disabled={general === "private"}
+                onChange={(p) => setGeneral(p === "write" ? "public-write" : "public-read")}
+                container={dialogRef.current}
+              />
+            </div>
+
+            {saveError && <div className={styles.error}>{saveError}</div>}
+
+            {/* People with access */}
+            <div className={styles.list}>
+              {ownerId && (
+                <OwnerRow
+                  ownerId={ownerId}
+                  ownerEmail={acl.owner_email ?? null}
+                  ownerName={acl.owner_name ?? null}
+                  isYou={ownerId === user?.id}
+                  canTransfer={ownerId === user?.id || Boolean(user?.is_admin)}
+                  onTransfer={() => setTransferOpen(true)}
+                />
+              )}
+
+              {[...grants.values()].map((g) => {
+                const k = keyFor(g.kind, g.id);
+                const group =
+                  g.kind === "group" ? groups.find((x) => x.id === g.id) : undefined;
+                const name =
+                  g.kind === "group"
+                    ? g.groupName ?? group?.name ?? "Group"
+                    : displayName({ name: g.name, email: g.email ?? g.id });
+                const sub =
+                  g.kind === "group"
+                    ? group
+                      ? `${group.member_count} ${group.member_count === 1 ? "member" : "members"}`
+                      : "Group"
+                    : g.email ?? "";
+                return (
+                  <div key={k} className={styles.row}>
+                    <Avatar
+                      label={(name[0] ?? "?").toUpperCase()}
+                      size={28}
+                      title={name}
+                    />
+                    <span className={styles.rowText}>
+                      <span className={styles.rowName}>
+                        {g.kind === "group" ? (
+                          <SvgUsers size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />
+                        ) : null}
+                        {name}
+                      </span>
+                      {sub && <span className={styles.rowSub}>{sub}</span>}
+                    </span>
+                    <span className={styles.rowRight}>
+                      <PermSelect
+                        value={g.permission}
+                        onChange={(p) => setPermission(k, p)}
+                        onRemove={() => removeGrant(k)}
+                        container={dialogRef.current}
+                      />
+                    </span>
+                  </div>
+                );
+              })}
+
+              {baseline.inherited.map((e) => (
+                <InheritedRow key={e.id} entry={e} groups={groups} />
+              ))}
+            </div>
           </div>
         )}
 
-        {isLoading || !acl ? (
-          <LoadingSpinner />
-        ) : (
-          <>
-            <Section title="Visibility">
-              <div style={{ fontSize: 14, color: color.text.secondary }}>
-                {(() => {
-                  const v = visibility(acl);
-                  if (v === "private") {
-                    return (
-                      <span>
-                        <strong>Private</strong> — only the owner and explicit grants below can access.
-                      </span>
-                    );
-                  }
-                  if (v === "public-read") {
-                    return (
-                      <span>
-                        <strong>Public (read-only)</strong> — every signed-in user can read; only the owner and explicit write grants can edit.
-                      </span>
-                    );
-                  }
-                  return (
-                    <span>
-                      <strong>Public</strong> — every signed-in user can read and edit.
-                    </span>
-                  );
-                })()}
-              </div>
-            </Section>
-
-            <Section title="Owner">
-              <OwnerControls
-                path={path}
-                ownerId={acl.owner_user_id}
-                users={users}
-                onChanged={() => void refresh()}
-              />
-            </Section>
-
-            <Section title="Grants">
-              <Grants
-                entries={acl.entries}
-                users={users}
-                groups={groups}
-                onRevoke={async (id) => {
-                  await revokeAcl(id);
-                  await refresh();
-                }}
-              />
-            </Section>
-
-            <Section title="Add grant">
-              <GrantForm
-                path={path}
-                users={users}
-                groups={groups}
-                onGranted={() => void refresh()}
-              />
-            </Section>
-          </>
-        )}
+        <footer className={styles.footer}>
+          <Button
+            prominence="tertiary"
+            size="md"
+            icon={SvgLink}
+            onClick={() => void copyLink()}
+          >
+            Copy Link
+          </Button>
+          <span className={styles.footerRight}>
+            {copied && <span className={styles.copied}>Copied</span>}
+            <Button prominence="tertiary" size="md" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button
+              variant="action"
+              size="md"
+              disabled={!dirty || saving || forbidden}
+              onClick={() => void save()}
+            >
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          </span>
+        </footer>
       </div>
+
+      {transferOpen && acl && (
+        <TransferModal
+          path={path}
+          currentOwnerId={ownerId}
+          open={transferOpen}
+          onClose={() => setTransferOpen(false)}
+          onTransferred={() => {
+            setTransferOpen(false);
+            void refresh();
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -138,285 +547,213 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
 // Sub-components                                                              //
 // --------------------------------------------------------------------------- //
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
+function PermSelect({
+  value,
+  onChange,
+  onRemove,
+  disabled,
+  container,
+}: {
+  value: Permission;
+  onChange: (p: Permission) => void;
+  onRemove?: () => void;
+  disabled?: boolean;
+  container: HTMLElement | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const label = value === "write" ? "Edit" : "View";
+  const icon = value === "write" ? SvgEdit : SvgEye;
   return (
-    <section style={{ marginBottom: 20 }}>
-      <h3 style={{ fontSize: 13, fontWeight: 600, color: color.text.secondary, margin: "0 0 8px 0" }}>
-        {title}
-      </h3>
-      {children}
-    </section>
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <SelectButton
+          size="sm"
+          variant="select-light"
+          icon={icon}
+          rightIcon={SvgChevronDown}
+          disabled={disabled}
+        >
+          {label}
+        </SelectButton>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="end" sideOffset={4} container={container}>
+        <Popover.Menu>
+          {[
+            <LineItemButton
+              key="view"
+              icon={SvgEye}
+              title="View"
+              state={value === "read" ? "selected" : "empty"}
+              rightChildren={value === "read" ? <SvgCheck size={16} /> : undefined}
+              onClick={() => {
+                onChange("read");
+                setOpen(false);
+              }}
+            />,
+            <LineItemButton
+              key="edit"
+              icon={SvgEdit}
+              title="Edit"
+              state={value === "write" ? "selected" : "empty"}
+              rightChildren={value === "write" ? <SvgCheck size={16} /> : undefined}
+              onClick={() => {
+                onChange("write");
+                setOpen(false);
+              }}
+            />,
+            onRemove ? null : undefined,
+            onRemove ? (
+              <LineItemButton
+                key="remove"
+                icon={SvgX}
+                title="Remove access"
+                color="danger"
+                onClick={() => {
+                  onRemove();
+                  setOpen(false);
+                }}
+              />
+            ) : undefined,
+          ]}
+        </Popover.Menu>
+      </Popover.Content>
+    </Popover>
   );
 }
 
-function OwnerControls({
-  path,
+function ScopeSelect({
+  value,
+  onChange,
+  container,
+}: {
+  value: "invited" | "anyone";
+  onChange: (v: "invited" | "anyone") => void;
+  container: HTMLElement | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const label = value === "invited" ? "Only those invited" : "Anyone signed in";
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <SelectButton
+          size="sm"
+          variant="select-light"
+          icon={value === "invited" ? SvgLock : SvgGlobe}
+          rightIcon={SvgChevronDown}
+        >
+          {label}
+        </SelectButton>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="start" sideOffset={4} container={container}>
+        <Popover.Menu>
+          {[
+            <LineItemButton
+              key="invited"
+              icon={SvgLock}
+              title="Only those invited"
+              state={value === "invited" ? "selected" : "empty"}
+              onClick={() => {
+                if (value !== "invited") {
+                  onChange("invited");
+                }
+                setOpen(false);
+              }}
+            />,
+            <LineItemButton
+              key="anyone"
+              icon={SvgGlobe}
+              title="Anyone signed in"
+              state={value === "anyone" ? "selected" : "empty"}
+              onClick={() => {
+                if (value !== "anyone") {
+                  onChange("anyone");
+                }
+                setOpen(false);
+              }}
+            />,
+          ]}
+        </Popover.Menu>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
+function OwnerRow({
   ownerId,
-  users,
-  onChanged,
+  ownerEmail,
+  ownerName,
+  isYou,
+  canTransfer,
+  onTransfer,
 }: {
-  path: string;
-  ownerId: string | null;
-  users: AdminUser[];
-  onChanged: () => void;
+  ownerId: string;
+  ownerEmail: string | null;
+  ownerName: string | null;
+  isYou: boolean;
+  canTransfer: boolean;
+  onTransfer: () => void;
 }) {
-  const ownerLabel = useMemo(() => {
-    if (!ownerId) return "—";
-    const u = users.find((x) => x.id === ownerId);
-    return u ? u.email : ownerId;
-  }, [ownerId, users]);
-  const [transferTo, setTransferTo] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  async function transfer() {
-    setBusy(true);
-    setErr(null);
-    try {
-      await transferOwnership(path, transferTo || null);
-      setTransferTo("");
-      onChanged();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
+  const name = displayName({ name: ownerName, email: ownerEmail ?? ownerId });
   return (
-    <div>
-      <div style={{ fontSize: 14, marginBottom: 8 }}>{ownerLabel}</div>
-      <div style={{ display: "flex", gap: 8 }}>
-        <select value={transferTo} onChange={(e) => setTransferTo(e.target.value)} style={inputStyle}>
-          <option value="">Transfer ownership to…</option>
-          {users.map((u) => (
-            <option key={u.id} value={u.id}>
-              {u.email}
-            </option>
-          ))}
-        </select>
-        <Button size="sm" onClick={() => void transfer()} disabled={busy || !transferTo}>
-          Transfer
-        </Button>
-      </div>
-      {err && <div style={{ color: color.state.danger.fg, marginTop: 6, fontSize: 13 }}>{err}</div>}
-    </div>
-  );
-}
-
-function Grants({
-  entries,
-  users,
-  groups,
-  onRevoke,
-}: {
-  entries: AclEntry[];
-  users: AdminUser[];
-  groups: { id: string; name: string }[];
-  onRevoke: (id: string) => Promise<void>;
-}) {
-  if (entries.length === 0) {
-    return <div style={{ fontSize: 13, color: color.text.muted }}>No explicit grants.</div>;
-  }
-  return (
-    <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
-      {entries.map((e) => (
-        <li
-          key={e.id}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            padding: "6px 0",
-            borderBottom: `1px solid ${color.border.subtle}`,
-            fontSize: 13,
-          }}
-        >
-          <span>
-            <PrincipalLabel
-              kind={e.principal_kind}
-              id={e.principal_id}
-              users={users}
-              groups={groups}
-            />
-            {" "}
-            <span style={{ color: color.text.muted }}>
-              · {e.permission}
-              {e.resource_kind === "folder"
-                ? ` · folder${e.resource_path ? ` "${e.resource_path}"` : " (root)"}`
-                : ""}
-            </span>
-          </span>
-          {e.resource_kind === "page" ? (
-            <Button size="sm" variant="danger" onClick={() => void onRevoke(e.id)}>
-              Revoke
-            </Button>
-          ) : (
-            <span style={{ fontSize: 11, color: color.text.faint }}>inherited</span>
-          )}
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-function PrincipalLabel({
-  kind,
-  id,
-  users,
-  groups,
-}: {
-  kind: PrincipalKind;
-  id: string | null;
-  users: AdminUser[];
-  groups: { id: string; name: string }[];
-}) {
-  if (kind === "everyone") return <strong>Everyone</strong>;
-  if (kind === "user") {
-    const u = id ? users.find((x) => x.id === id) : null;
-    return <span>👤 {u ? u.email : id ?? "?"}</span>;
-  }
-  if (kind === "group") {
-    const g = id ? groups.find((x) => x.id === id) : null;
-    return <span>👥 {g ? g.name : id ?? "?"}</span>;
-  }
-  return <span>{kind}</span>;
-}
-
-function GrantForm({
-  path,
-  users,
-  groups,
-  onGranted,
-}: {
-  path: string;
-  users: AdminUser[];
-  groups: { id: string; name: string }[];
-  onGranted: () => void;
-}) {
-  const [principalKind, setPrincipalKind] = useState<PrincipalKind>("user");
-  const [principalId, setPrincipalId] = useState("");
-  const [permission, setPermission] = useState<Permission>("read");
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-
-  async function submit() {
-    setBusy(true);
-    setErr(null);
-    try {
-      await grantAcl({
-        resource_kind: "page",
-        resource_path: path,
-        principal_kind: principalKind,
-        principal_id: principalKind === "everyone" ? null : principalId,
-        permission,
-      });
-      setPrincipalId("");
-      onGranted();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  const canSubmit =
-    !busy && (principalKind === "everyone" || principalId !== "");
-
-  return (
-    <div style={{ display: "grid", gap: 8 }}>
-      <div style={{ display: "flex", gap: 8 }}>
-        <select
-          value={principalKind}
-          onChange={(e) => {
-            setPrincipalKind(e.target.value as PrincipalKind);
-            setPrincipalId("");
-          }}
-          style={inputStyle}
-        >
-          <option value="user">User</option>
-          <option value="group">Group</option>
-          <option value="everyone">Everyone</option>
-        </select>
-        {principalKind === "user" ? (
-          <select value={principalId} onChange={(e) => setPrincipalId(e.target.value)} style={inputStyle}>
-            <option value="">Pick a user…</option>
-            {users.map((u) => (
-              <option key={u.id} value={u.id}>
-                {u.email}
-              </option>
-            ))}
-          </select>
-        ) : principalKind === "group" ? (
-          <select value={principalId} onChange={(e) => setPrincipalId(e.target.value)} style={inputStyle}>
-            <option value="">Pick a group…</option>
-            {groups.map((g) => (
-              <option key={g.id} value={g.id}>
-                {g.name}
-              </option>
-            ))}
-          </select>
-        ) : (
-          <span style={{ flex: 1, fontSize: 13, color: color.text.muted, alignSelf: "center" }}>
-            All signed-in users
-          </span>
+    <div className={styles.row}>
+      <Avatar label={initials({ name: ownerName, email: ownerEmail ?? ownerId })} size={28} title={name} />
+      <span className={styles.rowText}>
+        <span className={styles.rowName}>
+          {name}
+          {isYou ? " (you)" : ""}
+        </span>
+        {ownerEmail && <span className={styles.rowSub}>{ownerEmail}</span>}
+      </span>
+      <span className={styles.rowRight}>
+        <span className={styles.ownerTag}>Owner</span>
+        {canTransfer && (
+          <button
+            className={styles.transferBtn}
+            onClick={onTransfer}
+            aria-label="Transfer ownership"
+            title="Transfer ownership"
+          >
+            <SvgArrowExchange size={16} />
+          </button>
         )}
-        <select value={permission} onChange={(e) => setPermission(e.target.value as Permission)} style={inputStyle}>
-          <option value="read">Read</option>
-          <option value="write">Write</option>
-        </select>
-      </div>
-      <Button onClick={() => void submit()} disabled={!canSubmit}>
-        Grant access
-      </Button>
-      {err && <div style={{ color: color.state.danger.fg, fontSize: 13 }}>{err}</div>}
+      </span>
     </div>
   );
 }
 
-// --------------------------------------------------------------------------- //
-// Styles                                                                      //
-// --------------------------------------------------------------------------- //
-
-const overlayStyle: React.CSSProperties = {
-  position: "fixed",
-  inset: 0,
-  background: color.overlay,
-  display: "flex",
-  alignItems: "flex-start",
-  justifyContent: "center",
-  // 80px on tall viewports for a generous top gap; clamps down to 5vh
-  // (~33px on a 667px-tall iPhone) so the modal doesn't get pushed off
-  // screen on short phone viewports.
-  paddingTop: "max(20px, min(80px, 5vh))",
-  paddingLeft: 16,
-  paddingRight: 16,
-  zIndex: 50,
-};
-const modalStyle: React.CSSProperties = {
-  background: color.bg.page,
-  borderRadius: radius.lg,
-  width: "min(560px, 100%)",
-  maxHeight: "calc(100vh - 80px)",
-  overflowY: "auto",
-  padding: 24,
-  boxShadow: shadow.modal,
-};
-const inputStyle: React.CSSProperties = {
-  flex: 1,
-  padding: "6px 10px",
-  fontSize: 13,
-  border: `1px solid ${color.border.default}`,
-  borderRadius: radius.sm,
-  background: color.bg.page,
-};
-const iconBtnStyle: React.CSSProperties = {
-  background: "transparent",
-  border: "none",
-  fontSize: 24,
-  cursor: "pointer",
-  color: color.text.muted,
-  width: 32,
-  height: 32,
-  lineHeight: 1,
-};
+function InheritedRow({
+  entry,
+  groups,
+}: {
+  entry: AclEntry;
+  groups: { id: string; name: string }[];
+}) {
+  let name: string;
+  let icon = <SvgUser size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />;
+  if (entry.principal_kind === "everyone") {
+    name = "Anyone signed in";
+    icon = <SvgGlobe size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />;
+  } else if (entry.principal_kind === "group") {
+    name = entry.group_name ?? groups.find((g) => g.id === entry.principal_id)?.name ?? "Group";
+    icon = <SvgUsers size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />;
+  } else {
+    name = displayName({ name: entry.principal_name, email: entry.principal_email ?? entry.principal_id ?? "?" });
+  }
+  const where = entry.resource_path ? `folder "${entry.resource_path}"` : "root folder";
+  return (
+    <div className={styles.row}>
+      <span className={styles.rowText}>
+        <span className={styles.rowName}>
+          {icon}
+          {name}
+        </span>
+        <span className={styles.rowSub}>
+          {entry.permission === "write" ? "Can edit" : "Can view"} · inherited from {where}
+        </span>
+      </span>
+      <span className={styles.rowRight}>
+        <span className={styles.inheritedTag}>Inherited</span>
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -609,7 +609,7 @@ function PermSelect({
         <span className={boxed ? styles.permBox : styles.menuTrigger}>
           <OpenButton
             variant="select-light"
-            size="sm"
+            size={boxed ? "lg" : "sm"}
             icon={icon}
             disabled={disabled}
             width={boxed ? "full" : undefined}
@@ -680,7 +680,7 @@ function ScopeSelect({
         <span className={styles.scopeBox}>
           <OpenButton
             variant="select-light"
-            size="sm"
+            size="lg"
             width="full"
             justifyContent="between"
             rounding="sm"

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -164,7 +164,17 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
   const baseline = useMemo(() => deriveBaseline(acl), [acl]);
 
   const [grants, setGrants] = useState<Map<string, GrantDraft>>(new Map());
-  const [general, setGeneral] = useState<Visibility>("private");
+  // Scope (who) and the general permission (what) are independent: the
+  // permission stays selectable even while "Only those invited" is chosen —
+  // it only takes effect (as an `everyone` grant) once scope is "anyone".
+  const [scope, setScope] = useState<"invited" | "anyone">("invited");
+  const [generalPerm, setGeneralPerm] = useState<Permission>("read");
+  const general: Visibility =
+    scope === "invited"
+      ? "private"
+      : generalPerm === "write"
+        ? "public-write"
+        : "public-read";
   const [query, setQuery] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
   const [transferOpen, setTransferOpen] = useState(false);
@@ -175,7 +185,8 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
   // Reset working state to the loaded baseline whenever the ACL changes.
   useEffect(() => {
     setGrants(new Map(baseline.grants));
-    setGeneral(baseline.general);
+    setScope(baseline.general === "private" ? "invited" : "anyone");
+    setGeneralPerm(baseline.general === "public-write" ? "write" : "read");
     setSaveError(null);
   }, [baseline]);
 
@@ -456,26 +467,14 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
               {/* General access */}
               <div className={styles.generalRow}>
                 <span className={styles.inheritedIcon}>
-                  {general === "private" ? (
+                  {scope === "invited" ? (
                     <SvgLock size={18} />
                   ) : (
                     <SvgGlobe size={18} />
                   )}
                 </span>
-                <ScopeSelect
-                  value={general === "private" ? "invited" : "anyone"}
-                  onChange={(scope) =>
-                    setGeneral(scope === "invited" ? "private" : "public-read")
-                  }
-                />
-                <PermSelect
-                  boxed
-                  value={general === "public-write" ? "write" : "read"}
-                  disabled={general === "private"}
-                  onChange={(p) =>
-                    setGeneral(p === "write" ? "public-write" : "public-read")
-                  }
-                />
+                <ScopeSelect value={scope} onChange={setScope} />
+                <PermSelect boxed value={generalPerm} onChange={setGeneralPerm} />
               </div>
 
               <Divider paddingParallel="fit" paddingPerpendicular="2xs" />

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -330,16 +330,20 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
           permission: "write",
         });
       }
-      await refresh();
-      onClose();
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : "Failed to save changes");
       // Re-pull the ACL so the baseline reflects whatever partially applied;
       // otherwise a retry re-issues already-committed grants/revokes and 404s.
       await refresh();
-    } finally {
       setSaving(false);
+      return;
     }
+    // All mutations committed — the save succeeded. Close immediately and
+    // refresh the cache best-effort; a failing refetch must NOT surface as a
+    // save error or keep the dialog open after the DB already changed.
+    setSaving(false);
+    onClose();
+    void refresh();
   };
 
   const forbidden = error instanceof ApiError && error.status === 403;

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -659,7 +659,7 @@ function ScopeSelect({
   onChange: (v: "invited" | "anyone") => void;
 }) {
   const [open, setOpen] = useState(false);
-  const label = value === "invited" ? "Only those invited" : "Anyone signed in";
+  const label = value === "invited" ? "Only those invited" : "Anyone";
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
@@ -690,7 +690,7 @@ function ScopeSelect({
           />
           <LineItemButton
             icon={SvgGlobe}
-            title="Anyone signed in"
+            title="Anyone"
             sizePreset="main-ui"
             variant="section"
             state={value === "anyone" ? "selected" : "empty"}
@@ -769,7 +769,7 @@ function InheritedRow({
   let name: string;
   let Icon = SvgUser;
   if (entry.principal_kind === "everyone") {
-    name = "Anyone signed in";
+    name = "Anyone";
     Icon = SvgGlobe;
   } else if (entry.principal_kind === "group") {
     name =

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -2,11 +2,18 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import { Button, Popover, SelectButton } from "@onyx-ai/opal/components";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  OpenButton,
+  Popover,
+  PopoverMenu,
+  Text,
+} from "@onyx-ai/opal/components";
 import {
   SvgArrowExchange,
   SvgCheck,
-  SvgChevronDown,
   SvgEdit,
   SvgEye,
   SvgGlobe,
@@ -199,6 +206,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
     next.set(k, { kind: "user", id: u.id, permission: "read", email: u.email, name: u.name });
     setGrants(next);
     setQuery("");
+    setPickerOpen(false);
   };
   const addGroup = (gid: string, name: string) => {
     const k = keyFor("group", gid);
@@ -207,6 +215,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
     next.set(k, { kind: "group", id: gid, permission: "read", groupName: name });
     setGrants(next);
     setQuery("");
+    setPickerOpen(false);
   };
   const setPermission = (k: string, permission: Permission) => {
     const cur = grants.get(k);
@@ -300,12 +309,10 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
   const forbidden = error instanceof ApiError && error.status === 403;
   const kindNoun = resourceKind === "folder" ? "folder" : "page";
 
-  // Picker candidates, excluding owner + already-granted principals (shown
-  // as "Shared" rather than addable).
-  const addedKeys = grants;
   const pickerGroups = groupResults;
   const pickerUsers = userResults;
-  const showPicker = pickerOpen && (pickerGroups.length > 0 || pickerUsers.length > 0);
+  const hasResults = pickerGroups.length > 0 || pickerUsers.length > 0;
+  const showPicker = pickerOpen && hasResults;
 
   return (
     <div
@@ -325,94 +332,118 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
             <SvgShare size={20} />
           </span>
           <div className={styles.headerText}>
-            <h2 className={styles.title}>
-              Share <span className={styles.titleName}>{lastSegment(path)}</span>
-            </h2>
-            <span className={styles.subtitle}>
-              Share this {kindNoun} with people or groups
-            </span>
+            <Text as="h2" font="main-content-emphasis">
+              {`Share ${lastSegment(path)}`}
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              {`Share this ${kindNoun} with people or groups`}
+            </Text>
           </div>
-          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
-            <SvgX size={18} />
-          </button>
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgX}
+            tooltip="Close"
+            onClick={onClose}
+          />
         </header>
 
         {forbidden ? (
           <div className={styles.content}>
-            <div className={styles.error}>
-              Only the owner or an admin can manage sharing for this {kindNoun}.
-            </div>
+            <Text font="secondary-body" color="text-02">
+              {`Only the owner or an admin can manage sharing for this ${kindNoun}.`}
+            </Text>
           </div>
         ) : isLoading || !acl ? (
           <div className={styles.content}>
-            <div className={styles.loading}>Loading…</div>
+            <Text font="secondary-body" color="text-03">
+              Loading…
+            </Text>
           </div>
         ) : (
           <div className={styles.content}>
-            {/* Add people / groups */}
-            <div className={styles.inputWrap}>
-              <input
-                className={styles.input}
-                placeholder="Add users and groups"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                onFocus={() => setPickerOpen(true)}
-                onBlur={() => window.setTimeout(() => setPickerOpen(false), 120)}
-              />
-              {showPicker && (
-                <div className={styles.results}>
+            {/* Add people / groups — InputTypeIn anchors a portaled results menu */}
+            <Popover
+              open={showPicker}
+              onOpenChange={(o) => {
+                if (!o) setPickerOpen(false);
+              }}
+            >
+              <Popover.Anchor asChild>
+                <div className={styles.anchorWrap}>
+                  <InputTypeIn
+                    searchIcon
+                    placeholder="Add users and groups"
+                    value={query}
+                    onChange={(e) => {
+                      setQuery(e.target.value);
+                      setPickerOpen(true);
+                    }}
+                    onFocus={() => setPickerOpen(true)}
+                  />
+                </div>
+              </Popover.Anchor>
+              <Popover.Content
+                width="trigger"
+                align="start"
+                sideOffset={4}
+                container={typeof document !== "undefined" ? document.body : undefined}
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                onCloseAutoFocus={(e) => e.preventDefault()}
+              >
+                <PopoverMenu>
                   {pickerGroups.map((g) => {
-                    const already = addedKeys.has(keyFor("group", g.id));
+                    const already = grants.has(keyFor("group", g.id));
                     return (
-                      <button
+                      <LineItemButton
                         key={`g-${g.id}`}
-                        type="button"
-                        className={styles.resultRow}
-                        disabled={already}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
+                        icon={SvgUsers}
+                        title={g.name}
+                        description={`${g.member_count} ${g.member_count === 1 ? "member" : "members"}`}
+                        sizePreset="main-ui"
+                        variant="section"
+                        rightChildren={
+                          already ? (
+                            <Text font="secondary-body" color="text-03">
+                              Shared
+                            </Text>
+                          ) : undefined
+                        }
+                        onClick={() => {
                           if (!already) addGroup(g.id, g.name);
                         }}
-                      >
-                        <Avatar label={(g.name[0] ?? "?").toUpperCase()} size={28} />
-                        <span className={styles.resultText}>
-                          <span className={styles.resultName}>{g.name}</span>
-                          <span className={styles.resultSub}>
-                            {g.member_count} {g.member_count === 1 ? "member" : "members"}
-                          </span>
-                        </span>
-                        {already && <span className={styles.resultTag}>Shared</span>}
-                      </button>
+                      />
                     );
                   })}
                   {pickerUsers.map((u) => {
                     const already =
-                      addedKeys.has(keyFor("user", u.id)) || u.id === ownerId;
+                      grants.has(keyFor("user", u.id)) || u.id === ownerId;
                     return (
-                      <button
+                      <LineItemButton
                         key={`u-${u.id}`}
-                        type="button"
-                        className={styles.resultRow}
-                        disabled={already}
-                        onMouseDown={(e) => {
-                          e.preventDefault();
+                        icon={SvgUser}
+                        title={displayName(u)}
+                        description={u.email}
+                        sizePreset="main-ui"
+                        variant="section"
+                        rightChildren={
+                          already ? (
+                            <Text font="secondary-body" color="text-03">
+                              Shared
+                            </Text>
+                          ) : undefined
+                        }
+                        onClick={() => {
                           if (!already) addUser(u);
                         }}
-                      >
-                        <Avatar label={initials(u)} size={28} title={displayName(u)} />
-                        <span className={styles.resultText}>
-                          <span className={styles.resultName}>{displayName(u)}</span>
-                          <span className={styles.resultSub}>{u.email}</span>
-                        </span>
-                        {already && <span className={styles.resultTag}>Shared</span>}
-                      </button>
+                      />
                     );
                   })}
-                </div>
-              )}
-            </div>
+                </PopoverMenu>
+              </Popover.Content>
+            </Popover>
 
-            {/* General access — the scope dropdown carries the lock/globe icon */}
+            {/* General access */}
             <div className={styles.generalRow}>
               <ScopeSelect
                 value={general === "private" ? "invited" : "anyone"}
@@ -428,7 +459,11 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
               />
             </div>
 
-            {saveError && <div className={styles.error}>{saveError}</div>}
+            {saveError && (
+              <Text font="secondary-body" color="text-02">
+                {saveError}
+              </Text>
+            )}
 
             {/* People with access */}
             <div className={styles.list}>
@@ -459,27 +494,22 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                     : g.email ?? "";
                 return (
                   <div key={k} className={styles.row}>
-                    <Avatar
-                      label={(name[0] ?? "?").toUpperCase()}
-                      size={28}
-                      title={name}
-                    />
-                    <span className={styles.rowText}>
-                      <span className={styles.rowName}>
-                        {g.kind === "group" ? (
-                          <SvgUsers size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />
-                        ) : null}
+                    <Avatar label={(name[0] ?? "?").toUpperCase()} size={28} title={name} />
+                    <div className={styles.rowText}>
+                      <Text font="main-ui-body" nowrap>
                         {name}
-                      </span>
-                      {sub && <span className={styles.rowSub}>{sub}</span>}
-                    </span>
-                    <span className={styles.rowRight}>
-                      <PermSelect
-                        value={g.permission}
-                        onChange={(p) => setPermission(k, p)}
-                        onRemove={() => removeGrant(k)}
-                      />
-                    </span>
+                      </Text>
+                      {sub && (
+                        <Text font="secondary-body" color="text-03" nowrap>
+                          {sub}
+                        </Text>
+                      )}
+                    </div>
+                    <PermSelect
+                      value={g.permission}
+                      onChange={(p) => setPermission(k, p)}
+                      onRemove={() => removeGrant(k)}
+                    />
                   </div>
                 );
               })}
@@ -498,10 +528,9 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
             icon={SvgLink}
             onClick={() => void copyLink()}
           >
-            Copy Link
+            {copied ? "Copied" : "Copy Link"}
           </Button>
           <span className={styles.footerRight}>
-            {copied && <span className={styles.copied}>Copied</span>}
             <Button prominence="tertiary" size="md" onClick={onClose}>
               Cancel
             </Button>
@@ -555,50 +584,51 @@ function PermSelect({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <span className={styles.menuTrigger}>
-          <SelectButton
-            size="sm"
-            variant="select-light"
-            icon={icon}
-            rightIcon={SvgChevronDown}
-            disabled={disabled}
-          >
+          <OpenButton variant="select-light" size="sm" icon={icon} disabled={disabled}>
             {label}
-          </SelectButton>
+          </OpenButton>
         </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="end" sideOffset={4}>
-        <div className={styles.menu}>
-          <MenuRow
+        <PopoverMenu>
+          <LineItemButton
             icon={SvgEye}
-            label="View"
-            selected={value === "read"}
+            title="View"
+            sizePreset="main-ui"
+            variant="section"
+            state={value === "read" ? "selected" : "empty"}
+            rightChildren={value === "read" ? <SvgCheck size={16} /> : undefined}
             onClick={() => {
               onChange("read");
               setOpen(false);
             }}
           />
-          <MenuRow
+          <LineItemButton
             icon={SvgEdit}
-            label="Edit"
-            selected={value === "write"}
+            title="Edit"
+            sizePreset="main-ui"
+            variant="section"
+            state={value === "write" ? "selected" : "empty"}
+            rightChildren={value === "write" ? <SvgCheck size={16} /> : undefined}
             onClick={() => {
               onChange("write");
               setOpen(false);
             }}
           />
-          {onRemove && <div className={styles.menuDivider} />}
-          {onRemove && (
-            <MenuRow
+          {onRemove ? null : undefined}
+          {onRemove ? (
+            <LineItemButton
               icon={SvgX}
-              label="Remove access"
-              danger
+              title="Remove access"
+              sizePreset="main-ui"
+              variant="section"
               onClick={() => {
                 onRemove();
                 setOpen(false);
               }}
             />
-          )}
-        </div>
+          ) : undefined}
+        </PopoverMenu>
       </Popover.Content>
     </Popover>
   );
@@ -617,71 +647,42 @@ function ScopeSelect({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <span className={styles.menuTrigger}>
-          <SelectButton
-            size="sm"
+          <OpenButton
             variant="select-light"
+            size="sm"
             icon={value === "invited" ? SvgLock : SvgGlobe}
-            rightIcon={SvgChevronDown}
           >
             {label}
-          </SelectButton>
+          </OpenButton>
         </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
-        <div className={styles.menu}>
-          <MenuRow
+        <PopoverMenu>
+          <LineItemButton
             icon={SvgLock}
-            label="Only those invited"
-            selected={value === "invited"}
+            title="Only those invited"
+            sizePreset="main-ui"
+            variant="section"
+            state={value === "invited" ? "selected" : "empty"}
             onClick={() => {
               if (value !== "invited") onChange("invited");
               setOpen(false);
             }}
           />
-          <MenuRow
+          <LineItemButton
             icon={SvgGlobe}
-            label="Anyone signed in"
-            selected={value === "anyone"}
+            title="Anyone signed in"
+            sizePreset="main-ui"
+            variant="section"
+            state={value === "anyone" ? "selected" : "empty"}
             onClick={() => {
               if (value !== "anyone") onChange("anyone");
               setOpen(false);
             }}
           />
-        </div>
+        </PopoverMenu>
       </Popover.Content>
     </Popover>
-  );
-}
-
-function MenuRow({
-  icon: Icon,
-  label,
-  selected,
-  danger,
-  onClick,
-}: {
-  icon: (props: { size?: number }) => React.ReactNode;
-  label: string;
-  selected?: boolean;
-  danger?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      className={`${styles.menuItem}${danger ? ` ${styles.menuItemDanger}` : ""}`}
-      onClick={onClick}
-    >
-      <span className={styles.menuItemIcon}>
-        <Icon size={16} />
-      </span>
-      <span className={styles.menuItemLabel}>{label}</span>
-      {selected && (
-        <span className={styles.menuItemCheck}>
-          <SvgCheck size={16} />
-        </span>
-      )}
-    </button>
   );
 }
 
@@ -703,25 +704,33 @@ function OwnerRow({
   const name = displayName({ name: ownerName, email: ownerEmail ?? ownerId });
   return (
     <div className={styles.row}>
-      <Avatar label={initials({ name: ownerName, email: ownerEmail ?? ownerId })} size={28} title={name} />
-      <span className={styles.rowText}>
-        <span className={styles.rowName}>
-          {name}
-          {isYou ? " (you)" : ""}
-        </span>
-        {ownerEmail && <span className={styles.rowSub}>{ownerEmail}</span>}
-      </span>
+      <Avatar
+        label={initials({ name: ownerName, email: ownerEmail ?? ownerId })}
+        size={28}
+        title={name}
+      />
+      <div className={styles.rowText}>
+        <Text font="main-ui-body" nowrap>
+          {isYou ? `${name} (you)` : name}
+        </Text>
+        {ownerEmail && (
+          <Text font="secondary-body" color="text-03" nowrap>
+            {ownerEmail}
+          </Text>
+        )}
+      </div>
       <span className={styles.rowRight}>
-        <span className={styles.ownerTag}>Owner</span>
+        <Text font="secondary-body" color="text-03">
+          Owner
+        </Text>
         {canTransfer && (
-          <button
-            className={styles.transferBtn}
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgArrowExchange}
+            tooltip="Transfer ownership"
             onClick={onTransfer}
-            aria-label="Transfer ownership"
-            title="Transfer ownership"
-          >
-            <SvgArrowExchange size={16} />
-          </button>
+          />
         )}
       </span>
     </div>
@@ -736,30 +745,40 @@ function InheritedRow({
   groups: { id: string; name: string }[];
 }) {
   let name: string;
-  let icon = <SvgUser size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />;
+  let Icon = SvgUser;
   if (entry.principal_kind === "everyone") {
     name = "Anyone signed in";
-    icon = <SvgGlobe size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />;
+    Icon = SvgGlobe;
   } else if (entry.principal_kind === "group") {
-    name = entry.group_name ?? groups.find((g) => g.id === entry.principal_id)?.name ?? "Group";
-    icon = <SvgUsers size={13} style={{ verticalAlign: "-2px", marginRight: 4 }} />;
+    name =
+      entry.group_name ??
+      groups.find((g) => g.id === entry.principal_id)?.name ??
+      "Group";
+    Icon = SvgUsers;
   } else {
-    name = displayName({ name: entry.principal_name, email: entry.principal_email ?? entry.principal_id ?? "?" });
+    name = displayName({
+      name: entry.principal_name,
+      email: entry.principal_email ?? entry.principal_id ?? "?",
+    });
   }
   const where = entry.resource_path ? `folder "${entry.resource_path}"` : "root folder";
   return (
     <div className={styles.row}>
-      <span className={styles.rowText}>
-        <span className={styles.rowName}>
-          {icon}
-          {name}
-        </span>
-        <span className={styles.rowSub}>
-          {entry.permission === "write" ? "Can edit" : "Can view"} · inherited from {where}
-        </span>
+      <span className={styles.inheritedIcon}>
+        <Icon size={16} />
       </span>
+      <div className={styles.rowText}>
+        <Text font="main-ui-body" nowrap>
+          {name}
+        </Text>
+        <Text font="secondary-body" color="text-03" nowrap>
+          {`${entry.permission === "write" ? "Can edit" : "Can view"} · inherited from ${where}`}
+        </Text>
+      </div>
       <span className={styles.rowRight}>
-        <span className={styles.inheritedTag}>Inherited</span>
+        <Text font="secondary-body" color="text-03">
+          Inherited
+        </Text>
       </span>
     </div>
   );

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -184,11 +184,19 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
 
   // Reset working state to the loaded baseline whenever the ACL changes.
   useEffect(() => {
+    if (!open) return;
     setGrants(new Map(baseline.grants));
     setScope(baseline.general === "private" ? "invited" : "anyone");
     setGeneralPerm(baseline.general === "public-write" ? "write" : "read");
     setSaveError(null);
-  }, [baseline]);
+  }, [baseline, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    setPickerOpen(false);
+    setCopied(false);
+  }, [open]);
 
   // Escape to close.
   useEffect(() => {

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -2,12 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 
-import {
-  Button,
-  LineItemButton,
-  Popover,
-  SelectButton,
-} from "@onyx-ai/opal/components";
+import { Button, Popover, SelectButton } from "@onyx-ai/opal/components";
 import {
   SvgArrowExchange,
   SvgCheck,
@@ -569,45 +564,38 @@ function PermSelect({
         </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="end" sideOffset={4}>
-        <Popover.Menu>
-          {[
-            <LineItemButton
-              key="view"
-              icon={SvgEye}
-              title="View"
-              state={value === "read" ? "selected" : "empty"}
-              rightChildren={value === "read" ? <SvgCheck size={16} /> : undefined}
+        <div className={styles.menu}>
+          <MenuRow
+            icon={SvgEye}
+            label="View"
+            selected={value === "read"}
+            onClick={() => {
+              onChange("read");
+              setOpen(false);
+            }}
+          />
+          <MenuRow
+            icon={SvgEdit}
+            label="Edit"
+            selected={value === "write"}
+            onClick={() => {
+              onChange("write");
+              setOpen(false);
+            }}
+          />
+          {onRemove && <div className={styles.menuDivider} />}
+          {onRemove && (
+            <MenuRow
+              icon={SvgX}
+              label="Remove access"
+              danger
               onClick={() => {
-                onChange("read");
+                onRemove();
                 setOpen(false);
               }}
-            />,
-            <LineItemButton
-              key="edit"
-              icon={SvgEdit}
-              title="Edit"
-              state={value === "write" ? "selected" : "empty"}
-              rightChildren={value === "write" ? <SvgCheck size={16} /> : undefined}
-              onClick={() => {
-                onChange("write");
-                setOpen(false);
-              }}
-            />,
-            onRemove ? null : undefined,
-            onRemove ? (
-              <LineItemButton
-                key="remove"
-                icon={SvgX}
-                title="Remove access"
-                color="danger"
-                onClick={() => {
-                  onRemove();
-                  setOpen(false);
-                }}
-              />
-            ) : undefined,
-          ]}
-        </Popover.Menu>
+            />
+          )}
+        </div>
       </Popover.Content>
     </Popover>
   );
@@ -637,36 +625,60 @@ function ScopeSelect({
         </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
-        <Popover.Menu>
-          {[
-            <LineItemButton
-              key="invited"
-              icon={SvgLock}
-              title="Only those invited"
-              state={value === "invited" ? "selected" : "empty"}
-              onClick={() => {
-                if (value !== "invited") {
-                  onChange("invited");
-                }
-                setOpen(false);
-              }}
-            />,
-            <LineItemButton
-              key="anyone"
-              icon={SvgGlobe}
-              title="Anyone signed in"
-              state={value === "anyone" ? "selected" : "empty"}
-              onClick={() => {
-                if (value !== "anyone") {
-                  onChange("anyone");
-                }
-                setOpen(false);
-              }}
-            />,
-          ]}
-        </Popover.Menu>
+        <div className={styles.menu}>
+          <MenuRow
+            icon={SvgLock}
+            label="Only those invited"
+            selected={value === "invited"}
+            onClick={() => {
+              if (value !== "invited") onChange("invited");
+              setOpen(false);
+            }}
+          />
+          <MenuRow
+            icon={SvgGlobe}
+            label="Anyone signed in"
+            selected={value === "anyone"}
+            onClick={() => {
+              if (value !== "anyone") onChange("anyone");
+              setOpen(false);
+            }}
+          />
+        </div>
       </Popover.Content>
     </Popover>
+  );
+}
+
+function MenuRow({
+  icon: Icon,
+  label,
+  selected,
+  danger,
+  onClick,
+}: {
+  icon: (props: { size?: number }) => React.ReactNode;
+  label: string;
+  selected?: boolean;
+  danger?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`${styles.menuItem}${danger ? ` ${styles.menuItemDanger}` : ""}`}
+      onClick={onClick}
+    >
+      <span className={styles.menuItemIcon}>
+        <Icon size={16} />
+      </span>
+      <span className={styles.menuItemLabel}>{label}</span>
+      {selected && (
+        <span className={styles.menuItemCheck}>
+          <SvgCheck size={16} />
+        </span>
+      )}
+    </button>
   );
 }
 

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -40,6 +40,7 @@ import {
   type Visibility,
 } from "@/lib/permissions";
 import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
+import { markdown } from "@onyx-ai/opal/utils";
 
 import { TransferModal } from "./TransferModal";
 import styles from "./ShareDialog.module.css";
@@ -334,7 +335,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
           </span>
           <div className={styles.headerText}>
             <Text as="h2" font="main-content-emphasis">
-              {`Share ${lastSegment(path)}`}
+              {markdown(`Share *${lastSegment(path)}*`)}
             </Text>
             <Text font="secondary-body" color="text-03">
               {`Share this ${kindNoun} with people or groups`}
@@ -400,7 +401,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                         key={`g-${g.id}`}
                         icon={SvgUsers}
                         title={g.name}
-                        description={`${g.member_count} ${g.member_count === 1 ? "member" : "members"}`}
+                        description={`${g.member_count} ${g.member_count === 1 ? "user" : "users"}`}
                         sizePreset="main-ui"
                         variant="section"
                         rightChildren={
@@ -490,7 +491,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                 const sub =
                   g.kind === "group"
                     ? group
-                      ? `${group.member_count} ${group.member_count === 1 ? "member" : "members"}`
+                      ? `${group.member_count} ${group.member_count === 1 ? "user" : "users"}`
                       : "Group"
                     : g.email ?? "";
                 return (

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -4,8 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   Button,
-  Card,
-  Divider,
   InputTypeIn,
   LineItemButton,
   OpenButton,
@@ -366,7 +364,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
           </div>
         ) : (
           <div className={styles.content}>
-            <Card background="heavy" border="none" rounding="lg" padding="sm">
             <div className={styles.cardStack}>
             {/* Add people / groups — InputTypeIn anchors a portaled results menu */}
             <Popover
@@ -471,7 +468,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                   }
                 />
                 <PermSelect
-                  boxed
                   value={general === "public-write" ? "write" : "read"}
                   disabled={general === "private"}
                   onChange={(p) =>
@@ -479,8 +475,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                   }
                 />
               </div>
-
-              <Divider paddingParallel="fit" />
 
               {/* People with access */}
               <div className={styles.list}>
@@ -541,7 +535,6 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                 ))}
               </div>
             </div>
-            </Card>
           </div>
         )}
 
@@ -595,13 +588,11 @@ function PermSelect({
   onChange,
   onRemove,
   disabled,
-  boxed,
 }: {
   value: Permission;
   onChange: (p: Permission) => void;
   onRemove?: () => void;
   disabled?: boolean;
-  boxed?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const label = value === "write" ? "Edit" : "View";
@@ -609,16 +600,8 @@ function PermSelect({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <span className={boxed ? styles.permBox : styles.menuTrigger}>
-          <OpenButton
-            variant="select-light"
-            size="sm"
-            icon={icon}
-            disabled={disabled}
-            width={boxed ? "full" : undefined}
-            justifyContent={boxed ? "between" : undefined}
-            rounding={boxed ? "sm" : undefined}
-          >
+        <span className={styles.menuTrigger}>
+          <OpenButton variant="select-light" size="sm" icon={icon} disabled={disabled}>
             {label}
           </OpenButton>
         </span>

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -626,7 +626,7 @@ function PermSelect({
             icon={SvgEye}
             title="View"
             sizePreset="main-ui"
-            variant="section"
+            variant="body"
             state={value === "read" ? "selected" : "empty"}
             rightChildren={value === "read" ? <SvgCheck size={16} /> : undefined}
             onClick={() => {
@@ -638,7 +638,7 @@ function PermSelect({
             icon={SvgEdit}
             title="Edit"
             sizePreset="main-ui"
-            variant="section"
+            variant="body"
             state={value === "write" ? "selected" : "empty"}
             rightChildren={value === "write" ? <SvgCheck size={16} /> : undefined}
             onClick={() => {
@@ -652,7 +652,7 @@ function PermSelect({
               icon={SvgX}
               title="Remove access"
               sizePreset="main-ui"
-              variant="section"
+              variant="body"
               onClick={() => {
                 onRemove();
                 setOpen(false);
@@ -695,7 +695,7 @@ function ScopeSelect({
             icon={SvgLock}
             title="Only those invited"
             sizePreset="main-ui"
-            variant="section"
+            variant="body"
             state={value === "invited" ? "selected" : "empty"}
             onClick={() => {
               if (value !== "invited") onChange("invited");
@@ -706,7 +706,7 @@ function ScopeSelect({
             icon={SvgGlobe}
             title="Anyone"
             sizePreset="main-ui"
-            variant="section"
+            variant="body"
             state={value === "anyone" ? "selected" : "empty"}
             onClick={() => {
               if (value !== "anyone") onChange("anyone");

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -67,7 +67,10 @@ interface GrantDraft {
 interface Baseline {
   grants: Map<string, GrantDraft>;
   general: Visibility;
-  entryIdByKey: Map<string, string>;
+  // All ACL row IDs per principal — a principal can hold multiple rows
+  // (e.g. read + write); removing them must revoke every row, not just the
+  // strongest, or the weaker one resurfaces on refresh.
+  entryIdByKey: Map<string, string[]>;
   everyoneReadId: string | null;
   everyoneWriteId: string | null;
   inherited: AclEntry[];
@@ -91,7 +94,7 @@ function deriveBaseline(
 ): Baseline {
   if (!acl) return EMPTY_BASELINE;
   const grants = new Map<string, GrantDraft>();
-  const entryIdByKey = new Map<string, string>();
+  const entryIdByKey = new Map<string, string[]>();
   let everyoneReadId: string | null = null;
   let everyoneWriteId: string | null = null;
   const inherited: AclEntry[] = [];
@@ -110,18 +113,23 @@ function deriveBaseline(
     if (e.principal_kind !== "user" && e.principal_kind !== "group") continue;
     if (!e.principal_id) continue;
     const k = keyFor(e.principal_kind, e.principal_id);
+    // Record every row ID for the principal so removal revokes them all.
+    const ids = entryIdByKey.get(k) ?? [];
+    ids.push(e.id);
+    entryIdByKey.set(k, ids);
+    // Display the strongest grant (write > read); upgrade read → write but
+    // never downgrade.
     const existing = grants.get(k);
-    // Collapse a duplicate principal to its strongest grant (write > read).
-    if (existing && existing.permission === "write") continue;
-    grants.set(k, {
-      kind: e.principal_kind,
-      id: e.principal_id,
-      permission: e.permission,
-      email: e.principal_email,
-      name: e.principal_name,
-      groupName: e.group_name,
-    });
-    entryIdByKey.set(k, e.id);
+    if (!existing || (existing.permission !== "write" && e.permission === "write")) {
+      grants.set(k, {
+        kind: e.principal_kind,
+        id: e.principal_id,
+        permission: e.permission,
+        email: e.principal_email,
+        name: e.principal_name,
+        groupName: e.group_name,
+      });
+    }
   }
 
   const general: Visibility = everyoneWriteId
@@ -282,11 +290,9 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
         const n = grants.get(k);
         if (n && !o) adds.push(n);
         else if (o && !n) {
-          const id = baseline.entryIdByKey.get(k);
-          if (id) revokes.push(id);
+          revokes.push(...(baseline.entryIdByKey.get(k) ?? []));
         } else if (o && n && o.permission !== n.permission) {
-          const id = baseline.entryIdByKey.get(k);
-          if (id) revokes.push(id);
+          revokes.push(...(baseline.entryIdByKey.get(k) ?? []));
           adds.push(n);
         }
       }

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -246,7 +246,15 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
 
   const copyLink = async () => {
     try {
-      await navigator.clipboard.writeText(window.location.href);
+      const trimmed = path.replace(/\/+$/, "");
+      const encodedPath = trimmed
+        .split("/")
+        .filter(Boolean)
+        .map((segment) => encodeURIComponent(segment))
+        .join("/");
+      const targetPath = encodedPath ? `/app/wiki/${encodedPath}` : "/app/wiki";
+      const shareUrl = `${window.location.origin}${targetPath}`;
+      await navigator.clipboard.writeText(shareUrl);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);
     } catch {

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   Button,
+  Divider,
   InputTypeIn,
   LineItemButton,
   OpenButton,
@@ -467,6 +468,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                     setGeneral(scope === "invited" ? "private" : "public-read")
                   }
                 />
+                <span className={styles.vDivider} />
                 <PermSelect
                   value={general === "public-write" ? "write" : "read"}
                   disabled={general === "private"}
@@ -475,6 +477,8 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                   }
                 />
               </div>
+
+              <Divider paddingParallel="fit" paddingPerpendicular="2xs" />
 
               {/* People with access */}
               <div className={styles.list}>

--- a/frontend/src/components/wiki/TransferModal.module.css
+++ b/frontend/src/components/wiki/TransferModal.module.css
@@ -55,6 +55,24 @@
   width: 100%;
 }
 
+/* Selected new-owner row — same shaded line-item treatment as the share
+   modal's grantee rows. */
+.selectedRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 6px 8px;
+  background: var(--color-bg-sunken);
+  border-radius: var(--radius-md);
+}
+.rowText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+
 .footer {
   display: flex;
   align-items: center;

--- a/frontend/src/components/wiki/TransferModal.module.css
+++ b/frontend/src/components/wiki/TransferModal.module.css
@@ -17,7 +17,9 @@
   box-shadow: var(--shadow-modal);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  /* visible (not hidden) so the user-search popover can extend past the
+     short modal body; header/footer round their own outer corners. */
+  overflow: visible;
 }
 
 .header {
@@ -26,6 +28,7 @@
   gap: 8px;
   padding: 16px;
   background: var(--color-bg-page);
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 .headerIcon {
   display: inline-flex;
@@ -72,7 +75,9 @@
   flex-direction: column;
   gap: 8px;
   padding: 16px;
-  overflow-y: auto;
+  /* visible so the user-search popover (absolute, anchored to the input)
+     isn't clipped — it scrolls internally via .results. */
+  overflow: visible;
 }
 .label {
   font-size: 12px;
@@ -93,11 +98,25 @@
   border-color: var(--color-border-focus);
 }
 
-.list {
+.inputWrap {
+  position: relative;
+}
+.results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 1;
+  background: var(--color-bg-page);
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-popover);
+  padding: 4px;
+  max-height: 240px;
+  overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 2px;
-  margin-top: 4px;
 }
 .row {
   display: flex;
@@ -111,11 +130,8 @@
   cursor: pointer;
   text-align: left;
 }
-.row:hover {
+.row:hover:not(:disabled) {
   background: var(--color-bg-hover);
-}
-.rowSelected {
-  background: var(--color-accent-subtle-bg);
 }
 .row:disabled {
   cursor: default;
@@ -145,10 +161,6 @@
   color: var(--color-text-faint);
   flex-shrink: 0;
 }
-.check {
-  color: var(--color-accent-subtle-fg);
-  flex-shrink: 0;
-}
 .empty {
   font-size: 13px;
   color: var(--color-text-muted);
@@ -170,4 +182,5 @@
   gap: 8px;
   padding: 16px;
   background: var(--color-bg-page);
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
 }

--- a/frontend/src/components/wiki/TransferModal.module.css
+++ b/frontend/src/components/wiki/TransferModal.module.css
@@ -1,3 +1,5 @@
+/* Layout only — typography, inputs, menus, and buttons come from OPAL. */
+
 .scrim {
   position: fixed;
   inset: 0;
@@ -17,9 +19,7 @@
   box-shadow: var(--shadow-modal);
   display: flex;
   flex-direction: column;
-  /* visible (not hidden) so the user-search popover can extend past the
-     short modal body; header/footer round their own outer corners. */
-  overflow: visible;
+  overflow: hidden;
 }
 
 .header {
@@ -28,7 +28,6 @@
   gap: 8px;
   padding: 16px;
   background: var(--color-bg-page);
-  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
 }
 .headerIcon {
   display: inline-flex;
@@ -43,136 +42,17 @@
   flex: 1;
   min-width: 0;
 }
-.title {
-  margin: 0;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-}
-.titleName {
-  font-style: italic;
-}
-.closeBtn {
-  flex-shrink: 0;
-  width: 28px;
-  height: 28px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-md);
-  color: var(--color-text-muted);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.closeBtn:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-text-primary);
-}
 
 .content {
   display: flex;
   flex-direction: column;
   gap: 8px;
   padding: 16px;
-  /* visible so the user-search popover (absolute, anchored to the input)
-     isn't clipped — it scrolls internally via .results. */
-  overflow: visible;
-}
-.label {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-}
-.input {
-  width: 100%;
-  padding: 8px 10px;
-  font-size: 14px;
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-page);
-  color: var(--color-text-primary);
-}
-.input:focus {
-  outline: none;
-  border-color: var(--color-border-focus);
 }
 
-.inputWrap {
-  position: relative;
-}
-.results {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  z-index: 1;
-  background: var(--color-bg-page);
-  border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-md);
-  box-shadow: var(--shadow-popover);
-  padding: 4px;
-  max-height: 240px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-.row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.anchorWrap {
+  display: block;
   width: 100%;
-  padding: 6px 8px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  text-align: left;
-}
-.row:hover:not(:disabled) {
-  background: var(--color-bg-hover);
-}
-.row:disabled {
-  cursor: default;
-}
-.rowText {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-.rowName {
-  font-size: 14px;
-  color: var(--color-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.rowSub {
-  font-size: 12px;
-  color: var(--color-text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.rowTag {
-  font-size: 12px;
-  color: var(--color-text-faint);
-  flex-shrink: 0;
-}
-.empty {
-  font-size: 13px;
-  color: var(--color-text-muted);
-  padding: 8px;
-}
-.error {
-  font-size: 13px;
-  color: var(--color-state-danger-fg);
-}
-.note {
-  font-size: 12px;
-  color: var(--color-text-muted);
 }
 
 .footer {
@@ -182,5 +62,4 @@
   gap: 8px;
   padding: 16px;
   background: var(--color-bg-page);
-  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
 }

--- a/frontend/src/components/wiki/TransferModal.module.css
+++ b/frontend/src/components/wiki/TransferModal.module.css
@@ -1,0 +1,173 @@
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--color-overlay);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: max(20px, min(80px, 5vh)) 16px;
+  z-index: 110;
+}
+
+.dialog {
+  background: var(--color-bg-panel);
+  border-radius: var(--radius-lg);
+  width: min(480px, 100%);
+  max-height: calc(100vh - 80px);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 16px;
+  background: var(--color-bg-page);
+}
+.headerIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-top: 2px;
+  color: var(--color-text-secondary);
+}
+.headerText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+.title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.titleName {
+  font-style: italic;
+}
+.closeBtn {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.closeBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  overflow-y: auto;
+}
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+.input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: 14px;
+  border: 1px solid var(--color-border-default);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-page);
+  color: var(--color-text-primary);
+}
+.input:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-top: 4px;
+}
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  text-align: left;
+}
+.row:hover {
+  background: var(--color-bg-hover);
+}
+.rowSelected {
+  background: var(--color-accent-subtle-bg);
+}
+.row:disabled {
+  cursor: default;
+}
+.rowText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.rowName {
+  font-size: 14px;
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rowSub {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.rowTag {
+  font-size: 12px;
+  color: var(--color-text-faint);
+  flex-shrink: 0;
+}
+.check {
+  color: var(--color-accent-subtle-fg);
+  flex-shrink: 0;
+}
+.empty {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  padding: 8px;
+}
+.error {
+  font-size: 13px;
+  color: var(--color-state-danger-fg);
+}
+.note {
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px;
+  background: var(--color-bg-page);
+}

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -120,7 +120,7 @@ export function TransferModal({
               <div className={styles.anchorWrap}>
                 <InputTypeIn
                   searchIcon
-                  placeholder="Add a user or group"
+                  placeholder="Add a user"
                   value={query}
                   onChange={(e) => {
                     setQuery(e.target.value);

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -16,6 +16,7 @@ import { markdown } from "@onyx-ai/opal/utils";
 import { Avatar } from "@/components/common/Avatar";
 import { transferOwnership } from "@/lib/permissions";
 import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
+import { lastSegment } from "@/lib/wiki";
 
 import styles from "./TransferModal.module.css";
 
@@ -25,13 +26,6 @@ interface TransferModalProps {
   open: boolean;
   onClose: () => void;
   onTransferred: () => void;
-}
-
-function lastSegment(path: string): string {
-  const clean = path.replace(/\/+$/, "");
-  if (!clean) return "Wiki";
-  const seg = clean.split("/").pop() ?? clean;
-  return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
 }
 
 export function TransferModal({

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "@onyx-ai/opal/components";
 import { SvgArrowExchange, SvgUser, SvgX } from "@onyx-ai/opal/icons";
+import { markdown } from "@onyx-ai/opal/utils";
 
 import { transferOwnership } from "@/lib/permissions";
 import { displayName, useUserSearch, type UserLite } from "@/lib/users";
@@ -93,7 +94,7 @@ export function TransferModal({
           </span>
           <div className={styles.headerText}>
             <Text as="h2" font="main-content-emphasis">
-              {`Transfer ${lastSegment(path)}`}
+              {markdown(`Transfer *${lastSegment(path)}*`)}
             </Text>
           </div>
           <Button

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -13,8 +13,9 @@ import {
 import { SvgArrowExchange, SvgUser, SvgX } from "@onyx-ai/opal/icons";
 import { markdown } from "@onyx-ai/opal/utils";
 
+import { Avatar } from "@/components/common/Avatar";
 import { transferOwnership } from "@/lib/permissions";
-import { displayName, useUserSearch, type UserLite } from "@/lib/users";
+import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
 
 import styles from "./TransferModal.module.css";
 
@@ -160,7 +161,7 @@ export function TransferModal({
                       onClick={() => {
                         if (isOwner) return;
                         setSelected(u);
-                        setQuery(displayName(u));
+                        setQuery("");
                         setPickerOpen(false);
                       }}
                     />
@@ -169,6 +170,33 @@ export function TransferModal({
               </PopoverMenu>
             </Popover.Content>
           </Popover>
+
+          {selected && (
+            <div className={styles.selectedRow}>
+              <Avatar
+                label={initials(selected)}
+                size={28}
+                title={displayName(selected)}
+              />
+              <div className={styles.rowText}>
+                <Text font="main-ui-body" nowrap>
+                  {displayName(selected)}
+                </Text>
+                {selected.email && (
+                  <Text font="secondary-body" color="text-03" nowrap>
+                    {selected.email}
+                  </Text>
+                )}
+              </div>
+              <Button
+                prominence="tertiary"
+                size="sm"
+                icon={SvgX}
+                tooltip="Remove"
+                onClick={() => setSelected(null)}
+              />
+            </div>
+          )}
 
           <Text font="secondary-body" color="text-03">
             The current owner is kept as an editor after transfer.

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { Button } from "@onyx-ai/opal/components";
-import { SvgArrowExchange, SvgCheck, SvgX } from "@onyx-ai/opal/icons";
+import { SvgArrowExchange, SvgX } from "@onyx-ai/opal/icons";
 
 import { Avatar } from "@/components/common/Avatar";
 import { transferOwnership } from "@/lib/permissions";
@@ -35,10 +35,11 @@ export function TransferModal({
 }: TransferModalProps) {
   const [query, setQuery] = useState("");
   const [selected, setSelected] = useState<UserLite | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { users, isLoading } = useUserSearch(query, open);
+  const { users, isLoading } = useUserSearch(query, open && pickerOpen);
 
   useEffect(() => {
     if (!open) return;
@@ -94,54 +95,61 @@ export function TransferModal({
 
         <div className={styles.content}>
           <span className={styles.label}>Transfer Ownership To</span>
-          <input
-            className={styles.input}
-            placeholder="Add a user or group"
-            value={query}
-            autoFocus
-            onChange={(e) => setQuery(e.target.value)}
-          />
+          <div className={styles.inputWrap}>
+            <input
+              className={styles.input}
+              placeholder="Add a user or group"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelected(null);
+                setPickerOpen(true);
+              }}
+              onFocus={() => setPickerOpen(true)}
+              onBlur={() => window.setTimeout(() => setPickerOpen(false), 120)}
+            />
+            {pickerOpen && (
+              <div className={styles.results}>
+                {isLoading && users.length === 0 && (
+                  <div className={styles.empty}>Searching…</div>
+                )}
+                {!isLoading && users.length === 0 && (
+                  <div className={styles.empty}>No users found.</div>
+                )}
+                {users.map((u) => {
+                  const isOwner = u.id === currentOwnerId;
+                  return (
+                    <button
+                      key={u.id}
+                      type="button"
+                      className={styles.row}
+                      disabled={isOwner}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        if (isOwner) return;
+                        setSelected(u);
+                        setQuery(displayName(u));
+                        setPickerOpen(false);
+                      }}
+                    >
+                      <Avatar label={initials(u)} size={28} title={displayName(u)} />
+                      <span className={styles.rowText}>
+                        <span className={styles.rowName}>{displayName(u)}</span>
+                        <span className={styles.rowSub}>{u.email}</span>
+                      </span>
+                      {isOwner && <span className={styles.rowTag}>Current Owner</span>}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
 
           <span className={styles.note}>
             The current owner is kept as an editor after transfer.
           </span>
 
           {error && <div className={styles.error}>{error}</div>}
-
-          <div className={styles.list}>
-            {isLoading && users.length === 0 && (
-              <div className={styles.empty}>Searching…</div>
-            )}
-            {!isLoading && users.length === 0 && (
-              <div className={styles.empty}>No users found.</div>
-            )}
-            {users.map((u) => {
-              const isOwner = u.id === currentOwnerId;
-              const isSel = selected?.id === u.id;
-              return (
-                <button
-                  key={u.id}
-                  type="button"
-                  className={`${styles.row} ${isSel ? styles.rowSelected : ""}`}
-                  disabled={isOwner}
-                  onClick={() => setSelected(u)}
-                >
-                  <Avatar label={initials(u)} size={28} title={displayName(u)} />
-                  <span className={styles.rowText}>
-                    <span className={styles.rowName}>{displayName(u)}</span>
-                    <span className={styles.rowSub}>{u.email}</span>
-                  </span>
-                  {isOwner ? (
-                    <span className={styles.rowTag}>Current Owner</span>
-                  ) : isSel ? (
-                    <span className={styles.check}>
-                      <SvgCheck size={16} />
-                    </span>
-                  ) : null}
-                </button>
-              );
-            })}
-          </div>
         </div>
 
         <footer className={styles.footer}>

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Button } from "@onyx-ai/opal/components";
+import { SvgArrowExchange, SvgCheck, SvgX } from "@onyx-ai/opal/icons";
+
+import { Avatar } from "@/components/common/Avatar";
+import { transferOwnership } from "@/lib/permissions";
+import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
+
+import styles from "./TransferModal.module.css";
+
+interface TransferModalProps {
+  path: string;
+  currentOwnerId: string | null;
+  open: boolean;
+  onClose: () => void;
+  onTransferred: () => void;
+}
+
+function lastSegment(path: string): string {
+  const clean = path.replace(/\/+$/, "");
+  if (!clean) return "Wiki";
+  const seg = clean.split("/").pop() ?? clean;
+  return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
+}
+
+export function TransferModal({
+  path,
+  currentOwnerId,
+  open,
+  onClose,
+  onTransferred,
+}: TransferModalProps) {
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<UserLite | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const { users, isLoading } = useUserSearch(query, open);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const transfer = async () => {
+    if (!selected) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await transferOwnership(path, selected.id);
+      onTransferred();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Transfer failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className={styles.scrim}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Transfer ${lastSegment(path)}`}
+      >
+        <header className={styles.header}>
+          <span className={styles.headerIcon}>
+            <SvgArrowExchange size={20} />
+          </span>
+          <div className={styles.headerText}>
+            <h2 className={styles.title}>
+              Transfer <span className={styles.titleName}>{lastSegment(path)}</span>
+            </h2>
+          </div>
+          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
+            <SvgX size={18} />
+          </button>
+        </header>
+
+        <div className={styles.content}>
+          <span className={styles.label}>Transfer Ownership To</span>
+          <input
+            className={styles.input}
+            placeholder="Add a user or group"
+            value={query}
+            autoFocus
+            onChange={(e) => setQuery(e.target.value)}
+          />
+
+          <span className={styles.note}>
+            The current owner is kept as an editor after transfer.
+          </span>
+
+          {error && <div className={styles.error}>{error}</div>}
+
+          <div className={styles.list}>
+            {isLoading && users.length === 0 && (
+              <div className={styles.empty}>Searching…</div>
+            )}
+            {!isLoading && users.length === 0 && (
+              <div className={styles.empty}>No users found.</div>
+            )}
+            {users.map((u) => {
+              const isOwner = u.id === currentOwnerId;
+              const isSel = selected?.id === u.id;
+              return (
+                <button
+                  key={u.id}
+                  type="button"
+                  className={`${styles.row} ${isSel ? styles.rowSelected : ""}`}
+                  disabled={isOwner}
+                  onClick={() => setSelected(u)}
+                >
+                  <Avatar label={initials(u)} size={28} title={displayName(u)} />
+                  <span className={styles.rowText}>
+                    <span className={styles.rowName}>{displayName(u)}</span>
+                    <span className={styles.rowSub}>{u.email}</span>
+                  </span>
+                  {isOwner ? (
+                    <span className={styles.rowTag}>Current Owner</span>
+                  ) : isSel ? (
+                    <span className={styles.check}>
+                      <SvgCheck size={16} />
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        <footer className={styles.footer}>
+          <Button prominence="tertiary" size="md" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="action"
+            size="md"
+            disabled={!selected || busy}
+            onClick={() => void transfer()}
+          >
+            {busy ? "Transferring…" : "Transfer"}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/TransferModal.tsx
+++ b/frontend/src/components/wiki/TransferModal.tsx
@@ -2,12 +2,18 @@
 
 import { useEffect, useState } from "react";
 
-import { Button } from "@onyx-ai/opal/components";
-import { SvgArrowExchange, SvgX } from "@onyx-ai/opal/icons";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  PopoverMenu,
+  Text,
+} from "@onyx-ai/opal/components";
+import { SvgArrowExchange, SvgUser, SvgX } from "@onyx-ai/opal/icons";
 
-import { Avatar } from "@/components/common/Avatar";
 import { transferOwnership } from "@/lib/permissions";
-import { displayName, initials, useUserSearch, type UserLite } from "@/lib/users";
+import { displayName, useUserSearch, type UserLite } from "@/lib/users";
 
 import styles from "./TransferModal.module.css";
 
@@ -39,7 +45,7 @@ export function TransferModal({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { users, isLoading } = useUserSearch(query, open && pickerOpen);
+  const { users } = useUserSearch(query, open && pickerOpen);
 
   useEffect(() => {
     if (!open) return;
@@ -66,6 +72,8 @@ export function TransferModal({
     }
   };
 
+  const showResults = pickerOpen && users.length > 0;
+
   return (
     <div
       className={styles.scrim}
@@ -84,72 +92,92 @@ export function TransferModal({
             <SvgArrowExchange size={20} />
           </span>
           <div className={styles.headerText}>
-            <h2 className={styles.title}>
-              Transfer <span className={styles.titleName}>{lastSegment(path)}</span>
-            </h2>
+            <Text as="h2" font="main-content-emphasis">
+              {`Transfer ${lastSegment(path)}`}
+            </Text>
           </div>
-          <button className={styles.closeBtn} onClick={onClose} aria-label="Close">
-            <SvgX size={18} />
-          </button>
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgX}
+            tooltip="Close"
+            onClick={onClose}
+          />
         </header>
 
         <div className={styles.content}>
-          <span className={styles.label}>Transfer Ownership To</span>
-          <div className={styles.inputWrap}>
-            <input
-              className={styles.input}
-              placeholder="Add a user or group"
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setSelected(null);
-                setPickerOpen(true);
-              }}
-              onFocus={() => setPickerOpen(true)}
-              onBlur={() => window.setTimeout(() => setPickerOpen(false), 120)}
-            />
-            {pickerOpen && (
-              <div className={styles.results}>
-                {isLoading && users.length === 0 && (
-                  <div className={styles.empty}>Searching…</div>
-                )}
-                {!isLoading && users.length === 0 && (
-                  <div className={styles.empty}>No users found.</div>
-                )}
+          <Text font="secondary-action" color="text-02">
+            Transfer Ownership To
+          </Text>
+          <Popover
+            open={showResults}
+            onOpenChange={(o) => {
+              if (!o) setPickerOpen(false);
+            }}
+          >
+            <Popover.Anchor asChild>
+              <div className={styles.anchorWrap}>
+                <InputTypeIn
+                  searchIcon
+                  placeholder="Add a user or group"
+                  value={query}
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    setSelected(null);
+                    setPickerOpen(true);
+                  }}
+                  onFocus={() => setPickerOpen(true)}
+                />
+              </div>
+            </Popover.Anchor>
+            <Popover.Content
+              width="trigger"
+              align="start"
+              sideOffset={4}
+              container={typeof document !== "undefined" ? document.body : undefined}
+              onOpenAutoFocus={(e) => e.preventDefault()}
+              onCloseAutoFocus={(e) => e.preventDefault()}
+            >
+              <PopoverMenu>
                 {users.map((u) => {
                   const isOwner = u.id === currentOwnerId;
                   return (
-                    <button
+                    <LineItemButton
                       key={u.id}
-                      type="button"
-                      className={styles.row}
-                      disabled={isOwner}
-                      onMouseDown={(e) => {
-                        e.preventDefault();
+                      icon={SvgUser}
+                      title={displayName(u)}
+                      description={u.email}
+                      sizePreset="main-ui"
+                      variant="section"
+                      rightChildren={
+                        isOwner ? (
+                          <Text font="secondary-body" color="text-03">
+                            Current Owner
+                          </Text>
+                        ) : undefined
+                      }
+                      onClick={() => {
                         if (isOwner) return;
                         setSelected(u);
                         setQuery(displayName(u));
                         setPickerOpen(false);
                       }}
-                    >
-                      <Avatar label={initials(u)} size={28} title={displayName(u)} />
-                      <span className={styles.rowText}>
-                        <span className={styles.rowName}>{displayName(u)}</span>
-                        <span className={styles.rowSub}>{u.email}</span>
-                      </span>
-                      {isOwner && <span className={styles.rowTag}>Current Owner</span>}
-                    </button>
+                    />
                   );
                 })}
-              </div>
-            )}
-          </div>
+              </PopoverMenu>
+            </Popover.Content>
+          </Popover>
 
-          <span className={styles.note}>
+          <Text font="secondary-body" color="text-03">
             The current owner is kept as an editor after transfer.
-          </span>
+          </Text>
 
-          {error && <div className={styles.error}>{error}</div>}
+          {error && (
+            <Text font="secondary-body" color="text-02">
+              {error}
+            </Text>
+          )}
         </div>
 
         <footer className={styles.footer}>

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -29,6 +29,11 @@ export interface Group {
   description: string | null;
   created_by_user_id: string | null;
   created_at: string;
+  // Aggregate counts for the groups list UI (0 when not provided, e.g.
+  // the group-detail and create responses don't compute them).
+  member_count: number;
+  page_count: number;
+  folder_count: number;
 }
 
 export interface GroupMember {
@@ -47,11 +52,18 @@ export interface AclEntry {
   permission: Permission;
   granted_by_user_id: string | null;
   created_at: string;
+  // Display enrichment resolved server-side (null for `everyone` or a
+  // principal that no longer exists).
+  principal_email?: string | null;
+  principal_name?: string | null;
+  group_name?: string | null;
 }
 
 export interface PageAcl {
   path: string;
   owner_user_id: string | null;
+  owner_email?: string | null;
+  owner_name?: string | null;
   entries: AclEntry[];
 }
 

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -1,0 +1,66 @@
+/** User lookup for the share / transfer typeaheads.
+ *
+ * Backed by `GET /api/users/search?q=` (any signed-in user) — distinct
+ * from the admin-only `/admin/users`, so the sharing UI works for
+ * non-admin owners too. Read path is SWR-keyed; dedupe identical queries.
+ */
+import useSWR from "swr";
+
+export interface UserLite {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+/** Typeahead search. Pass `enabled=false` to suspend the request (e.g.
+ * when the picker is closed). SWR dedupes identical keys. */
+export function useUserSearch(query: string, enabled = true) {
+  const key = enabled
+    ? `/users/search?q=${encodeURIComponent(query.trim())}`
+    : null;
+  const { data, error, isLoading } = useSWR<{ users: UserLite[] }>(key);
+  return {
+    users: data?.users ?? [],
+    error: error as Error | undefined,
+    isLoading,
+  };
+}
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  name: string | null;
+  is_admin: boolean;
+  created_at: string;
+  groups: string[];
+}
+
+/** Admin-only full user list (`/admin/users`), including each user's
+ * groups. Distinct from `useUserSearch`, which any signed-in user can hit. */
+export function useAdminUsers() {
+  const { data, error, isLoading, mutate } = useSWR<{ users: AdminUser[] }>(
+    "/admin/users",
+  );
+  return {
+    users: data?.users ?? [],
+    error: error as Error | undefined,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+/** Best display label for a user — name if set, else email. */
+export function displayName(u: { name?: string | null; email: string }): string {
+  return (u.name && u.name.trim()) || u.email;
+}
+
+/** Up to two uppercase initials for an avatar, derived from name or email. */
+export function initials(u: { name?: string | null; email: string }): string {
+  const base = (u.name && u.name.trim()) || u.email;
+  const parts = base.split(/[\s@._-]+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return (parts[0] ?? "?").charAt(0).toUpperCase();
+  return (
+    (parts[0] ?? "").charAt(0) + (parts[1] ?? "").charAt(0)
+  ).toUpperCase();
+}

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -1,5 +1,14 @@
 import { apiFetch } from "@/lib/api";
 
+/** Last path segment as a display name — drops a trailing `.md`. Shared by the
+ * share + transfer dialogs so the two copies don't drift. */
+export function lastSegment(path: string): string {
+  const clean = path.replace(/\/+$/, "");
+  if (!clean) return "Wiki";
+  const seg = clean.split("/").pop() ?? clean;
+  return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
+}
+
 export interface WordDiff {
   prefix: string;
   removed: string;


### PR DESCRIPTION
## Description

Rebuilds the wiki sharing UI to the Figma mocks (Onyx Wiki file `9wHWslPrSBEpxG7CtlYVG1`). Backend ACL already existed; this is mostly the UI plus the support endpoints it needed.

- **Share modal** — Google-Docs style: typeahead add (users + groups), general access (Only those invited / Anyone signed in × View/Edit), per-row View/Edit dropdown, owner row + transfer, Copy Link, batch Save. OPAL primitives + CSS modules.
- **Transfer ownership** — separate modal; transfer now leaves the previous owner as an editor.
- **Folder/file sharing** — Share action on directory rows; folders grant `resource_kind: folder`.
- **Admin** — Groups (search, New Group, member/page/folder count cards, member mgmt) and Users (avatars, group tags, account-type dropdown, search) rebuilt to mocks.
- **Backend** — `GET /api/users/search` (any signed-in user, for the typeahead); member/page/folder counts on `GET /groups`; groups-per-user on `GET /admin/users`; ACL list enriched with principal/owner labels; transfer leaves prev owner as editor.

12 new backend tests; permissions suite 61 green. ruff + basedpyright (strict) + tsc clean. Touched backend files were `ruff format`-normalized (line-length 100).

**Not built** (no backend; not core to sharing): Users-page invite / requests-to-join / status, tokened public links, admin nav sidebar redesign.

## How Has This Been Tested?