### PR TITLE
feat(admin): Users & Groups page 

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -91,29 +91,36 @@ def update_user(
     if target is None:
         raise HTTPException(status_code=404, detail="not found")
 
-    if req.is_admin is not None and req.is_admin != bool(target["is_admin"]):
-        if (
-            not req.is_admin
-            and bool(target["is_admin"])
-            and users_repo.admin_count() <= 1
-        ):
-            raise HTTPException(status_code=400, detail="cannot demote the last admin")
+    was_admin = bool(target["is_admin"])
+    was_active = bool(target["is_active"])
+    # Effective state after this PATCH (fields default to current value).
+    final_admin = req.is_admin if req.is_admin is not None else was_admin
+    final_active = req.is_active if req.is_active is not None else was_active
+
+    # Validate every guard BEFORE mutating, so a rejected request never leaves
+    # a half-applied change. Guards check the *resulting* state, so e.g.
+    # demoting + deactivating in one call doesn't false-trip the last-admin
+    # check on a stale snapshot.
+    if req.is_active is False and user_id == actor.id:
+        raise HTTPException(status_code=400, detail="cannot deactivate yourself")
+
+    # An active admin being demoted and/or deactivated must not be the last one.
+    if (was_admin and was_active) and not (final_admin and final_active):
+        if users_repo.admin_count() <= 1:
+            detail = (
+                "cannot demote the last admin"
+                if not final_admin
+                else "cannot deactivate the last admin"
+            )
+            raise HTTPException(status_code=400, detail=detail)
+
+    if req.is_admin is not None and req.is_admin != was_admin:
         users_repo.set_admin(user_id, req.is_admin)
         log.info(
             "admin: %s set is_admin=%s on user %s", actor.id, req.is_admin, user_id
         )
 
-    if req.is_active is not None and req.is_active != bool(target["is_active"]):
-        if not req.is_active and user_id == actor.id:
-            raise HTTPException(status_code=400, detail="cannot deactivate yourself")
-        if (
-            not req.is_active
-            and bool(target["is_admin"])
-            and users_repo.admin_count() <= 1
-        ):
-            raise HTTPException(
-                status_code=400, detail="cannot deactivate the last admin"
-            )
+    if req.is_active is not None and req.is_active != was_active:
         users_repo.set_active(user_id, req.is_active)
         log.info(
             "admin: %s set is_active=%s on user %s", actor.id, req.is_active, user_id

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import csv
+import io
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from app.auth import User, users as users_repo
 from app.auth import groups as groups_repo
+from app.auth import invites
 from app.auth.deps import require_admin
 from app.ingest import settings as ingest_settings
 from app.ingest.settings import IngestSettings
@@ -20,12 +23,15 @@ from app.models.admin import (
     BraintrustConfigRequest,
     BraintrustView,
     IngestConfigRequest,
+    InviteUsersRequest,
+    InvitedUserView,
     IngestView,
     RegenerateKeyResponse,
     LLMConfigRequest,
     LLMView,
     OkResponse,
     UpdateUserRequest,
+    UserCounts,
     WebConfigRequest,
     WebView,
 )
@@ -44,12 +50,16 @@ log = logging.getLogger(__name__)
 
 
 def _user_view(row: dict[str, Any], groups: list[str] | None = None) -> AdminUserView:
+    is_active = bool(row["is_active"])
     return AdminUserView(
         id=row["id"],
         email=row["email"],
         name=row["name"],
         is_admin=bool(row["is_admin"]),
+        is_active=is_active,
+        status="active" if is_active else "inactive",
         created_at=row["created_at"],
+        updated_at=row["updated_at"],
         groups=groups or [],
     )
 
@@ -57,8 +67,17 @@ def _user_view(row: dict[str, Any], groups: list[str] | None = None) -> AdminUse
 @router.get("/users", response_model=AdminUserListResponse)
 def list_users(_actor: User = Depends(require_admin)) -> AdminUserListResponse:
     by_user = groups_repo.groups_by_user()
+    users = [_user_view(r, by_user.get(r["id"], [])) for r in users_repo.list_all()]
+    invited = [InvitedUserView(email=e) for e in invites.list_emails()]
+    status = users_repo.status_counts()
     return AdminUserListResponse(
-        users=[_user_view(r, by_user.get(r["id"], [])) for r in users_repo.list_all()],
+        users=users,
+        invited=invited,
+        counts=UserCounts(
+            active=status["active"],
+            inactive=status["inactive"],
+            invited=len(invited),
+        ),
     )
 
 
@@ -71,18 +90,84 @@ def update_user(
     target = users_repo.get_by_id(user_id)
     if target is None:
         raise HTTPException(status_code=404, detail="not found")
-    if not req.is_admin and bool(target["is_admin"]) and users_repo.admin_count() <= 1:
-        raise HTTPException(status_code=400, detail="cannot demote the last admin")
-    users_repo.set_admin(user_id, req.is_admin)
-    log.info(
-        "admin: %s set is_admin=%s on user %s",
-        actor.id,
-        req.is_admin,
-        user_id,
-    )
+
+    if req.is_admin is not None and req.is_admin != bool(target["is_admin"]):
+        if (
+            not req.is_admin
+            and bool(target["is_admin"])
+            and users_repo.admin_count() <= 1
+        ):
+            raise HTTPException(status_code=400, detail="cannot demote the last admin")
+        users_repo.set_admin(user_id, req.is_admin)
+        log.info(
+            "admin: %s set is_admin=%s on user %s", actor.id, req.is_admin, user_id
+        )
+
+    if req.is_active is not None and req.is_active != bool(target["is_active"]):
+        if not req.is_active and user_id == actor.id:
+            raise HTTPException(status_code=400, detail="cannot deactivate yourself")
+        if (
+            not req.is_active
+            and bool(target["is_admin"])
+            and users_repo.admin_count() <= 1
+        ):
+            raise HTTPException(
+                status_code=400, detail="cannot deactivate the last admin"
+            )
+        users_repo.set_active(user_id, req.is_active)
+        log.info(
+            "admin: %s set is_active=%s on user %s", actor.id, req.is_active, user_id
+        )
+
     row = users_repo.get_by_id(user_id)
     assert row is not None
-    return _user_view(row)
+    return _user_view(row, groups_repo.groups_by_user().get(user_id, []))
+
+
+@router.put("/users/invite", response_model=AdminUserListResponse)
+def invite_users(
+    req: InviteUsersRequest,
+    actor: User = Depends(require_admin),
+) -> AdminUserListResponse:
+    added = invites.add(req.emails, invited_by_user_id=actor.id)
+    log.info("admin: %s invited %d email(s)", actor.id, len(added))
+    return list_users(actor)
+
+
+@router.delete("/users/invited", response_model=OkResponse)
+def cancel_invite(
+    email: str = Query(...),
+    actor: User = Depends(require_admin),
+) -> OkResponse:
+    invites.remove(email)
+    log.info("admin: %s cancelled invite for %s", actor.id, email.strip().lower())
+    return OkResponse()
+
+
+@router.get("/users/download")
+def download_users_csv(_actor: User = Depends(require_admin)) -> Response:
+    by_user = groups_repo.groups_by_user()
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["email", "name", "role", "status", "groups", "created_at"])
+    for r in users_repo.list_all():
+        writer.writerow(
+            [
+                r["email"],
+                r["name"] or "",
+                "admin" if r["is_admin"] else "basic",
+                "active" if r["is_active"] else "inactive",
+                "; ".join(by_user.get(r["id"], [])),
+                r["created_at"],
+            ]
+        )
+    for email in invites.list_emails():
+        writer.writerow([email, "", "basic", "invited", "", ""])
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="users.csv"'},
+    )
 
 
 @router.delete("/users/{user_id}", response_model=OkResponse)
@@ -152,7 +237,9 @@ def put_llm(
         model = (req.model or "").strip()
         if provider not in _ALLOWED_PROVIDERS:
             allowed = ", ".join(f"'{p}'" for p in _ALLOWED_PROVIDERS)
-            raise HTTPException(status_code=400, detail=f"provider must be one of {allowed}")
+            raise HTTPException(
+                status_code=400, detail=f"provider must be one of {allowed}"
+            )
         if not model:
             raise HTTPException(status_code=400, detail="model is required")
     else:
@@ -171,13 +258,19 @@ def put_llm(
     anthropic_key = _resolve_secret(
         "anthropic_api_key", req.anthropic_api_key, current.anthropic_api_key
     )
-    openai_key = _resolve_secret("openai_api_key", req.openai_api_key, current.openai_api_key)
-    gemini_key = _resolve_secret("gemini_api_key", req.gemini_api_key, current.gemini_api_key)
+    openai_key = _resolve_secret(
+        "openai_api_key", req.openai_api_key, current.openai_api_key
+    )
+    gemini_key = _resolve_secret(
+        "gemini_api_key", req.gemini_api_key, current.gemini_api_key
+    )
     ollama_base_url = _resolve_secret(
         "ollama_base_url", req.ollama_base_url, current.ollama_base_url
     )
 
-    new_provider_models = req.provider_models if "provider_models" in sent_fields else None
+    new_provider_models = (
+        req.provider_models if "provider_models" in sent_fields else None
+    )
 
     if "ingest_selector_model" in sent_fields:
         ingest_selector_model = (req.ingest_selector_model or "").strip()
@@ -240,7 +333,9 @@ def put_web(
         return sent
 
     serper_key = _resolve("serper_api_key", req.serper_api_key, current.serper_api_key)
-    firecrawl_key = _resolve("firecrawl_api_key", req.firecrawl_api_key, current.firecrawl_api_key)
+    firecrawl_key = _resolve(
+        "firecrawl_api_key", req.firecrawl_api_key, current.firecrawl_api_key
+    )
 
     web_settings.upsert(
         serper_api_key=serper_key,
@@ -293,7 +388,9 @@ def put_ingest(
 
 
 @router.post("/ingest/regenerate-key", response_model=RegenerateKeyResponse)
-def regenerate_ingest_key(actor: User = Depends(require_admin)) -> RegenerateKeyResponse:
+def regenerate_ingest_key(
+    actor: User = Depends(require_admin),
+) -> RegenerateKeyResponse:
     key = ingest_settings.regenerate_key()
     log.info("admin: %s regenerated ingest api_key", actor.id)
     return RegenerateKeyResponse(api_key=key)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -5,6 +5,7 @@ Session cookies are minted via Starlette's ``SessionMiddleware``
 is all that's needed to "log in", and ``request.session.clear()`` to
 log out.
 """
+
 from __future__ import annotations
 
 import logging
@@ -18,6 +19,7 @@ from app.auth import User, users as users_repo
 from app.auth.basic import authenticate
 from app.auth.deps import require_user
 from app.auth.oidc import client as oidc_client, upsert_oidc_user
+from app.auth import invites
 from app.auth.whitelist import is_allowed, is_open
 from app.config import CONFIG
 from app.models.auth import (
@@ -56,7 +58,7 @@ def signup(req: SignupRequest, request: Request) -> AuthSession:
     name = (req.name or "").strip() or None
     if not email:
         raise HTTPException(status_code=400, detail="email is required")
-    if not is_allowed(email):
+    if not is_allowed(email) and not invites.is_invited(email):
         raise HTTPException(status_code=403, detail="email not allowed")
     if users_repo.get_by_email(email) is not None:
         raise HTTPException(status_code=409, detail="account already exists")
@@ -65,6 +67,8 @@ def signup(req: SignupRequest, request: Request) -> AuthSession:
     except IntegrityError as exc:
         log.warning("signup race: account already exists for %s", email, exc_info=True)
         raise HTTPException(status_code=409, detail="account already exists") from exc
+    # Consume the invite (if any) now that the account exists.
+    invites.remove(email)
     row = users_repo.get_by_id(user_id)
     assert row is not None
     user = User(id=row["id"], email=row["email"], name=row["name"], is_admin=row["is_admin"])
@@ -110,7 +114,9 @@ async def oidc_login(request: Request) -> Response:
     )
     return cast(
         Response,
-        await client.authorize_redirect(request, redirect_uri),  # pyright: ignore[reportUnknownMemberType]
+        await client.authorize_redirect(  # pyright: ignore[reportUnknownMemberType]
+            request, redirect_uri
+        ),
     )
 
 
@@ -148,13 +154,14 @@ async def oidc_callback(request: Request) -> Response:
     if userinfo.get("email_verified") is False:
         log.warning("oidc: email not verified for %s", email)
         return RedirectResponse(url="/login?error=oidc_email_unverified")
-    if not is_allowed(email):
+    if not is_allowed(email) and not invites.is_invited(email):
         log.info("oidc: email %s not in allow list", email)
         return RedirectResponse(url="/login?error=oidc_email_not_allowed")
 
     name_raw = userinfo.get("name")
     name = name_raw if isinstance(name_raw, str) else None
     user_id = upsert_oidc_user(email=email, name=name)
+    invites.remove(email)
     row = users_repo.get_by_id(user_id)
     assert row is not None
     user = User(id=row["id"], email=row["email"], name=row["name"], is_admin=row["is_admin"])

--- a/backend/app/api/permissions.py
+++ b/backend/app/api/permissions.py
@@ -22,6 +22,9 @@ from app.models.permissions import (
     GroupMemberOut,
     GroupMembersResponse,
     GroupOut,
+    GroupShareOut,
+    GroupSharesResponse,
+    GroupUpdateRequest,
     TransferOwnershipRequest,
     TransferOwnershipResponse,
 )
@@ -90,6 +93,23 @@ def get_group(
     return GroupMembersResponse(group=GroupOut(**g), members=members)
 
 
+@router.patch("/groups/{group_id}", response_model=GroupOut)
+def update_group(
+    group_id: str,
+    req: GroupUpdateRequest,
+    _actor: User = Depends(require_admin),
+) -> GroupOut:
+    try:
+        groups_repo.rename(group_id, req.name)
+    except groups_repo.GroupNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="not found") from exc
+    except groups_repo.GroupNameTakenError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    g = groups_repo.get(group_id)
+    assert g is not None
+    return GroupOut(**g)
+
+
 @router.delete("/groups/{group_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_group(
     group_id: str,
@@ -99,6 +119,19 @@ def delete_group(
         raise HTTPException(status_code=404, detail="not found")
     groups_repo.delete_group(group_id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/groups/{group_id}/shares", response_model=GroupSharesResponse)
+def list_group_shares(
+    group_id: str,
+    _actor: User = Depends(require_admin),
+) -> GroupSharesResponse:
+    """Pages and folders shared with this group — for the admin group page's
+    "shared resources" section, where access can be reviewed and revoked."""
+    if groups_repo.get(group_id) is None:
+        raise HTTPException(status_code=404, detail="not found")
+    shares = [GroupShareOut(**s) for s in acl.list_for_group(group_id)]
+    return GroupSharesResponse(shares=shares)
 
 
 @router.post("/groups/{group_id}/members", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/auth/basic.py
+++ b/backend/app/auth/basic.py
@@ -11,6 +11,9 @@ def authenticate(email: str, password: str) -> User | None:
         return None
     if not verify_password(password, row["password_hash"]):
         return None
+    if not row["is_active"]:
+        # Deactivated accounts can't authenticate.
+        return None
     return User(
         id=row["id"],
         email=row["email"],

--- a/backend/app/auth/deps.py
+++ b/backend/app/auth/deps.py
@@ -32,13 +32,16 @@ _BEARER_PREFIX = "Bearer "
 
 def current_user(request: Request) -> User | None:
     """Resolve the active user from the session cookie. Returns
-    ``None`` when there is no cookie, the signature is invalid, or
-    the user row has been deleted."""
+    ``None`` when there is no cookie, the signature is invalid, the
+    user row has been deleted, or the account is deactivated."""
     user_id = request.session.get("user_id")
     if not isinstance(user_id, str) or not user_id:
         return None
     row = users_repo.get_by_id(user_id)
     if row is None:
+        return None
+    if not row["is_active"]:
+        # A deactivated user's existing session stops authenticating.
         return None
     return User(
         id=row["id"],

--- a/backend/app/auth/groups.py
+++ b/backend/app/auth/groups.py
@@ -85,6 +85,25 @@ def get_by_name(name: str) -> dict[str, Any] | None:
         return _to_dict(g) if g else None
 
 
+def rename(group_id: str, name: str) -> None:
+    """Rename a group. Raises ``GroupNotFoundError`` if it doesn't exist and
+    ``GroupNameTakenError`` if another group already holds the name."""
+    name = name.strip()
+    if not name:
+        raise ValueError("group name required")
+    with session() as s:
+        g = s.get(Group, group_id)
+        if g is None:
+            raise GroupNotFoundError(group_id)
+        clash = s.scalar(
+            select(Group).where(Group.name == name, Group.id != group_id)
+        )
+        if clash is not None:
+            raise GroupNameTakenError(f"group name already in use: {name!r}")
+        g.name = name
+    log.info("group renamed id=%s name=%s", group_id, name)
+
+
 def delete_group(group_id: str) -> None:
     with session() as s:
         g = s.get(Group, group_id)

--- a/backend/app/auth/invites.py
+++ b/backend/app/auth/invites.py
@@ -1,0 +1,63 @@
+"""Invited-email repo — emails allowed to sign up but without an account yet.
+
+An invite is consumed (the row deleted) when the email signs up; see
+``app.auth.users.create``'s callers in ``app/api/auth.py``. Invited emails
+also pass the signup allowlist (``app.auth.whitelist``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+
+from app.db.models import InvitedUser, User
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+
+def list_emails() -> list[str]:
+    """Pending invites — invited emails that have NOT signed up yet."""
+    with session() as s:
+        invited = set(s.scalars(select(InvitedUser.email)).all())
+        if not invited:
+            return []
+        signed_up = set(s.scalars(select(User.email)).all())
+        return sorted(invited - signed_up)
+
+
+def count() -> int:
+    return len(list_emails())
+
+
+def is_invited(email: str) -> bool:
+    with session() as s:
+        return s.get(InvitedUser, email.strip().lower()) is not None
+
+
+def add(emails: list[str], invited_by_user_id: str | None) -> list[str]:
+    """Insert any new invited emails (skips ones that already have an account
+    or are already invited). Returns the emails actually added."""
+    cleaned = [e.strip().lower() for e in emails if e.strip()]
+    if not cleaned:
+        return []
+    added: list[str] = []
+    with session() as s:
+        existing_accounts = set(s.scalars(select(User.email)).all())
+        existing_invites = set(s.scalars(select(InvitedUser.email)).all())
+        for email in dict.fromkeys(cleaned):
+            if email in existing_accounts or email in existing_invites:
+                continue
+            s.add(InvitedUser(email=email, invited_by_user_id=invited_by_user_id))
+            added.append(email)
+    if added:
+        log.info("invited %d email(s): %s", len(added), ", ".join(added))
+    return added
+
+
+def remove(email: str) -> None:
+    with session() as s:
+        row = s.get(InvitedUser, email.strip().lower())
+        if row is not None:
+            s.delete(row)

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from sqlalchemy import func, or_, select
@@ -17,6 +18,11 @@ from app.models.user_settings import UserSettings
 log = logging.getLogger(__name__)
 
 
+def _now() -> str:
+    """UTC timestamp matching the ``YYYY-MM-DD HH:MM:SS`` column format."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
 def _to_dict(u: User) -> dict[str, Any]:
     return {
         "id": u.id,
@@ -24,7 +30,9 @@ def _to_dict(u: User) -> dict[str, Any]:
         "name": u.name,
         "password_hash": u.password_hash,
         "is_admin": u.is_admin,
+        "is_active": u.is_active,
         "created_at": u.created_at,
+        "updated_at": u.updated_at,
         "settings": _settings_with_defaults(u.settings),
     }
 
@@ -89,7 +97,10 @@ def search(query: str, limit: int = 20) -> list[dict[str, Any]]:
                 )
             )
         stmt = stmt.order_by(User.email.asc()).limit(limit)
-        return [{"id": u.id, "email": u.email, "name": u.name} for u in s.scalars(stmt).all()]
+        return [
+            {"id": u.id, "email": u.email, "name": u.name}
+            for u in s.scalars(stmt).all()
+        ]
 
 
 def create(email: str, password: str, name: str | None = None) -> str:
@@ -107,7 +118,9 @@ def create(email: str, password: str, name: str | None = None) -> str:
                 is_admin=is_admin,
             )
         )
-    log.info("user created id=%s email=%s is_admin=%s", user_id, email.lower(), is_admin)
+    log.info(
+        "user created id=%s email=%s is_admin=%s", user_id, email.lower(), is_admin
+    )
     return user_id
 
 
@@ -116,11 +129,39 @@ def set_admin(user_id: str, is_admin: bool) -> None:
         u = s.get(User, user_id)
         if u is not None:
             u.is_admin = is_admin
+            u.updated_at = _now()
+
+
+def set_active(user_id: str, is_active: bool) -> None:
+    with session() as s:
+        u = s.get(User, user_id)
+        if u is not None:
+            u.is_active = is_active
+            u.updated_at = _now()
+
+
+def status_counts() -> dict[str, int]:
+    """``{active, inactive}`` counts over real accounts (invited emails are
+    counted separately, in ``app.auth.invites``)."""
+    with session() as s:
+        active = (
+            s.scalar(
+                select(func.count()).select_from(User).where(User.is_active.is_(True))
+            )
+            or 0
+        )
+        total = s.scalar(select(func.count()).select_from(User)) or 0
+    return {"active": active, "inactive": total - active}
 
 
 def admin_count() -> int:
     with session() as s:
-        return s.scalar(select(func.count()).select_from(User).where(User.is_admin.is_(True))) or 0
+        return (
+            s.scalar(
+                select(func.count()).select_from(User).where(User.is_admin.is_(True))
+            )
+            or 0
+        )
 
 
 def delete(user_id: str) -> None:
@@ -138,6 +179,7 @@ def update_name(user_id: str, name: str | None) -> dict[str, Any] | None:
         if u is None:
             return None
         u.name = name
+        u.updated_at = _now()
         s.flush()
         return _to_dict(u)
 

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -155,10 +155,15 @@ def status_counts() -> dict[str, int]:
 
 
 def admin_count() -> int:
+    """Number of *active* admins. The last-admin guards (demote / delete /
+    deactivate) rely on this — an inactive admin can't log in, so counting
+    them would let the sole active admin be removed and lock everyone out."""
     with session() as s:
         return (
             s.scalar(
-                select(func.count()).select_from(User).where(User.is_admin.is_(True))
+                select(func.count())
+                .select_from(User)
+                .where(User.is_admin.is_(True), User.is_active.is_(True))
             )
             or 0
         )

--- a/backend/app/db/migrations/versions/0028_users_active_invited.py
+++ b/backend/app/db/migrations/versions/0028_users_active_invited.py
@@ -1,0 +1,58 @@
+"""user is_active + updated_at, and the invited_users table
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-06-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0028"
+down_revision: str = "0027"
+branch_labels = None
+depends_on = None
+
+_NOW = sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    user_cols = {c["name"] for c in insp.get_columns("users")}
+    if "is_active" not in user_cols:
+        op.add_column(
+            "users",
+            sa.Column(
+                "is_active",
+                sa.Boolean,
+                nullable=False,
+                server_default=sa.text("TRUE"),
+            ),
+        )
+    if "updated_at" not in user_cols:
+        op.add_column(
+            "users",
+            sa.Column("updated_at", sa.Text, nullable=False, server_default=_NOW),
+        )
+
+    if not insp.has_table("invited_users"):
+        op.create_table(
+            "invited_users",
+            sa.Column("email", sa.Text, primary_key=True),
+            sa.Column(
+                "invited_by_user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="SET NULL"),
+            ),
+            sa.Column("created_at", sa.Text, nullable=False, server_default=_NOW),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("invited_users")
+    op.drop_column("users", "updated_at")
+    op.drop_column("users", "is_active")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -60,8 +60,18 @@ class User(Base):
     name: Mapped[str | None] = mapped_column(Text)
     # Null when AUTH_MODE=oidc.
     password_hash: Mapped[str | None] = mapped_column(Text)
-    is_admin: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    is_admin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     # Per-user preferences (theme, timezone, etc.). Shape is enforced by the
     # ``UserSettings`` pydantic model in ``app/models/user_settings.py``;
     # the column itself is a free-form JSONB so adding a new preference
@@ -69,6 +79,21 @@ class User(Base):
     # field defaults from the pydantic model on read.
     settings: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+
+
+class InvitedUser(Base):
+    """An email that's been invited to sign up but hasn't created an account
+    yet. On signup the row is consumed (deleted) and a real ``User`` exists."""
+
+    __tablename__ = "invited_users"
+
+    email: Mapped[str] = mapped_column(Text, primary_key=True)
+    invited_by_user_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
 
 
@@ -82,7 +107,9 @@ class McpConnection(Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     transport: Mapped[str] = mapped_column(Text, nullable=False)  # "stdio" | "http"
     config_json: Mapped[str] = mapped_column(Text, nullable=False)
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 class McpToken(Base):
@@ -104,7 +131,9 @@ class McpToken(Base):
     )
     name: Mapped[str] = mapped_column(Text, nullable=False)
     token_hash: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     last_used_at: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (Index("idx_mcp_tokens_user", "user_id"),)
@@ -132,12 +161,16 @@ class McpJob(Base):
         Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     kind: Mapped[str] = mapped_column(Text, nullable=False)  # "update_doc_nl"
-    status: Mapped[str] = mapped_column(Text, nullable=False)  # pending|running|succeeded|failed
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False
+    )  # pending|running|succeeded|failed
     idempotency_key: Mapped[str | None] = mapped_column(Text)
     payload_json: Mapped[str] = mapped_column(Text, nullable=False)
     result_json: Mapped[str | None] = mapped_column(Text)
     error: Mapped[str | None] = mapped_column(Text)
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     finished_at: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (
@@ -258,12 +291,16 @@ class AgentSession(Base):
     working_dir: Mapped[str | None] = mapped_column(Text)
     first_turn_prompt: Mapped[str] = mapped_column(Text, nullable=False)
     cli_session_id: Mapped[str | None] = mapped_column(Text)
-    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'pending'"))
-    started_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'pending'")
+    )
+    started_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     last_activity_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
-    spawn_ok_at: Mapped[str | None] = mapped_column(Text) # beacon timestamp
+    spawn_ok_at: Mapped[str | None] = mapped_column(Text)  # beacon timestamp
     closed_at: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (
@@ -288,7 +325,9 @@ class LaunchCode(Base):
     mcp_token_id: Mapped[str] = mapped_column(
         Text, ForeignKey("mcp_tokens.id", ondelete="CASCADE"), nullable=False
     )
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     expires_at: Mapped[str] = mapped_column(Text, nullable=False)
     consumed_at: Mapped[str | None] = mapped_column(Text)
 
@@ -306,7 +345,9 @@ class PageWorkingDir(Base):
     machine_id: Mapped[str] = mapped_column(Text, primary_key=True)
     wiki_path: Mapped[str] = mapped_column(Text, primary_key=True)
     working_dir: Mapped[str] = mapped_column(Text, nullable=False)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 class LauncherToken(Base):
@@ -332,7 +373,9 @@ class LauncherToken(Base):
     )
     ciphertext: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     nonce: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -401,7 +444,9 @@ class Trigger(Base):
     # the schedule evaluator on each tick so croniter advances. DB-only —
     # not persisted to the YAML file (would commit on every fire).
     schedule_last_fired_at: Mapped[str | None] = mapped_column(Text)
-    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("TRUE"))
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("TRUE")
+    )
     file_path: Mapped[str | None] = mapped_column(Text)
     last_edited_at: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
@@ -426,8 +471,12 @@ class TriggerDestination(Base):
 
     id: Mapped[str] = mapped_column(Text, primary_key=True)
     name: Mapped[str] = mapped_column(Text, nullable=False)
-    description: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    description: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 class SlackWebhook(Base):
@@ -471,9 +520,15 @@ class ChatSession(Base):
     # Sessions created to bootstrap "drafting from template" conversations
     # are hidden from the session history list (the row stays so the
     # transcript can be re-rendered if anything in code still has the id).
-    hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    hidden: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (Index("idx_chat_sessions_user_updated", "user_id", "updated_at"),)
 
@@ -497,15 +552,23 @@ class ChatMessage(Base):
     )
     ordering: Mapped[int] = mapped_column(Integer, nullable=False)
     role: Mapped[str] = mapped_column(Text, nullable=False)
-    content: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    content: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
     events_json: Mapped[str | None] = mapped_column(Text)
     # Hidden seed messages live in the LLM history (so the model has the
     # template context) but are filtered out of the rendered transcript.
-    hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    hidden: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (
-        CheckConstraint("role IN ('user', 'assistant')", name="chat_messages_role_check"),
+        CheckConstraint(
+            "role IN ('user', 'assistant')", name="chat_messages_role_check"
+        ),
         Index("idx_chat_messages_session_order", "session_id", "ordering"),
     )
 
@@ -533,12 +596,18 @@ class DocumentTemplate(Base):
     # Admin-controlled ordering for the picker. Lower values render
     # first; ties fall back to ``name`` alphabetical. New rows land at
     # the end (max(sort_order) + 1) so admins decide where they live.
-    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
+    sort_order: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
     created_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 class DocumentDraft(Base):
@@ -559,7 +628,9 @@ class DocumentDraft(Base):
     created_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -571,11 +642,15 @@ class Event(Base):
     __tablename__ = "events"
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
-    ts: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    ts: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     kind: Mapped[str] = mapped_column(Text, nullable=False)
     actor: Mapped[str | None] = mapped_column(Text)
     target: Mapped[str | None] = mapped_column(Text)
-    payload_json: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'{}'"))
+    payload_json: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'{}'")
+    )
 
     __table_args__ = (
         Index("idx_events_ts", "ts"),
@@ -597,15 +672,27 @@ class LLMSettings(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
     provider: Mapped[str] = mapped_column(Text, nullable=False)
     model: Mapped[str] = mapped_column(Text, nullable=False)
-    anthropic_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    openai_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    gemini_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    ollama_base_url: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    anthropic_api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    openai_api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    gemini_api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    ollama_base_url: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
     provider_models: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
-    ingest_selector_model: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    ingest_selector_model: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (CheckConstraint("id = 1", name="llm_settings_singleton"),)
 
@@ -614,9 +701,15 @@ class WebSettings(Base):
     __tablename__ = "web_settings"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
-    serper_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    firecrawl_api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    serper_api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    firecrawl_api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (CheckConstraint("id = 1", name="web_settings_singleton"),)
 
@@ -629,7 +722,9 @@ class IngestSettings(Base):
         Integer, nullable=False, server_default=text("100000")
     )
     api_key: Mapped[str | None] = mapped_column(Text, nullable=True)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (CheckConstraint("id = 1", name="ingest_settings_singleton"),)
 
@@ -638,10 +733,18 @@ class BraintrustSettings(Base):
     __tablename__ = "braintrust_settings"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
-    project: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    api_key: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
-    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    project: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (CheckConstraint("id = 1", name="braintrust_settings_singleton"),)
 
@@ -662,7 +765,9 @@ class AgentActivity(Base):
     agent_name: Mapped[str | None] = mapped_column(Text)
     doc_path: Mapped[str] = mapped_column(Text, nullable=False)
     activity: Mapped[str] = mapped_column(Text, nullable=False)
-    description: Mapped[str | None] = mapped_column(Text)  # null = "N/A" in rendered frontmatter
+    description: Mapped[str | None] = mapped_column(
+        Text
+    )  # null = "N/A" in rendered frontmatter
     registered_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
@@ -681,7 +786,9 @@ class AgentActivity(Base):
     )
 
     __table_args__ = (
-        CheckConstraint("activity IN ('read', 'wrote')", name="agent_activity_kind_check"),
+        CheckConstraint(
+            "activity IN ('read', 'wrote')", name="agent_activity_kind_check"
+        ),
         # One row per (user, agent): a new upsert replaces the prior row
         # in place. Postgres 15+ NULLS NOT DISTINCT lets nullable
         # agent_name participate in uniqueness directly — no
@@ -753,7 +860,9 @@ class Group(Base):
     created_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 class GroupMember(Base):
@@ -765,7 +874,9 @@ class GroupMember(Base):
     user_id: Mapped[str] = mapped_column(
         Text, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
     )
-    added_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    added_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
 
 class WikiOwner(Base):
@@ -816,7 +927,9 @@ class AclEntry(Base):
     granted_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (
         CheckConstraint(
@@ -896,28 +1009,38 @@ class Comment(Base):
     )
 
     # Anchor — set on the thread root for scope='inline'; NULL otherwise.
-    scope: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'inline'"))
+    scope: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'inline'")
+    )
     anchor_sha: Mapped[str | None] = mapped_column(Text)
     start_offset: Mapped[int | None] = mapped_column(Integer)
     end_offset: Mapped[int | None] = mapped_column(Integer)
     quoted_text: Mapped[str | None] = mapped_column(Text)
 
     # Author
-    author_kind: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'user'"))
+    author_kind: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'user'")
+    )
     author_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )
 
     # Content + lifecycle
     body: Mapped[str] = mapped_column(Text, nullable=False)
-    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'open'"))
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'open'")
+    )
     resolved_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )
     resolved_at: Mapped[str | None] = mapped_column(Text)
 
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
 
     __table_args__ = (
         CheckConstraint(
@@ -960,7 +1083,9 @@ class IngestEvalSample(Base):
     __tablename__ = "ingest_eval_samples"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
     source_document_id: Mapped[str | None] = mapped_column(Text)
     source_type: Mapped[str | None] = mapped_column(Text)
     source_title: Mapped[str | None] = mapped_column(Text)

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -11,7 +11,14 @@ from pydantic import BaseModel, ConfigDict, Field
 
 
 class UpdateUserRequest(BaseModel):
-    is_admin: bool
+    """Both optional — PATCH whichever field(s) are present."""
+
+    is_admin: bool | None = None
+    is_active: bool | None = None
+
+
+class InviteUsersRequest(BaseModel):
+    emails: list[str]
 
 
 class LLMConfigRequest(BaseModel):
@@ -65,13 +72,29 @@ class AdminUserView(BaseModel):
     email: str
     name: str | None
     is_admin: bool
+    is_active: bool
+    # "active" | "inactive" — derived from is_active for the status column.
+    status: str
     created_at: str
+    updated_at: str
     # Names of the groups this user belongs to (for the admin users table).
     groups: list[str] = Field(default_factory=list)
 
 
+class InvitedUserView(BaseModel):
+    email: str
+
+
+class UserCounts(BaseModel):
+    active: int
+    inactive: int
+    invited: int
+
+
 class AdminUserListResponse(BaseModel):
     users: list[AdminUserView]
+    invited: list[InvitedUserView] = Field(default_factory=list)
+    counts: UserCounts
 
 
 class LLMView(BaseModel):

--- a/backend/app/models/permissions.py
+++ b/backend/app/models/permissions.py
@@ -56,6 +56,24 @@ class GroupMemberAddRequest(BaseModel):
     user_id: str = Field(min_length=1)
 
 
+class GroupUpdateRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+
+
+class GroupShareOut(BaseModel):
+    """A page or folder shared with a group — one ACL row, group-centric."""
+
+    id: str
+    resource_kind: str
+    resource_path: str
+    permission: str
+    created_at: str
+
+
+class GroupSharesResponse(BaseModel):
+    shares: list[GroupShareOut]
+
+
 # --------------------------------------------------------------------------- #
 # Wiki ACL grants                                                             #
 # --------------------------------------------------------------------------- #

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -341,6 +341,31 @@ def list_for_path(path: str) -> list[dict[str, Any]]:
     return [_entry_dict(e) for e in page_rows] + [_entry_dict(e) for e in folder_rows]
 
 
+def list_for_group(group_id: str) -> list[dict[str, Any]]:
+    """All ACL rows whose principal is ``group_id`` — the pages and folders
+    shared with the group. Ordered folders-then-pages, path-ascending.
+
+    Used by the admin group page to show (and revoke) what a group can
+    access. The inverse of ``list_for_path``'s resource-centric view.
+    """
+    with session() as s:
+        rows = list(
+            s.scalars(
+                select(AclEntry)
+                .where(
+                    AclEntry.principal_kind == "group",
+                    AclEntry.principal_id == group_id,
+                )
+                .order_by(
+                    AclEntry.resource_kind.asc(),
+                    AclEntry.resource_path.asc(),
+                    AclEntry.created_at.asc(),
+                )
+            ).all()
+        )
+    return [_entry_dict(e) for e in rows]
+
+
 def delete_all_for_path(path: str) -> None:
     """Drop every page-level ACL row keyed at ``path``. Folder rows are
     not touched (a folder grant can outlive any individual page in it).

--- a/backend/tests/integration/test_permissions_api.py
+++ b/backend/tests/integration/test_permissions_api.py
@@ -68,6 +68,90 @@ def test_member_addition_and_listing(integration):
     assert resp.json()["members"] == []
 
 
+def test_admin_can_rename_group(integration):
+    integration.signup(email="admin@x.com")
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+
+    resp = integration.client.patch(f"/api/groups/{gid}", json={"name": "platform"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "platform"
+
+    names = [g["name"] for g in integration.client.get("/api/groups").json()["groups"]]
+    assert names == ["platform"]
+
+
+def test_rename_to_duplicate_name_returns_409(integration):
+    integration.signup(email="admin@x.com")
+    integration.client.post("/api/groups", json={"name": "eng"})
+    gid = integration.client.post("/api/groups", json={"name": "growth"}).json()["id"]
+
+    resp = integration.client.patch(f"/api/groups/{gid}", json={"name": "eng"})
+    assert resp.status_code == 409
+
+
+def test_rename_nonexistent_group_returns_404(integration):
+    integration.signup(email="admin@x.com")
+    resp = integration.client.patch("/api/groups/grp_nope", json={"name": "x"})
+    assert resp.status_code == 404
+
+
+def test_non_admin_cannot_rename_group(integration):
+    integration.signup(email="admin@x.com")
+    bob = integration.signup(email="bob@x.com")
+    integration.signin(email="admin@x.com")
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+
+    integration.signin(user_id=bob)
+    assert integration.client.patch(f"/api/groups/{gid}", json={"name": "x"}).status_code == 403
+
+
+def test_group_shares_lists_granted_resources(integration):
+    integration.signup(email="admin@x.com")
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+    integration.put_doc("docs/spec.md", "# Spec")
+
+    # Grant the group a page (write) and a folder (read).
+    for kind, path, perm in [
+        ("page", "docs/spec.md", "write"),
+        ("folder", "docs", "read"),
+    ]:
+        r = integration.client.post(
+            "/api/wiki/acl",
+            json={
+                "resource_kind": kind,
+                "resource_path": path,
+                "principal_kind": "group",
+                "principal_id": gid,
+                "permission": perm,
+            },
+        )
+        assert r.status_code == 201, r.text
+
+    resp = integration.client.get(f"/api/groups/{gid}/shares")
+    assert resp.status_code == 200, resp.text
+    shares = resp.json()["shares"]
+    by_path = {s["resource_path"]: s for s in shares}
+    assert by_path["docs/spec.md"]["resource_kind"] == "page"
+    assert by_path["docs/spec.md"]["permission"] == "write"
+    assert by_path["docs"]["resource_kind"] == "folder"
+    assert by_path["docs"]["permission"] == "read"
+
+
+def test_group_shares_requires_admin(integration):
+    integration.signup(email="admin@x.com")
+    bob = integration.signup(email="bob@x.com")
+    integration.signin(email="admin@x.com")
+    gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]
+
+    integration.signin(user_id=bob)
+    assert integration.client.get(f"/api/groups/{gid}/shares").status_code == 403
+
+
+def test_group_shares_nonexistent_group_returns_404(integration):
+    integration.signup(email="admin@x.com")
+    assert integration.client.get("/api/groups/grp_nope/shares").status_code == 404
+
+
 def test_user_sees_only_their_groups(integration):
     integration.signup(email="admin@x.com")
     alice = integration.signup(email="alice@x.com")
@@ -227,10 +311,12 @@ def test_anonymous_calls_to_permission_endpoints_return_401(integration):
     # Read paths.
     assert integration.client.get("/api/groups").status_code == 401
     assert integration.client.get("/api/groups/grp_x").status_code == 401
+    assert integration.client.get("/api/groups/grp_x/shares").status_code == 401
     assert integration.client.get("/api/wiki/acl?path=x.md").status_code == 401
 
     # Write paths.
     assert integration.client.post("/api/groups", json={"name": "x"}).status_code == 401
+    assert integration.client.patch("/api/groups/grp_x", json={"name": "x"}).status_code == 401
     assert integration.client.delete("/api/groups/grp_x").status_code == 401
     assert (
         integration.client.post("/api/groups/grp_x/members", json={"user_id": "u_x"}).status_code

--- a/backend/tests/integration/test_permissions_api.py
+++ b/backend/tests/integration/test_permissions_api.py
@@ -68,6 +68,31 @@ def test_member_addition_and_listing(integration):
     assert resp.json()["members"] == []
 
 
+def test_combined_demote_and_deactivate_does_not_false_400(integration):
+    # Regression: a single PATCH demoting AND deactivating another admin used
+    # to commit the demotion then false-trip the last-admin guard on a stale
+    # snapshot. With two active admins, demoting+deactivating one must succeed
+    # fully (the actor remains an active admin).
+    admin1 = integration.signup(email="admin1@x.com")  # auto-admin
+    admin2 = integration.signup(email="admin2@x.com")
+    integration.signin(user_id=admin1)
+    assert (
+        integration.client.patch(
+            f"/api/admin/users/{admin2}", json={"is_admin": True}
+        ).status_code
+        == 200
+    )
+
+    resp = integration.client.patch(
+        f"/api/admin/users/{admin2}",
+        json={"is_admin": False, "is_active": False},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["is_admin"] is False
+    assert body["is_active"] is False
+
+
 def test_admin_can_rename_group(integration):
     integration.signup(email="admin@x.com")
     gid = integration.client.post("/api/groups", json={"name": "eng"}).json()["id"]

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -1,0 +1,51 @@
+"""Invited-email repo + user active/status counts."""
+
+from __future__ import annotations
+
+from app.auth import invites
+from app.auth import users as users_repo
+from tests._seed import seed_user
+
+
+def test_invite_add_list_remove(tmp_db):
+    added = invites.add(["A@x.com", "b@x.com", "a@x.com"], invited_by_user_id=None)
+    # Deduped + lowercased.
+    assert sorted(added) == ["a@x.com", "b@x.com"]
+    assert invites.list_emails() == ["a@x.com", "b@x.com"]
+    assert invites.count() == 2
+    assert invites.is_invited("A@x.com") is True
+
+    invites.remove("a@x.com")
+    assert invites.list_emails() == ["b@x.com"]
+
+
+def test_invite_skips_existing_account_and_dupes(tmp_db):
+    seed_user(uid="u1", email="taken@x.com")
+    # Already an account → not added; second add of same email → no dupe.
+    assert invites.add(["taken@x.com", "new@x.com"], invited_by_user_id=None) == [
+        "new@x.com"
+    ]
+    assert invites.add(["new@x.com"], invited_by_user_id=None) == []
+    assert invites.list_emails() == ["new@x.com"]
+
+
+def test_invited_email_dropped_from_list_once_signed_up(tmp_db):
+    invites.add(["future@x.com"], invited_by_user_id=None)
+    assert invites.list_emails() == ["future@x.com"]
+    # They sign up — list_emails filters out emails that now have an account
+    # even before the invite row is consumed.
+    seed_user(uid="u_future", email="future@x.com")
+    assert invites.list_emails() == []
+    assert invites.count() == 0
+
+
+def test_set_active_and_status_counts(tmp_db):
+    a = seed_user(uid="u_a", email="a@x.com")
+    seed_user(uid="u_b", email="b@x.com")
+    assert users_repo.status_counts() == {"active": 2, "inactive": 0}
+
+    users_repo.set_active(a, False)
+    assert users_repo.status_counts() == {"active": 1, "inactive": 1}
+    row = users_repo.get_by_id(a)
+    assert row is not None
+    assert row["is_active"] is False

--- a/backend/tests/test_invites.py
+++ b/backend/tests/test_invites.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from app.auth import invites
 from app.auth import users as users_repo
+from app.auth.basic import authenticate
 from tests._seed import seed_user
 
 
@@ -49,3 +50,22 @@ def test_set_active_and_status_counts(tmp_db):
     row = users_repo.get_by_id(a)
     assert row is not None
     assert row["is_active"] is False
+
+
+def test_admin_count_excludes_inactive(tmp_db):
+    seed_user(uid="u_a", email="a@x.com", is_admin=True)
+    b = seed_user(uid="u_b", email="b@x.com", is_admin=True)
+    assert users_repo.admin_count() == 2
+
+    # A deactivated admin can't log in, so the last-admin guards must not
+    # count them — otherwise the sole active admin could be removed.
+    users_repo.set_active(b, False)
+    assert users_repo.admin_count() == 1
+
+
+def test_deactivated_user_cannot_authenticate(tmp_db):
+    uid = users_repo.create("a@x.com", "secret-pw")
+    assert authenticate("a@x.com", "secret-pw") is not None
+
+    users_repo.set_active(uid, False)
+    assert authenticate("a@x.com", "secret-pw") is None

--- a/frontend/src/app/admin/groups/GroupMembersTable.tsx
+++ b/frontend/src/app/admin/groups/GroupMembersTable.tsx
@@ -10,7 +10,12 @@ import {
   createTableColumns,
 } from "@onyx-ai/opal/components";
 import { Content, IllustrationContent } from "@onyx-ai/opal/layouts";
-import { SvgMinusCircle, SvgPlusCircle, SvgUser, SvgUserShield } from "@onyx-ai/opal/icons";
+import {
+  SvgMinusCircle,
+  SvgPlusCircle,
+  SvgUser,
+  SvgUserShield,
+} from "@onyx-ai/opal/icons";
 import { SvgNoResult } from "@onyx-ai/opal/illustrations";
 import type { IconProps } from "@onyx-ai/opal/types";
 
@@ -56,10 +61,15 @@ const baseColumns = [
   tc.qualifier({
     content: "icon",
     iconSize: "lg",
-    getContent:
-      (row) =>
+    getContent: (row) =>
       function RowAvatar(props: IconProps) {
-        return <Avatar label={initials(row)} size={props.size ?? 28} title={displayName(row)} />;
+        return (
+          <Avatar
+            label={initials(row)}
+            size={props.size ?? 28}
+            title={displayName(row)}
+          />
+        );
       },
   }),
   tc.column("email", { header: "Name", weight: 30, cell: nameCell }),
@@ -120,7 +130,9 @@ export function GroupMembersTable({
             variant="danger"
             icon={SvgMinusCircle}
             tooltip="Remove"
-            onClick={() => onSelectionChange(selectedIds.filter((id) => id !== row.id))}
+            onClick={() =>
+              onSelectionChange(selectedIds.filter((id) => id !== row.id))
+            }
           />
         ),
       }),

--- a/frontend/src/app/admin/groups/GroupMembersTable.tsx
+++ b/frontend/src/app/admin/groups/GroupMembersTable.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  Button,
+  InputTypeIn,
+  Table,
+  Text,
+  createTableColumns,
+} from "@onyx-ai/opal/components";
+import { Content, IllustrationContent } from "@onyx-ai/opal/layouts";
+import { SvgMinusCircle, SvgPlusCircle, SvgUser, SvgUserShield } from "@onyx-ai/opal/icons";
+import { SvgNoResult } from "@onyx-ai/opal/illustrations";
+import type { IconProps } from "@onyx-ai/opal/types";
+
+import { Avatar } from "@/components/common/Avatar";
+import { displayName, initials } from "@/lib/users";
+
+import styles from "./groups.module.css";
+
+export interface MemberRow {
+  id: string;
+  email: string;
+  name: string | null;
+  is_admin: boolean;
+}
+
+const PAGE_SIZE = 10;
+const tc = createTableColumns<MemberRow>();
+
+function nameCell(_value: string, row: MemberRow) {
+  return (
+    <Content
+      sizePreset="main-ui"
+      variant="section"
+      title={displayName(row)}
+      description={row.name ? row.email : undefined}
+    />
+  );
+}
+
+function accountTypeCell(_value: boolean, row: MemberRow) {
+  const Icon = row.is_admin ? SvgUserShield : SvgUser;
+  return (
+    <span className={styles.acctType}>
+      <Icon size={16} />
+      <Text font="main-ui-body" color="text-03">
+        {row.is_admin ? "Admin" : "Basic"}
+      </Text>
+    </span>
+  );
+}
+
+const baseColumns = [
+  tc.qualifier({
+    content: "icon",
+    iconSize: "lg",
+    getContent:
+      (row) =>
+      function RowAvatar(props: IconProps) {
+        return <Avatar label={initials(row)} size={props.size ?? 28} title={displayName(row)} />;
+      },
+  }),
+  tc.column("email", { header: "Name", weight: 30, cell: nameCell }),
+  tc.column("is_admin", {
+    header: "Account Type",
+    weight: 18,
+    enableSorting: false,
+    cell: accountTypeCell,
+  }),
+];
+
+const addColumns = [...baseColumns, tc.actions({ showSorting: false })];
+
+/** Member management matching Onyx's EditGroupPage: an "Add" mode that shows
+ * every user as a multi-select checkbox table, and a view mode listing
+ * current members with a per-row remove. Controlled — the parent owns the
+ * selected-ids state and commits it on save/create. */
+export function GroupMembersTable({
+  allRows,
+  selectedIds,
+  onSelectionChange,
+  defaultAdding = false,
+}: {
+  allRows: MemberRow[];
+  selectedIds: string[];
+  onSelectionChange: (ids: string[]) => void;
+  defaultAdding?: boolean;
+}) {
+  const [isAdding, setIsAdding] = useState(defaultAdding);
+  const [search, setSearch] = useState("");
+
+  const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const memberRows = useMemo(
+    () => allRows.filter((r) => selectedSet.has(r.id)),
+    [allRows, selectedSet],
+  );
+  const currentRowSelection = useMemo(
+    () => Object.fromEntries(selectedIds.map((id) => [id, true])),
+    [selectedIds],
+  );
+  // Preserve any selected ids that aren't in the visible candidate list so a
+  // partial onSelectionChange can't silently drop them.
+  const hiddenIds = useMemo(() => {
+    const visible = new Set(allRows.map((r) => r.id));
+    return selectedIds.filter((id) => !visible.has(id));
+  }, [allRows, selectedIds]);
+
+  const viewColumns = useMemo(
+    () => [
+      ...baseColumns,
+      tc.actions({
+        showSorting: false,
+        showColumnVisibility: false,
+        cell: (row: MemberRow) => (
+          <Button
+            prominence="tertiary"
+            size="sm"
+            variant="danger"
+            icon={SvgMinusCircle}
+            tooltip="Remove"
+            onClick={() => onSelectionChange(selectedIds.filter((id) => id !== row.id))}
+          />
+        ),
+      }),
+    ],
+    [selectedIds, onSelectionChange],
+  );
+
+  return (
+    <div className={styles.fieldGroup}>
+      <div className={styles.sectionHead}>
+        <Text font="main-ui-action" color="text-04">
+          {isAdding ? "Add members" : `Members (${memberRows.length})`}
+        </Text>
+        {isAdding ? (
+          <Button
+            prominence="secondary"
+            size="sm"
+            onClick={() => {
+              setIsAdding(false);
+              setSearch("");
+            }}
+          >
+            Done
+          </Button>
+        ) : (
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgPlusCircle}
+            onClick={() => setIsAdding(true)}
+          >
+            Add
+          </Button>
+        )}
+      </div>
+
+      <InputTypeIn
+        searchIcon
+        variant="internal"
+        placeholder={isAdding ? "Search users…" : "Search members…"}
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+
+      {isAdding ? (
+        <Table
+          key="add"
+          data={allRows}
+          columns={addColumns}
+          getRowId={(r) => r.id}
+          pageSize={PAGE_SIZE}
+          searchTerm={search}
+          selectionBehavior="multi-select"
+          initialRowSelection={currentRowSelection}
+          onSelectionChange={(ids) => onSelectionChange([...ids, ...hiddenIds])}
+          footer={{}}
+          emptyState={
+            <IllustrationContent
+              illustration={SvgNoResult}
+              title="No users found"
+              description="No users match your search."
+            />
+          }
+        />
+      ) : (
+        <Table
+          key="view"
+          data={memberRows}
+          columns={viewColumns}
+          getRowId={(r) => r.id}
+          pageSize={PAGE_SIZE}
+          searchTerm={search}
+          footer={{}}
+          emptyState={
+            <IllustrationContent
+              illustration={SvgNoResult}
+              title="No members"
+              description="Add members to this group."
+            />
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/groups/GroupSharesEditor.tsx
+++ b/frontend/src/app/admin/groups/GroupSharesEditor.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  OpenButton,
+  Popover,
+  PopoverMenu,
+  Table,
+  Text,
+  createTableColumns,
+} from "@onyx-ai/opal/components";
+import { Content, IllustrationContent } from "@onyx-ai/opal/layouts";
+import {
+  SvgCheck,
+  SvgEdit,
+  SvgEye,
+  SvgFileText,
+  SvgFolder,
+  SvgPlusCircle,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+import { SvgNoResult } from "@onyx-ai/opal/illustrations";
+
+import type { Permission, ResourceKind, WikiPathEntry } from "@/lib/permissions";
+import { lastSegment } from "@/lib/wiki";
+
+import styles from "./groups.module.css";
+
+export interface ShareDraft {
+  resource_kind: ResourceKind;
+  resource_path: string;
+  permission: Permission;
+  id?: string; // present for shares that already exist on the server
+}
+
+export function shareKey(s: { resource_kind: ResourceKind; resource_path: string }): string {
+  return `${s.resource_kind}:${s.resource_path}`;
+}
+
+interface DocRow {
+  id: string; // shareKey
+  kind: ResourceKind;
+  path: string;
+  label: string;
+}
+
+const PAGE_SIZE = 10;
+const tc = createTableColumns<DocRow>();
+
+function docNameCell(label: string, row: DocRow) {
+  return <Content sizePreset="main-ui" variant="section" title={label} description={row.path} />;
+}
+
+const docColumns = [
+  tc.qualifier({
+    content: "icon",
+    getContent: (row) => (row.kind === "folder" ? SvgFolder : SvgFileText),
+  }),
+  tc.column("label", { header: "Name", weight: 40, cell: docNameCell }),
+  tc.actions({ showSorting: false }),
+];
+
+/** Every page + folder in the wiki, as selectable rows. Folders are derived
+ * from the ancestor directories of every tracked path. */
+function deriveDocRows(entries: WikiPathEntry[]): DocRow[] {
+  const folders = new Set<string>();
+  const pages: DocRow[] = [];
+  for (const e of entries) {
+    const base = e.path.split("/").pop() ?? "";
+    if (base !== ".gitkeep" && e.path.endsWith(".md")) {
+      pages.push({
+        id: `page:${e.path}`,
+        kind: "page",
+        path: e.path,
+        label: lastSegment(e.path) || e.path,
+      });
+    }
+    const parts = e.path.split("/");
+    parts.pop();
+    let acc = "";
+    for (const p of parts) {
+      acc = acc ? `${acc}/${p}` : p;
+      if (acc) folders.add(acc);
+    }
+  }
+  const folderRows: DocRow[] = [...folders].sort().map((path) => ({
+    id: `folder:${path}`,
+    kind: "folder",
+    path,
+    label: lastSegment(path) || path,
+  }));
+  return [...folderRows, ...pages.sort((a, b) => a.path.localeCompare(b.path))];
+}
+
+/** Sharing editor matching the member-management UX: an "Add" mode that shows
+ * every page/folder as a multi-select checkbox table, and a view mode listing
+ * the shared docs with a per-row View/Edit toggle and remove. */
+export function GroupSharesEditor({
+  shares,
+  onChange,
+  wikiEntries,
+  defaultAdding = false,
+}: {
+  shares: ShareDraft[];
+  onChange: (next: ShareDraft[]) => void;
+  wikiEntries: WikiPathEntry[];
+  defaultAdding?: boolean;
+}) {
+  const [isAdding, setIsAdding] = useState(defaultAdding);
+  const [search, setSearch] = useState("");
+
+  const docRows = useMemo(() => deriveDocRows(wikiEntries), [wikiEntries]);
+  const docById = useMemo(() => new Map(docRows.map((d) => [d.id, d])), [docRows]);
+
+  const selectedKeys = useMemo(() => shares.map(shareKey), [shares]);
+  const currentRowSelection = useMemo(
+    () => Object.fromEntries(selectedKeys.map((k) => [k, true])),
+    [selectedKeys],
+  );
+  // Shares whose doc isn't in the candidate list (e.g. a page that no longer
+  // lists) — preserve them across selection changes.
+  const hiddenShares = useMemo(
+    () => shares.filter((s) => !docById.has(shareKey(s))),
+    [shares, docById],
+  );
+
+  function onTableSelectionChange(keys: string[]) {
+    const existing = new Map(shares.map((s) => [shareKey(s), s]));
+    const next: ShareDraft[] = [];
+    for (const key of keys) {
+      const prev = existing.get(key);
+      if (prev) {
+        next.push(prev);
+        continue;
+      }
+      const doc = docById.get(key);
+      if (doc) next.push({ resource_kind: doc.kind, resource_path: doc.path, permission: "read" });
+    }
+    onChange([...next, ...hiddenShares]);
+  }
+
+  function setPermission(key: string, permission: Permission) {
+    onChange(shares.map((s) => (shareKey(s) === key ? { ...s, permission } : s)));
+  }
+
+  function removeShare(key: string) {
+    onChange(shares.filter((s) => shareKey(s) !== key));
+  }
+
+  const sharedSorted = useMemo(
+    () => [...shares].sort((a, b) => a.resource_path.localeCompare(b.resource_path)),
+    [shares],
+  );
+
+  return (
+    <div className={styles.fieldGroup}>
+      <div className={styles.sectionHead}>
+        <Text font="main-ui-action" color="text-04">
+          {isAdding ? "Add pages & folders" : `Shared pages & folders (${shares.length})`}
+        </Text>
+        {isAdding ? (
+          <Button
+            prominence="secondary"
+            size="sm"
+            onClick={() => {
+              setIsAdding(false);
+              setSearch("");
+            }}
+          >
+            Done
+          </Button>
+        ) : (
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgPlusCircle}
+            onClick={() => setIsAdding(true)}
+          >
+            Add
+          </Button>
+        )}
+      </div>
+
+      {isAdding ? (
+        <>
+          <InputTypeIn
+            searchIcon
+            variant="internal"
+            placeholder="Search pages and folders…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <Table
+            key="add-docs"
+            data={docRows}
+            columns={docColumns}
+            getRowId={(r) => r.id}
+            pageSize={PAGE_SIZE}
+            searchTerm={search}
+            selectionBehavior="multi-select"
+            initialRowSelection={currentRowSelection}
+            onSelectionChange={onTableSelectionChange}
+            footer={{}}
+            emptyState={
+              <IllustrationContent
+                illustration={SvgNoResult}
+                title="No pages or folders"
+                description="No pages or folders match your search."
+              />
+            }
+          />
+        </>
+      ) : shares.length === 0 ? (
+        <Text font="secondary-body" color="text-03">
+          Nothing shared with this group yet. Add a page or folder to grant the group access.
+        </Text>
+      ) : (
+        <div className={styles.sharesList}>
+          {sharedSorted.map((s) => {
+            const key = shareKey(s);
+            const Icon = s.resource_kind === "folder" ? SvgFolder : SvgFileText;
+            const label =
+              s.resource_path === ""
+                ? "Root folder"
+                : lastSegment(s.resource_path) || s.resource_path;
+            return (
+              <div key={key} className={styles.shareRow}>
+                <span className={styles.shareIcon}>
+                  <Icon size={18} />
+                </span>
+                <div className={styles.shareText}>
+                  <Text font="main-ui-body" nowrap>
+                    {label}
+                  </Text>
+                  {s.resource_path && s.resource_path !== label && (
+                    <Text font="secondary-body" color="text-03" nowrap>
+                      {s.resource_path}
+                    </Text>
+                  )}
+                </div>
+                <PermSelect value={s.permission} onChange={(p) => setPermission(key, p)} />
+                <Button
+                  prominence="tertiary"
+                  size="sm"
+                  variant="danger"
+                  icon={SvgX}
+                  tooltip="Remove"
+                  onClick={() => removeShare(key)}
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PermSelect({
+  value,
+  onChange,
+}: {
+  value: Permission;
+  onChange: (p: Permission) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const label = value === "write" ? "Can edit" : "Can view";
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <span className={styles.pickerTrigger}>
+          <OpenButton variant="select-light" size="sm" icon={value === "write" ? SvgEdit : SvgEye}>
+            {label}
+          </OpenButton>
+        </span>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="end" sideOffset={4}>
+        <PopoverMenu>
+          <LineItemButton
+            icon={SvgEye}
+            title="Can view"
+            sizePreset="main-ui"
+            variant="body"
+            state={value === "read" ? "selected" : "empty"}
+            rightChildren={value === "read" ? <SvgCheck size={16} /> : undefined}
+            onClick={() => {
+              onChange("read");
+              setOpen(false);
+            }}
+          />
+          <LineItemButton
+            icon={SvgEdit}
+            title="Can edit"
+            sizePreset="main-ui"
+            variant="body"
+            state={value === "write" ? "selected" : "empty"}
+            rightChildren={value === "write" ? <SvgCheck size={16} /> : undefined}
+            onClick={() => {
+              onChange("write");
+              setOpen(false);
+            }}
+          />
+        </PopoverMenu>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/frontend/src/app/admin/groups/GroupSharesEditor.tsx
+++ b/frontend/src/app/admin/groups/GroupSharesEditor.tsx
@@ -25,7 +25,11 @@ import {
 } from "@onyx-ai/opal/icons";
 import { SvgNoResult } from "@onyx-ai/opal/illustrations";
 
-import type { Permission, ResourceKind, WikiPathEntry } from "@/lib/permissions";
+import type {
+  Permission,
+  ResourceKind,
+  WikiPathEntry,
+} from "@/lib/permissions";
 import { lastSegment } from "@/lib/wiki";
 
 import styles from "./groups.module.css";
@@ -37,7 +41,10 @@ export interface ShareDraft {
   id?: string; // present for shares that already exist on the server
 }
 
-export function shareKey(s: { resource_kind: ResourceKind; resource_path: string }): string {
+export function shareKey(s: {
+  resource_kind: ResourceKind;
+  resource_path: string;
+}): string {
   return `${s.resource_kind}:${s.resource_path}`;
 }
 
@@ -52,7 +59,14 @@ const PAGE_SIZE = 10;
 const tc = createTableColumns<DocRow>();
 
 function docNameCell(label: string, row: DocRow) {
-  return <Content sizePreset="main-ui" variant="section" title={label} description={row.path} />;
+  return (
+    <Content
+      sizePreset="main-ui"
+      variant="section"
+      title={label}
+      description={row.path}
+    />
+  );
 }
 
 const docColumns = [
@@ -114,7 +128,10 @@ export function GroupSharesEditor({
   const [search, setSearch] = useState("");
 
   const docRows = useMemo(() => deriveDocRows(wikiEntries), [wikiEntries]);
-  const docById = useMemo(() => new Map(docRows.map((d) => [d.id, d])), [docRows]);
+  const docById = useMemo(
+    () => new Map(docRows.map((d) => [d.id, d])),
+    [docRows],
+  );
 
   const selectedKeys = useMemo(() => shares.map(shareKey), [shares]);
   const currentRowSelection = useMemo(
@@ -138,13 +155,20 @@ export function GroupSharesEditor({
         continue;
       }
       const doc = docById.get(key);
-      if (doc) next.push({ resource_kind: doc.kind, resource_path: doc.path, permission: "read" });
+      if (doc)
+        next.push({
+          resource_kind: doc.kind,
+          resource_path: doc.path,
+          permission: "read",
+        });
     }
     onChange([...next, ...hiddenShares]);
   }
 
   function setPermission(key: string, permission: Permission) {
-    onChange(shares.map((s) => (shareKey(s) === key ? { ...s, permission } : s)));
+    onChange(
+      shares.map((s) => (shareKey(s) === key ? { ...s, permission } : s)),
+    );
   }
 
   function removeShare(key: string) {
@@ -152,7 +176,10 @@ export function GroupSharesEditor({
   }
 
   const sharedSorted = useMemo(
-    () => [...shares].sort((a, b) => a.resource_path.localeCompare(b.resource_path)),
+    () =>
+      [...shares].sort((a, b) =>
+        a.resource_path.localeCompare(b.resource_path),
+      ),
     [shares],
   );
 
@@ -160,7 +187,9 @@ export function GroupSharesEditor({
     <div className={styles.fieldGroup}>
       <div className={styles.sectionHead}>
         <Text font="main-ui-action" color="text-04">
-          {isAdding ? "Add pages & folders" : `Shared pages & folders (${shares.length})`}
+          {isAdding
+            ? "Add pages & folders"
+            : `Shared pages & folders (${shares.length})`}
         </Text>
         {isAdding ? (
           <Button
@@ -216,7 +245,8 @@ export function GroupSharesEditor({
         </>
       ) : shares.length === 0 ? (
         <Text font="secondary-body" color="text-03">
-          Nothing shared with this group yet. Add a page or folder to grant the group access.
+          Nothing shared with this group yet. Add a page or folder to grant the
+          group access.
         </Text>
       ) : (
         <div className={styles.sharesList}>
@@ -242,7 +272,10 @@ export function GroupSharesEditor({
                     </Text>
                   )}
                 </div>
-                <PermSelect value={s.permission} onChange={(p) => setPermission(key, p)} />
+                <PermSelect
+                  value={s.permission}
+                  onChange={(p) => setPermission(key, p)}
+                />
                 <Button
                   prominence="tertiary"
                   size="sm"
@@ -273,7 +306,11 @@ function PermSelect({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <span className={styles.pickerTrigger}>
-          <OpenButton variant="select-light" size="sm" icon={value === "write" ? SvgEdit : SvgEye}>
+          <OpenButton
+            variant="select-light"
+            size="sm"
+            icon={value === "write" ? SvgEdit : SvgEye}
+          >
             {label}
           </OpenButton>
         </span>
@@ -286,7 +323,9 @@ function PermSelect({
             sizePreset="main-ui"
             variant="body"
             state={value === "read" ? "selected" : "empty"}
-            rightChildren={value === "read" ? <SvgCheck size={16} /> : undefined}
+            rightChildren={
+              value === "read" ? <SvgCheck size={16} /> : undefined
+            }
             onClick={() => {
               onChange("read");
               setOpen(false);
@@ -298,7 +337,9 @@ function PermSelect({
             sizePreset="main-ui"
             variant="body"
             state={value === "write" ? "selected" : "empty"}
-            rightChildren={value === "write" ? <SvgCheck size={16} /> : undefined}
+            rightChildren={
+              value === "write" ? <SvgCheck size={16} /> : undefined
+            }
             onClick={() => {
               onChange("write");
               setOpen(false);

--- a/frontend/src/app/admin/groups/[id]/page.tsx
+++ b/frontend/src/app/admin/groups/[id]/page.tsx
@@ -4,7 +4,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useSWRConfig } from "swr";
 
-import { Button, Card, Divider, InputTypeIn, Text } from "@onyx-ai/opal/components";
+import {
+  Button,
+  Card,
+  Divider,
+  InputTypeIn,
+  Text,
+} from "@onyx-ai/opal/components";
 import { SvgTrash, SvgUsers } from "@onyx-ai/opal/icons";
 import { IllustrationContent, SettingsLayouts } from "@onyx-ai/opal/layouts";
 import { SvgNoResult } from "@onyx-ai/opal/illustrations";
@@ -24,7 +30,11 @@ import {
 import { useAdminUsers } from "@/lib/users";
 
 import { GroupMembersTable, type MemberRow } from "../GroupMembersTable";
-import { GroupSharesEditor, shareKey, type ShareDraft } from "../GroupSharesEditor";
+import {
+  GroupSharesEditor,
+  shareKey,
+  type ShareDraft,
+} from "../GroupSharesEditor";
 import styles from "../groups.module.css";
 
 export default function AdminEditGroupPage() {
@@ -43,7 +53,11 @@ function EditGroup() {
 
   const { group, members, isLoading, error, refresh } = useGroup(groupId);
   const { users } = useAdminUsers();
-  const { shares: serverShares, refresh: refreshShares } = useGroupShares(groupId);
+  const {
+    shares: serverShares,
+    isLoading: sharesLoading,
+    refresh: refreshShares,
+  } = useGroupShares(groupId);
   const { entries: wikiEntries } = useWikiPaths();
 
   // Editable local state, seeded once from the server.
@@ -61,7 +75,10 @@ function EditGroup() {
   const initialSharesRef = useRef<ShareDraft[]>([]);
 
   useEffect(() => {
-    if (initialized || !group) return;
+    // Wait for BOTH group and shares to load — group can arrive first, and
+    // seeding then would capture an empty share set and hide existing grants
+    // (and a save would revoke them).
+    if (initialized || !group || sharesLoading) return;
     setName(group.name);
     initialNameRef.current = group.name;
     const ids = members.map((m) => m.id);
@@ -76,10 +93,16 @@ function EditGroup() {
     setShares(drafts);
     initialSharesRef.current = drafts;
     setInitialized(true);
-  }, [initialized, group, members, serverShares]);
+  }, [initialized, group, members, serverShares, sharesLoading]);
 
   const allRows = useMemo<MemberRow[]>(
-    () => users.map((u) => ({ id: u.id, email: u.email, name: u.name, is_admin: u.is_admin })),
+    () =>
+      users.map((u) => ({
+        id: u.id,
+        email: u.email,
+        name: u.name,
+        is_admin: u.is_admin,
+      })),
     [users],
   );
 
@@ -87,12 +110,18 @@ function EditGroup() {
     if (!initialized) return false;
     if (name.trim() !== initialNameRef.current) return true;
     const initMembers = new Set(initialMemberIdsRef.current);
-    if (selectedIds.length !== initMembers.size || selectedIds.some((id) => !initMembers.has(id)))
+    if (
+      selectedIds.length !== initMembers.size ||
+      selectedIds.some((id) => !initMembers.has(id))
+    )
       return true;
-    const initByKey = new Map(initialSharesRef.current.map((s) => [shareKey(s), s.permission]));
+    const initByKey = new Map(
+      initialSharesRef.current.map((s) => [shareKey(s), s.permission]),
+    );
     const locByKey = new Map(shares.map((s) => [shareKey(s), s.permission]));
     if (initByKey.size !== locByKey.size) return true;
-    for (const [k, perm] of locByKey) if (initByKey.get(k) !== perm) return true;
+    for (const [k, perm] of locByKey)
+      if (initByKey.get(k) !== perm) return true;
     return false;
   }, [initialized, name, selectedIds, shares]);
 
@@ -105,20 +134,25 @@ function EditGroup() {
     setBusy(true);
     setError2(null);
     try {
-      if (trimmed !== initialNameRef.current) await renameGroup(groupId, trimmed);
+      if (trimmed !== initialNameRef.current)
+        await renameGroup(groupId, trimmed);
 
       const initMembers = new Set(initialMemberIdsRef.current);
       const localMembers = new Set(selectedIds);
-      for (const id of selectedIds) if (!initMembers.has(id)) await addGroupMember(groupId, id);
+      for (const id of selectedIds)
+        if (!initMembers.has(id)) await addGroupMember(groupId, id);
       for (const id of initialMemberIdsRef.current)
         if (!localMembers.has(id)) await removeGroupMember(groupId, id);
 
-      const initByKey = new Map(initialSharesRef.current.map((s) => [shareKey(s), s]));
+      const initByKey = new Map(
+        initialSharesRef.current.map((s) => [shareKey(s), s]),
+      );
       const locByKey = new Map(shares.map((s) => [shareKey(s), s]));
       // revoke removed or permission-changed
       for (const [key, init] of initByKey) {
         const loc = locByKey.get(key);
-        if ((!loc || loc.permission !== init.permission) && init.id) await revokeAcl(init.id);
+        if ((!loc || loc.permission !== init.permission) && init.id)
+          await revokeAcl(init.id);
       }
       // grant new or permission-changed
       for (const [key, loc] of locByKey) {
@@ -146,7 +180,8 @@ function EditGroup() {
 
   function onDelete() {
     if (!group) return;
-    if (!confirm(`Delete group "${group.name}"? Members aren't deleted.`)) return;
+    if (!confirm(`Delete group "${group.name}"? Members aren't deleted.`))
+      return;
     setIsDeleting(true);
     setError2(null);
     deleteGroup(groupId)
@@ -198,7 +233,12 @@ function EditGroup() {
       >
         Cancel
       </Button>
-      <Button variant="action" size="md" disabled={!dirty || busy} onClick={() => void save()}>
+      <Button
+        variant="action"
+        size="md"
+        disabled={!dirty || busy}
+        onClick={() => void save()}
+      >
         {busy ? "Saving…" : "Save Changes"}
       </Button>
     </span>
@@ -234,7 +274,11 @@ function EditGroup() {
 
         <Divider />
 
-        <GroupSharesEditor shares={shares} onChange={setShares} wikiEntries={wikiEntries} />
+        <GroupSharesEditor
+          shares={shares}
+          onChange={setShares}
+          wikiEntries={wikiEntries}
+        />
 
         {error2 && (
           <Text font="secondary-body" color="text-02">

--- a/frontend/src/app/admin/groups/[id]/page.tsx
+++ b/frontend/src/app/admin/groups/[id]/page.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useSWRConfig } from "swr";
+
+import { Button, Card, Divider, InputTypeIn, Text } from "@onyx-ai/opal/components";
+import { SvgTrash, SvgUsers } from "@onyx-ai/opal/icons";
+import { IllustrationContent, SettingsLayouts } from "@onyx-ai/opal/layouts";
+import { SvgNoResult } from "@onyx-ai/opal/illustrations";
+
+import { RequireAdmin } from "@/components/RequireAdmin";
+import {
+  addGroupMember,
+  deleteGroup,
+  grantAcl,
+  removeGroupMember,
+  renameGroup,
+  revokeAcl,
+  useGroup,
+  useGroupShares,
+  useWikiPaths,
+} from "@/lib/permissions";
+import { useAdminUsers } from "@/lib/users";
+
+import { GroupMembersTable, type MemberRow } from "../GroupMembersTable";
+import { GroupSharesEditor, shareKey, type ShareDraft } from "../GroupSharesEditor";
+import styles from "../groups.module.css";
+
+export default function AdminEditGroupPage() {
+  return (
+    <RequireAdmin>
+      <EditGroup />
+    </RequireAdmin>
+  );
+}
+
+function EditGroup() {
+  const router = useRouter();
+  const params = useParams<{ id: string }>();
+  const groupId = params.id;
+  const { mutate } = useSWRConfig();
+
+  const { group, members, isLoading, error, refresh } = useGroup(groupId);
+  const { users } = useAdminUsers();
+  const { shares: serverShares, refresh: refreshShares } = useGroupShares(groupId);
+  const { entries: wikiEntries } = useWikiPaths();
+
+  // Editable local state, seeded once from the server.
+  const [initialized, setInitialized] = useState(false);
+  const [name, setName] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [shares, setShares] = useState<ShareDraft[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error2, setError2] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // Server snapshots for diffing on save.
+  const initialNameRef = useRef("");
+  const initialMemberIdsRef = useRef<string[]>([]);
+  const initialSharesRef = useRef<ShareDraft[]>([]);
+
+  useEffect(() => {
+    if (initialized || !group) return;
+    setName(group.name);
+    initialNameRef.current = group.name;
+    const ids = members.map((m) => m.id);
+    setSelectedIds(ids);
+    initialMemberIdsRef.current = ids;
+    const drafts: ShareDraft[] = serverShares.map((s) => ({
+      resource_kind: s.resource_kind,
+      resource_path: s.resource_path,
+      permission: s.permission,
+      id: s.id,
+    }));
+    setShares(drafts);
+    initialSharesRef.current = drafts;
+    setInitialized(true);
+  }, [initialized, group, members, serverShares]);
+
+  const allRows = useMemo<MemberRow[]>(
+    () => users.map((u) => ({ id: u.id, email: u.email, name: u.name, is_admin: u.is_admin })),
+    [users],
+  );
+
+  const dirty = useMemo(() => {
+    if (!initialized) return false;
+    if (name.trim() !== initialNameRef.current) return true;
+    const initMembers = new Set(initialMemberIdsRef.current);
+    if (selectedIds.length !== initMembers.size || selectedIds.some((id) => !initMembers.has(id)))
+      return true;
+    const initByKey = new Map(initialSharesRef.current.map((s) => [shareKey(s), s.permission]));
+    const locByKey = new Map(shares.map((s) => [shareKey(s), s.permission]));
+    if (initByKey.size !== locByKey.size) return true;
+    for (const [k, perm] of locByKey) if (initByKey.get(k) !== perm) return true;
+    return false;
+  }, [initialized, name, selectedIds, shares]);
+
+  async function save() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError2("Group name is required.");
+      return;
+    }
+    setBusy(true);
+    setError2(null);
+    try {
+      if (trimmed !== initialNameRef.current) await renameGroup(groupId, trimmed);
+
+      const initMembers = new Set(initialMemberIdsRef.current);
+      const localMembers = new Set(selectedIds);
+      for (const id of selectedIds) if (!initMembers.has(id)) await addGroupMember(groupId, id);
+      for (const id of initialMemberIdsRef.current)
+        if (!localMembers.has(id)) await removeGroupMember(groupId, id);
+
+      const initByKey = new Map(initialSharesRef.current.map((s) => [shareKey(s), s]));
+      const locByKey = new Map(shares.map((s) => [shareKey(s), s]));
+      // revoke removed or permission-changed
+      for (const [key, init] of initByKey) {
+        const loc = locByKey.get(key);
+        if ((!loc || loc.permission !== init.permission) && init.id) await revokeAcl(init.id);
+      }
+      // grant new or permission-changed
+      for (const [key, loc] of locByKey) {
+        const init = initByKey.get(key);
+        if (!init || init.permission !== loc.permission) {
+          await grantAcl({
+            resource_kind: loc.resource_kind,
+            resource_path: loc.resource_path,
+            principal_kind: "group",
+            principal_id: groupId,
+            permission: loc.permission,
+          });
+        }
+      }
+
+      void mutate("/groups");
+      await Promise.all([refresh(), refreshShares()]);
+      router.push("/admin/groups");
+    } catch (e) {
+      setError2(e instanceof Error ? e.message : "Failed to save group");
+      await Promise.all([refresh(), refreshShares()]);
+      setBusy(false);
+    }
+  }
+
+  function onDelete() {
+    if (!group) return;
+    if (!confirm(`Delete group "${group.name}"? Members aren't deleted.`)) return;
+    setIsDeleting(true);
+    setError2(null);
+    deleteGroup(groupId)
+      .then(() => {
+        void mutate("/groups");
+        router.push("/admin/groups");
+      })
+      .catch((e) => {
+        setError2(e instanceof Error ? e.message : "Failed to delete group");
+        setIsDeleting(false);
+      });
+  }
+
+  if (isLoading || (!initialized && !error && group)) {
+    return (
+      <SettingsLayouts.Root width="md">
+        <SettingsLayouts.Header icon={SvgUsers} title="Edit Group" backButton />
+        <SettingsLayouts.Body>
+          <Text font="secondary-body" color="text-03">
+            Loading…
+          </Text>
+        </SettingsLayouts.Body>
+      </SettingsLayouts.Root>
+    );
+  }
+
+  if (error || !group) {
+    return (
+      <SettingsLayouts.Root width="md">
+        <SettingsLayouts.Header icon={SvgUsers} title="Group" backButton />
+        <SettingsLayouts.Body>
+          <IllustrationContent
+            illustration={SvgNoResult}
+            title="Group not found"
+            description="This group doesn't exist or may have been deleted."
+          />
+        </SettingsLayouts.Body>
+      </SettingsLayouts.Root>
+    );
+  }
+
+  const headerActions = (
+    <span className={styles.headerActions}>
+      <Button
+        prominence="secondary"
+        size="md"
+        onClick={() => router.push("/admin/groups")}
+        disabled={busy}
+      >
+        Cancel
+      </Button>
+      <Button variant="action" size="md" disabled={!dirty || busy} onClick={() => void save()}>
+        {busy ? "Saving…" : "Save Changes"}
+      </Button>
+    </span>
+  );
+
+  return (
+    <SettingsLayouts.Root width="md">
+      <SettingsLayouts.Header
+        icon={SvgUsers}
+        title="Edit Group"
+        backButton
+        rightChildren={headerActions}
+      />
+      <SettingsLayouts.Body>
+        <div className={styles.fieldGroup}>
+          <Text font="main-ui-body" color="text-04">
+            Group Name
+          </Text>
+          <InputTypeIn
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name your group"
+          />
+        </div>
+
+        <Divider />
+
+        <GroupMembersTable
+          allRows={allRows}
+          selectedIds={selectedIds}
+          onSelectionChange={setSelectedIds}
+        />
+
+        <Divider />
+
+        <GroupSharesEditor shares={shares} onChange={setShares} wikiEntries={wikiEntries} />
+
+        {error2 && (
+          <Text font="secondary-body" color="text-02">
+            {error2}
+          </Text>
+        )}
+
+        <Card rounding="lg" padding="fit">
+          <div className={styles.deleteCard}>
+            <div className={styles.deleteText}>
+              <Text font="main-ui-body">Delete this group</Text>
+              <Text font="secondary-body" color="text-03">
+                Members will lose access to anything shared with this group.
+              </Text>
+            </div>
+            <Button
+              variant="danger"
+              prominence="secondary"
+              size="md"
+              icon={SvgTrash}
+              disabled={busy || isDeleting}
+              onClick={onDelete}
+            >
+              Delete Group
+            </Button>
+          </div>
+        </Card>
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/frontend/src/app/admin/groups/[id]/page.tsx
+++ b/frontend/src/app/admin/groups/[id]/page.tsx
@@ -173,7 +173,13 @@ function EditGroup() {
       router.push("/admin/groups");
     } catch (e) {
       setError2(e instanceof Error ? e.message : "Failed to save group");
+      // A save can fail partway (some ACL grants/revokes applied, then one
+      // errors). Re-pull the server state and re-seed the baseline so a retry
+      // diffs against reality — otherwise it would re-revoke an already-gone
+      // entry (404) or re-grant an applied one. Dropping `initialized` lets the
+      // seeding effect repopulate every ref + the editable state from truth.
       await Promise.all([refresh(), refreshShares()]);
+      setInitialized(false);
       setBusy(false);
     }
   }

--- a/frontend/src/app/admin/groups/create/page.tsx
+++ b/frontend/src/app/admin/groups/create/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button, Divider, InputTypeIn, Text } from "@onyx-ai/opal/components";
+import { SvgUsers } from "@onyx-ai/opal/icons";
+import { SettingsLayouts } from "@onyx-ai/opal/layouts";
+
+import { RequireAdmin } from "@/components/RequireAdmin";
+import {
+  addGroupMember,
+  createGroup,
+  grantAcl,
+  useWikiPaths,
+} from "@/lib/permissions";
+import { useAdminUsers } from "@/lib/users";
+
+import { GroupMembersTable, type MemberRow } from "../GroupMembersTable";
+import { GroupSharesEditor, type ShareDraft } from "../GroupSharesEditor";
+import styles from "../groups.module.css";
+
+export default function AdminCreateGroupPage() {
+  return (
+    <RequireAdmin>
+      <CreateGroup />
+    </RequireAdmin>
+  );
+}
+
+function CreateGroup() {
+  const router = useRouter();
+  const { users } = useAdminUsers();
+  const { entries: wikiEntries } = useWikiPaths();
+
+  const [name, setName] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [shares, setShares] = useState<ShareDraft[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const allRows = useMemo<MemberRow[]>(
+    () => users.map((u) => ({ id: u.id, email: u.email, name: u.name, is_admin: u.is_admin })),
+    [users],
+  );
+
+  async function create() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Group name is required.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      const g = await createGroup(trimmed);
+      for (const id of selectedIds) await addGroupMember(g.id, id);
+      for (const s of shares) {
+        await grantAcl({
+          resource_kind: s.resource_kind,
+          resource_path: s.resource_path,
+          principal_kind: "group",
+          principal_id: g.id,
+          permission: s.permission,
+        });
+      }
+      router.push(`/admin/groups/${g.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create group");
+      setBusy(false);
+    }
+  }
+
+  const headerActions = (
+    <span className={styles.headerActions}>
+      <Button
+        prominence="secondary"
+        size="md"
+        onClick={() => router.push("/admin/groups")}
+        disabled={busy}
+      >
+        Cancel
+      </Button>
+      <Button variant="action" size="md" disabled={!name.trim() || busy} onClick={() => void create()}>
+        {busy ? "Creating…" : "Create"}
+      </Button>
+    </span>
+  );
+
+  return (
+    <SettingsLayouts.Root width="md">
+      <SettingsLayouts.Header
+        icon={SvgUsers}
+        title="Create Group"
+        backButton
+        rightChildren={headerActions}
+      />
+      <SettingsLayouts.Body>
+        <div className={styles.fieldGroup}>
+          <Text font="main-ui-body" color="text-04">
+            Group Name
+          </Text>
+          <InputTypeIn
+            placeholder="Name your group"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+
+        <Divider />
+
+        <GroupMembersTable
+          allRows={allRows}
+          selectedIds={selectedIds}
+          onSelectionChange={setSelectedIds}
+          defaultAdding
+        />
+
+        <Divider />
+
+        <GroupSharesEditor
+          shares={shares}
+          onChange={setShares}
+          wikiEntries={wikiEntries}
+          defaultAdding
+        />
+
+        {error && (
+          <Text font="secondary-body" color="text-02">
+            {error}
+          </Text>
+        )}
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/frontend/src/app/admin/groups/create/page.tsx
+++ b/frontend/src/app/admin/groups/create/page.tsx
@@ -58,8 +58,12 @@ function CreateGroup() {
     }
     setBusy(true);
     setError(null);
+    // Tracks the created group across the try/catch: createGroup commits the
+    // row first, so if a later member/share step fails the group still exists.
+    let createdId: string | null = null;
     try {
       const g = await createGroup(trimmed);
+      createdId = g.id;
       for (const id of selectedIds) await addGroupMember(g.id, id);
       for (const s of shares) {
         await grantAcl({
@@ -72,6 +76,13 @@ function CreateGroup() {
       }
       router.push(`/admin/groups/${g.id}`);
     } catch (e) {
+      // If the group was already created, retrying here would re-POST and 409
+      // (name taken), stranding the admin with an orphan group. Send them to
+      // its edit page to finish against the real (partially-applied) state.
+      if (createdId) {
+        router.push(`/admin/groups/${createdId}`);
+        return;
+      }
       setError(e instanceof Error ? e.message : "Failed to create group");
       setBusy(false);
     }

--- a/frontend/src/app/admin/groups/create/page.tsx
+++ b/frontend/src/app/admin/groups/create/page.tsx
@@ -40,7 +40,13 @@ function CreateGroup() {
   const [error, setError] = useState<string | null>(null);
 
   const allRows = useMemo<MemberRow[]>(
-    () => users.map((u) => ({ id: u.id, email: u.email, name: u.name, is_admin: u.is_admin })),
+    () =>
+      users.map((u) => ({
+        id: u.id,
+        email: u.email,
+        name: u.name,
+        is_admin: u.is_admin,
+      })),
     [users],
   );
 
@@ -81,7 +87,12 @@ function CreateGroup() {
       >
         Cancel
       </Button>
-      <Button variant="action" size="md" disabled={!name.trim() || busy} onClick={() => void create()}>
+      <Button
+        variant="action"
+        size="md"
+        disabled={!name.trim() || busy}
+        onClick={() => void create()}
+      >
         {busy ? "Creating…" : "Create"}
       </Button>
     </span>

--- a/frontend/src/app/admin/groups/groups.module.css
+++ b/frontend/src/app/admin/groups/groups.module.css
@@ -11,31 +11,19 @@
   min-width: 0;
 }
 
-.createCard {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 16px;
-  border-radius: var(--border-radius-12);
-  background: var(--background-tint-02);
-  margin-bottom: 16px;
-}
-.createRow {
-  display: flex;
-  gap: 8px;
-}
-
 .cards {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
-/* Group rows are subtle grey-fill surfaces, not bordered cards (per mock). */
-.card {
-  background: var(--background-tint-02);
-  border-radius: var(--border-radius-12);
-  overflow: hidden;
-  padding: 4px;
+.emptyCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.errorRow {
+  margin-bottom: 12px;
 }
 .cardRight {
   display: inline-flex;
@@ -44,26 +32,40 @@
   color: var(--text-04);
 }
 
-/* Detail view */
-.detailHead {
-  display: flex;
+/* Create / edit pages */
+.headerActions {
+  display: inline-flex;
   align-items: center;
-  gap: 10px;
-  margin: 4px 0;
-  color: var(--text-04);
-}
-.detailSpacer {
-  flex: 1;
-}
-.sectionTitle {
-  margin: 20px 0 8px;
-}
-.addRow {
-  display: flex;
   gap: 8px;
 }
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.sectionHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.nameRow {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Member picker + list (shared by create/edit) */
 .pickerTrigger {
   display: inline-flex;
+}
+.menuEmpty {
+  padding: 6px 10px;
+}
+.memberList {
+  display: flex;
+  flex-direction: column;
 }
 .memberRow {
   display: flex;
@@ -77,4 +79,62 @@
   flex-direction: column;
   min-width: 0;
   flex: 1;
+}
+
+/* Shared resources list */
+.sharesList {
+  display: flex;
+  flex-direction: column;
+}
+.shareRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border-01);
+}
+.shareIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--text-04);
+}
+.shareText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.sharePerm {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-04);
+}
+
+/* Account-type cell in the members table */
+.acctType {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-04);
+}
+
+/* Search box inside the share-picker popover */
+.pickerSearch {
+  padding: 4px;
+}
+
+/* Delete card */
+.deleteCard {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px;
+}
+.deleteText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
 }

--- a/frontend/src/app/admin/groups/page.tsx
+++ b/frontend/src/app/admin/groups/page.tsx
@@ -1,52 +1,24 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSWRConfig } from "swr";
 
-import {
-  Button,
-  InputTypeIn,
-  LineItemButton,
-  OpenButton,
-  Popover,
-  PopoverMenu,
-  Text,
-} from "@onyx-ai/opal/components";
-import {
-  SvgChevronLeft,
-  SvgChevronRight,
-  SvgPlus,
-  SvgTrash,
-  SvgUser,
-  SvgUserPlus,
-  SvgUsers,
-  SvgX,
-} from "@onyx-ai/opal/icons";
+import { Button, Card, InputTypeIn, Text } from "@onyx-ai/opal/components";
+import { ContentAction, IllustrationContent } from "@onyx-ai/opal/layouts";
+import { SvgChevronRight, SvgPlusCircle, SvgUsers } from "@onyx-ai/opal/icons";
+import { SettingsLayouts } from "@onyx-ai/opal/layouts";
+import { SvgNoResult } from "@onyx-ai/opal/illustrations";
 
-import { Avatar } from "@/components/common/Avatar";
-import { useConfirm } from "@/components/common/ConfirmDialog";
-import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
-import { ApiError } from "@/lib/api";
-import {
-  addGroupMember,
-  createGroup,
-  deleteGroup,
-  removeGroupMember,
-  useGroup,
-  useGroups,
-  type Group,
-} from "@/lib/permissions";
-import { useIsMobile } from "@/lib/viewport";
-import { displayName, initials, useAdminUsers } from "@/lib/users";
+import { renameGroup, useGroups, type Group } from "@/lib/permissions";
 
 import styles from "./groups.module.css";
 
 function groupSub(g: Group): string {
   const parts: string[] = [];
   if (g.folder_count > 0) {
-    parts.push(
-      `${g.folder_count} ${g.folder_count === 1 ? "folder" : "folders"}`,
-    );
+    parts.push(`${g.folder_count} ${g.folder_count === 1 ? "folder" : "folders"}`);
   }
   if (g.page_count > 0) {
     parts.push(`${g.page_count} wiki ${g.page_count === 1 ? "page" : "pages"}`);
@@ -55,91 +27,72 @@ function groupSub(g: Group): string {
 }
 
 export default function AdminGroupsPage() {
-  const isMobile = useIsMobile();
   return (
     <RequireAdmin>
-      <main
-        style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 880 }}
-      >
-        <BackLink />
-        <PageHeader
-          title="Groups"
-          description="Groups bundle users so wiki pages can be shared with everyone at once."
-        />
-        <GroupsManager />
-      </main>
+      <SettingsLayouts.Root width="md">
+        <SettingsLayouts.Header icon={SvgUsers} title="Groups" backButton />
+        <SettingsLayouts.Body>
+          <GroupsList />
+        </SettingsLayouts.Body>
+      </SettingsLayouts.Root>
     </RequireAdmin>
   );
 }
 
-function GroupsManager() {
-  const { groups, error, isLoading, refresh } = useGroups();
-  const [selected, setSelected] = useState<string | null>(null);
+function GroupsList() {
+  const router = useRouter();
+  const { mutate } = useSWRConfig();
+  const { groups, error, isLoading } = useGroups();
   const [query, setQuery] = useState("");
-  const [creating, setCreating] = useState(false);
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [busy, setBusy] = useState(false);
-  const confirmDialog = useConfirm();
-  const [createError, setCreateError] = useState<string | null>(null);
+  const [renameError, setRenameError] = useState<string | null>(null);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return groups.filter((g) => !q || g.name.toLowerCase().includes(q));
   }, [groups, query]);
 
-  async function onCreate(e: React.FormEvent) {
-    e.preventDefault();
-    if (!name.trim()) return;
-    setBusy(true);
-    setCreateError(null);
+  async function handleRename(id: string, newName: string) {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    setRenameError(null);
     try {
-      const g = await createGroup(name.trim(), description.trim() || undefined);
-      setName("");
-      setDescription("");
-      setCreating(false);
-      await refresh();
-      setSelected(g.id);
-    } catch (err) {
-      setCreateError(
-        err instanceof Error ? err.message : "Failed to create group",
-      );
-    } finally {
-      setBusy(false);
+      await renameGroup(id, trimmed);
+      void mutate("/groups");
+    } catch (e) {
+      setRenameError(e instanceof Error ? e.message : "Failed to rename group");
+      void mutate("/groups"); // revert the inline edit to the server value
     }
   }
 
-  async function onDelete(g: Group) {
-    if (
-      !(await confirmDialog({
-        title: `Delete group "${g.name}"?`,
-        body: "Members aren't deleted.",
-        confirmLabel: "Delete",
-      }))
-    )
-      return;
-    await deleteGroup(g.id);
-    if (selected === g.id) setSelected(null);
-    await refresh();
-  }
-
-  if (selected) {
-    const g = groups.find((x) => x.id === selected);
-    return (
-      <GroupDetail
-        groupId={selected}
-        onBack={() => setSelected(null)}
-        onDelete={g ? () => void onDelete(g) : undefined}
-      />
-    );
-  }
-
-  if (error)
+  if (error) {
     return (
       <Text font="secondary-body" color="text-02">
         {error.message}
       </Text>
     );
+  }
+
+  // No groups at all → bordered empty card with the create action (Onyx's
+  // AdminListHeader empty state).
+  if (!isLoading && groups.length === 0) {
+    return (
+      <Card rounding="lg" padding="lg">
+        <div className={styles.emptyCard}>
+          <Text font="main-ui-body" color="text-03">
+            Create groups to organize users and manage access.
+          </Text>
+          <Button
+            variant="action"
+            size="md"
+            rightIcon={SvgPlusCircle}
+            onClick={() => router.push("/admin/groups/create")}
+          >
+            New Group
+          </Button>
+        </div>
+      </Card>
+    );
+  }
 
   return (
     <>
@@ -147,6 +100,7 @@ function GroupsManager() {
         <div className={styles.searchWrap}>
           <InputTypeIn
             searchIcon
+            variant="internal"
             placeholder="Search groups…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -155,49 +109,19 @@ function GroupsManager() {
         <Button
           variant="action"
           size="md"
-          rightIcon={SvgPlus}
-          onClick={() => setCreating((v) => !v)}
+          rightIcon={SvgPlusCircle}
+          onClick={() => router.push("/admin/groups/create")}
         >
           New Group
         </Button>
       </div>
 
-      {creating && (
-        <form className={styles.createCard} onSubmit={onCreate}>
-          <InputTypeIn
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Group name (e.g. Engineering)"
-          />
-          <InputTypeIn
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="Description (optional)"
-          />
-          <div className={styles.createRow}>
-            <Button
-              type="submit"
-              variant="action"
-              size="md"
-              disabled={busy || !name.trim()}
-            >
-              Create
-            </Button>
-            <Button
-              type="button"
-              prominence="tertiary"
-              size="md"
-              onClick={() => setCreating(false)}
-            >
-              Cancel
-            </Button>
-          </div>
-          {createError && (
-            <Text font="secondary-body" color="text-02">
-              {createError}
-            </Text>
-          )}
-        </form>
+      {renameError && (
+        <div className={styles.errorRow}>
+          <Text font="secondary-body" color="text-02">
+            {renameError}
+          </Text>
+        </div>
       )}
 
       {isLoading ? (
@@ -205,199 +129,43 @@ function GroupsManager() {
           Loading…
         </Text>
       ) : filtered.length === 0 ? (
-        <Text font="secondary-body" color="text-03">
-          {query ? "No groups match your search." : "No groups yet."}
-        </Text>
+        <IllustrationContent
+          illustration={SvgNoResult}
+          title="No groups found"
+          description={`No groups matching "${query}"`}
+        />
       ) : (
         <div className={styles.cards}>
           {filtered.map((g) => (
-            <div key={g.id} className={styles.card}>
-              <LineItemButton
+            <Card key={g.id} rounding="lg" padding="sm">
+              <ContentAction
                 icon={SvgUsers}
                 title={g.name}
                 description={groupSub(g)}
                 sizePreset="main-content"
                 variant="section"
+                editable
+                onTitleChange={(newName) => void handleRename(g.id, newName)}
                 rightChildren={
                   <span className={styles.cardRight}>
                     <Text font="secondary-body" color="text-03">
                       {`${g.member_count} ${g.member_count === 1 ? "Member" : "Members"}`}
                     </Text>
-                    <SvgChevronRight size={18} />
+                    <Button
+                      icon={SvgChevronRight}
+                      prominence="tertiary"
+                      size="sm"
+                      tooltip="View group"
+                      aria-label="View group"
+                      onClick={() => router.push(`/admin/groups/${g.id}`)}
+                    />
                   </span>
                 }
-                onClick={() => setSelected(g.id)}
               />
-            </div>
+            </Card>
           ))}
         </div>
       )}
     </>
-  );
-}
-
-function GroupDetail({
-  groupId,
-  onBack,
-  onDelete,
-}: {
-  groupId: string;
-  onBack: () => void;
-  onDelete?: () => void;
-}) {
-  const { group, members, isLoading, refresh } = useGroup(groupId);
-  const { users } = useAdminUsers();
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const candidates = useMemo(() => {
-    const memberIds = new Set(members.map((m) => m.id));
-    return users.filter((u) => !memberIds.has(u.id));
-  }, [users, members]);
-
-  async function add(userId: string) {
-    setBusy(true);
-    setError(null);
-    try {
-      await addGroupMember(groupId, userId);
-      setPickerOpen(false);
-      await refresh();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to add member");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  async function remove(userId: string) {
-    setBusy(true);
-    try {
-      await removeGroupMember(groupId, userId);
-      await refresh();
-    } catch (err) {
-      if (err instanceof ApiError) setError(err.message);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  if (isLoading || !group)
-    return (
-      <Text font="secondary-body" color="text-03">
-        Loading…
-      </Text>
-    );
-
-  return (
-    <div>
-      <Button
-        prominence="tertiary"
-        size="sm"
-        icon={SvgChevronLeft}
-        onClick={onBack}
-      >
-        All groups
-      </Button>
-      <div className={styles.detailHead}>
-        <SvgUsers size={22} />
-        <Text as="h2" font="heading-h3">
-          {group.name}
-        </Text>
-        <span className={styles.detailSpacer} />
-        {onDelete && (
-          <Button
-            prominence="tertiary"
-            size="sm"
-            variant="danger"
-            icon={SvgTrash}
-            onClick={onDelete}
-          >
-            Delete group
-          </Button>
-        )}
-      </div>
-      {group.description && (
-        <Text font="secondary-body" color="text-03">
-          {group.description}
-        </Text>
-      )}
-
-      <div className={styles.sectionTitle}>
-        <Text font="main-ui-action" color="text-02">
-          Add member
-        </Text>
-      </div>
-      <div className={styles.addRow}>
-        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-          <Popover.Trigger asChild>
-            <span className={styles.pickerTrigger}>
-              <OpenButton variant="select-light" size="md" icon={SvgUserPlus}>
-                {candidates.length ? "Choose a user…" : "No users to add"}
-              </OpenButton>
-            </span>
-          </Popover.Trigger>
-          <Popover.Content width="trigger" align="start" sideOffset={4}>
-            <PopoverMenu>
-              {candidates.map((u) => (
-                <LineItemButton
-                  key={u.id}
-                  icon={SvgUser}
-                  title={displayName({ name: u.name, email: u.email })}
-                  description={u.email}
-                  sizePreset="main-ui"
-                  variant="section"
-                  onClick={() => void add(u.id)}
-                />
-              ))}
-            </PopoverMenu>
-          </Popover.Content>
-        </Popover>
-      </div>
-      {error && (
-        <Text font="secondary-body" color="text-02">
-          {error}
-        </Text>
-      )}
-
-      <div className={styles.sectionTitle}>
-        <Text font="main-ui-action" color="text-02">
-          {`Members (${members.length})`}
-        </Text>
-      </div>
-      {members.length === 0 ? (
-        <Text font="secondary-body" color="text-03">
-          No members yet.
-        </Text>
-      ) : (
-        members.map((m) => (
-          <div key={m.id} className={styles.memberRow}>
-            <Avatar
-              label={initials({ name: m.name, email: m.email })}
-              size={28}
-              title={displayName({ name: m.name, email: m.email })}
-            />
-            <div className={styles.memberText}>
-              <Text font="main-ui-body" nowrap>
-                {displayName({ name: m.name, email: m.email })}
-              </Text>
-              <Text font="secondary-body" color="text-03" nowrap>
-                {m.email}
-              </Text>
-            </div>
-            <Button
-              prominence="tertiary"
-              size="sm"
-              variant="danger"
-              icon={SvgX}
-              onClick={() => void remove(m.id)}
-              disabled={busy}
-            >
-              Remove
-            </Button>
-          </div>
-        ))
-      )}
-    </div>
   );
 }

--- a/frontend/src/app/admin/groups/page.tsx
+++ b/frontend/src/app/admin/groups/page.tsx
@@ -18,7 +18,9 @@ import styles from "./groups.module.css";
 function groupSub(g: Group): string {
   const parts: string[] = [];
   if (g.folder_count > 0) {
-    parts.push(`${g.folder_count} ${g.folder_count === 1 ? "folder" : "folders"}`);
+    parts.push(
+      `${g.folder_count} ${g.folder_count === 1 ? "folder" : "folders"}`,
+    );
   }
   if (g.page_count > 0) {
     parts.push(`${g.page_count} wiki ${g.page_count === 1 ? "page" : "pages"}`);

--- a/frontend/src/app/admin/users/EditUserModal.tsx
+++ b/frontend/src/app/admin/users/EditUserModal.tsx
@@ -9,6 +9,7 @@ import {
   Popover,
   PopoverMenu,
   Text,
+  Tooltip,
 } from "@onyx-ai/opal/components";
 import { SvgCheck, SvgLogOut, SvgUsers } from "@onyx-ai/opal/icons";
 
@@ -65,7 +66,9 @@ export default function EditUserModal({
 
   const dropdownGroups = useMemo(() => {
     const q = search.trim().toLowerCase();
-    return q ? allGroups.filter((g) => g.name.toLowerCase().includes(q)) : allGroups;
+    return q
+      ? allGroups.filter((g) => g.name.toLowerCase().includes(q))
+      : allGroups;
   }, [allGroups, search]);
 
   const joinedGroups = useMemo(
@@ -91,8 +94,12 @@ export default function EditUserModal({
     setBusy(true);
     setError(null);
     try {
-      const toAdd = [...memberIds].filter((id) => !initialMemberIdsRef.current.has(id));
-      const toRemove = [...initialMemberIdsRef.current].filter((id) => !memberIds.has(id));
+      const toAdd = [...memberIds].filter(
+        (id) => !initialMemberIdsRef.current.has(id),
+      );
+      const toRemove = [...initialMemberIdsRef.current].filter(
+        (id) => !memberIds.has(id),
+      );
       for (const gid of toAdd) await addGroupMember(gid, user.id);
       for (const gid of toRemove) await removeGroupMember(gid, user.id);
       onMutate();
@@ -112,7 +119,12 @@ export default function EditUserModal({
         if (e.target === e.currentTarget && !busy) onClose();
       }}
     >
-      <div className={styles.dialog} role="dialog" aria-modal="true" aria-label="Edit groups">
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Edit groups"
+      >
         <header className={styles.dialogHead}>
           <span className={styles.pageIcon}>
             <SvgUsers size={20} />
@@ -190,27 +202,20 @@ export default function EditUserModal({
               </Text>
             ) : (
               joinedGroups.map((g) => (
-                <button
+                <LineItemButton
                   key={g.id}
-                  type="button"
-                  className={styles.egRow}
+                  icon={SvgUsers}
+                  title={g.name}
+                  description={`${g.member_count} ${g.member_count === 1 ? "user" : "users"}`}
+                  sizePreset="main-ui"
+                  variant="section"
+                  rightChildren={
+                    <Tooltip tooltip="Remove from group" side="left">
+                      <SvgLogOut size={16} />
+                    </Tooltip>
+                  }
                   onClick={() => toggle(g.id)}
-                >
-                  <span className={styles.egRowIcon}>
-                    <SvgUsers size={18} />
-                  </span>
-                  <span className={styles.egRowText}>
-                    <Text font="main-ui-body" nowrap>
-                      {g.name}
-                    </Text>
-                    <Text font="secondary-body" color="text-03" nowrap>
-                      {`${g.member_count} ${g.member_count === 1 ? "user" : "users"}`}
-                    </Text>
-                  </span>
-                  <span className={styles.egRowRemove}>
-                    <SvgLogOut size={16} />
-                  </span>
-                </button>
+                />
               ))
             )}
           </div>
@@ -223,7 +228,12 @@ export default function EditUserModal({
         </div>
 
         <footer className={styles.dialogFoot}>
-          <Button prominence="secondary" size="md" onClick={onClose} disabled={busy}>
+          <Button
+            prominence="secondary"
+            size="md"
+            onClick={onClose}
+            disabled={busy}
+          >
             Cancel
           </Button>
           <Button

--- a/frontend/src/app/admin/users/EditUserModal.tsx
+++ b/frontend/src/app/admin/users/EditUserModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   Button,
@@ -40,17 +40,28 @@ export default function EditUserModal({
   onClose: () => void;
   onMutate: () => void;
 }) {
-  const { groups: allGroups } = useGroups();
+  const { groups: allGroups, isLoading: groupsLoading } = useGroups();
 
-  const initialMemberIds = useMemo(
-    () => new Set(allGroups.filter((g) => user.groups.includes(g.name)).map((g) => g.id)),
-    [allGroups, user.groups],
-  );
-  const [memberIds, setMemberIds] = useState<Set<string>>(initialMemberIds);
+  // Seed membership ONCE groups have loaded — reading it synchronously at
+  // mount would capture an empty set while /groups is still fetching, and
+  // saving would then drop every group the user is in.
+  const [memberIds, setMemberIds] = useState<Set<string>>(new Set());
+  const [initialized, setInitialized] = useState(false);
+  const initialMemberIdsRef = useRef<Set<string>>(new Set());
   const [search, setSearch] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (initialized || groupsLoading) return;
+    const ids = new Set(
+      allGroups.filter((g) => user.groups.includes(g.name)).map((g) => g.id),
+    );
+    setMemberIds(ids);
+    initialMemberIdsRef.current = ids;
+    setInitialized(true);
+  }, [initialized, groupsLoading, allGroups, user.groups]);
 
   const dropdownGroups = useMemo(() => {
     const q = search.trim().toLowerCase();
@@ -63,8 +74,9 @@ export default function EditUserModal({
   );
 
   const hasChanges =
-    memberIds.size !== initialMemberIds.size ||
-    [...memberIds].some((id) => !initialMemberIds.has(id));
+    initialized &&
+    (memberIds.size !== initialMemberIdsRef.current.size ||
+      [...memberIds].some((id) => !initialMemberIdsRef.current.has(id)));
 
   function toggle(groupId: string) {
     setMemberIds((prev) => {
@@ -79,8 +91,8 @@ export default function EditUserModal({
     setBusy(true);
     setError(null);
     try {
-      const toAdd = [...memberIds].filter((id) => !initialMemberIds.has(id));
-      const toRemove = [...initialMemberIds].filter((id) => !memberIds.has(id));
+      const toAdd = [...memberIds].filter((id) => !initialMemberIdsRef.current.has(id));
+      const toRemove = [...initialMemberIdsRef.current].filter((id) => !memberIds.has(id));
       for (const gid of toAdd) await addGroupMember(gid, user.id);
       for (const gid of toRemove) await removeGroupMember(gid, user.id);
       onMutate();

--- a/frontend/src/app/admin/users/EditUserModal.tsx
+++ b/frontend/src/app/admin/users/EditUserModal.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  PopoverMenu,
+  Text,
+} from "@onyx-ai/opal/components";
+import { SvgCheck, SvgLogOut, SvgUsers } from "@onyx-ai/opal/icons";
+
+import {
+  addGroupMember,
+  removeGroupMember,
+  useGroups,
+} from "@/lib/permissions";
+import { displayName } from "@/lib/users";
+
+import styles from "./users.module.css";
+
+export interface EditUserTarget {
+  id: string;
+  email: string;
+  name: string | null;
+  groups: string[]; // group names the user currently belongs to
+}
+
+/** Manage which groups a user belongs to. Mirrors Onyx's EditUserModal
+ * (groups portion) — search + toggle, joined list with remove, save the
+ * diff via add/remove member. agent-wiki has no roles, so only groups. */
+export default function EditUserModal({
+  user,
+  onClose,
+  onMutate,
+}: {
+  user: EditUserTarget;
+  onClose: () => void;
+  onMutate: () => void;
+}) {
+  const { groups: allGroups } = useGroups();
+
+  const initialMemberIds = useMemo(
+    () => new Set(allGroups.filter((g) => user.groups.includes(g.name)).map((g) => g.id)),
+    [allGroups, user.groups],
+  );
+  const [memberIds, setMemberIds] = useState<Set<string>>(initialMemberIds);
+  const [search, setSearch] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dropdownGroups = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return q ? allGroups.filter((g) => g.name.toLowerCase().includes(q)) : allGroups;
+  }, [allGroups, search]);
+
+  const joinedGroups = useMemo(
+    () => allGroups.filter((g) => memberIds.has(g.id)),
+    [allGroups, memberIds],
+  );
+
+  const hasChanges =
+    memberIds.size !== initialMemberIds.size ||
+    [...memberIds].some((id) => !initialMemberIds.has(id));
+
+  function toggle(groupId: string) {
+    setMemberIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupId)) next.delete(groupId);
+      else next.add(groupId);
+      return next;
+    });
+  }
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      const toAdd = [...memberIds].filter((id) => !initialMemberIds.has(id));
+      const toRemove = [...initialMemberIds].filter((id) => !memberIds.has(id));
+      for (const gid of toAdd) await addGroupMember(gid, user.id);
+      for (const gid of toRemove) await removeGroupMember(gid, user.id);
+      onMutate();
+      onClose();
+    } catch (e) {
+      onMutate();
+      setError(e instanceof Error ? e.message : "Failed to update groups");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      className={styles.scrim}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div className={styles.dialog} role="dialog" aria-modal="true" aria-label="Edit groups">
+        <header className={styles.dialogHead}>
+          <span className={styles.pageIcon}>
+            <SvgUsers size={20} />
+          </span>
+          <div className={styles.dialogHeadText}>
+            <Text as="h2" font="main-content-emphasis">
+              Edit Groups
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              {user.name ? `${displayName(user)} (${user.email})` : user.email}
+            </Text>
+          </div>
+        </header>
+
+        <div className={styles.dialogBody}>
+          <Popover
+            open={pickerOpen}
+            onOpenChange={(o) => {
+              setPickerOpen(o);
+              if (!o) setSearch("");
+            }}
+          >
+            <Popover.Anchor asChild>
+              <div>
+                <InputTypeIn
+                  searchIcon
+                  placeholder="Search groups to join…"
+                  value={search}
+                  onChange={(e) => {
+                    setSearch(e.target.value);
+                    setPickerOpen(true);
+                  }}
+                  onFocus={() => setPickerOpen(true)}
+                />
+              </div>
+            </Popover.Anchor>
+            <Popover.Content
+              width="trigger"
+              align="start"
+              sideOffset={4}
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              <PopoverMenu>
+                {dropdownGroups.length === 0
+                  ? [
+                      <div key="empty" className={styles.menuEmpty}>
+                        <Text font="secondary-body" color="text-03">
+                          No groups found
+                        </Text>
+                      </div>,
+                    ]
+                  : dropdownGroups.map((g) => {
+                      const isMember = memberIds.has(g.id);
+                      return (
+                        <LineItemButton
+                          key={g.id}
+                          icon={isMember ? SvgCheck : SvgUsers}
+                          title={g.name}
+                          description={`${g.member_count} ${g.member_count === 1 ? "user" : "users"}`}
+                          sizePreset="main-ui"
+                          variant="section"
+                          state={isMember ? "selected" : "empty"}
+                          onClick={() => toggle(g.id)}
+                        />
+                      );
+                    })}
+              </PopoverMenu>
+            </Popover.Content>
+          </Popover>
+
+          <div className={styles.egJoined}>
+            {joinedGroups.length === 0 ? (
+              <Text font="secondary-body" color="text-03">
+                {`${displayName(user)} is not in any groups.`}
+              </Text>
+            ) : (
+              joinedGroups.map((g) => (
+                <button
+                  key={g.id}
+                  type="button"
+                  className={styles.egRow}
+                  onClick={() => toggle(g.id)}
+                >
+                  <span className={styles.egRowIcon}>
+                    <SvgUsers size={18} />
+                  </span>
+                  <span className={styles.egRowText}>
+                    <Text font="main-ui-body" nowrap>
+                      {g.name}
+                    </Text>
+                    <Text font="secondary-body" color="text-03" nowrap>
+                      {`${g.member_count} ${g.member_count === 1 ? "user" : "users"}`}
+                    </Text>
+                  </span>
+                  <span className={styles.egRowRemove}>
+                    <SvgLogOut size={16} />
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+
+          {error && (
+            <Text font="secondary-body" color="text-02">
+              {error}
+            </Text>
+          )}
+        </div>
+
+        <footer className={styles.dialogFoot}>
+          <Button prominence="secondary" size="md" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="action"
+            size="md"
+            disabled={busy || !hasChanges}
+            onClick={() => void save()}
+          >
+            {busy ? "Saving…" : "Save Changes"}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import {
   Button,
@@ -97,7 +91,10 @@ export default function AdminUsersPage() {
           <UsersTable />
         </SettingsLayouts.Body>
       </SettingsLayouts.Root>
-      <InviteUsersModal open={inviteOpen} onClose={() => setInviteOpen(false)} />
+      <InviteUsersModal
+        open={inviteOpen}
+        onClose={() => setInviteOpen(false)}
+      />
     </RequireAdmin>
   );
 }
@@ -119,7 +116,9 @@ function UsersTable() {
   // Group names + how many users hold each — drives the Groups filter list.
   const groupCounts = useMemo(() => {
     const m = new Map<string, number>();
-    users.forEach((u) => u.groups.forEach((g) => m.set(g, (m.get(g) ?? 0) + 1)));
+    users.forEach((u) =>
+      u.groups.forEach((g) => m.set(g, (m.get(g) ?? 0) + 1)),
+    );
     return m;
   }, [users]);
   const allGroups = useMemo(
@@ -137,7 +136,11 @@ function UsersTable() {
   );
 
   const rows = useMemo<Row[]>(() => {
-    const userRows: Row[] = users.map((u) => ({ kind: "user", id: u.id, user: u }));
+    const userRows: Row[] = users.map((u) => ({
+      kind: "user",
+      id: u.id,
+      user: u,
+    }));
     const invitedRows: Row[] = invited.map((i) => ({
       kind: "invited",
       id: `invite:${i.email}`,
@@ -149,10 +152,12 @@ function UsersTable() {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return rows.filter((r) => {
-      const status: UserStatus = r.kind === "invited" ? "invited" : r.user.status;
+      const status: UserStatus =
+        r.kind === "invited" ? "invited" : r.user.status;
       if (statusFilter && status !== statusFilter) return false;
       if (groupFilter) {
-        if (r.kind === "invited" || !r.user.groups.includes(groupFilter)) return false;
+        if (r.kind === "invited" || !r.user.groups.includes(groupFilter))
+          return false;
       }
       if (!q) return true;
       if (r.kind === "invited") return r.email.toLowerCase().includes(q);
@@ -165,7 +170,10 @@ function UsersTable() {
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
-  const pageRows = filtered.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+  const pageRows = filtered.slice(
+    safePage * PAGE_SIZE,
+    (safePage + 1) * PAGE_SIZE,
+  );
 
   async function withBusy(id: string, fn: () => Promise<void>) {
     setBusyId(id);
@@ -190,9 +198,23 @@ function UsersTable() {
       <div className={styles.statsWrap}>
         <Card rounding="lg" padding="fit">
           <div className={styles.stats}>
-            <StatCell value={counts.active} label="active users" onClick={() => { setStatusFilter("active"); setPage(0); }} />
+            <StatCell
+              value={counts.active}
+              label="active users"
+              onClick={() => {
+                setStatusFilter("active");
+                setPage(0);
+              }}
+            />
             <span className={styles.statDivider} />
-            <StatCell value={counts.invited} label="pending invites" onClick={() => { setStatusFilter("invited"); setPage(0); }} />
+            <StatCell
+              value={counts.invited}
+              label="pending invites"
+              onClick={() => {
+                setStatusFilter("invited");
+                setPage(0);
+              }}
+            />
           </div>
         </Card>
       </div>
@@ -248,11 +270,27 @@ function UsersTable() {
 
       <div className={styles.table} style={{ ["--cols" as string]: cols }}>
         <div className={styles.headRow}>
-          <Text font="secondary-action" color="text-03">Name</Text>
-          {!isMobile && <Text font="secondary-action" color="text-03">Groups</Text>}
-          {!isMobile && <Text font="secondary-action" color="text-03">Account Type</Text>}
-          <Text font="secondary-action" color="text-03">Status</Text>
-          {!isMobile && <Text font="secondary-action" color="text-03">Last Updated</Text>}
+          <Text font="secondary-action" color="text-03">
+            Name
+          </Text>
+          {!isMobile && (
+            <Text font="secondary-action" color="text-03">
+              Groups
+            </Text>
+          )}
+          {!isMobile && (
+            <Text font="secondary-action" color="text-03">
+              Account Type
+            </Text>
+          )}
+          <Text font="secondary-action" color="text-03">
+            Status
+          </Text>
+          {!isMobile && (
+            <Text font="secondary-action" color="text-03">
+              Last Updated
+            </Text>
+          )}
           <span />
         </div>
 
@@ -273,9 +311,15 @@ function UsersTable() {
                 isMobile={isMobile}
                 isSelf={r.user.id === currentUserId}
                 busy={busyId === r.id}
-                onSetAdmin={(makeAdmin) => void withBusy(r.id, () => setUserAdmin(r.user.id, makeAdmin))}
-                onSetActive={(active) => void withBusy(r.id, () => setUserActive(r.user.id, active))}
-                onDelete={() => void withBusy(r.id, () => deleteUser(r.user.id))}
+                onSetAdmin={(makeAdmin) =>
+                  void withBusy(r.id, () => setUserAdmin(r.user.id, makeAdmin))
+                }
+                onSetActive={(active) =>
+                  void withBusy(r.id, () => setUserActive(r.user.id, active))
+                }
+                onDelete={() =>
+                  void withBusy(r.id, () => deleteUser(r.user.id))
+                }
                 onEditGroups={() =>
                   setEditUser({
                     id: r.user.id,
@@ -291,7 +335,9 @@ function UsersTable() {
                 email={r.email}
                 isMobile={isMobile}
                 busy={busyId === r.id}
-                onCancel={() => void withBusy(r.id, () => cancelInvite(r.email))}
+                onCancel={() =>
+                  void withBusy(r.id, () => cancelInvite(r.email))
+                }
               />
             ),
           )
@@ -340,11 +386,21 @@ function UsersTable() {
   );
 }
 
-function StatCell({ value, label, onClick }: { value: number; label: string; onClick: () => void }) {
+function StatCell({
+  value,
+  label,
+  onClick,
+}: {
+  value: number;
+  label: string;
+  onClick: () => void;
+}) {
   return (
     <button type="button" className={styles.statCell} onClick={onClick}>
       <Text font="main-content-emphasis">{value.toLocaleString()}</Text>
-      <Text font="secondary-body" color="text-03">{label}</Text>
+      <Text font="secondary-body" color="text-03">
+        {label}
+      </Text>
     </button>
   );
 }
@@ -440,7 +496,11 @@ function GroupFilter({
   );
 }
 
-const STATUS_OPTIONS: { value: UserStatus; label: string; key: "active" | "inactive" | "invited" }[] = [
+const STATUS_OPTIONS: {
+  value: UserStatus;
+  label: string;
+  key: "active" | "inactive" | "invited";
+}[] = [
   { value: "active", label: "Active", key: "active" },
   { value: "inactive", label: "Inactive", key: "inactive" },
   { value: "invited", label: "Invite Pending", key: "invited" },
@@ -509,7 +569,13 @@ function StatusFilter({
 // Group chips — measured overflow ("+N"), tooltip with all groups             //
 // --------------------------------------------------------------------------- //
 
-function GroupsCell({ groups, onClick }: { groups: string[]; onClick?: () => void }) {
+function GroupsCell({
+  groups,
+  onClick,
+}: {
+  groups: string[];
+  onClick?: () => void;
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [visibleCount, setVisibleCount] = useState<number | null>(null);
 
@@ -570,7 +636,11 @@ function GroupsCell({ groups, onClick }: { groups: string[]; onClick?: () => voi
 
   let inner: React.ReactNode;
   if (groups.length === 0) {
-    inner = <Text font="secondary-body" color="text-05">—</Text>;
+    inner = (
+      <Text font="secondary-body" color="text-05">
+        —
+      </Text>
+    );
   } else {
     const cell = (
       <div ref={containerRef} className={styles.tags}>
@@ -608,7 +678,12 @@ function GroupsCell({ groups, onClick }: { groups: string[]; onClick?: () => voi
 
   if (!onClick) return inner;
   return (
-    <button type="button" className={styles.groupsCellButton} onClick={onClick} title="Edit groups">
+    <button
+      type="button"
+      className={styles.groupsCellButton}
+      onClick={onClick}
+      title="Edit groups"
+    >
       {inner}
     </button>
   );
@@ -616,7 +691,11 @@ function GroupsCell({ groups, onClick }: { groups: string[]; onClick?: () => voi
 
 function StatusText({ status }: { status: UserStatus }) {
   return (
-    <Text font="secondary-body" color={status === "active" ? "text-05" : "text-03"} nowrap>
+    <Text
+      font="secondary-body"
+      color={status === "active" ? "text-05" : "text-03"}
+      nowrap
+    >
       {STATUS_LABEL[status]}
     </Text>
   );
@@ -643,64 +722,71 @@ function UserRowView({
 }) {
   return (
     <Card rounding="lg" padding="fit">
-    <div className={styles.row}>
-      <span className={styles.who}>
-        <Avatar label={initials(u)} size={32} title={displayName(u)} />
-        <span className={styles.whoText}>
-          <Text font="main-ui-body" nowrap>{displayName(u)}</Text>
-          <Text font="secondary-body" color="text-03" nowrap>{u.email}</Text>
+      <div className={styles.row}>
+        <span className={styles.who}>
+          <Avatar label={initials(u)} size={32} title={displayName(u)} />
+          <span className={styles.whoText}>
+            <Text font="main-ui-body" nowrap>
+              {displayName(u)}
+            </Text>
+            <Text font="secondary-body" color="text-03" nowrap>
+              {u.email}
+            </Text>
+          </span>
         </span>
-      </span>
 
-      {!isMobile && <GroupsCell groups={u.groups} onClick={onEditGroups} />}
+        {!isMobile && <GroupsCell groups={u.groups} onClick={onEditGroups} />}
 
-      {!isMobile && (
-        <AccountTypeSelect
-          isAdmin={u.is_admin}
-          disabled={busy || (u.is_admin && isSelf)}
-          onChange={onSetAdmin}
-        />
-      )}
+        {!isMobile && (
+          <AccountTypeSelect
+            isAdmin={u.is_admin}
+            disabled={busy || (u.is_admin && isSelf)}
+            onChange={onSetAdmin}
+          />
+        )}
 
-      <StatusText status={u.status} />
+        <StatusText status={u.status} />
 
-      {!isMobile && (
-        <Text font="secondary-body" color="text-03" nowrap>{relativeTime(u.updated_at)}</Text>
-      )}
+        {!isMobile && (
+          <Text font="secondary-body" color="text-03" nowrap>
+            {relativeTime(u.updated_at)}
+          </Text>
+        )}
 
-      <RowActions disabled={busy}>
-        <LineItemButton
-          icon={SvgUsers}
-          title="Edit groups"
-          sizePreset="main-ui"
-          variant="body"
-          onClick={onEditGroups}
-        />
-        <LineItemButton
-          icon={u.is_active ? SvgX : SvgUser}
-          title={u.is_active ? "Deactivate" : "Activate"}
-          sizePreset="main-ui"
-          variant="body"
-          onClick={() => onSetActive(!u.is_active)}
-        />
-        <LineItemButton
-          icon={SvgUserShield}
-          title={u.is_admin ? "Make basic" : "Make admin"}
-          sizePreset="main-ui"
-          variant="body"
-          onClick={() => onSetAdmin(!u.is_admin)}
-        />
-        <LineItemButton
-          icon={SvgX}
-          title="Delete user"
-          sizePreset="main-ui"
-          variant="body"
-          onClick={() => {
-            if (confirm(`Delete ${u.email}? This cannot be undone.`)) onDelete();
-          }}
-        />
-      </RowActions>
-    </div>
+        <RowActions disabled={busy}>
+          <LineItemButton
+            icon={SvgUsers}
+            title="Edit groups"
+            sizePreset="main-ui"
+            variant="body"
+            onClick={onEditGroups}
+          />
+          <LineItemButton
+            icon={u.is_active ? SvgX : SvgUser}
+            title={u.is_active ? "Deactivate" : "Activate"}
+            sizePreset="main-ui"
+            variant="body"
+            onClick={() => onSetActive(!u.is_active)}
+          />
+          <LineItemButton
+            icon={SvgUserShield}
+            title={u.is_admin ? "Make basic" : "Make admin"}
+            sizePreset="main-ui"
+            variant="body"
+            onClick={() => onSetAdmin(!u.is_admin)}
+          />
+          <LineItemButton
+            icon={SvgX}
+            title="Delete user"
+            sizePreset="main-ui"
+            variant="body"
+            onClick={() => {
+              if (confirm(`Delete ${u.email}? This cannot be undone.`))
+                onDelete();
+            }}
+          />
+        </RowActions>
+      </div>
     </Card>
   );
 }
@@ -718,41 +804,73 @@ function InvitedRowView({
 }) {
   return (
     <Card rounding="lg" padding="fit">
-    <div className={styles.row}>
-      <span className={styles.who}>
-        <Avatar label={initials({ email })} size={32} title={email} />
-        <span className={styles.whoText}>
-          <Text font="main-ui-body" nowrap>{email}</Text>
-          <Text font="secondary-body" color="text-03" nowrap>Invited</Text>
+      <div className={styles.row}>
+        <span className={styles.who}>
+          <Avatar label={initials({ email })} size={32} title={email} />
+          <span className={styles.whoText}>
+            <Text font="main-ui-body" nowrap>
+              {email}
+            </Text>
+            <Text font="secondary-body" color="text-03" nowrap>
+              Invited
+            </Text>
+          </span>
         </span>
-      </span>
-      {!isMobile && <span className={styles.tags}><Text font="secondary-body" color="text-05">—</Text></span>}
-      {!isMobile && <Text font="secondary-body" color="text-05" nowrap>Basic</Text>}
-      <StatusText status="invited" />
-      {!isMobile && <Text font="secondary-body" color="text-05" nowrap>—</Text>}
-      <RowActions disabled={busy}>
-        <LineItemButton
-          icon={SvgX}
-          title="Cancel invite"
-          sizePreset="main-ui"
-          variant="body"
-          onClick={onCancel}
-        />
-      </RowActions>
-    </div>
+        {!isMobile && (
+          <span className={styles.tags}>
+            <Text font="secondary-body" color="text-05">
+              —
+            </Text>
+          </span>
+        )}
+        {!isMobile && (
+          <Text font="secondary-body" color="text-05" nowrap>
+            Basic
+          </Text>
+        )}
+        <StatusText status="invited" />
+        {!isMobile && (
+          <Text font="secondary-body" color="text-05" nowrap>
+            —
+          </Text>
+        )}
+        <RowActions disabled={busy}>
+          <LineItemButton
+            icon={SvgX}
+            title="Cancel invite"
+            sizePreset="main-ui"
+            variant="body"
+            onClick={onCancel}
+          />
+        </RowActions>
+      </div>
     </Card>
   );
 }
 
-function RowActions({ disabled, children }: { disabled?: boolean; children: React.ReactNode }) {
+function RowActions({
+  disabled,
+  children,
+}: {
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
   const [open, setOpen] = useState(false);
-  const items: React.ReactNode[] = Array.isArray(children) ? children : [children];
+  const items: React.ReactNode[] = Array.isArray(children)
+    ? children
+    : [children];
   return (
     <span className={styles.actions}>
       <Popover open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <span className={styles.menuTrigger}>
-            <Button prominence="tertiary" size="sm" icon={SvgMoreHorizontal} disabled={disabled} tooltip="Actions" />
+            <Button
+              prominence="tertiary"
+              size="sm"
+              icon={SvgMoreHorizontal}
+              disabled={disabled}
+              tooltip="Actions"
+            />
           </span>
         </Popover.Trigger>
         <Popover.Content width="fit" align="end" sideOffset={4}>
@@ -777,7 +895,12 @@ function AccountTypeSelect({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <span className={styles.menuTrigger}>
-          <OpenButton variant="select-light" size="sm" icon={isAdmin ? SvgUserShield : SvgUser} disabled={disabled}>
+          <OpenButton
+            variant="select-light"
+            size="sm"
+            icon={isAdmin ? SvgUserShield : SvgUser}
+            disabled={disabled}
+          >
             {isAdmin ? "Admin" : "Basic"}
           </OpenButton>
         </span>
@@ -790,7 +913,10 @@ function AccountTypeSelect({
             sizePreset="main-ui"
             variant="body"
             state={!isAdmin ? "selected" : "empty"}
-            onClick={() => { onChange(false); setOpen(false); }}
+            onClick={() => {
+              onChange(false);
+              setOpen(false);
+            }}
           />
           <LineItemButton
             icon={SvgUserShield}
@@ -798,7 +924,10 @@ function AccountTypeSelect({
             sizePreset="main-ui"
             variant="body"
             state={isAdmin ? "selected" : "empty"}
-            onClick={() => { onChange(true); setOpen(false); }}
+            onClick={() => {
+              onChange(true);
+              setOpen(false);
+            }}
           />
         </PopoverMenu>
       </Popover.Content>
@@ -826,13 +955,21 @@ function parseEmails(value: string, existing: Chip[]): Chip[] {
   const next: Chip[] = [];
   for (const email of entries) {
     const dup =
-      existing.some((c) => c.label === email) || next.some((c) => c.label === email);
-    if (!dup) next.push({ id: email, label: email, error: !EMAIL_REGEX.test(email) });
+      existing.some((c) => c.label === email) ||
+      next.some((c) => c.label === email);
+    if (!dup)
+      next.push({ id: email, label: email, error: !EMAIL_REGEX.test(email) });
   }
   return next;
 }
 
-function InviteUsersModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+function InviteUsersModal({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
   const { refresh } = useAdminUsers();
   const [chips, setChips] = useState<Chip[]>([]);
   const [value, setValue] = useState("");
@@ -906,18 +1043,32 @@ function InviteUsersModal({ open, onClose }: { open: boolean; onClose: () => voi
         if (e.target === e.currentTarget && !busy) close();
       }}
     >
-      <div className={styles.dialog} role="dialog" aria-modal="true" aria-label="Invite users">
+      <div
+        className={styles.dialog}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Invite users"
+      >
         <header className={styles.dialogHead}>
           <span className={styles.pageIcon}>
             <SvgMail size={20} />
           </span>
           <div className={styles.dialogHeadText}>
-            <Text as="h2" font="main-content-emphasis">Invite Users</Text>
+            <Text as="h2" font="main-content-emphasis">
+              Invite Users
+            </Text>
             <Text font="secondary-body" color="text-03">
               They&apos;ll be able to sign up with these email addresses.
             </Text>
           </div>
-          <Button prominence="tertiary" size="sm" icon={SvgX} tooltip="Close" onClick={close} disabled={busy} />
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgX}
+            tooltip="Close"
+            onClick={close}
+            disabled={busy}
+          />
         </header>
         <div className={styles.dialogBody}>
           <ChipField
@@ -936,10 +1087,21 @@ function InviteUsersModal({ open, onClose }: { open: boolean; onClose: () => voi
               </Text>
             </div>
           )}
-          {error && <Text font="secondary-body" color="text-02">{error}</Text>}
+          {error && (
+            <Text font="secondary-body" color="text-02">
+              {error}
+            </Text>
+          )}
         </div>
         <footer className={styles.dialogFoot}>
-          <Button prominence="secondary" size="md" onClick={close} disabled={busy}>Cancel</Button>
+          <Button
+            prominence="secondary"
+            size="md"
+            onClick={close}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
           <Button
             variant="action"
             size="md"
@@ -971,14 +1133,13 @@ function ChipField({
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   return (
-    <div
-      className={styles.chipField}
-      onClick={() => inputRef.current?.focus()}
-    >
+    <div className={styles.chipField} onClick={() => inputRef.current?.focus()}>
       {chips.map((c) => (
         <span
           key={c.id}
-          className={c.error ? `${styles.chip} ${styles.chipError}` : styles.chip}
+          className={
+            c.error ? `${styles.chip} ${styles.chipError}` : styles.chip
+          }
         >
           <Text font="secondary-body" color={c.error ? "text-02" : "text-04"}>
             {c.label}

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -434,13 +434,15 @@ function GroupFilter({
       }}
     >
       <Popover.Trigger asChild>
-        <FilterButton
-          icon={SvgUsers}
-          active={value !== null}
-          onClear={() => onChange(null)}
-        >
-          {value ?? "All Groups"}
-        </FilterButton>
+        <span className={styles.menuTrigger}>
+          <FilterButton
+            icon={SvgUsers}
+            active={value !== null}
+            onClear={() => onChange(null)}
+          >
+            {value ?? "All Groups"}
+          </FilterButton>
+        </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
         <PopoverMenu>
@@ -519,13 +521,15 @@ function StatusFilter({
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
-        <FilterButton
-          icon={SvgUserShield}
-          active={value !== null}
-          onClear={() => onChange(null)}
-        >
-          {value ? STATUS_LABEL[value] : "All Status"}
-        </FilterButton>
+        <span className={styles.menuTrigger}>
+          <FilterButton
+            icon={SvgUserShield}
+            active={value !== null}
+            onClear={() => onChange(null)}
+          >
+            {value ? STATUS_LABEL[value] : "All Status"}
+          </FilterButton>
+        </span>
       </Popover.Trigger>
       <Popover.Content width="fit" align="start" sideOffset={4}>
         <PopoverMenu>

--- a/frontend/src/app/admin/users/page.tsx
+++ b/frontend/src/app/admin/users/page.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import {
   Button,
+  Card,
+  FilterButton,
   InputTypeIn,
   LineItemButton,
   OpenButton,
@@ -11,39 +19,85 @@ import {
   PopoverMenu,
   Tag,
   Text,
+  Tooltip,
 } from "@onyx-ai/opal/components";
-import { SvgTrash, SvgUser, SvgUserShield } from "@onyx-ai/opal/icons";
+import {
+  SvgAlertTriangle,
+  SvgCheck,
+  SvgDownload,
+  SvgMail,
+  SvgMoreHorizontal,
+  SvgUser,
+  SvgUserPlus,
+  SvgUsers,
+  SvgUserShield,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+
+import { IllustrationContent, SettingsLayouts } from "@onyx-ai/opal/layouts";
+import { SvgNoResult } from "@onyx-ai/opal/illustrations";
 
 import { Avatar } from "@/components/common/Avatar";
-import { useConfirm } from "@/components/common/ConfirmDialog";
-import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
-import { apiFetch } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { useIsMobile } from "@/lib/viewport";
 import {
+  cancelInvite,
+  deleteUser,
   displayName,
+  downloadUsersCsv,
   initials,
+  inviteUsers,
+  relativeTime,
+  setUserActive,
+  setUserAdmin,
   useAdminUsers,
   type AdminUser,
+  type UserStatus,
 } from "@/lib/users";
+
+import EditUserModal, { type EditUserTarget } from "./EditUserModal";
 
 import styles from "./users.module.css";
 
+const PAGE_SIZE = 10;
+
+// A table row is either a real account or a pending invite.
+type Row =
+  | { kind: "user"; id: string; user: AdminUser }
+  | { kind: "invited"; id: string; email: string };
+
+const STATUS_LABEL: Record<UserStatus, string> = {
+  active: "Active",
+  inactive: "Inactive",
+  invited: "Invite Pending",
+};
+
 export default function AdminUsersPage() {
-  const isMobile = useIsMobile();
+  const [inviteOpen, setInviteOpen] = useState(false);
   return (
     <RequireAdmin>
-      <main
-        style={{ padding: isMobile ? "16px 12px" : "24px 32px", maxWidth: 960 }}
-      >
-        <BackLink />
-        <PageHeader
-          title="Users"
-          description="Promote or demote admins, or remove accounts. The last admin cannot be demoted or deleted."
+      <SettingsLayouts.Root width="lg">
+        <SettingsLayouts.Header
+          icon={SvgUser}
+          title="Users & Requests"
+          backButton
+          rightChildren={
+            <Button
+              variant="action"
+              size="md"
+              icon={SvgUserPlus}
+              onClick={() => setInviteOpen(true)}
+            >
+              Invite Users
+            </Button>
+          }
         />
-        <UsersTable />
-      </main>
+        <SettingsLayouts.Body>
+          <UsersTable />
+        </SettingsLayouts.Body>
+      </SettingsLayouts.Root>
+      <InviteUsersModal open={inviteOpen} onClose={() => setInviteOpen(false)} />
     </RequireAdmin>
   );
 }
@@ -52,77 +106,135 @@ function UsersTable() {
   const { user: currentUser } = useAuth();
   const currentUserId = currentUser?.id ?? "";
   const isMobile = useIsMobile();
-  const { users, error: loadError, refresh } = useAdminUsers();
+  const { users, invited, counts, error: loadError, refresh } = useAdminUsers();
+
   const [query, setQuery] = useState("");
+  const [groupFilter, setGroupFilter] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<UserStatus | null>(null);
+  const [page, setPage] = useState(0);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
-  const confirmDialog = useConfirm();
+  const [editUser, setEditUser] = useState<EditUserTarget | null>(null);
+
+  // Group names + how many users hold each — drives the Groups filter list.
+  const groupCounts = useMemo(() => {
+    const m = new Map<string, number>();
+    users.forEach((u) => u.groups.forEach((g) => m.set(g, (m.get(g) ?? 0) + 1)));
+    return m;
+  }, [users]);
+  const allGroups = useMemo(
+    () => [...groupCounts.keys()].sort(),
+    [groupCounts],
+  );
+
+  const statusCounts = useMemo(
+    () => ({
+      active: counts.active,
+      inactive: counts.inactive,
+      invited: counts.invited,
+    }),
+    [counts],
+  );
+
+  const rows = useMemo<Row[]>(() => {
+    const userRows: Row[] = users.map((u) => ({ kind: "user", id: u.id, user: u }));
+    const invitedRows: Row[] = invited.map((i) => ({
+      kind: "invited",
+      id: `invite:${i.email}`,
+      email: i.email,
+    }));
+    return [...userRows, ...invitedRows];
+  }, [users, invited]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return users;
-    return users.filter(
-      (u) =>
-        u.email.toLowerCase().includes(q) ||
-        (u.name ?? "").toLowerCase().includes(q),
-    );
-  }, [users, query]);
+    return rows.filter((r) => {
+      const status: UserStatus = r.kind === "invited" ? "invited" : r.user.status;
+      if (statusFilter && status !== statusFilter) return false;
+      if (groupFilter) {
+        if (r.kind === "invited" || !r.user.groups.includes(groupFilter)) return false;
+      }
+      if (!q) return true;
+      if (r.kind === "invited") return r.email.toLowerCase().includes(q);
+      return (
+        r.user.email.toLowerCase().includes(q) ||
+        (r.user.name ?? "").toLowerCase().includes(q)
+      );
+    });
+  }, [rows, query, statusFilter, groupFilter]);
 
-  async function setAdmin(u: AdminUser, makeAdmin: boolean) {
-    if (u.is_admin === makeAdmin) return;
-    setBusyId(u.id);
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages - 1);
+  const pageRows = filtered.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE);
+
+  async function withBusy(id: string, fn: () => Promise<void>) {
+    setBusyId(id);
     setActionError(null);
     try {
-      await apiFetch<AdminUser>(`/admin/users/${u.id}`, {
-        method: "PATCH",
-        body: JSON.stringify({ is_admin: makeAdmin }),
-      });
+      await fn();
       await refresh();
     } catch (e) {
-      setActionError(e instanceof Error ? e.message : "Failed to update user");
-    } finally {
-      setBusyId(null);
-    }
-  }
-
-  async function remove(u: AdminUser) {
-    if (
-      !(await confirmDialog({
-        title: `Delete ${u.email}?`,
-        body: "This cannot be undone.",
-        confirmLabel: "Delete",
-      }))
-    )
-      return;
-    setBusyId(u.id);
-    setActionError(null);
-    try {
-      await apiFetch<void>(`/admin/users/${u.id}`, { method: "DELETE" });
-      await refresh();
-    } catch (e) {
-      setActionError(e instanceof Error ? e.message : "Failed to delete user");
+      setActionError(e instanceof Error ? e.message : "Action failed");
     } finally {
       setBusyId(null);
     }
   }
 
   const cols = isMobile
-    ? "1fr auto auto"
-    : "minmax(0, 2fr) minmax(0, 1.5fr) 130px 110px 70px";
+    ? "minmax(0,1fr) 120px 44px"
+    : "minmax(0,2fr) minmax(0,1.4fr) 132px 120px 110px 44px";
 
   return (
     <div>
-      <div className={styles.stat}>
-        <Text font="secondary-body" color="text-03">
-          {`${users.length} ${users.length === 1 ? "active user" : "active users"}`}
-        </Text>
+      {/* Stats */}
+      <div className={styles.statsWrap}>
+        <Card rounding="lg" padding="fit">
+          <div className={styles.stats}>
+            <StatCell value={counts.active} label="active users" onClick={() => { setStatusFilter("active"); setPage(0); }} />
+            <span className={styles.statDivider} />
+            <StatCell value={counts.invited} label="pending invites" onClick={() => { setStatusFilter("invited"); setPage(0); }} />
+          </div>
+        </Card>
       </div>
+
       <div className={styles.searchWrap}>
         <InputTypeIn
           searchIcon
           placeholder="Search users…"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) => {
+            setQuery(e.target.value);
+            setPage(0);
+          }}
+        />
+      </div>
+
+      {/* Filters */}
+      <div className={styles.filters}>
+        <GroupFilter
+          groups={allGroups}
+          counts={groupCounts}
+          value={groupFilter}
+          onChange={(v) => {
+            setGroupFilter(v);
+            setPage(0);
+          }}
+        />
+        <StatusFilter
+          value={statusFilter}
+          counts={statusCounts}
+          onChange={(v) => {
+            setStatusFilter(v);
+            setPage(0);
+          }}
+        />
+        <span className={styles.headSpacer} />
+        <Button
+          prominence="tertiary"
+          size="sm"
+          icon={SvgDownload}
+          tooltip="Download CSV"
+          onClick={() => void downloadUsersCsv()}
         />
       </div>
 
@@ -136,98 +248,518 @@ function UsersTable() {
 
       <div className={styles.table} style={{ ["--cols" as string]: cols }}>
         <div className={styles.headRow}>
-          <Text font="secondary-action" color="text-03">
-            Name
-          </Text>
-          {!isMobile && (
-            <Text font="secondary-action" color="text-03">
-              Groups
-            </Text>
-          )}
-          <Text font="secondary-action" color="text-03">
-            Account type
-          </Text>
-          {!isMobile && (
-            <Text font="secondary-action" color="text-03">
-              Created
-            </Text>
-          )}
+          <Text font="secondary-action" color="text-03">Name</Text>
+          {!isMobile && <Text font="secondary-action" color="text-03">Groups</Text>}
+          {!isMobile && <Text font="secondary-action" color="text-03">Account Type</Text>}
+          <Text font="secondary-action" color="text-03">Status</Text>
+          {!isMobile && <Text font="secondary-action" color="text-03">Last Updated</Text>}
           <span />
         </div>
 
-        {filtered.length === 0 ? (
+        {pageRows.length === 0 ? (
           <div className={styles.emptyRow}>
-            <Text font="secondary-body" color="text-03">
-              No users match your search.
-            </Text>
+            <IllustrationContent
+              illustration={SvgNoResult}
+              title="No users found"
+              description="Try adjusting your search or filters."
+            />
           </div>
         ) : (
-          filtered.map((u) => {
-            const isSelf = u.id === currentUserId;
-            const busy = busyId === u.id;
-            return (
-              <div key={u.id} className={styles.row}>
-                <span className={styles.who}>
-                  <Avatar
-                    label={initials(u)}
-                    size={32}
-                    title={displayName(u)}
-                  />
-                  <span className={styles.whoText}>
-                    <Text font="main-ui-body" nowrap>
-                      {displayName(u)}
-                    </Text>
-                    <Text font="secondary-body" color="text-03" nowrap>
-                      {u.email}
-                    </Text>
-                  </span>
-                </span>
-
-                {!isMobile && (
-                  <span className={styles.tags}>
-                    {u.groups.length === 0 ? (
-                      <Text font="secondary-body" color="text-05">
-                        —
-                      </Text>
-                    ) : (
-                      u.groups.map((g) => (
-                        <Tag key={g} title={g} color="gray" />
-                      ))
-                    )}
-                  </span>
-                )}
-
-                <AccountTypeSelect
-                  isAdmin={u.is_admin}
-                  disabled={busy || (u.is_admin && isSelf)}
-                  onChange={(makeAdmin) => void setAdmin(u, makeAdmin)}
-                />
-
-                {!isMobile && (
-                  <Text font="secondary-body" color="text-03" nowrap>
-                    {u.created_at.split(" ")[0]}
-                  </Text>
-                )}
-
-                <span className={styles.actions}>
-                  <Button
-                    prominence="tertiary"
-                    size="sm"
-                    variant="danger"
-                    icon={SvgTrash}
-                    onClick={() => void remove(u)}
-                    disabled={busy || isSelf}
-                    tooltip={
-                      isSelf ? "You can't delete yourself" : "Delete user"
-                    }
-                  />
-                </span>
-              </div>
-            );
-          })
+          pageRows.map((r) =>
+            r.kind === "user" ? (
+              <UserRowView
+                key={r.id}
+                u={r.user}
+                isMobile={isMobile}
+                isSelf={r.user.id === currentUserId}
+                busy={busyId === r.id}
+                onSetAdmin={(makeAdmin) => void withBusy(r.id, () => setUserAdmin(r.user.id, makeAdmin))}
+                onSetActive={(active) => void withBusy(r.id, () => setUserActive(r.user.id, active))}
+                onDelete={() => void withBusy(r.id, () => deleteUser(r.user.id))}
+                onEditGroups={() =>
+                  setEditUser({
+                    id: r.user.id,
+                    email: r.user.email,
+                    name: r.user.name,
+                    groups: r.user.groups,
+                  })
+                }
+              />
+            ) : (
+              <InvitedRowView
+                key={r.id}
+                email={r.email}
+                isMobile={isMobile}
+                busy={busyId === r.id}
+                onCancel={() => void withBusy(r.id, () => cancelInvite(r.email))}
+              />
+            ),
+          )
         )}
       </div>
+
+      <div className={styles.tableFoot}>
+        <Text font="secondary-body" color="text-03">
+          {filtered.length === 0
+            ? "No users"
+            : `Showing ${safePage * PAGE_SIZE + 1}–${Math.min((safePage + 1) * PAGE_SIZE, filtered.length)} of ${filtered.length}`}
+        </Text>
+        {totalPages > 1 && (
+          <span className={styles.pager}>
+            <Button
+              prominence="tertiary"
+              size="sm"
+              disabled={safePage === 0}
+              onClick={() => setPage(safePage - 1)}
+            >
+              Prev
+            </Button>
+            <Text font="secondary-body" color="text-03">
+              {`${safePage + 1} / ${totalPages}`}
+            </Text>
+            <Button
+              prominence="tertiary"
+              size="sm"
+              disabled={safePage >= totalPages - 1}
+              onClick={() => setPage(safePage + 1)}
+            >
+              Next
+            </Button>
+          </span>
+        )}
+      </div>
+
+      {editUser && (
+        <EditUserModal
+          user={editUser}
+          onClose={() => setEditUser(null)}
+          onMutate={refresh}
+        />
+      )}
     </div>
+  );
+}
+
+function StatCell({ value, label, onClick }: { value: number; label: string; onClick: () => void }) {
+  return (
+    <button type="button" className={styles.statCell} onClick={onClick}>
+      <Text font="main-content-emphasis">{value.toLocaleString()}</Text>
+      <Text font="secondary-body" color="text-03">{label}</Text>
+    </button>
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Filters — Onyx FilterButton chrome (clearable X, count badges)              //
+// --------------------------------------------------------------------------- //
+
+function GroupFilter({
+  groups,
+  counts,
+  value,
+  onChange,
+}: {
+  groups: string[];
+  counts: Map<string, number>;
+  value: string | null;
+  onChange: (v: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const filtered = search
+    ? groups.filter((g) => g.toLowerCase().includes(search.toLowerCase()))
+    : groups;
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) setSearch("");
+      }}
+    >
+      <Popover.Trigger asChild>
+        <FilterButton
+          icon={SvgUsers}
+          active={value !== null}
+          onClear={() => onChange(null)}
+        >
+          {value ?? "All Groups"}
+        </FilterButton>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="start" sideOffset={4}>
+        <PopoverMenu>
+          {groups.length > 6 && (
+            <InputTypeIn
+              searchIcon
+              variant="internal"
+              placeholder="Search groups…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+          )}
+          <LineItemButton
+            icon={value === null ? SvgCheck : SvgUsers}
+            title="All Groups"
+            sizePreset="main-ui"
+            variant="body"
+            state={value === null ? "selected" : "empty"}
+            onClick={() => {
+              onChange(null);
+              setOpen(false);
+            }}
+          />
+          {filtered.map((g) => (
+            <LineItemButton
+              key={g}
+              icon={value === g ? SvgCheck : SvgUsers}
+              title={g}
+              sizePreset="main-ui"
+              variant="body"
+              state={value === g ? "selected" : "empty"}
+              rightChildren={
+                <Text font="secondary-body" color="text-03">
+                  {String(counts.get(g) ?? 0)}
+                </Text>
+              }
+              onClick={() => {
+                onChange(g);
+                setOpen(false);
+              }}
+            />
+          ))}
+          {filtered.length === 0 && (
+            <div className={styles.menuEmpty}>
+              <Text font="secondary-body" color="text-03">
+                No groups found
+              </Text>
+            </div>
+          )}
+        </PopoverMenu>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
+const STATUS_OPTIONS: { value: UserStatus; label: string; key: "active" | "inactive" | "invited" }[] = [
+  { value: "active", label: "Active", key: "active" },
+  { value: "inactive", label: "Inactive", key: "inactive" },
+  { value: "invited", label: "Invite Pending", key: "invited" },
+];
+
+function StatusFilter({
+  value,
+  counts,
+  onChange,
+}: {
+  value: UserStatus | null;
+  counts: { active: number; inactive: number; invited: number };
+  onChange: (v: UserStatus | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <FilterButton
+          icon={SvgUserShield}
+          active={value !== null}
+          onClear={() => onChange(null)}
+        >
+          {value ? STATUS_LABEL[value] : "All Status"}
+        </FilterButton>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="start" sideOffset={4}>
+        <PopoverMenu>
+          <LineItemButton
+            icon={value === null ? SvgCheck : SvgUser}
+            title="All Status"
+            sizePreset="main-ui"
+            variant="body"
+            state={value === null ? "selected" : "empty"}
+            onClick={() => {
+              onChange(null);
+              setOpen(false);
+            }}
+          />
+          {STATUS_OPTIONS.map((opt) => (
+            <LineItemButton
+              key={opt.value}
+              icon={value === opt.value ? SvgCheck : SvgUser}
+              title={opt.label}
+              sizePreset="main-ui"
+              variant="body"
+              state={value === opt.value ? "selected" : "empty"}
+              rightChildren={
+                <Text font="secondary-body" color="text-03">
+                  {String(counts[opt.key])}
+                </Text>
+              }
+              onClick={() => {
+                onChange(opt.value);
+                setOpen(false);
+              }}
+            />
+          ))}
+        </PopoverMenu>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Group chips — measured overflow ("+N"), tooltip with all groups             //
+// --------------------------------------------------------------------------- //
+
+function GroupsCell({ groups, onClick }: { groups: string[]; onClick?: () => void }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState<number | null>(null);
+
+  // Re-enter the measurement phase whenever the group set changes.
+  useLayoutEffect(() => {
+    setVisibleCount(null);
+  }, [groups]);
+
+  // After the "render all" phase, measure how many pills fit.
+  useLayoutEffect(() => {
+    if (visibleCount !== null) return;
+    const container = containerRef.current;
+    if (!container || groups.length <= 1) {
+      setVisibleCount(groups.length);
+      return;
+    }
+    const tags = container.querySelectorAll<HTMLElement>("[data-group-tag]");
+    if (tags.length === 0) return;
+    const containerWidth = container.clientWidth;
+    const gap = 4;
+    const counterWidth = 34; // approximate "+N" pill width
+    let used = 0;
+    let count = 0;
+    for (let i = 0; i < tags.length; i++) {
+      const tagWidth = tags[i]!.offsetWidth;
+      const gapBefore = count > 0 ? gap : 0;
+      const hasMore = i < tags.length - 1;
+      const reserve = hasMore ? gap + counterWidth : 0;
+      if (used + gapBefore + tagWidth + reserve <= containerWidth) {
+        used += gapBefore + tagWidth;
+        count++;
+      } else {
+        break;
+      }
+    }
+    setVisibleCount(Math.max(1, count));
+  }, [visibleCount, groups]);
+
+  // Re-measure on width changes (responsive / column resize).
+  const lastWidthRef = useRef(0);
+  useEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? 0;
+      if (Math.abs(width - lastWidthRef.current) < 1) return;
+      lastWidthRef.current = width;
+      setVisibleCount(null);
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [groups]);
+
+  const isMeasuring = visibleCount === null;
+  const effectiveVisible = visibleCount ?? groups.length;
+  const overflowCount = groups.length - effectiveVisible;
+  const hasOverflow = !isMeasuring && overflowCount > 0;
+
+  let inner: React.ReactNode;
+  if (groups.length === 0) {
+    inner = <Text font="secondary-body" color="text-05">—</Text>;
+  } else {
+    const cell = (
+      <div ref={containerRef} className={styles.tags}>
+        {(isMeasuring ? groups : groups.slice(0, effectiveVisible)).map((g) => (
+          <span key={g} data-group-tag className={styles.tagChip}>
+            <Tag title={g} color="gray" />
+          </span>
+        ))}
+        {hasOverflow && (
+          <span className={styles.tagChip}>
+            <Tag title={`+${overflowCount}`} color="gray" />
+          </span>
+        )}
+      </div>
+    );
+    inner = hasOverflow ? (
+      <Tooltip
+        side="bottom"
+        align="start"
+        delayDuration={200}
+        tooltip={
+          <div className={styles.tagsTooltip}>
+            {groups.map((g) => (
+              <Tag key={g} title={g} color="gray" />
+            ))}
+          </div>
+        }
+      >
+        {cell}
+      </Tooltip>
+    ) : (
+      cell
+    );
+  }
+
+  if (!onClick) return inner;
+  return (
+    <button type="button" className={styles.groupsCellButton} onClick={onClick} title="Edit groups">
+      {inner}
+    </button>
+  );
+}
+
+function StatusText({ status }: { status: UserStatus }) {
+  return (
+    <Text font="secondary-body" color={status === "active" ? "text-05" : "text-03"} nowrap>
+      {STATUS_LABEL[status]}
+    </Text>
+  );
+}
+
+function UserRowView({
+  u,
+  isMobile,
+  isSelf,
+  busy,
+  onSetAdmin,
+  onSetActive,
+  onDelete,
+  onEditGroups,
+}: {
+  u: AdminUser;
+  isMobile: boolean;
+  isSelf: boolean;
+  busy: boolean;
+  onSetAdmin: (makeAdmin: boolean) => void;
+  onSetActive: (active: boolean) => void;
+  onDelete: () => void;
+  onEditGroups: () => void;
+}) {
+  return (
+    <Card rounding="lg" padding="fit">
+    <div className={styles.row}>
+      <span className={styles.who}>
+        <Avatar label={initials(u)} size={32} title={displayName(u)} />
+        <span className={styles.whoText}>
+          <Text font="main-ui-body" nowrap>{displayName(u)}</Text>
+          <Text font="secondary-body" color="text-03" nowrap>{u.email}</Text>
+        </span>
+      </span>
+
+      {!isMobile && <GroupsCell groups={u.groups} onClick={onEditGroups} />}
+
+      {!isMobile && (
+        <AccountTypeSelect
+          isAdmin={u.is_admin}
+          disabled={busy || (u.is_admin && isSelf)}
+          onChange={onSetAdmin}
+        />
+      )}
+
+      <StatusText status={u.status} />
+
+      {!isMobile && (
+        <Text font="secondary-body" color="text-03" nowrap>{relativeTime(u.updated_at)}</Text>
+      )}
+
+      <RowActions disabled={busy}>
+        <LineItemButton
+          icon={SvgUsers}
+          title="Edit groups"
+          sizePreset="main-ui"
+          variant="body"
+          onClick={onEditGroups}
+        />
+        <LineItemButton
+          icon={u.is_active ? SvgX : SvgUser}
+          title={u.is_active ? "Deactivate" : "Activate"}
+          sizePreset="main-ui"
+          variant="body"
+          onClick={() => onSetActive(!u.is_active)}
+        />
+        <LineItemButton
+          icon={SvgUserShield}
+          title={u.is_admin ? "Make basic" : "Make admin"}
+          sizePreset="main-ui"
+          variant="body"
+          onClick={() => onSetAdmin(!u.is_admin)}
+        />
+        <LineItemButton
+          icon={SvgX}
+          title="Delete user"
+          sizePreset="main-ui"
+          variant="body"
+          onClick={() => {
+            if (confirm(`Delete ${u.email}? This cannot be undone.`)) onDelete();
+          }}
+        />
+      </RowActions>
+    </div>
+    </Card>
+  );
+}
+
+function InvitedRowView({
+  email,
+  isMobile,
+  busy,
+  onCancel,
+}: {
+  email: string;
+  isMobile: boolean;
+  busy: boolean;
+  onCancel: () => void;
+}) {
+  return (
+    <Card rounding="lg" padding="fit">
+    <div className={styles.row}>
+      <span className={styles.who}>
+        <Avatar label={initials({ email })} size={32} title={email} />
+        <span className={styles.whoText}>
+          <Text font="main-ui-body" nowrap>{email}</Text>
+          <Text font="secondary-body" color="text-03" nowrap>Invited</Text>
+        </span>
+      </span>
+      {!isMobile && <span className={styles.tags}><Text font="secondary-body" color="text-05">—</Text></span>}
+      {!isMobile && <Text font="secondary-body" color="text-05" nowrap>Basic</Text>}
+      <StatusText status="invited" />
+      {!isMobile && <Text font="secondary-body" color="text-05" nowrap>—</Text>}
+      <RowActions disabled={busy}>
+        <LineItemButton
+          icon={SvgX}
+          title="Cancel invite"
+          sizePreset="main-ui"
+          variant="body"
+          onClick={onCancel}
+        />
+      </RowActions>
+    </div>
+    </Card>
+  );
+}
+
+function RowActions({ disabled, children }: { disabled?: boolean; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const items: React.ReactNode[] = Array.isArray(children) ? children : [children];
+  return (
+    <span className={styles.actions}>
+      <Popover open={open} onOpenChange={setOpen}>
+        <Popover.Trigger asChild>
+          <span className={styles.menuTrigger}>
+            <Button prominence="tertiary" size="sm" icon={SvgMoreHorizontal} disabled={disabled} tooltip="Actions" />
+          </span>
+        </Popover.Trigger>
+        <Popover.Content width="fit" align="end" sideOffset={4}>
+          <PopoverMenu>{items}</PopoverMenu>
+        </Popover.Content>
+      </Popover>
+    </span>
   );
 }
 
@@ -245,12 +777,7 @@ function AccountTypeSelect({
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Trigger asChild>
         <span className={styles.menuTrigger}>
-          <OpenButton
-            variant="select-light"
-            size="sm"
-            icon={isAdmin ? SvgUserShield : SvgUser}
-            disabled={disabled}
-          >
+          <OpenButton variant="select-light" size="sm" icon={isAdmin ? SvgUserShield : SvgUser} disabled={disabled}>
             {isAdmin ? "Admin" : "Basic"}
           </OpenButton>
         </span>
@@ -261,26 +788,223 @@ function AccountTypeSelect({
             icon={SvgUser}
             title="Basic"
             sizePreset="main-ui"
-            variant="section"
+            variant="body"
             state={!isAdmin ? "selected" : "empty"}
-            onClick={() => {
-              onChange(false);
-              setOpen(false);
-            }}
+            onClick={() => { onChange(false); setOpen(false); }}
           />
           <LineItemButton
             icon={SvgUserShield}
             title="Admin"
             sizePreset="main-ui"
-            variant="section"
+            variant="body"
             state={isAdmin ? "selected" : "empty"}
-            onClick={() => {
-              onChange(true);
-              setOpen(false);
-            }}
+            onClick={() => { onChange(true); setOpen(false); }}
           />
         </PopoverMenu>
       </Popover.Content>
     </Popover>
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Invite modal — chip field (type email + Enter; chips are removable)         //
+// --------------------------------------------------------------------------- //
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface Chip {
+  id: string;
+  label: string;
+  error: boolean;
+}
+
+function parseEmails(value: string, existing: Chip[]): Chip[] {
+  const entries = value
+    .split(/[\s,;]+/)
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+  const next: Chip[] = [];
+  for (const email of entries) {
+    const dup =
+      existing.some((c) => c.label === email) || next.some((c) => c.label === email);
+    if (!dup) next.push({ id: email, label: email, error: !EMAIL_REGEX.test(email) });
+  }
+  return next;
+}
+
+function InviteUsersModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { refresh } = useAdminUsers();
+  const [chips, setChips] = useState<Chip[]>([]);
+  const [value, setValue] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  function reset() {
+    setChips([]);
+    setValue("");
+    setError(null);
+    setBusy(false);
+  }
+
+  function close() {
+    onClose();
+    setTimeout(reset, 200);
+  }
+
+  function commit(raw: string) {
+    const added = parseEmails(raw, chips);
+    if (added.length > 0) setChips((prev) => [...prev, ...added]);
+    setValue("");
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === "," || e.key === ";") {
+      e.preventDefault();
+      if (value.trim()) commit(value);
+    } else if (e.key === "Backspace" && !value && chips.length > 0) {
+      setChips((prev) => prev.slice(0, -1));
+    }
+  }
+
+  function removeChip(id: string) {
+    setChips((prev) => prev.filter((c) => c.id !== id));
+  }
+
+  async function submit() {
+    const pending = value.trim();
+    const all = pending ? [...chips, ...parseEmails(pending, chips)] : chips;
+    if (pending) {
+      setChips(all);
+      setValue("");
+    }
+    const valid = all.filter((c) => !c.error).map((c) => c.label);
+    if (valid.length === 0) {
+      setError("Add at least one valid email address.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await inviteUsers(valid);
+      await refresh();
+      close();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to invite users");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const hasInvalid = chips.some((c) => c.error);
+
+  return (
+    <div
+      className={styles.scrim}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget && !busy) close();
+      }}
+    >
+      <div className={styles.dialog} role="dialog" aria-modal="true" aria-label="Invite users">
+        <header className={styles.dialogHead}>
+          <span className={styles.pageIcon}>
+            <SvgMail size={20} />
+          </span>
+          <div className={styles.dialogHeadText}>
+            <Text as="h2" font="main-content-emphasis">Invite Users</Text>
+            <Text font="secondary-body" color="text-03">
+              They&apos;ll be able to sign up with these email addresses.
+            </Text>
+          </div>
+          <Button prominence="tertiary" size="sm" icon={SvgX} tooltip="Close" onClick={close} disabled={busy} />
+        </header>
+        <div className={styles.dialogBody}>
+          <ChipField
+            chips={chips}
+            value={value}
+            onChange={setValue}
+            onKeyDown={onKeyDown}
+            onBlur={() => value.trim() && commit(value)}
+            onRemove={removeChip}
+          />
+          {hasInvalid && (
+            <div className={styles.chipWarn}>
+              <SvgAlertTriangle size={14} />
+              <Text font="secondary-body" color="text-03">
+                Some email addresses are invalid and will be skipped.
+              </Text>
+            </div>
+          )}
+          {error && <Text font="secondary-body" color="text-02">{error}</Text>}
+        </div>
+        <footer className={styles.dialogFoot}>
+          <Button prominence="secondary" size="md" onClick={close} disabled={busy}>Cancel</Button>
+          <Button
+            variant="action"
+            size="md"
+            disabled={busy || (chips.length > 0 && chips.every((c) => c.error))}
+            onClick={() => void submit()}
+          >
+            {busy ? "Inviting…" : "Invite"}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function ChipField({
+  chips,
+  value,
+  onChange,
+  onKeyDown,
+  onBlur,
+  onRemove,
+}: {
+  chips: Chip[];
+  value: string;
+  onChange: (v: string) => void;
+  onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onBlur: () => void;
+  onRemove: (id: string) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  return (
+    <div
+      className={styles.chipField}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {chips.map((c) => (
+        <span
+          key={c.id}
+          className={c.error ? `${styles.chip} ${styles.chipError}` : styles.chip}
+        >
+          <Text font="secondary-body" color={c.error ? "text-02" : "text-04"}>
+            {c.label}
+          </Text>
+          <button
+            type="button"
+            className={styles.chipRemove}
+            aria-label={`Remove ${c.label}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove(c.id);
+            }}
+          >
+            <SvgX size={12} />
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        className={styles.chipInput}
+        value={value}
+        placeholder={chips.length === 0 ? "Add an email and press Enter" : ""}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+      />
+    </div>
   );
 }

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -1,9 +1,54 @@
 /* Layout only — typography, inputs, menus, and buttons come from OPAL. */
 
-.stat {
+.pageIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--text-04);
+}
+.headSpacer {
+  flex: 1;
+}
+
+/* Stats bar — white OPAL Card (set in JSX); cells split evenly inside. */
+.statsWrap {
+  margin-bottom: 16px;
+}
+.stats {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  padding: 4px;
+}
+.statCell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  border-radius: var(--border-radius-08);
+  cursor: pointer;
+  text-align: left;
+}
+.statCell:hover {
+  background: var(--background-tint-02);
+}
+.statDivider {
+  width: 1px;
+  align-self: stretch;
+  margin: 8px 0;
+  background: var(--border-02);
+}
+
+.searchWrap {
   margin-bottom: 12px;
 }
-.searchWrap {
+.filters {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin-bottom: 16px;
 }
 .errorRow {
@@ -13,21 +58,23 @@
 .table {
   display: flex;
   flex-direction: column;
+  gap: 4px;
 }
 .headRow {
   display: grid;
   grid-template-columns: var(--cols);
   gap: 12px;
-  padding: 8px;
-  border-bottom: 1px solid var(--border-01);
+  padding: 4px 12px;
+  margin-bottom: 4px;
 }
+/* Each row is wrapped in an OPAL Card (white surface) in JSX; this is the
+   grid inside it. */
 .row {
   display: grid;
   grid-template-columns: var(--cols);
   gap: 12px;
   align-items: center;
-  padding: 10px 8px;
-  border-bottom: 1px solid var(--border-01);
+  padding: 8px 12px;
 }
 .who {
   display: flex;
@@ -42,18 +89,210 @@
 }
 .tags {
   display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+}
+.tagChip {
+  flex: 0 0 auto;
+}
+.tagsTooltip {
+  display: flex;
   flex-wrap: wrap;
   gap: 4px;
+  max-width: 224px;
+}
+.menuEmpty {
+  padding: 6px 10px;
+}
+.groupsCellButton {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  border-radius: var(--border-radius-08);
+  cursor: pointer;
+  text-align: left;
+}
+.groupsCellButton:hover {
+  background: var(--background-tint-02);
+}
+
+/* Edit-groups modal: joined group rows */
+.egJoined {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.egRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px;
+  border: none;
+  background: var(--background-tint-02);
+  border-radius: var(--border-radius-08);
+  cursor: pointer;
+  text-align: left;
+}
+.egRow:hover {
+  background: var(--background-tint-02);
+}
+.egRowIcon {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--text-04);
+}
+.egRowText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.egRowRemove {
+  display: inline-flex;
+  flex-shrink: 0;
+  color: var(--text-03);
 }
 .actions {
   display: flex;
   justify-content: flex-end;
 }
 .emptyRow {
-  padding: 16px 8px;
+  padding: 48px 8px;
+}
+.tableFoot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 8px 0;
+}
+.pager {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
-/* Ref-forwarding wrapper for OpenButton inside Popover.Trigger asChild. */
+/* Ref-forwarding wrapper for OpenButton/Button inside Popover.Trigger asChild. */
 .menuTrigger {
   display: inline-flex;
+}
+
+/* Invite modal */
+.scrim {
+  position: fixed;
+  inset: 0;
+  background: var(--mask-03);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: max(20px, min(80px, 5vh)) 16px;
+  z-index: 100;
+}
+.dialog {
+  background: var(--background-tint-01);
+  border-radius: var(--border-radius-12);
+  width: min(460px, 100%);
+  box-shadow: var(--shadow-modal);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.dialogHead {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 16px;
+  background: var(--background-tint-00);
+}
+.dialogHeadText {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+.dialogBody {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+}
+
+/* Invite chip field — chips + inline input inside one bordered box */
+.chipField {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 6px 8px;
+  border: 1px solid var(--border-02);
+  border-radius: var(--border-radius-08);
+  background: var(--background-tint-00);
+  cursor: text;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px 2px 8px;
+  border-radius: var(--border-radius-full);
+  background: var(--background-tint-02);
+  border: 1px solid var(--border-02);
+  max-width: 100%;
+}
+.chipError {
+  background: var(--status-error-01);
+  border-color: var(--status-error-02);
+}
+.chipRemove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border: none;
+  background: transparent;
+  border-radius: var(--border-radius-full);
+  color: var(--text-03);
+  cursor: pointer;
+}
+.chipRemove:hover {
+  background: var(--background-tint-02);
+  color: var(--text-05);
+}
+.chipInput {
+  flex: 1;
+  min-width: 120px;
+  border: none;
+  outline: none;
+  background: transparent;
+  padding: 4px 2px;
+  font: inherit;
+  color: var(--text-05);
+}
+.chipWarn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--status-text-warning-05);
+}
+.dialogFoot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 16px;
+  background: var(--background-tint-00);
 }

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -132,37 +132,6 @@
   max-height: 220px;
   overflow-y: auto;
 }
-.egRow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 8px;
-  border: none;
-  background: var(--background-tint-02);
-  border-radius: var(--border-radius-08);
-  cursor: pointer;
-  text-align: left;
-}
-.egRow:hover {
-  background: var(--background-tint-02);
-}
-.egRowIcon {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--text-04);
-}
-.egRowText {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  flex: 1;
-}
-.egRowRemove {
-  display: inline-flex;
-  flex-shrink: 0;
-  color: var(--text-03);
-}
 .actions {
   display: flex;
   justify-content: flex-end;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,6 +43,32 @@ export async function apiFetch<T>(
   return res.json() as Promise<T>;
 }
 
+/** Like {@link apiFetch} but for binary downloads (CSV exports, etc.):
+ * same base URL, credentials, and `{error}`-envelope handling, but resolves
+ * the body as a Blob instead of JSON. Keeps binary endpoints on the same
+ * network seam. */
+export async function apiFetchBlob(
+  path: string,
+  init?: RequestInit,
+): Promise<Blob> {
+  const isAbsolute = /^https?:\/\//i.test(path);
+  const url = isAbsolute ? path : `${BASE}${path}`;
+  const credentials: RequestCredentials =
+    init?.credentials ?? (isAbsolute ? "omit" : "include");
+  const res = await fetch(url, { ...init, credentials });
+  if (!res.ok) {
+    let message = `${res.status} ${res.statusText}`;
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // non-JSON error body — keep the generic message
+    }
+    throw new ApiError(res.status, message);
+  }
+  return res.blob();
+}
+
 /** SSE-style streaming POST. Parses ``data: {...json}\n\n`` frames and
  * dispatches them through ``onEvent``. Pre-stream HTTP errors come back as
  * ``ApiError`` (matching ``apiFetch``). The promise resolves when the server

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -134,7 +134,9 @@ export interface WikiPathEntry {
 }
 
 export function useWikiPaths() {
-  const { data, error, isLoading } = useSWR<{ entries: WikiPathEntry[] }>("/wiki");
+  const { data, error, isLoading } = useSWR<{ entries: WikiPathEntry[] }>(
+    "/wiki",
+  );
   return {
     entries: data?.entries ?? [],
     error: error as Error | undefined,

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -5,8 +5,10 @@
  *   POST   /api/groups                                — create (admin)
  *   GET    /api/groups/:id                            — group + members
  *   DELETE /api/groups/:id                            — delete (admin)
+ *   PATCH  /api/groups/:id                            — rename (admin)
  *   POST   /api/groups/:id/members                    — add (admin)
  *   DELETE /api/groups/:id/members/:user_id           — remove (admin)
+ *   GET    /api/groups/:id/shares                      — pages/folders shared with group (admin)
  *   GET    /api/wiki/acl?path=<path>                  — list grants (owner/admin)
  *   POST   /api/wiki/acl                              — create grant (owner/admin)
  *   DELETE /api/wiki/acl/:id                          — revoke (owner/admin)
@@ -41,6 +43,15 @@ export interface GroupMember {
   email: string;
   name: string | null;
   is_admin: boolean;
+}
+
+/** A page or folder shared with a group (one ACL row, group-centric). */
+export interface GroupShare {
+  id: string;
+  resource_kind: ResourceKind;
+  resource_path: string;
+  permission: Permission;
+  created_at: string;
 }
 
 export interface AclEntry {
@@ -105,6 +116,44 @@ export function createGroup(
     method: "POST",
     body: JSON.stringify({ name, description: description ?? null }),
   });
+}
+
+export function renameGroup(id: string, name: string): Promise<Group> {
+  return apiFetch<Group>(`/groups/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ name }),
+  });
+}
+
+/** All wiki paths (pages + folders), for the group sharing picker. Admin
+ * sees everything. `path` ends in ".md" for pages; folders are the parent
+ * directories. */
+export interface WikiPathEntry {
+  path: string;
+  updated_at: string;
+}
+
+export function useWikiPaths() {
+  const { data, error, isLoading } = useSWR<{ entries: WikiPathEntry[] }>("/wiki");
+  return {
+    entries: data?.entries ?? [],
+    error: error as Error | undefined,
+    isLoading,
+  };
+}
+
+/** Pages and folders shared with a group — SWR-keyed so the group page
+ * revalidates after a revoke. */
+export function useGroupShares(id: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<{ shares: GroupShare[] }>(
+    id ? `/groups/${id}/shares` : null,
+  );
+  return {
+    shares: data?.shares ?? [],
+    error: error as Error | undefined,
+    isLoading,
+    refresh: mutate,
+  };
 }
 
 export function deleteGroup(id: string): Promise<void> {

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -6,7 +6,7 @@
  */
 import useSWR from "swr";
 
-import { ApiError, apiFetch } from "@/lib/api";
+import { apiFetch, apiFetchBlob } from "@/lib/api";
 
 export interface UserLite {
   id: string;
@@ -76,14 +76,20 @@ export function useAdminUsers() {
   };
 }
 
-export async function setUserAdmin(userId: string, isAdmin: boolean): Promise<void> {
+export async function setUserAdmin(
+  userId: string,
+  isAdmin: boolean,
+): Promise<void> {
   await apiFetch(`/admin/users/${userId}`, {
     method: "PATCH",
     body: JSON.stringify({ is_admin: isAdmin }),
   });
 }
 
-export async function setUserActive(userId: string, isActive: boolean): Promise<void> {
+export async function setUserActive(
+  userId: string,
+  isActive: boolean,
+): Promise<void> {
   await apiFetch(`/admin/users/${userId}`, {
     method: "PATCH",
     body: JSON.stringify({ is_active: isActive }),
@@ -107,26 +113,9 @@ export async function cancelInvite(email: string): Promise<void> {
   });
 }
 
-/** Fetch the users CSV (text/csv — not JSON, so a raw fetch, not apiFetch). */
+/** Download the users CSV via the binary arm of the api seam (apiFetchBlob). */
 export async function downloadUsersCsv(): Promise<void> {
-  // A binary download can't go through apiFetch<T> (it parses JSON), so this
-  // is the one hand-rolled fetch — but it mirrors apiFetch's contract:
-  // credentials included, and the {error} envelope surfaced as an ApiError.
-  const base = process.env.NEXT_PUBLIC_API_BASE ?? "/api";
-  const res = await fetch(`${base}/admin/users/download`, {
-    credentials: "include",
-  });
-  if (!res.ok) {
-    let message = "Failed to download users CSV";
-    try {
-      const body = (await res.json()) as { error?: string };
-      if (body.error) message = body.error;
-    } catch {
-      /* non-JSON error body — keep the generic message */
-    }
-    throw new ApiError(res.status, message);
-  }
-  const blob = await res.blob();
+  const blob = await apiFetchBlob("/admin/users/download");
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -6,7 +6,7 @@
  */
 import useSWR from "swr";
 
-import { apiFetch } from "@/lib/api";
+import { ApiError, apiFetch } from "@/lib/api";
 
 export interface UserLite {
   id: string;
@@ -109,11 +109,23 @@ export async function cancelInvite(email: string): Promise<void> {
 
 /** Fetch the users CSV (text/csv — not JSON, so a raw fetch, not apiFetch). */
 export async function downloadUsersCsv(): Promise<void> {
+  // A binary download can't go through apiFetch<T> (it parses JSON), so this
+  // is the one hand-rolled fetch — but it mirrors apiFetch's contract:
+  // credentials included, and the {error} envelope surfaced as an ApiError.
   const base = process.env.NEXT_PUBLIC_API_BASE ?? "/api";
   const res = await fetch(`${base}/admin/users/download`, {
     credentials: "include",
   });
-  if (!res.ok) throw new Error("Failed to download users CSV");
+  if (!res.ok) {
+    let message = "Failed to download users CSV";
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body.error) message = body.error;
+    } catch {
+      /* non-JSON error body — keep the generic message */
+    }
+    throw new ApiError(res.status, message);
+  }
   const blob = await res.blob();
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -6,6 +6,8 @@
  */
 import useSWR from "swr";
 
+import { apiFetch } from "@/lib/api";
+
 export interface UserLite {
   id: string;
   email: string;
@@ -26,27 +28,118 @@ export function useUserSearch(query: string, enabled = true) {
   };
 }
 
+export type UserStatus = "active" | "inactive" | "invited";
+
 export interface AdminUser {
   id: string;
   email: string;
   name: string | null;
   is_admin: boolean;
+  is_active: boolean;
+  status: "active" | "inactive";
   created_at: string;
+  updated_at: string;
   groups: string[];
 }
 
-/** Admin-only full user list (`/admin/users`), including each user's
- * groups. Distinct from `useUserSearch`, which any signed-in user can hit. */
+export interface InvitedUserRow {
+  email: string;
+}
+
+export interface AdminUserCounts {
+  active: number;
+  inactive: number;
+  invited: number;
+}
+
+interface AdminUsersResponse {
+  users: AdminUser[];
+  invited: InvitedUserRow[];
+  counts: AdminUserCounts;
+}
+
+const EMPTY_COUNTS: AdminUserCounts = { active: 0, inactive: 0, invited: 0 };
+
+/** Admin-only full user list (`/admin/users`) — accepted users (with status +
+ * groups), pending invites, and counts. Distinct from `useUserSearch`, which
+ * any signed-in user can hit. */
 export function useAdminUsers() {
-  const { data, error, isLoading, mutate } = useSWR<{ users: AdminUser[] }>(
-    "/admin/users",
-  );
+  const { data, error, isLoading, mutate } =
+    useSWR<AdminUsersResponse>("/admin/users");
   return {
     users: data?.users ?? [],
+    invited: data?.invited ?? [],
+    counts: data?.counts ?? EMPTY_COUNTS,
     error: error as Error | undefined,
     isLoading,
     refresh: mutate,
   };
+}
+
+export async function setUserAdmin(userId: string, isAdmin: boolean): Promise<void> {
+  await apiFetch(`/admin/users/${userId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ is_admin: isAdmin }),
+  });
+}
+
+export async function setUserActive(userId: string, isActive: boolean): Promise<void> {
+  await apiFetch(`/admin/users/${userId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ is_active: isActive }),
+  });
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+  await apiFetch(`/admin/users/${userId}`, { method: "DELETE" });
+}
+
+export async function inviteUsers(emails: string[]): Promise<void> {
+  await apiFetch("/admin/users/invite", {
+    method: "PUT",
+    body: JSON.stringify({ emails }),
+  });
+}
+
+export async function cancelInvite(email: string): Promise<void> {
+  await apiFetch(`/admin/users/invited?email=${encodeURIComponent(email)}`, {
+    method: "DELETE",
+  });
+}
+
+/** Fetch the users CSV (text/csv — not JSON, so a raw fetch, not apiFetch). */
+export async function downloadUsersCsv(): Promise<void> {
+  const base = process.env.NEXT_PUBLIC_API_BASE ?? "/api";
+  const res = await fetch(`${base}/admin/users/download`, {
+    credentials: "include",
+  });
+  if (!res.ok) throw new Error("Failed to download users CSV");
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "users.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+/** Compact relative time ("3h ago", "2d ago") from a "YYYY-MM-DD HH:MM:SS"
+ * UTC timestamp, for the Last Updated column. */
+export function relativeTime(ts: string | null | undefined): string {
+  if (!ts) return "—";
+  const then = Date.parse(ts.includes("T") ? ts : ts.replace(" ", "T") + "Z");
+  if (Number.isNaN(then)) return "—";
+  const secs = Math.max(0, Math.floor((Date.now() - then) / 1000));
+  if (secs < 60) return "just now";
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(months / 12)}y ago`;
 }
 
 /** Best display label for a user — name if set, else email. */


### PR DESCRIPTION
## Description

Brings the admin **Users** and **Groups** pages to parity with the Figma mocks + Onyx's implementation.

**Users**
- Backend: `users.is_active`/`updated_at`, `invited_users` table, signup (basic + OIDC) consumes invites; `GET /admin/users` returns users + pending invites + counts; `PATCH` (self / last-admin guards); invite / cancel-invite / CSV-download endpoints.
- Frontend: chip-field invite modal, `FilterButton` group + status filters with counts, `+N` group chips, clickable chips + row action → edit-user-groups modal, status column, pagination, CSV.

**Groups**
- Route-based like Onyx: `/admin/groups/create` + `/admin/groups/[id]` replace the inline detail panel.
- List: inline rename (`ContentAction` editable → `PATCH /groups/{id}`), member count, View-group chevron, empty-state card.
- Create/edit: OPAL `Table` member management (multi-select Add mode + per-row remove); sharing — pick pages/folders via a multi-select Table with View/Edit to grant the group ACL access. Edit batches name/members/shares behind Save Changes; create defaults to Add mode.
- Backend: `PATCH /groups/{id}` (rename), `GET /groups/{id}/shares`, `acl.list_for_group`.

**Scope:** roles / SCIM / connectors / token-limits / "requests to join" are Onyx-only and omitted by design.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check