### PR TITLE
fix(ingest): attribute connector-pushed commits to "Onyx Ingest"

### DIFF
--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -72,7 +72,6 @@ _COMMIT_MESSAGE_MAX = 80
 _INGEST_AUTHOR = "Onyx Ingest <onyx-ingest@local>"
 
 
-
 @documents_queue.task()
 def update_document_from_payload(doc_id: str, source: str, payload: dict[str, Any]) -> None:
     log.info("update_document_from_payload doc_id=%s source=%s", doc_id, source)

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -66,6 +66,11 @@ _DEBOUNCE_SECONDS = int(os.environ.get("MCP_NL_DEBOUNCE_SECONDS", "30"))
 # instruction may be long, but we only want a quick handle.
 _COMMIT_MESSAGE_MAX = 80
 
+# Git author for connector-pushed ingestion commits — these have no human
+# user, so without this they'd fall back to the generic "AI Wiki Helper".
+# The originating connector + URL still ride in the commit message.
+_INGEST_AUTHOR = "Onyx Ingest <onyx-ingest@local>"
+
 
 
 @documents_queue.task()
@@ -250,6 +255,18 @@ _ = CONFIG
 
 @documents_queue.task()
 def process_pushed_document(push: dict[str, Any]) -> None:
+    """Reconcile a connector-pushed document into the wiki (task entry point).
+
+    Ingestion has no human principal — it's authenticated by the shared ingest
+    key (see ``app/api/documents.py``), so there's no user to credit. Bind the
+    ``Onyx Ingest`` author for the run so its commits surface under that name in
+    history instead of the generic fallback, then delegate to the reconciler.
+    """
+    with wiki_utils.system_author(_INGEST_AUTHOR):
+        _reconcile_pushed_document(push)
+
+
+def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     """Reconcile a document pushed from an external system into the wiki.
 
     ``push`` is the validated payload from POST /api/wiki/ingest. Shape:

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -10,6 +10,9 @@ from __future__ import annotations
 
 import difflib
 import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import timedelta
 from pathlib import Path
 from typing import Any
@@ -96,6 +99,29 @@ def assert_base_sha(path: str, base_sha: str | None) -> dict[str, str] | None:
 
 _FALLBACK_AUTHOR = "AI Wiki Helper <ai-wiki-helper@local>"
 
+# Explicit git author for system-initiated commits that legitimately have no
+# user in context (document ingestion from a connector, etc.). Bound by the
+# ``system_author`` context manager; consulted by ``author_string`` before it
+# degrades to ``_FALLBACK_AUTHOR``.
+_system_author_var: ContextVar[str | None] = ContextVar("system_author", default=None)
+
+
+@contextmanager
+def system_author(identity: str) -> Generator[None, None, None]:
+    """Attribute userless commits inside this block to ``identity`` instead of
+    the generic ``_FALLBACK_AUTHOR``.
+
+    ``identity`` is a full git author string (``"Name <email>"``). Used by
+    background paths that have no human principal but a known non-human actor
+    — e.g. ``"Onyx Ingest <onyx-ingest@local>"`` for connector pushes. A no-op
+    when a user *is* bound: ``author_string`` credits the user in that case.
+    """
+    token = _system_author_var.set(identity)
+    try:
+        yield
+    finally:
+        _system_author_var.reset(token)
+
 
 def author_string() -> str | None:
     """Git author for a wiki commit driven by an agent tool call.
@@ -104,14 +130,15 @@ def author_string() -> str | None:
     the current user and an agent identity are bound — so commits made
     via MCP credit the human and name the agent acting on their behalf
     (e.g. ``"Yuhong Sun via Claude Code <yuhong@onyx.app>"``). With only
-    a user bound, drops the ``via`` clause; with neither, falls back to
-    the legacy bot author so seed scripts and orphaned background paths
-    still produce a valid commit. Direct UI/API edits set their own
-    per-user author at the API seam (see ``app/api/wiki.py``).
+    a user bound, drops the ``via`` clause. With no user, uses the
+    ``system_author`` identity if one is bound (e.g. ingestion), else
+    falls back to the legacy bot author so seed scripts and orphaned
+    background paths still produce a valid commit. Direct UI/API edits
+    set their own per-user author at the API seam (see ``app/api/wiki.py``).
     """
     user = _current_user_or_none()
     if user is None:
-        return _FALLBACK_AUTHOR
+        return _system_author_var.get() or _FALLBACK_AUTHOR
     display = user.name or user.email
     agent_name = agent_activity.agent_name_var.get()
     if agent_name:

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -176,6 +176,29 @@ def test_new_body_commits(mock_search, mock_reconcile, mock_read, mock_commit, m
     mock_notify.assert_called_once()
 
 
+@patch("app.tasks.wiki_update.wiki_git.head_sha_for_path", return_value="headsha")
+@patch("app.wiki.utils.wiki_notify.after_doc_write")
+@patch("app.tasks.wiki_update.wiki_git.commit_file", return_value="sha123")
+@patch("app.tasks.wiki_update.wiki_git.read_file", return_value="old body")
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_commit_attributed_to_onyx_ingest(
+    mock_search, mock_reconcile, mock_read, mock_commit, mock_notify, mock_head, monkeypatch
+):
+    # No human user is bound on the ingest path, so the commit author would
+    # otherwise fall back to "AI Wiki Helper". process_pushed_document binds the
+    # Onyx Ingest identity for the run instead.
+    monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
+    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_reconcile.return_value = (["new body"], 1)
+    _run(_make_push())
+    assert mock_commit.call_args.kwargs["author"] == "Onyx Ingest <onyx-ingest@local>"
+    # And the binding is unwound after the run — no leak into later tasks.
+    from app.wiki.utils import author_string
+
+    assert author_string() == "AI Wiki Helper <ai-wiki-helper@local>"
+
+
 @patch("app.tasks.wiki_update.wiki_git.commit_file")
 @patch("app.tasks.wiki_update.wiki_git.read_file", return_value="body")
 @patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -23,6 +23,7 @@ from app.ingest import search as ingest_search
 from app.ingest.source_tiers import is_filtered
 from app.llm.agents.common import IRRELEVANT_SENTINEL
 from app.llm.settings import _EMPTY as _EMPTY_LLM_SETTINGS, LLMSettings
+from app.wiki.utils import author_string
 
 
 @pytest.fixture(autouse=True)
@@ -194,8 +195,6 @@ def test_commit_attributed_to_onyx_ingest(
     _run(_make_push())
     assert mock_commit.call_args.kwargs["author"] == "Onyx Ingest <onyx-ingest@local>"
     # And the binding is unwound after the run — no leak into later tasks.
-    from app.wiki.utils import author_string
-
     assert author_string() == "AI Wiki Helper <ai-wiki-helper@local>"
 
 


### PR DESCRIPTION
## Problem

In a page's History, connector-ingested edits show up as the generic **"AI Wiki Helper"** (the same catch-all used by seed scripts and orphaned background paths), even though they're really the Onyx ingest pipeline updating a page from an external source.

## Why it happened

`POST /api/documents/ingest` authenticates with the **shared ingest API key** (`_require_ingest_key`), not a user session or per-user token — so there is genuinely **no human principal** in context. The ingest task `process_pushed_document` then commits via `commit_and_fan_out`, whose `author_string()` resolves the author from the current-user ContextVar and, finding none bound, degrades to:

```python
_FALLBACK_AUTHOR = "AI Wiki Helper <ai-wiki-helper@local>"
```

This is the structural difference from the MCP path (`agent_update_document_nl`), where the MCP token is tied to a specific user, so it can `set_current_user(...)` and credit "Bo via Claude Code". Ingest had no identity bound at all — even though it *knows* the source connector (`source_label`) and already stamps it into the commit message.

## Fix

Give the ingest path its own explicit, non-human identity instead of recovering a user that doesn't exist:

- **`app/wiki/utils.py`** — add a `system_author(identity)` context manager backed by a ContextVar. `author_string()` consults it when no user is bound, before falling back to `_FALLBACK_AUTHOR`. No-op when a user *is* bound (the user is still credited).
- **`app/tasks/wiki_update.py`** — `process_pushed_document` is now a thin task entry that binds `"Onyx Ingest <onyx-ingest@local>"` for the run and delegates to `_reconcile_pushed_document` (the existing body, unchanged).

The connector + URL still ride in the commit message (the history **↗** source link), so per-source detail isn't lost — only the author identity changes. `history()` reads `%an`, so the panel shows **"Onyx Ingest"**, and `parseCommitAuthor` leaves it as a plain person (no spurious "via" agent mapping).

## Testing

- New `test_commit_attributed_to_onyx_ingest` — asserts the ingest commit's `author` is `"Onyx Ingest <onyx-ingest@local>"`, and that the binding unwinds after the run (no ContextVar leak into later in-thread tasks).
- `tests/test_ingest_pipeline.py`, `test_commit_and_fan_out_ai_merge.py`, `test_commit_merge_retry.py`, `tests/integration/test_doc_ingest_flow.py` all pass.
- ruff + basedpyright clean.