### PR TITLE
fix(helm): derive PUBLIC_BASE_URL from ingress.host + bump chart to 0.3.19

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.18
+version: 0.3.19
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/_helpers.tpl
+++ b/deploy/helm/agent-workspace/templates/_helpers.tpl
@@ -74,7 +74,7 @@ and wiki path stay in lockstep.
 - name: INGEST_EVAL_LOGGING
   value: {{ .Values.ingestEvalLogging | default false | quote }}
 - name: PUBLIC_BASE_URL
-  value: {{ required "publicBaseUrl is required (e.g. https://wiki.example.com)" .Values.publicBaseUrl | quote }}
+  value: {{ default (printf "https://%s" .Values.ingress.host) .Values.publicBaseUrl | quote }}
 - name: SECURE_COOKIES
   value: {{ .Values.secureCookies | quote }}
 {{- if eq .Values.auth.mode "oidc" }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -59,12 +59,12 @@ launchersEnabled: false
 # decision (committed / no_change / irrelevant). Off by default; enable on
 # environments where you want to collect real traffic for eval review.
 ingestEvalLogging: false
-# Browser-facing wiki origin (e.g. "https://wiki.example.com",
-# no trailing slash). REQUIRED. Backend advertises this URL in
-# launcher launch URIs, redirect targets, email links. Not inferred
-# from request headers — explicit operator config (cf. GitLab
-# external_url, Sentry system.url-prefix). Backend fails to start
-# if unset or malformed.
+# Browser-facing wiki origin (e.g. "https://wiki.example.com", no
+# trailing slash). Backend advertises this URL in launcher launch URIs,
+# redirect targets, email links. Optional: when left empty the chart
+# derives "https://<ingress.host>" (same pattern as auth.oidc.redirectUri).
+# Set it only to override that default (cf. GitLab external_url, Sentry
+# system.url-prefix).
 publicBaseUrl: ""
 
 auth:


### PR DESCRIPTION
## Description

**Bug:** every dev-wiki backend/worker pod crashloops on boot:
`pydantic_core.ValidationError: PUBLIC_BASE_URL is required`.

**Cause:** the backend now hard-requires `PUBLIC_BASE_URL` (`config.py`). The chart added the env var in #141 as `required .Values.publicBaseUrl`, but the deploy's values file never sets it — and `Chart.yaml` was left at `0.3.18`, so chart-releaser's `skip_existing` never republished. The deploy kept pulling the stale `0.3.18` chart that has no `PUBLIC_BASE_URL` at all.

**Fix:**
- Derive `PUBLIC_BASE_URL` from `ingress.host` (`https://<host>`), same pattern as `OIDC_REDIRECT_URI`. `publicBaseUrl` still works as an optional override.
- Bump chart `0.3.18` → `0.3.19` so chart-releaser actually publishes to `gh-pages`.

No `cloud-deployment-yamls` values change needed — `dev-wiki` derives `https://dev-wiki.onyx.app` automatically.

`helm template` verified: no override → `https://dev-wiki.onyx.app`; with override → honored.

## How Has This Been Tested?