### PR TITLE
fix(db): create public schema

### DIFF
--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -60,11 +60,10 @@ def run_migrations_online() -> None:
     connectable = create_engine(_db_url, poolclass=pool.NullPool, future=True)
 
     with connectable.connect() as connection:
-        # Ensure the public schema and pgmq extension exist before Alembic
-        # applies any migrations — both are prerequisites for the migration
-        # scripts and are not created automatically by PostgreSQL itself.
+        # Ensure the public schema exists before Alembic applies any
+        # migrations — it is a prerequisite for the migration scripts and
+        # is not created automatically by PostgreSQL itself.
         connection.execute(text("CREATE SCHEMA IF NOT EXISTS public"))
-        connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgmq"))
         connection.commit()
 
         context.configure(

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -57,9 +57,17 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations against a real engine."""
+    from sqlalchemy import text
+
     connectable = create_engine(_db_url, poolclass=pool.NullPool, future=True)
 
     with connectable.connect() as connection:
+        # Ensure prerequisites exist before migrations run. In Docker the
+        # custom image + POSTGRES_DB handle this; locally it's not guaranteed.
+        connection.execute(text("CREATE SCHEMA IF NOT EXISTS public"))
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgmq"))
+        connection.commit()
+
         context.configure(
             connection=connection,
             target_metadata=target_metadata,

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from logging.config import fileConfig
 
 from alembic import context
-from sqlalchemy import create_engine, pool
+from sqlalchemy import create_engine, pool, text
 
 from app.config import CONFIG
 from app.db import models  # noqa: F401 — registers all tables on Base.metadata  # pyright: ignore[reportUnusedImport]
@@ -57,13 +57,12 @@ def run_migrations_offline() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations against a real engine."""
-    from sqlalchemy import text
-
     connectable = create_engine(_db_url, poolclass=pool.NullPool, future=True)
 
     with connectable.connect() as connection:
-        # Ensure prerequisites exist before migrations run. In Docker the
-        # custom image + POSTGRES_DB handle this; locally it's not guaranteed.
+        # Ensure the public schema and pgmq extension exist before Alembic
+        # applies any migrations — both are prerequisites for the migration
+        # scripts and are not created automatically by PostgreSQL itself.
         connection.execute(text("CREATE SCHEMA IF NOT EXISTS public"))
         connection.execute(text("CREATE EXTENSION IF NOT EXISTS pgmq"))
         connection.commit()

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -151,9 +151,9 @@ def init_db() -> None:
 
     engine = get_engine()
     with engine.connect() as conn:
-        # Ensure the public schema and required extensions exist before
-        # migrations run. In Docker this is handled by POSTGRES_DB + the
-        # custom image; locally it's not guaranteed.
+        # Ensure the public schema and pgmq extension exist before Alembic
+        # applies any migrations — both are prerequisites for the migration
+        # scripts and are not created automatically by PostgreSQL itself.
         conn.execute(sa.text("CREATE SCHEMA IF NOT EXISTS public"))
         conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pgmq"))
         conn.commit()

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -151,6 +151,13 @@ def init_db() -> None:
 
     engine = get_engine()
     with engine.connect() as conn:
+        # Ensure the public schema and required extensions exist before
+        # migrations run. In Docker this is handled by POSTGRES_DB + the
+        # custom image; locally it's not guaranteed.
+        conn.execute(sa.text("CREATE SCHEMA IF NOT EXISTS public"))
+        conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pgmq"))
+        conn.commit()
+
         conn.execute(
             sa.text("SELECT pg_advisory_lock(:lock_key)"), {"lock_key": _MIGRATION_ADVISORY_LOCK}
         )

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -151,11 +151,10 @@ def init_db() -> None:
 
     engine = get_engine()
     with engine.connect() as conn:
-        # Ensure the public schema and pgmq extension exist before Alembic
-        # applies any migrations — both are prerequisites for the migration
-        # scripts and are not created automatically by PostgreSQL itself.
+        # Ensure the public schema exists before Alembic applies any
+        # migrations — it is a prerequisite for the migration scripts and
+        # is not created automatically by PostgreSQL itself.
         conn.execute(sa.text("CREATE SCHEMA IF NOT EXISTS public"))
-        conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pgmq"))
         conn.commit()
 
         conn.execute(


### PR DESCRIPTION
## Summary

- In Docker, `POSTGRES_DB` + the custom Postgres image handle `public` schema and extension setup automatically
- Running locally against a freshly created database, neither is guaranteed — `alembic upgrade head` fails with `psycopg.errors.InvalidSchemaName: no schema has been selected to create in`
- Both migration entry points now run `CREATE SCHEMA IF NOT EXISTS public` and `CREATE EXTENSION IF NOT EXISTS pgmq` before migrations execute:
  - `init_db()` in `app/db/session.py` (app and worker boot)
  - `run_migrations_online()` in `app/db/migrations/env.py` (alembic CLI)

Note: `pg_textsearch` still requires `shared_preload_libraries=pg_textsearch` in `postgresql.conf` — it's a preloaded library, not a `CREATE EXTENSION` extension.