### PR TITLE
fix(comments): tolerate rendered whitespace with no raw counterpart

### DIFF
--- a/frontend/src/lib/commentAnchor.ts
+++ b/frontend/src/lib/commentAnchor.ts
@@ -90,8 +90,10 @@ function charsAlign(raw: string, rendered: string): boolean {
 }
 
 /** Align an element's rendered text to its raw-markdown slice by subsequence
- * walk, skipping raw-only syntax chars. Returns null if a rendered char has no
- * counterpart in the raw slice (the selection/highlight then just isn't mapped). */
+ * walk, skipping raw-only syntax chars. Rendered whitespace with no raw
+ * counterpart is tolerated (react-markdown adds newlines around block
+ * structure); a non-whitespace rendered char with no counterpart returns null
+ * (the selection/highlight then just isn't mapped). */
 function alignBlock(el: HTMLElement, body: string, starts: number[]): BlockAlign | null {
   const pos = parseSourcePos(el.getAttribute("data-sourcepos") ?? "");
   if (!pos) return null;
@@ -103,10 +105,21 @@ function alignBlock(el: HTMLElement, body: string, starts: number[]): BlockAlign
   const rawAt: number[] = new Array<number>(rendered.length);
   let j = 0;
   for (let i = 0; i < rendered.length; i++) {
-    while (j < raw.length && !charsAlign(raw[j]!, rendered[i]!)) j++;
-    if (j >= raw.length) return null; // rendered char absent from raw → unmappable
-    rawAt[i] = blockStart + j;
-    j++;
+    const ch = rendered[i]!;
+    let k = j;
+    while (k < raw.length && !charsAlign(raw[k]!, ch)) k++;
+    if (k < raw.length) {
+      rawAt[i] = blockStart + k;
+      j = k + 1;
+    } else if (/\s/.test(ch)) {
+      // Rendered whitespace with no raw counterpart: react-markdown emits
+      // extra newlines around block structure (e.g. between a list item's text
+      // and its nested sublist) that the raw slice doesn't carry. Map it to the
+      // current position without consuming raw, instead of failing the block.
+      rawAt[i] = blockStart + Math.min(j, raw.length);
+    } else {
+      return null; // a non-whitespace rendered char absent from raw (e.g. an entity)
+    }
   }
   return { el, blockStart, blockEnd, rawAt };
 }


### PR DESCRIPTION
## Symptom

Selecting text that spans a **list item with a nested sublist** (e.g. a bullet and its sub-bullets) shows no Comment button — you can't comment on it. Plain paragraphs and even bold/multi-paragraph selections (fixed in #173) work; lists don't.

## Root cause

`selectionToAnchor` resolves each endpoint via `alignBlock`, which subsequence-aligns an element's rendered `textContent` to its raw-markdown slice. I reproduced the real react-markdown + `rehypeSourcePos` output for a nested list:

```
<li data-sourcepos=3:1-7:23> text="Wiki pages (manual)" "\n" "\n"
  <ul data-sourcepos=4:3-7:23> text="\n" ...
    <li>create</li> <li>view</li> <li>edit</li> <li>versioning history</li>
```

So the outer `<li>`'s `textContent` is `"Wiki pages (manual)\n\n\ncreate\nview\nedit\nversioning history\n"` — react-markdown emits extra newlines around the block structure, including a **trailing** one. But the raw slice (`3:1-7:23`) ends at `"versioning history"` with **no trailing newline**. The subsequence walk ran off the end of `raw` on that trailing whitespace and hit `return null`, which nulled the whole selection → no button.

## Fix

`alignBlock` now tolerates **rendered whitespace with no raw counterpart** — maps it to the current position without consuming `raw`, instead of failing the block. Only a non-whitespace rendered char with no counterpart (e.g. an HTML entity) still bails. Markdown freely adds/collapses whitespace around block structure, so this is the right rule; it's strictly more permissive, so existing cases are unaffected. The same primitive feeds `paintCommentHighlights`, so list-spanning comment highlights are fixed too.

## Verification

No frontend test runner exists in this repo, so verified two ways:
- Rendered the exact markdown through the real `unified` + `remark-gfm` + `remark-rehype` + `rehypeSourcePos` pipeline to capture the true `textContent` / `data-sourcepos`.
- Ran the old vs new `alignBlock` walk on those strings: **old → `null`** (the bug), **new → maps successfully**.
- `npm run typecheck` passes.