### PR TITLE
fix(sidebar): keep .md suffix in Recents links

### DIFF
--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -166,9 +166,11 @@ export function AppSidebar() {
                 </div>
                 <div className="flex flex-col gap-px">
                   {pages.map((page) => {
-                    const slug = page.path.replace(/\.md$/, "");
-                    const label = slug.split("/").pop() ?? slug;
-                    const href = `/app/wiki/${slug}`;
+                    const label = (page.path.split("/").pop() ?? page.path).replace(
+                      /\.md$/,
+                      "",
+                    );
+                    const href = `/app/wiki/${page.path}`;
                     const active = pathname === href;
                     return (
                       <SidebarTab


### PR DESCRIPTION
## Description

**Bug:** Clicking a Recents entry in the sidebar opened the empty-folder Explorer ("This folder is empty") instead of the document.

**Cause:** The wiki route gates file-vs-folder on `slugPath.endsWith(".md")` (`[[...slug]]/page.tsx`). The Recents links stripped `.md` from the href, so every recent doc resolved as a folder. WikiSearch and Explorer already keep `.md`; the sidebar was the odd one out.

**Fix:** Keep `.md` in the href; strip it only for the display label. Active-highlight now matches too, since `pathname` carries `.md`.

## How Has This Been Tested?