### PR TITLE
fix(triggers): follow scope_path when a page/folder is moved

### DIFF
--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+import posixpath
 import uuid
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -450,6 +451,84 @@ def purge_invalid_triggers(*, actor: str | None = None) -> int:
                 trigger_id,
             )
     return deleted
+
+
+def _is_trigger_file(path: str) -> bool:
+    name = posixpath.basename(path)
+    return name.startswith(".trigger_") and name.endswith(".yaml")
+
+
+def repoint_scopes_for_moves(moves: list[tuple[str, str]], *, actor: str | None) -> None:
+    """Rewrite trigger scopes after a path move so they don't dangle.
+
+    A trigger's ``scope_path`` lives *inside* its committed YAML, and the
+    YAML's filename/location is derived from that scope (``compute_path``). A
+    plain ``git mv`` relocates files but never rewrites YAML content, so a
+    rename leaves trigger scopes pointing at paths that no longer exist. Fix
+    the YAML files here; the caller (``after_path_move``) reconverges the
+    Postgres cache via ``rebuild_from_filesystem`` immediately after, so this
+    only touches the on-disk source of truth.
+
+    Two cases, read off the per-file ``(old, new)`` pairs:
+      A. A trigger YAML rode along in a folder move (it's a tracked file under
+         the moved folder). It's already at ``new`` on disk but still names the
+         old scope — invert ``compute_path`` against its new location to get
+         the corrected scope and rewrite the content in place.
+      B. A ``.md`` doc moved but its sibling doc-scoped trigger YAML did *not*
+         (a single-file rename doesn't sweep sibling files). Relocate + rewrite
+         the YAML to match the doc's new path.
+    """
+    handled_ids: set[str] = set()
+
+    # Case A — trigger YAMLs that physically moved with a folder.
+    for old_p, new_p in moves:
+        if old_p == new_p or not _is_trigger_file(old_p):
+            continue
+        try:
+            data = storage.read_trigger(new_p)  # at new_p post-mv; old scope still inside
+        except Exception:
+            log.warning("repoint_scopes_for_moves: unreadable trigger %s", new_p, exc_info=True)
+            continue
+        old_scope = data.get("scope_path") or ""
+        new_dir = posixpath.dirname(new_p)
+        if storage.kind_of_scope(old_scope) == "doc":
+            base = posixpath.basename(old_scope)
+            new_scope = f"{new_dir}/{base}" if new_dir else base
+        else:
+            new_scope = new_dir
+        handled_ids.add(data["id"])
+        if new_scope == old_scope:
+            continue
+        data["scope_path"] = new_scope
+        storage.write_trigger(data, file_path=new_p, actor=actor)
+
+    # Case B — docs whose sibling doc-scoped trigger YAML stayed put.
+    moved_yaml_olds = {old_p for old_p, _ in moves if _is_trigger_file(old_p)}
+    for old_p, new_p in moves:
+        if old_p == new_p or not old_p.endswith(".md"):
+            continue
+        with session() as s:
+            triggers = [
+                _to_dict(t)
+                for t in s.scalars(select(Trigger).where(Trigger.scope_path == old_p)).all()
+            ]
+        for trig in triggers:
+            old_file_path = trig.get("file_path")
+            if (
+                trig["id"] in handled_ids
+                or not old_file_path
+                or old_file_path in moved_yaml_olds
+            ):
+                continue
+            handled_ids.add(trig["id"])
+            new_file_path = storage.compute_path(scope_path=new_p, trigger_id=trig["id"])
+            trig["scope_path"] = new_p
+            if new_file_path == old_file_path:
+                storage.write_trigger(trig, file_path=new_file_path, actor=actor)
+            else:
+                storage.move_trigger(
+                    trig, old_file_path=old_file_path, new_file_path=new_file_path, actor=actor
+                )
 
 
 def rebuild_from_filesystem() -> int:

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -190,12 +190,16 @@ def after_path_move(
     # Triggers store their scope_path inside the moved YAML (and the YAML's
     # location is derived from it), so a git mv leaves scopes dangling. Rewrite
     # the affected YAMLs, then reconverge the absolute file_path cache from
-    # disk. Best-effort — a trigger reconcile failure must not abort the move's
-    # other side effects.
+    # disk. Both best-effort, in *separate* try blocks: a partial repoint
+    # failure must still let the rebuild run, or the cache would stay stale
+    # against the YAMLs that were rewritten until some later incidental rebuild.
     try:
         triggers_repo.repoint_scopes_for_moves(moves, actor=actor)
+    except Exception:
+        log.exception("trigger scope repoint after path move failed")
+    try:
         triggers_repo.rebuild_from_filesystem()
     except Exception:
-        log.exception("trigger scope/cache reconcile after path move failed")
+        log.exception("trigger cache rebuild after path move failed")
     if list_changed:
         mcp_pubsub.publish_list_changed()

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -187,12 +187,15 @@ def after_path_move(
             agent_activity.delete_for_doc(old_p)
             drafts.delete(old_p)
             page_dirs.delete_all_for_page(old_p)
-    # Trigger YAMLs moved with their folder; their absolute file_path cache is
-    # stale until reconverged from disk. Best-effort — a cache rebuild failure
-    # must not abort the move's other side effects.
+    # Triggers store their scope_path inside the moved YAML (and the YAML's
+    # location is derived from it), so a git mv leaves scopes dangling. Rewrite
+    # the affected YAMLs, then reconverge the absolute file_path cache from
+    # disk. Best-effort — a trigger reconcile failure must not abort the move's
+    # other side effects.
     try:
+        triggers_repo.repoint_scopes_for_moves(moves, actor=actor)
         triggers_repo.rebuild_from_filesystem()
     except Exception:
-        log.exception("trigger cache rebuild after path move failed")
+        log.exception("trigger scope/cache reconcile after path move failed")
     if list_changed:
         mcp_pubsub.publish_list_changed()

--- a/backend/tests/test_triggers_repo.py
+++ b/backend/tests/test_triggers_repo.py
@@ -175,3 +175,66 @@ def test_fire_counts_by_sha_empty_input(tmp_repo):
     from app.triggers import repo
 
     assert repo.fire_counts_by_sha(set()) == {}
+
+
+# --------------------------------------------------------------------------- #
+# Scope follows a path move (repoint_scopes_for_moves via after_path_move)     #
+# --------------------------------------------------------------------------- #
+
+
+def test_folder_rename_repoints_doc_scoped_trigger(tmp_repo):
+    # A folder move sweeps the doc *and* its sibling .trigger YAML; the YAML's
+    # scope_path content must be rewritten to the doc's new path.
+    from app.triggers import repo
+    from app.wiki import git as wiki_git, notify
+
+    uid = seed_user(email="a@b.com")
+    wiki_git.commit_file("proj/old/doc.md", "# Doc\n", "seed", author=None)
+    t = _create(
+        repo, owner_user_id=uid, scope_path="proj/old/doc.md", nl_description="x", message="m"
+    )
+
+    sha, moves = wiki_git.move_path("proj/old", "proj/new", "move folder", author=None)
+    notify.after_path_move(moves, sha, actor=None)
+
+    got = repo.get(t["id"])
+    assert got is not None
+    assert got["scope_path"] == "proj/new/doc.md"
+    assert got["file_path"] == f"proj/new/.trigger_{t['id']}_doc.yaml"
+
+
+def test_folder_rename_repoints_folder_scoped_trigger(tmp_repo):
+    from app.triggers import repo
+    from app.wiki import git as wiki_git, notify
+
+    uid = seed_user(email="a@b.com")
+    t = _create(repo, owner_user_id=uid, scope_path="proj/old", nl_description="x", message="m")
+
+    sha, moves = wiki_git.move_path("proj/old", "proj/new", "move folder", author=None)
+    notify.after_path_move(moves, sha, actor=None)
+
+    got = repo.get(t["id"])
+    assert got is not None
+    assert got["scope_path"] == "proj/new"
+    assert got["file_path"] == f"proj/new/.trigger_{t['id']}.yaml"
+
+
+def test_single_doc_rename_relocates_doc_scoped_trigger(tmp_repo):
+    # Renaming just the doc does NOT sweep the sibling YAML, so the trigger must
+    # be relocated + rewritten to the doc's new path (and renamed docbase).
+    from app.triggers import repo
+    from app.wiki import git as wiki_git, notify
+
+    uid = seed_user(email="a@b.com")
+    wiki_git.commit_file("notes/doc.md", "# Doc\n", "seed", author=None)
+    t = _create(
+        repo, owner_user_id=uid, scope_path="notes/doc.md", nl_description="x", message="m"
+    )
+
+    sha, moves = wiki_git.move_path("notes/doc.md", "notes/renamed.md", "rename doc", author=None)
+    notify.after_path_move(moves, sha, actor=None)
+
+    got = repo.get(t["id"])
+    assert got is not None
+    assert got["scope_path"] == "notes/renamed.md"
+    assert got["file_path"] == f"notes/.trigger_{t['id']}_renamed.yaml"


### PR DESCRIPTION
## Problem

A trigger's `scope_path` is stored **inside** its committed YAML, and the YAML's filename/location is *derived* from that scope (`storage.compute_path`). A plain `git mv` (how page/folder moves work) relocates files but never rewrites YAML content — so after a move, the trigger's `scope_path` still points at the old path, `rebuild_from_filesystem` caches the stale value, and the trigger watches a location that no longer exists.

**A folder rename silently broke every trigger scoped inside it.** This is the remaining gap from the move-reconciliation audit (#176 covered the other live caches; this was split out because it rewrites committed YAML).

## Two move shapes

`move_path` returns per-file `(old, new)` pairs. Two distinct cases break triggers:

- **A — folder rename:** the `.trigger_*.yaml` files are tracked files *under* the folder, so they ride along in the `git mv`. Their location updates but the `scope_path` content doesn't.
- **B — single-doc rename:** the doc-scoped YAML (`.trigger_<id>_<docbase>.yaml`) is a *sibling*, not under the renamed file, so `git ls-files -- doc.md` never includes it — **the YAML doesn't move at all**, and both its `scope_path` and filename `docbase` go stale.

## Fix

New `repo.repoint_scopes_for_moves(moves, actor)`, called from `after_path_move` **before** `rebuild_from_filesystem`:

- **A:** for each moved trigger YAML, invert `compute_path` against its *new* location to derive the corrected scope (folder-scoped → new dir; doc-scoped → new dir + docbase) and rewrite `scope_path` in place.
- **B:** for each moved `.md` doc whose sibling YAML did *not* move, look up doc-scoped triggers at the old path and `move_trigger()` them (relocate + rewrite) — reusing the exact path the trigger *update* flow already uses. A guard skips triggers already handled by A.

Only the YAML source-of-truth is touched; the existing `rebuild_from_filesystem` call reconverges the Postgres cache right after. Because it lives in the shared hook, **both the HTTP route and the agent-tool move path** get it.

Corrections are follow-up commits after the move (additive history, consistent with how `move_trigger` already works).

## Testing

New tests in `test_triggers_repo.py` for all three shapes — folder rename (doc-scoped + folder-scoped) and single-doc rename — asserting both `scope_path` and the recomputed YAML `file_path`. `test_triggers_repo / _fanout / _diff / _api`, `test_move_notify`, `test_dir_tools` all pass (65). ruff + basedpyright clean.

## Not included

`documents.path` vestigial-table cleanup is a separate PR (no file overlap).