### PR TITLE
fix(delete): drop page-scoped live state when a page/folder is deleted

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -297,6 +297,7 @@ def delete_document_by_path(
     # The .md pages being removed: the file itself, or every page under a
     # folder. We snapshot these *before* the delete so the post-delete fan-out
     # (which drops each page's caches) covers a folder delete too.
+    md_paths: list[str]
     if abs_path.is_file() and rel.endswith(".md"):
         md_paths = [rel]
     elif abs_path.is_dir():

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -294,18 +294,25 @@ def delete_document_by_path(
     abs_path = filesystem.absolute(rel)
     if not abs_path.exists():
         raise HTTPException(status_code=404, detail="not found")
+    # The .md pages being removed: the file itself, or every page under a
+    # folder. We snapshot these *before* the delete so the post-delete fan-out
+    # (which drops each page's caches) covers a folder delete too.
     if abs_path.is_file() and rel.endswith(".md"):
-        require_can("write", rel, user)
+        md_paths = [rel]
     elif abs_path.is_dir():
-        for p in wiki_git.list_paths(rel):
-            if p.endswith(".md"):
-                require_can("write", p, user)
+        md_paths = [p for p in wiki_git.list_paths(rel) if p.endswith(".md")]
+    else:
+        md_paths = []
+    for p in md_paths:
+        require_can("write", p, user)
     author = _git_author(user)
     sha = wiki_git.delete_path(rel, f"delete {rel}", author=author)
-    wiki_notify.after_doc_delete(rel, sha, author)
-    wiki_drafts.delete(rel)
-    wiki_git.delete_drafts_for_path(rel)
-    log.info("doc deleted %s by %s sha=%s", rel, author or "?", sha[:8])
+    for p in md_paths:
+        # Drops FTS / ACL / comments / activity / drafts / working-dir state
+        # for each removed page.
+        wiki_notify.after_doc_delete(p, sha, author)
+        wiki_git.delete_drafts_for_path(p)
+    log.info("doc deleted %s (%d pages) by %s sha=%s", rel, len(md_paths), author or "?", sha[:8])
     return DeleteDocumentResponse(sha=sha)
 
 

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -104,8 +104,17 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     that sha is empty (the file is gone) and ``before`` at ``sha^`` is
     the body just before deletion.
 
-    Also drops the page's owner + page-level ACL rows. Folder ACLs
-    above the page are untouched.
+    Drops every Postgres row that is a *live pointer* to the page: the
+    owner + page-level ACL rows (folder ACLs above are untouched), the
+    agent-activity rail, template-draft state, and per-(user, machine)
+    working-dir bindings. Comments are kept as tombstones (orphaned, not
+    deleted) since they have archival value; the rest are operational state
+    with none. Point-in-time records (launch history, eval samples) are left
+    alone.
+
+    Caller deletes one ``.md`` at a time — for a folder delete it invokes
+    this per nested page (see ``api/wiki.py``), so the folder path itself
+    never reaches here.
 
     MCP-side: subscribers to the deleted path get one final
     ``notifications/resources/updated`` with ``changeKind="delete"`` so
@@ -119,6 +128,12 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     # The body is gone, so there's nothing to re-anchor against — orphan the
     # page's comments (keeps them as tombstones) rather than dropping them.
     comments.orphan_all_for_doc(rel_path)
+    # No-TTL pointers (drafts, working-dirs) would otherwise mis-bind a page
+    # later recreated at this path; agent_activity is TTL'd but cleared here
+    # for symmetry with the move-out-of-.md-space path.
+    agent_activity.delete_for_doc(rel_path)
+    drafts.delete(rel_path)
+    page_dirs.delete_all_for_page(rel_path)
     fan_out_trigger_eval(rel_path, sha, ChangeKind.DELETE, actor)
     mcp_pubsub.publish_doc_delete(rel_path, sha)
     mcp_pubsub.publish_list_changed()

--- a/backend/tests/test_delete_notify.py
+++ b/backend/tests/test_delete_notify.py
@@ -52,16 +52,25 @@ def test_delete_folder_fans_out_to_nested_pages(tmp_repo):
     # Deleting a folder must clean every nested page's state, not just the
     # folder path (which isn't a .md and would otherwise no-op the hook).
     admin = seed_user(uid="u_admin", email="admin@x.com", is_admin=True)
-    wiki_git.commit_file("proj/a.md", "# A\n", "seed a", author=None)
-    wiki_git.commit_file("proj/b.md", "# B\n", "seed b", author=None)
-    for p in ("proj/a.md", "proj/b.md"):
+    tid = _seed_template()
+    nested = ("proj/a.md", "proj/b.md")
+    for p in nested:
+        wiki_git.commit_file(p, "# Page\n", f"seed {p}", author=None)
         page_dirs.set_for_page(user_id=admin, machine_id="m1", wiki_path=p, working_dir="/tmp/x")
+        drafts.create(
+            path=p, template_id=tid, template_body_snapshot="# T\n", created_by_user_id=admin
+        )
+        agent_activity.upsert_activity(
+            user_id=admin, agent_name=p, doc_path=p, activity="wrote", description=None
+        )
 
     client = TestClient(create_app())
     login_fastapi(client, admin)
     resp = client.delete("/api/wiki/file?path=proj")
     assert resp.status_code == 200
 
-    # Both nested pages' no-TTL working-dir bindings are gone.
-    assert page_dirs.get_for_page(user_id=admin, machine_id="m1", wiki_path="proj/a.md") is None
-    assert page_dirs.get_for_page(user_id=admin, machine_id="m1", wiki_path="proj/b.md") is None
+    # Every nested page's live state is cleared — not just the working-dir one.
+    for p in nested:
+        assert page_dirs.get_for_page(user_id=admin, machine_id="m1", wiki_path=p) is None
+        assert drafts.get(p) is None
+        assert agent_activity.list_for_doc(p) == []

--- a/backend/tests/test_delete_notify.py
+++ b/backend/tests/test_delete_notify.py
@@ -1,0 +1,67 @@
+"""Page-scoped live state dies with the page on delete.
+
+``after_doc_delete`` drops the page's ACL/owner, comments (orphaned as
+tombstones), agent-activity, draft, and working-dir state. The delete endpoint
+fans this out per nested page so a *folder* delete cleans up too — important for
+the no-TTL pointers (drafts, working-dirs), which would otherwise mis-bind a
+page later recreated at the same path.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.db import page_dirs
+from app.db.models import DocumentTemplate
+from app.db.session import session
+from app.main import create_app
+from app.wiki import agent_activity, drafts, notify
+from app.wiki import git as wiki_git
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _seed_template(tid: str = "tmpl_1") -> str:
+    with session() as s:
+        s.add(DocumentTemplate(id=tid, name=f"name-{tid}", body="# T\n"))
+    return tid
+
+
+def test_after_doc_delete_drops_page_scoped_state(tmp_repo):
+    user = seed_user()
+    tid = _seed_template()
+    sha = wiki_git.commit_file("a.md", "# A\n", "seed", author=None)
+    agent_activity.upsert_activity(
+        user_id=user, agent_name=None, doc_path="a.md", activity="wrote", description=None
+    )
+    drafts.create(
+        path="a.md", template_id=tid, template_body_snapshot="# T\n", created_by_user_id=user
+    )
+    page_dirs.set_for_page(
+        user_id=user, machine_id="m1", wiki_path="a.md", working_dir="/tmp/x"
+    )
+
+    notify.after_doc_delete("a.md", sha, actor=None)
+
+    assert agent_activity.list_for_doc("a.md") == []
+    assert drafts.get("a.md") is None
+    assert page_dirs.get_for_page(user_id=user, machine_id="m1", wiki_path="a.md") is None
+
+
+def test_delete_folder_fans_out_to_nested_pages(tmp_repo):
+    # Deleting a folder must clean every nested page's state, not just the
+    # folder path (which isn't a .md and would otherwise no-op the hook).
+    admin = seed_user(uid="u_admin", email="admin@x.com", is_admin=True)
+    wiki_git.commit_file("proj/a.md", "# A\n", "seed a", author=None)
+    wiki_git.commit_file("proj/b.md", "# B\n", "seed b", author=None)
+    for p in ("proj/a.md", "proj/b.md"):
+        page_dirs.set_for_page(user_id=admin, machine_id="m1", wiki_path=p, working_dir="/tmp/x")
+
+    client = TestClient(create_app())
+    login_fastapi(client, admin)
+    resp = client.delete("/api/wiki/file?path=proj")
+    assert resp.status_code == 200
+
+    # Both nested pages' no-TTL working-dir bindings are gone.
+    assert page_dirs.get_for_page(user_id=admin, machine_id="m1", wiki_path="proj/a.md") is None
+    assert page_dirs.get_for_page(user_id=admin, machine_id="m1", wiki_path="proj/b.md") is None


### PR DESCRIPTION
## What

Closes the delete-side counterpart of the move-reconciliation work. Deleting a page left several live pointers stranded; and folder deletes cleaned up nothing at all.

## Two issues

**1. `after_doc_delete` left live pointers behind.** It dropped ACL/owner, FTS, and comments (kept as tombstones), but never touched:
- `agent_activity` (TTL'd — self-heals, but inconsistent)
- `document_drafts` (**no TTL**)
- `page_working_dirs` (**no TTL**)

The no-TTL ones are the real bug: delete `a.md`, recreate `a.md` later, and the new page silently inherits the dead page's draft banner / working-dir binding.

**2. Folder deletes cleaned up *nothing*.** The endpoint handles both file and folder deletes but called `after_doc_delete(rel)` once — and the hook is `.md`-gated, so a folder path no-ops it entirely. Every nested page's FTS/ACL/comments/activity/draft/working-dir state was left orphaned.

## Fix

- **`after_doc_delete`** now also drops `agent_activity`, `document_drafts`, and `page_working_dirs` for the page — mirroring the move-out-of-`.md`-space branch (comments stay tombstoned; point-in-time records left alone).
- **Delete endpoint** snapshots the affected `.md` pages *before* deleting (the file itself, or every page under a folder — it already gathered these for the ACL check), then fans out `after_doc_delete` per page. So a folder delete now cleans every page it removes. The redundant API-layer `wiki_drafts.delete` is removed (the hook does it per page now).

## Testing

New `tests/test_delete_notify.py`: unit test that `after_doc_delete` drops activity/draft/working-dir state, and an endpoint test that deleting a **folder** clears the no-TTL bindings for every nested page. `test_comment_notify`, `test_move_notify`, `test_wiki_drafts`, `test_save_to_fire_e2e`, permissions + comments API suites all pass (90). ruff + basedpyright clean.

## Not included (flagged follow-up)

A folder delete also removes `.trigger_*.yaml` files, but the `triggers` cache isn't reconciled on delete (the move path does this via `rebuild_from_filesystem`; delete doesn't). That's trigger *config*, a distinct concern from page-scoped pointers — tracked for a separate PR.