### PR TITLE
fix(frontend): repair opal 0.1.4 import breakage (typecheck green)

### DIFF
--- a/frontend/src/components/wiki/WikiSearch.tsx
+++ b/frontend/src/components/wiki/WikiSearch.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { InputTypeIn } from "@onyx-ai/opal/components";
 import { useRouter } from "next/navigation";
 import {
   forwardRef,
@@ -165,21 +164,75 @@ export const WikiSearch = forwardRef<WikiSearchHandle>(function WikiSearch(_, re
 
   return (
     <div ref={containerRef} style={{ position: "relative", width: "100%" }}>
-      <InputTypeIn
-        ref={inputRef}
-        variant="internal"
-        searchIcon
-        clearButton
-        value={query}
-        onChange={(e) => {
-          setQuery(e.target.value);
-          setOpen(true);
-        }}
-        onFocus={() => setOpen(true)}
-        onKeyDown={onKeyDown}
-        placeholder="Search…"
-        aria-label="Search wiki"
-      />
+      <div style={{ position: "relative", width: "100%" }}>
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            left: 9,
+            top: "50%",
+            transform: "translateY(-50%)",
+            display: "flex",
+            color: color.text.muted,
+            pointerEvents: "none",
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6">
+            <circle cx="7" cy="7" r="4.5" />
+            <line x1="10.5" y1="10.5" x2="14" y2="14" strokeLinecap="round" />
+          </svg>
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+          placeholder="Search…"
+          aria-label="Search wiki"
+          style={{
+            width: "100%",
+            boxSizing: "border-box",
+            padding: "8px 28px 8px 28px",
+            border: `1px solid ${color.border.default}`,
+            borderRadius: radius.sm,
+            background: color.bg.page,
+            color: color.text.primary,
+            fontSize: 13,
+            outline: "none",
+          }}
+        />
+        {query && (
+          <button
+            type="button"
+            aria-label="Clear search"
+            onClick={() => {
+              setQuery("");
+              inputRef.current?.focus();
+            }}
+            style={{
+              position: "absolute",
+              right: 6,
+              top: "50%",
+              transform: "translateY(-50%)",
+              appearance: "none",
+              border: "none",
+              background: "transparent",
+              color: color.text.muted,
+              cursor: "pointer",
+              fontSize: 15,
+              lineHeight: 1,
+              padding: 2,
+            }}
+          >
+            ×
+          </button>
+        )}
+      </div>
 
       {showDropdown && (
         <div

--- a/frontend/src/lib/nav/registry.ts
+++ b/frontend/src/lib/nav/registry.ts
@@ -1,7 +1,7 @@
 import {
   SvgActions,
   SvgActivity,
-  SvgDocFile,
+  SvgFileText,
   SvgDownloadCloud,
   SvgGlobe,
   SvgKey,
@@ -52,6 +52,6 @@ export const ADMIN_NAV_ENTRIES = [
   { href: "/admin/groups",     label: "Groups",           icon: SvgOrganization },
   { href: "/admin/health",     label: "Health",           icon: SvgActivity     },
   { href: "/admin/braintrust", label: "Braintrust",       icon: SvgLinkedDots   },
-  { href: "/admin/templates",  label: "Templates",        icon: SvgDocFile      },
+  { href: "/admin/templates",  label: "Templates",        icon: SvgFileText      },
   { href: "/admin/ingest",     label: "Onyx Connection",  icon: SvgDownloadCloud},
 ] as const satisfies NavEntry[];

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { Button, SidebarTab, Text } from "@onyx-ai/opal/components";
 import {
-  SvgDocFile,
+  SvgFileText,
   SvgSearch,
   SvgSettings,
   SvgSidebar,
@@ -178,7 +178,7 @@ export function AppSidebar() {
                         href={href}
                         selected={active}
                         folded={collapsed}
-                        icon={SvgDocFile}
+                        icon={SvgFileText}
                         tooltip={undefined}
                         nested
                         onClick={() => {


### PR DESCRIPTION
## What
`npm run typecheck` / `next build` have been **red on `main`** since the `@onyx-ai/opal ^0.1.4` bump (#149) removed/renamed exports. This restores a green build.

- **`SvgDocFile` → `SvgFileText`** (icon renamed) in `lib/nav/registry.ts` and `sections/sidebar/AppSidebar.tsx`.
- **`WikiSearch`** used `InputTypeIn`, which opal removed with no drop-in. Rebuilt the search box as a **themed native `<input>`** (theme tokens) preserving all behavior: search icon, clear button, imperative focus handle/ref, `value`/`onChange`/`onFocus`/`onKeyDown`, placeholder, aria-label, and the dropdown wiring.

## Why
`next build` type-checks the whole project and aborts on these, so they block the **frontend Docker image** and show red CI typecheck on every frontend PR (e.g. comments #161). Unrelated to any feature work — purely the opal-bump regression.

## Verify
`npm run typecheck` → **0 errors**.