### PR TITLE
feat(home): Welcome landing + directory sidebar with contextual actions

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -27,6 +27,8 @@ from app.models.file_system import (
     FolderHitView,
     GetDocumentResponse,
     ListDocumentsResponse,
+    ListRecentPagesResponse,
+    RecentPageView,
     MergeRequest,
     MergeResponse,
     MovedFile,
@@ -74,6 +76,31 @@ log = logging.getLogger(__name__)
 _DEPRECATES_RE = re.compile(r"^Deprecates:\s*(.+)$", re.MULTILINE)
 _SHA_RE = re.compile(r"^[0-9a-f]{4,40}$")
 
+_FRONTMATTER_RE = re.compile(r"^---\n.*?\n---\n", re.DOTALL)
+# Preview payload cap per card — enough to fill the masked card, bounded so
+# a wide "recent" fan-out doesn't ship whole documents to the client.
+_PREVIEW_MAX_CHARS = 600
+
+
+def _title_and_preview(body: str, path: str) -> tuple[str, str]:
+    """Split a doc body into a card title + masked preview.
+
+    Title = leading ``# H1`` if the body opens with one (after any YAML
+    frontmatter), else the filename without ``.md``. Preview = the body
+    with frontmatter and that leading heading removed, capped.
+    """
+    stripped = _FRONTMATTER_RE.sub("", body, count=1).lstrip("\n")
+    title = ""
+    newline = stripped.find("\n")
+    first_line = stripped if newline == -1 else stripped[:newline]
+    if first_line.startswith("# "):
+        title = first_line[2:].strip()
+        stripped = "" if newline == -1 else stripped[newline + 1 :].lstrip("\n")
+    if not title:
+        base = path.rsplit("/", 1)[-1]
+        title = base[:-3] if base.endswith(".md") else base
+    return title, stripped[:_PREVIEW_MAX_CHARS]
+
 
 def _git_author(user: User | None) -> str | None:
     if user is None:
@@ -97,6 +124,40 @@ def list_documents(
         raw = [(p, ts) for p, ts in raw if not p.endswith(".md") or p in visible]
     entries = [DocumentEntry(path=p, updated_at=ts) for p, ts in raw]
     return ListDocumentsResponse(entries=entries)
+
+
+@router.get("/recent", response_model=ListRecentPagesResponse)
+def list_recent_pages(
+    user: User = Depends(require_user),
+    limit: int = Query(12, ge=1, le=50),
+) -> ListRecentPagesResponse:
+    """Pages the current user has worked on, with a title + masked preview.
+
+    Feeds the home-page "Recent Pages" grid. Sourced from the user's own
+    git authorship (pages they created or edited), newest-first; still
+    ACL-filtered so a page they can no longer see is dropped.
+    """
+    raw = wiki_git.paths_authored_by(user.email)
+    md = [(p, ts) for p, ts in raw if p.endswith(".md")]
+    if not user.is_admin:
+        from app.wiki import acl as _acl
+
+        visible = set(_acl.filter_paths_in_python(user.id, False, [p for p, _ in md]))
+        md = [(p, ts) for p, ts in md if p in visible]
+    # Newest first; empty timestamps sink to the bottom.
+    md.sort(key=lambda pt: pt[1], reverse=True)
+    pages: list[RecentPageView] = []
+    for path, ts in md[:limit]:
+        abs_path = filesystem.absolute(path)
+        if not abs_path.is_file():
+            continue
+        try:
+            body = abs_path.read_text()
+        except OSError:
+            continue
+        title, preview = _title_and_preview(body, path)
+        pages.append(RecentPageView(path=path, title=title, updated_at=ts, preview=preview))
+    return ListRecentPagesResponse(pages=pages)
 
 
 @router.get("/file", response_model=GetDocumentResponse)
@@ -151,9 +212,7 @@ def put_document_by_path(
     msg = f"{change_kind} {rel}"
     # Read-modify-write: only when editing an existing page from a known base.
     # New pages (and force-saves with no base_sha) commit as-is.
-    base_body = (
-        wiki_git.read_file(rel, ref=req.base_sha) if existed and req.base_sha else None
-    )
+    base_body = wiki_git.read_file(rel, ref=req.base_sha) if existed and req.base_sha else None
     try:
         # skip_acl: the write gate already ran above via require_can. ai_merge
         # is off so an unresolvable merge raises -> 409 (the conflict UI).

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -102,6 +102,24 @@ class StarredDocsResponse(BaseModel):
     paths: list[str]
 
 
+class RecentPageView(BaseModel):
+    """A recently-updated page for the home-page "Recent Pages" grid.
+
+    ``title`` is the doc's leading ``# H1`` when present, else the
+    filename. ``preview`` is the body with frontmatter and that leading
+    heading stripped — the card renders it as masked markdown.
+    """
+
+    path: str
+    title: str
+    updated_at: str
+    preview: str
+
+
+class ListRecentPagesResponse(BaseModel):
+    pages: list[RecentPageView]
+
+
 class GetDocumentResponse(BaseModel):
     path: str
     body: str

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -163,7 +163,9 @@ def commit_file(
                         raise GitCommitLockError(rel_path) from e
                     log.info(
                         "commit_file: lock race for %s, retrying (%d/%d)",
-                        rel_path, attempt + 1, _COMMIT_RETRY_MAX,
+                        rel_path,
+                        attempt + 1,
+                        _COMMIT_RETRY_MAX,
                     )
                     time.sleep(0.05 * (attempt + 1))
                     continue
@@ -503,6 +505,42 @@ def list_paths_with_mtime(prefix: str = "") -> list[tuple[str, str]]:
             mtime[line] = current_ts
     tracked = list_paths(prefix)
     return [(p, mtime.get(p, "")) for p in tracked]
+
+
+def paths_authored_by(author_email: str, limit: int = 50) -> list[tuple[str, str]]:
+    """``(.md path, ISO author-time)`` for files this author last touched.
+
+    Newest-first by author-time, one entry per path (first sighting wins).
+    Used by the home "Recent Pages" grid to surface pages the current user
+    has actually worked on (created or edited), not every recent page.
+    """
+    sep = "\x1f"
+    # Bound the walk so a deep history isn't fully scanned on every home-page
+    # load. A path can recur across commits, so allow generous headroom over
+    # `limit` to still collect that many distinct paths.
+    out = _run(
+        [
+            "log",
+            "--max-count=%d" % (limit * 20),
+            # --author is a regex; escape so metachars in an email (".", "+")
+            # match literally and can't pull in or skip the wrong author.
+            "--author=%s" % re.escape(author_email),
+            "--name-only",
+            "--pretty=format:%s%%aI" % sep,
+        ],
+        check=False,
+    ).stdout
+    seen: dict[str, str] = {}
+    current_ts: str | None = None
+    for line in out.splitlines():
+        if line.startswith(sep):
+            current_ts = line[len(sep) :]
+            continue
+        if not line or current_ts is None:
+            continue
+        if line.endswith(".md") and line not in seen:
+            seen[line] = current_ts
+    return list(seen.items())[:limit]
 
 
 def paths_changed_in(sha: str) -> list[str]:

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -35,6 +35,7 @@ import { TriggerModal } from "@/components/triggers/TriggerModal";
 import { DiffView } from "@/components/wiki/DiffView";
 import { HistoryPanel } from "@/components/wiki/HistoryPanel";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
+import { WikiHome } from "@/components/wiki/WikiHome";
 import {
   closeSession,
   useAgentSessions,
@@ -139,13 +140,12 @@ export default function WikiRoute() {
       </main>
     );
 
-  return isFile ? (
-    <FileViewer path={slugPath} />
-  ) : isNewMode ? (
-    <NewDocView dir={slugPath} />
-  ) : (
-    <Explorer dir={slugPath} />
-  );
+  if (isFile) return <FileViewer path={slugPath} />;
+  if (isNewMode) return <NewDocView dir={slugPath} />;
+  // Wiki root with no doc open → the "Welcome to Onyx Wiki" landing.
+  // Sub-folders still render the directory explorer.
+  if (slugPath === "") return <WikiHome />;
+  return <Explorer dir={slugPath} />;
 }
 
 function Explorer({ dir }: { dir: string }) {
@@ -521,6 +521,7 @@ function Explorer({ dir }: { dir: string }) {
 
 function NewDocView({ dir }: { dir: string }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const isMobile = useIsMobile();
   const { setDrafting, requestExpand } = useDrafting();
   const [filename, setFilename] = useState("");
@@ -622,6 +623,21 @@ function NewDocView({ dir }: { dir: string }) {
     // session.
     setDrafting({ kind: "blank", path: null });
   }
+
+  // Deep-link from the home page: ``?template=<id>`` pre-applies that
+  // template once the summaries load, so the landing's template cards
+  // drop the user straight into a seeded draft.
+  const templateParam = searchParams?.get("template") ?? null;
+  const autoTemplateRef = useRef(false);
+  useEffect(() => {
+    if (autoTemplateRef.current) return;
+    if (!templateParam || !templates) return;
+    const match = templates.find((t) => t.id === templateParam);
+    if (!match) return;
+    autoTemplateRef.current = true;
+    void onPickTemplate(match);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [templateParam, templates]);
 
   async function onCreate() {
     if (!filenameValid) {

--- a/frontend/src/app/css/z-index.css
+++ b/frontend/src/app/css/z-index.css
@@ -1,0 +1,51 @@
+:root {
+  /* Base layers */
+  --z-base: 0;
+  --z-content: 1;
+  /* Settings header must sit above sticky table headers (--z-sticky: 10) so
+     the page header scrolls over pinned columns without being obscured. */
+  --z-settings-header: 11;
+  --z-app-layout: 9;
+  --z-sticky: 10;
+
+  /* Interactive overlays */
+  --z-modal-overlay: 900;
+  --z-modal: 1000;
+  --z-toast: 1100;
+  --z-popover: 1200;
+  --z-tooltip: 1300;
+}
+
+/* Base layers */
+.z-base {
+  z-index: var(--z-base);
+}
+.z-content {
+  z-index: var(--z-content);
+}
+.z-settings-header {
+  z-index: var(--z-settings-header);
+}
+.z-app-layout {
+  z-index: var(--z-app-layout);
+}
+.z-sticky {
+  z-index: var(--z-sticky);
+}
+
+/* Interactive overlays */
+.z-modal-overlay {
+  z-index: var(--z-modal-overlay);
+}
+.z-modal {
+  z-index: var(--z-modal);
+}
+.z-toast {
+  z-index: var(--z-toast);
+}
+.z-popover {
+  z-index: var(--z-popover);
+}
+.z-tooltip {
+  z-index: var(--z-tooltip);
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "@onyx-ai/opal/root.css";
+@import "./css/z-index.css";
 @config "../../tailwind.config.cjs";
 
 /* Tell the browser which color scheme is active so native UI (scrollbars,
@@ -72,12 +73,11 @@
 
 /* ── Radix popovers ───────────────────────────────────────────────────────
    Opal's Popover/SelectButton menus must float above modal scrims
-   (z-index 100–110). Radix sets `z-index: auto` inline on the wrapper
-   and Opal strips className/style from Popover.Content, so !important
-   is the only way to lift the menu above the modal.
-   ───────────────────────────────────────────────────────────────────── */
+   (--z-modal). Radix sets `z-index: auto` inline on the wrapper and Opal
+   strips className/style from Popover.Content, so !important is the only way
+   to lift the menu above the modal. Uses the onyx --z-popover layer. */
 [data-radix-popper-content-wrapper] {
-  z-index: 1000 !important;
+  z-index: var(--z-popover) !important;
 }
 
 /* Floating menus keep their shadow for depth but drop the hard border. */

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -8,7 +8,7 @@
   align-items: flex-start;
   justify-content: center;
   padding: max(20px, min(80px, 5vh)) 16px;
-  z-index: 100;
+  z-index: var(--z-modal);
 }
 
 .dialog {

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   Button,
@@ -187,6 +187,10 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
         : "public-read";
   const [query, setQuery] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
+  // The input anchors the results popover. Radix would treat the click that
+  // focuses the input as an "outside" interaction and dismiss the popover the
+  // instant it opens; this ref lets us keep it open for anchor interactions.
+  const anchorRef = useRef<HTMLDivElement>(null);
   const [transferOpen, setTransferOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
@@ -437,7 +441,7 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                 }}
               >
                 <Popover.Anchor asChild>
-                  <div className={styles.anchorWrap}>
+                  <div className={styles.anchorWrap} ref={anchorRef}>
                     <InputTypeIn
                       searchIcon
                       placeholder="Add users and groups"
@@ -459,6 +463,15 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
                   }
                   onOpenAutoFocus={(e) => e.preventDefault()}
                   onCloseAutoFocus={(e) => e.preventDefault()}
+                  onInteractOutside={(e) => {
+                    // Keep the results open when the interaction is on the
+                    // input itself (the click that opened it).
+                    const target = (e.detail as { originalEvent: Event })
+                      .originalEvent.target as Node | null;
+                    if (target && anchorRef.current?.contains(target)) {
+                      e.preventDefault();
+                    }
+                  }}
                 >
                   <PopoverMenu>
                     {pickerGroups.map((g) => {

--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -1,0 +1,268 @@
+/* Home / "Welcome to Onyx Wiki" landing. Colors, borders, and surfaces all
+   come from OPAL components (SelectCard, Divider, InputTypeIn, Button, Text,
+   Section). These classes are layout-only — column width, the card grids, the
+   gutter offset, and the masked markdown preview (which has no OPAL primitive). */
+
+.scroll {
+  height: 100vh;
+  overflow-y: auto;
+}
+
+/* Top header — folder chip + breadcrumb */
+.topHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+}
+
+/* Directory breadcrumb — Home › seg › seg */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.modeBox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--border-radius-12);
+  background: var(--background-tint-03);
+  color: var(--text-05);
+}
+
+.crumb {
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--text-04);
+}
+
+.body {
+  display: flex;
+  align-items: flex-start;
+  /* Gap kept wider than the AI-input gutter icon's -28px hang so the centered
+     column can never sit close enough for that icon to overlap the sidebar. */
+  gap: 40px;
+  padding: 0 16px 64px;
+}
+
+/* Permanent directory sidebar — sticky; its list scrolls rather than growing. */
+.sidebar {
+  flex: 0 0 240px;
+  width: 240px;
+  position: sticky;
+  top: 8px;
+  align-self: flex-start;
+}
+
+.column {
+  flex: 1;
+  max-width: 672px;
+  margin: 0 auto;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+/* Hero */
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 4px 16px 24px;
+}
+
+.heroMark {
+  display: flex;
+  color: var(--text-05);
+}
+
+.heroTitle {
+  margin: 0;
+  font-size: 24px;
+  line-height: 36px;
+  font-weight: 600;
+  letter-spacing: -0.24px;
+  color: var(--text-04);
+}
+
+.dividerWrap {
+  padding: 0 16px;
+}
+.midDividerWrap {
+  padding: 24px 16px;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px 4px;
+}
+
+.secHead {
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 600;
+  color: var(--text-04);
+}
+
+.secHeadLg {
+  font-size: 18px;
+  line-height: 28px;
+  font-weight: 600;
+  letter-spacing: -0.18px;
+  color: var(--text-04);
+}
+
+/* Templates strip */
+.templates {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 8px;
+}
+.templateCell {
+  display: flex;
+  min-width: 0;
+}
+
+/* "More Templates" — full-width row: label left, chevron far right (mock 319:27988). */
+.moreRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+  margin: 0 8px;
+  width: calc(100% - 16px);
+  padding: 8px;
+  border: none;
+  background: transparent;
+  border-radius: var(--border-radius-04);
+  cursor: pointer;
+}
+.moreRow:hover {
+  background: var(--background-tint-03);
+}
+.moreLabel {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-04);
+}
+.moreChevron {
+  color: var(--text-03);
+  flex: 0 0 auto;
+}
+
+/* Blank-page glyph — plain OPAL plus-circle icon, not an interactive Button. */
+.blankGlyph {
+  display: inline-flex;
+  color: var(--text-03);
+}
+
+/* AI input — box left edge aligns with the card grid (padding 8px); the octagon
+   mark hangs into the left gutter, vertically centered, out of the input flow. */
+.aiRow {
+  position: relative;
+  padding: 8px 8px;
+}
+.aiGutterIcon {
+  position: absolute;
+  left: -28px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  color: var(--text-03);
+}
+.aiInputWrap {
+  width: 100%;
+  min-width: 0;
+}
+
+/* Recent Pages grid */
+.recentGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 0 8px;
+}
+.recentCell {
+  display: flex;
+  min-width: 0;
+}
+
+/* Card body layout — fixed height with a masked, fading markdown preview. */
+.recentInner {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  height: 144px;
+  overflow: hidden;
+}
+
+.cardHead {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 12px;
+  overflow: hidden;
+}
+
+.cardFoot {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+  padding: 4px 4px 4px 12px;
+}
+
+.cardPreview {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  color: var(--text-03);
+  -webkit-mask-image: linear-gradient(to bottom, #000 62%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 62%, transparent 100%);
+}
+.cardPreview :global(*) {
+  font-size: 12px !important;
+  line-height: 16px !important;
+  margin: 0 0 2px !important;
+  overflow-wrap: break-word;
+}
+.cardPreview :global(h1),
+.cardPreview :global(h2),
+.cardPreview :global(h3),
+.cardPreview :global(strong) {
+  font-weight: 600;
+  color: var(--text-04);
+}
+.cardPreview :global(pre),
+.cardPreview :global(code) {
+  white-space: pre-wrap;
+}
+
+.empty {
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--text-03);
+}
+
+@media (max-width: 720px) {
+  .column {
+    width: 100%;
+  }
+  .templates,
+  .recentGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import useSWR from "swr";
+
+import {
+  Button,
+  Divider,
+  InputTypeIn,
+  SelectCard,
+  Text,
+} from "@onyx-ai/opal/components";
+import { Section } from "@onyx-ai/opal/layouts";
+import {
+  SvgArrowUp,
+  SvgChevronRight,
+  SvgFolder,
+  SvgMoreHorizontal,
+  SvgOnyxOctagon,
+  SvgPlusCircle,
+} from "@onyx-ai/opal/icons";
+import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
+
+import { relativeTime } from "@/lib/time";
+import { listTemplateSummaries } from "@/lib/templates";
+import type { DocumentTemplateSummary } from "@/lib/templates";
+import type { RecentPage } from "@/lib/wiki";
+
+import { WikiTree } from "./WikiTree";
+import styles from "./WikiHome.module.css";
+
+// Stash key for the typed "write with AI" prompt; the new-page composer
+// picks it up to seed the assistant.
+const AI_PROMPT_KEY = "wiki:aiPrompt";
+
+export function WikiHome() {
+  const router = useRouter();
+  const [aiPrompt, setAiPrompt] = useState("");
+
+  const { data: recentData } = useSWR<{ pages: RecentPage[] }>(
+    "/wiki/recent?limit=12",
+  );
+  const recent = recentData?.pages ?? [];
+
+  const { data: templates } = useSWR<DocumentTemplateSummary[]>(
+    "templates:summaries",
+    listTemplateSummaries,
+  );
+  const featured = (templates ?? []).slice(0, 2);
+
+  function startNewPage(templateId?: string) {
+    const qs = templateId
+      ? `?new=1&template=${encodeURIComponent(templateId)}`
+      : "?new=1";
+    router.push(`/app/wiki${qs}`);
+  }
+
+  function onAiSubmit(e: FormEvent) {
+    e.preventDefault();
+    const prompt = aiPrompt.trim();
+    if (!prompt) return;
+    try {
+      sessionStorage.setItem(AI_PROMPT_KEY, prompt);
+    } catch {
+      // sessionStorage may be unavailable (private mode).
+    }
+    router.push("/app/wiki?new=1");
+  }
+
+  return (
+    <main className={styles.scroll}>
+      {/* Top header — breadcrumb (Home root; tree self-navigates by expanding) */}
+      <div className={styles.topHeader}>
+        <div className={styles.breadcrumb}>
+          <span className={styles.modeBox}>
+            <SvgFolder size={18} />
+          </span>
+          <span className={styles.crumb}>Home</span>
+        </div>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.sidebar}>
+          <WikiTree />
+        </div>
+
+        <div className={styles.column}>
+          {/* Hero */}
+          <div className={styles.hero}>
+            <span className={styles.heroMark}>
+              <SvgOnyxLogo size={32} />
+            </span>
+            <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
+          </div>
+          <div className={styles.dividerWrap}>
+            <Divider />
+          </div>
+
+          {/* Start a new page */}
+          <div className={styles.sectionHeader}>
+            <span className={styles.secHead}>Start a new page</span>
+          </div>
+          <div className={styles.templates}>
+            <div className={styles.templateCell}>
+              <TemplateCard
+                title="Blank page"
+                glyph={
+                  <span className={styles.blankGlyph}>
+                    <SvgPlusCircle size={22} />
+                  </span>
+                }
+                onClick={() => startNewPage()}
+              />
+            </div>
+            {featured.map((t) => (
+              <div key={t.id} className={styles.templateCell}>
+                <TemplateCard
+                  title={t.name}
+                  description={t.description ?? ""}
+                  onClick={() => startNewPage(t.id)}
+                />
+              </div>
+            ))}
+          </div>
+          <button
+            type="button"
+            className={styles.moreRow}
+            onClick={() => startNewPage()}
+          >
+            <span className={styles.moreLabel}>More Templates</span>
+            <SvgChevronRight size={18} className={styles.moreChevron} />
+          </button>
+
+          {/* Write with AI */}
+          <div className={styles.aiRow}>
+            <span className={styles.aiGutterIcon}>
+              <SvgOnyxOctagon size={18} />
+            </span>
+            <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
+              <InputTypeIn
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                placeholder="Start writing with AI…"
+                aria-label="Start writing with AI"
+                rightChildren={
+                  <Button
+                    type="submit"
+                    size="sm"
+                    prominence="tertiary"
+                    icon={SvgArrowUp}
+                    disabled={!aiPrompt.trim()}
+                    aria-label="Start writing"
+                  />
+                }
+              />
+            </form>
+          </div>
+
+          <div className={styles.midDividerWrap}>
+            <Divider />
+          </div>
+
+          {/* Recent Pages */}
+          <div className={styles.sectionHeader}>
+            <span className={styles.secHeadLg}>Recent Pages</span>
+          </div>
+          {recent.length === 0 ? (
+            <p className={styles.empty}>
+              No pages yet. Create one to get started.
+            </p>
+          ) : (
+            <div className={styles.recentGrid}>
+              {recent.map((p) => (
+                <div key={p.path} className={styles.recentCell}>
+                  <RecentCard
+                    page={p}
+                    onClick={() => router.push(`/app/wiki/${p.path}`)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function TemplateCard({
+  title,
+  description,
+  glyph,
+  onClick,
+}: {
+  title: string;
+  description?: string;
+  glyph?: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <SelectCard
+      state="empty"
+      onClick={onClick}
+      padding="sm"
+      rounding="lg"
+      border="solid"
+    >
+      <Section
+        flexDirection="column"
+        alignItems="start"
+        justifyContent="start"
+        gap={0.25}
+        width="full"
+        height="full"
+      >
+        <Text font="main-ui-action" color="text-05" nowrap>
+          {title}
+        </Text>
+        {glyph ? (
+          glyph
+        ) : description ? (
+          <Text font="secondary-body" color="text-03">
+            {description}
+          </Text>
+        ) : null}
+      </Section>
+    </SelectCard>
+  );
+}
+
+function RecentCard({
+  page,
+  onClick,
+}: {
+  page: RecentPage;
+  onClick: () => void;
+}) {
+  return (
+    <SelectCard
+      state="empty"
+      onClick={onClick}
+      padding="fit"
+      rounding="lg"
+      border="solid"
+    >
+      <div className={styles.recentInner}>
+        <div className={styles.cardHead}>
+          <Text font="main-ui-action" color="text-04" nowrap>
+            {page.title}
+          </Text>
+          <div className={styles.cardPreview}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              {page.preview}
+            </ReactMarkdown>
+          </div>
+        </div>
+        <Divider />
+        <div className={styles.cardFoot}>
+          <Text font="secondary-body" color="text-03" nowrap>
+            {page.updated_at
+              ? `Updated ${relativeTime(page.updated_at, "long")}`
+              : "—"}
+          </Text>
+          <Button
+            size="sm"
+            prominence="tertiary"
+            icon={SvgMoreHorizontal}
+            aria-label="More"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+          />
+        </div>
+      </div>
+    </SelectCard>
+  );
+}

--- a/frontend/src/components/wiki/WikiItemModals.module.css
+++ b/frontend/src/components/wiki/WikiItemModals.module.css
@@ -1,4 +1,5 @@
-/* Layout only — typography, inputs, menus, and buttons come from OPAL. */
+/* Rename / Move modals — same shell conventions as TransferModal (scrim via
+   --mask-03, --shadow-modal, radius-lg). Layout only. */
 
 .scrim {
   position: fixed;
@@ -14,12 +15,17 @@
 .dialog {
   background: var(--background-tint-01);
   border-radius: var(--border-radius-12);
-  width: min(480px, 100%);
+  width: min(440px, 100%);
   max-height: calc(100vh - 80px);
   box-shadow: var(--shadow-modal);
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* Wider variant for the move modal so full folder paths stay readable. */
+.dialogWide {
+  width: min(720px, 100%);
 }
 
 .header {
@@ -48,29 +54,33 @@
   flex-direction: column;
   gap: 8px;
   padding: 16px;
+  min-height: 0;
 }
 
-.anchorWrap {
-  display: block;
-  width: 100%;
-}
-
-/* Selected new-owner row — same shaded line-item treatment as the share
-   modal's grantee rows. */
-.selectedRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  min-height: 48px;
-  padding: 6px 8px;
-  background: var(--background-tint-02);
-  border-radius: var(--border-radius-08);
-}
-.rowText {
+/* Scrollable destination folder TREE for the move modal — folders expand to
+   reveal nested subfolders. */
+.destList {
   display: flex;
   flex-direction: column;
-  min-width: 0;
+  gap: 2px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+.destRow {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  box-sizing: border-box;
+}
+/* Aligns chevron-less rows with the OPAL chevron Button's 16px footprint so
+   every folder icon lines up regardless of whether the row has a chevron. */
+.destChevronSpacer {
+  flex: 0 0 auto;
+  width: 16px;
+}
+.destTab {
   flex: 1;
+  min-width: 0;
 }
 
 .footer {

--- a/frontend/src/components/wiki/WikiItemModals.tsx
+++ b/frontend/src/components/wiki/WikiItemModals.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import {
+  Button,
+  InputTypeIn,
+  SidebarTab,
+  Text,
+} from "@onyx-ai/opal/components";
+import {
+  SvgChevronDown,
+  SvgChevronRight,
+  SvgEdit,
+  SvgFolder,
+  SvgFolderIn,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+import { markdown } from "@onyx-ai/opal/utils";
+
+import { apiFetch } from "@/lib/api";
+import { lastSegment } from "@/lib/wiki";
+
+import styles from "./WikiItemModals.module.css";
+
+const isFolderPath = (path: string) => !path.endsWith(".md");
+const parentOf = (path: string) =>
+  path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "";
+const baseName = (path: string) => path.slice(path.lastIndexOf("/") + 1);
+
+async function movePath(oldPath: string, newPath: string) {
+  await apiFetch("/wiki/move", {
+    method: "POST",
+    body: JSON.stringify({ old_path: oldPath, new_path: newPath }),
+  });
+}
+
+function useEscape(onClose: () => void) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+}
+
+/** Rename a file or folder in place (same parent, new last segment). */
+export function RenameModal({
+  path,
+  onClose,
+  onDone,
+}: {
+  path: string;
+  onClose: () => void;
+  onDone: (newPath: string) => void;
+}) {
+  const folder = isFolderPath(path);
+  const parent = parentOf(path);
+  const current = folder ? baseName(path) : baseName(path).replace(/\.md$/, "");
+  const [name, setName] = useState(current);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEscape(onClose);
+
+  const submit = async () => {
+    const clean = name.trim().replace(/\//g, "");
+    if (!clean) return;
+    if (clean === current) {
+      onClose();
+      return;
+    }
+    const newPath =
+      (parent ? `${parent}/` : "") + clean + (folder ? "" : ".md");
+    setBusy(true);
+    setError(null);
+    try {
+      await movePath(path, newPath);
+      onDone(newPath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Rename failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className={styles.scrim}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className={styles.dialog} role="dialog" aria-modal="true">
+        <header className={styles.header}>
+          <span className={styles.headerIcon}>
+            <SvgEdit size={20} />
+          </span>
+          <div className={styles.headerText}>
+            <Text as="h2" font="main-content-emphasis">
+              {markdown(`Rename *${lastSegment(path)}*`)}
+            </Text>
+          </div>
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgX}
+            tooltip="Close"
+            onClick={onClose}
+          />
+        </header>
+
+        <div className={styles.content}>
+          <InputTypeIn
+            value={name}
+            autoFocus
+            placeholder={folder ? "Folder name" : "Page name"}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submit();
+            }}
+          />
+          {error && (
+            <Text font="secondary-body" color="text-02">
+              {error}
+            </Text>
+          )}
+        </div>
+
+        <footer className={styles.footer}>
+          <Button prominence="tertiary" size="md" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="action"
+            size="md"
+            disabled={busy || !name.trim()}
+            onClick={() => void submit()}
+          >
+            {busy ? "Renaming…" : "Rename"}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+/** Direct child folders of `parent`, derived from the flat folder-path list. */
+function subfoldersOf(folders: string[], parent: string): string[] {
+  const prefix = parent ? `${parent}/` : "";
+  const direct = new Set<string>();
+  for (const f of folders) {
+    if (!f || f === parent || !f.startsWith(prefix)) continue;
+    const seg = f.slice(prefix.length).split("/")[0];
+    if (seg) direct.add(prefix + seg);
+  }
+  return [...direct].sort((a, b) => a.localeCompare(b));
+}
+
+/** One expandable destination folder in the move tree. Folders with children
+ * can be expanded to drill into nested subfolders; invalid destinations (the
+ * item's current parent, or a moved folder's own subtree) are shown disabled
+ * so they can still be navigated through. */
+function DestNode({
+  dest,
+  folders,
+  target,
+  onSelect,
+  canSelect,
+  depth,
+}: {
+  dest: string;
+  folders: string[];
+  target: string | null;
+  onSelect: (dest: string) => void;
+  canSelect: (dest: string) => boolean;
+  depth: number;
+}) {
+  const [open, setOpen] = useState(false);
+  const subs = subfoldersOf(folders, dest);
+  const selectable = canSelect(dest);
+  return (
+    <>
+      <div
+        className={styles.destRow}
+        style={{ paddingLeft: `${depth * 16}px` }}
+      >
+        {subs.length > 0 ? (
+          <Button
+            prominence="tertiary"
+            size="2xs"
+            icon={open ? SvgChevronDown : SvgChevronRight}
+            tooltip={open ? "Collapse" : "Expand"}
+            onClick={() => setOpen((o) => !o)}
+          />
+        ) : (
+          <span className={styles.destChevronSpacer} />
+        )}
+        <div className={styles.destTab}>
+          <SidebarTab
+            variant="sidebar-light"
+            icon={SvgFolder}
+            selected={target === dest}
+            disabled={!selectable}
+            onClick={() => selectable && onSelect(dest)}
+          >
+            {baseName(dest)}
+          </SidebarTab>
+        </div>
+      </div>
+      {open &&
+        subs.map((s) => (
+          <DestNode
+            key={s}
+            dest={s}
+            folders={folders}
+            target={target}
+            onSelect={onSelect}
+            canSelect={canSelect}
+            depth={depth + 1}
+          />
+        ))}
+    </>
+  );
+}
+
+/** Move a file or folder into a different existing folder. */
+export function MoveModal({
+  path,
+  folders,
+  onClose,
+  onDone,
+}: {
+  path: string;
+  folders: string[];
+  onClose: () => void;
+  onDone: (newPath: string) => void;
+}) {
+  const folder = isFolderPath(path);
+  const parent = parentOf(path);
+  const base = baseName(path);
+
+  // A folder is a valid destination unless it's the item's current parent
+  // (no-op) or — for a folder being moved — itself or one of its descendants.
+  const canSelect = (dest: string) =>
+    dest !== parent &&
+    !(folder && (dest === path || dest.startsWith(`${path}/`)));
+
+  const rootFolders = subfoldersOf(folders, "");
+
+  const [target, setTarget] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useEscape(onClose);
+
+  const submit = async () => {
+    if (target === null) return;
+    const newPath = (target ? `${target}/` : "") + base;
+    setBusy(true);
+    setError(null);
+    try {
+      await movePath(path, newPath);
+      onDone(newPath);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Move failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className={styles.scrim}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className={`${styles.dialog} ${styles.dialogWide}`}
+        role="dialog"
+        aria-modal="true"
+      >
+        <header className={styles.header}>
+          <span className={styles.headerIcon}>
+            <SvgFolderIn size={20} />
+          </span>
+          <div className={styles.headerText}>
+            <Text as="h2" font="main-content-emphasis">
+              {markdown(`Move *${lastSegment(path)}*`)}
+            </Text>
+          </div>
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgX}
+            tooltip="Close"
+            onClick={onClose}
+          />
+        </header>
+
+        <div className={styles.content}>
+          <Text font="secondary-action" color="text-02">
+            Move to
+          </Text>
+          <div className={styles.destList}>
+            <div className={styles.destRow}>
+              <span className={styles.destChevronSpacer} />
+              <div className={styles.destTab}>
+                <SidebarTab
+                  variant="sidebar-light"
+                  icon={SvgFolder}
+                  selected={target === ""}
+                  disabled={!canSelect("")}
+                  onClick={() => canSelect("") && setTarget("")}
+                >
+                  Home
+                </SidebarTab>
+              </div>
+            </div>
+            {rootFolders.map((f) => (
+              <DestNode
+                key={f}
+                dest={f}
+                folders={folders}
+                target={target}
+                onSelect={setTarget}
+                canSelect={canSelect}
+                depth={0}
+              />
+            ))}
+          </div>
+          {error && (
+            <Text font="secondary-body" color="text-02">
+              {error}
+            </Text>
+          )}
+        </div>
+
+        <footer className={styles.footer}>
+          <Button prominence="tertiary" size="md" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="action"
+            size="md"
+            disabled={busy || target === null}
+            onClick={() => void submit()}
+          >
+            {busy ? "Moving…" : "Move"}
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -1,0 +1,141 @@
+/* Permanent directory sidebar. Shows one level at a time; the list scrolls
+   instead of the panel growing. Panel surface matches the mock: filled
+   tint card (#fafafa → bg-panel), #e6e6e6 → border-default, 12px radius. */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--background-tint-01);
+  border: 1px solid var(--border-01);
+  border-radius: var(--border-radius-12);
+  padding: 4px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 4px 4px 8px 12px;
+  box-sizing: border-box;
+}
+
+.actions {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}
+
+/* Inline new-folder input (OPAL InputTypeIn) — appears under the header when
+   the +folder button is toggled. */
+.folderForm {
+  padding: 2px 4px 6px;
+}
+.folderError {
+  padding: 2px 8px 6px;
+  font-size: 12px;
+  color: var(--status-text-error-05);
+}
+
+/* Tree list — scrolls both axes rather than growing or truncating. Vertical
+   when it outgrows the viewport; horizontal when deep nesting + long names
+   run past the panel width (labels keep their natural width below). */
+.list {
+  max-height: calc(100vh - 120px);
+  overflow: auto;
+  width: 100%;
+}
+
+/* Let row labels keep their full width (OPAL truncates with an ellipsis by
+   default) so long/deep names overflow and drive the horizontal scroll. */
+.list :global(p) {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+/* Expanded folder's children — indented one level (mock's "Folded" pl-8).
+   Recursion accumulates 8px per depth; sized to content so it can overflow. */
+.nested {
+  width: max-content;
+  min-width: 100%;
+  padding-left: 8px;
+  box-sizing: border-box;
+}
+
+/* Row wrapper — holds the SidebarTab plus the hover-revealed "⋯" menu, which
+   overlays the row's right edge (panel-coloured so it sits over the label). */
+.rowWrap {
+  position: relative;
+  width: 100%;
+}
+.rowMenu {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.rowWrap:hover .rowMenu,
+.rowMenu:focus-within,
+.rowMenu[data-open] {
+  opacity: 1;
+}
+/* "⋯" More button (657:29879): 24px, white surface (tint/00 → bg-page),
+   rounded-08 (md). Sits over the row's right edge. */
+.moreBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--border-radius-08);
+  background: var(--background-tint-00);
+  color: var(--text-03);
+  cursor: pointer;
+}
+.moreBtn:hover {
+  background: var(--background-tint-03);
+  color: var(--text-04);
+}
+
+/* Contextual menu (657:41564): fixed 160px width, line items in a column. */
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 160px;
+  box-sizing: border-box;
+}
+/* Delete item — danger red (#dc2626 → --status-text-error-05) on icon + label.
+   !important to override OPAL LineItemButton's own text/icon color; scoped to
+   the single wrapped Delete item. */
+.danger,
+.danger :global(*) {
+  color: var(--status-text-error-05) !important;
+}
+
+.empty {
+  padding: 8px 12px;
+}
+
+/* Transient toast (e.g. "Link copied") — bottom-centre, auto-dismisses. */
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
+  z-index: var(--z-toast);
+  padding: 8px 14px;
+  border-radius: var(--border-radius-08);
+  background: var(--background-tint-04);
+  color: var(--text-05);
+  font-size: 13px;
+  box-shadow: var(--shadow-popover);
+}

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type FormEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import useSWR, { useSWRConfig } from "swr";
+
+import {
+  Button,
+  Divider,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  SidebarTab,
+  Text,
+} from "@onyx-ai/opal/components";
+import {
+  SvgEdit,
+  SvgFileText,
+  SvgFolder,
+  SvgFolderIn,
+  SvgFolderOpen,
+  SvgFolderPlus,
+  SvgLink,
+  SvgMoreHorizontal,
+  SvgPlus,
+  SvgShare,
+  SvgSparkle,
+  SvgTrash,
+} from "@onyx-ai/opal/icons";
+
+import { apiFetch } from "@/lib/api";
+import { RunAgentPanel } from "./RunAgentPanel";
+import { ShareDialog } from "./ShareDialog";
+import { MoveModal, RenameModal } from "./WikiItemModals";
+import styles from "./WikiTree.module.css";
+
+interface Entry {
+  path: string;
+  updated_at: string;
+}
+
+// Persist which folders are expanded so the tree restores on refresh.
+const EXPANDED_KEY = "wiki:expandedFolders";
+
+/** Per-row contextual-menu actions, provided once by WikiTree and consumed by
+ * every RowMenu via context (avoids drilling through the recursive tree). */
+interface RowActions {
+  share: (path: string) => void;
+  rename: (path: string) => void;
+  move: (path: string) => void;
+  copyLink: (path: string) => void;
+  launchAgent: (path: string) => void;
+  remove: (path: string, isFolder: boolean) => void;
+}
+const ActionsContext = createContext<RowActions | null>(null);
+
+/** Direct child folders + files of `dir`, derived from the flat path list. */
+function childrenOf(entries: Entry[], dir: string) {
+  const prefix = dir ? dir + "/" : "";
+  const folders = new Set<string>();
+  const files: string[] = [];
+  for (const e of entries) {
+    if (!e.path.startsWith(prefix)) continue;
+    const rest = e.path.slice(prefix.length);
+    if (!rest) continue;
+    const slash = rest.indexOf("/");
+    if (slash === -1) {
+      if (rest.endsWith(".md")) files.push(rest);
+    } else {
+      folders.add(rest.slice(0, slash));
+    }
+  }
+  return {
+    folders: [...folders].sort((a, b) => a.localeCompare(b)),
+    files: files.sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+/** Every folder path in the tree (plus root ""), for the move-destination list. */
+function collectFolders(entries: Entry[]): string[] {
+  const set = new Set<string>([""]);
+  for (const e of entries) {
+    const parts = e.path.split("/");
+    parts.pop();
+    let cur = "";
+    for (const p of parts) {
+      cur = cur ? `${cur}/${p}` : p;
+      set.add(cur);
+    }
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+type IconComponent = React.ComponentProps<typeof SidebarTab>["icon"];
+
+/**
+ * Per-row "⋯" actions menu (contextual menu node 657:41564). Spec: 160px wide,
+ * compact line items, two dividers, Delete in danger red. Folders omit
+ * "Launch Agent" (it adds a doc to an agent run). The trigger stops propagation
+ * so it doesn't navigate/expand the row.
+ */
+function RowMenu({
+  path,
+  isFolder,
+  open,
+  onOpenChange,
+}: {
+  path: string;
+  isFolder: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const actions = useContext(ActionsContext);
+  const run = (fn?: (p: string) => void) => () => {
+    onOpenChange(false);
+    fn?.(path);
+  };
+  return (
+    <div className={styles.rowMenu} data-open={open || undefined}>
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <Popover.Trigger asChild>
+          <button
+            type="button"
+            className={styles.moreBtn}
+            aria-label="More actions"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <SvgMoreHorizontal size={16} />
+          </button>
+        </Popover.Trigger>
+        <Popover.Content align="start" sideOffset={4} width="fit">
+          <div className={styles.menu}>
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgShare}
+              title="Share"
+              onClick={run(actions?.share)}
+            />
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgEdit}
+              title="Rename"
+              onClick={run(actions?.rename)}
+            />
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgFolderIn}
+              title="Move"
+              onClick={run(actions?.move)}
+            />
+            <Divider />
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgLink}
+              title="Copy Link"
+              onClick={run(actions?.copyLink)}
+            />
+            {!isFolder && (
+              <LineItemButton
+                variant="body"
+                sizePreset="main-ui"
+                icon={SvgSparkle}
+                title="Launch Agent"
+                onClick={run(actions?.launchAgent)}
+              />
+            )}
+            <Divider />
+            <span className={styles.danger}>
+              <LineItemButton
+                variant="body"
+                sizePreset="main-ui"
+                icon={SvgTrash}
+                title="Delete"
+                onClick={() => {
+                  onOpenChange(false);
+                  actions?.remove(path, isFolder);
+                }}
+              />
+            </span>
+          </div>
+        </Popover.Content>
+      </Popover>
+    </div>
+  );
+}
+
+/**
+ * One tree row: an OPAL SidebarTab plus the hover-/open-revealed "⋯" menu. The
+ * row goes to its `selected` state while its menu is open, matching the mock's
+ * selected `Projects` row (657:29879).
+ */
+function Row({
+  icon,
+  label,
+  path,
+  isFolder,
+  onClick,
+}: {
+  icon: IconComponent;
+  label: string;
+  path: string;
+  isFolder: boolean;
+  onClick: () => void;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  return (
+    <div className={styles.rowWrap}>
+      <SidebarTab
+        variant="sidebar-light"
+        icon={icon}
+        selected={menuOpen}
+        onClick={onClick}
+      >
+        {label}
+      </SidebarTab>
+      <RowMenu
+        path={path}
+        isFolder={isFolder}
+        open={menuOpen}
+        onOpenChange={setMenuOpen}
+      />
+    </div>
+  );
+}
+
+/** A folder row that expands inline to show its children, indented one level
+ * (8px) via `.nested` — matching the mock's "Folded" group. */
+function FolderNode({
+  entries,
+  dir,
+  name,
+  onOpenFile,
+  expanded,
+  onToggle,
+}: {
+  entries: Entry[];
+  dir: string;
+  name: string;
+  onOpenFile: (path: string) => void;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+}) {
+  const full = dir ? `${dir}/${name}` : name;
+  const open = expanded.has(full);
+  const { folders, files } = open
+    ? childrenOf(entries, full)
+    : { folders: [], files: [] };
+  return (
+    <>
+      <Row
+        icon={open ? SvgFolderOpen : SvgFolder}
+        label={name}
+        path={full}
+        isFolder
+        onClick={() => onToggle(full)}
+      />
+      {open && (folders.length > 0 || files.length > 0) && (
+        <div className={styles.nested}>
+          {folders.map((f) => (
+            <FolderNode
+              key={f}
+              entries={entries}
+              dir={full}
+              name={f}
+              onOpenFile={onOpenFile}
+              expanded={expanded}
+              onToggle={onToggle}
+            />
+          ))}
+          {files.map((f) => (
+            <Row
+              key={f}
+              icon={SvgFileText}
+              label={f.replace(/\.md$/, "")}
+              path={`${full}/${f}`}
+              isFolder={false}
+              onClick={() => onOpenFile(`${full}/${f}`)}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+/**
+ * Permanent directory sidebar — a nested, expandable tree. Owns the per-row
+ * contextual-menu actions (share / rename / move / copy link / launch agent /
+ * delete), rendering the reused ShareDialog + RunAgentPanel and the Rename /
+ * Move modals once. The list scrolls rather than the panel growing.
+ */
+export function WikiTree() {
+  const router = useRouter();
+  const { mutate } = useSWRConfig();
+  const { data } = useSWR<{ entries: Entry[] }>("/wiki");
+  const entries = data?.entries ?? [];
+  const { folders, files } = childrenOf(entries, "");
+  const openFile = (path: string) => router.push(`/app/wiki/${path}`);
+
+  const [addingFolder, setAddingFolder] = useState(false);
+  const [folderName, setFolderName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Contextual-menu targets — each holds the path of the row that opened it.
+  const [sharePath, setSharePath] = useState<string | null>(null);
+  const [renamePath, setRenamePath] = useState<string | null>(null);
+  const [movePath, setMovePath] = useState<string | null>(null);
+  const [agentPath, setAgentPath] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  // Expanded folders, persisted to sessionStorage so they survive a refresh.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(EXPANDED_KEY);
+      if (raw) setExpanded(new Set(JSON.parse(raw) as string[]));
+    } catch {
+      // sessionStorage unavailable (private mode) — start collapsed.
+    }
+  }, []);
+  const toggleFolder = (path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      try {
+        sessionStorage.setItem(EXPANDED_KEY, JSON.stringify([...next]));
+      } catch {
+        // ignore persistence failure
+      }
+      return next;
+    });
+  };
+
+  const refresh = () => void mutate("/wiki");
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 2000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const actions: RowActions = {
+    share: setSharePath,
+    rename: setRenamePath,
+    move: setMovePath,
+    launchAgent: setAgentPath,
+    copyLink: (path) => {
+      const encoded = path.split("/").map(encodeURIComponent).join("/");
+      const url = `${window.location.origin}/app/wiki/${encoded}`;
+      navigator.clipboard
+        .writeText(url)
+        .then(() => setToast("Link copied"))
+        .catch(() => setToast("Couldn't copy link"));
+    },
+    remove: async (path, isFolder) => {
+      const label = path.replace(/\.md$/, "").split("/").pop() ?? path;
+      const message = isFolder
+        ? `Delete folder "${label}" and everything in it? This cannot be undone.`
+        : `Delete ${label}? This cannot be undone.`;
+      if (!window.confirm(message)) return;
+      try {
+        await apiFetch(`/wiki/file?path=${encodeURIComponent(path)}`, {
+          method: "DELETE",
+        });
+        refresh();
+      } catch (e) {
+        setToast(e instanceof Error ? e.message : "Delete failed");
+      }
+    },
+  };
+
+  async function createFolder(e: FormEvent) {
+    e.preventDefault();
+    const name = folderName.trim().replace(/\/+$/, "");
+    if (!name) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiFetch("/wiki/folder", {
+        method: "POST",
+        body: JSON.stringify({ path: name }),
+      });
+      setFolderName("");
+      setAddingFolder(false);
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "create failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <ActionsContext.Provider value={actions}>
+      <div className={styles.panel}>
+        <div className={styles.header}>
+          <Text font="secondary-body" color="text-03">
+            Directory
+          </Text>
+          <div className={styles.actions}>
+            <Button
+              prominence="tertiary"
+              size="sm"
+              icon={SvgPlus}
+              tooltip="New page"
+              onClick={() => router.push("/app/wiki?new=1")}
+            />
+            <Button
+              prominence="tertiary"
+              size="sm"
+              icon={SvgFolderPlus}
+              tooltip="New folder"
+              onClick={() => setAddingFolder((v) => !v)}
+            />
+          </div>
+        </div>
+
+        {addingFolder && (
+          <form className={styles.folderForm} onSubmit={createFolder}>
+            <InputTypeIn
+              value={folderName}
+              onChange={(e) => setFolderName(e.target.value)}
+              placeholder="folder-name (or subdir/folder-name)"
+              aria-label="New folder name"
+              autoFocus
+            />
+          </form>
+        )}
+        {error && <div className={styles.folderError}>{error}</div>}
+
+        <div className={styles.list}>
+          {folders.map((f) => (
+            <FolderNode
+              key={f}
+              entries={entries}
+              dir=""
+              name={f}
+              onOpenFile={openFile}
+              expanded={expanded}
+              onToggle={toggleFolder}
+            />
+          ))}
+          {files.map((f) => (
+            <Row
+              key={f}
+              icon={SvgFileText}
+              label={f.replace(/\.md$/, "")}
+              path={f}
+              isFolder={false}
+              onClick={() => openFile(f)}
+            />
+          ))}
+          {folders.length === 0 && files.length === 0 && (
+            <div className={styles.empty}>
+              <Text font="secondary-body" color="text-03">
+                No pages yet
+              </Text>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Overlays are portaled to <body> so they escape the sticky sidebar's
+          stacking context (otherwise the page content paints over the scrim). */}
+      {typeof document !== "undefined" &&
+        createPortal(
+          <>
+            {sharePath !== null && (
+              <ShareDialog
+                path={sharePath}
+                open
+                onClose={() => setSharePath(null)}
+              />
+            )}
+            {renamePath !== null && (
+              <RenameModal
+                path={renamePath}
+                onClose={() => setRenamePath(null)}
+                onDone={() => {
+                  setRenamePath(null);
+                  refresh();
+                }}
+              />
+            )}
+            {movePath !== null && (
+              <MoveModal
+                path={movePath}
+                folders={collectFolders(entries)}
+                onClose={() => setMovePath(null)}
+                onDone={() => {
+                  setMovePath(null);
+                  refresh();
+                }}
+              />
+            )}
+            {/* RunAgentPanel renders its own scrim, so no separate backdrop. */}
+            <RunAgentPanel
+              open={agentPath !== null}
+              onClose={() => setAgentPath(null)}
+              wikiPath={agentPath}
+            />
+            {toast && <div className={styles.toast}>{toast}</div>}
+          </>,
+          document.body,
+        )}
+    </ActionsContext.Provider>
+  );
+}

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -9,6 +9,14 @@ export function lastSegment(path: string): string {
   return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
 }
 
+/** Shape of a home "Recent Pages" card; the grid fetches `/wiki/recent` directly. */
+export interface RecentPage {
+  path: string;
+  title: string;
+  updated_at: string;
+  preview: string;
+}
+
 export interface WordDiff {
   prefix: string;
   removed: string;


### PR DESCRIPTION
## Description

Home / Welcome page + directory sidebar for the wiki.

- **Landing**: hero, "Start a new page" templates, write-with-AI input, Recent Pages grid.
- **Directory sidebar** (permanent): nested expandable tree, scrollable both axes, expanded folders persist to `sessionStorage`.
- **Per-row `⋯` menu**: Share (reuses `ShareDialog`), Rename + Move (new modals → `/wiki/move`; Move is an expandable folder-tree picker), Copy Link (toast), Launch Agent (reuses `RunAgentPanel`, files only), Delete. Red Delete; folders omit Launch Agent.
- **Backend**: `GET /api/wiki/recent` powers the recent grid.
- **z-index**: adopt onyx's `css/z-index.css` as the single overlay-layering source; existing wiki overlays migrated onto it.

OPAL-first throughout (Button / InputTypeIn / SidebarTab / LineItemButton / Popover); matched to the Figma mocks (node `319:26530`).

## How Has This Been Tested?

<!-- filled in by author -->