### PR TITLE
fix(triggers/events): honest schedule label + local-timezone event times

### DIFF
--- a/frontend/src/app/app/events/page.tsx
+++ b/frontend/src/app/app/events/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@onyx-ai/opal/components";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { useRequireAuth } from "@/lib/auth";
+import { browserTimezone } from "@/lib/cron";
 import { useEvents } from "@/lib/events";
 import { formatInTimezone, formatScopePath } from "@/lib/format";
 import { useIsMobile } from "@/lib/viewport";
@@ -11,7 +12,9 @@ import { useIsMobile } from "@/lib/viewport";
 export default function EventsPage() {
   const { user, loading } = useRequireAuth();
   const isMobile = useIsMobile();
-  const timezone = user?.settings.timezone ?? "UTC";
+  // Prefer the user's configured wiki timezone; otherwise fall back to the
+  // browser's local zone rather than UTC, so timestamps read in local time.
+  const timezone = user?.settings.timezone ?? browserTimezone();
   const { events, error, isValidating, refresh } = useEvents({
     kind: "trigger.fire",
     limit: 200,

--- a/frontend/src/app/app/triggers/page.tsx
+++ b/frontend/src/app/app/triggers/page.tsx
@@ -241,7 +241,7 @@ export default function TriggersPage() {
                       <>
                         {" "}
                         <span className="text-xs text-(--text-02)">
-                          · last fired{" "}
+                          · last checked{" "}
                           {formatRelative(t.schedule_last_fired_at)}
                         </span>
                       </>


### PR DESCRIPTION
Two small, related fixes to how trigger/schedule times are presented. (Combines what was briefly split into #191.)

## 1. Schedule trigger: "last checked", not "last fired"

`schedule_last_fired_at` is stamped in a `finally` on **every** evaluation tick — match or not (`tasks/triggers.py`). So the value means "last *checked*," but the triggers UI labeled it **"last fired,"** implying a fire (and Slack dispatch) that often didn't happen. This was the source of real confusion: a daily trigger that evaluated to no-match still showed "last fired 8 min ago" despite never firing or sending anything.

Relabel the UI to **"last checked"** (`triggers/page.tsx`) to match what the field actually tracks. (No backend/field rename — purely the user-facing label.)

## 2. Events: render timestamps in local time

The Events page fell back to `"UTC"` when no wiki timezone was configured, so fires showed in UTC (e.g. "16:40" for a 09:40 local fire). Fall back to the browser's timezone via the existing `browserTimezone()` helper instead. Precedence: explicit wiki-timezone setting → browser-local → UTC.

## Testing

`npm run typecheck` passes. These were the only `last fired` label and `settings.timezone ?? "UTC"` sites in the codebase.