### PR TITLE
feat(triggers): give schedule triggers a since-last-check diff

### DIFF
--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -59,6 +59,7 @@ from app.triggers.engine import (
     find_matching_triggers,
     render_delta_message,
     render_schedule_message,
+    schedule_window_start,
 )
 from app.wiki import acl as wiki_acl
 from app.wiki import git as wiki_git
@@ -212,7 +213,13 @@ def evaluate_due_schedule_triggers(now: datetime) -> int:
     fired = 0
     for trigger in triggers:
         try:
-            if _evaluate_one_schedule(trigger, now_iso=now_iso, wiki_snapshot=wiki_snapshot):
+            since_iso = schedule_window_start(trigger, now).isoformat(timespec="seconds")
+            if _evaluate_one_schedule(
+                trigger,
+                now_iso=now_iso,
+                since_iso=since_iso,
+                wiki_snapshot=wiki_snapshot,
+            ):
                 fired += 1
         finally:
             # Always advance last_fired_at, even on no-match or exception,
@@ -226,10 +233,14 @@ def _evaluate_one_schedule(
     trigger: TriggerRecord,
     *,
     now_iso: str,
+    since_iso: str,
     wiki_snapshot: str,
 ) -> bool:
     """Evaluate a single schedule trigger; record a ``trigger.fire`` event
     on match. Returns True if it fired.
+
+    ``since_iso`` bounds the "changes since last check" diff window (the
+    previous tick / last fire — see ``schedule_window_start``).
     """
     if not _owner_can_read_scope(trigger):
         log.info(
@@ -241,6 +252,7 @@ def _evaluate_one_schedule(
     payload = diff_helper.build_schedule_payload(
         scope_path=trigger.scope_path,
         when_iso=now_iso,
+        since_iso=since_iso,
         wiki_snapshot=wiki_snapshot,
     )
     match = evaluate_schedule(trigger, payload)

--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -193,10 +193,7 @@ def _in_scope(path: str, scope_path: str) -> bool:
 def _read_or_empty(path: str, ref: str) -> str:
     """Body of ``path`` at ``ref``, or ``""`` if it didn't exist there
     (a brand-new file at the window start, or a path deleted by HEAD)."""
-    try:
-        return wiki_git.read_file(path, ref)
-    except Exception:
-        return ""
+    return wiki_git.read_file_opt(path, ref) or ""
 
 
 def _change_entry(path: str, before: str, after: str) -> str | None:

--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -46,6 +46,9 @@ _CHANGE_BODY_BUDGET = 8_000
 # A diff covering more than this fraction of the file isn't a useful summary;
 # fall back to passing the bodies straight through.
 _DIFF_DENSITY_FALLBACK = 0.5
+# Soft cap on the whole CHANGES-SINCE block. Keeps a busy window from
+# crowding the snapshot out of the model's context.
+_CHANGES_TOTAL_BUDGET = 60_000
 
 
 def build_wiki_snapshot() -> str:
@@ -151,23 +154,112 @@ def build_schedule_payload(
     *,
     scope_path: str,
     when_iso: str,
+    since_iso: str | None = None,
     wiki_snapshot: str | None = None,
 ) -> str:
     """Payload for a schedule-kind trigger evaluation.
 
-    No diff section — schedule ticks aren't tied to a commit. We give the
-    LLM the full wiki snapshot plus a SCHEDULED CHECK block that names
-    the trigger's scope and the tick time, so the prompt can tell the
-    model to evaluate against current state.
+    A schedule tick isn't tied to a single commit, so we give the LLM the
+    full wiki snapshot for overall-state conditions. When ``since_iso`` is
+    provided (the previous tick / last fire), we also append a CHANGES
+    SINCE LAST CHECK block — the diffs committed under ``scope_path`` over
+    ``[since_iso, when_iso]`` — so the trigger can reason about *change*
+    over the window ("a new doc appeared", "X was updated since yesterday")
+    and not just current state. The trailing SCHEDULED CHECK block names
+    the scope and tick time.
     """
     snapshot = wiki_snapshot if wiki_snapshot is not None else build_wiki_snapshot()
     scope_label = scope_path or "(whole wiki)"
-    block = (
+    parts = [snapshot]
+    if since_iso is not None:
+        parts.append(build_changes_since(scope_path=scope_path, since_iso=since_iso))
+    parts.append(
         f"=== SCHEDULED CHECK ===\n"
         f"Scope: {scope_label}\n"
         f"Time: {when_iso}\n"
     )
-    return f"{snapshot}\n\n{block}"
+    return "\n\n".join(parts)
+
+
+def _in_scope(path: str, scope_path: str) -> bool:
+    """Is ``path`` under the trigger's scope? Empty scope = whole wiki."""
+    if not scope_path:
+        return True
+    if path == scope_path:
+        return True
+    return path.startswith(scope_path.rstrip("/") + "/")
+
+
+def _read_or_empty(path: str, ref: str) -> str:
+    """Body of ``path`` at ``ref``, or ``""`` if it didn't exist there
+    (a brand-new file at the window start, or a path deleted by HEAD)."""
+    try:
+        return wiki_git.read_file(path, ref)
+    except Exception:
+        return ""
+
+
+def _change_entry(path: str, before: str, after: str) -> str | None:
+    """One ``--- <path> (kind)`` entry for the changes-since block. Returns
+    ``None`` when there's no effective change (touched then reverted)."""
+    if before == after:
+        return None
+    if not before:
+        body = _truncate(after, _CHANGE_BODY_BUDGET)
+        return f"--- {path}  (new file)\n{body.rstrip()}\n"
+    if not after:
+        return f"--- {path}  (deleted)\n"
+    diff = _unified_diff(before, after)
+    if diff and _diff_density(diff, after) <= _DIFF_DENSITY_FALLBACK:
+        return f"--- {path}  (edited)\n{_truncate(diff, _CHANGE_BODY_BUDGET).rstrip()}\n"
+    # High-density rewrite: the diff is noise; show both bodies.
+    return (
+        f"--- {path}  (rewritten)\n"
+        f"BEFORE:\n{_truncate(before, _CHANGE_BODY_BUDGET).rstrip()}\n\n"
+        f"AFTER:\n{_truncate(after, _CHANGE_BODY_BUDGET).rstrip()}\n"
+    )
+
+
+def build_changes_since(*, scope_path: str, since_iso: str) -> str:
+    """The CHANGES SINCE LAST CHECK block for a schedule fire.
+
+    Diffs every ``.md`` doc under ``scope_path`` committed since
+    ``since_iso`` (the previous tick / last fire) against its body at the
+    window start, reusing the delta path's unified-diff + density-fallback
+    logic. New files show their full body; deletions are noted. The block
+    is explicitly "(no changes in this window)" when nothing matched, so
+    the model can tell "nothing changed" apart from "I wasn't given a diff".
+    """
+    header = f"=== CHANGES SINCE LAST CHECK (since {since_iso}) ==="
+    empty = f"{header}\n(no changes in this window)\n"
+    before_ref = wiki_git.rev_before(since_iso)
+    touched = sorted(
+        p
+        for p in wiki_git.paths_touched_since(since_iso)
+        if p.endswith(".md") and _in_scope(p, scope_path)
+    )
+    if not touched:
+        return empty
+
+    chunks = [header]
+    total = len(header)
+    truncated = 0
+    for path in touched:
+        if total >= _CHANGES_TOTAL_BUDGET:
+            truncated += 1
+            continue
+        after = _read_or_empty(path, "HEAD")
+        before = _read_or_empty(path, before_ref) if before_ref else ""
+        entry = _change_entry(path, before, after)
+        if entry is None:
+            continue
+        chunks.append(entry)
+        total += len(entry)
+    if truncated:
+        chunks.append(f"[truncated {truncated} more changed docs to fit budget]\n")
+    if len(chunks) == 1:
+        return empty
+    return "\n".join(chunks)
 
 
 def _unified_diff(before: str, after: str) -> str:

--- a/backend/app/triggers/engine.py
+++ b/backend/app/triggers/engine.py
@@ -5,8 +5,11 @@ Two flavors:
                     a meaningful update. Uses an LLM check against the
                     ``nl_description`` of the trigger.
   * **schedule**  — fires on cron, evaluated by the periodic task. Same NL
-                    gate as delta, but the payload is a snapshot of the
-                    current wiki (no diff) since there's no commit.
+                    gate as delta. The payload is a snapshot of the current
+                    wiki plus a "changes since last check" diff covering the
+                    window since the previous tick (see ``schedule_window_start``),
+                    so a schedule trigger can reason about change over time
+                    and not just current state.
 
 When a doc is updated we evaluate triggers whose ``scope_path`` matches the
 doc itself or any parent directory. When the schedule scheduler ticks we
@@ -15,7 +18,7 @@ load all enabled schedule triggers and ask croniter whether each is due.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from zoneinfo import ZoneInfo
 
@@ -191,6 +194,47 @@ def _parse_iso(raw: str | None) -> datetime | None:
     return parsed
 
 
+# Cap on the "changes since last check" lookback. A stale base (worker
+# downtime, a backdated start_at, a trigger idle for weeks) shouldn't pull
+# the whole repo history into the eval payload.
+_MAX_SCHEDULE_LOOKBACK = timedelta(days=14)
+
+
+def schedule_window_start(t: TriggerRecord, now: datetime) -> datetime:
+    """Start of the "changes since last check" window for a schedule fire.
+
+    Subsequent fires use the prior fire time (``schedule_last_fired_at``).
+    The first fire has no prior fire, so we fall back to the previous cron
+    tick before ``now`` — one interval back — so the first fire sees the
+    same one-interval window of changes as every later fire (a daily
+    schedule always looks back ~a day, hourly ~an hour, etc).
+
+    Clamped to ``_MAX_SCHEDULE_LOOKBACK`` before ``now`` so a stale base
+    can't dump the whole repo history into the payload.
+    """
+    now_utc = now.astimezone(timezone.utc) if now.tzinfo else now.replace(tzinfo=timezone.utc)
+    last_fired = _parse_iso(t.schedule_last_fired_at)
+    start = last_fired if last_fired is not None else _previous_tick(t, now_utc)
+    floor = now_utc - _MAX_SCHEDULE_LOOKBACK
+    return max(start, floor)
+
+
+def _previous_tick(t: TriggerRecord, now_utc: datetime) -> datetime:
+    """The most recent cron fire strictly before ``now`` (one interval
+    back). Falls back to the max-lookback floor if cron/tz are missing or
+    croniter can't resolve a prior tick."""
+    floor = now_utc - _MAX_SCHEDULE_LOOKBACK
+    if not t.schedule_cron or not t.schedule_timezone:
+        return floor
+    try:
+        tz = ZoneInfo(t.schedule_timezone)
+        itr = croniter(t.schedule_cron, now_utc.astimezone(tz))
+        return itr.get_prev(datetime).astimezone(timezone.utc)
+    except Exception:
+        log.exception("schedule_window_start: prev-tick failed for %s", t.id)
+        return floor
+
+
 def evaluate_delta(trigger: TriggerRecord, payload: str) -> MatchResult:
     """Phase 1 LLM check: does this delta satisfy ``trigger.nl_description``?
 
@@ -211,9 +255,10 @@ def render_delta_message(
 def evaluate_schedule(trigger: TriggerRecord, payload: str) -> MatchResult:
     """Phase 1 LLM check for a schedule tick.
 
-    ``payload`` is the wiki-snapshot + scheduled-check block from
-    ``app.triggers.diff.build_schedule_payload``. The prompt asks the
-    model to evaluate against current wiki state (no diff is available).
+    ``payload`` is the wiki-snapshot + changes-since-last-check diff +
+    scheduled-check block from ``app.triggers.diff.build_schedule_payload``.
+    The prompt evaluates change-over-time conditions against the diff and
+    overall-state conditions against the snapshot.
     """
     return nl_matches_snapshot(trigger.nl_description, payload)
 

--- a/backend/app/triggers/natural_language.py
+++ b/backend/app/triggers/natural_language.py
@@ -236,26 +236,33 @@ def render_message(
 # --------------------------------------------------------------------------- #
 
 _SCHEDULE_EVAL_SYSTEM_PROMPT = """\
-You evaluate whether the current state of a wiki satisfies a \
-natural-language trigger description. The trigger fires on a schedule, \
-not on an edit, so there is no diff to inspect — only the latest \
-version of the wiki and the scope the trigger is watching.
+You evaluate whether a wiki satisfies a natural-language trigger \
+description. The trigger fires on a schedule (cron), so it is evaluated \
+periodically rather than on a single edit.
 
 The user message gives you, in order:
   1. The trigger description ("if …").
   2. A snapshot of the whole wiki at its latest version.
-  3. A SCHEDULED CHECK block naming the trigger's scope and the tick time.
+  3. A CHANGES SINCE LAST CHECK block: the diffs (new files, edits, \
+rewrites, deletions) committed under the trigger's scope since the \
+previous scheduled check. It reads "(no changes in this window)" when \
+nothing changed in the window.
+  4. A SCHEDULED CHECK block naming the trigger's scope and the tick time.
 
 How to evaluate:
-  * Evaluate the trigger description against the **current state** of \
-the wiki, focusing on the document(s) under the listed scope. There is \
-no diff: this is a state check, not a change check.
+  * If the trigger describes a CHANGE over time ("a new doc was added", \
+"X was updated", "the status changed since last week"), evaluate it \
+against the CHANGES SINCE LAST CHECK block. If that block reports no \
+changes, such a trigger does NOT fire.
+  * If the trigger describes overall STATE ("X is still marked blocked", \
+"there is no owner listed"), evaluate it against the current snapshot, \
+focusing on the document(s) under the listed scope.
   * Be conservative: false positives are louder than false negatives. \
-If the wiki state doesn't clearly satisfy the description, say no.
+If the wiki doesn't clearly satisfy the description, say no.
   * Use only what is in the payload below. Do not bring in outside \
 knowledge or speculate.
-  * The reason must quote or paraphrase the specific state that \
-satisfies the trigger.
+  * The reason must quote or paraphrase the specific change or state \
+that satisfies the trigger.
 
 Always respond by calling the `report` tool exactly once.\
 """
@@ -265,8 +272,8 @@ def matches_snapshot(nl_description: str, payload: str) -> MatchResult:
     """Phase 1 for schedule triggers: does current wiki state satisfy the
     trigger?
 
-    ``payload`` is the wiki-snapshot + SCHEDULED CHECK block from
-    ``app.triggers.diff.build_schedule_payload``.
+    ``payload`` is the wiki-snapshot + CHANGES SINCE LAST CHECK diff +
+    SCHEDULED CHECK block from ``app.triggers.diff.build_schedule_payload``.
     """
     user_msg = f"Trigger description (if):\n{nl_description}\n\n{payload}"
     try:
@@ -302,13 +309,16 @@ The user message gives you, in order:
   1. The owner's message instruction ("send …").
   2. A one-line "match reason" produced by the firing-condition check.
   3. A snapshot of the whole wiki at its latest version.
-  4. A SCHEDULED CHECK block naming the trigger's scope and tick time.
+  4. A CHANGES SINCE LAST CHECK block: what changed under the scope since \
+the previous check (may read "(no changes in this window)").
+  5. A SCHEDULED CHECK block naming the trigger's scope and tick time.
 
 Guidance:
   * Follow the owner's instruction. Keep the message concise and \
 specific — quote concrete values from the wiki where useful.
-  * Ground the message in the current wiki state, scoped to the \
-SCHEDULED CHECK scope.
+  * Ground the message in the current wiki state and, when the \
+instruction is about what changed, the CHANGES SINCE LAST CHECK block, \
+scoped to the SCHEDULED CHECK scope.
   * Do not include meta-commentary ("the trigger fired because…"), \
 internal IDs, or explanations of your reasoning. Output only the \
 delivered message text.

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -429,6 +429,20 @@ def paths_touched_since(since_iso: str) -> set[str]:
     return {line for line in out.splitlines() if line.strip()}
 
 
+def rev_before(iso: str) -> str | None:
+    """The newest commit at or before ``iso`` (any timestamp ``git rev-list
+    --before`` accepts), or ``None`` if the repo has no commit that old.
+
+    Used to resolve the "before" ref for a time-windowed diff: diffing this
+    ref against HEAD captures the net change over ``[iso, now]``.
+    """
+    out = _run(
+        ["rev-list", "-1", f"--before={iso}", "HEAD"],
+        check=False,
+    ).stdout.strip()
+    return out or None
+
+
 def list_paths_with_head_sha(prefix: str = "") -> list[tuple[str, str]]:
     """``(path, HEAD-touching sha)`` for every tracked file under ``prefix``.
 

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -271,6 +271,18 @@ def read_file(rel_path: str, ref: str = "HEAD") -> str:
         raise UnknownSha(ref) from e
 
 
+def read_file_opt(rel_path: str, ref: str = "HEAD") -> str | None:
+    """Like ``read_file`` but returns ``None`` when the path doesn't exist
+    at ``ref`` — and stays quiet about it.
+
+    A path absent at a ref is a normal, expected outcome for time-windowed
+    diffs (a file that's brand-new in the window has no body at the window
+    start), so this skips the ERROR log ``read_file`` would emit.
+    """
+    res = _run(["show", f"{ref}:{rel_path}"], check=False)
+    return res.stdout if res.returncode == 0 else None
+
+
 def path_at_ref(current_rel_path: str, ref: str) -> str | None:
     """Return the path ``current_rel_path`` had at commit ``ref``.
 

--- a/backend/tests/test_schedule_triggers.py
+++ b/backend/tests/test_schedule_triggers.py
@@ -36,6 +36,27 @@ class _FakeResp(BaseModel):
     usage: dict = {}
 
 
+def _record(**overrides):
+    from app.triggers.engine import TriggerRecord
+
+    base = TriggerRecord(
+        id="trg_x",
+        owner_user_id="usr_x",
+        scope_path="a.md",
+        kind="schedule",
+        nl_description="x",
+        message="m",
+        destination="event_log",
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+        schedule_cron="0 * * * *",
+        schedule_timezone="UTC",
+    )
+    return base.model_copy(update=overrides)
+
+
 def _matched_response(matched: bool, reason: str = "test reason") -> _FakeResp:
     return _FakeResp(
         tool_calls=[
@@ -377,6 +398,82 @@ def test_evaluator_skips_owner_without_read(tmp_repo):
 
     assert fired == 0
     assert list_events(kind="trigger.fire") == []
+
+
+# --------------------------------------------------------------------------- #
+# schedule_window_start — the "changes since last check" window               #
+# --------------------------------------------------------------------------- #
+
+
+def test_window_start_uses_last_fired_when_present():
+    from app.triggers.engine import schedule_window_start
+
+    now = _now()
+    last = now - timedelta(minutes=10)
+    start = schedule_window_start(_record(schedule_last_fired_at=_iso(last)), now)
+    assert abs((start - last).total_seconds()) < 1
+
+
+def test_window_start_first_fire_uses_previous_cron_tick():
+    from app.triggers.engine import schedule_window_start
+
+    now = _now()
+    # Hourly cron, never fired: window start is the most recent top-of-hour
+    # at or before now — i.e. < 1h back, on the hour boundary.
+    start = schedule_window_start(_record(schedule_last_fired_at=None), now)
+    assert start <= now
+    assert now - start < timedelta(hours=1)
+    assert start.minute == 0 and start.second == 0
+
+
+def test_window_start_clamps_stale_base():
+    from app.triggers.engine import schedule_window_start
+
+    now = _now()
+    stale = now - timedelta(days=30)
+    start = schedule_window_start(_record(schedule_last_fired_at=_iso(stale)), now)
+    # Clamped to the 14-day lookback floor, not the 30-day-old base.
+    assert abs((now - start) - timedelta(days=14)).total_seconds() < 60
+
+
+# --------------------------------------------------------------------------- #
+# evaluator threads the changes-since diff into the payload                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_evaluator_payload_includes_changes_since_block(tmp_repo):
+    from app.tasks.triggers import evaluate_due_schedule_triggers
+    from app.wiki import git as wiki_git
+
+    uid = seed_user(is_admin=True, email="a@b.com")
+    wiki_git.commit_file("watched.md", "# Watched\n\nstatus: green\n", "seed", author=None)
+    last = _iso(_now() - timedelta(minutes=10))
+    seed_trigger(
+        tid="trg_sched_diff",
+        owner_user_id=uid,
+        scope_path="",
+        kind="schedule",
+        nl_description="any change",
+        message="ping",
+        schedule_cron="* * * * *",
+        schedule_timezone="UTC",
+        schedule_last_fired_at=last,
+    )
+
+    seen: list[str] = []
+
+    def _capture(messages, **kw):
+        seen.append(messages[1]["content"])
+        # First call is the eval gate, second is render.
+        return _matched_response(True, "changed") if len(seen) == 1 else _rendered_response("ok")
+
+    with patch("app.triggers.natural_language.complete", side_effect=_capture):
+        evaluate_due_schedule_triggers(_now())
+
+    assert seen, "evaluator never called the LLM"
+    assert "CHANGES SINCE LAST CHECK" in seen[0]
+    # watched.md was committed within the 10-min window → shows as a change.
+    assert "watched.md" in seen[0]
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_triggers_diff.py
+++ b/backend/tests/test_triggers_diff.py
@@ -6,10 +6,17 @@ versions of every tracked .md), and the combined payload.
 """
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from app.triggers import diff as diff_helper
+from app.triggers.diff import _change_entry  # pyright: ignore[reportPrivateUsage]
 from app.models.wiki import ChangeKind
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat(timespec="seconds")
 
 
 # --------------------------------------------------------------------------- #
@@ -146,3 +153,96 @@ def test_new_file_payload_accepts_prebuilt_snapshot(repo_with_docs):
     )
     assert payload.startswith(custom)
     assert "alpha body" not in payload
+
+
+# --------------------------------------------------------------------------- #
+# _change_entry — per-path classification                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_change_entry_new_file_shows_full_body():
+    out = _change_entry("n.md", "", "# New\n\nbody\n")
+    assert out is not None
+    assert "(new file)" in out
+    assert "body" in out
+
+
+def test_change_entry_deleted_is_noted():
+    out = _change_entry("gone.md", "had content\n", "")
+    assert out is not None
+    assert "(deleted)" in out
+    assert "had content" not in out  # body of a deleted file isn't echoed
+
+
+def test_change_entry_edit_low_density_is_unified_diff():
+    before = "\n".join(f"line {i}" for i in range(50))
+    after = before.replace("line 25", "line 25 — updated")
+    out = _change_entry("g.md", before, after)
+    assert out is not None
+    assert "(edited)" in out
+    assert "line 25 — updated" in out
+
+
+def test_change_entry_high_density_rewrite_shows_both_bodies():
+    out = _change_entry("g.md", "old\n", "completely different content\n")
+    assert out is not None
+    assert "(rewritten)" in out
+    assert "BEFORE:" in out and "AFTER:" in out
+
+
+def test_change_entry_no_effective_change_returns_none():
+    assert _change_entry("g.md", "same\n", "same\n") is None
+
+
+# --------------------------------------------------------------------------- #
+# build_changes_since                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_changes_since_lists_recent_docs_as_new_when_no_prior_commit(repo_with_docs):
+    # All commits in the fixture happened "now"; a window opened an hour ago
+    # has no commit before it, so every touched .md is a brand-new file.
+    since = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+    out = diff_helper.build_changes_since(scope_path="", since_iso=since)
+    assert "=== CHANGES SINCE LAST CHECK" in out
+    assert "--- a.md  (new file)" in out
+    assert "alpha body" in out
+    # YAML trigger files never appear in the diff block
+    assert ".trigger_x.yaml" not in out
+
+
+def test_changes_since_respects_scope(repo_with_docs):
+    since = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+    out = diff_helper.build_changes_since(scope_path="auth", since_iso=since)
+    assert "auth/passwords.md" in out
+    assert "--- a.md" not in out  # outside the scope
+
+
+def test_changes_since_empty_window(repo_with_docs):
+    # A window opening in the future captures nothing.
+    since = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
+    out = diff_helper.build_changes_since(scope_path="", since_iso=since)
+    assert "(no changes in this window)" in out
+
+
+# --------------------------------------------------------------------------- #
+# build_schedule_payload                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_schedule_payload_without_since_has_no_changes_block(repo_with_docs):
+    payload = diff_helper.build_schedule_payload(scope_path="", when_iso="2026-06-03T09:00:00+00:00")
+    assert "=== WIKI (latest version) ===" in payload
+    assert "=== SCHEDULED CHECK ===" in payload
+    assert "CHANGES SINCE LAST CHECK" not in payload
+
+
+def test_schedule_payload_with_since_orders_snapshot_changes_check(repo_with_docs):
+    since = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
+    payload = diff_helper.build_schedule_payload(
+        scope_path="", when_iso="2026-06-03T09:00:00+00:00", since_iso=since
+    )
+    snap_idx = payload.index("WIKI (latest version)")
+    chg_idx = payload.index("CHANGES SINCE LAST CHECK")
+    chk_idx = payload.index("=== SCHEDULED CHECK ===")
+    assert snap_idx < chg_idx < chk_idx

--- a/backend/tests/test_wiki_git.py
+++ b/backend/tests/test_wiki_git.py
@@ -49,3 +49,22 @@ def test_read_at_pre_rename_ref_via_resolved_path(tmp_repo):
     historical = wiki_git.path_at_ref("new.md", create_sha)
     assert historical == "old.md"
     assert wiki_git.read_file(historical, ref=create_sha) == "original body\n"
+
+
+def test_read_file_opt_returns_body_when_present(tmp_repo):
+    from app.wiki import git as wiki_git
+
+    sha = wiki_git.commit_file("a.md", "hello\n", "create", author=None)
+    assert wiki_git.read_file_opt("a.md", sha) == "hello\n"
+
+
+def test_read_file_opt_returns_none_when_absent_at_ref(tmp_repo):
+    """A path that doesn't exist at the ref returns None (no raise, no error
+    log) — the expected case for a file that's new within a diff window."""
+    from app.wiki import git as wiki_git
+
+    base_sha = wiki_git.commit_file("a.md", "x\n", "create a", author=None)
+    # b.md is added only later, so it doesn't exist at base_sha.
+    wiki_git.commit_file("b.md", "y\n", "create b", author=None)
+
+    assert wiki_git.read_file_opt("b.md", base_sha) is None


### PR DESCRIPTION
## What

Schedule-trigger evaluation only received a flat snapshot of current wiki state, so change-over-time conditions ("a new doc appeared", "X changed since yesterday") couldn't fire. Schedule payloads now also include a `CHANGES SINCE LAST CHECK` block diffing what changed under the trigger's scope since the previous fire.

## How

- `schedule_window_start()` picks the window: subsequent fires use `schedule_last_fired_at`; the first fire falls back to the previous cron tick (one interval back), clamped to a 14-day max lookback so a stale base can't dump the whole repo into context.
- `build_changes_since()` resolves the window-start commit via the new `git.rev_before()` and emits per-doc diffs (new file / edit / rewrite / deletion), reusing the delta path's density-fallback logic. The snapshot is retained, so overall-state conditions still work.
- The schedule eval/render prompts now distinguish change conditions (evaluated against the diff) from state conditions (against the snapshot).

## Testing

`ruff` + `basedpyright` clean; full trigger/schedule suite passes (123 tests, incl. new coverage for the window logic, diff block, and payload wiring).