### PR TITLE
feat(comments): repo + real-time re-anchoring on commit (Phase 1, PR 2/3)

### DIFF
--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -1,0 +1,37 @@
+"""Enumerations for wiki page comments.
+
+``str, Enum`` so members compare/serialize as their string value (matching the
+``ChangeKind`` pattern in ``app/models/wiki.py``). These are the single source
+of truth for the valid column values; the DB CHECK constraints in
+``app/db/models.py`` mirror them, the repo validates against them, and the HTTP
+layer will type its request/response fields with them.
+"""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class CommentScope(str, Enum):
+    """What a comment is attached to."""
+
+    INLINE = "inline"  # anchored to a character range in the body
+    PAGE = "page"  # whole-page (footer) thread
+
+
+class CommentAuthorKind(str, Enum):
+    """Who wrote a comment."""
+
+    USER = "user"
+    AGENT = "agent"
+
+
+class CommentStatus(str, Enum):
+    """Lifecycle state of a comment thread.
+
+    ``ORPHANED`` is set only by the re-anchor path when a span collapses — it is
+    never a status a caller may set directly (see the repo's resolve path).
+    """
+
+    OPEN = "open"
+    RESOLVED = "resolved"
+    ORPHANED = "orphaned"

--- a/backend/app/wiki/comment_remap.py
+++ b/backend/app/wiki/comment_remap.py
@@ -1,0 +1,93 @@
+"""Re-anchor wiki page comments when a commit changes the page body.
+
+Runs **synchronously** from ``app.wiki.notify`` right after a write commits, so
+a comment's stored offsets are correct as soon as the save returns — no
+eventual-consistency window. This applies uniformly to human saves, API edits,
+and agent rewrites, since all of them land as commits through ``notify``.
+
+It's cheap to do inline because the git reads are **batched by anchor_sha**: in
+steady state every comment on a page shares the same anchor (the previous
+HEAD), so we read the old body once and the new body once regardless of how
+many comments the page has, then run an in-memory ``difflib`` diff per comment
+(see ``app/wiki/comment_anchor.py``). Two git reads plus pure-CPU diffs sit well
+within a request budget.
+
+The caller in ``notify`` swallows failures so a remap hiccup can never break a
+save, and the API read path remaps inline if it ever sees a stale anchor — so
+correctness never depends on this having run.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from app.wiki import comment_anchor, comments
+from app.wiki import git as wiki_git
+from app.wiki.git import UnknownSha
+
+log = logging.getLogger(__name__)
+
+
+def remap_comments(path: str) -> None:
+    """Bring every stale comment anchor on ``path`` up to the current HEAD."""
+    if not path.endswith(".md"):
+        return
+    head = wiki_git.head_sha_for_path(path)
+    if head is None:
+        return  # untracked / no commits touch this path
+    roots = comments.roots_needing_remap(path, head)
+    if not roots:
+        return
+    try:
+        new_body = wiki_git.read_file(path, head)
+    except UnknownSha:
+        log.warning("remap_comments: cannot read %s at HEAD %s", path, head)
+        return
+
+    # Group by the commit each comment is anchored at: comments on a page
+    # almost always share one anchor_sha (the previous HEAD), so this reads
+    # each old body once rather than once per comment.
+    by_anchor: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for c in roots:
+        by_anchor[c["anchor_sha"]].append(c)
+
+    for anchor_sha, group in by_anchor.items():
+        old_body = _read_old_body(path, anchor_sha)
+        if old_body is None:
+            continue
+        for c in group:
+            _apply(c, old_body, new_body, head)
+
+
+def _read_old_body(path: str, anchor_sha: str) -> str | None:
+    """Read the page body at ``anchor_sha``, following any rename so
+    ``git show <sha>:<path>`` resolves. Returns ``None`` (caller skips the
+    group) when the anchor commit isn't reachable — better to leave those
+    comments untouched and retry on the next commit than to guess."""
+    old_path = wiki_git.path_at_ref(path, anchor_sha)
+    if old_path is None:
+        log.warning("remap_comments: anchor %s not in history of %s", anchor_sha, path)
+        return None
+    try:
+        return wiki_git.read_file(old_path, anchor_sha)
+    except UnknownSha:
+        log.warning("remap_comments: cannot read %s at anchor %s", old_path, anchor_sha)
+        return None
+
+
+def _apply(c: dict[str, Any], old_body: str, new_body: str, head: str) -> None:
+    result = comment_anchor.remap_range(
+        old_body, new_body, c["start_offset"], c["end_offset"]
+    )
+    if result is None:
+        comments.orphan(c["id"])
+    else:
+        start, end = result
+        comments.apply_remap(
+            c["id"],
+            start_offset=start,
+            end_offset=end,
+            quoted_text=new_body[start:end],
+            anchor_sha=head,
+        )

--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -1,0 +1,331 @@
+"""Comments repo — SQLAlchemy ORM. Free functions over the ``Comment`` model.
+
+Comments are **Postgres-only** (never written to the wiki git repo) and are
+anchored to a page by ``doc_path`` + a character range; see
+``app/db/models.py:Comment`` and ``app/wiki/comment_anchor.py`` for the anchor
+model. Like every repo here, these functions open their own ``session()`` and
+return plain dicts so callers don't depend on the ORM.
+
+Threads: a top-level comment is a *root* (``thread_root_id == id``,
+``parent_id is None``) and carries the anchor + resolve state. Replies share
+the root's ``thread_root_id`` and leave the anchor columns NULL. ``resolve`` /
+``reopen`` act on the root; ``remap`` / ``orphan`` are called by the
+commit-time re-anchor task.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import func, select, update
+
+from app.db.models import Comment
+from app.db.session import execute_dml, session
+
+log = logging.getLogger(__name__)
+
+_VALID_SCOPES = {"inline", "page"}
+_VALID_AUTHOR_KINDS = {"user", "agent"}
+# Statuses a caller may set. 'orphaned' is system-only (set by the re-anchor
+# task when a span collapses), so it is not accepted from the resolve path.
+_SETTABLE_STATUSES = {"open", "resolved"}
+
+
+def _to_dict(c: Comment) -> dict[str, Any]:
+    return {
+        "id": c.id,
+        "doc_path": c.doc_path,
+        "thread_root_id": c.thread_root_id,
+        "parent_id": c.parent_id,
+        "scope": c.scope,
+        "anchor_sha": c.anchor_sha,
+        "start_offset": c.start_offset,
+        "end_offset": c.end_offset,
+        "quoted_text": c.quoted_text,
+        "author_kind": c.author_kind,
+        "author_user_id": c.author_user_id,
+        "body": c.body,
+        "status": c.status,
+        "resolved_by_user_id": c.resolved_by_user_id,
+        "resolved_at": c.resolved_at,
+        "created_at": c.created_at,
+        "updated_at": c.updated_at,
+    }
+
+
+def _now_text(s: Any) -> str:
+    """ISO timestamp matching the column's server_default."""
+    return s.scalar(
+        select(func.to_char(func.timezone("UTC", func.now()), "YYYY-MM-DD HH24:MI:SS"))
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Create                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def create_thread(
+    *,
+    doc_path: str,
+    body: str,
+    author_user_id: str | None,
+    anchor_sha: str | None,
+    start_offset: int | None,
+    end_offset: int | None,
+    quoted_text: str | None,
+    scope: str = "inline",
+    author_kind: str = "user",
+) -> dict[str, Any]:
+    """Create a new root comment (starts a thread). Returns the row dict.
+
+    For ``scope='inline'`` the anchor (``anchor_sha`` + both offsets) is
+    required — the DB enforces this too, but we fail early with a clear error.
+    """
+    if scope not in _VALID_SCOPES:
+        raise ValueError(f"invalid scope: {scope!r}")
+    if author_kind not in _VALID_AUTHOR_KINDS:
+        raise ValueError(f"invalid author_kind: {author_kind!r}")
+    if scope == "inline" and (
+        anchor_sha is None or start_offset is None or end_offset is None
+    ):
+        raise ValueError("inline comment requires anchor_sha + start/end offset")
+
+    cid = f"cmt_{uuid.uuid4().hex[:12]}"
+    with session() as s:
+        now = _now_text(s)
+        c = Comment(
+            id=cid,
+            doc_path=doc_path,
+            thread_root_id=cid,
+            parent_id=None,
+            scope=scope,
+            anchor_sha=anchor_sha,
+            start_offset=start_offset,
+            end_offset=end_offset,
+            quoted_text=quoted_text,
+            author_kind=author_kind,
+            author_user_id=author_user_id,
+            body=body,
+            status="open",
+            created_at=now,
+            updated_at=now,
+        )
+        s.add(c)
+        s.flush()
+        result = _to_dict(c)
+    log.info("comment thread created id=%s doc=%s", cid, doc_path)
+    return result
+
+
+def add_reply(
+    *,
+    parent_id: str,
+    body: str,
+    author_user_id: str | None,
+    author_kind: str = "user",
+) -> dict[str, Any] | None:
+    """Reply to an existing comment. ``thread_root_id`` and ``doc_path`` are
+    inherited from the parent; the anchor columns stay NULL (replies inherit
+    the thread's position). Returns the row dict, or ``None`` if the parent
+    doesn't exist."""
+    if author_kind not in _VALID_AUTHOR_KINDS:
+        raise ValueError(f"invalid author_kind: {author_kind!r}")
+    cid = f"cmt_{uuid.uuid4().hex[:12]}"
+    with session() as s:
+        parent = s.get(Comment, parent_id)
+        if parent is None:
+            return None
+        now = _now_text(s)
+        c = Comment(
+            id=cid,
+            doc_path=parent.doc_path,
+            thread_root_id=parent.thread_root_id,
+            parent_id=parent_id,
+            scope=parent.scope,
+            anchor_sha=None,
+            start_offset=None,
+            end_offset=None,
+            quoted_text=None,
+            author_kind=author_kind,
+            author_user_id=author_user_id,
+            body=body,
+            status="open",
+            created_at=now,
+            updated_at=now,
+        )
+        s.add(c)
+        s.flush()
+        return _to_dict(c)
+
+
+# --------------------------------------------------------------------------- #
+# Read                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def get(comment_id: str) -> dict[str, Any] | None:
+    with session() as s:
+        c = s.get(Comment, comment_id)
+        return _to_dict(c) if c else None
+
+
+def list_for_doc(doc_path: str) -> list[dict[str, Any]]:
+    """All comments on a page (roots + replies), oldest first. The API layer
+    groups these into threads by ``thread_root_id`` and decides what to show
+    (e.g. hiding resolved threads)."""
+    with session() as s:
+        rows = s.scalars(
+            select(Comment)
+            .where(Comment.doc_path == doc_path)
+            .order_by(Comment.created_at.asc())
+        ).all()
+        return [_to_dict(c) for c in rows]
+
+
+def list_thread(thread_root_id: str) -> list[dict[str, Any]]:
+    with session() as s:
+        rows = s.scalars(
+            select(Comment)
+            .where(Comment.thread_root_id == thread_root_id)
+            .order_by(Comment.created_at.asc())
+        ).all()
+        return [_to_dict(c) for c in rows]
+
+
+# --------------------------------------------------------------------------- #
+# Mutate — user-driven                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def edit_body(comment_id: str, body: str) -> dict[str, Any] | None:
+    with session() as s:
+        c = s.get(Comment, comment_id)
+        if c is None:
+            return None
+        c.body = body
+        c.updated_at = _now_text(s)
+        s.flush()
+        return _to_dict(c)
+
+
+def set_thread_status(
+    thread_root_id: str,
+    status: str,
+    *,
+    resolved_by_user_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Resolve (``'resolved'``) or reopen (``'open'``) a thread. Acts on the
+    root row; replies don't carry meaningful status. Returns the updated root
+    dict, or ``None`` if the root doesn't exist."""
+    if status not in _SETTABLE_STATUSES:
+        raise ValueError(f"status must be one of {_SETTABLE_STATUSES}, got {status!r}")
+    with session() as s:
+        root = s.get(Comment, thread_root_id)
+        if root is None:
+            return None
+        now = _now_text(s)
+        root.status = status
+        root.updated_at = now
+        if status == "resolved":
+            root.resolved_by_user_id = resolved_by_user_id
+            root.resolved_at = now
+        else:
+            root.resolved_by_user_id = None
+            root.resolved_at = None
+        s.flush()
+        return _to_dict(root)
+
+
+def delete(comment_id: str) -> bool:
+    """Delete a comment. Deleting a root removes its replies via the
+    ``parent_id`` ON DELETE CASCADE. Returns True if a row was deleted."""
+    with session() as s:
+        c = s.get(Comment, comment_id)
+        if c is None:
+            return False
+        s.delete(c)
+        return True
+
+
+# --------------------------------------------------------------------------- #
+# Mutate — re-anchor task (commit-time drift)                                 #
+# --------------------------------------------------------------------------- #
+
+
+def roots_needing_remap(doc_path: str, head_sha: str) -> list[dict[str, Any]]:
+    """Inline thread roots on ``doc_path`` whose stored anchor is not yet at
+    ``head_sha`` and can still be remapped (not orphaned). The re-anchor task
+    diffs each one's body-at-``anchor_sha`` to the body at HEAD."""
+    with session() as s:
+        rows = s.scalars(
+            select(Comment).where(
+                Comment.doc_path == doc_path,
+                Comment.parent_id.is_(None),
+                Comment.scope == "inline",
+                Comment.status != "orphaned",
+                Comment.anchor_sha != head_sha,
+            )
+        ).all()
+        return [_to_dict(c) for c in rows]
+
+
+def apply_remap(
+    comment_id: str,
+    *,
+    start_offset: int,
+    end_offset: int,
+    quoted_text: str,
+    anchor_sha: str,
+) -> None:
+    """Advance a comment's anchor to a new commit after a successful remap.
+
+    Refreshes the offsets + ``quoted_text`` to the new body and sets
+    ``anchor_sha`` to the version they now describe. Does **not** touch
+    ``updated_at`` — a re-anchor is system bookkeeping, not user activity."""
+    with session() as s:
+        c = s.get(Comment, comment_id)
+        if c is None:
+            return
+        c.start_offset = start_offset
+        c.end_offset = end_offset
+        c.quoted_text = quoted_text
+        c.anchor_sha = anchor_sha
+
+
+def orphan(comment_id: str) -> None:
+    """Mark a comment orphaned (its anchored span collapsed). Offsets,
+    ``anchor_sha`` and ``quoted_text`` are left untouched so they freeze as the
+    tombstone of the last version the comment was anchored to."""
+    with session() as s:
+        c = s.get(Comment, comment_id)
+        if c is None:
+            return
+        c.status = "orphaned"
+
+
+def reassign_doc_path(old_path: str, new_path: str) -> int:
+    """Re-key all comments from ``old_path`` to ``new_path`` (page move/rename).
+    Returns the number of rows moved."""
+    with session() as s:
+        return execute_dml(
+            s,
+            update(Comment)
+            .where(Comment.doc_path == old_path)
+            .values(doc_path=new_path)
+            .execution_options(synchronize_session=False),
+        )
+
+
+def orphan_all_for_doc(doc_path: str) -> int:
+    """Orphan every still-anchored comment on a page (page deleted). Returns
+    the number of rows orphaned."""
+    with session() as s:
+        return execute_dml(
+            s,
+            update(Comment)
+            .where(Comment.doc_path == doc_path, Comment.status != "orphaned")
+            .values(status="orphaned")
+            .execution_options(synchronize_session=False),
+        )

--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -22,14 +22,17 @@ from sqlalchemy import func, select, update
 
 from app.db.models import Comment
 from app.db.session import execute_dml, session
+from app.models.comment import CommentAuthorKind, CommentScope, CommentStatus
 
 log = logging.getLogger(__name__)
 
-_VALID_SCOPES = {"inline", "page"}
-_VALID_AUTHOR_KINDS = {"user", "agent"}
+# Derived from the enums in app/models/comment.py so they stay the single
+# source of truth (the DB CHECK constraints mirror the same values).
+_VALID_SCOPES = frozenset(s.value for s in CommentScope)
+_VALID_AUTHOR_KINDS = frozenset(k.value for k in CommentAuthorKind)
 # Statuses a caller may set. 'orphaned' is system-only (set by the re-anchor
-# task when a span collapses), so it is not accepted from the resolve path.
-_SETTABLE_STATUSES = {"open", "resolved"}
+# path when a span collapses), so it is not accepted from the resolve path.
+_SETTABLE_STATUSES = frozenset({CommentStatus.OPEN.value, CommentStatus.RESOLVED.value})
 
 
 def _to_dict(c: Comment) -> dict[str, Any]:
@@ -75,8 +78,8 @@ def create_thread(
     start_offset: int | None,
     end_offset: int | None,
     quoted_text: str | None,
-    scope: str = "inline",
-    author_kind: str = "user",
+    scope: str = CommentScope.INLINE.value,
+    author_kind: str = CommentAuthorKind.USER.value,
 ) -> dict[str, Any]:
     """Create a new root comment (starts a thread). Returns the row dict.
 
@@ -87,7 +90,7 @@ def create_thread(
         raise ValueError(f"invalid scope: {scope!r}")
     if author_kind not in _VALID_AUTHOR_KINDS:
         raise ValueError(f"invalid author_kind: {author_kind!r}")
-    if scope == "inline" and (
+    if scope == CommentScope.INLINE.value and (
         anchor_sha is None or start_offset is None or end_offset is None
     ):
         raise ValueError("inline comment requires anchor_sha + start/end offset")
@@ -108,7 +111,7 @@ def create_thread(
             author_kind=author_kind,
             author_user_id=author_user_id,
             body=body,
-            status="open",
+            status=CommentStatus.OPEN.value,
             created_at=now,
             updated_at=now,
         )
@@ -124,7 +127,7 @@ def add_reply(
     parent_id: str,
     body: str,
     author_user_id: str | None,
-    author_kind: str = "user",
+    author_kind: str = CommentAuthorKind.USER.value,
 ) -> dict[str, Any] | None:
     """Reply to an existing comment. ``thread_root_id`` and ``doc_path`` are
     inherited from the parent; the anchor columns stay NULL (replies inherit
@@ -151,7 +154,7 @@ def add_reply(
             author_kind=author_kind,
             author_user_id=author_user_id,
             body=body,
-            status="open",
+            status=CommentStatus.OPEN.value,
             created_at=now,
             updated_at=now,
         )
@@ -228,7 +231,7 @@ def set_thread_status(
         now = _now_text(s)
         root.status = status
         root.updated_at = now
-        if status == "resolved":
+        if status == CommentStatus.RESOLVED.value:
             root.resolved_by_user_id = resolved_by_user_id
             root.resolved_at = now
         else:
@@ -263,8 +266,8 @@ def roots_needing_remap(doc_path: str, head_sha: str) -> list[dict[str, Any]]:
             select(Comment).where(
                 Comment.doc_path == doc_path,
                 Comment.parent_id.is_(None),
-                Comment.scope == "inline",
-                Comment.status != "orphaned",
+                Comment.scope == CommentScope.INLINE.value,
+                Comment.status != CommentStatus.ORPHANED.value,
                 Comment.anchor_sha != head_sha,
             )
         ).all()
@@ -302,7 +305,7 @@ def orphan(comment_id: str) -> None:
         c = s.get(Comment, comment_id)
         if c is None:
             return
-        c.status = "orphaned"
+        c.status = CommentStatus.ORPHANED.value
 
 
 def reassign_doc_path(old_path: str, new_path: str) -> int:
@@ -325,7 +328,7 @@ def orphan_all_for_doc(doc_path: str) -> int:
         return execute_dml(
             s,
             update(Comment)
-            .where(Comment.doc_path == doc_path, Comment.status != "orphaned")
-            .values(status="orphaned")
+            .where(Comment.doc_path == doc_path, Comment.status != CommentStatus.ORPHANED.value)
+            .values(status=CommentStatus.ORPHANED.value)
             .execution_options(synchronize_session=False),
         )

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -166,5 +166,10 @@ def after_path_move(
             # commit may also change content; path_at_ref follows the rename).
             comments.reassign_doc_path(old_p, new_p)
             _remap_comments_safe(new_p)
+        elif old_is_md:
+            # The page left .md-space (renamed to a non-doc path) — there's no
+            # new doc to carry the comments onto, so orphan them rather than
+            # strand them on a path that no longer exists.
+            comments.orphan_all_for_doc(old_p)
     if list_changed:
         mcp_pubsub.publish_list_changed()

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -29,12 +29,29 @@ clean (``api/`` → ``wiki/`` ← ``tools/``).
 """
 from __future__ import annotations
 
+import logging
+
 from app.db import fts
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
-from app.wiki import acl
+from app.wiki import acl, comments
+from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind
+
+log = logging.getLogger(__name__)
+
+
+def _remap_comments_safe(path: str) -> None:
+    """Re-anchor comments inline, but never let a remap failure abort a save.
+
+    A stale comment self-heals on the next edit (and the API read path remaps
+    on a stale anchor), so swallowing here only ever costs a brief position
+    inaccuracy — never a lost write."""
+    try:
+        remap_comments(path)
+    except Exception:
+        log.exception("comment remap failed for %s", path)
 
 
 def after_doc_write(
@@ -69,6 +86,9 @@ def after_doc_write(
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
     index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
+    # Drift any comments anchored to this page onto the new body. A no-op on
+    # CREATE (no comments yet); the real work is on EDIT.
+    _remap_comments_safe(rel_path)
     mcp_pubsub.publish_doc_update(rel_path, sha, change_kind)
     if change_kind == ChangeKind.CREATE:
         mcp_pubsub.publish_list_changed()
@@ -95,6 +115,9 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
         return
     fts.delete_document(rel_path)
     acl.on_page_deleted(rel_path)
+    # The body is gone, so there's nothing to re-anchor against — orphan the
+    # page's comments (keeps them as tombstones) rather than dropping them.
+    comments.orphan_all_for_doc(rel_path)
     fan_out_trigger_eval(rel_path, sha, ChangeKind.DELETE, actor)
     mcp_pubsub.publish_doc_delete(rel_path, sha)
     mcp_pubsub.publish_list_changed()
@@ -138,5 +161,10 @@ def after_path_move(
             fan_out_trigger_eval(new_p, sha, ChangeKind.CREATE, actor)
             mcp_pubsub.publish_doc_update(new_p, sha, ChangeKind.CREATE)
             list_changed = True
+        if old_is_md and new_is_md:
+            # Re-key comments to the new path, then re-anchor them (a rename
+            # commit may also change content; path_at_ref follows the rename).
+            comments.reassign_doc_path(old_p, new_p)
+            _remap_comments_safe(new_p)
     if list_changed:
         mcp_pubsub.publish_list_changed()

--- a/backend/tests/test_comment_remap.py
+++ b/backend/tests/test_comment_remap.py
@@ -7,13 +7,15 @@ one commit, edits the page, then asserts the comment drifted or orphaned. Uses
 """
 from __future__ import annotations
 
+from typing import Any
+
 from app.wiki import comment_remap, comments
 from app.wiki import git as wiki_git
 
 _PATH = "notes.md"
 
 
-def _anchor(path: str, sha: str, body: str, phrase: str) -> dict:
+def _anchor(path: str, sha: str, body: str, phrase: str) -> dict[str, Any]:
     start = body.index(phrase)
     return comments.create_thread(
         doc_path=path,

--- a/backend/tests/test_comment_remap.py
+++ b/backend/tests/test_comment_remap.py
@@ -1,0 +1,99 @@
+"""Real-time comment re-anchoring (app/wiki/comment_remap.py).
+
+Integration-level: commits real bodies to a tmp wiki repo, anchors a comment at
+one commit, edits the page, then asserts the comment drifted or orphaned. Uses
+``tmp_repo`` (DB + initialized git repo) and drives ``remap_comments`` directly
+(it's synchronous), rather than going through the notify hook.
+"""
+from __future__ import annotations
+
+from app.wiki import comment_remap, comments
+from app.wiki import git as wiki_git
+
+_PATH = "notes.md"
+
+
+def _anchor(path: str, sha: str, body: str, phrase: str) -> dict:
+    start = body.index(phrase)
+    return comments.create_thread(
+        doc_path=path,
+        body="is this still right?",
+        author_user_id=None,
+        anchor_sha=sha,
+        start_offset=start,
+        end_offset=start + len(phrase),
+        quoted_text=phrase,
+    )
+
+
+def test_edit_before_span_drifts_anchor_to_head(tmp_repo):
+    body1 = "Intro paragraph.\nThe target sentence stays put.\n"
+    sha1 = wiki_git.commit_file(_PATH, body1, "create")
+    c = _anchor(_PATH, sha1, body1, "target sentence")
+
+    body2 = "Intro paragraph, now considerably longer.\nThe target sentence stays put.\n"
+    sha2 = wiki_git.commit_file(_PATH, body2, "edit")
+    comment_remap.remap_comments(_PATH)
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert got["status"] == "open"
+    assert got["anchor_sha"] == sha2  # advanced to HEAD
+    # offsets shifted, and now point at the same text in the new body
+    assert body2[got["start_offset"] : got["end_offset"]] == "target sentence"
+    assert got["quoted_text"] == "target sentence"
+
+
+def test_deleted_anchor_orphans_and_freezes_tombstone(tmp_repo):
+    body1 = "Keep first line.\nThis sentence will be removed entirely.\nKeep last line.\n"
+    sha1 = wiki_git.commit_file(_PATH, body1, "create")
+    c = _anchor(_PATH, sha1, body1, "This sentence will be removed entirely")
+    start = c["start_offset"]
+
+    body2 = "Keep first line.\nKeep last line.\n"
+    wiki_git.commit_file(_PATH, body2, "edit")
+    comment_remap.remap_comments(_PATH)
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert got["status"] == "orphaned"
+    # tombstone frozen at the last good anchor
+    assert got["anchor_sha"] == sha1
+    assert got["start_offset"] == start
+    assert got["quoted_text"] == "This sentence will be removed entirely"
+
+
+def test_unchanged_span_keeps_exact_offsets(tmp_repo):
+    body1 = "Alpha.\nBeta sentence to comment on.\nGamma.\n"
+    sha1 = wiki_git.commit_file(_PATH, body1, "create")
+    c = _anchor(_PATH, sha1, body1, "Beta sentence to comment on")
+    s, e = c["start_offset"], c["end_offset"]
+
+    # Edit only the last line; the commented span is untouched.
+    body2 = "Alpha.\nBeta sentence to comment on.\nGamma extended with more words.\n"
+    sha2 = wiki_git.commit_file(_PATH, body2, "edit")
+    comment_remap.remap_comments(_PATH)
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert (got["start_offset"], got["end_offset"]) == (s, e)  # unchanged
+    assert got["anchor_sha"] == sha2
+
+
+def test_already_at_head_is_noop(tmp_repo):
+    body = "A line worth commenting on.\n"
+    sha1 = wiki_git.commit_file(_PATH, body, "create")
+    c = _anchor(_PATH, sha1, body, "worth commenting")
+
+    comment_remap.remap_comments(_PATH)  # HEAD == anchor_sha already
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert got["anchor_sha"] == sha1
+    assert (got["start_offset"], got["end_offset"]) == (c["start_offset"], c["end_offset"])
+
+
+def test_noop_without_comments_or_non_md(tmp_repo):
+    wiki_git.commit_file("empty.md", "nothing anchored here\n", "create")
+    comment_remap.remap_comments("empty.md")  # no comments -> no-op, no raise
+    comment_remap.remap_comments("notes.txt")  # non-.md -> ignored

--- a/backend/tests/test_comments_repo.py
+++ b/backend/tests/test_comments_repo.py
@@ -1,0 +1,225 @@
+"""Comments repo (app/wiki/comments.py) — CRUD, threading, and the re-anchor
+helpers the commit-time drift task relies on.
+
+DB-backed (uses the per-test schema from the ``tmp_db`` fixture), mirroring
+``test_acl.py``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.wiki import comments
+from tests._seed import seed_user
+
+_DOC = "guides/setup.md"
+
+
+def _seed_root(author: str, *, doc: str = _DOC, sha: str = "sha1") -> dict:
+    return comments.create_thread(
+        doc_path=doc,
+        body="is this still accurate?",
+        author_user_id=author,
+        anchor_sha=sha,
+        start_offset=10,
+        end_offset=25,
+        quoted_text="the old wording",
+    )
+
+
+def test_create_thread_is_its_own_root(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice)
+    assert root["id"].startswith("cmt_")
+    assert root["thread_root_id"] == root["id"]
+    assert root["parent_id"] is None
+    assert root["status"] == "open"
+    assert root["scope"] == "inline"
+    assert root["author_kind"] == "user"
+    assert (root["start_offset"], root["end_offset"]) == (10, 25)
+    assert comments.get(root["id"]) == root
+
+
+def test_inline_thread_requires_anchor(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    with pytest.raises(ValueError):
+        comments.create_thread(
+            doc_path=_DOC,
+            body="x",
+            author_user_id=alice,
+            anchor_sha=None,
+            start_offset=None,
+            end_offset=None,
+            quoted_text=None,
+        )
+
+
+def test_invalid_scope_and_author_kind_rejected(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    with pytest.raises(ValueError):
+        comments.create_thread(
+            doc_path=_DOC, body="x", author_user_id=alice, anchor_sha="s",
+            start_offset=0, end_offset=1, quoted_text="x", scope="bogus",
+        )
+    with pytest.raises(ValueError):
+        comments.create_thread(
+            doc_path=_DOC, body="x", author_user_id=alice, anchor_sha="s",
+            start_offset=0, end_offset=1, quoted_text="x", author_kind="robot",
+        )
+
+
+def test_reply_inherits_thread_and_doc_leaves_anchor_null(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    bob = seed_user(uid="u_bob", email="bob@x.com")
+    root = _seed_root(alice)
+
+    reply = comments.add_reply(parent_id=root["id"], body="yes, just edited", author_user_id=bob)
+    assert reply is not None
+    assert reply["thread_root_id"] == root["id"]
+    assert reply["parent_id"] == root["id"]
+    assert reply["doc_path"] == _DOC
+    assert reply["scope"] == "inline"
+    assert reply["anchor_sha"] is None
+    assert reply["start_offset"] is None
+
+    thread = comments.list_thread(root["id"])
+    assert [c["id"] for c in thread] == [root["id"], reply["id"]]
+
+
+def test_reply_to_missing_parent_returns_none(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    assert comments.add_reply(parent_id="cmt_missing", body="x", author_user_id=alice) is None
+
+
+def test_list_for_doc_returns_all_rows_oldest_first(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    r1 = _seed_root(alice)
+    r2 = _seed_root(alice, sha="sha1")
+    comments.add_reply(parent_id=r1["id"], body="reply", author_user_id=alice)
+
+    rows = comments.list_for_doc(_DOC)
+    assert len(rows) == 3
+    # other docs aren't included
+    assert comments.list_for_doc("other/page.md") == []
+    # all belong to one of the two threads
+    assert {r["thread_root_id"] for r in rows} == {r1["id"], r2["id"]}
+
+
+def test_edit_body(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice)
+    updated = comments.edit_body(root["id"], "actually never mind")
+    assert updated is not None
+    assert updated["body"] == "actually never mind"
+    assert comments.edit_body("cmt_missing", "x") is None
+
+
+def test_resolve_and_reopen_thread(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    bob = seed_user(uid="u_bob", email="bob@x.com")
+    root = _seed_root(alice)
+
+    resolved = comments.set_thread_status(root["id"], "resolved", resolved_by_user_id=bob)
+    assert resolved is not None
+    assert resolved["status"] == "resolved"
+    assert resolved["resolved_by_user_id"] == bob
+    assert resolved["resolved_at"] is not None
+
+    reopened = comments.set_thread_status(root["id"], "open")
+    assert reopened is not None
+    assert reopened["status"] == "open"
+    assert reopened["resolved_by_user_id"] is None
+    assert reopened["resolved_at"] is None
+
+
+def test_set_status_rejects_system_only_and_unknown(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice)
+    for bad in ("orphaned", "bogus"):
+        with pytest.raises(ValueError):
+            comments.set_thread_status(root["id"], bad)
+
+
+def test_delete_root_cascades_replies(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice)
+    reply = comments.add_reply(parent_id=root["id"], body="r", author_user_id=alice)
+    assert reply is not None
+
+    assert comments.delete(root["id"]) is True
+    assert comments.get(root["id"]) is None
+    assert comments.get(reply["id"]) is None  # cascaded
+    assert comments.delete("cmt_missing") is False
+
+
+# --------------------------------------------------------------------------- #
+# Re-anchor helpers                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_roots_needing_remap_filters(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice, sha="sha1")
+    reply = comments.add_reply(parent_id=root["id"], body="r", author_user_id=alice)
+    assert reply is not None
+
+    # Already at head -> nothing to do.
+    assert comments.roots_needing_remap(_DOC, "sha1") == []
+    # Head advanced -> the root needs remapping; the reply is excluded.
+    need = comments.roots_needing_remap(_DOC, "sha2")
+    assert [c["id"] for c in need] == [root["id"]]
+
+    # Orphaned roots are excluded; resolved roots are still remapped.
+    comments.orphan(root["id"])
+    assert comments.roots_needing_remap(_DOC, "sha2") == []
+
+
+def test_apply_remap_advances_anchor_without_bumping_updated_at(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice, sha="sha1")
+    before = comments.get(root["id"])
+    assert before is not None
+
+    comments.apply_remap(
+        root["id"], start_offset=3, end_offset=9, quoted_text="new text", anchor_sha="sha2"
+    )
+    after = comments.get(root["id"])
+    assert after is not None
+    assert (after["start_offset"], after["end_offset"]) == (3, 9)
+    assert after["quoted_text"] == "new text"
+    assert after["anchor_sha"] == "sha2"
+    assert after["updated_at"] == before["updated_at"]  # re-anchor is not user activity
+
+
+def test_orphan_freezes_anchor_as_tombstone(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice, sha="sha1")
+    comments.orphan(root["id"])
+    after = comments.get(root["id"])
+    assert after is not None
+    assert after["status"] == "orphaned"
+    # Offsets + quoted_text left intact as the tombstone.
+    assert (after["start_offset"], after["end_offset"]) == (10, 25)
+    assert after["quoted_text"] == "the old wording"
+    assert after["anchor_sha"] == "sha1"
+
+
+def test_reassign_doc_path_on_move(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice)
+    comments.add_reply(parent_id=root["id"], body="r", author_user_id=alice)
+
+    moved = comments.reassign_doc_path(_DOC, "guides/install.md")
+    assert moved == 2  # root + reply
+    assert comments.list_for_doc(_DOC) == []
+    assert len(comments.list_for_doc("guides/install.md")) == 2
+
+
+def test_orphan_all_for_doc_on_delete(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    r1 = _seed_root(alice, sha="sha1")
+    r2 = _seed_root(alice, sha="sha1")
+    comments.orphan(r1["id"])  # already orphaned -> not counted again
+
+    orphaned = comments.orphan_all_for_doc(_DOC)
+    assert orphaned == 1  # only r2 was still anchored
+    assert comments.get(r2["id"])["status"] == "orphaned"

--- a/backend/tests/test_comments_repo.py
+++ b/backend/tests/test_comments_repo.py
@@ -6,6 +6,8 @@ DB-backed (uses the per-test schema from the ``tmp_db`` fixture), mirroring
 """
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from app.wiki import comments
@@ -14,7 +16,7 @@ from tests._seed import seed_user
 _DOC = "guides/setup.md"
 
 
-def _seed_root(author: str, *, doc: str = _DOC, sha: str = "sha1") -> dict:
+def _seed_root(author: str, *, doc: str = _DOC, sha: str = "sha1") -> dict[str, Any]:
     return comments.create_thread(
         doc_path=doc,
         body="is this still accurate?",
@@ -222,4 +224,6 @@ def test_orphan_all_for_doc_on_delete(tmp_db):
 
     orphaned = comments.orphan_all_for_doc(_DOC)
     assert orphaned == 1  # only r2 was still anchored
-    assert comments.get(r2["id"])["status"] == "orphaned"
+    got = comments.get(r2["id"])
+    assert got is not None
+    assert got["status"] == "orphaned"


### PR DESCRIPTION
## What

Backend **domain layer** for human comments, on top of the schema + anchor core merged in #152. **No HTTP surface yet** — the API router is held for the comment-permission decision (default-open vs default-closed), so it lands in PR 3 alongside the frontend.

## Contents

- **`app/wiki/comments.py`** — repo (free functions over `session()`, returns dicts):
  - lifecycle: `create_thread`, `add_reply`, `get`, `list_for_doc`, `list_thread`, `edit_body`, `set_thread_status` (resolve/reopen), `delete` (cascades replies via the `parent_id` FK).
  - re-anchor helpers: `roots_needing_remap`, `apply_remap`, `orphan`, `reassign_doc_path`, `orphan_all_for_doc`.
- **`app/wiki/comment_remap.py`** — **synchronous, real-time** re-anchoring. On each commit it diff-transforms every stale inline thread root from its `anchor_sha` to HEAD (via the `comment_anchor` module from #152), advancing the anchor on success or orphaning on collapse.
  - Git reads **batch by `anchor_sha`** — one old + one new body read per edit, regardless of comment count.
  - Follows renames via `path_at_ref`; an unreadable anchor commit is skipped and retried on the next commit (never wrongly orphaned).
- **`app/wiki/notify.py`** — wires it into the single commit seam:
  - **write** → remap (wrapped so a remap failure can never abort a save),
  - **move** → re-key `doc_path` + remap,
  - **delete** → orphan the page's comments (kept as tombstones).
  - Fires for **human *and* agent** commits alike — both land here.

## Behavior notes

- **Real-time, not queued** — comments are correct the instant a save returns; no eventual-consistency window. Cheap because the git I/O is constant per edit, not per comment.
- **Safe by default** — a remap failure is swallowed (logged); the read path (PR 3 API) will re-anchor on a stale `anchor_sha` as a backstop.

## Tests

- `tests/test_comments_repo.py` — CRUD, threading, cascade-delete, the remap-helper filters, orphan-tombstone.
- `tests/test_comment_remap.py` — integration: commits real bodies to a tmp wiki repo and asserts drift / orphan-with-tombstone / unchanged-exact / no-op cases.

## Follow-ups (tracked, not blocking)

- **API router** (`app/api/comments.py`) + the ACL `comment` permission — next PR, once the default-policy decision is made.
- Minor perf: `remap_range` recomputes its diff per comment within a same-`anchor_sha` batch; could hoist the opcodes out of the loop (small bodies, low priority).

Stacked conceptually on #152 (already merged to `main`), so this diffs cleanly against `main`.