### PR TITLE
feat(comments): HTTP API for comments (Phase 1, PR 3)

### DIFF
--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -1,0 +1,212 @@
+"""Comments API — thin HTTP layer over ``app.wiki.comments``.
+
+Inline comments on wiki pages: list (grouped into threads), create, reply,
+edit, resolve/reopen, delete. Every route gates on ``require_can("read", path,
+user)`` — read access to a page is enough to comment (feedback, not mutation);
+edit/delete additionally require the author (or an admin).
+
+Business logic lives in the repo + re-anchor modules; this layer parses, gates,
+serializes, and fires the activity event.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+
+from app.auth import User, require_can
+from app.auth.deps import require_user
+from app.db.models import Event
+from app.db.session import session
+from app.models.comment import (
+    CommentListResponse,
+    CommentStatus,
+    CommentThreadView,
+    CommentView,
+    CreateCommentRequest,
+    CreateReplyRequest,
+    EditCommentRequest,
+)
+from app.wiki import comment_remap, comments as comments_repo, filesystem
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _safe_path(path: str) -> str:
+    if not path:
+        raise HTTPException(status_code=400, detail="path required")
+    try:
+        return filesystem.safe_rel_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+def _load(comment_id: str) -> dict[str, Any]:
+    c = comments_repo.get(comment_id)
+    if c is None:
+        raise HTTPException(status_code=404, detail="comment not found")
+    return c
+
+
+def _require_author_or_admin(comment: dict[str, Any], user: User) -> None:
+    if not (user.is_admin or comment["author_user_id"] == user.id):
+        raise HTTPException(
+            status_code=403, detail="only the author can modify this comment"
+        )
+
+
+def _group_threads(rows: list[dict[str, Any]]) -> list[CommentThreadView]:
+    """Group flat rows into threads (root + replies), oldest thread first."""
+    by_thread: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        by_thread[r["thread_root_id"]].append(r)
+    threads: list[CommentThreadView] = []
+    for members in by_thread.values():
+        root = next((m for m in members if m["id"] == m["thread_root_id"]), None)
+        if root is None:
+            continue  # defensive: replies with no surviving root
+        replies = sorted(
+            (m for m in members if m["id"] != root["id"]),
+            key=lambda m: m["created_at"],
+        )
+        threads.append(
+            CommentThreadView(
+                root=CommentView.model_validate(root),
+                replies=[CommentView.model_validate(m) for m in replies],
+            )
+        )
+    threads.sort(key=lambda t: t.root.created_at)
+    return threads
+
+
+def _fire_event(doc_path: str, row: dict[str, Any], user: User) -> None:
+    with session() as s:
+        s.add(
+            Event(
+                kind="page.comment",
+                actor=user.id,
+                target=doc_path,
+                payload_json=json.dumps(
+                    {
+                        "comment_id": row["id"],
+                        "thread_root_id": row["thread_root_id"],
+                        "doc_path": doc_path,
+                    }
+                ),
+            )
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Routes                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@router.get("", response_model=CommentListResponse)
+def list_comments(
+    path: str = "", user: User = Depends(require_user)
+) -> CommentListResponse:
+    rel = _safe_path(path)
+    require_can("read", rel, user)
+    # Backstop: re-anchor any comment whose anchor lags HEAD (idempotent — a
+    # no-op once the on-commit remap has run, which is the normal case).
+    try:
+        comment_remap.remap_comments(rel)
+    except Exception:
+        log.exception("comment remap backstop failed for %s", rel)
+    return CommentListResponse(threads=_group_threads(comments_repo.list_for_doc(rel)))
+
+
+@router.post("", response_model=CommentView, status_code=status.HTTP_201_CREATED)
+def create_comment(
+    req: CreateCommentRequest, user: User = Depends(require_user)
+) -> CommentView:
+    rel = _safe_path(req.path)
+    require_can("read", rel, user)
+    if req.end_offset <= req.start_offset:
+        raise HTTPException(status_code=400, detail="end_offset must be > start_offset")
+    row = comments_repo.create_thread(
+        doc_path=rel,
+        body=req.body,
+        author_user_id=user.id,
+        anchor_sha=req.anchor_sha,
+        start_offset=req.start_offset,
+        end_offset=req.end_offset,
+        quoted_text=req.quoted_text,
+    )
+    _fire_event(rel, row, user)
+    return CommentView.model_validate(row)
+
+
+@router.post(
+    "/{comment_id}/replies",
+    response_model=CommentView,
+    status_code=status.HTTP_201_CREATED,
+)
+def reply_to_comment(
+    comment_id: str, req: CreateReplyRequest, user: User = Depends(require_user)
+) -> CommentView:
+    parent = _load(comment_id)
+    require_can("read", parent["doc_path"], user)
+    row = comments_repo.add_reply(
+        parent_id=comment_id, body=req.body, author_user_id=user.id
+    )
+    if row is None:  # parent deleted between load and insert
+        raise HTTPException(status_code=404, detail="comment not found")
+    return CommentView.model_validate(row)
+
+
+@router.patch("/{comment_id}", response_model=CommentView)
+def edit_comment(
+    comment_id: str, req: EditCommentRequest, user: User = Depends(require_user)
+) -> CommentView:
+    c = _load(comment_id)
+    require_can("read", c["doc_path"], user)
+    _require_author_or_admin(c, user)
+    row = comments_repo.edit_body(comment_id, req.body)
+    if row is None:
+        raise HTTPException(status_code=404, detail="comment not found")
+    return CommentView.model_validate(row)
+
+
+@router.post("/{comment_id}/resolve", response_model=CommentView)
+def resolve_thread(
+    comment_id: str, user: User = Depends(require_user)
+) -> CommentView:
+    c = _load(comment_id)
+    require_can("read", c["doc_path"], user)
+    row = comments_repo.set_thread_status(
+        c["thread_root_id"], CommentStatus.RESOLVED.value, resolved_by_user_id=user.id
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="comment not found")
+    return CommentView.model_validate(row)
+
+
+@router.post("/{comment_id}/reopen", response_model=CommentView)
+def reopen_thread(comment_id: str, user: User = Depends(require_user)) -> CommentView:
+    c = _load(comment_id)
+    require_can("read", c["doc_path"], user)
+    row = comments_repo.set_thread_status(c["thread_root_id"], CommentStatus.OPEN.value)
+    if row is None:
+        raise HTTPException(status_code=404, detail="comment not found")
+    return CommentView.model_validate(row)
+
+
+@router.delete("/{comment_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_comment(comment_id: str, user: User = Depends(require_user)) -> Response:
+    c = _load(comment_id)
+    require_can("read", c["doc_path"], user)
+    _require_author_or_admin(c, user)
+    comments_repo.delete(comment_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -122,27 +122,27 @@ def _fire_event(doc_path: str, row: dict[str, Any], user: User) -> None:
 def list_comments(
     path: str = "", user: User = Depends(require_user)
 ) -> CommentListResponse:
-    rel = _safe_path(path)
-    require_can("read", rel, user)
+    rel_path = _safe_path(path)
+    require_can("read", rel_path, user)
     # Backstop: re-anchor any comment whose anchor lags HEAD (idempotent — a
     # no-op once the on-commit remap has run, which is the normal case).
     try:
-        comment_remap.remap_comments(rel)
+        comment_remap.remap_comments(rel_path)
     except Exception:
-        log.exception("comment remap backstop failed for %s", rel)
-    return CommentListResponse(threads=_group_threads(comments_repo.list_for_doc(rel)))
+        log.exception("comment remap backstop failed for %s", rel_path)
+    return CommentListResponse(threads=_group_threads(comments_repo.list_for_doc(rel_path)))
 
 
 @router.post("", response_model=CommentView, status_code=status.HTTP_201_CREATED)
 def create_comment(
     req: CreateCommentRequest, user: User = Depends(require_user)
 ) -> CommentView:
-    rel = _safe_path(req.path)
-    require_can("read", rel, user)
+    rel_path = _safe_path(req.path)
+    require_can("read", rel_path, user)
     if req.end_offset <= req.start_offset:
         raise HTTPException(status_code=400, detail="end_offset must be > start_offset")
     row = comments_repo.create_thread(
-        doc_path=rel,
+        doc_path=rel_path,
         body=req.body,
         author_user_id=user.id,
         anchor_sha=req.anchor_sha,
@@ -150,7 +150,7 @@ def create_comment(
         end_offset=req.end_offset,
         quoted_text=req.quoted_text,
     )
-    _fire_event(rel, row, user)
+    _fire_event(rel_path, row, user)
     return CommentView.model_validate(row)
 
 

--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -90,21 +90,27 @@ def _group_threads(rows: list[dict[str, Any]]) -> list[CommentThreadView]:
 
 
 def _fire_event(doc_path: str, row: dict[str, Any], user: User) -> None:
-    with session() as s:
-        s.add(
-            Event(
-                kind="page.comment",
-                actor=user.id,
-                target=doc_path,
-                payload_json=json.dumps(
-                    {
-                        "comment_id": row["id"],
-                        "thread_root_id": row["thread_root_id"],
-                        "doc_path": doc_path,
-                    }
-                ),
+    """Best-effort activity-feed event. The comment is already committed by the
+    time this runs, so a failure here must not 500 the request (which could
+    prompt a retry and a duplicate comment) — log and move on."""
+    try:
+        with session() as s:
+            s.add(
+                Event(
+                    kind="page.comment",
+                    actor=user.id,
+                    target=doc_path,
+                    payload_json=json.dumps(
+                        {
+                            "comment_id": row["id"],
+                            "thread_root_id": row["thread_root_id"],
+                            "doc_path": doc_path,
+                        }
+                    ),
+                )
             )
-        )
+    except Exception:
+        log.exception("failed to record page.comment event for %s", doc_path)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.api import (
     agent_sessions,
     auth,
     chat,
+    comments,
     documents,
     wiki,
     events,
@@ -197,6 +198,7 @@ def create_app() -> FastAPI:
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")
     app.include_router(triggers.router, prefix="/api/triggers")
     app.include_router(wiki.router, prefix="/api/wiki")
+    app.include_router(comments.router, prefix="/api/comments")
     app.include_router(documents.router, prefix="/api/documents")
     app.include_router(chat.router, prefix="/api/chat")
     app.include_router(mcp_server.router, prefix="/api/mcp")

--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from enum import Enum
 
+from pydantic import BaseModel, Field
+
 
 class CommentScope(str, Enum):
     """What a comment is attached to."""
@@ -35,3 +37,64 @@ class CommentStatus(str, Enum):
     OPEN = "open"
     RESOLVED = "resolved"
     ORPHANED = "orphaned"
+
+
+# --------------------------------------------------------------------------- #
+# HTTP shapes                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+class CreateCommentRequest(BaseModel):
+    """Start an inline comment thread on a page.
+
+    ``anchor_sha`` + the offsets are the version the client *read* and computed
+    the selection against — not necessarily current HEAD. The server stores
+    them as-is; the re-anchor path drifts them to HEAD. (This is what makes a
+    comment created against a stale view land correctly.)
+    """
+
+    path: str = Field(min_length=1)
+    anchor_sha: str = Field(min_length=1)
+    start_offset: int = Field(ge=0)
+    end_offset: int = Field(gt=0)
+    quoted_text: str
+    body: str = Field(min_length=1)
+
+
+class CreateReplyRequest(BaseModel):
+    body: str = Field(min_length=1)
+
+
+class EditCommentRequest(BaseModel):
+    body: str = Field(min_length=1)
+
+
+class CommentView(BaseModel):
+    id: str
+    doc_path: str
+    thread_root_id: str
+    parent_id: str | None
+    scope: CommentScope
+    anchor_sha: str | None
+    start_offset: int | None
+    end_offset: int | None
+    quoted_text: str | None
+    author_kind: CommentAuthorKind
+    author_user_id: str | None
+    body: str
+    status: CommentStatus
+    resolved_by_user_id: str | None
+    resolved_at: str | None
+    created_at: str
+    updated_at: str
+
+
+class CommentThreadView(BaseModel):
+    """A root comment plus its replies (oldest first)."""
+
+    root: CommentView
+    replies: list[CommentView]
+
+
+class CommentListResponse(BaseModel):
+    threads: list[CommentThreadView]

--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -57,7 +57,7 @@ class CreateCommentRequest(BaseModel):
     anchor_sha: str = Field(min_length=1)
     start_offset: int = Field(ge=0)
     end_offset: int = Field(gt=0)
-    quoted_text: str
+    quoted_text: str = Field(min_length=1)
     body: str = Field(min_length=1)
 
 

--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -242,12 +242,28 @@ def set_thread_status(
 
 
 def delete(comment_id: str) -> bool:
-    """Delete a comment. Deleting a root removes its replies via the
-    ``parent_id`` ON DELETE CASCADE. Returns True if a row was deleted."""
+    """Delete a comment. Returns True if a row was deleted.
+
+    - **Root** (``parent_id IS NULL``): deletes the whole thread — every reply
+      cascades via the ``parent_id`` ON DELETE CASCADE.
+    - **Non-root**: deletes only this comment; its direct replies are *kept* by
+      first re-parenting them up to this comment's parent, so a mid-thread
+      delete never takes the replies-to-it down with it.
+    """
     with session() as s:
         c = s.get(Comment, comment_id)
         if c is None:
             return False
+        if c.parent_id is not None:
+            # Promote this comment's children to its parent, then delete only
+            # this node (nothing references it anymore, so the cascade is a
+            # no-op beyond the single row).
+            s.execute(
+                update(Comment)
+                .where(Comment.parent_id == comment_id)
+                .values(parent_id=c.parent_id)
+                .execution_options(synchronize_session=False)
+            )
         s.delete(c)
         return True
 

--- a/backend/tests/test_comment_notify.py
+++ b/backend/tests/test_comment_notify.py
@@ -1,0 +1,79 @@
+"""Comment lifecycle wiring in ``app/wiki/notify.py``.
+
+The repo + remap functions are tested in isolation elsewhere; these tests assert
+that the post-write hooks actually invoke them — a doc write re-anchors, a delete
+orphans, a move re-keys, and a move out of ``.md``-space orphans.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.wiki import ChangeKind
+from app.wiki import comments, notify
+from app.wiki import git as wiki_git
+
+
+def _seed_comment(path: str, sha: str, body: str, phrase: str) -> dict[str, Any]:
+    start = body.index(phrase)
+    return comments.create_thread(
+        doc_path=path,
+        body="anchored here?",
+        author_user_id=None,
+        anchor_sha=sha,
+        start_offset=start,
+        end_offset=start + len(phrase),
+        quoted_text=phrase,
+    )
+
+
+def test_after_doc_write_remaps_comments(tmp_repo):
+    v1 = "Alpha beta. The target phrase stays. End."
+    sha1 = wiki_git.commit_file("a.md", v1, "seed", author=None)
+    c = _seed_comment("a.md", sha1, v1, "target phrase stays")
+
+    v2 = "The target phrase stays. End."  # dropped the leading "Alpha beta. "
+    sha2 = wiki_git.commit_file("a.md", v2, "edit", author=None)
+    notify.after_doc_write("a.md", sha2, ChangeKind.EDIT, actor=None)
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert got["anchor_sha"] == sha2  # advanced to HEAD
+    assert v2[got["start_offset"] : got["end_offset"]] == "target phrase stays"
+
+
+def test_after_doc_delete_orphans_comments(tmp_repo):
+    body = "Keep this sentence here."
+    sha = wiki_git.commit_file("a.md", body, "seed", author=None)
+    c = _seed_comment("a.md", sha, body, "sentence")
+
+    notify.after_doc_delete("a.md", sha, actor=None)
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert got["status"] == "orphaned"
+
+
+def test_after_path_move_md_to_md_rekeys_comments(tmp_repo):
+    body = "Keep this sentence here."
+    sha = wiki_git.commit_file("a.md", body, "seed", author=None)
+    c = _seed_comment("a.md", sha, body, "sentence")
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert comments.list_for_doc("a.md") == []
+    moved = comments.get(c["id"])
+    assert moved is not None
+    assert moved["doc_path"] == "b.md"
+
+
+def test_after_path_move_md_to_non_md_orphans_comments(tmp_repo):
+    body = "Keep this sentence here."
+    sha = wiki_git.commit_file("a.md", body, "seed", author=None)
+    c = _seed_comment("a.md", sha, body, "sentence")
+
+    notify.after_path_move([("a.md", "notes.txt")], sha, actor=None)
+
+    got = comments.get(c["id"])
+    assert got is not None
+    assert got["status"] == "orphaned"
+    assert got["doc_path"] == "a.md"  # not re-keyed — there's no new doc

--- a/backend/tests/test_comments_api.py
+++ b/backend/tests/test_comments_api.py
@@ -1,0 +1,173 @@
+"""Tests for ``app/api/comments.py`` — the HTTP layer for wiki comments.
+
+Uses a real wiki repo (``tmp_repo``) so anchors reference real commit SHAs and
+the GET re-anchor backstop has a repo to read. Pages committed directly via
+``wiki_git`` are unmanaged, so the ACL resolver treats them as implicit-public
+(read granted) — enough to exercise the comment routes.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import git as wiki_git
+from tests._auth import login_fastapi
+from tests._seed import list_events, seed_user
+
+_PATH = "guides/setup.md"
+_BODY = "Intro line here.\nThe target sentence to comment on.\nClosing line.\n"
+
+
+@pytest.fixture
+def client(tmp_repo):
+    return TestClient(create_app())
+
+
+def _commit_page(body: str = _BODY, path: str = _PATH) -> str:
+    return wiki_git.commit_file(path, body, "seed", author=None)
+
+
+def _create(client: TestClient, sha: str, phrase: str = "target sentence", *, path: str = _PATH):
+    start = _BODY.index(phrase)
+    return client.post(
+        "/api/comments",
+        json={
+            "path": path,
+            "anchor_sha": sha,
+            "start_offset": start,
+            "end_offset": start + len(phrase),
+            "quoted_text": phrase,
+            "body": "is this still accurate?",
+        },
+    )
+
+
+def test_unauthenticated_is_401(client):
+    assert client.get(f"/api/comments?path={_PATH}").status_code == 401
+
+
+def test_create_then_list_as_thread(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    sha = _commit_page()
+
+    r = _create(client, sha)
+    assert r.status_code == 201
+    created = r.json()
+    assert created["thread_root_id"] == created["id"]
+    assert created["scope"] == "inline"
+    assert created["status"] == "open"
+    assert created["author_user_id"] == uid
+
+    listing = client.get(f"/api/comments?path={_PATH}").json()
+    assert len(listing["threads"]) == 1
+    thread = listing["threads"][0]
+    assert thread["root"]["id"] == created["id"]
+    assert thread["replies"] == []
+
+
+def test_create_fires_page_comment_event(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    sha = _commit_page()
+    _create(client, sha)
+    events = list_events("page.comment")
+    assert len(events) == 1
+    assert events[0]["target"] == _PATH
+
+
+def test_reply_shows_under_root(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    sha = _commit_page()
+    root = _create(client, sha).json()
+
+    r = client.post(f"/api/comments/{root['id']}/replies", json={"body": "yep"})
+    assert r.status_code == 201
+    reply = r.json()
+    assert reply["parent_id"] == root["id"]
+    assert reply["thread_root_id"] == root["id"]
+    assert reply["anchor_sha"] is None  # replies inherit position, no anchor
+
+    thread = client.get(f"/api/comments?path={_PATH}").json()["threads"][0]
+    assert [c["id"] for c in thread["replies"]] == [reply["id"]]
+
+
+def test_resolve_and_reopen(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    sha = _commit_page()
+    root = _create(client, sha).json()
+
+    resolved = client.post(f"/api/comments/{root['id']}/resolve").json()
+    assert resolved["status"] == "resolved"
+    assert resolved["resolved_by_user_id"] == uid
+
+    reopened = client.post(f"/api/comments/{root['id']}/reopen").json()
+    assert reopened["status"] == "open"
+    assert reopened["resolved_by_user_id"] is None
+
+
+def test_edit_is_author_only(client):
+    author = seed_user(uid="u_author", email="author@x.com")
+    other = seed_user(uid="u_other", email="other@x.com")
+    login_fastapi(client, author)
+    sha = _commit_page()
+    root = _create(client, sha).json()
+
+    # Author can edit.
+    login_fastapi(client, author)
+    ok = client.patch(f"/api/comments/{root['id']}", json={"body": "edited"})
+    assert ok.status_code == 200
+    assert ok.json()["body"] == "edited"
+
+    # A different user cannot.
+    login_fastapi(client, other)
+    forbidden = client.patch(f"/api/comments/{root['id']}", json={"body": "nope"})
+    assert forbidden.status_code == 403
+
+
+def test_delete_is_author_only_and_cascades(client):
+    author = seed_user(uid="u_author", email="author@x.com")
+    other = seed_user(uid="u_other", email="other@x.com")
+    login_fastapi(client, author)
+    sha = _commit_page()
+    root = _create(client, sha).json()
+    client.post(f"/api/comments/{root['id']}/replies", json={"body": "r"})
+
+    # Non-author blocked.
+    login_fastapi(client, other)
+    assert client.delete(f"/api/comments/{root['id']}").status_code == 403
+
+    # Author deletes root -> thread (incl. reply) gone.
+    login_fastapi(client, author)
+    assert client.delete(f"/api/comments/{root['id']}").status_code == 204
+    assert client.get(f"/api/comments?path={_PATH}").json()["threads"] == []
+
+
+def test_create_rejects_inverted_range(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    sha = _commit_page()
+    r = client.post(
+        "/api/comments",
+        json={
+            "path": _PATH,
+            "anchor_sha": sha,
+            "start_offset": 10,
+            "end_offset": 5,
+            "quoted_text": "x",
+            "body": "bad range",
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_actions_on_missing_comment_404(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    assert client.post("/api/comments/cmt_missing/replies", json={"body": "x"}).status_code == 404
+    assert client.patch("/api/comments/cmt_missing", json={"body": "x"}).status_code == 404
+    assert client.post("/api/comments/cmt_missing/resolve").status_code == 404
+    assert client.delete("/api/comments/cmt_missing").status_code == 404

--- a/backend/tests/test_comments_repo.py
+++ b/backend/tests/test_comments_repo.py
@@ -149,8 +149,26 @@ def test_delete_root_cascades_replies(tmp_db):
 
     assert comments.delete(root["id"]) is True
     assert comments.get(root["id"]) is None
-    assert comments.get(reply["id"]) is None  # cascaded
+    assert comments.get(reply["id"]) is None  # whole thread gone
     assert comments.delete("cmt_missing") is False
+
+
+def test_delete_middle_comment_keeps_children(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _seed_root(alice)
+    mid = comments.add_reply(parent_id=root["id"], body="mid", author_user_id=alice)
+    assert mid is not None
+    leaf = comments.add_reply(parent_id=mid["id"], body="leaf", author_user_id=alice)
+    assert leaf is not None
+
+    # Delete the middle comment — the leaf must survive, re-parented up to root.
+    assert comments.delete(mid["id"]) is True
+    assert comments.get(mid["id"]) is None
+    surviving = comments.get(leaf["id"])
+    assert surviving is not None
+    assert surviving["parent_id"] == root["id"]  # promoted to the deleted node's parent
+    assert surviving["thread_root_id"] == root["id"]
+    assert comments.get(root["id"]) is not None
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

The HTTP layer for wiki comments — a thin router over the repo + re-anchor module merged in #157. With this, comments are usable end-to-end via the API (frontend is the next PR).

## Endpoints (`/api/comments`)

| Method | Route | Purpose |
|--------|-------|---------|
| `GET` | `?path=…` | list a page's comments, grouped into threads (root + replies) |
| `POST` | `` | create an inline comment thread |
| `POST` | `/{id}/replies` | reply |
| `PATCH` | `/{id}` | edit body |
| `POST` | `/{id}/resolve` · `/{id}/reopen` | resolve / reopen the thread |
| `DELETE` | `/{id}` | delete (cascades replies) |

## Gating

- **`require_can("read", path, user)`** to view *and* to comment — read access is enough (feedback, not mutation; matches today's openness). A dedicated `comment` ACL tier stays an additive follow-up if we want to restrict.
- **edit / delete** additionally require the **author or an admin**.
- **resolve / reopen** act on the thread **root** regardless of which member id is passed.

## Notable

- **Client-supplied anchor.** `create` stores the `anchor_sha` + offsets the client *read* (not current HEAD), so a comment made against a slightly stale view still lands correctly once re-anchored. This is the create-vs-concurrent-edit contract.
- **GET re-anchor backstop.** The list endpoint runs `remap_comments(path)` first — idempotent (a no-op once the on-commit remap has run), but heals any comment whose anchor lags HEAD if an eager remap was ever swallowed.
- **Event.** `create` fires `Event(kind="page.comment")` into the activity feed.
- `app/models/comment.py` gains the request/response models, typed with the `Comment*` enums.

## Tests (`tests/test_comments_api.py`)

create/list-as-thread, reply, resolve/reopen, author-only edit + delete (+ cascade), inverted-range → 400, missing-comment → 404, unauth → 401, event fired. ruff + whole-project basedpyright clean.

tested api locally

## Follow-ups (not blocking)

- Frontend render-mode UI (next PR).
- Dedicated `comment` permission tier, if we decide to restrict.
- Rename `notify` → `post_write` (separate cleanup PR).