### PR TITLE
feat(comments): schema + diff-transform anchor core (Phase 1, PR 1/3)

### DIFF
--- a/backend/app/db/migrations/versions/0022_comments.py
+++ b/backend/app/db/migrations/versions/0022_comments.py
@@ -1,0 +1,78 @@
+"""add comments table for human comments on wiki pages
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-06-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0022"
+down_revision: str = "0021"
+branch_labels = None
+depends_on = None
+
+_NOW = sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')")
+
+
+def upgrade() -> None:
+    # create_all in 0001 already materializes this table on fresh installs;
+    # skip if it exists so upgrading existing DBs and fresh installs both work.
+    bind = op.get_bind()
+    if sa.inspect(bind).has_table("comments"):
+        return
+    op.create_table(
+        "comments",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("doc_path", sa.Text, nullable=False),
+        sa.Column("thread_root_id", sa.Text, nullable=False),
+        sa.Column(
+            "parent_id",
+            sa.Text,
+            sa.ForeignKey("comments.id", ondelete="CASCADE"),
+        ),
+        sa.Column("scope", sa.Text, nullable=False, server_default=sa.text("'inline'")),
+        sa.Column("anchor_sha", sa.Text),
+        sa.Column("start_offset", sa.Integer),
+        sa.Column("end_offset", sa.Integer),
+        sa.Column("quoted_text", sa.Text),
+        sa.Column("author_kind", sa.Text, nullable=False, server_default=sa.text("'user'")),
+        sa.Column(
+            "author_user_id",
+            sa.Text,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+        ),
+        sa.Column("body", sa.Text, nullable=False),
+        sa.Column("status", sa.Text, nullable=False, server_default=sa.text("'open'")),
+        sa.Column(
+            "resolved_by_user_id",
+            sa.Text,
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+        ),
+        sa.Column("resolved_at", sa.Text),
+        sa.Column("created_at", sa.Text, nullable=False, server_default=_NOW),
+        sa.Column("updated_at", sa.Text, nullable=False, server_default=_NOW),
+        sa.CheckConstraint("scope IN ('inline', 'page')", name="comments_scope_check"),
+        sa.CheckConstraint(
+            "author_kind IN ('user', 'agent')", name="comments_author_kind_check"
+        ),
+        sa.CheckConstraint(
+            "status IN ('open', 'resolved', 'orphaned')", name="comments_status_check"
+        ),
+        sa.CheckConstraint(
+            "scope <> 'inline' OR parent_id IS NOT NULL OR "
+            "(anchor_sha IS NOT NULL AND start_offset IS NOT NULL "
+            "AND end_offset IS NOT NULL)",
+            name="comments_inline_root_anchored",
+        ),
+    )
+    op.create_index("idx_comments_doc_status", "comments", ["doc_path", "status"])
+    op.create_index("idx_comments_thread", "comments", ["thread_root_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_comments_thread", table_name="comments")
+    op.drop_index("idx_comments_doc_status", table_name="comments")
+    op.drop_table("comments")

--- a/backend/app/db/migrations/versions/0022_comments.py
+++ b/backend/app/db/migrations/versions/0022_comments.py
@@ -67,6 +67,10 @@ def upgrade() -> None:
             "AND end_offset IS NOT NULL)",
             name="comments_inline_root_anchored",
         ),
+        sa.CheckConstraint(
+            "start_offset IS NULL OR end_offset > start_offset",
+            name="comments_anchor_nonempty",
+        ),
     )
     op.create_index("idx_comments_doc_status", "comments", ["doc_path", "status"])
     op.create_index("idx_comments_thread", "comments", ["thread_root_id"])

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -740,12 +740,12 @@ class Comment(Base):
     parent (NULL for roots) and cascades on delete. The anchor lives on the
     **root** of a thread; replies leave the anchor columns NULL.
 
-    **Reserved for later phases.** ``scope='page'`` (whole-page threads,
-    Phase 2) and ``author_kind='agent'`` (AI-authored comments, Phase 3) are
-    valid values now so those features need no migration. v1 only ever writes
-    ``scope='inline'`` / ``author_kind='user'``. ``thread_root_id`` references
-    a comment id but is not a real FK (enforced at the repo layer), matching
-    the ``acl_entries.principal_id`` convention.
+    ``scope`` distinguishes a text-anchored (``inline``) comment from a
+    whole-page thread; ``author_kind`` records whether the author is a ``user``
+    or an ``agent``. Both are stored as open enumerations so either dimension
+    can grow without a migration. ``thread_root_id`` references a comment id but
+    is not a real FK (enforced at the repo layer), matching the
+    ``acl_entries.principal_id`` convention.
     """
 
     __tablename__ = "comments"
@@ -803,6 +803,12 @@ class Comment(Base):
             "(anchor_sha IS NOT NULL AND start_offset IS NOT NULL "
             "AND end_offset IS NOT NULL)",
             name="comments_inline_root_anchored",
+        ),
+        # Offsets must form a non-empty half-open range; a zero-width or
+        # inverted anchor has no text to highlight.
+        CheckConstraint(
+            "start_offset IS NULL OR end_offset > start_offset",
+            name="comments_anchor_nonempty",
         ),
         Index("idx_comments_doc_status", "doc_path", "status"),
         Index("idx_comments_thread", "thread_root_id"),

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -714,6 +714,102 @@ class AclEntry(Base):
 
 
 # --------------------------------------------------------------------------- #
+# Comments — human discussion anchored to wiki pages (Postgres-only)          #
+# --------------------------------------------------------------------------- #
+
+
+class Comment(Base):
+    """A comment anchored to a span of a wiki page.
+
+    **Postgres-only.** Comments are never written to the wiki git repo or
+    the ``wiki-data`` volume (same as ACLs/owners) — they are discussion
+    *about* content, not content, so git history stays clean for agents.
+
+    **Position anchor.** ``[start_offset, end_offset)`` is a character range
+    into the page body *as of* ``anchor_sha``. The range is re-derived by a
+    diff-transform on every commit (the lightweight ``remap_comments`` task),
+    so it tracks human *and* agent edits with the same mechanism. The two
+    endpoints map independently, so a mid-span edit resizes the highlight;
+    the comment is ``orphaned`` only when the span collapses to empty.
+    ``quoted_text`` is **display-only** — the snippet shown in the UI and the
+    tombstone kept when a comment orphans. It is never used to re-locate the
+    anchor (no fuzzy matching).
+
+    **Threading.** ``thread_root_id`` groups a thread (a root comment's
+    ``thread_root_id`` equals its own ``id``); ``parent_id`` is the direct
+    parent (NULL for roots) and cascades on delete. The anchor lives on the
+    **root** of a thread; replies leave the anchor columns NULL.
+
+    **Reserved for later phases.** ``scope='page'`` (whole-page threads,
+    Phase 2) and ``author_kind='agent'`` (AI-authored comments, Phase 3) are
+    valid values now so those features need no migration. v1 only ever writes
+    ``scope='inline'`` / ``author_kind='user'``. ``thread_root_id`` references
+    a comment id but is not a real FK (enforced at the repo layer), matching
+    the ``acl_entries.principal_id`` convention.
+    """
+
+    __tablename__ = "comments"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    doc_path: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Threading
+    thread_root_id: Mapped[str] = mapped_column(Text, nullable=False)
+    parent_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("comments.id", ondelete="CASCADE")
+    )
+
+    # Anchor — set on the thread root for scope='inline'; NULL otherwise.
+    scope: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'inline'"))
+    anchor_sha: Mapped[str | None] = mapped_column(Text)
+    start_offset: Mapped[int | None] = mapped_column(Integer)
+    end_offset: Mapped[int | None] = mapped_column(Integer)
+    quoted_text: Mapped[str | None] = mapped_column(Text)
+
+    # Author
+    author_kind: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'user'"))
+    author_user_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+
+    # Content + lifecycle
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'open'"))
+    resolved_by_user_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    resolved_at: Mapped[str | None] = mapped_column(Text)
+
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+
+    __table_args__ = (
+        CheckConstraint(
+            "scope IN ('inline', 'page')",
+            name="comments_scope_check",
+        ),
+        CheckConstraint(
+            "author_kind IN ('user', 'agent')",
+            name="comments_author_kind_check",
+        ),
+        CheckConstraint(
+            "status IN ('open', 'resolved', 'orphaned')",
+            name="comments_status_check",
+        ),
+        # An inline thread root must carry a full anchor; replies (parent_id
+        # set) and page-scoped comments leave the anchor columns NULL.
+        CheckConstraint(
+            "scope <> 'inline' OR parent_id IS NOT NULL OR "
+            "(anchor_sha IS NOT NULL AND start_offset IS NOT NULL "
+            "AND end_offset IS NOT NULL)",
+            name="comments_inline_root_anchored",
+        ),
+        Index("idx_comments_doc_status", "doc_path", "status"),
+        Index("idx_comments_thread", "thread_root_id"),
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Ingest eval samples — opt-in eval logging (INGEST_EVAL_LOGGING=true)     #
 # --------------------------------------------------------------------------- #
 

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -1,0 +1,90 @@
+"""Position-based re-anchoring for wiki page comments.
+
+A comment anchors to a half-open character range ``[start, end)`` into a page
+body at a known commit (``anchor_sha``). When the page changes, we re-derive
+the range against the new body from the *exact* diff between the two versions
+— never a fuzzy text search.
+
+The two endpoints are mapped **independently**, so an edit *inside* the span
+resizes it: a deletion shrinks the highlight, an insertion grows it. The
+comment is treated as *orphaned* only when its span collapses to empty
+(``start >= end`` after mapping) — i.e. nothing the endpoints can straddle
+survived.
+
+What collapses, and what doesn't:
+
+- A pure **deletion** of the anchored text → orphan.
+- A **clean replacement** (the span is exactly one replaced region with no
+  characters in common) → orphan.
+- A **rewrite that keeps incidental characters** (shared words, spaces, common
+  letters — the realistic agent-rewrite case) does *not* collapse; the comment
+  **migrates onto the surviving/replacement text** instead of orphaning. This
+  is a deliberate consequence of using the exact diff rather than a fuzzy
+  similarity threshold: we never decide "close enough is gone." Tightening this
+  to orphan heavy rewrites would require coarser (word-level) granularity or a
+  survival threshold; deferred on purpose.
+
+Boundary rule: ``start`` biases toward the content that follows it and ``end``
+toward the content that precedes it, so text inserted exactly at either edge
+lands *outside* the highlight rather than silently extending it.
+
+Offsets are Unicode **code-point** indices into the body. The frontend must
+count the same way (iterate code points, not UTF-16 units) for astral
+characters to line up; wiki markdown is overwhelmingly BMP, so this only
+matters for emoji and similar.
+
+Pure module — no I/O. Callers pass the two bodies in; ``app/wiki/git.py``
+reads them at the relevant refs.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from difflib import SequenceMatcher
+
+# Endpoint association: +1 sticks to following content, -1 to preceding.
+_START = 1
+_END = -1
+
+# (tag, i1, i2, j1, j2) as returned by SequenceMatcher.get_opcodes().
+_Opcode = tuple[str, int, int, int, int]
+
+
+def _map_pos(opcodes: Sequence[_Opcode], pos: int, assoc: int) -> int:
+    """Map a single position from old to new coordinates.
+
+    ``assoc`` picks the tie-break at a boundary several opcodes touch:
+    ``_START`` (+1) prefers the later opcode, ``_END`` (-1) the earlier one.
+    Inside a changed (non-``equal``) opcode the position collapses to the
+    far edge for ``_START`` and the near edge for ``_END`` — so a position
+    swallowed by a deletion lands on the deletion point from both sides.
+    """
+    candidates = [op for op in opcodes if op[1] <= pos <= op[2]]
+    if not candidates:  # defensive — opcodes always tile [0, len(old)]
+        return opcodes[-1][4] if opcodes else 0
+    tag, i1, _i2, j1, j2 = candidates[-1] if assoc > 0 else candidates[0]
+    if tag == "equal":
+        return j1 + (pos - i1)
+    return j2 if assoc > 0 else j1
+
+
+def remap_range(
+    old_body: str, new_body: str, start: int, end: int
+) -> tuple[int, int] | None:
+    """Map ``[start, end)`` from ``old_body`` onto ``new_body``.
+
+    Returns the new ``(start, end)`` tuple, or ``None`` when the span
+    collapsed (the anchored text was entirely removed) — i.e. the comment
+    should be orphaned.
+    """
+    if not 0 <= start <= end <= len(old_body):
+        raise ValueError(
+            f"range [{start}, {end}) out of bounds for body of len {len(old_body)}"
+        )
+    if old_body == new_body:
+        return (start, end)
+    opcodes = SequenceMatcher(None, old_body, new_body, autojunk=False).get_opcodes()
+    new_start = _map_pos(opcodes, start, _START)
+    new_end = _map_pos(opcodes, end, _END)
+    if new_start >= new_end:
+        return None
+    return (new_start, new_end)

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -1,63 +1,72 @@
 """Position-based re-anchoring for wiki page comments.
 
 A comment anchors to a half-open character range ``[start, end)`` into a page
-body at a known commit (``anchor_sha``). When the page changes, we re-derive
-the range against the new body from the *exact* diff between the two versions
-— never a fuzzy text search.
+body at a known commit (``anchor_sha``). When the page changes, we re-derive the
+range against the new body from the *exact* diff between the two versions —
+never a fuzzy text search.
 
-The two endpoints are mapped **independently**, so an edit *inside* the span
-resizes it: a deletion shrinks the highlight, an insertion grows it. The
-comment is treated as *orphaned* only when its span collapses to empty
-(``start >= end`` after mapping) — i.e. nothing the endpoints can straddle
-survived.
+**Endpoints — character-precise.** The two ends are mapped independently through
+a character-level diff, so an edit *inside* the span resizes it (a deletion
+shrinks the highlight, an insertion grows it) and an unchanged span keeps its
+exact offsets. ``start`` biases toward following content and ``end`` toward
+preceding content, so text inserted at an edge lands outside the highlight.
 
-What collapses, and what doesn't:
+**Orphan decision — word level.** Whether to *trust* the remapped span is judged
+on a separate **word/token** diff, not the character diff. A character diff
+treats coincidental shared letters and spaces as "preserved," which makes a
+rewritten span look half-survived and yields confidently-wrong anchors; a token
+diff makes a genuine rewrite register as a clean replacement. A comment is
+orphaned (shows its ``quoted_text`` tombstone instead of a highlight) when:
 
-- A pure **deletion** of the anchored text → orphan.
-- A **clean replacement** (the span is exactly one replaced region with no
-  characters in common) → orphan.
-- A **rewrite that keeps incidental characters** (shared words, spaces, common
-  letters — the realistic agent-rewrite case) does *not* collapse; the comment
-  **migrates onto the surviving/replacement text** instead of orphaning. This
-  is a deliberate consequence of using the exact diff rather than a fuzzy
-  similarity threshold: we never decide "close enough is gone." Tightening this
-  to orphan heavy rewrites would require coarser (word-level) granularity or a
-  survival threshold; deferred on purpose.
+- the span collapses to empty (``start >= end``): the whole region was removed;
+- too little of the remapped span is preserved *whole words* (below
+  ``_MIN_PRESERVED``): the alignment landed mostly on rewritten text; or
+- the survivor is only whitespace: nothing real is left to anchor to.
 
-Boundary rule: ``start`` biases toward the content that follows it and ``end``
-toward the content that precedes it, so text inserted exactly at either edge
-lands *outside* the highlight rather than silently extending it.
+Orphaning is the safe failure mode — better a tombstone than a confidently wrong
+anchor.
 
 Offsets are Unicode **code-point** indices into the body. The frontend must
 count the same way (iterate code points, not UTF-16 units) for astral
-characters to line up; wiki markdown is overwhelmingly BMP, so this only
-matters for emoji and similar.
+characters to line up; wiki markdown is overwhelmingly BMP, so this only matters
+for emoji and similar.
 
-Pure module — no I/O. Callers pass the two bodies in; ``app/wiki/git.py``
-reads them at the relevant refs.
+Pure module — no I/O. Callers pass the two bodies in; ``app/wiki/git.py`` reads
+them at the relevant refs.
 """
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from difflib import SequenceMatcher
+
+# A token is a run of whitespace or a run of non-whitespace; concatenating all
+# token texts reproduces the body exactly.
+_TOKEN_RE = re.compile(r"\s+|\S+")
 
 # Endpoint association: +1 sticks to following content, -1 to preceding.
 _START = 1
 _END = -1
+
+# A remapped span must be at least this fraction *preserved* (covered by
+# unchanged whole tokens) to be trusted; below it the alignment has likely
+# landed on rewritten text the comment never referred to, so we orphan. The one
+# tunable knob — raise it to orphan more aggressively, lower it to keep more
+# migrated anchors.
+_MIN_PRESERVED = 0.5
 
 # (tag, i1, i2, j1, j2) as returned by SequenceMatcher.get_opcodes().
 _Opcode = tuple[str, int, int, int, int]
 
 
 def _map_pos(opcodes: Sequence[_Opcode], pos: int, assoc: int) -> int:
-    """Map a single position from old to new coordinates.
+    """Map a single character position from old to new coordinates.
 
-    ``assoc`` picks the tie-break at a boundary several opcodes touch:
-    ``_START`` (+1) prefers the later opcode, ``_END`` (-1) the earlier one.
-    Inside a changed (non-``equal``) opcode the position collapses to the
-    far edge for ``_START`` and the near edge for ``_END`` — so a position
-    swallowed by a deletion lands on the deletion point from both sides.
-    """
+    ``assoc`` picks the tie-break at a boundary several opcodes touch: ``_START``
+    (+1) prefers the later opcode, ``_END`` (-1) the earlier one. Inside a
+    changed (non-``equal``) opcode the position collapses to the far edge for
+    ``_START`` and the near edge for ``_END`` — so a position swallowed by a
+    deletion lands on the deletion point from both sides."""
     candidates = [op for op in opcodes if op[1] <= pos <= op[2]]
     if not candidates:  # defensive — opcodes always tile [0, len(old)]
         return opcodes[-1][4] if opcodes else 0
@@ -67,14 +76,44 @@ def _map_pos(opcodes: Sequence[_Opcode], pos: int, assoc: int) -> int:
     return j2 if assoc > 0 else j1
 
 
+def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_end: int) -> float:
+    """Fraction of the new span ``[new_start, new_end)`` covered by whole tokens
+    that survived unchanged from ``old_body``.
+
+    Diffs at word/whitespace-token granularity (not characters) so coincidental
+    shared letters in a rewrite don't count as "preserved" — that's what keeps a
+    genuine rewrite from looking half-survived."""
+    span = new_end - new_start
+    if span <= 0:
+        return 0.0
+    old_tokens = [m.group() for m in _TOKEN_RE.finditer(old_body)]
+    new_tokens = [(m.group(), m.start()) for m in _TOKEN_RE.finditer(new_body)]
+    new_len = len(new_body)
+
+    def token_start(idx: int) -> int:
+        return new_tokens[idx][1] if idx < len(new_tokens) else new_len
+
+    opcodes = SequenceMatcher(
+        None, old_tokens, [t[0] for t in new_tokens], autojunk=False
+    ).get_opcodes()
+    kept = 0
+    for tag, _i1, _i2, j1, j2 in opcodes:
+        if tag != "equal":
+            continue
+        lo = max(new_start, token_start(j1))
+        hi = min(new_end, token_start(j2))
+        if hi > lo:
+            kept += hi - lo
+    return kept / span
+
+
 def remap_range(
     old_body: str, new_body: str, start: int, end: int
 ) -> tuple[int, int] | None:
     """Map ``[start, end)`` from ``old_body`` onto ``new_body``.
 
-    Returns the new ``(start, end)`` tuple, or ``None`` when the span
-    collapsed (the anchored text was entirely removed) — i.e. the comment
-    should be orphaned.
+    Returns the new ``(start, end)`` tuple, or ``None`` when the comment should
+    be orphaned (span removed, mostly rewritten, or whitespace-only survivor).
     """
     if not 0 <= start <= end <= len(old_body):
         raise ValueError(
@@ -82,9 +121,15 @@ def remap_range(
         )
     if old_body == new_body:
         return (start, end)
+
     opcodes = SequenceMatcher(None, old_body, new_body, autojunk=False).get_opcodes()
     new_start = _map_pos(opcodes, start, _START)
     new_end = _map_pos(opcodes, end, _END)
+
     if new_start >= new_end:
-        return None
+        return None  # whole span deleted/replaced
+    if _word_preserved_fraction(old_body, new_body, new_start, new_end) < _MIN_PRESERVED:
+        return None  # alignment landed on mostly-rewritten text — orphan, don't mislead
+    if not new_body[new_start:new_end].strip():
+        return None  # only whitespace survived — nothing real to anchor to
     return (new_start, new_end)

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -71,18 +71,16 @@ def test_clean_disjoint_replacement_orphans():
     assert remap_range(old, new, s, e) is None
 
 
-def test_rewrite_sharing_characters_migrates_not_orphan():
-    # Realistic agent rewrite: shared words/spaces/letters mean the span does
-    # NOT collapse — the comment migrates onto the rewritten text rather than
-    # orphaning. Documents the deliberate exact-diff (non-fuzzy) behavior.
+def test_rewrite_sharing_characters_orphans_via_survival_guard():
+    # Realistic agent rewrite: difflib shares incidental characters
+    # (spaces/letters) so the span doesn't fully collapse, but the remapped
+    # range would land mostly on text the user never commented on. The
+    # preserved-fraction guard orphans it rather than migrating to a wrong
+    # location.
     old = "see the old wording here"
     new = "see the brand new phrasing here"
     s, e = old.index("old wording"), old.index("old wording") + len("old wording")
-    result = remap_range(old, new, s, e)
-    assert result is not None
-    # The migrated range lands within the rewritten middle, never past the
-    # untouched " here" suffix.
-    assert result[1] <= new.index(" here")
+    assert remap_range(old, new, s, e) is None
 
 
 def test_insertion_at_start_edge_stays_outside():
@@ -119,6 +117,23 @@ def test_sentence_removed_later_comment_stays_put():
     e = s + len("Third sentence.")
     result = remap_range(old, new, s, e)
     assert _slice(new, result) == "Third sentence."
+
+
+def test_survival_guard_keeps_real_surviving_tail():
+    # Even though most of the span's characters were deleted, the survivor
+    # ("keep") is a contiguous preserved block, so the remapped highlight is
+    # 100% preserved content -> kept, not orphaned.
+    old = "remove this whole leading clause but keep"
+    new = "keep"
+    result = remap_range(old, new, 0, len(old))
+    assert _slice(new, result) == "keep"
+
+
+def test_survival_guard_orphans_when_highlight_would_be_mostly_new():
+    # Tiny survivor swamped by inserted text the comment never referred to.
+    old = "fox"
+    new = "a long inserted sentence f o x with lots of new words around"
+    assert remap_range(old, new, 0, 3) is None
 
 
 def test_out_of_bounds_raises():

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -1,0 +1,135 @@
+"""Unit tests for the comment diff-transform anchor (app/wiki/comment_anchor.py).
+
+These are pure — no DB, no git, no fixtures. The most meaningful assertion is
+that the *text under the remapped range* is what we expect, so most cases
+slice ``new_body`` with the result.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.wiki.comment_anchor import remap_range
+
+
+def _slice(new_body: str, result: tuple[int, int] | None) -> str:
+    assert result is not None
+    return new_body[result[0] : result[1]]
+
+
+def test_unchanged_body_returns_same_range():
+    body = "the quick brown fox"
+    assert remap_range(body, body, 4, 9) == (4, 9)
+
+
+def test_edit_before_span_shifts_both_endpoints():
+    old = "intro. the target sentence."
+    new = "a much longer intro. the target sentence."
+    # "target sentence" in old
+    s, e = old.index("target"), old.index("target") + len("target sentence")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "target sentence"
+
+
+def test_edit_after_span_leaves_it_untouched():
+    old = "keep this. drop that."
+    new = "keep this. drop that entirely, plus more."
+    s, e = 0, len("keep this")
+    assert remap_range(old, new, s, e) == (0, len("keep this"))
+
+
+def test_mid_span_deletion_shrinks_highlight():
+    # Comment spans "brown fox"; the inner " bro" ... delete chars from the middle.
+    old = "the quick brown fox jumps"
+    new = "the quick fox jumps"  # removed "brown "
+    s, e = old.index("quick"), old.index("fox") + len("fox")  # "quick brown fox"
+    result = remap_range(old, new, s, e)
+    # Still anchored, now covering the surviving "quick fox".
+    assert _slice(new, result) == "quick fox"
+
+
+def test_mid_span_insertion_grows_highlight():
+    old = "the quick fox"
+    new = "the quick brown fox"  # inserted "brown " inside the span
+    s, e = old.index("quick"), old.index("fox") + len("fox")  # "quick fox"
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "quick brown fox"
+
+
+def test_whole_span_deleted_orphans():
+    old = "alpha BETA gamma"
+    new = "alpha gamma"  # "BETA " removed
+    s, e = old.index("BETA"), old.index("BETA") + len("BETA")
+    assert remap_range(old, new, s, e) is None
+
+
+def test_clean_disjoint_replacement_orphans():
+    # The span is exactly one replaced region with no characters in common,
+    # so both endpoints collapse onto the replacement boundary -> orphan.
+    old = "alpha QQQQ omega"
+    new = "alpha ZZZZ omega"
+    s, e = old.index("QQQQ"), old.index("QQQQ") + len("QQQQ")
+    assert remap_range(old, new, s, e) is None
+
+
+def test_rewrite_sharing_characters_migrates_not_orphan():
+    # Realistic agent rewrite: shared words/spaces/letters mean the span does
+    # NOT collapse — the comment migrates onto the rewritten text rather than
+    # orphaning. Documents the deliberate exact-diff (non-fuzzy) behavior.
+    old = "see the old wording here"
+    new = "see the brand new phrasing here"
+    s, e = old.index("old wording"), old.index("old wording") + len("old wording")
+    result = remap_range(old, new, s, e)
+    assert result is not None
+    # The migrated range lands within the rewritten middle, never past the
+    # untouched " here" suffix.
+    assert result[1] <= new.index(" here")
+
+
+def test_insertion_at_start_edge_stays_outside():
+    # Insert immediately before the span — the new text must NOT be highlighted.
+    old = "highlighted tail"
+    new = "PREFIX highlighted tail"
+    s, e = 0, len("highlighted")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "highlighted"
+
+
+def test_insertion_at_end_edge_stays_outside():
+    # Insert immediately after the span — the new text must NOT be highlighted.
+    old = "head highlighted"
+    new = "head highlighted SUFFIX"
+    s, e = old.index("highlighted"), len(old)
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "highlighted"
+
+
+def test_deletion_overlapping_start_keeps_surviving_tail():
+    old = "remove keep"
+    new = "keep"  # "remove " deleted, span started inside the deleted part
+    s, e = 0, len(old)  # whole "remove keep"
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "keep"
+
+
+def test_sentence_removed_later_comment_stays_put():
+    # A doc-shaped case: a comment on the 3rd sentence survives deleting the 1st.
+    old = "First sentence. Second sentence. Third sentence."
+    new = "Second sentence. Third sentence."
+    s = old.index("Third sentence.")
+    e = s + len("Third sentence.")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "Third sentence."
+
+
+def test_out_of_bounds_raises():
+    with pytest.raises(ValueError):
+        remap_range("short", "longer body", 0, 99)
+
+
+def test_disjoint_full_rewrite_orphans():
+    # No characters in common between the spanned region and its replacement
+    # -> the span collapses and the comment orphans.
+    old = "keep [[[[[[[[[[ keep"
+    new = "keep )))))))))) keep"
+    s, e = old.index("[["), old.index("[[") + 10
+    assert remap_range(old, new, s, e) is None


### PR DESCRIPTION
## What

First of three PRs adding **human comments on wiki pages**. This is the pure backend foundation — **no API, no UI** — so nothing user-facing is exposed yet. PR 2 adds the repo/API + commit-hook remap task; PR 3 adds the render-mode frontend.

## Contents

- **`comments` table** (`app/db/models.py`) + migration `0022_comments.py`.
  - **Postgres-only**, like ACLs — comments are never written to the wiki git repo or `wiki-data` volume (keeps git history clean for agents).
  - **Position anchor:** `[start_offset, end_offset)` into the body at `anchor_sha`, plus display-only `quoted_text` (snippet / orphan tombstone — never used to re-locate).
  - **Threading:** `thread_root_id` + `parent_id`; anchor lives on the thread root.
  - **Reserved for later phases:** `scope='page'` (page-level threads) and `author_kind='agent'` (AI-authored) are valid values now, so those features need no migration.
  - Migration is `has_table`-guarded to match `0021` (fresh installs get the table from `0001`'s `create_all`).
- **`app/wiki/comment_anchor.py`** — `remap_range(old, new, start, end)`.
  - Maps the two endpoints **independently** through the **exact** git diff (`difflib` opcodes): a mid-span deletion shrinks the highlight, an insertion grows it.
  - Orphans (`None`) **only when the span collapses** to empty.
  - Boundary bias: `start` sticks to following content, `end` to preceding, so text inserted at an edge lands *outside* the highlight.
  - **No fuzzy matching** — by design.

## Behavior worth a look in review

With an exact char-level diff:
- a **clean deletion** or **disjoint replacement** → the comment **orphans**;
- a **rewrite that shares characters** (words/spaces/letters — the realistic agent-rewrite case) → the comment **migrates onto the rewritten text** rather than orphaning.

This is the deliberate consequence of "exact diff, no fuzzy threshold," and is documented in the module docstring. The stricter "rewrites orphan with a tombstone" would need word-level granularity or a survival threshold — deferred.

## Tests

14 unit tests in `tests/test_comment_anchor.py` (pure, no DB): clean translate, mid-span shrink/grow, edits before/after, boundary-insert-stays-outside, collapse-to-orphan (deletion + disjoint replacement), migrate-on-shared-char-rewrite, out-of-bounds. `ruff` + `basedpyright` clean.

## Not in this PR

Repo, API router, `remap_comments` queue task (PR 2); render-mode UI (PR 3); design doc.