### PR TITLE
fix(comments): snap remapped anchors to whole words

### DIFF
--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -107,6 +107,21 @@ def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_e
     return kept / span
 
 
+def _is_word_char(c: str) -> bool:
+    return c.isalnum() or c == "_"
+
+
+def _snap_to_words(body: str, start: int, end: int) -> tuple[int, int]:
+    """Expand ``[start, end)`` outward over adjacent word characters so a
+    remapped anchor never lands mid-word. Stops at whitespace and punctuation,
+    so a span ending before "." doesn't swallow the period."""
+    while start > 0 and _is_word_char(body[start - 1]):
+        start -= 1
+    while end < len(body) and _is_word_char(body[end]):
+        end += 1
+    return start, end
+
+
 def remap_range(
     old_body: str, new_body: str, start: int, end: int
 ) -> tuple[int, int] | None:
@@ -128,6 +143,11 @@ def remap_range(
 
     if new_start >= new_end:
         return None  # whole span deleted/replaced
+    # Snap to whole-word boundaries so an edited word inside the span re-anchors
+    # cleanly (e.g. "variable"->"parameter" keeps the full word, not "parame";
+    # and pulling in the surrounding preserved word lifts the survival fraction
+    # for in-place edits like "weekly"->"biweekly" instead of orphaning).
+    new_start, new_end = _snap_to_words(new_body, new_start, new_end)
     if _word_preserved_fraction(old_body, new_body, new_start, new_end) < _MIN_PRESERVED:
         return None  # alignment landed on mostly-rewritten text — orphan, don't mislead
     if not new_body[new_start:new_end].strip():

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -144,9 +144,9 @@ def remap_range(
     if new_start >= new_end:
         return None  # whole span deleted/replaced
     # Snap to whole-word boundaries so an edited word inside the span re-anchors
-    # cleanly (e.g. "variable"->"parameter" keeps the full word, not "parame";
-    # and pulling in the surrounding preserved word lifts the survival fraction
-    # for in-place edits like "weekly"->"biweekly" instead of orphaning).
+    # cleanly (e.g. "variable"->"parameter" anchors to the full word; pulling in
+    # the surrounding preserved word also lifts the survival fraction for in-place
+    # edits like "weekly"->"biweekly").
     new_start, new_end = _snap_to_words(new_body, new_start, new_end)
     if _word_preserved_fraction(old_body, new_body, new_start, new_end) < _MIN_PRESERVED:
         return None  # alignment landed on mostly-rewritten text — orphan, don't mislead

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -136,6 +136,30 @@ def test_survival_guard_orphans_when_highlight_would_be_mostly_new():
     assert remap_range(old, new, 0, 3) is None
 
 
+def test_word_replacement_keeps_full_word_not_mid_word():
+    # "variable" -> "parameter": the span must re-anchor to the whole new word,
+    # not truncate mid-word (the reported "environment parame" bug).
+    old = "set via the environment variable here"
+    new = "set via the environment parameter here"
+    s, e = old.index("environment variable"), old.index("environment variable") + len(
+        "environment variable"
+    )
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "environment parameter"
+
+
+def test_in_place_word_edit_keeps_via_word_snap():
+    # "weekly" -> "biweekly" inside a span that starts mid-word: snapping pulls
+    # in the preserved word ("rotation"), so it re-anchors instead of orphaning.
+    old = "The rotation is weekly here"
+    new = "The rotation is biweekly here"
+    s = old.index("n is weekly")
+    e = s + len("n is weekly")
+    result = remap_range(old, new, s, e)
+    assert result is not None
+    assert _slice(new, result) == "rotation is biweekly"
+
+
 def test_out_of_bounds_raises():
     with pytest.raises(ValueError):
         remap_range("short", "longer body", 0, 99)


### PR DESCRIPTION
## Problem
Two remap failures on word edits (reported from the running app), both rooted in char-level endpoint mapping:
- **`variable` → `parameter`**: comment kept, but the span truncated **mid-word** to `"environment parame"` (SequenceMatcher partially aligned the two words char-by-char).
- **`weekly` → `biweekly`**: comment **orphaned** — the changed word dropped the word-survival fraction below `_MIN_PRESERVED`.

## Fix
After mapping the endpoints, **snap them outward over adjacent word characters** (`_snap_to_words`). It stops at whitespace *and* punctuation, so a span ending before `.` doesn't swallow the period.

- Re-anchors to the **full edited word** (`environment parameter`, not `parame`).
- Pulling in the surrounding **preserved word** raises the survival fraction, so an in-place edit **migrates** (`rotation is biweekly`) instead of orphaning.

## Tests
Adds regression tests for both reported cases; all 18 anchor tests pass. ruff + basedpyright clean.

Backend-only; pairs with the frontend comments PR (#161).