### PR TITLE
fix(triggers): OPAL Button takes variant="action" not "primary"

### DIFF
--- a/frontend/src/app/app/triggers/page.tsx
+++ b/frontend/src/app/app/triggers/page.tsx
@@ -439,7 +439,7 @@ function SlackChannelsCard() {
       >
         <h2 style={{ margin: 0, fontSize: 16 }}>Slack channels</h2>
         {!adding && (
-          <Button variant="primary" size="sm" onClick={() => setAdding(true)}>
+          <Button variant="action" size="sm" onClick={() => setAdding(true)}>
             + Add channel
           </Button>
         )}
@@ -488,7 +488,7 @@ function SlackChannelsCard() {
           )}
           <div style={{ display: "flex", gap: 8 }}>
             <Button
-              variant="primary"
+              variant="action"
               size="sm"
               disabled={busy || !name.trim() || !url.trim()}
               onClick={() => void onAdd()}

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -444,7 +444,7 @@ export function TriggerModal({ open, initial, onClose, onSaved, lockScope }: Pro
               <div style={{ display: "flex", gap: 8 }}>
                 <Button
                   type="button"
-                  variant="primary"
+                  variant="action"
                   size="sm"
                   disabled={busy || !newChannelName.trim() || !newChannelUrl.trim()}
                   onClick={() => void onAddChannel()}


### PR DESCRIPTION
OPAL `Button` (`variant: default | action | danger`) has no `"primary"`. `next build` typecheck on `main` fails:

```
Type error: Type '"primary"' is not assignable to type 'InteractiveStatelessVariant | undefined'.
./src/app/app/triggers/page.tsx:442
```

## Root cause — semantic merge, not the opal bump

- opal `0.1.4` integrity matches the lockfile; it **never** had a `"primary"` variant. The bump (#149) is innocent.
- #167 (`feat/trigger-slack-destination`) added three accent CTAs with `variant="primary"`. On its branch, `triggers/page.tsx` still imported the **legacy** local `Button` (which accepts `"primary"`), so its `Frontend build` check passed green ([run](https://github.com/onyx-dot-app/agent-wiki/actions/runs/26858305470)).
- #140 had already swapped that import to **OPAL** on `main`. The squash-merge combined #140's OPAL import with #167's `primary` buttons — a combination **no PR CI ever built**.
- `frontend.yml` runs `on: pull_request` only, never on push to `main`, so merged `main` was never build-checked.

## Fix

Map all three accent CTAs to `variant="action"` per the buttons seam in `CLAUDE.md`:

- `src/app/app/triggers/page.tsx` (Add Slack channel + Add buttons)
- `src/components/triggers/TriggerModal.tsx` (Add channel)

`npm run build` now passes locally (`/app/triggers` compiles).

## Follow-up (not in this PR)

`frontend.yml` has no `push: branches: [main]` trigger — post-merge breakage is invisible. Worth adding so merge-skew like this is caught.
