### PR TITLE
fix(history): show diffs for commits from before a rename

### DIFF
--- a/backend/app/wiki/diff.py
+++ b/backend/app/wiki/diff.py
@@ -231,18 +231,26 @@ def _promote_word_diff(hunk: DiffHunk) -> DiffHunk:
 def parse_commit_diff(sha: str, rel: str) -> FileDiffResponse:
     """Build a structured diff for ``sha`` vs its parent, scoped to ``rel``.
 
+    ``rel`` is the file's *current* path. The history panel lists commits via
+    ``git log --follow``, so it includes commits from before a rename, when the
+    file lived at a different name. Diffing those against the current ``rel``
+    would touch nothing ("sha does not touch path"); resolve the name the file
+    had at ``sha`` (via ``path_at_ref``) and diff that instead — same fix the
+    read-at-ref path uses.
+
     First-commit (no parent) → ``parent_sha`` is None, ``is_creation`` is
-    True, every line is an ``add``. ``rel`` not touched by ``sha`` → returns
-    an empty-hunks response; callers (the API route) should translate that
-    into 404 for end users. Unknown SHA (passes hex regex but doesn't
+    True, every line is an ``add``. ``rel`` genuinely not touched by ``sha`` →
+    returns an empty-hunks response; callers (the API route) should translate
+    that into 404 for end users. Unknown SHA (passes hex regex but doesn't
     resolve in the repo) → same empty-hunks response, same 404 at the route.
     """
+    effective_rel = wiki_git.path_at_ref(rel, sha) or rel
     try:
         parent = wiki_git.parent_sha(sha)
         # Pass unified=99_999 so the full doc body lands in `context`
         # lines around the hunks; the FE renders the whole file with
         # +/- highlights on changed lines instead of just hunk windows.
-        raw = wiki_git.diff_for_commit(sha, rel, unified=99_999)
+        raw = wiki_git.diff_for_commit(sha, effective_rel, unified=99_999)
     except UnknownSha:
         return FileDiffResponse(
             path=rel,

--- a/backend/app/wiki/diff.py
+++ b/backend/app/wiki/diff.py
@@ -244,7 +244,7 @@ def parse_commit_diff(sha: str, rel: str) -> FileDiffResponse:
     that into 404 for end users. Unknown SHA (passes hex regex but doesn't
     resolve in the repo) → same empty-hunks response, same 404 at the route.
     """
-    effective_rel = wiki_git.path_at_ref(rel, sha) or rel
+    effective_rel: str = wiki_git.path_at_ref(rel, sha) or rel
     try:
         parent = wiki_git.parent_sha(sha)
         # Pass unified=99_999 so the full doc body lands in `context`

--- a/backend/tests/test_wiki_diff.py
+++ b/backend/tests/test_wiki_diff.py
@@ -293,3 +293,26 @@ def test_parse_commit_diff_creation(doc_with_two_commits: tuple[str, str, str]) 
     assert out.is_creation is True
     assert out.hunks  # at least one
     assert all(line.kind == "add" for hunk in out.hunks for line in hunk.lines)
+
+
+def test_parse_commit_diff_pre_rename_commit_resolves_old_path(tmp_repo: None) -> None:
+    # Regression: the history panel lists commits via `git log --follow`, so it
+    # includes commits from before a rename. Clicking such a commit diffs it
+    # against the file's *current* name — which the pre-rename commit never
+    # touched, yielding empty hunks and a "sha does not touch path" 404.
+    # parse_commit_diff must resolve the historical name at that sha.
+    old = "notes/old name.md"
+    new = "projects/new name.md"
+    wiki_git.commit_file(old, "alpha old gamma\n", "create", author=None)
+    edit = wiki_git.commit_file(old, "alpha new gamma\n", "edit", author=None)
+    wiki_git.move_path(old, new, "rename", author=None)
+
+    # Query the pre-rename edit by the file's *current* (post-rename) path.
+    out = parse_commit_diff(edit, new)
+    assert out.sha == edit
+    assert out.path == new
+    assert out.hunks, "pre-rename commit should still diff, not 404"
+    word_lines = [line for hunk in out.hunks for line in hunk.lines if line.kind == "word"]
+    assert word_lines and word_lines[0].word_diff is not None
+    assert word_lines[0].word_diff.removed == "old"
+    assert word_lines[0].word_diff.added == "new"

--- a/backend/tests/test_wiki_diff.py
+++ b/backend/tests/test_wiki_diff.py
@@ -296,11 +296,10 @@ def test_parse_commit_diff_creation(doc_with_two_commits: tuple[str, str, str]) 
 
 
 def test_parse_commit_diff_pre_rename_commit_resolves_old_path(tmp_repo: None) -> None:
-    # Regression: the history panel lists commits via `git log --follow`, so it
-    # includes commits from before a rename. Clicking such a commit diffs it
-    # against the file's *current* name — which the pre-rename commit never
-    # touched, yielding empty hunks and a "sha does not touch path" 404.
-    # parse_commit_diff must resolve the historical name at that sha.
+    # The history panel walks commits via `git log --follow`, which includes
+    # pre-rename commits when the file lived at a different path. Querying a
+    # pre-rename commit by the file's current name must still produce a diff;
+    # parse_commit_diff resolves the historical path at that sha via path_at_ref.
     old = "notes/old name.md"
     new = "projects/new name.md"
     wiki_git.commit_file(old, "alpha old gamma\n", "create", author=None)


### PR DESCRIPTION
## Problem

After renaming a page or moving it between folders, clicking an **older** commit in the History panel shows a red **"sha does not touch path"** error instead of the diff.

## Why

The history panel lists a file's commits via `git log --follow` (`history()` in `app/wiki/git.py`), so the list includes commits from *before* the rename — when the file lived at a different path. Clicking one calls `GET /wiki/file/diff`, which runs `parse_commit_diff(sha, rel)` with `rel` = the file's **current** path. For a pre-rename commit, `git show <sha> -- <current_path>` touches nothing → empty hunks → the route returns 404 `"sha does not touch path"` (`app/api/wiki.py:425`).

The read-at-ref **content** endpoint already handles this (`app/api/wiki.py:112` uses `path_at_ref(rel, ref) or rel`); the **diff** endpoint just never got the same treatment.

## Fix

In `parse_commit_diff` (`app/wiki/diff.py`), resolve the name the file had at `sha` via the existing `--follow`-based `path_at_ref()` helper and diff *that* path, falling back to the current `rel` when the sha isn't in the follow-history (so genuine "untouched" cases still 404 as before). The response still reports the current path the user is viewing.

One-line change in behavior; no API/shape change.

## Testing

- New `test_parse_commit_diff_pre_rename_commit_resolves_old_path`: creates a file, edits it, renames it across folders, then asserts that diffing the **pre-rename edit by the file's current name** returns hunks (was a 404) with the expected word-diff.
- `tests/test_wiki_diff.py`, `test_wiki_git.py`, `test_wiki_diff_api.py` all pass (33).
- ruff + basedpyright clean.