### PR TITLE
fix(evals-ci): set PUBLIC_BASE_URL in eval workflows

### DIFF
--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -45,8 +45,8 @@ jobs:
       EVAL_MODELS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.models || 'claude-sonnet-4-6,gpt-5' }}
       SELECTOR_MODELS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.selector_models || 'claude-haiku-4-5,gpt-5-mini' }}
       OPENSEARCH_URL: ""
-      # Required by app.config since #141. Evals never serve browsers or
-      # build launcher links — any valid value satisfies the validator.
+      # Required by app.config. Evals never serve browsers or build
+      # launcher links — any valid value satisfies the validator.
       PUBLIC_BASE_URL: "http://localhost:3088"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/evals-nightly.yml
+++ b/.github/workflows/evals-nightly.yml
@@ -45,6 +45,9 @@ jobs:
       EVAL_MODELS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.models || 'claude-sonnet-4-6,gpt-5' }}
       SELECTOR_MODELS: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.selector_models || 'claude-haiku-4-5,gpt-5-mini' }}
       OPENSEARCH_URL: ""
+      # Required by app.config since #141. Evals never serve browsers or
+      # build launcher links — any valid value satisfies the validator.
+      PUBLIC_BASE_URL: "http://localhost:3088"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/evals-smoke.yml
+++ b/.github/workflows/evals-smoke.yml
@@ -36,8 +36,8 @@ jobs:
         working-directory: backend
     env:
       OPENSEARCH_URL: ""
-      # Required by app.config since #141; harmless for dry-run but set it
-      # so any path that loads CONFIG doesn't crash at import.
+      # Required by app.config; harmless for dry-run but set it so any
+      # path that loads CONFIG doesn't crash at import.
       PUBLIC_BASE_URL: "http://localhost:3088"
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/evals-smoke.yml
+++ b/.github/workflows/evals-smoke.yml
@@ -36,6 +36,9 @@ jobs:
         working-directory: backend
     env:
       OPENSEARCH_URL: ""
+      # Required by app.config since #141; harmless for dry-run but set it
+      # so any path that loads CONFIG doesn't crash at import.
+      PUBLIC_BASE_URL: "http://localhost:3088"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

The 2026-06-02 scheduled **Evals nightly failed** ([run 26800556197](https://github.com/onyx-dot-app/agent-wiki/actions/runs/26800556197/job/79006105568)).

**Root cause:** [#141](https://github.com/onyx-dot-app/agent-wiki/pull/141) (commit ca52326) made `public_base_url` a **required, validated** field in `app/config.py` (`:54`, validator `:64-69`). The eval workflows never set `PUBLIC_BASE_URL`, so every live eval step crashed at `CONFIG` validation → wrote no output files → the regression gate (`ci_assert_nightly`, #132) then failed on the missing surface files.

**Fix:** set `PUBLIC_BASE_URL=http://localhost:3088` in both eval workflows' `env`. Evals never serve browsers or build launcher links, so any valid value satisfies the validator. Smoke is dry-run (didn't crash) but gets the var too for safety against any CONFIG-loading path.

The regression gate worked as designed — it surfaced the breakage loudly instead of a silent green nightly.

## How Has This Been Tested?

## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check