### PR TITLE
ci(tests): only run backend tests when backend/ changes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,11 @@ concurrency:
 
 on:
   pull_request:
+    # Only run when backend code changes — there's nothing here for a
+    # frontend-only or workflow-only PR to exercise. Mirrors frontend.yml's
+    # `paths` guard. (backend/** covers deps too: pyproject.toml + uv.lock.)
+    paths:
+      - "backend/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The **Backend tests** workflow (`tests.yml`) ran on *every* PR — including frontend-only and workflow-only changes that exercise none of the backend. This adds a `paths` guard so it only runs when backend code changes.

## Change

```yaml
on:
  pull_request:
    paths:
      - "backend/**"
  workflow_dispatch:
```

- `backend/**` covers code **and** deps (`pyproject.toml`, `uv.lock` live under `backend/`).
- Mirrors the existing `frontend.yml` `paths: frontend/**` guard for symmetry.
- The check is already **non-blocking** (not in branch-protection's required list — see the comment at the top of the workflow), so skipping it on unrelated PRs does not gate merges and won't leave a stuck "pending" required check.

`workflow_dispatch` still allows manual runs against any branch.
