### PR TITLE
fix(triggers): schedule triggers fire reliably (rebuild cursor + rename-aware window)

### DIFF
--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -246,7 +246,13 @@ def build_changes_since(*, scope_path: str, since_iso: str) -> str:
             truncated += 1
             continue
         after = _read_or_empty(path, "HEAD")
-        before = _read_or_empty(path, before_ref) if before_ref else ""
+        # The doc may have been renamed within the window; read its *before*
+        # body at the name it had at ``before_ref``, or the diff degrades to a
+        # spurious "(new file)" and hides the real edit.
+        before = ""
+        if before_ref:
+            before_path = wiki_git.path_at_ref(path, before_ref) or path
+            before = _read_or_empty(before_path, before_ref)
         entry = _change_entry(path, before, after)
         if entry is None:
             continue

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -558,6 +558,18 @@ def rebuild_from_filesystem() -> int:
 
     fallback_now = _now_iso()
     with session() as s:
+        # schedule_last_fired_at is runtime cursor state, intentionally not
+        # stored in the YAML — so carry it across the rebuild instead of
+        # nulling it, or every rebuild (boot, and per-move via after_path_move)
+        # would reset the schedule cursor and re-evaluate fired windows.
+        preserved_last_fired: dict[str, str | None] = {
+            tid: last
+            for tid, last in s.execute(
+                select(Trigger.id, Trigger.schedule_last_fired_at).where(
+                    Trigger.schedule_last_fired_at.is_not(None)
+                )
+            ).all()
+        }
         s.execute(sa_delete(Trigger))
 
         # Triggers reference ``users.id``; the wiki may carry YAMLs from an
@@ -633,7 +645,7 @@ def rebuild_from_filesystem() -> int:
                     schedule_cron=cron_value,
                     schedule_timezone=tz_value,
                     schedule_start_at=start_at_value,
-                    schedule_last_fired_at=None,
+                    schedule_last_fired_at=preserved_last_fired.get(data["id"]),
                 )
             )
             loaded += 1

--- a/backend/tests/test_schedule_triggers.py
+++ b/backend/tests/test_schedule_triggers.py
@@ -515,3 +515,27 @@ def test_rebuild_from_filesystem_loads_schedule_yaml(tmp_repo):
     assert fetched["kind"] == "schedule"
     assert fetched["schedule_cron"] == "0 9 * * 1"
     assert fetched["schedule_timezone"] == "UTC"
+
+
+def test_rebuild_preserves_schedule_last_fired_at(tmp_repo):
+    # schedule_last_fired_at is runtime cursor state, never written to the YAML.
+    # A rebuild (boot, or per-move via after_path_move) must carry it across, or
+    # the cron cursor resets and the trigger re-evaluates already-fired windows.
+    from app.triggers import repo
+
+    uid = seed_user(email="a@b.com")
+    t = repo.create(
+        owner_user_id=uid,
+        scope_path="watched.md",
+        nl_description="status",
+        message="msg",
+        kind="schedule",
+        schedule_cron="0 9 * * *",
+        schedule_timezone="America/Los_Angeles",
+    )
+    repo.record_schedule_fire(t["id"], "2026-06-04T16:00:00+00:00")
+    assert repo.get(t["id"])["schedule_last_fired_at"] == "2026-06-04T16:00:00+00:00"
+
+    repo.rebuild_from_filesystem()
+
+    assert repo.get(t["id"])["schedule_last_fired_at"] == "2026-06-04T16:00:00+00:00"

--- a/backend/tests/test_schedule_triggers.py
+++ b/backend/tests/test_schedule_triggers.py
@@ -534,8 +534,10 @@ def test_rebuild_preserves_schedule_last_fired_at(tmp_repo):
         schedule_timezone="America/Los_Angeles",
     )
     repo.record_schedule_fire(t["id"], "2026-06-04T16:00:00+00:00")
-    assert repo.get(t["id"])["schedule_last_fired_at"] == "2026-06-04T16:00:00+00:00"
+    before = repo.get(t["id"])
+    assert before is not None and before["schedule_last_fired_at"] == "2026-06-04T16:00:00+00:00"
 
     repo.rebuild_from_filesystem()
 
-    assert repo.get(t["id"])["schedule_last_fired_at"] == "2026-06-04T16:00:00+00:00"
+    after = repo.get(t["id"])
+    assert after is not None and after["schedule_last_fired_at"] == "2026-06-04T16:00:00+00:00"

--- a/backend/tests/test_triggers_diff.py
+++ b/backend/tests/test_triggers_diff.py
@@ -239,10 +239,11 @@ def _commit_date(iso: str):
         yield
     finally:
         for k in keys:
-            if prev[k] is None:
+            v = prev[k]
+            if v is None:
                 os.environ.pop(k, None)
             else:
-                os.environ[k] = prev[k]
+                os.environ[k] = v
 
 
 def test_changes_since_follows_rename(tmp_repo, tmp_config):

--- a/backend/tests/test_triggers_diff.py
+++ b/backend/tests/test_triggers_diff.py
@@ -6,6 +6,8 @@ versions of every tracked .md), and the combined payload.
 """
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -223,6 +225,47 @@ def test_changes_since_empty_window(repo_with_docs):
     since = _iso(datetime.now(timezone.utc) + timedelta(hours=1))
     out = diff_helper.build_changes_since(scope_path="", since_iso=since)
     assert "(no changes in this window)" in out
+
+
+@contextmanager
+def _commit_date(iso: str):
+    """Force the git committer/author date of commits made in the block, so
+    a time-windowed diff can place the window between commits deterministically."""
+    keys = ("GIT_AUTHOR_DATE", "GIT_COMMITTER_DATE")
+    prev = {k: os.environ.get(k) for k in keys}
+    for k in keys:
+        os.environ[k] = iso
+    try:
+        yield
+    finally:
+        for k in keys:
+            if prev[k] is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev[k]
+
+
+def test_changes_since_follows_rename(tmp_repo, tmp_config):
+    # A doc renamed mid-window must still show the edit diff, not a spurious
+    # "(new file)". The before-state has to be read at the doc's name as of the
+    # window-start ref, not its current name.
+    from app.wiki import git as wiki_git
+
+    with _commit_date("2026-01-01T00:00:00+00:00"):
+        wiki_git.commit_file("old.md", "# T\n\n- [ ] task one\n", "create", author=None)
+    with _commit_date("2026-01-01T00:10:00+00:00"):
+        wiki_git.move_path("old.md", "new.md", "rename", author=None)
+    with _commit_date("2026-01-01T00:20:00+00:00"):
+        wiki_git.commit_file("new.md", "# T\n\n- [x] task one\n", "complete", author=None)
+
+    # Window opens after the create, before the rename → before-ref is the
+    # create commit (where the doc was still "old.md").
+    out = diff_helper.build_changes_since(
+        scope_path="new.md", since_iso="2026-01-01T00:05:00+00:00"
+    )
+    assert "new.md" in out
+    assert "(new file)" not in out  # the rename no longer hides the edit
+    assert "[x] task one" in out  # the completion transition is visible
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes a daily-schedule trigger that never fired despite its condition being met — diagnosed live on the `agent-wiki-dev-wiki` EKS cluster. The schedule path is mechanically fine (correct timezone, dispatch wired, `slack_webhook_id` present); it was failing because the LLM evaluated **no-match**, for two compounding reasons. Both fixed here (one PR, two commits).

## A. `rebuild_from_filesystem` reset the schedule cursor

`schedule_last_fired_at` is the cron cursor — runtime state, intentionally **not** stored in the YAML. The rebuild reconstructed the row with it `None`, so every rebuild (boot, and **per page-move** since #176 wired `rebuild_from_filesystem` into `after_path_move`) wiped the cursor. The trigger then went "due" again and re-evaluated an already-fired window. (This is what produced the "evaluated at 16:00 *and* 16:10" in prod logs — a local `_is_due` repro confirmed it's not due at 16:10 *unless* the cursor was reset.)

**Fix:** snapshot `schedule_last_fired_at` per trigger before the cache `DELETE`, carry it onto the rebuilt row. Same class as the #180 `slack_webhook_id` fix.

## B. The change-window didn't follow renames

`build_changes_since` is a two-snapshot diff: body at the window-start ref vs `HEAD`. It read the *before* body at each doc's **current** path. The doc had been renamed mid-window (`individual_notes/…` → `Individual Notes/…`), so the old ref had nothing at the new name → the diff degraded to a spurious **`(new file)`** showing every item already `[x]`, with no `[ ]`→`[x]` transition. The schedule prompt ("be conservative; if not clearly satisfied, say no") then declined to fire.

**Fix:** resolve the before-name with `path_at_ref(path, before_ref)` (the helper from #175/#177) so the real edit diff — the completion transition — is what the model sees.

## Verified on prod

`build_changes_since` over the window returned the doc as `(new file)`; logs showed `schedule eval: 0/1 fired` at 16:00 and again at 16:10 (the cursor reset).

## Testing

- `test_rebuild_preserves_schedule_last_fired_at` — cursor survives a rebuild.
- `test_changes_since_follows_rename` — a doc renamed mid-window shows the edit diff (not `(new file)`), using controlled commit dates so the window lands between commits.
- Full trigger suites pass (72). ruff + basedpyright clean.

## Noted follow-up (not in scope)

For full rename-robustness, `paths_touched_since`/`_in_scope` should also follow renames for the edge case where a doc was renamed but only edited *before* the rename within the window. Left out as a rare edge case.