### PR TITLE
chore(db): drop the vestigial documents table

### DIFF
--- a/backend/app/db/migrations/versions/0024_drop_documents.py
+++ b/backend/app/db/migrations/versions/0024_drop_documents.py
@@ -1,0 +1,53 @@
+"""drop the vestigial ``documents`` table
+
+The ``documents`` table (a metadata mirror of wiki page paths) had no readers
+or writers in application code — page listing builds from ``git ls-files``, not
+this table — so it was dead weight. Drop it.
+
+Guarded on the live inspector: ``0001_initial`` runs
+``Base.metadata.create_all`` against the *current* model registry, and the
+``Document`` model has been removed, so freshly-bootstrapped databases never
+create the table in the first place. Only existing databases carry it.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-06-03 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0024"
+down_revision: str | None = "0023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "documents" in inspector.get_table_names():
+        op.drop_table("documents")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "documents" in inspector.get_table_names():
+        return
+    op.create_table(
+        "documents",
+        sa.Column("id", sa.Text, primary_key=True),
+        sa.Column("path", sa.Text, nullable=False, unique=True),
+        sa.Column("title", sa.Text),
+        sa.Column(
+            "updated_at",
+            sa.Text,
+            nullable=False,
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+        ),
+    )

--- a/backend/app/db/migrations/versions/0024_drop_documents.py
+++ b/backend/app/db/migrations/versions/0024_drop_documents.py
@@ -1,17 +1,13 @@
-"""drop the vestigial ``documents`` table
-
-The ``documents`` table (a metadata mirror of wiki page paths) had no readers
-or writers in application code — page listing builds from ``git ls-files``, not
-this table — so it was dead weight. Drop it.
+"""drop the ``documents`` table
 
 Guarded on the live inspector: ``0001_initial`` runs
-``Base.metadata.create_all`` against the *current* model registry, and the
-``Document`` model has been removed, so freshly-bootstrapped databases never
-create the table in the first place. Only existing databases carry it.
+``Base.metadata.create_all`` against the current model registry, and the
+``Document`` model is gone, so freshly-bootstrapped databases never create the
+table — the guard makes the drop a no-op there; only existing databases carry
+it. Downgrade recreates it (also guarded).
 
 Revision ID: 0024
 Revises: 0023
-Create Date: 2026-06-03 00:00:00.000000+00:00
 """
 from __future__ import annotations
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -256,20 +256,6 @@ class LauncherToken(Base):
 
 
 # --------------------------------------------------------------------------- #
-# Documents (metadata) — canonical content lives in git                       #
-# --------------------------------------------------------------------------- #
-
-
-class Document(Base):
-    __tablename__ = "documents"
-
-    id: Mapped[str] = mapped_column(Text, primary_key=True)
-    path: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
-    title: Mapped[str | None] = mapped_column(Text)
-    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
-
-
-# --------------------------------------------------------------------------- #
 # Triggers — git-backed YAML is the source of truth; this is a lookup cache   #
 # --------------------------------------------------------------------------- #
 

--- a/backend/tests/test_acl.py
+++ b/backend/tests/test_acl.py
@@ -762,19 +762,20 @@ def test_deleting_owner_user_clears_owner_row(tmp_db):
 
 
 def test_visible_paths_filter_against_db(tmp_db):
-    """Exercise the SQL predicate end-to-end against the documents table."""
-    from sqlalchemy import select as sa_select
+    """Exercise the SQL predicate end-to-end. It accepts any path-column
+    expression, so feed it a literal VALUES table of candidate paths rather
+    than depending on a particular table existing."""
+    from sqlalchemy import String, column, select as sa_select, values
 
-    from app.db.models import Document
     from app.db.session import session
 
     alice = seed_user(uid="u_alice", email="alice@x.com")
     bob = seed_user(uid="u_bob", email="bob@x.com")
 
-    # Insert document rows so the predicate has something to filter.
-    with session() as s:
-        s.add(Document(id="d_public", path="public.md", title="Public"))
-        s.add(Document(id="d_private", path="private.md", title="Private"))
+    # Candidate paths to filter (stand-in for "every page in a listing").
+    candidates = values(column("path", String), name="candidates").data(
+        [("public.md",), ("private.md",)]
+    )
 
     # Public doc — Alice can see (default-public ACL set by on_page_created).
     acl.on_page_created("public.md", owner_user_id=None)
@@ -782,17 +783,17 @@ def test_visible_paths_filter_against_db(tmp_db):
     # Bob's private doc — Alice cannot see.
     acl.set_owner("private.md", bob)
 
-    pred = acl.visible_paths_filter(alice, False, Document.path)
+    pred = acl.visible_paths_filter(alice, False, candidates.c.path)
     with session() as s:
         rows = s.scalars(
-            sa_select(Document.path).where(pred).order_by(Document.path)
+            sa_select(candidates.c.path).where(pred).order_by(candidates.c.path)
         ).all()
     assert list(rows) == ["public.md"]
 
     # Admin filter is universal-true.
-    pred_admin = acl.visible_paths_filter("u_admin", True, Document.path)
+    pred_admin = acl.visible_paths_filter("u_admin", True, candidates.c.path)
     with session() as s:
         rows = s.scalars(
-            sa_select(Document.path).where(pred_admin).order_by(Document.path)
+            sa_select(candidates.c.path).where(pred_admin).order_by(candidates.c.path)
         ).all()
     assert list(rows) == ["private.md", "public.md"]


### PR DESCRIPTION
## What

Remove the `documents` Postgres table. It was a metadata mirror of wiki page paths with **no readers or writers in application code** — page listing builds from `git ls-files` (`api/wiki.py`), and search/ACL never touch it. Its sole consumer was a test using it as a convenient path-column table.

(Identified during the rename/move audit. Separate from the `triggers.scope_path` fix — no file overlap.)

## Changes

- **Remove the `Document` ORM model** (`app/db/models.py`).
- **`0024_drop_documents` migration** — drops the table, **guarded** on the live inspector: `0001_initial` runs `Base.metadata.create_all` against the *current* registry, so once the model is gone, freshly-bootstrapped databases never create the table — the guard makes the drop a no-op there and only affects existing DBs. Downgrade recreates it (also guarded).
- **Rework `test_visible_paths_filter_against_db`** (`tests/test_acl.py`) — it only used `Document` as a generic path column to exercise `acl.visible_paths_filter`. Now it filters a literal `VALUES` table of candidate paths, so the predicate test no longer depends on any particular table.

## Testing

- `test_acl.py` — 40 pass (the reworked predicate test runs through the per-test `alembic upgrade head`, exercising the guarded drop on a fresh schema).
- Migration validated both directions against the dev DB: upgrade drops the table, downgrade recreates it, upgrade drops again.
- ruff + basedpyright clean.