### PR TITLE
ci(frontend): production-build check on FE changes

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -26,9 +26,22 @@ jobs:
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
 
+      - name: Cache bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      # Frozen: fail if bun.lock is out of sync with package.json rather than
+      # silently resolving a different graph — that drift is exactly what this
+      # job exists to catch.
       - name: Install deps
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Production build
         run: bun run build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,34 @@
+name: Frontend build
+
+# Guards against breakage that only shows up at build time (e.g. a missing
+# package export). Runs the real production build via bun, only when
+# frontend files change.
+
+concurrency:
+  group: frontend-build-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install deps
+        run: bun install
+
+      - name: Production build
+        run: bun run build


### PR DESCRIPTION
## Description

Adds a CI job that runs the frontend **production build** (`bun run build`) on any PR touching `frontend/**`.

Why: the existing checks (pre-commit + pytest) don't compile the frontend, so a build-time breakage — e.g. importing a package export that the installed version doesn't ship (the recent `@onyx-ai/opal` `root.css` / `InputTypeIn` gap) — merges green and only fails at deploy. A unit test wouldn't catch it; the actual build does.

Lightweight: bun, single job, path-filtered to `frontend/**`.

Note: not added to branch-protection required checks here — flip that on in repo settings if it should block merges.

## How Has This Been Tested?