### PR TITLE
feat(frontend): add LoadingSpinner, replace literal "Loading…" text

### DIFF
--- a/frontend/src/app/admin/braintrust/page.tsx
+++ b/frontend/src/app/admin/braintrust/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
@@ -119,7 +120,7 @@ function BraintrustForm() {
     }
   }
 
-  if (!settings) return <div>Loading…</div>;
+  if (!settings) return <LoadingSpinner />;
 
   // Server-side: enabled is forced to false unless project AND key are both
   // set. Mirror that gating here so the toggle button is greyed out until

--- a/frontend/src/app/admin/groups/page.tsx
+++ b/frontend/src/app/admin/groups/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { ApiError, apiFetch } from "@/lib/api";
@@ -111,7 +112,7 @@ function GroupsManager() {
 
         <h3 style={{ fontSize: 14 }}>Groups</h3>
         {isLoading ? (
-          <div style={{ color: color.text.muted, fontSize: 13 }}>Loading…</div>
+          <LoadingSpinner />
         ) : groups.length === 0 ? (
           <div style={{ color: color.text.muted, fontSize: 13 }}>No groups yet.</div>
         ) : (
@@ -193,7 +194,7 @@ function GroupDetail({ groupId }: { groupId: string }) {
     }
   }
 
-  if (isLoading || !group) return <div style={{ color: color.text.muted }}>Loading…</div>;
+  if (isLoading || !group) return <LoadingSpinner />;
 
   return (
     <div>

--- a/frontend/src/app/admin/health/page.tsx
+++ b/frontend/src/app/admin/health/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { useHealth } from "@/lib/health";
@@ -88,7 +89,7 @@ export default function AdminHealthPage() {
         </section>
 
         <h2 style={{ fontSize: 16, fontWeight: 600, margin: "0 0 10px" }}>Queues</h2>
-        {!data && !error && <p style={{ color: color.text.muted, fontSize: 13 }}>Loading…</p>}
+        {!data && !error && <LoadingSpinner />}
         {data && (
           <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
             {data.queues.map((q) => {

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type FormEvent } from "react";
 import { mutate as globalMutate } from "swr";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
@@ -145,7 +146,7 @@ function IngestForm() {
     }
   }
 
-  if (!settings || !llmSettings) return <div>Loading…</div>;
+  if (!settings || !llmSettings) return <LoadingSpinner />;
 
   const dirty = maxDocChars !== String(settings.max_doc_chars);
 

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type FormEvent } from "react";
 import { mutate as globalMutate } from "swr";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
@@ -119,7 +120,7 @@ function LLMPage() {
   useEffect(() => { void load(); }, []);
 
   if (error) return <div style={{ color: color.state.danger.fg }}>{error}</div>;
-  if (!settings) return <div style={{ color: color.text.muted }}>Loading…</div>;
+  if (!settings) return <LoadingSpinner />;
 
   const configured = ALL_PROVIDERS.filter((p) => isConfigured(p, settings));
   const unconfigured = ALL_PROVIDERS.filter((p) => !isConfigured(p, settings));

--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type CSSProperties, type FormEvent } from "react";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import {
@@ -41,7 +42,7 @@ function TemplatesList() {
   const [reordering, setReordering] = useState<string | null>(null);
   const [reorderError, setReorderError] = useState<string | null>(null);
 
-  if (isLoading) return <div>Loading…</div>;
+  if (isLoading) return <LoadingSpinner />;
   if (error) return <div style={{ color: color.state.danger.fg }}>{error.message}</div>;
 
   async function move(index: number, direction: -1 | 1) {

--- a/frontend/src/app/admin/web/page.tsx
+++ b/frontend/src/app/admin/web/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
@@ -102,7 +103,7 @@ function WebForm() {
     }
   }
 
-  if (!settings) return <div>Loading…</div>;
+  if (!settings) return <LoadingSpinner />;
 
   return (
     <form onSubmit={onSubmit} style={{ display: "flex", flexDirection: "column", gap: 16 }}>

--- a/frontend/src/app/app/agents/page.tsx
+++ b/frontend/src/app/app/agents/page.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 
 import { SetupWizard } from "@/components/agents/SetupWizard";
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { ApiError } from "@/lib/api";
 import {
@@ -26,7 +27,11 @@ export default function AgentsPage() {
   const isMobile = useIsMobile();
 
   if (loading || !user)
-    return <main style={{ padding: isMobile ? 16 : 32 }}>Loading…</main>;
+    return (
+      <main style={{ padding: isMobile ? 16 : 32 }}>
+        <LoadingSpinner center />
+      </main>
+    );
 
   return (
     <main
@@ -119,9 +124,7 @@ function TokenManager() {
 
       {reveal && <RevealOnce token={reveal} onClose={() => setReveal(null)} />}
 
-      {isLoading && tokens.length === 0 && !error && (
-        <p style={{ color: color.text.muted, fontSize: 14 }}>Loading…</p>
-      )}
+      {isLoading && tokens.length === 0 && !error && <LoadingSpinner />}
 
       {!isLoading && tokens.length === 0 && (
         <p style={{ color: color.text.muted, fontSize: 14 }}>

--- a/frontend/src/app/app/events/page.tsx
+++ b/frontend/src/app/app/events/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { useRequireAuth } from "@/lib/auth";
 import { useEvents } from "@/lib/events";
@@ -18,7 +19,12 @@ export default function EventsPage() {
   });
   const errorMessage = error?.message ?? null;
 
-  if (loading || !user) return <main style={{ padding: isMobile ? 16 : 32 }}>Loading…</main>;
+  if (loading || !user)
+    return (
+      <main style={{ padding: isMobile ? 16 : 32 }}>
+        <LoadingSpinner center />
+      </main>
+    );
 
   return (
     <main style={{ padding: isMobile ? "16px 12px" : "24px 32px" }}>
@@ -27,7 +33,7 @@ export default function EventsPage() {
           description="Trigger fires, newest first."
           actions={
             <Button onClick={() => void refresh()} disabled={isValidating}>
-              {isValidating ? "Loading…" : "Refresh"}
+              {isValidating ? <LoadingSpinner size={14} /> : "Refresh"}
             </Button>
           }
         />

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState, type CSSProperties, type FormEvent, type 
 
 import { Button } from "@/components/common/Button";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
 import { color, radius } from "@/lib/theme";
@@ -44,7 +45,11 @@ export default function SettingsPage() {
   const isMobile = useIsMobile();
 
   if (loading || !user) {
-    return <main style={{ padding: isMobile ? 16 : 32 }}>Loading…</main>;
+    return (
+      <main style={{ padding: isMobile ? 16 : 32 }}>
+        <LoadingSpinner center />
+      </main>
+    );
   }
 
   return (

--- a/frontend/src/app/app/triggers/page.tsx
+++ b/frontend/src/app/app/triggers/page.tsx
@@ -3,6 +3,7 @@
 import { useState, type CSSProperties } from "react";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { TriggerHistoryModal } from "@/components/triggers/TriggerHistoryModal";
 import { TriggerModal } from "@/components/triggers/TriggerModal";
@@ -63,7 +64,12 @@ export default function TriggersPage() {
 
   const listError = mutationError ?? listSwrError?.message ?? null;
 
-  if (loading || !user) return <main style={{ padding: isMobile ? 16 : 32 }}>Loading…</main>;
+  if (loading || !user)
+    return (
+      <main style={{ padding: isMobile ? 16 : 32 }}>
+        <LoadingSpinner center />
+      </main>
+    );
 
   async function onToggle(t: Trigger) {
     setBusyId(t.id);

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -15,6 +15,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import useSWR from "swr";
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { TriggerModal } from "@/components/triggers/TriggerModal";
 import { DiffView } from "@/components/wiki/DiffView";
@@ -105,7 +106,11 @@ export default function WikiRoute() {
   }, [slugPath]);
 
   if (loading || !user)
-    return <main style={{ padding: isMobile ? 16 : 32 }}>Loading…</main>;
+    return (
+      <main style={{ padding: isMobile ? 16 : 32 }}>
+        <LoadingSpinner center />
+      </main>
+    );
 
   return isFile ? (
     <FileViewer path={slugPath} />
@@ -2331,7 +2336,7 @@ function FileViewer({ path }: { path: string }) {
         </div>
       )}
 
-      {loading && <p>Loading…</p>}
+      {loading && <LoadingSpinner />}
 
       {!loading && !error && (
         <div style={{ flex: 1, minHeight: 0, display: "flex", gap: 16 }}>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useState, type CSSProperties, type FormEvent } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { useAuth } from "@/lib/auth";
 import { color, radius, shadow } from "@/lib/theme";
 
@@ -197,7 +198,13 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={<main style={{ padding: 32 }}>Loading…</main>}>
+    <Suspense
+      fallback={
+        <main style={{ padding: 32 }}>
+          <LoadingSpinner center />
+        </main>
+      }
+    >
       <LoginForm />
     </Suspense>
   );

--- a/frontend/src/app/signup/page.tsx
+++ b/frontend/src/app/signup/page.tsx
@@ -5,6 +5,7 @@ import { Suspense, useEffect, useState, type CSSProperties, type FormEvent } fro
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { useAuth } from "@/lib/auth";
 import { color, radius, shadow } from "@/lib/theme";
 
@@ -155,7 +156,13 @@ function SignupForm() {
 
 export default function SignupPage() {
   return (
-    <Suspense fallback={<main style={{ padding: 32 }}>Loading…</main>}>
+    <Suspense
+      fallback={
+        <main style={{ padding: 32 }}>
+          <LoadingSpinner center />
+        </main>
+      }
+    >
       <SignupForm />
     </Suspense>
   );

--- a/frontend/src/components/chat/ChatHistoryPanel.tsx
+++ b/frontend/src/components/chat/ChatHistoryPanel.tsx
@@ -7,6 +7,7 @@ import {
   deleteSession,
   listSessions,
 } from "@/lib/chat";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { color, radius } from "@/lib/theme";
 
 interface Props {
@@ -135,7 +136,9 @@ export function ChatHistoryPanel({
           </div>
         )}
         {loading && sessions.length === 0 && (
-          <p style={{ color: color.text.muted, fontSize: 13, padding: 8, margin: 0 }}>Loading…</p>
+          <div style={{ padding: 8 }}>
+            <LoadingSpinner />
+          </div>
         )}
         {!loading && sessions.length === 0 && !error && (
           <p style={{ color: color.text.muted, fontSize: 13, padding: 8, margin: 0 }}>

--- a/frontend/src/components/common/LoadingSpinner.module.css
+++ b/frontend/src/components/common/LoadingSpinner.module.css
@@ -1,0 +1,28 @@
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.ring {
+  display: inline-block;
+  flex-shrink: 0;
+  border: 2px solid var(--color-border-default);
+  border-top-color: var(--color-text-secondary);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+.wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--color-text-muted);
+  font-size: 14px;
+}
+
+.center {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+}

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,41 @@
+import styles from "./LoadingSpinner.module.css";
+
+// Canonical loading indicator. Replaces literal "Loading…" text everywhere.
+// Bare animated ring by default; pass `label` for a ring+text row, `center`
+// to fill and center its container (full-page / panel fallbacks).
+export function LoadingSpinner({
+  size = 16,
+  label,
+  center = false,
+}: {
+  size?: number;
+  label?: string;
+  center?: boolean;
+}) {
+  const wrapped = Boolean(label) || center;
+
+  const ring = (
+    <span
+      role={wrapped ? undefined : "status"}
+      aria-label={wrapped ? undefined : "Loading"}
+      aria-hidden={wrapped ? true : undefined}
+      className={styles.ring}
+      style={{ width: size, height: size }}
+    />
+  );
+
+  if (!wrapped) return ring;
+
+  // A single status region: visible label (if any) is the accessible name,
+  // else fall back to "Loading"; the ring itself is decorative here.
+  return (
+    <span
+      role="status"
+      aria-label={label ? undefined : "Loading"}
+      className={center ? `${styles.wrap} ${styles.center}` : styles.wrap}
+    >
+      {ring}
+      {label ? <span>{label}</span> : null}
+    </span>
+  );
+}

--- a/frontend/src/components/triggers/TriggerHistoryModal.tsx
+++ b/frontend/src/components/triggers/TriggerHistoryModal.tsx
@@ -8,6 +8,7 @@ import {
   type Trigger,
   type TriggerCommit,
 } from "@/lib/triggers";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { color, radius, shadow } from "@/lib/theme";
 
 interface Props {
@@ -99,7 +100,7 @@ export function TriggerHistoryModal({ trigger, onClose, onSelectVersion }: Props
           new commit. Trigger <em>fires</em> live on the Events tab.
         </p>
 
-        {loading && <div style={{ fontSize: 13, color: color.text.muted }}>Loading…</div>}
+        {loading && <LoadingSpinner />}
 
         {error && (
           <div

--- a/frontend/src/components/wiki/DiffView.tsx
+++ b/frontend/src/components/wiki/DiffView.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { absoluteTime, relativeTime } from "@/lib/time";
 import type { FileDiffResponse } from "@/lib/wiki";
 
@@ -111,9 +112,7 @@ export function DiffView({
           )
         ) : loading ? (
           <div className={styles.empty}>
-            <Text font="secondary-body" color="text-03">
-              Loading…
-            </Text>
+            <LoadingSpinner />
           </div>
         ) : bodyError ? (
           <div className={styles.empty}>

--- a/frontend/src/components/wiki/HistoryPanel.tsx
+++ b/frontend/src/components/wiki/HistoryPanel.tsx
@@ -4,6 +4,7 @@ import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
 import type { IconProps } from "@onyx-ai/opal/types";
 import type { ComponentType } from "react";
 
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { color } from "@/lib/theme";
 import { relativeTime } from "@/lib/time";
 import {
@@ -111,7 +112,11 @@ export function HistoryPanel({
         }}
       >
         {error && <PanelMessage>{error}</PanelMessage>}
-        {!error && commits === null && <PanelMessage>Loading…</PanelMessage>}
+        {!error && commits === null && (
+          <div style={{ padding: 12 }}>
+            <LoadingSpinner />
+          </div>
+        )}
         {!error && commits && commits.length === 0 && (
           <PanelMessage>No history yet.</PanelMessage>
         )}

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/common/Button";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { ApiError, apiFetch } from "@/lib/api";
 import {
   grantAcl,
@@ -67,7 +68,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
         )}
 
         {isLoading || !acl ? (
-          <div style={{ color: color.text.muted, fontSize: 14 }}>Loading…</div>
+          <LoadingSpinner />
         ) : (
           <>
             <Section title="Visibility">


### PR DESCRIPTION
## Description

Adds a single reusable `LoadingSpinner` (`components/common/`) — CSS Module, theme tokens, module-local `spin` keyframe — and replaces every literal "Loading…" text across the app.

- **23 sites / 18 files**: page gates, admin pages, Suspense fallbacks, panels, modals.
- Full-page gates → `<LoadingSpinner center />`; inline spots → bare; Refresh button → `size={14}` ring.
- `role="status"` with a single accessible name (ring `aria-hidden` when a label/wrapper is present).
- Keyframe lives **in the module** — CSS Modules scopes `animation` names, so a global keyframe wouldn't match.

## How Has This Been Tested?

## Additional Options
- [ ] Override Linear Check