### PR TITLE
fix(comments): credit in-place word edits in remap survival guard

### DIFF
--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -15,12 +15,16 @@ preceding content, so text inserted at an edge lands outside the highlight.
 on a separate **word/token** diff, not the character diff. A character diff
 treats coincidental shared letters and spaces as "preserved," which makes a
 rewritten span look half-survived and yields confidently-wrong anchors; a token
-diff makes a genuine rewrite register as a clean replacement. A comment is
-orphaned (shows its ``quoted_text`` tombstone instead of a highlight) when:
+diff makes a genuine rewrite register as a clean replacement. Tokens that
+survive unchanged count in full; a token *edited in place* (a typo fix, a
+pluralization, "weekly"→"biweekly") gets **partial credit** by how similar the
+old and new run are, so an ordinary human edit inside the span keeps its anchor
+instead of orphaning. A comment is orphaned (shows its ``quoted_text`` tombstone
+instead of a highlight) when:
 
 - the span collapses to empty (``start >= end``): the whole region was removed;
-- too little of the remapped span is preserved *whole words* (below
-  ``_MIN_PRESERVED``): the alignment landed mostly on rewritten text; or
+- too little of the remapped span carries over (below ``_MIN_PRESERVED``): the
+  alignment landed mostly on rewritten/unrelated text; or
 - the survivor is only whitespace: nothing real is left to anchor to.
 
 Orphaning is the safe failure mode — better a tombstone than a confidently wrong
@@ -48,11 +52,12 @@ _TOKEN_RE = re.compile(r"\s+|\S+")
 _START = 1
 _END = -1
 
-# A remapped span must be at least this fraction *preserved* (covered by
-# unchanged whole tokens) to be trusted; below it the alignment has likely
-# landed on rewritten text the comment never referred to, so we orphan. The one
-# tunable knob — raise it to orphan more aggressively, lower it to keep more
-# migrated anchors.
+# A remapped span must carry over at least this fraction from the old span —
+# unchanged tokens at full weight, in-place-edited tokens at their char-level
+# similarity — to be trusted; below it the alignment has likely landed on
+# rewritten text the comment never referred to, so we orphan. The one tunable
+# knob — raise it to orphan more aggressively, lower it to keep more migrated
+# anchors.
 _MIN_PRESERVED = 0.5
 
 # (tag, i1, i2, j1, j2) as returned by SequenceMatcher.get_opcodes().
@@ -77,12 +82,20 @@ def _map_pos(opcodes: Sequence[_Opcode], pos: int, assoc: int) -> int:
 
 
 def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_end: int) -> float:
-    """Fraction of the new span ``[new_start, new_end)`` covered by whole tokens
-    that survived unchanged from ``old_body``.
+    """How much of the new span ``[new_start, new_end)`` carries over from
+    ``old_body``, scored at word/whitespace-token granularity.
 
-    Diffs at word/whitespace-token granularity (not characters) so coincidental
-    shared letters in a rewrite don't count as "preserved" — that's what keeps a
-    genuine rewrite from looking half-survived."""
+    Diffing at token granularity (not characters) is what stops a genuine
+    rewrite from looking half-survived: difflib won't align two unrelated runs
+    on coincidental shared letters/spaces when the unit is a whole token.
+
+    Tokens that survive **unchanged** (``equal`` opcodes) count in full. A token
+    run that was **edited in place** (``replace`` opcode) gets *partial* credit
+    equal to the character-level similarity between the old and new run — so a
+    one-letter typo fix, a pluralization, or "weekly"→"biweekly" still reads as
+    mostly-preserved (the comment follows the edit), while a run replaced by
+    unrelated text scores near zero and orphans. Inserted/deleted runs count for
+    nothing."""
     span = new_end - new_start
     if span <= 0:
         return 0.0
@@ -96,14 +109,22 @@ def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_e
     opcodes = SequenceMatcher(
         None, old_tokens, [t[0] for t in new_tokens], autojunk=False
     ).get_opcodes()
-    kept = 0
-    for tag, _i1, _i2, j1, j2 in opcodes:
-        if tag != "equal":
-            continue
+    kept = 0.0
+    for tag, i1, i2, j1, j2 in opcodes:
+        if tag not in ("equal", "replace"):
+            continue  # insert / delete preserve nothing
         lo = max(new_start, token_start(j1))
         hi = min(new_end, token_start(j2))
-        if hi > lo:
-            kept += hi - lo
+        overlap = hi - lo
+        if overlap <= 0:
+            continue
+        if tag == "equal":
+            kept += overlap
+        else:  # replace — credit the in-place edit by how similar the runs are
+            old_run = "".join(old_tokens[i1:i2])
+            new_run = "".join(t[0] for t in new_tokens[j1:j2])
+            similarity = SequenceMatcher(None, old_run, new_run, autojunk=False).ratio()
+            kept += similarity * overlap
     return kept / span
 
 

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -161,15 +161,16 @@ def test_in_place_word_edit_keeps_via_word_snap():
 
 
 # --------------------------------------------------------------------------- #
-# In-place human edits: a word changed inside the span used to orphan because   #
-# the survival guard scored the edited word as a wholly-new token. The guard    #
-# now gives partial credit by character similarity, so these keep their anchor. #
+# In-place human edits: a word changed inside the span keeps its anchor. The     #
+# survival guard gives a replaced token partial credit by the character          #
+# similarity of its old and new run, so high-overlap edits (typos, plurals,      #
+# prefixes) stay trusted.                                                        #
 # --------------------------------------------------------------------------- #
 
 
 def test_single_word_span_edit_keeps():
     # The whole span is one word that's edited in place — no surrounding word to
-    # lean on. Partial credit (high char overlap) keeps it; before it orphaned.
+    # lean on. Partial credit (high char overlap) keeps it.
     old = "on-call rotation is weekly."
     new = "on-call rotation is biweekly."
     s, e = old.index("weekly"), old.index("weekly") + len("weekly")
@@ -203,12 +204,14 @@ def test_number_change_in_span_keeps():
     assert _slice(new, result) == "50 connections"
 
 
-def test_short_span_replaced_by_unrelated_text_still_orphans():
-    # Partial credit must NOT rescue a genuine rewrite: a one-word span swapped
-    # for an unrelated word shares too little to trust.
-    old = "the cat sat on the mat"
-    new = "the dashboard sat on the mat"
-    s, e = old.index("cat"), old.index("cat") + len("cat")
+def test_partial_credit_does_not_rescue_unrelated_rewrite():
+    # The span maps onto replacement text (it does not collapse), so the survival
+    # guard actually runs. Partial credit must NOT rescue it: rewording "quick
+    # fix" to the unrelated "thorough overhaul" shares too few characters, so the
+    # preserved fraction stays well below the threshold and the comment orphans.
+    old = "a quick fix applied"
+    new = "a thorough overhaul applied"
+    s, e = old.index("quick fix"), old.index("quick fix") + len("quick fix")
     assert remap_range(old, new, s, e) is None
 
 

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -160,6 +160,58 @@ def test_in_place_word_edit_keeps_via_word_snap():
     assert _slice(new, result) == "rotation is biweekly"
 
 
+# --------------------------------------------------------------------------- #
+# In-place human edits: a word changed inside the span used to orphan because   #
+# the survival guard scored the edited word as a wholly-new token. The guard    #
+# now gives partial credit by character similarity, so these keep their anchor. #
+# --------------------------------------------------------------------------- #
+
+
+def test_single_word_span_edit_keeps():
+    # The whole span is one word that's edited in place — no surrounding word to
+    # lean on. Partial credit (high char overlap) keeps it; before it orphaned.
+    old = "on-call rotation is weekly."
+    new = "on-call rotation is biweekly."
+    s, e = old.index("weekly"), old.index("weekly") + len("weekly")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "biweekly"
+
+
+def test_typo_fix_inside_word_keeps():
+    old = "set the threshold to 80 percent"
+    new = "set the threshhold to 80 percent"  # doubled 'h'
+    s, e = old.index("threshold"), old.index("threshold") + len("threshold")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "threshhold"
+
+
+def test_pluralize_single_word_keeps():
+    old = "restart the pod now"
+    new = "restart the pods now"
+    s, e = old.index("pod"), old.index("pod") + len("pod")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "pods"
+
+
+def test_number_change_in_span_keeps():
+    # Surrounding words survive; the changed token shares no chars but is a small
+    # fraction of the span, so the span stays well above the threshold.
+    old = "limit is 20 connections per worker"
+    new = "limit is 50 connections per worker"
+    s, e = old.index("20 connections"), old.index("20 connections") + len("20 connections")
+    result = remap_range(old, new, s, e)
+    assert _slice(new, result) == "50 connections"
+
+
+def test_short_span_replaced_by_unrelated_text_still_orphans():
+    # Partial credit must NOT rescue a genuine rewrite: a one-word span swapped
+    # for an unrelated word shares too little to trust.
+    old = "the cat sat on the mat"
+    new = "the dashboard sat on the mat"
+    s, e = old.index("cat"), old.index("cat") + len("cat")
+    assert remap_range(old, new, s, e) is None
+
+
 def test_out_of_bounds_raises():
     with pytest.raises(ValueError):
         remap_range("short", "longer body", 0, 99)


### PR DESCRIPTION
## Problem

The diff-transform remap (`comment_anchor.py`) — the default that keeps a comment's anchor accurate as a page is edited — **over-orphaned ordinary human edits**. The word-level survival guard scored an edited word as a wholly-new token, so a short commented span whose one word changed fell under `_MIN_PRESERVED` and tombstoned, even though the anchor was still correct.

Reproduced against the prior code (all of these wrongly orphaned):

| edit | span | before | after |
|------|------|--------|-------|
| `weekly`→`biweekly` | `weekly` | ORPHAN | `biweekly` |
| `weekly`→`biweekly` | `is weekly` | ORPHAN | `is biweekly` |
| typo fix | `threshold` | ORPHAN | `threshhold` |
| pluralize | `pod` | ORPHAN | `pods` |

## Fix

Give `replace` opcodes **partial credit** in the survival guard, equal to the character-level similarity between the old and new token run. Unchanged tokens still count in full; insert/delete count for nothing.

- An in-place word edit scores near its char-overlap (high) → **keeps** its anchor.
- A token replaced by unrelated text scores near zero → **still orphans**.

The anti-coincidental property the guard exists for still holds: alignment is at token granularity, not scattered characters — a genuine rewrite doesn't get rescued (verified: full rewrites, disjoint replacements, and unrelated single-word swaps still orphan).

## Scope

This is the dedicated **remap-accuracy** PR — improving the diff-transform *default* (the floor under every edit path). In-editor markers (human path) and AI citation-remap are later phases. No frontend changes.

## Tests

Adds regression tests for the human-edit keeps and an unrelated-rewrite that must still orphan. Full `test_comment_anchor` / `test_comment_remap` / `test_comments_repo` suites pass; ruff + basedpyright clean.