### PR TITLE
fix(mcp): return 404 on unknown session id

### DIFF
--- a/backend/app/api/mcp_server.py
+++ b/backend/app/api/mcp_server.py
@@ -30,7 +30,7 @@ from app.db import agent_sessions as agent_sessions_repo
 from app.launchers.current_session import set_current_agent_session_id
 from app.mcp_server import pubsub as mcp_pubsub
 from app.mcp_server import session as mcp_session
-from app.mcp_server.transport import dispatch
+from app.mcp_server.transport import UnknownSessionError, dispatch
 from app.wiki import agent_activity
 
 router = APIRouter()
@@ -107,6 +107,13 @@ async def transport_post(
     try:
         with set_current_user(user), set_current_agent_session_id(agent_sid):
             response, outgoing = dispatch(cast("dict[str, Any]", body), incoming, user)
+    except UnknownSessionError as exc:
+        # Stale/unknown session id → 404 so the client starts a new session.
+        return Response(
+            content=json.dumps(exc.jsonrpc_error()),
+            media_type="application/json",
+            status_code=404,
+        )
     finally:
         agent_activity.agent_name_var.reset(agent_token)
 
@@ -147,7 +154,10 @@ async def transport_sse(
     if not sess_id:
         raise HTTPException(status_code=400, detail=f"missing {SESSION_HEADER} header")
     sess = mcp_session.get(sess_id)
-    if sess is None or not sess.initialized:
+    if sess is None:
+        # Unknown/expired id (header present) → 404 so the client re-inits.
+        raise HTTPException(status_code=404, detail="missing or invalid Mcp-Session-Id")
+    if not sess.initialized:
         raise HTTPException(status_code=400, detail="session not initialized")
     if sess.user_id != bearer_user.id:
         # Bearer resolves to user A but the supplied session id was

--- a/backend/app/mcp_server/transport.py
+++ b/backend/app/mcp_server/transport.py
@@ -17,6 +17,7 @@ enough to keep here.
 Spec reference (MCP 2025-03-26):
   https://spec.modelcontextprotocol.io/specification/2025-03-26/
 """
+
 from __future__ import annotations
 
 import logging
@@ -52,8 +53,29 @@ INVALID_PARAMS = -32602
 INTERNAL_ERROR = -32603
 
 
+class UnknownSessionError(Exception):
+    """A request carried an ``Mcp-Session-Id`` the server doesn't recognize.
+
+    Sessions are in-memory and don't survive a backend restart, so a stale
+    id is the common case after a redeploy. The HTTP layer maps this to a
+    404 so the client starts a fresh session — per the MCP Streamable HTTP
+    spec, a 404 to a request bearing a session id is the signal to
+    re-initialize. (Contrast with a request that omits the header entirely,
+    which is a plain protocol error, not a recoverable stale session.)
+    """
+
+    def __init__(self, request_id: Any) -> None:
+        self.request_id = request_id
+        super().__init__("missing or invalid Mcp-Session-Id")
+
+    def jsonrpc_error(self) -> dict[str, Any]:
+        return _error(self.request_id, INVALID_REQUEST, "missing or invalid Mcp-Session-Id")
+
+
 def dispatch(
-    message: dict[str, Any], session_id: str | None, bearer_user: User,
+    message: dict[str, Any],
+    session_id: str | None,
+    bearer_user: User,
 ) -> tuple[dict[str, Any] | None, str | None]:
     """Process one JSON-RPC message.
 
@@ -86,6 +108,9 @@ def dispatch(
 
     try:
         return _route(method, params, request_id, is_notification, session_id, bearer_user)
+    except UnknownSessionError:
+        # Surfaced to the HTTP layer as a 404 so the client re-initializes.
+        raise
     except Exception:
         log.exception("mcp transport: handler raised for method=%s", method)
         if is_notification:
@@ -113,10 +138,15 @@ def _route(
         if is_notification:
             # Stale notification for a session we don't track; ignore.
             return None, session_id
-        return (
-            _error(request_id, INVALID_REQUEST, "missing or invalid Mcp-Session-Id"),
-            session_id,
-        )
+        if session_id is None:
+            # No session header at all — a plain protocol error, not a
+            # recoverable stale session. Stays an HTTP-200 JSON-RPC error.
+            return (
+                _error(request_id, INVALID_REQUEST, "missing or invalid Mcp-Session-Id"),
+                session_id,
+            )
+        # Header present but unknown/expired → 404 so the client re-inits.
+        raise UnknownSessionError(request_id)
 
     if method == "notifications/initialized":
         sess.initialized = True
@@ -216,7 +246,8 @@ def _handle_resources_unsubscribe(
 
 
 def _handle_initialize(
-    _params: dict[str, Any], bearer_user: User,
+    _params: dict[str, Any],
+    bearer_user: User,
 ) -> tuple[dict[str, Any], str]:
     """Mint a fresh session for the authenticated user, return the
     capabilities envelope. The session is created in the
@@ -266,9 +297,7 @@ def _success(request_id: Any, result: Any) -> dict[str, Any]:
     return {"jsonrpc": "2.0", "id": request_id, "result": result}
 
 
-def _error(
-    request_id: Any, code: int, message: str, data: Any = None
-) -> dict[str, Any]:
+def _error(request_id: Any, code: int, message: str, data: Any = None) -> dict[str, Any]:
     err: dict[str, Any] = {"code": code, "message": message}
     if data is not None:
         err["data"] = data

--- a/backend/tests/test_mcp_server_transport.py
+++ b/backend/tests/test_mcp_server_transport.py
@@ -1,5 +1,6 @@
 """Tests for the inbound MCP transport — bearer auth, session
 handshake, JSON-RPC dispatch."""
+
 from __future__ import annotations
 
 import pytest
@@ -208,6 +209,55 @@ def test_request_without_session_id_is_protocol_error(client):
     # JSON-RPC 2.0 "Invalid Request"
     assert body["error"]["code"] == -32600
     assert "Mcp-Session-Id" in body["error"]["message"]
+
+
+def test_unknown_session_id_request_is_404(client):
+    # A request bearing an Mcp-Session-Id the server doesn't recognize
+    # (e.g. the session died on a backend restart) must return HTTP 404 so
+    # the client re-initializes, per the MCP Streamable HTTP spec.
+    uid = seed_user(uid="u1", email="u1@x.com")
+    raw = _mint_token(uid)
+
+    res = client.post(
+        "/api/mcp",
+        json={"jsonrpc": "2.0", "id": 7, "method": "tools/list"},
+        headers={
+            "Authorization": f"Bearer {raw}",
+            "Mcp-Session-Id": "mcps_does-not-exist",
+        },
+    )
+    assert res.status_code == 404
+    assert res.json()["error"]["code"] == -32600
+
+
+def test_unknown_session_id_sse_is_404(client):
+    # Same rule on the SSE GET stream — a stale session id reconnecting
+    # gets 404, not 400, so the client knows to start a fresh session.
+    uid = seed_user(uid="u1", email="u1@x.com")
+    raw = _mint_token(uid)
+
+    res = client.get(
+        "/api/mcp",
+        headers={
+            "Authorization": f"Bearer {raw}",
+            "Mcp-Session-Id": "mcps_does-not-exist",
+        },
+    )
+    assert res.status_code == 404
+
+
+def test_uninitialized_session_sse_is_400(client):
+    # A *known* session that simply hasn't sent notifications/initialized
+    # yet is a protocol-ordering error (400), distinct from an unknown id.
+    uid = seed_user(uid="u1", email="u1@x.com")
+    raw = _mint_token(uid)
+    auth = {"Authorization": f"Bearer {raw}"}
+
+    res = client.post("/api/mcp", json=_initialize_request(), headers=auth)
+    sess_id = res.headers["Mcp-Session-Id"]
+
+    res = client.get("/api/mcp", headers={**auth, "Mcp-Session-Id": sess_id})
+    assert res.status_code == 400
 
 
 def test_method_before_initialized_ack_is_error(client):


### PR DESCRIPTION
## Description

In-memory MCP sessions die when the backend pod restarts (nightly redeploys), so Claude Code's stored `Mcp-Session-Id` goes stale. The transport answered a request bearing an unknown id with HTTP-200 + JSON-RPC `-32600`, which the client can't recover from — it just surfaces `fetching tools failed: missing or invalid Mcp-Session-Id`.

Per the MCP Streamable HTTP spec, an unrecognized session id must return **HTTP 404** — the client's signal to start a fresh session. Mapped on both transports:

- **POST**: `_route` raises `UnknownSessionError` for a present-but-unknown id → handler returns 404. A request that omits the header entirely stays a plain protocol error (200 / `-32600`), not a recoverable stale session.
- **GET (SSE)**: split the combined check — unknown id → 404, known-but-uninitialized → 400.

Net: after a redeploy, CC gets 404 → re-initializes transparently → the error stops.

## How Has This Been Tested?