### PR TITLE
fix(events): show timestamps in the user's local timezone

### DIFF
--- a/frontend/src/app/app/events/page.tsx
+++ b/frontend/src/app/app/events/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@onyx-ai/opal/components";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { useRequireAuth } from "@/lib/auth";
+import { browserTimezone } from "@/lib/cron";
 import { useEvents } from "@/lib/events";
 import { formatInTimezone, formatScopePath } from "@/lib/format";
 import { useIsMobile } from "@/lib/viewport";
@@ -11,7 +12,9 @@ import { useIsMobile } from "@/lib/viewport";
 export default function EventsPage() {
   const { user, loading } = useRequireAuth();
   const isMobile = useIsMobile();
-  const timezone = user?.settings.timezone ?? "UTC";
+  // Prefer the user's configured wiki timezone; otherwise fall back to the
+  // browser's local zone rather than UTC, so timestamps read in local time.
+  const timezone = user?.settings.timezone ?? browserTimezone();
   const { events, error, isValidating, refresh } = useEvents({
     kind: "trigger.fire",
     limit: 200,


### PR DESCRIPTION
## Problem

The Events page renders trigger-fire timestamps in **UTC** when no wiki timezone is configured — e.g. a fire at 09:40 local shows as "Jun 04, 2026, 16:40". (`events/page.tsx:14` did `user?.settings.timezone ?? "UTC"`.)

## Fix

Fall back to the **browser's** timezone via the existing `browserTimezone()` helper (`lib/cron.ts`) instead of hardcoded UTC. Precedence is now: explicit wiki-timezone setting → browser local → UTC (the helper's own safe fallback). This matches how the rest of the UI renders times (the triggers page already uses browser-local `toLocaleString()`).

One line of logic; `formatTs` already converts the stored UTC `ts` correctly — it was only the default zone that was wrong.

## Testing

`npm run typecheck` passes. This was the only `settings.timezone ?? "UTC"` site in the codebase.