### PR TITLE
fix(move): re-point all live path-keyed caches on a page rename/move

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -265,14 +265,9 @@ def move_document_or_folder(
         log.warning("move_path git error %s -> %s: %s", old_rel, new_rel, exc.stderr)
         raise HTTPException(status_code=500, detail="git move failed") from exc
 
+    # after_path_move re-points every live path-keyed cache (ACL, comments,
+    # activity, drafts, working-dirs) and reconverges the trigger cache.
     wiki_notify.after_path_move(moves, sha, author)
-
-    # Trigger YAML files may have moved with their containing folder. The
-    # Postgres cache stores their absolute file_path; reconverge from disk.
-    try:
-        triggers_repo.rebuild_from_filesystem()
-    except Exception:
-        log.exception("trigger cache rebuild after move %s -> %s failed", old_rel, new_rel)
 
     log.info(
         "move %s -> %s by %s sha=%s files=%d", old_rel, new_rel, author or "?", sha[:8], len(moves)

--- a/backend/app/db/page_dirs.py
+++ b/backend/app/db/page_dirs.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.db.models import PageWorkingDir
@@ -55,6 +55,18 @@ def set_for_page(
     )
     with session() as s:
         s.execute(stmt)
+
+
+def rename_page(*, old_wiki_path: str, new_wiki_path: str) -> None:
+    """Re-point every (user, machine) working-dir binding from a page's old
+    path to its new one when it's renamed/moved. The move flow guarantees
+    ``new_wiki_path`` is free, so the PK rewrite can't collide."""
+    with session() as s:
+        s.execute(
+            update(PageWorkingDir)
+            .where(PageWorkingDir.wiki_path == old_wiki_path)
+            .values(wiki_path=new_wiki_path)
+        )
 
 
 def clear(*, user_id: str, machine_id: str, wiki_path: str) -> None:

--- a/backend/app/db/page_dirs.py
+++ b/backend/app/db/page_dirs.py
@@ -69,6 +69,14 @@ def rename_page(*, old_wiki_path: str, new_wiki_path: str) -> None:
         )
 
 
+def delete_all_for_page(wiki_path: str) -> None:
+    """Drop every (user, machine) binding for a page that no longer exists
+    (deleted, or renamed out of .md-space). These rows have no TTL, so leaving
+    them would mis-bind a future page created at the same path."""
+    with session() as s:
+        s.execute(delete(PageWorkingDir).where(PageWorkingDir.wiki_path == wiki_path))
+
+
 def clear(*, user_id: str, machine_id: str, wiki_path: str) -> None:
     with session() as s:
         s.execute(

--- a/backend/app/wiki/drafts.py
+++ b/backend/app/wiki/drafts.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from app.db.models import DocumentDraft, DocumentTemplate
 from app.db.session import session
@@ -73,6 +73,16 @@ def delete(path: str) -> bool:
             return False
         s.delete(row)
         return True
+
+
+def rename(old_path: str, new_path: str) -> None:
+    """Re-key a draft row when its page is renamed/moved. No-op if no draft
+    exists at ``old_path``. ``path`` is the PK; the move flow guarantees
+    ``new_path`` is free, so a straight key rewrite can't collide."""
+    with session() as s:
+        s.execute(
+            update(DocumentDraft).where(DocumentDraft.path == old_path).values(path=new_path)
+        )
 
 
 def clear_if_diverged(path: str, current_body: str) -> bool:

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -186,6 +186,7 @@ def after_path_move(
             comments.orphan_all_for_doc(old_p)
             agent_activity.delete_for_doc(old_p)
             drafts.delete(old_p)
+            page_dirs.delete_all_for_page(old_p)
     # Trigger YAMLs moved with their folder; their absolute file_path cache is
     # stale until reconverged from disk. Best-effort — a cache rebuild failure
     # must not abort the move's other side effects.

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -31,11 +31,12 @@ from __future__ import annotations
 
 import logging
 
-from app.db import fts
+from app.db import fts, page_dirs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
-from app.wiki import acl, comments
+from app.triggers import repo as triggers_repo
+from app.wiki import acl, agent_activity, comments, drafts
 from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind
 
@@ -138,9 +139,17 @@ def after_path_move(
     Non-``.md`` moves (e.g. ``.gitkeep``) are skipped — they don't carry
     doc content and triggers can't evaluate them.
 
-    ACL rows and owner rows keyed by path are rewritten in one pass via
-    ``acl.on_path_moved`` so a rename doesn't strand permissions on a
-    no-longer-existing path.
+    Every Postgres row that is a *live pointer* to the page is re-pointed to
+    the new path so nothing strands on a path that no longer exists:
+    ACL + owner rows in one pass via ``acl.on_path_moved``; comments; the
+    agent-activity rail; template-draft state; and per-(user, machine)
+    working-dir bindings. Point-in-time records (launch history, ingest eval
+    samples, the audit log) are deliberately left alone.
+
+    The trigger cache is reconverged from disk once at the end — trigger
+    YAMLs ride along with their folder in the ``git mv``, but their stored
+    ``file_path`` is absolute. Doing it here (rather than in the API route)
+    means the agent-tool move path gets it too.
 
     MCP-side: each affected path gets the corresponding update or
     delete, and a single ``list_changed`` is fired at the end (the
@@ -166,10 +175,23 @@ def after_path_move(
             # commit may also change content; path_at_ref follows the rename).
             comments.reassign_doc_path(old_p, new_p)
             _remap_comments_safe(new_p)
+            # Other live pointers follow the page to its new path.
+            agent_activity.rename_doc(old_p, new_p)
+            drafts.rename(old_p, new_p)
+            page_dirs.rename_page(old_wiki_path=old_p, new_wiki_path=new_p)
         elif old_is_md:
             # The page left .md-space (renamed to a non-doc path) — there's no
-            # new doc to carry the comments onto, so orphan them rather than
-            # strand them on a path that no longer exists.
+            # new doc to carry these onto, so drop them rather than strand them
+            # on a path that no longer exists.
             comments.orphan_all_for_doc(old_p)
+            agent_activity.delete_for_doc(old_p)
+            drafts.delete(old_p)
+    # Trigger YAMLs moved with their folder; their absolute file_path cache is
+    # stale until reconverged from disk. Best-effort — a cache rebuild failure
+    # must not abort the move's other side effects.
+    try:
+        triggers_repo.rebuild_from_filesystem()
+    except Exception:
+        log.exception("trigger cache rebuild after path move failed")
     if list_changed:
         mcp_pubsub.publish_list_changed()

--- a/backend/tests/test_move_notify.py
+++ b/backend/tests/test_move_notify.py
@@ -1,0 +1,99 @@
+"""Live path-keyed caches follow a page rename/move via ``after_path_move``.
+
+The hook re-points every Postgres row that is a *live pointer* to the page
+(ACL/owner and comments are covered elsewhere; here: the agent-activity rail,
+template-draft state, and per-(user, machine) working-dir bindings) and
+reconverges the trigger cache from disk. Point-in-time records are left alone.
+"""
+from __future__ import annotations
+
+from app.db import page_dirs
+from app.db.models import DocumentTemplate
+from app.db.session import session
+from app.wiki import agent_activity, drafts, notify
+from app.wiki import git as wiki_git
+
+from tests._seed import seed_user
+
+
+def _seed_template(tid: str = "tmpl_1") -> str:
+    with session() as s:
+        s.add(DocumentTemplate(id=tid, name=f"name-{tid}", body="# T\n"))
+    return tid
+
+
+def test_after_path_move_repoints_agent_activity(tmp_repo):
+    user = seed_user()
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+    agent_activity.upsert_activity(
+        user_id=user, agent_name=None, doc_path="a.md", activity="wrote", description=None
+    )
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert agent_activity.list_for_doc("a.md") == []
+    assert len(agent_activity.list_for_doc("b.md")) == 1
+
+
+def test_after_path_move_repoints_drafts(tmp_repo):
+    user = seed_user()
+    tid = _seed_template()
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+    drafts.create(
+        path="a.md", template_id=tid, template_body_snapshot="# T\n", created_by_user_id=user
+    )
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert drafts.get("a.md") is None
+    moved = drafts.get("b.md")
+    assert moved is not None and moved["template_id"] == tid
+
+
+def test_after_path_move_repoints_page_working_dirs(tmp_repo):
+    user = seed_user()
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+    page_dirs.set_for_page(
+        user_id=user, machine_id="m1", wiki_path="a.md", working_dir="/tmp/checkout"
+    )
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert page_dirs.get_for_page(user_id=user, machine_id="m1", wiki_path="a.md") is None
+    assert (
+        page_dirs.get_for_page(user_id=user, machine_id="m1", wiki_path="b.md") == "/tmp/checkout"
+    )
+
+
+def test_after_path_move_out_of_md_space_clears_activity_and_drafts(tmp_repo):
+    # A page renamed out of .md-space has no new doc to carry these onto, so
+    # they're dropped rather than stranded. (The move API blocks this, but the
+    # hook handles it defensively, mirroring how comments are orphaned.)
+    user = seed_user()
+    tid = _seed_template()
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+    agent_activity.upsert_activity(
+        user_id=user, agent_name=None, doc_path="a.md", activity="wrote", description=None
+    )
+    drafts.create(
+        path="a.md", template_id=tid, template_body_snapshot="# T\n", created_by_user_id=user
+    )
+
+    notify.after_path_move([("a.md", "notes.txt")], sha, actor=None)
+
+    assert agent_activity.list_for_doc("a.md") == []
+    assert drafts.get("a.md") is None
+
+
+def test_after_path_move_reconverges_trigger_cache(tmp_repo, monkeypatch):
+    # Reconvergence lives in the hook (not the API route) so the agent-tool
+    # move path — which also calls after_path_move — picks it up too.
+    calls: list[int] = []
+    monkeypatch.setattr(
+        notify.triggers_repo, "rebuild_from_filesystem", lambda: calls.append(1)
+    )
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert calls == [1]

--- a/backend/tests/test_move_notify.py
+++ b/backend/tests/test_move_notify.py
@@ -78,11 +78,16 @@ def test_after_path_move_out_of_md_space_clears_activity_and_drafts(tmp_repo):
     drafts.create(
         path="a.md", template_id=tid, template_body_snapshot="# T\n", created_by_user_id=user
     )
+    page_dirs.set_for_page(
+        user_id=user, machine_id="m1", wiki_path="a.md", working_dir="/tmp/checkout"
+    )
 
     notify.after_path_move([("a.md", "notes.txt")], sha, actor=None)
 
     assert agent_activity.list_for_doc("a.md") == []
     assert drafts.get("a.md") is None
+    # No-TTL working-dir binding must be dropped too, or a future a.md inherits it.
+    assert page_dirs.get_for_page(user_id=user, machine_id="m1", wiki_path="a.md") is None
 
 
 def test_after_path_move_reconverges_trigger_cache(tmp_repo, monkeypatch):


### PR DESCRIPTION
## Background

This came out of auditing "when a wiki page/folder is renamed or moved, which Postgres rows should follow it?" The answer: **every *live pointer* to the page must follow; *point-in-time* records must not** (rewriting those falsifies provenance).

`after_path_move` already re-pointed ACL/owner rows, comments, and FTS — but several other live pointers were stranded on the old path.

## What this fixes

Re-point the remaining live path-keyed caches in `after_path_move` (the shared hook both the HTTP route and the agent tool call):

- **`agent_activity.doc_path`** — the activity rail. `rename_doc()` existed but was never wired into the move lifecycle, so a renamed page's in-flight agents showed on the old path until their TTL expired.
- **`document_drafts.path`** — template-draft state (new `drafts.rename()` helper).
- **`page_working_dirs.wiki_path`** — per-(user, machine) launcher working-dir bindings (new `page_dirs.rename_page()` helper).

When a page leaves `.md`-space, activity + draft rows are dropped (mirroring how comments are orphaned).

Also **moved the trigger-cache reconvergence** (`rebuild_from_filesystem`) out of the HTTP move route into `after_path_move`, so the **agent-tool move path gets it too** — previously an agent-initiated folder move left `triggers.file_path` stale until the next process boot.

Point-in-time records (`agent_sessions`, `ingest_eval_samples`, `events`) are intentionally left untouched.

## Audit verdict (for reviewers)

| Row | Verdict | Before | After |
|---|---|---|---|
| `acl_entries.resource_path`, `wiki_owners.path` | follow | ✅ | ✅ |
| `comments.doc_path` | follow | ✅ | ✅ |
| `triggers.file_path` | follow | ⚠️ HTTP route only | ✅ both paths |
| `agent_activity.doc_path` | follow | ❌ | ✅ |
| `document_drafts.path` | follow | ❌ | ✅ |
| `page_working_dirs.wiki_path` | follow | ❌ | ✅ |
| `agent_sessions.*`, `ingest_eval_samples.wiki_path`, `events.target` | point-in-time | leave | leave |

## Known follow-up (separate PR)

`triggers.scope_path` is stored *inside* the moved trigger YAML and is **not** rewritten on a folder rename, so triggers scoped inside a renamed folder still dangle. That's a content-rewrite fix (edits committed YAML) and deserves its own focused PR — not included here.

## Testing

- New `tests/test_move_notify.py`: asserts `after_path_move` re-points agent_activity / drafts / page_working_dirs, drops them on a move out of `.md`-space, and reconverges the trigger cache.
- `test_comment_notify.py`, `test_wiki_agent_activity.py`, `test_dir_tools.py` pass (32 total).
- ruff + basedpyright clean.