### PR TITLE
fix(triggers): preserve slack_webhook_id on cache rebuild

### DIFF
--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -624,9 +624,7 @@ def rebuild_from_filesystem() -> int:
                     kind=data["kind"],
                     nl_description=data["nl_description"],
                     action_json=action_payload,
-                    # Carry the Slack channel link from the YAML; omitting it
-                    # here nulled the cache on every rebuild (boot, path move),
-                    # so slack triggers showed "(channel removed)" in the UI.
+                    # The Slack channel link the UI resolves to a channel name.
                     slack_webhook_id=data.get("slack_webhook_id"),
                     enabled=bool(data.get("enabled", True)),
                     file_path=file_path,

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -624,6 +624,10 @@ def rebuild_from_filesystem() -> int:
                     kind=data["kind"],
                     nl_description=data["nl_description"],
                     action_json=action_payload,
+                    # Carry the Slack channel link from the YAML; omitting it
+                    # here nulled the cache on every rebuild (boot, path move),
+                    # so slack triggers showed "(channel removed)" in the UI.
+                    slack_webhook_id=data.get("slack_webhook_id"),
                     enabled=bool(data.get("enabled", True)),
                     file_path=file_path,
                     created_at=created_at,

--- a/backend/tests/test_trigger_slack.py
+++ b/backend/tests/test_trigger_slack.py
@@ -57,3 +57,19 @@ def test_flip_to_event_log_clears_webhook(tmp_repo):
     assert updated is not None
     assert updated["destination"] == "event_log"
     assert updated["slack_webhook_id"] is None
+
+
+def test_rebuild_preserves_slack_webhook_id(tmp_repo):
+    # Regression: rebuild_from_filesystem dropped slack_webhook_id when
+    # reconstructing the cache row, so any rebuild (boot, path move) made the
+    # channel show as "(channel removed)" even though the YAML still had it.
+    seed_user("usr_1")
+    wh = slack_webhooks.create("usr_1", "PM Standup", _HOOK)
+    t = _create("usr_1", destination="slack", slack_webhook_id=wh["id"])
+
+    triggers_repo.rebuild_from_filesystem()
+
+    rebuilt = triggers_repo.get(t["id"])
+    assert rebuilt is not None
+    assert rebuilt["destination"] == "slack"
+    assert rebuilt["slack_webhook_id"] == wh["id"]

--- a/backend/tests/test_trigger_slack.py
+++ b/backend/tests/test_trigger_slack.py
@@ -60,9 +60,8 @@ def test_flip_to_event_log_clears_webhook(tmp_repo):
 
 
 def test_rebuild_preserves_slack_webhook_id(tmp_repo):
-    # Regression: rebuild_from_filesystem dropped slack_webhook_id when
-    # reconstructing the cache row, so any rebuild (boot, path move) made the
-    # channel show as "(channel removed)" even though the YAML still had it.
+    # slack_webhook_id must survive rebuild_from_filesystem so the UI can still
+    # resolve the channel after a cache rebuild (boot, path move).
     seed_user("usr_1")
     wh = slack_webhooks.create("usr_1", "PM Standup", _HOOK)
     t = _create("usr_1", destination="slack", slack_webhook_id=wh["id"])


### PR DESCRIPTION
## Symptom

A Slack-destination trigger shows **"Slack · (channel removed)"** in the Triggers UI even though it's enabled and a channel was set.

The frontend resolves the channel by matching `trigger.slack_webhook_id` against the user's webhooks (`app/app/triggers/page.tsx:66-67`); no match → `"Slack · (channel removed)"`. So the trigger's `slack_webhook_id` had gone NULL in the Postgres cache.

## Root cause

`rebuild_from_filesystem` reconstructs each `Trigger` cache row from its YAML, but the `Trigger(...)` constructor **omitted `slack_webhook_id`** — so it defaulted to NULL on every rebuild. The YAML still carries the id (`storage.serialize` writes it; `parse` reads it into `data`), and `create()`/`update()` set it correctly on the row — but the rebuild path dropped it.

This got triggered far more often by recent work: `after_path_move` now reconverges the trigger cache via `rebuild_from_filesystem` on **every page/folder move** (in addition to boot). So a single move would silently strip the channel from all Slack triggers.

## Fix

Carry `slack_webhook_id=data.get("slack_webhook_id")` from the YAML (the source of truth) into the rebuilt row — one line, alongside the other fields the rebuild already restores.

**Existing affected triggers self-heal** on the next rebuild (boot or any move): their YAML still has the id, so the corrected rebuild repopulates the cache.

## Testing

New `test_rebuild_preserves_slack_webhook_id` in `test_trigger_slack.py` — creates a Slack trigger, runs `rebuild_from_filesystem`, asserts the channel link survives. `test_trigger_slack` + `test_triggers_repo` pass (19). ruff + basedpyright clean.