### PR TITLE
chore(deps): bump @onyx-ai/opal to ^0.1.4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@onyx-ai/opal": "^0.1.3",
+    "@onyx-ai/opal": "^0.1.4",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.2.4",


### PR DESCRIPTION
## Description

Bumps `@onyx-ai/opal` `^0.1.3` → `^0.1.4`.

main's frontend already imports opal exports that the published `0.1.3` didn't ship — `globals.css` imports `@onyx-ai/opal/root.css`, and the #138 routing work imports `InputTypeIn` / `SvgDocFile`. Against `0.1.3` the frontend fails to typecheck/build. `0.1.4` (now published) includes them.

## How Has This Been Tested?