### PR TITLE
feat(comments): render-mode comments UI (Phase 1, PR 4)

### DIFF
--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -275,15 +275,22 @@ def delete(comment_id: str) -> bool:
 
 def roots_needing_remap(doc_path: str, head_sha: str) -> list[dict[str, Any]]:
     """Inline thread roots on ``doc_path`` whose stored anchor is not yet at
-    ``head_sha`` and can still be remapped (not orphaned). The re-anchor task
-    diffs each one's body-at-``anchor_sha`` to the body at HEAD."""
+    ``head_sha`` and should track edits — i.e. **open** threads only. The
+    re-anchor task diffs each one's body-at-``anchor_sha`` to the body at HEAD.
+
+    Orphaned and resolved threads are deliberately excluded. Orphaned ones have
+    no live span left; resolved ones are done, so re-anchoring a resolved
+    comment (and re-orphaning it when its span is gone) would silently flip it
+    back out of ``resolved`` — which read as "resolve doesn't stick". A reopened
+    thread returns to ``open`` and re-enters this pool, so its anchor catches up
+    then."""
     with session() as s:
         rows = s.scalars(
             select(Comment).where(
                 Comment.doc_path == doc_path,
                 Comment.parent_id.is_(None),
                 Comment.scope == CommentScope.INLINE.value,
-                Comment.status != CommentStatus.ORPHANED.value,
+                Comment.status == CommentStatus.OPEN.value,
                 Comment.anchor_sha != head_sha,
             )
         ).all()

--- a/backend/tests/test_comments_repo.py
+++ b/backend/tests/test_comments_repo.py
@@ -188,7 +188,15 @@ def test_roots_needing_remap_filters(tmp_db):
     need = comments.roots_needing_remap(_DOC, "sha2")
     assert [c["id"] for c in need] == [root["id"]]
 
-    # Orphaned roots are excluded; resolved roots are still remapped.
+    # Resolved roots are excluded: re-anchoring (and possibly re-orphaning) a
+    # resolved thread would flip it back out of `resolved`. Reopening returns it
+    # to the pool.
+    comments.set_thread_status(root["id"], "resolved", resolved_by_user_id=alice)
+    assert comments.roots_needing_remap(_DOC, "sha2") == []
+    comments.set_thread_status(root["id"], "open")
+    assert [c["id"] for c in comments.roots_needing_remap(_DOC, "sha2")] == [root["id"]]
+
+    # Orphaned roots are excluded too — no live span left to track.
     comments.orphan(root["id"])
     assert comments.roots_needing_remap(_DOC, "sha2") == []
 

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -30,7 +30,12 @@ import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { FolderIcon, FileIcon } from "@/components/wiki/WikiIcons";
 import { apiFetch, ApiError } from "@/lib/api";
-import { selectionToAnchor, type CommentDraft } from "@/lib/commentAnchor";
+import { listComments } from "@/lib/comments";
+import {
+  paintCommentHighlights,
+  selectionToAnchor,
+  type CommentDraft,
+} from "@/lib/commentAnchor";
 import { rehypeSourcePos } from "@/lib/rehypeSourcePos";
 import { useRequireAuth } from "@/lib/auth";
 import { useDrafting } from "@/lib/drafting";
@@ -51,7 +56,11 @@ import {
   fetchFileHistory,
   type FileDiffResponse,
 } from "@/lib/wiki";
-import type { DocumentActivity, DocumentActivityResponse } from "@/types";
+import type {
+  CommentThreadView,
+  DocumentActivity,
+  DocumentActivityResponse,
+} from "@/types";
 
 interface DocEntry {
   path: string;
@@ -1415,10 +1424,58 @@ function FileViewer({ path }: { path: string }) {
   // composed; `selTool` is the floating "Comment" affordance shown on select.
   const [commentsOpen, setCommentsOpen] = useState(false);
   const [commentDraft, setCommentDraft] = useState<CommentDraft | null>(null);
+  const [commentThreads, setCommentThreads] = useState<CommentThreadView[]>([]);
   const [selTool, setSelTool] = useState<{ x: number; y: number; draft: CommentDraft } | null>(
     null,
   );
   const articleRef = useRef<HTMLElement | null>(null);
+  // Page owns the comment threads (so highlights render even with the panel
+  // closed). Auto-open the panel once per path when a page has comments.
+  const autoOpenedPathRef = useRef<string | null>(null);
+
+  const refreshComments = useCallback(async () => {
+    try {
+      const t = await listComments(path);
+      setCommentThreads(t);
+      if (t.length > 0 && autoOpenedPathRef.current !== path) {
+        autoOpenedPathRef.current = path;
+        setCommentsOpen(true);
+      }
+    } catch {
+      // comments are non-critical chrome; ignore load failures
+    }
+  }, [path]);
+
+  useEffect(() => {
+    autoOpenedPathRef.current = null;
+    setCommentThreads([]);
+    void refreshComments();
+  }, [refreshComments]);
+
+  // Paint Google-Docs-style highlights over the rendered article for each
+  // (non-orphaned) anchored comment. Cleared in edit/diff mode (no article).
+  useEffect(() => {
+    const el = articleRef.current;
+    if (!el || editing || viewingSha) {
+      if (el) paintCommentHighlights(el, body, []);
+      return;
+    }
+    const targets = commentThreads
+      .map((t) => t.root)
+      .filter(
+        (r) =>
+          r.status !== "orphaned" &&
+          r.start_offset !== null &&
+          r.end_offset !== null &&
+          r.quoted_text !== null,
+      )
+      .map((r) => ({
+        startOffset: r.start_offset as number,
+        endOffset: r.end_offset as number,
+        quotedText: r.quoted_text as string,
+      }));
+    paintCommentHighlights(el, body, targets);
+  }, [commentThreads, body, editing, viewingSha]);
 
   // On a text selection in the rendered article, offer a floating "Comment"
   // affordance anchored above the selection (render mode only).
@@ -2515,6 +2572,8 @@ function FileViewer({ path }: { path: string }) {
               path={path}
               headSha={headSha}
               draft={commentDraft}
+              threads={commentThreads}
+              onChanged={refreshComments}
               onDraftConsumed={() => setCommentDraft(null)}
               onClose={() => {
                 setCommentsOpen(false);
@@ -2589,6 +2648,8 @@ function FileViewer({ path }: { path: string }) {
               path={path}
               headSha={headSha}
               draft={commentDraft}
+              threads={commentThreads}
+              onChanged={refreshComments}
               onDraftConsumed={() => setCommentDraft(null)}
               onClose={() => {
                 setCommentsOpen(false);

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -27,8 +27,11 @@ import {
   type AgentSessionSummary,
 } from "@/lib/launchers";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
+import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { FolderIcon, FileIcon } from "@/components/wiki/WikiIcons";
 import { apiFetch, ApiError } from "@/lib/api";
+import { selectionToAnchor, type CommentDraft } from "@/lib/commentAnchor";
+import { rehypeSourcePos } from "@/lib/rehypeSourcePos";
 import { useRequireAuth } from "@/lib/auth";
 import { useDrafting } from "@/lib/drafting";
 import { rememberWikiPath } from "@/lib/lastViewed";
@@ -1408,6 +1411,42 @@ function FileViewer({ path }: { path: string }) {
   const [commits, setCommits] = useState<CommitInfo[] | null>(null);
   const [diffData, setDiffData] = useState<FileDiffResponse | null>(null);
   const [historyError, setHistoryError] = useState<string | null>(null);
+  // Comments (render-mode). `commentDraft` is a pending text selection being
+  // composed; `selTool` is the floating "Comment" affordance shown on select.
+  const [commentsOpen, setCommentsOpen] = useState(false);
+  const [commentDraft, setCommentDraft] = useState<CommentDraft | null>(null);
+  const [selTool, setSelTool] = useState<{ x: number; y: number; draft: CommentDraft } | null>(
+    null,
+  );
+  const articleRef = useRef<HTMLElement | null>(null);
+
+  // On a text selection in the rendered article, offer a floating "Comment"
+  // affordance anchored above the selection (render mode only).
+  const onArticleMouseUp = useCallback(() => {
+    const el = articleRef.current;
+    const sel = window.getSelection();
+    if (!el || !sel || sel.rangeCount === 0) {
+      setSelTool(null);
+      return;
+    }
+    const draft = selectionToAnchor(el, body);
+    if (!draft) {
+      setSelTool(null);
+      return;
+    }
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    setSelTool({ x: rect.left + rect.width / 2, y: rect.top, draft });
+  }, [body]);
+
+  useEffect(() => {
+    const onSel = () => {
+      const s = window.getSelection();
+      if (!s || s.isCollapsed) setSelTool(null);
+    };
+    document.addEventListener("selectionchange", onSel);
+    return () => document.removeEventListener("selectionchange", onSel);
+  }, []);
+
   // Active-agents panel (collapsible chip near the top of the doc).
   // We always know the count (so the chip can label "Active agents (N)"),
   // but the entry list only renders when the user expands it.
@@ -2017,6 +2056,21 @@ function FileViewer({ path }: { path: string }) {
               >
                 History
               </Button>
+              <Button
+                onClick={() => setCommentsOpen((v) => !v)}
+                aria-pressed={commentsOpen}
+                style={
+                  commentsOpen
+                    ? {
+                        background: color.accent.subtleBg,
+                        color: color.accent.subtleFg,
+                        borderColor: color.accent.subtleBorder,
+                      }
+                    : undefined
+                }
+              >
+                Comments
+              </Button>
             </div>
             <Button variant="primary" onClick={startEdit}>
               Edit
@@ -2432,10 +2486,15 @@ function FileViewer({ path }: { path: string }) {
               </div>
             ) : (
               <article
+                ref={articleRef}
                 className="markdown"
                 style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+                onMouseUp={onArticleMouseUp}
               >
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeSourcePos]}
+                >
                   {body}
                 </ReactMarkdown>
               </article>
@@ -2449,6 +2508,18 @@ function FileViewer({ path }: { path: string }) {
               viewingSha={viewingSha}
               onPick={onPickCommit}
               onClose={() => setHistoryOpen(false)}
+            />
+          )}
+          {commentsOpen && !isMobile && (
+            <CommentsPanel
+              path={path}
+              headSha={headSha}
+              draft={commentDraft}
+              onDraftConsumed={() => setCommentDraft(null)}
+              onClose={() => {
+                setCommentsOpen(false);
+                setCommentDraft(null);
+              }}
             />
           )}
         </div>
@@ -2494,6 +2565,80 @@ function FileViewer({ path }: { path: string }) {
             />
           </div>
         </>
+      )}
+      {commentsOpen && isMobile && (
+        <>
+          <div
+            onClick={() => setCommentsOpen(false)}
+            aria-hidden
+            style={{ position: "fixed", inset: 0, background: color.overlay, zIndex: 60 }}
+          />
+          <div
+            style={{
+              position: "fixed",
+              top: 0,
+              right: 0,
+              bottom: 0,
+              width: "min(360px, 100vw)",
+              zIndex: 70,
+              display: "flex",
+              boxShadow: shadow.panel,
+            }}
+          >
+            <CommentsPanel
+              path={path}
+              headSha={headSha}
+              draft={commentDraft}
+              onDraftConsumed={() => setCommentDraft(null)}
+              onClose={() => {
+                setCommentsOpen(false);
+                setCommentDraft(null);
+              }}
+              fullHeight
+            />
+          </div>
+        </>
+      )}
+      {selTool && (
+        <div
+          onMouseDown={(e) => e.preventDefault()}
+          style={{
+            position: "fixed",
+            left: selTool.x,
+            top: selTool.y - 8,
+            transform: "translate(-50%, -100%)",
+            zIndex: 80,
+            background: color.bg.panel,
+            border: `1px solid ${color.border.default}`,
+            borderRadius: radius.md,
+            boxShadow: shadow.popover,
+            padding: 4,
+          }}
+        >
+          <button
+            onClick={() => {
+              setCommentDraft(selTool.draft);
+              setCommentsOpen(true);
+              setSelTool(null);
+              window.getSelection()?.removeAllRanges();
+            }}
+            style={{
+              appearance: "none",
+              border: "none",
+              background: "transparent",
+              color: color.text.primary,
+              cursor: "pointer",
+              fontSize: 13,
+              padding: "6px 10px",
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              whiteSpace: "nowrap",
+            }}
+          >
+            💬 Comment
+          </button>
+        </div>
       )}
     </main>
   );

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -1486,31 +1486,94 @@ function FileViewer({ path }: { path: string }) {
     void refreshComments();
   }, [refreshComments]);
 
+  // Render the markdown once per body change and reuse the element on every
+  // unrelated re-render (panel open/close, active-comment change, …). A fresh
+  // <ReactMarkdown> element would let React reconcile and replace the article's
+  // text nodes, which silently invalidates the CSS Highlight Ranges painted
+  // over them — the bug where highlights vanished until you clicked a comment.
+  const renderedBody = useMemo(
+    () => (
+      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSourcePos]}>
+        {body}
+      </ReactMarkdown>
+    ),
+    [body],
+  );
+
   // Paint Google-Docs-style highlights over the rendered article for each
   // (non-orphaned) anchored comment. Cleared in edit/diff mode (no article).
+  //
+  // On a fresh load the comments and the doc body arrive on separate renders,
+  // and react-markdown commits its text nodes a tick later than this effect
+  // runs — so a single synchronous (or even rAF-deferred) paint finds no text
+  // to range over and silently no-ops, which is why nothing was highlighted
+  // until a click happened to re-run the paint against a settled DOM. We make
+  // it robust by (a) painting now, (b) painting on the next frame, and (c)
+  // watching the article subtree with a MutationObserver and repainting whenever
+  // react-markdown finally swaps in / replaces the rendered nodes. The CSS
+  // Custom Highlight API doesn't mutate the DOM, so this never loops.
   useEffect(() => {
     const el = articleRef.current;
-    if (!el || editing || viewingSha) {
-      if (el) paintCommentHighlights(el, body, []);
-      return;
-    }
-    const targets = commentThreads
-      .map((t) => t.root)
-      .filter(
-        (r) =>
-          r.status !== "orphaned" &&
-          r.start_offset !== null &&
-          r.end_offset !== null &&
-          r.quoted_text !== null,
-      )
-      .map((r) => ({
-        startOffset: r.start_offset as number,
-        endOffset: r.end_offset as number,
-        quotedText: r.quoted_text as string,
-        active: r.id === activeCommentId,
-      }));
-    paintCommentHighlights(el, body, targets);
-  }, [commentThreads, body, editing, viewingSha, activeCommentId]);
+    if (!el) return;
+    const clear = editing || viewingSha;
+    const targets = clear
+      ? []
+      : commentThreads
+          .map((t) => t.root)
+          .filter(
+            // Resolved threads disappear from the panel, so drop their doc
+            // highlight too; orphaned ones have no live span to paint.
+            (r) =>
+              r.status !== "orphaned" &&
+              r.status !== "resolved" &&
+              r.start_offset !== null &&
+              r.end_offset !== null &&
+              r.quoted_text !== null,
+          )
+          .map((r) => ({
+            startOffset: r.start_offset as number,
+            endOffset: r.end_offset as number,
+            quotedText: r.quoted_text as string,
+            active: r.id === activeCommentId,
+          }));
+
+    let cancelled = false;
+    let raf = 0;
+    let attempts = 0;
+    const MAX_ATTEMPTS = 60; // ~1s at 60fps, then give up (some spans may be unmappable)
+    const tick = () => {
+      if (cancelled) return;
+      const painted = paintCommentHighlights(el, body, targets);
+      attempts += 1;
+      // The markdown text nodes commit a tick after React renders, so the first
+      // paint can find nothing to range over. Retry per-frame until every target
+      // lands (or we hit the cap) — this is what makes highlights appear on a
+      // fresh load instead of only after a click re-ran the paint.
+      if (painted < targets.length && attempts < MAX_ATTEMPTS) {
+        raf = requestAnimationFrame(tick);
+      }
+    };
+    tick();
+
+    // Repaint when react-markdown later swaps nodes (e.g. an edit/remap rerenders
+    // the body). Reset the retry budget so the fresh DOM gets a full set of tries.
+    const observer = new MutationObserver(() => {
+      attempts = 0;
+      cancelAnimationFrame(raf);
+      tick();
+    });
+    observer.observe(el, { childList: true, subtree: true, characterData: true });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+    };
+    // `loading` gates whether <article> is mounted: when the body is primed by
+    // the SWR cache before `loading` flips, `body` doesn't change on mount, so
+    // without this dep the effect wouldn't re-run and the article would mount
+    // with no paint (highlights only appeared after a click). Re-run on mount.
+  }, [commentThreads, body, editing, viewingSha, activeCommentId, loading]);
 
   // On a text selection in the rendered article, offer a floating "Comment"
   // affordance anchored above the selection (render mode only).
@@ -2586,12 +2649,7 @@ function FileViewer({ path }: { path: string }) {
                 style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
                 onMouseUp={onArticleMouseUp}
               >
-                <ReactMarkdown
-                  remarkPlugins={[remarkGfm]}
-                  rehypePlugins={[rehypeSourcePos]}
-                >
-                  {body}
-                </ReactMarkdown>
+                {renderedBody}
               </article>
             )}
           </div>

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -2615,29 +2615,19 @@ function FileViewer({ path }: { path: string }) {
             padding: 4,
           }}
         >
-          <button
+          <Button
+            variant="ghost"
+            size="sm"
             onClick={() => {
               setCommentDraft(selTool.draft);
               setCommentsOpen(true);
               setSelTool(null);
               window.getSelection()?.removeAllRanges();
             }}
-            style={{
-              appearance: "none",
-              border: "none",
-              background: "transparent",
-              color: color.text.primary,
-              cursor: "pointer",
-              fontSize: 13,
-              padding: "6px 10px",
-              display: "flex",
-              alignItems: "center",
-              gap: 6,
-              whiteSpace: "nowrap",
-            }}
+            style={{ display: "flex", alignItems: "center", gap: 6, whiteSpace: "nowrap" }}
           >
             💬 Comment
-          </button>
+          </Button>
         </div>
       )}
     </main>

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -1425,6 +1425,7 @@ function FileViewer({ path }: { path: string }) {
   const [commentsOpen, setCommentsOpen] = useState(false);
   const [commentDraft, setCommentDraft] = useState<CommentDraft | null>(null);
   const [commentThreads, setCommentThreads] = useState<CommentThreadView[]>([]);
+  const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const [selTool, setSelTool] = useState<{ x: number; y: number; draft: CommentDraft } | null>(
     null,
   );
@@ -1473,9 +1474,10 @@ function FileViewer({ path }: { path: string }) {
         startOffset: r.start_offset as number,
         endOffset: r.end_offset as number,
         quotedText: r.quoted_text as string,
+        active: r.id === activeCommentId,
       }));
     paintCommentHighlights(el, body, targets);
-  }, [commentThreads, body, editing, viewingSha]);
+  }, [commentThreads, body, editing, viewingSha, activeCommentId]);
 
   // On a text selection in the rendered article, offer a floating "Comment"
   // affordance anchored above the selection (render mode only).
@@ -1897,6 +1899,9 @@ function FileViewer({ path }: { path: string }) {
       } catch {
         // fresh fetch failed — body already shows the local draft
       }
+      // The commit re-anchored comments server-side; refetch so the panel +
+      // highlights reflect the drift (won't re-open the panel — guarded).
+      void refreshComments();
       // The server clears the draft row when the body diverges from
       // the template snapshot — re-sync our context so the chat
       // banner disappears at the same moment.
@@ -2574,6 +2579,8 @@ function FileViewer({ path }: { path: string }) {
               draft={commentDraft}
               threads={commentThreads}
               onChanged={refreshComments}
+              activeId={activeCommentId}
+              onActivate={setActiveCommentId}
               onDraftConsumed={() => setCommentDraft(null)}
               onClose={() => {
                 setCommentsOpen(false);
@@ -2650,6 +2657,8 @@ function FileViewer({ path }: { path: string }) {
               draft={commentDraft}
               threads={commentThreads}
               onChanged={refreshComments}
+              activeId={activeCommentId}
+              onActivate={setActiveCommentId}
               onDraftConsumed={() => setCommentDraft(null)}
               onClose={() => {
                 setCommentsOpen(false);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -355,3 +355,9 @@ textarea::placeholder {
 .scroll-x-hidden::-webkit-scrollbar {
   display: none;
 }
+
+/* Inline highlight for commented spans (CSS Custom Highlight API). The wiki
+   page registers Ranges under this name via paintCommentHighlights(). */
+::highlight(wiki-comment) {
+  background-color: var(--color-accent-subtle-bg);
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -60,6 +60,9 @@ html {
   --color-accent-subtle-bg-hover: #e8e7e4;
   --color-accent-subtle-fg: #37352f;
   --color-accent-subtle-border: #dcdbd8;
+  /* Commented-span highlight (Google-Docs-style yellow). Semi-transparent so it
+     blends over code-span backgrounds too. */
+  --color-comment-highlight: rgba(255, 212, 0, 0.38);
 
   /* Semantic state colors */
   --color-state-success-bg: #dcfce7;
@@ -140,6 +143,8 @@ html {
   --color-accent-subtle-bg-hover: #46433e;
   --color-accent-subtle-fg: #ededec;
   --color-accent-subtle-border: #555049;
+  /* Dimmer amber so it reads on the dark page without glowing. */
+  --color-comment-highlight: rgba(250, 204, 21, 0.3);
 
   /* State colors — desaturated for dark mode, foregrounds lifted. */
   --color-state-success-bg: #14361f;
@@ -359,5 +364,5 @@ textarea::placeholder {
 /* Inline highlight for commented spans (CSS Custom Highlight API). The wiki
    page registers Ranges under this name via paintCommentHighlights(). */
 ::highlight(wiki-comment) {
-  background-color: var(--color-accent-subtle-bg);
+  background-color: var(--color-comment-highlight);
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -61,8 +61,10 @@ html {
   --color-accent-subtle-fg: #37352f;
   --color-accent-subtle-border: #dcdbd8;
   /* Commented-span highlight (Google-Docs-style yellow). Semi-transparent so it
-     blends over code-span backgrounds too. */
+     blends over code-span backgrounds too. The -active shade is the stronger
+     orange shown when its comment thread is selected. */
   --color-comment-highlight: rgba(255, 212, 0, 0.38);
+  --color-comment-highlight-active: rgba(255, 159, 28, 0.6);
 
   /* Semantic state colors */
   --color-state-success-bg: #dcfce7;
@@ -145,6 +147,7 @@ html {
   --color-accent-subtle-border: #555049;
   /* Dimmer amber so it reads on the dark page without glowing. */
   --color-comment-highlight: rgba(250, 204, 21, 0.3);
+  --color-comment-highlight-active: rgba(255, 159, 28, 0.5);
 
   /* State colors — desaturated for dark mode, foregrounds lifted. */
   --color-state-success-bg: #14361f;
@@ -365,4 +368,7 @@ textarea::placeholder {
    page registers Ranges under this name via paintCommentHighlights(). */
 ::highlight(wiki-comment) {
   background-color: var(--color-comment-highlight);
+}
+::highlight(wiki-comment-active) {
+  background-color: var(--color-comment-highlight-active);
 }

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -111,13 +111,14 @@
   gap: 6px;
   margin-top: 8px;
 }
-.replies {
-  margin-top: 8px;
-  padding-left: 10px;
-  border-left: 2px solid var(--color-border-subtle);
+.threadBody {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
+}
+
+.replyBox {
+  margin-top: 10px;
 }
 
 .textarea {

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -5,7 +5,6 @@
   min-height: 0;
   background: var(--color-bg-panel);
   border-left: 1px solid var(--color-border-subtle);
-  box-shadow: var(--shadow-panel);
 }
 
 .fullHeight {
@@ -14,50 +13,51 @@
   border-left: none;
 }
 
-.header {
+/* No title bar — comments float as separate cards (Google-Docs style). Just a
+   quiet close affordance pinned to the top-right. */
+.closeRow {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--color-border-subtle);
+  justify-content: flex-end;
+  padding: 6px 8px 0;
 }
 
 .scroll {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 12px;
+  padding: 4px 12px 16px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
 }
 
+/* Each thread is its own floating card, clearly separated from its neighbors —
+   not rows inside one panel. */
 .thread {
   border: 1px solid var(--color-border-subtle);
-  border-radius: 8px;
-  padding: 10px;
+  border-radius: 12px;
+  padding: 14px;
   background: var(--color-bg-page);
+  box-shadow: var(--shadow-sm);
   cursor: pointer;
 }
 .threadResolved {
   opacity: 0.65;
 }
-/* Selected thread — matches the orange doc highlight on its referenced span. */
+/* Selected thread — a crisp bold (near-black, accent) outline on the white card.
+   No layout shift: the extra weight comes from a 1px ring, not a wider border. */
 .threadActive {
-  border-color: var(--color-comment-highlight-active);
-  box-shadow: 0 0 0 1px var(--color-comment-highlight-active);
+  border-color: var(--color-accent-bg);
+  box-shadow: 0 0 0 1px var(--color-accent-bg);
 }
 
 /* Tombstone shown in place of the (now-removed) quote box when the referenced
-   text was deleted from the doc, so there's no highlight to point at. */
+   text was deleted from the doc, so there's no highlight to point at. Plain
+   muted text — no colored callout. */
 .orphanedNote {
   font-size: 12px;
-  color: var(--color-state-warning-fg);
-  background: var(--color-state-warning-bg);
-  border-left: 3px solid var(--color-state-warning-border);
-  padding: 4px 8px;
-  border-radius: 4px;
+  color: var(--color-text-muted);
+  font-style: italic;
   margin-bottom: 8px;
 }
 
@@ -84,28 +84,59 @@
 
 .metaRow {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   margin-bottom: 4px;
+  min-height: 24px;
 }
 .time {
   font-size: 11px;
   color: var(--color-text-muted);
 }
-.badge {
+/* Right-aligned trailing group: resolved badge + overflow menu. */
+.metaRight {
   margin-left: auto;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 1px 6px;
-  border-radius: 9999px;
-  border: 1px solid var(--color-border-default);
-  color: var(--color-text-muted);
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
-.badgeResolved {
-  background: var(--color-state-success-bg);
-  border-color: var(--color-state-success-border);
-  color: var(--color-state-success-fg);
+/* Overflow (⋯) menu trigger — hidden until the comment is hovered/focused, or
+   forced visible while its menu is open. Always shown on touch (no hover). */
+.kebab {
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.comment:hover .kebab,
+.comment:focus-within .kebab,
+.kebabOpen {
+  opacity: 1;
+}
+@media (hover: none) {
+  .kebab {
+    opacity: 1;
+  }
+}
+/* Icon-only overflow trigger (Radix renders this <button> directly). */
+.kebabBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.kebabBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+.kebabBtn svg {
+  width: 16px;
+  height: 16px;
 }
 
 .body {
@@ -120,27 +151,6 @@
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 8px;
-}
-
-/* Per-comment Edit/Delete — revealed on hover (or keyboard focus within) so the
-   thread stays quiet until you reach for it. Always visible on touch, which has
-   no hover state. */
-.commentActions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-top: 8px;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-.comment:hover .commentActions,
-.comment:focus-within .commentActions {
-  opacity: 1;
-}
-@media (hover: none) {
-  .commentActions {
-    opacity: 1;
-  }
 }
 .threadBody {
   display: flex;
@@ -181,4 +191,19 @@
   color: var(--color-state-danger-fg);
   font-size: 12px;
   padding: 4px 0;
+}
+
+/* Low-key toggle to reveal/hide the resolved threads kept out of the main list. */
+.resolvedToggle {
+  align-self: flex-start;
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  padding: 4px 2px;
+  cursor: pointer;
+}
+.resolvedToggle:hover {
+  color: var(--color-text-primary);
+  text-decoration: underline;
 }

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -23,18 +23,6 @@
   border-bottom: 1px solid var(--color-border-subtle);
 }
 
-.title {
-  font-weight: 600;
-  color: var(--color-text-primary);
-  font-size: 14px;
-}
-
-.count {
-  color: var(--color-text-muted);
-  font-weight: 400;
-  margin-left: 6px;
-}
-
 .scroll {
   flex: 1;
   min-height: 0;
@@ -43,13 +31,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-}
-
-.empty {
-  color: var(--color-text-muted);
-  font-size: 13px;
-  text-align: center;
-  padding: 24px 8px;
 }
 
 .quote {
@@ -91,11 +72,6 @@
   align-items: baseline;
   gap: 8px;
   margin-bottom: 4px;
-}
-.author {
-  font-weight: 600;
-  font-size: 13px;
-  color: var(--color-text-primary);
 }
 .time {
   font-size: 11px;

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -1,0 +1,209 @@
+.panel {
+  display: flex;
+  flex-direction: column;
+  width: 340px;
+  min-height: 0;
+  background: var(--color-bg-panel);
+  border-left: 1px solid var(--color-border-subtle);
+  box-shadow: var(--shadow-panel);
+}
+
+.fullHeight {
+  width: 100%;
+  height: 100%;
+  border-left: none;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.title {
+  font-weight: 600;
+  color: var(--color-text-primary);
+  font-size: 14px;
+}
+
+.count {
+  color: var(--color-text-muted);
+  font-weight: 400;
+  margin-left: 6px;
+}
+
+.closeBtn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 16px;
+  line-height: 1;
+}
+.closeBtn:hover {
+  background: var(--color-bg-hover);
+}
+
+.scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px 8px;
+}
+
+.quote {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  background: var(--color-accent-subtle-bg);
+  border-left: 3px solid var(--color-accent-subtle-border);
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-bottom: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.quoteOrphaned {
+  border-left-color: var(--color-state-warning-border);
+  background: var(--color-state-warning-bg);
+  color: var(--color-state-warning-fg);
+}
+
+.thread {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-bg-page);
+}
+.threadResolved {
+  opacity: 0.65;
+}
+
+.draft {
+  border: 1px solid var(--color-accent-subtle-border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-bg-sunken);
+}
+
+.metaRow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.author {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--color-text-primary);
+}
+.time {
+  font-size: 11px;
+  color: var(--color-text-muted);
+}
+.badge {
+  margin-left: auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 9999px;
+  border: 1px solid var(--color-border-default);
+  color: var(--color-text-muted);
+}
+.badgeResolved {
+  background: var(--color-state-success-bg);
+  border-color: var(--color-state-success-border);
+  color: var(--color-state-success-fg);
+}
+.badgeOrphaned {
+  background: var(--color-state-warning-bg);
+  border-color: var(--color-state-warning-border);
+  color: var(--color-state-warning-fg);
+}
+
+.body {
+  font-size: 13px;
+  color: var(--color-text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.linkBtn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+.linkBtn:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text-primary);
+}
+.linkBtnDanger:hover {
+  color: var(--color-state-danger-fg);
+}
+
+.replies {
+  margin-top: 8px;
+  padding-left: 10px;
+  border-left: 2px solid var(--color-border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 54px;
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 6px;
+  background: var(--color-bg-page);
+  color: var(--color-text-primary);
+}
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-border-focus);
+}
+
+.composeRow {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.error {
+  color: var(--color-state-danger-fg);
+  font-size: 12px;
+  padding: 4px 0;
+}

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -33,6 +33,43 @@
   gap: 10px;
 }
 
+.thread {
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-bg-page);
+  cursor: pointer;
+}
+.threadResolved {
+  opacity: 0.65;
+}
+/* Selected thread — matches the orange doc highlight on its referenced span. */
+.threadActive {
+  border-color: var(--color-comment-highlight-active);
+  box-shadow: 0 0 0 1px var(--color-comment-highlight-active);
+}
+
+/* Tombstone shown in place of the (now-removed) quote box when the referenced
+   text was deleted from the doc, so there's no highlight to point at. */
+.orphanedNote {
+  font-size: 12px;
+  color: var(--color-state-warning-fg);
+  background: var(--color-state-warning-bg);
+  border-left: 3px solid var(--color-state-warning-border);
+  padding: 4px 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+.draft {
+  border: 1px solid var(--color-accent-subtle-border);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--color-bg-sunken);
+}
+/* Preview of the selected span while drafting a new comment — confirms the
+   anchor before the comment (and its doc highlight) exist. Existing comments
+   point at the doc highlight instead, so they have no quote box. */
 .quote {
   font-size: 12px;
   color: var(--color-text-secondary);
@@ -43,28 +80,6 @@
   margin-bottom: 6px;
   white-space: pre-wrap;
   word-break: break-word;
-}
-.quoteOrphaned {
-  border-left-color: var(--color-state-warning-border);
-  background: var(--color-state-warning-bg);
-  color: var(--color-state-warning-fg);
-}
-
-.thread {
-  border: 1px solid var(--color-border-subtle);
-  border-radius: 8px;
-  padding: 10px;
-  background: var(--color-bg-page);
-}
-.threadResolved {
-  opacity: 0.65;
-}
-
-.draft {
-  border: 1px solid var(--color-accent-subtle-border);
-  border-radius: 8px;
-  padding: 10px;
-  background: var(--color-bg-sunken);
 }
 
 .metaRow {
@@ -92,11 +107,6 @@
   border-color: var(--color-state-success-border);
   color: var(--color-state-success-fg);
 }
-.badgeOrphaned {
-  background: var(--color-state-warning-bg);
-  border-color: var(--color-state-warning-border);
-  color: var(--color-state-warning-fg);
-}
 
 .body {
   font-size: 13px;
@@ -110,6 +120,27 @@
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 8px;
+}
+
+/* Per-comment Edit/Delete — revealed on hover (or keyboard focus within) so the
+   thread stays quiet until you reach for it. Always visible on touch, which has
+   no hover state. */
+.commentActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.comment:hover .commentActions,
+.comment:focus-within .commentActions {
+  opacity: 1;
+}
+@media (hover: none) {
+  .commentActions {
+    opacity: 1;
+  }
 }
 .threadBody {
   display: flex;

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -35,21 +35,6 @@
   margin-left: 6px;
 }
 
-.closeBtn {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  padding: 4px 8px;
-  border-radius: 6px;
-  font-size: 16px;
-  line-height: 1;
-}
-.closeBtn:hover {
-  background: var(--color-bg-hover);
-}
-
 .scroll {
   flex: 1;
   min-height: 0;
@@ -150,24 +135,6 @@
   gap: 6px;
   margin-top: 8px;
 }
-.linkBtn {
-  appearance: none;
-  border: none;
-  background: transparent;
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  font-size: 12px;
-  padding: 2px 4px;
-  border-radius: 4px;
-}
-.linkBtn:hover {
-  background: var(--color-bg-hover);
-  color: var(--color-text-primary);
-}
-.linkBtnDanger:hover {
-  color: var(--color-state-danger-fg);
-}
-
 .replies {
   margin-top: 8px;
   padding-left: 10px;

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -35,7 +35,7 @@
    not rows inside one panel. */
 .thread {
   border: 1px solid var(--color-border-subtle);
-  border-radius: 12px;
+  border-radius: var(--radius-lg);
   padding: 14px;
   background: var(--color-bg-page);
   box-shadow: var(--shadow-sm);
@@ -63,7 +63,7 @@
 
 .draft {
   border: 1px solid var(--color-accent-subtle-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   padding: 10px;
   background: var(--color-bg-sunken);
 }
@@ -76,7 +76,7 @@
   background: var(--color-accent-subtle-bg);
   border-left: 3px solid var(--color-accent-subtle-border);
   padding: 4px 8px;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   margin-bottom: 6px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -125,7 +125,7 @@
   height: 28px;
   padding: 0;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
@@ -171,7 +171,7 @@
   font-size: 13px;
   padding: 8px 10px;
   border: 1px solid var(--color-border-default);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--color-bg-page);
   color: var(--color-text-primary);
 }
@@ -193,17 +193,9 @@
   padding: 4px 0;
 }
 
-/* Low-key toggle to reveal/hide the resolved threads kept out of the main list. */
+/* Left-aligns the low-key OPAL toggle that reveals/hides the resolved threads
+   kept out of the main list. */
 .resolvedToggle {
-  align-self: flex-start;
-  border: none;
-  background: transparent;
-  color: var(--color-text-muted);
-  font-size: 12px;
-  padding: 4px 2px;
-  cursor: pointer;
-}
-.resolvedToggle:hover {
-  color: var(--color-text-primary);
-  text-decoration: underline;
+  display: flex;
+  justify-content: flex-start;
 }

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import { Button, Text } from "@onyx-ai/opal/components";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
 import {
   createComment,
   deleteComment,
   editComment,
-  listComments,
   reopenThread,
   replyToComment,
   resolveThread,
@@ -25,8 +24,11 @@ interface Props {
   path: string;
   headSha: string | null;
   draft: CommentDraft | null;
+  /** Threads are owned by the page (so highlights stay in sync); the panel
+   * renders them and calls `onChanged` after a mutation to trigger a refetch. */
+  threads: CommentThreadView[];
+  onChanged: () => void | Promise<void>;
   onDraftConsumed: () => void;
-  onThreadsChange?: (threads: CommentThreadView[]) => void;
   onClose: () => void;
   fullHeight?: boolean;
 }
@@ -46,37 +48,15 @@ export function CommentsPanel({
   path,
   headSha,
   draft,
+  threads,
+  onChanged,
   onDraftConsumed,
-  onThreadsChange,
   onClose,
   fullHeight,
 }: Props) {
   const { user } = useAuth();
-  const [threads, setThreads] = useState<CommentThreadView[]>([]);
-  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-
-  const onThreadsChangeRef = useRef(onThreadsChange);
-  onThreadsChangeRef.current = onThreadsChange;
-
-  const refresh = useCallback(async () => {
-    try {
-      const t = await listComments(path);
-      setThreads(t);
-      onThreadsChangeRef.current?.(t);
-      setError(null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to load comments");
-    } finally {
-      setLoading(false);
-    }
-  }, [path]);
-
-  useEffect(() => {
-    setLoading(true);
-    void refresh();
-  }, [refresh]);
 
   // Returns true on success so callers can clear/close their input only when
   // the action actually went through.
@@ -85,7 +65,7 @@ export function CommentsPanel({
       setBusy(true);
       try {
         await fn();
-        await refresh();
+        await onChanged();
         return true;
       } catch (e) {
         setError(e instanceof Error ? e.message : "action failed");
@@ -94,7 +74,7 @@ export function CommentsPanel({
         setBusy(false);
       }
     },
-    [refresh],
+    [onChanged],
   );
 
   const total = threads.length;
@@ -138,11 +118,7 @@ export function CommentsPanel({
           />
         )}
 
-        {loading ? (
-          <Text font="secondary-body" color="text-03">
-            Loading…
-          </Text>
-        ) : total === 0 && !draft ? (
+        {total === 0 && !draft ? (
           <Text font="secondary-body" color="text-03">
             No comments yet. Select text in the page to add one.
           </Text>
@@ -231,6 +207,9 @@ function Thread({
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyBody, setReplyBody] = useState("");
   const resolved = root.status === "resolved";
+  // One flat conversation (Google-Docs style): the root and every reply render
+  // uniformly, appended in order — no nesting/indentation.
+  const conversation = [root, ...thread.replies];
 
   return (
     <div className={`${styles.thread} ${resolved ? styles.threadResolved : ""}`}>
@@ -241,77 +220,62 @@ function Thread({
         {root.quoted_text}
       </div>
 
-      <Comment
-        comment={root}
-        canModify={isAdmin || root.author_user_id === selfId}
-        selfId={selfId}
-        busy={busy}
-        onEdit={onEdit}
-        onDelete={onDelete}
-      />
-
-      <div className={styles.actions}>
-        <Button
-          prominence="tertiary"
-          size="sm"
-          disabled={busy}
-          onClick={() => setReplyOpen((v) => !v)}
-        >
-          Reply
-        </Button>
-        {resolved ? (
-          <Button prominence="tertiary" size="sm" disabled={busy} onClick={onReopen}>
-            Reopen
-          </Button>
-        ) : (
-          <Button prominence="tertiary" size="sm" disabled={busy} onClick={onResolve}>
-            Resolve
-          </Button>
-        )}
+      <div className={styles.threadBody}>
+        {conversation.map((c) => (
+          <Comment
+            key={c.id}
+            comment={c}
+            canModify={isAdmin || c.author_user_id === selfId}
+            selfId={selfId}
+            busy={busy}
+            onEdit={onEdit}
+            onDelete={onDelete}
+          />
+        ))}
       </div>
 
-      {(thread.replies.length > 0 || replyOpen) && (
-        <div className={styles.replies}>
-          {thread.replies.map((r) => (
-            <Comment
-              key={r.id}
-              comment={r}
-              canModify={isAdmin || r.author_user_id === selfId}
-              selfId={selfId}
-              busy={busy}
-              onEdit={onEdit}
-              onDelete={onDelete}
-            />
-          ))}
-          {replyOpen && (
-            <div>
-              <textarea
-                className={styles.textarea}
-                placeholder="Reply…"
-                value={replyBody}
-                autoFocus
-                onChange={(e) => setReplyBody(e.target.value)}
-              />
-              <div className={styles.composeRow}>
-                <Button prominence="tertiary" size="sm" onClick={() => setReplyOpen(false)}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="action"
-                  size="sm"
-                  disabled={busy || !replyBody.trim()}
-                  onClick={async () => {
-                    // Clear/close only on success so a failed reply isn't lost.
-                    if (await onReply(replyBody.trim())) {
-                      setReplyBody("");
-                      setReplyOpen(false);
-                    }
-                  }}
-                >
-                  Reply
-                </Button>
-              </div>
-            </div>
+      {replyOpen ? (
+        <div className={styles.replyBox}>
+          <textarea
+            className={styles.textarea}
+            placeholder="Reply…"
+            value={replyBody}
+            autoFocus
+            onChange={(e) => setReplyBody(e.target.value)}
+          />
+          <div className={styles.composeRow}>
+            <Button prominence="tertiary" size="sm" onClick={() => setReplyOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="action"
+              size="sm"
+              disabled={busy || !replyBody.trim()}
+              onClick={async () => {
+                // Clear/close only on success so a failed reply isn't lost.
+                if (await onReply(replyBody.trim())) {
+                  setReplyBody("");
+                  setReplyOpen(false);
+                }
+              }}
+            >
+              Reply
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.actions}>
+          <Button prominence="tertiary" size="sm" disabled={busy} onClick={() => setReplyOpen(true)}>
+            Reply
+          </Button>
+          {resolved ? (
+            <Button prominence="tertiary" size="sm" disabled={busy} onClick={onReopen}>
+              Reopen
+            </Button>
+          ) : (
+            <Button prominence="tertiary" size="sm" disabled={busy} onClick={onResolve}>
+              Resolve
+            </Button>
           )}
         </div>
       )}

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Button, Text } from "@onyx-ai/opal/components";
+import { Button, LineItemButton, Popover, Text } from "@onyx-ai/opal/components";
+import { SvgEdit, SvgMoreHorizontal, SvgTrash } from "@onyx-ai/opal/icons";
 import { useCallback, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
@@ -82,14 +83,46 @@ export function CommentsPanel({
     [onChanged],
   );
 
-  const total = threads.length;
+  const [showResolved, setShowResolved] = useState(false);
+
+  // Order threads to match the doc: by their referenced position (start_offset)
+  // top-to-bottom. Orphaned threads ("Original content deleted") have no live
+  // anchor, so they sink to the bottom, ordered among themselves by creation.
+  const orderedThreads = [...threads].sort((a, b) => {
+    const ao = a.root.status === "orphaned" ? null : a.root.start_offset;
+    const bo = b.root.status === "orphaned" ? null : b.root.start_offset;
+    if (ao === null && bo === null) return a.root.created_at.localeCompare(b.root.created_at);
+    if (ao === null) return 1;
+    if (bo === null) return -1;
+    return ao - bo;
+  });
+
+  // Resolved threads drop out of the main list (Google-Docs style) — they're
+  // "done", so they shouldn't clutter the doc. They stay reachable (to reopen)
+  // behind a toggle.
+  const openThreads = orderedThreads.filter((t) => t.root.status !== "resolved");
+  const resolvedThreads = orderedThreads.filter((t) => t.root.status === "resolved");
+
+  const renderThread = (t: CommentThreadView) => (
+    <Thread
+      key={t.root.id}
+      thread={t}
+      selfId={user?.id}
+      isAdmin={!!user?.is_admin}
+      busy={busy}
+      active={t.root.id === activeId}
+      onActivate={() => onActivate(t.root.id)}
+      onReply={(body) => run(() => replyToComment(t.root.id, body))}
+      onResolve={() => run(() => resolveThread(t.root.id))}
+      onReopen={() => run(() => reopenThread(t.root.id))}
+      onEdit={(id, body) => run(() => editComment(id, body))}
+      onDelete={(id) => run(() => deleteComment(id))}
+    />
+  );
 
   return (
     <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
-      <div className={styles.header}>
-        <Text font="main-ui-action" color="text-04">
-          {`Comments${total ? ` (${total})` : ""}`}
-        </Text>
+      <div className={styles.closeRow}>
         <Button prominence="tertiary" size="sm" onClick={onClose} aria-label="Close comments">
           ×
         </Button>
@@ -123,27 +156,29 @@ export function CommentsPanel({
           />
         )}
 
-        {total === 0 && !draft ? (
+        {openThreads.length === 0 && resolvedThreads.length === 0 && !draft ? (
           <Text font="secondary-body" color="text-03">
             No comments yet. Select text in the page to add one.
           </Text>
         ) : (
-          threads.map((t) => (
-            <Thread
-              key={t.root.id}
-              thread={t}
-              selfId={user?.id}
-              isAdmin={!!user?.is_admin}
-              busy={busy}
-              active={t.root.id === activeId}
-              onActivate={() => onActivate(t.root.id)}
-              onReply={(body) => run(() => replyToComment(t.root.id, body))}
-              onResolve={() => run(() => resolveThread(t.root.id))}
-              onReopen={() => run(() => reopenThread(t.root.id))}
-              onEdit={(id, body) => run(() => editComment(id, body))}
-              onDelete={(id) => run(() => deleteComment(id))}
-            />
-          ))
+          <>
+            {openThreads.map(renderThread)}
+
+            {resolvedThreads.length > 0 && (
+              <>
+                <button
+                  type="button"
+                  className={styles.resolvedToggle}
+                  onClick={() => setShowResolved((v) => !v)}
+                >
+                  {showResolved
+                    ? `Hide resolved (${resolvedThreads.length})`
+                    : `Show resolved (${resolvedThreads.length})`}
+                </button>
+                {showResolved && resolvedThreads.map(renderThread)}
+              </>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -313,6 +348,7 @@ function Comment({
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(comment.body);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <div className={styles.comment}>
@@ -325,9 +361,51 @@ function Comment({
             {relativeTime(toIso(comment.created_at), "short")}
           </Text>
         </span>
-        {comment.status === "resolved" && (
-          <span className={`${styles.badge} ${styles.badgeResolved}`}>resolved</span>
-        )}
+        <span className={styles.metaRight}>
+          {canModify && !editing && (
+            // Overflow menu (Google-Docs style) keeps Edit/Delete off the card
+            // until hovered, so comments stay compact. Forced visible while open.
+            <span className={`${styles.kebab} ${menuOpen ? styles.kebabOpen : ""}`}>
+              <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+                {/* Radix renders its own <button> here (no asChild) so the
+                    trigger's onClick/ref/data-state are guaranteed to wire up —
+                    OPAL's Button isn't a Radix Slot and drops them. */}
+                <Popover.Trigger
+                  className={styles.kebabBtn}
+                  aria-label="Comment actions"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <SvgMoreHorizontal />
+                </Popover.Trigger>
+                <Popover.Content width="fit" align="end">
+                  <Popover.Menu>
+                    <LineItemButton
+                      title="Edit"
+                      icon={SvgEdit}
+                      sizePreset="main-ui"
+                      variant="section"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        setEditing(true);
+                      }}
+                    />
+                    <LineItemButton
+                      title="Delete"
+                      color="danger"
+                      icon={SvgTrash}
+                      sizePreset="main-ui"
+                      variant="section"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onDelete(comment.id);
+                      }}
+                    />
+                  </Popover.Menu>
+                </Popover.Content>
+              </Popover>
+            </span>
+          )}
+        </span>
       </div>
 
       {editing ? (
@@ -363,17 +441,6 @@ function Comment({
         </div>
       ) : (
         <div className={styles.body}>{comment.body}</div>
-      )}
-
-      {canModify && !editing && (
-        <div className={styles.commentActions}>
-          <Button prominence="tertiary" size="sm" disabled={busy} onClick={() => setEditing(true)}>
-            Edit
-          </Button>
-          <Button variant="danger" size="sm" disabled={busy} onClick={() => onDelete(comment.id)}>
-            Delete
-          </Button>
-        </div>
       )}
     </div>
   );

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -166,15 +166,17 @@ export function CommentsPanel({
 
             {resolvedThreads.length > 0 && (
               <>
-                <button
-                  type="button"
-                  className={styles.resolvedToggle}
-                  onClick={() => setShowResolved((v) => !v)}
-                >
-                  {showResolved
-                    ? `Hide resolved (${resolvedThreads.length})`
-                    : `Show resolved (${resolvedThreads.length})`}
-                </button>
+                <div className={styles.resolvedToggle}>
+                  <Button
+                    prominence="tertiary"
+                    size="sm"
+                    onClick={() => setShowResolved((v) => !v)}
+                  >
+                    {showResolved
+                      ? `Hide resolved (${resolvedThreads.length})`
+                      : `Show resolved (${resolvedThreads.length})`}
+                  </Button>
+                </div>
                 {showResolved && resolvedThreads.map(renderThread)}
               </>
             )}

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { Button, Text } from "@onyx-ai/opal/components";
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Button } from "@/components/common/Button";
 import { useAuth } from "@/lib/auth";
 import {
   createComment,
@@ -102,10 +102,10 @@ export function CommentsPanel({
   return (
     <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
       <div className={styles.header}>
-        <span className={styles.title}>
-          Comments<span className={styles.count}>{total ? ` (${total})` : ""}</span>
-        </span>
-        <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close comments">
+        <Text font="main-ui-action" color="text-04">
+          {`Comments${total ? ` (${total})` : ""}`}
+        </Text>
+        <Button prominence="tertiary" size="sm" onClick={onClose} aria-label="Close comments">
           ×
         </Button>
       </div>
@@ -139,11 +139,13 @@ export function CommentsPanel({
         )}
 
         {loading ? (
-          <div className={styles.empty}>Loading…</div>
+          <Text font="secondary-body" color="text-03">
+            Loading…
+          </Text>
         ) : total === 0 && !draft ? (
-          <div className={styles.empty}>
+          <Text font="secondary-body" color="text-03">
             No comments yet. Select text in the page to add one.
-          </div>
+          </Text>
         ) : (
           threads.map((t) => (
             <Thread
@@ -188,11 +190,11 @@ function DraftComposer({
         onChange={(e) => setBody(e.target.value)}
       />
       <div className={styles.composeRow}>
-        <Button variant="ghost" size="sm" onClick={onCancel}>
+        <Button prominence="tertiary" size="sm" onClick={onCancel}>
           Cancel
         </Button>
         <Button
-          variant="primary"
+          variant="action"
           size="sm"
           disabled={disabled || !body.trim()}
           onClick={() => onSubmit(body.trim())}
@@ -249,15 +251,20 @@ function Thread({
       />
 
       <div className={styles.actions}>
-        <Button variant="ghost" size="sm" disabled={busy} onClick={() => setReplyOpen((v) => !v)}>
+        <Button
+          prominence="tertiary"
+          size="sm"
+          disabled={busy}
+          onClick={() => setReplyOpen((v) => !v)}
+        >
           Reply
         </Button>
         {resolved ? (
-          <Button variant="ghost" size="sm" disabled={busy} onClick={onReopen}>
+          <Button prominence="tertiary" size="sm" disabled={busy} onClick={onReopen}>
             Reopen
           </Button>
         ) : (
-          <Button variant="ghost" size="sm" disabled={busy} onClick={onResolve}>
+          <Button prominence="tertiary" size="sm" disabled={busy} onClick={onResolve}>
             Resolve
           </Button>
         )}
@@ -286,11 +293,11 @@ function Thread({
                 onChange={(e) => setReplyBody(e.target.value)}
               />
               <div className={styles.composeRow}>
-                <Button variant="ghost" size="sm" onClick={() => setReplyOpen(false)}>
+                <Button prominence="tertiary" size="sm" onClick={() => setReplyOpen(false)}>
                   Cancel
                 </Button>
                 <Button
-                  variant="primary"
+                  variant="action"
                   size="sm"
                   disabled={busy || !replyBody.trim()}
                   onClick={async () => {
@@ -333,9 +340,13 @@ function Comment({
   return (
     <div>
       <div className={styles.metaRow}>
-        <span className={styles.author}>{authorLabel(comment.author_user_id, selfId)}</span>
+        <Text font="main-ui-action" color="text-04">
+          {authorLabel(comment.author_user_id, selfId)}
+        </Text>
         <span className={styles.time} title={absoluteTime(toIso(comment.created_at))}>
-          {relativeTime(toIso(comment.created_at), "short")}
+          <Text font="secondary-body" color="text-03">
+            {relativeTime(toIso(comment.created_at), "short")}
+          </Text>
         </span>
         {comment.status === "resolved" && (
           <span className={`${styles.badge} ${styles.badgeResolved}`}>resolved</span>
@@ -355,7 +366,7 @@ function Comment({
           />
           <div className={styles.composeRow}>
             <Button
-              variant="ghost"
+              prominence="tertiary"
               size="sm"
               onClick={() => {
                 setDraft(comment.body);
@@ -365,7 +376,7 @@ function Comment({
               Cancel
             </Button>
             <Button
-              variant="primary"
+              variant="action"
               size="sm"
               disabled={busy || !draft.trim()}
               onClick={async () => {
@@ -382,15 +393,10 @@ function Comment({
 
       {canModify && !editing && (
         <div className={styles.actions}>
-          <Button variant="ghost" size="sm" disabled={busy} onClick={() => setEditing(true)}>
+          <Button prominence="tertiary" size="sm" disabled={busy} onClick={() => setEditing(true)}>
             Edit
           </Button>
-          <Button
-            variant="danger"
-            size="sm"
-            disabled={busy}
-            onClick={() => onDelete(comment.id)}
-          >
+          <Button variant="danger" size="sm" disabled={busy} onClick={() => onDelete(comment.id)}>
             Delete
           </Button>
         </div>

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -1,0 +1,384 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/common/Button";
+import { useAuth } from "@/lib/auth";
+import {
+  createComment,
+  deleteComment,
+  editComment,
+  listComments,
+  reopenThread,
+  replyToComment,
+  resolveThread,
+} from "@/lib/comments";
+import type { CommentDraft } from "@/lib/commentAnchor";
+import type { CommentThreadView, CommentView } from "@/types";
+
+import styles from "./CommentsPanel.module.css";
+
+export type { CommentDraft };
+
+interface Props {
+  path: string;
+  headSha: string | null;
+  draft: CommentDraft | null;
+  onDraftConsumed: () => void;
+  onThreadsChange?: (threads: CommentThreadView[]) => void;
+  onClose: () => void;
+  fullHeight?: boolean;
+}
+
+function authorLabel(authorUserId: string | null, selfId: string | undefined): string {
+  if (authorUserId && authorUserId === selfId) return "You";
+  return "User";
+}
+
+export function CommentsPanel({
+  path,
+  headSha,
+  draft,
+  onDraftConsumed,
+  onThreadsChange,
+  onClose,
+  fullHeight,
+}: Props) {
+  const { user } = useAuth();
+  const [threads, setThreads] = useState<CommentThreadView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Hand the latest threads up without making `refresh` depend on the (possibly
+  // unstable) callback identity — avoids a refetch loop.
+  const onThreadsChangeRef = useRef(onThreadsChange);
+  onThreadsChangeRef.current = onThreadsChange;
+
+  const refresh = useCallback(async () => {
+    try {
+      const t = await listComments(path);
+      setThreads(t);
+      onThreadsChangeRef.current?.(t);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to load comments");
+    } finally {
+      setLoading(false);
+    }
+  }, [path]);
+
+  useEffect(() => {
+    setLoading(true);
+    void refresh();
+  }, [refresh]);
+
+  const run = useCallback(
+    async (fn: () => Promise<unknown>) => {
+      setBusy(true);
+      try {
+        await fn();
+        await refresh();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "action failed");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [refresh],
+  );
+
+  const total = threads.length;
+
+  return (
+    <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
+      <div className={styles.header}>
+        <span className={styles.title}>
+          Comments<span className={styles.count}>{total ? ` (${total})` : ""}</span>
+        </span>
+        <button className={styles.closeBtn} onClick={onClose} aria-label="Close comments">
+          ×
+        </button>
+      </div>
+
+      <div className={styles.scroll}>
+        {error && <div className={styles.error}>{error}</div>}
+
+        {draft && (
+          <DraftComposer
+            draft={draft}
+            disabled={busy || !headSha}
+            onCancel={onDraftConsumed}
+            onSubmit={(body) =>
+              run(async () => {
+                if (!headSha) throw new Error("page version unknown — reload and retry");
+                await createComment({
+                  path,
+                  anchorSha: headSha,
+                  startOffset: draft.startOffset,
+                  endOffset: draft.endOffset,
+                  quotedText: draft.quotedText,
+                  body,
+                });
+                onDraftConsumed();
+              })
+            }
+          />
+        )}
+
+        {loading ? (
+          <div className={styles.empty}>Loading…</div>
+        ) : total === 0 && !draft ? (
+          <div className={styles.empty}>
+            No comments yet. Select text in the page to add one.
+          </div>
+        ) : (
+          threads.map((t) => (
+            <Thread
+              key={t.root.id}
+              thread={t}
+              selfId={user?.id}
+              isAdmin={!!user?.is_admin}
+              busy={busy}
+              onReply={(body) => run(() => replyToComment(t.root.id, body))}
+              onResolve={() => run(() => resolveThread(t.root.id))}
+              onReopen={() => run(() => reopenThread(t.root.id))}
+              onEdit={(id, body) => run(() => editComment(id, body))}
+              onDelete={(id) => run(() => deleteComment(id))}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DraftComposer({
+  draft,
+  disabled,
+  onSubmit,
+  onCancel,
+}: {
+  draft: CommentDraft;
+  disabled: boolean;
+  onSubmit: (body: string) => void;
+  onCancel: () => void;
+}) {
+  const [body, setBody] = useState("");
+  return (
+    <div className={styles.draft}>
+      <div className={styles.quote}>{draft.quotedText}</div>
+      <textarea
+        className={styles.textarea}
+        placeholder="Add a comment…"
+        value={body}
+        autoFocus
+        onChange={(e) => setBody(e.target.value)}
+      />
+      <div className={styles.composeRow}>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          size="sm"
+          disabled={disabled || !body.trim()}
+          onClick={() => onSubmit(body.trim())}
+        >
+          Comment
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Thread({
+  thread,
+  selfId,
+  isAdmin,
+  busy,
+  onReply,
+  onResolve,
+  onReopen,
+  onEdit,
+  onDelete,
+}: {
+  thread: CommentThreadView;
+  selfId: string | undefined;
+  isAdmin: boolean;
+  busy: boolean;
+  onReply: (body: string) => void;
+  onResolve: () => void;
+  onReopen: () => void;
+  onEdit: (id: string, body: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const { root } = thread;
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [replyBody, setReplyBody] = useState("");
+  const resolved = root.status === "resolved";
+
+  return (
+    <div className={`${styles.thread} ${resolved ? styles.threadResolved : ""}`}>
+      <div
+        className={`${styles.quote} ${root.status === "orphaned" ? styles.quoteOrphaned : ""}`}
+      >
+        {root.status === "orphaned" ? "(text removed) " : ""}
+        {root.quoted_text}
+      </div>
+
+      <Comment
+        comment={root}
+        canModify={isAdmin || root.author_user_id === selfId}
+        selfId={selfId}
+        busy={busy}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+
+      <div className={styles.actions}>
+        <button className={styles.linkBtn} disabled={busy} onClick={() => setReplyOpen((v) => !v)}>
+          Reply
+        </button>
+        {resolved ? (
+          <button className={styles.linkBtn} disabled={busy} onClick={onReopen}>
+            Reopen
+          </button>
+        ) : (
+          <button className={styles.linkBtn} disabled={busy} onClick={onResolve}>
+            Resolve
+          </button>
+        )}
+      </div>
+
+      {(thread.replies.length > 0 || replyOpen) && (
+        <div className={styles.replies}>
+          {thread.replies.map((r) => (
+            <Comment
+              key={r.id}
+              comment={r}
+              canModify={isAdmin || r.author_user_id === selfId}
+              selfId={selfId}
+              busy={busy}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+          {replyOpen && (
+            <div>
+              <textarea
+                className={styles.textarea}
+                placeholder="Reply…"
+                value={replyBody}
+                autoFocus
+                onChange={(e) => setReplyBody(e.target.value)}
+              />
+              <div className={styles.composeRow}>
+                <Button variant="ghost" size="sm" onClick={() => setReplyOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  size="sm"
+                  disabled={busy || !replyBody.trim()}
+                  onClick={() => {
+                    onReply(replyBody.trim());
+                    setReplyBody("");
+                    setReplyOpen(false);
+                  }}
+                >
+                  Reply
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Comment({
+  comment,
+  canModify,
+  selfId,
+  busy,
+  onEdit,
+  onDelete,
+}: {
+  comment: CommentView;
+  canModify: boolean;
+  selfId: string | undefined;
+  busy: boolean;
+  onEdit: (id: string, body: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(comment.body);
+
+  return (
+    <div>
+      <div className={styles.metaRow}>
+        <span className={styles.author}>{authorLabel(comment.author_user_id, selfId)}</span>
+        <span className={styles.time}>{comment.created_at}</span>
+        {comment.status === "resolved" && (
+          <span className={`${styles.badge} ${styles.badgeResolved}`}>resolved</span>
+        )}
+        {comment.status === "orphaned" && (
+          <span className={`${styles.badge} ${styles.badgeOrphaned}`}>orphaned</span>
+        )}
+      </div>
+
+      {editing ? (
+        <div>
+          <textarea
+            className={styles.textarea}
+            value={draft}
+            autoFocus
+            onChange={(e) => setDraft(e.target.value)}
+          />
+          <div className={styles.composeRow}>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setDraft(comment.body);
+                setEditing(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              disabled={busy || !draft.trim()}
+              onClick={() => {
+                onEdit(comment.id, draft.trim());
+                setEditing(false);
+              }}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className={styles.body}>{comment.body}</div>
+      )}
+
+      {canModify && !editing && (
+        <div className={styles.actions}>
+          <button className={styles.linkBtn} disabled={busy} onClick={() => setEditing(true)}>
+            Edit
+          </button>
+          <button
+            className={`${styles.linkBtn} ${styles.linkBtnDanger}`}
+            disabled={busy}
+            onClick={() => onDelete(comment.id)}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -14,6 +14,7 @@ import {
   resolveThread,
 } from "@/lib/comments";
 import type { CommentDraft } from "@/lib/commentAnchor";
+import { absoluteTime, relativeTime } from "@/lib/time";
 import type { CommentThreadView, CommentView } from "@/types";
 
 import styles from "./CommentsPanel.module.css";
@@ -35,6 +36,12 @@ function authorLabel(authorUserId: string | null, selfId: string | undefined): s
   return "User";
 }
 
+/** Backend timestamps are "YYYY-MM-DD HH:MM:SS" in UTC (not ISO). Normalize so
+ * Date parses them as UTC, not local. */
+function toIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}
+
 export function CommentsPanel({
   path,
   headSha,
@@ -50,8 +57,6 @@ export function CommentsPanel({
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  // Hand the latest threads up without making `refresh` depend on the (possibly
-  // unstable) callback identity — avoids a refetch loop.
   const onThreadsChangeRef = useRef(onThreadsChange);
   onThreadsChangeRef.current = onThreadsChange;
 
@@ -73,14 +78,18 @@ export function CommentsPanel({
     void refresh();
   }, [refresh]);
 
+  // Returns true on success so callers can clear/close their input only when
+  // the action actually went through.
   const run = useCallback(
-    async (fn: () => Promise<unknown>) => {
+    async (fn: () => Promise<unknown>): Promise<boolean> => {
       setBusy(true);
       try {
         await fn();
         await refresh();
+        return true;
       } catch (e) {
         setError(e instanceof Error ? e.message : "action failed");
+        return false;
       } finally {
         setBusy(false);
       }
@@ -96,9 +105,9 @@ export function CommentsPanel({
         <span className={styles.title}>
           Comments<span className={styles.count}>{total ? ` (${total})` : ""}</span>
         </span>
-        <button className={styles.closeBtn} onClick={onClose} aria-label="Close comments">
+        <Button variant="ghost" size="sm" onClick={onClose} aria-label="Close comments">
           ×
-        </button>
+        </Button>
       </div>
 
       <div className={styles.scroll}>
@@ -109,20 +118,23 @@ export function CommentsPanel({
             draft={draft}
             disabled={busy || !headSha}
             onCancel={onDraftConsumed}
-            onSubmit={(body) =>
-              run(async () => {
-                if (!headSha) throw new Error("page version unknown — reload and retry");
-                await createComment({
+            onSubmit={async (body) => {
+              if (!headSha) {
+                setError("page version unknown — reload and retry");
+                return;
+              }
+              const ok = await run(() =>
+                createComment({
                   path,
                   anchorSha: headSha,
                   startOffset: draft.startOffset,
                   endOffset: draft.endOffset,
                   quotedText: draft.quotedText,
                   body,
-                });
-                onDraftConsumed();
-              })
-            }
+                }),
+              );
+              if (ok) onDraftConsumed();
+            }}
           />
         )}
 
@@ -207,10 +219,10 @@ function Thread({
   selfId: string | undefined;
   isAdmin: boolean;
   busy: boolean;
-  onReply: (body: string) => void;
+  onReply: (body: string) => Promise<boolean>;
   onResolve: () => void;
   onReopen: () => void;
-  onEdit: (id: string, body: string) => void;
+  onEdit: (id: string, body: string) => Promise<boolean>;
   onDelete: (id: string) => void;
 }) {
   const { root } = thread;
@@ -237,17 +249,17 @@ function Thread({
       />
 
       <div className={styles.actions}>
-        <button className={styles.linkBtn} disabled={busy} onClick={() => setReplyOpen((v) => !v)}>
+        <Button variant="ghost" size="sm" disabled={busy} onClick={() => setReplyOpen((v) => !v)}>
           Reply
-        </button>
+        </Button>
         {resolved ? (
-          <button className={styles.linkBtn} disabled={busy} onClick={onReopen}>
+          <Button variant="ghost" size="sm" disabled={busy} onClick={onReopen}>
             Reopen
-          </button>
+          </Button>
         ) : (
-          <button className={styles.linkBtn} disabled={busy} onClick={onResolve}>
+          <Button variant="ghost" size="sm" disabled={busy} onClick={onResolve}>
             Resolve
-          </button>
+          </Button>
         )}
       </div>
 
@@ -281,10 +293,12 @@ function Thread({
                   variant="primary"
                   size="sm"
                   disabled={busy || !replyBody.trim()}
-                  onClick={() => {
-                    onReply(replyBody.trim());
-                    setReplyBody("");
-                    setReplyOpen(false);
+                  onClick={async () => {
+                    // Clear/close only on success so a failed reply isn't lost.
+                    if (await onReply(replyBody.trim())) {
+                      setReplyBody("");
+                      setReplyOpen(false);
+                    }
                   }}
                 >
                   Reply
@@ -310,7 +324,7 @@ function Comment({
   canModify: boolean;
   selfId: string | undefined;
   busy: boolean;
-  onEdit: (id: string, body: string) => void;
+  onEdit: (id: string, body: string) => Promise<boolean>;
   onDelete: (id: string) => void;
 }) {
   const [editing, setEditing] = useState(false);
@@ -320,7 +334,9 @@ function Comment({
     <div>
       <div className={styles.metaRow}>
         <span className={styles.author}>{authorLabel(comment.author_user_id, selfId)}</span>
-        <span className={styles.time}>{comment.created_at}</span>
+        <span className={styles.time} title={absoluteTime(toIso(comment.created_at))}>
+          {relativeTime(toIso(comment.created_at), "short")}
+        </span>
         {comment.status === "resolved" && (
           <span className={`${styles.badge} ${styles.badgeResolved}`}>resolved</span>
         )}
@@ -352,9 +368,8 @@ function Comment({
               variant="primary"
               size="sm"
               disabled={busy || !draft.trim()}
-              onClick={() => {
-                onEdit(comment.id, draft.trim());
-                setEditing(false);
+              onClick={async () => {
+                if (await onEdit(comment.id, draft.trim())) setEditing(false);
               }}
             >
               Save
@@ -367,16 +382,17 @@ function Comment({
 
       {canModify && !editing && (
         <div className={styles.actions}>
-          <button className={styles.linkBtn} disabled={busy} onClick={() => setEditing(true)}>
+          <Button variant="ghost" size="sm" disabled={busy} onClick={() => setEditing(true)}>
             Edit
-          </button>
-          <button
-            className={`${styles.linkBtn} ${styles.linkBtnDanger}`}
+          </Button>
+          <Button
+            variant="danger"
+            size="sm"
             disabled={busy}
             onClick={() => onDelete(comment.id)}
           >
             Delete
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -28,6 +28,9 @@ interface Props {
    * renders them and calls `onChanged` after a mutation to trigger a refetch. */
   threads: CommentThreadView[];
   onChanged: () => void | Promise<void>;
+  /** Selected thread (its span gets the orange highlight in the doc). */
+  activeId: string | null;
+  onActivate: (id: string | null) => void;
   onDraftConsumed: () => void;
   onClose: () => void;
   fullHeight?: boolean;
@@ -50,6 +53,8 @@ export function CommentsPanel({
   draft,
   threads,
   onChanged,
+  activeId,
+  onActivate,
   onDraftConsumed,
   onClose,
   fullHeight,
@@ -130,6 +135,8 @@ export function CommentsPanel({
               selfId={user?.id}
               isAdmin={!!user?.is_admin}
               busy={busy}
+              active={t.root.id === activeId}
+              onActivate={() => onActivate(t.root.id)}
               onReply={(body) => run(() => replyToComment(t.root.id, body))}
               onResolve={() => run(() => resolveThread(t.root.id))}
               onReopen={() => run(() => reopenThread(t.root.id))}
@@ -187,6 +194,8 @@ function Thread({
   selfId,
   isAdmin,
   busy,
+  active,
+  onActivate,
   onReply,
   onResolve,
   onReopen,
@@ -197,6 +206,8 @@ function Thread({
   selfId: string | undefined;
   isAdmin: boolean;
   busy: boolean;
+  active: boolean;
+  onActivate: () => void;
   onReply: (body: string) => Promise<boolean>;
   onResolve: () => void;
   onReopen: () => void;
@@ -212,13 +223,15 @@ function Thread({
   const conversation = [root, ...thread.replies];
 
   return (
-    <div className={`${styles.thread} ${resolved ? styles.threadResolved : ""}`}>
-      <div
-        className={`${styles.quote} ${root.status === "orphaned" ? styles.quoteOrphaned : ""}`}
-      >
-        {root.status === "orphaned" ? "(text removed) " : ""}
-        {root.quoted_text}
-      </div>
+    // Clicking the thread selects it (its span gets the orange highlight). The
+    // commented text itself lives as a highlight in the doc, so no quote box.
+    <div
+      className={`${styles.thread} ${resolved ? styles.threadResolved : ""} ${active ? styles.threadActive : ""}`}
+      onClick={onActivate}
+    >
+      {root.status === "orphaned" && (
+        <div className={styles.orphanedNote}>Original content deleted</div>
+      )}
 
       <div className={styles.threadBody}>
         {conversation.map((c) => (
@@ -302,7 +315,7 @@ function Comment({
   const [draft, setDraft] = useState(comment.body);
 
   return (
-    <div>
+    <div className={styles.comment}>
       <div className={styles.metaRow}>
         <Text font="main-ui-action" color="text-04">
           {authorLabel(comment.author_user_id, selfId)}
@@ -314,9 +327,6 @@ function Comment({
         </span>
         {comment.status === "resolved" && (
           <span className={`${styles.badge} ${styles.badgeResolved}`}>resolved</span>
-        )}
-        {comment.status === "orphaned" && (
-          <span className={`${styles.badge} ${styles.badgeOrphaned}`}>orphaned</span>
         )}
       </div>
 
@@ -356,7 +366,7 @@ function Comment({
       )}
 
       {canModify && !editing && (
-        <div className={styles.actions}>
+        <div className={styles.commentActions}>
           <Button prominence="tertiary" size="sm" disabled={busy} onClick={() => setEditing(true)}>
             Edit
           </Button>

--- a/frontend/src/lib/commentAnchor.ts
+++ b/frontend/src/lib/commentAnchor.ts
@@ -123,11 +123,14 @@ export function selectionToAnchor(article: HTMLElement, body: string): CommentDr
 // --------------------------------------------------------------------------- //
 
 const HIGHLIGHT_NAME = "wiki-comment";
+const ACTIVE_HIGHLIGHT_NAME = "wiki-comment-active";
 
 export interface HighlightTarget {
   startOffset: number;
   endOffset: number;
   quotedText: string;
+  /** The selected/active thread gets the stronger (orange) highlight. */
+  active?: boolean;
 }
 
 // Minimal typings for the CSS Custom Highlight API (not in every TS lib yet).
@@ -179,6 +182,7 @@ export function paintCommentHighlights(
 
   if (targets.length === 0) {
     reg.delete(HIGHLIGHT_NAME);
+    reg.delete(ACTIVE_HIGHLIGHT_NAME);
     return;
   }
 
@@ -193,7 +197,8 @@ export function paintCommentHighlights(
     })
     .filter((b): b is { el: HTMLElement; bStart: number; bEnd: number; size: number } => b !== null);
 
-  const ranges: Range[] = [];
+  const defaultRanges: Range[] = [];
+  const activeRanges: Range[] = [];
   for (const t of targets) {
     // Innermost block whose source range contains the comment's start.
     const candidates = blocks
@@ -202,12 +207,15 @@ export function paintCommentHighlights(
     for (const cand of candidates) {
       const range = rangeForText(cand.el, t.quotedText);
       if (range) {
-        ranges.push(range);
+        (t.active ? activeRanges : defaultRanges).push(range);
         break;
       }
     }
   }
 
-  if (ranges.length === 0) reg.delete(HIGHLIGHT_NAME);
-  else reg.set(HIGHLIGHT_NAME, new Ctor(...ranges));
+  // Two registries: default (light) and the selected thread (strong).
+  if (defaultRanges.length) reg.set(HIGHLIGHT_NAME, new Ctor(...defaultRanges));
+  else reg.delete(HIGHLIGHT_NAME);
+  if (activeRanges.length) reg.set(ACTIVE_HIGHLIGHT_NAME, new Ctor(...activeRanges));
+  else reg.delete(ACTIVE_HIGHLIGHT_NAME);
 }

--- a/frontend/src/lib/commentAnchor.ts
+++ b/frontend/src/lib/commentAnchor.ts
@@ -1,0 +1,118 @@
+/** Map a rendered-view text selection back to raw-markdown character offsets.
+ *
+ * The wiki page renders raw markdown via react-markdown with `sourcePos`, which
+ * stamps each block element with `data-sourcepos="L:C-L:C"` (1-based source
+ * line:col). We use that to find the block's char range in the raw body, then
+ * locate the selected text within the block's raw slice for a precise offset.
+ *
+ * v1 limits (return null — caller just doesn't offer "comment"):
+ *  - selection spanning multiple blocks,
+ *  - selection whose rendered text isn't a verbatim substring of the block's
+ *    raw markdown (i.e. it crosses inline syntax like `code` or **bold**).
+ * Plain-prose selections — the common case — map exactly. The backend's exact
+ * offsets + drift take over after creation.
+ */
+
+export interface CommentDraft {
+  startOffset: number;
+  endOffset: number;
+  quotedText: string;
+}
+
+/** Char offset of the start of each 1-based source line. */
+function lineStartOffsets(body: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] === "\n") starts.push(i + 1);
+  }
+  return starts;
+}
+
+function offsetOf(starts: number[], line: number, col: number): number {
+  const base = starts[Math.min(line, starts.length) - 1] ?? 0;
+  return base + (col - 1);
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (!needle) return 0;
+  let count = 0;
+  let from = 0;
+  for (;;) {
+    const i = haystack.indexOf(needle, from);
+    if (i < 0) return count;
+    count++;
+    from = i + 1;
+  }
+}
+
+/** Index of the (0-based) `nth` occurrence of `needle` in `haystack`, or -1. */
+function nthIndexOf(haystack: string, needle: string, nth: number): number {
+  let from = 0;
+  for (let k = 0; ; k++) {
+    const i = haystack.indexOf(needle, from);
+    if (i < 0) return -1;
+    if (k === nth) return i;
+    from = i + 1;
+  }
+}
+
+/** Nearest ancestor element (inclusive) carrying a `data-sourcepos` attribute. */
+function closestSourcePos(node: Node | null): HTMLElement | null {
+  let el: Node | null = node;
+  while (el && el.nodeType !== Node.ELEMENT_NODE) el = el.parentNode;
+  let cur = el as HTMLElement | null;
+  while (cur && !cur.hasAttribute("data-sourcepos")) cur = cur.parentElement;
+  return cur;
+}
+
+function parseSourcePos(
+  sp: string,
+): { startLine: number; startCol: number; endLine: number; endCol: number } | null {
+  const m = /^(\d+):(\d+)-(\d+):(\d+)$/.exec(sp.trim());
+  if (!m) return null;
+  return {
+    startLine: Number(m[1]),
+    startCol: Number(m[2]),
+    endLine: Number(m[3]),
+    endCol: Number(m[4]),
+  };
+}
+
+/** Resolve the current window selection (inside `article`) to a raw-markdown
+ * anchor, or null if it can't be mapped precisely. */
+export function selectionToAnchor(article: HTMLElement, body: string): CommentDraft | null {
+  const sel = window.getSelection();
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
+  const text = sel.toString();
+  if (!text.trim()) return null;
+
+  const range = sel.getRangeAt(0);
+  if (!article.contains(range.commonAncestorContainer)) return null;
+
+  const block = closestSourcePos(range.startContainer);
+  const endBlock = closestSourcePos(range.endContainer);
+  if (!block || block !== endBlock) return null; // single block only (v1)
+
+  const pos = parseSourcePos(block.getAttribute("data-sourcepos") ?? "");
+  if (!pos) return null;
+
+  const starts = lineStartOffsets(body);
+  const blockStart = offsetOf(starts, pos.startLine, pos.startCol);
+  const blockEnd = offsetOf(starts, pos.endLine, pos.endCol);
+  const slice = body.slice(blockStart, Math.max(blockStart, blockEnd));
+
+  // Which occurrence of the selected text did the user pick? Count how many
+  // times it appears in the block's *rendered* text before the selection
+  // start, then take that same occurrence in the raw slice (aligns for prose).
+  const pre = document.createRange();
+  pre.selectNodeContents(block);
+  pre.setEnd(range.startContainer, range.startOffset);
+  const occurrence = countOccurrences(pre.toString(), text);
+
+  const idx = nthIndexOf(slice, text, occurrence);
+  if (idx < 0) return null; // rendered text isn't verbatim in raw (inline syntax)
+
+  const startOffset = blockStart + idx;
+  const endOffset = startOffset + text.length;
+  return { startOffset, endOffset, quotedText: body.slice(startOffset, endOffset) };
+}

--- a/frontend/src/lib/commentAnchor.ts
+++ b/frontend/src/lib/commentAnchor.ts
@@ -170,20 +170,26 @@ function rangeForText(el: Element, needle: string): Range | null {
 }
 
 /** Repaint comment highlights over the rendered article. Pass an empty list to
- * clear (e.g. when entering edit mode). No-op where the API is unsupported. */
+ * clear (e.g. when entering edit mode). No-op where the API is unsupported.
+ *
+ * Returns the number of target ranges actually painted. Callers use this to
+ * detect "DOM not ready yet" (asked for N, painted < N) and retry — react-
+ * markdown commits its text nodes a tick after React renders, so an eager paint
+ * finds nothing to range over. Returns the target count when unsupported so
+ * callers don't retry forever on a browser without the Custom Highlight API. */
 export function paintCommentHighlights(
   article: HTMLElement,
   body: string,
   targets: HighlightTarget[],
-): void {
+): number {
   const reg = highlightRegistry();
   const Ctor = (globalThis as { Highlight?: HighlightCtor }).Highlight;
-  if (!reg || !Ctor) return;
+  if (!reg || !Ctor) return targets.length;
 
   if (targets.length === 0) {
     reg.delete(HIGHLIGHT_NAME);
     reg.delete(ACTIVE_HIGHLIGHT_NAME);
-    return;
+    return 0;
   }
 
   const starts = lineStartOffsets(body);
@@ -218,4 +224,6 @@ export function paintCommentHighlights(
   else reg.delete(HIGHLIGHT_NAME);
   if (activeRanges.length) reg.set(ACTIVE_HIGHLIGHT_NAME, new Ctor(...activeRanges));
   else reg.delete(ACTIVE_HIGHLIGHT_NAME);
+
+  return defaultRanges.length + activeRanges.length;
 }

--- a/frontend/src/lib/commentAnchor.ts
+++ b/frontend/src/lib/commentAnchor.ts
@@ -116,3 +116,98 @@ export function selectionToAnchor(article: HTMLElement, body: string): CommentDr
   const endOffset = startOffset + text.length;
   return { startOffset, endOffset, quotedText: body.slice(startOffset, endOffset) };
 }
+
+// --------------------------------------------------------------------------- //
+// Inline highlights — paint commented spans via the CSS Custom Highlight API  //
+// (registers Ranges, no DOM mutation, so it doesn't fight react-markdown).    //
+// --------------------------------------------------------------------------- //
+
+const HIGHLIGHT_NAME = "wiki-comment";
+
+export interface HighlightTarget {
+  startOffset: number;
+  endOffset: number;
+  quotedText: string;
+}
+
+// Minimal typings for the CSS Custom Highlight API (not in every TS lib yet).
+interface HighlightLike {
+  set(name: string, value: object): void;
+  delete(name: string): void;
+}
+type HighlightCtor = new (...ranges: Range[]) => object;
+
+function highlightRegistry(): HighlightLike | null {
+  const reg = (CSS as unknown as { highlights?: HighlightLike }).highlights;
+  return reg ?? null;
+}
+
+/** Build a DOM Range over the first occurrence of `needle` within `el`'s text. */
+function rangeForText(el: Element, needle: string): Range | null {
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const parts: { node: Text; start: number }[] = [];
+  let acc = "";
+  let n = walker.nextNode();
+  while (n) {
+    const t = n as Text;
+    parts.push({ node: t, start: acc.length });
+    acc += t.nodeValue ?? "";
+    n = walker.nextNode();
+  }
+  const idx = acc.indexOf(needle);
+  if (idx < 0) return null;
+  const end = idx + needle.length;
+  const startPart = parts.find((p) => p.start <= idx && idx < p.start + (p.node.length || 0));
+  const endPart = parts.find((p) => p.start < end && end <= p.start + (p.node.length || 0));
+  if (!startPart || !endPart) return null;
+  const range = document.createRange();
+  range.setStart(startPart.node, idx - startPart.start);
+  range.setEnd(endPart.node, end - endPart.start);
+  return range;
+}
+
+/** Repaint comment highlights over the rendered article. Pass an empty list to
+ * clear (e.g. when entering edit mode). No-op where the API is unsupported. */
+export function paintCommentHighlights(
+  article: HTMLElement,
+  body: string,
+  targets: HighlightTarget[],
+): void {
+  const reg = highlightRegistry();
+  const Ctor = (globalThis as { Highlight?: HighlightCtor }).Highlight;
+  if (!reg || !Ctor) return;
+
+  if (targets.length === 0) {
+    reg.delete(HIGHLIGHT_NAME);
+    return;
+  }
+
+  const starts = lineStartOffsets(body);
+  const blocks = Array.from(article.querySelectorAll<HTMLElement>("[data-sourcepos]"))
+    .map((el) => {
+      const pos = parseSourcePos(el.getAttribute("data-sourcepos") ?? "");
+      if (!pos) return null;
+      const bStart = offsetOf(starts, pos.startLine, pos.startCol);
+      const bEnd = offsetOf(starts, pos.endLine, pos.endCol);
+      return { el, bStart, bEnd, size: bEnd - bStart };
+    })
+    .filter((b): b is { el: HTMLElement; bStart: number; bEnd: number; size: number } => b !== null);
+
+  const ranges: Range[] = [];
+  for (const t of targets) {
+    // Innermost block whose source range contains the comment's start.
+    const candidates = blocks
+      .filter((b) => b.bStart <= t.startOffset && t.startOffset < b.bEnd)
+      .sort((a, b) => a.size - b.size);
+    for (const cand of candidates) {
+      const range = rangeForText(cand.el, t.quotedText);
+      if (range) {
+        ranges.push(range);
+        break;
+      }
+    }
+  }
+
+  if (ranges.length === 0) reg.delete(HIGHLIGHT_NAME);
+  else reg.set(HIGHLIGHT_NAME, new Ctor(...ranges));
+}

--- a/frontend/src/lib/comments.ts
+++ b/frontend/src/lib/comments.ts
@@ -1,0 +1,62 @@
+import { apiFetch } from "./api";
+import type { CommentThreadView, CommentView } from "@/types";
+
+/** List a page's comments, grouped into threads (root + replies). */
+export async function listComments(path: string): Promise<CommentThreadView[]> {
+  const r = await apiFetch<{ threads: CommentThreadView[] }>(
+    `/comments?path=${encodeURIComponent(path)}`,
+  );
+  return r.threads;
+}
+
+export interface CreateCommentInput {
+  path: string;
+  /** The commit the offsets were computed against (the version the client read). */
+  anchorSha: string;
+  startOffset: number;
+  endOffset: number;
+  quotedText: string;
+  body: string;
+}
+
+/** Start an inline comment thread anchored to a text range. */
+export function createComment(input: CreateCommentInput): Promise<CommentView> {
+  return apiFetch<CommentView>("/comments", {
+    method: "POST",
+    body: JSON.stringify({
+      path: input.path,
+      anchor_sha: input.anchorSha,
+      start_offset: input.startOffset,
+      end_offset: input.endOffset,
+      quoted_text: input.quotedText,
+      body: input.body,
+    }),
+  });
+}
+
+/** Reply to a comment (root or another reply). */
+export function replyToComment(commentId: string, body: string): Promise<CommentView> {
+  return apiFetch<CommentView>(`/comments/${commentId}/replies`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+}
+
+export function editComment(commentId: string, body: string): Promise<CommentView> {
+  return apiFetch<CommentView>(`/comments/${commentId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ body }),
+  });
+}
+
+export function resolveThread(commentId: string): Promise<CommentView> {
+  return apiFetch<CommentView>(`/comments/${commentId}/resolve`, { method: "POST" });
+}
+
+export function reopenThread(commentId: string): Promise<CommentView> {
+  return apiFetch<CommentView>(`/comments/${commentId}/reopen`, { method: "POST" });
+}
+
+export function deleteComment(commentId: string): Promise<void> {
+  return apiFetch<void>(`/comments/${commentId}`, { method: "DELETE" });
+}

--- a/frontend/src/lib/rehypeSourcePos.ts
+++ b/frontend/src/lib/rehypeSourcePos.ts
@@ -1,0 +1,36 @@
+/** Minimal rehype plugin: copy each element's source position into a
+ * `data-sourcepos="L:C-L:C"` attribute.
+ *
+ * react-markdown v9 dropped the built-in `sourcePos` option, but the hast nodes
+ * still carry `position` (mdast positions pass through remark-rehype). The
+ * comment-anchor mapper (`selectionToAnchor`) reads `data-sourcepos` to map a
+ * rendered selection back to raw-markdown offsets. Hand-rolled walk so we don't
+ * add a `unist-util-visit` dependency.
+ */
+
+interface HastNode {
+  type: string;
+  position?: {
+    start?: { line: number; column: number };
+    end?: { line: number; column: number };
+  };
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+}
+
+export function rehypeSourcePos() {
+  return (tree: HastNode): HastNode => {
+    const walk = (node: HastNode): void => {
+      const { start, end } = node.position ?? {};
+      if (node.type === "element" && start && end) {
+        node.properties = node.properties ?? {};
+        // camelCase `dataSourcepos` is serialized to the `data-sourcepos`
+        // attribute by property-information (react-markdown's attribute layer).
+        node.properties.dataSourcepos = `${start.line}:${start.column}-${end.line}:${end.column}`;
+      }
+      node.children?.forEach(walk);
+    };
+    walk(tree);
+    return tree;
+  };
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,6 +38,35 @@ export interface DocumentActivity {
   expires_at: string;
 }
 
+export type CommentScope = "inline" | "page";
+export type CommentAuthorKind = "user" | "agent";
+export type CommentStatus = "open" | "resolved" | "orphaned";
+
+export interface CommentView {
+  id: string;
+  doc_path: string;
+  thread_root_id: string;
+  parent_id: string | null;
+  scope: CommentScope;
+  anchor_sha: string | null;
+  start_offset: number | null;
+  end_offset: number | null;
+  quoted_text: string | null;
+  author_kind: CommentAuthorKind;
+  author_user_id: string | null;
+  body: string;
+  status: CommentStatus;
+  resolved_by_user_id: string | null;
+  resolved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CommentThreadView {
+  root: CommentView;
+  replies: CommentView[];
+}
+
 export interface DocumentActivityResponse {
   path: string;
   agents: DocumentActivity[];


### PR DESCRIPTION
## What

The frontend for wiki comments — turns the backend (#152/#157/#160) into a user-facing feature, in **read/render mode** (in-editor comments are Phase 2).

## Flow
Select text in the rendered page → a Google-Docs-style floating **💬 Comment** affordance appears → opens the **Comments** side-panel with the snippet quoted → type → post. Threads support reply, resolve/reopen, and author-only edit/delete.

## Contents
- **`src/lib/comments.ts`** + types in `src/types` — typed `apiFetch` client (list/create/reply/edit/resolve/reopen/delete).
- **`src/lib/commentAnchor.ts`** — maps a rendered selection back to **raw-markdown offsets** via `data-sourcepos` (single-block, plain-prose v1; correctly disambiguates repeated substrings).
- **`src/lib/rehypeSourcePos.ts`** — tiny rehype plugin that stamps `data-sourcepos` (react-markdown v9 dropped the built-in `sourcePos` option).
- **`CommentsPanel`** (+ CSS module) — threads (root + flat replies), create-from-selection, reply, resolve/reopen, author-only edit/delete; themed for light/dark, desktop side-panel + mobile sheet.
- **`page.tsx`** — floating affordance on selection, "Comments" toggle beside History, sends `head_sha` as the anchor version (the create-vs-edit contract).

## Notes / follow-ups (not blocking)
- **Inline highlights** of existing comments on the rendered text are **not** in this PR (panel shows the quoted snippet). Planned via the CSS Custom Highlight API.
- **Author display** shows "You"/"User" — the API returns `author_user_id` only; add `author_display` to the backend `CommentView` later.
- Selection mapping is single-block, plain-prose; selections crossing inline syntax return no affordance (v1).
- **Note on CI typecheck:** `npm run typecheck` is already red on `main` from the `opal ^0.1.4` bump (`InputTypeIn`/`SvgDocFile` in `WikiSearch`/sidebar — unrelated to comments, owned by frontend folk). The comment files are tsc-clean in isolation.

<img width="1363" height="741" alt="Screenshot 2026-06-02 at 12 05 39 PM" src="https://github.com/user-attachments/assets/9261d04e-a784-4ca0-babd-e57324f1f362" />

