### PR TITLE
fix(comments): show the author's name instead of a generic "User"

### DIFF
--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -81,6 +81,9 @@ class CommentView(BaseModel):
     quoted_text: str | None
     author_kind: CommentAuthorKind
     author_user_id: str | None
+    # Human label for the author (user's name/email, or "Agent"); None when the
+    # author can't be resolved. Display-only — authorization still uses the id.
+    author_display: str | None = None
     body: str
     status: CommentStatus
     resolved_by_user_id: str | None

--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from collections.abc import Iterable
 from typing import Any
 
 from sqlalchemy import func, select, update
@@ -36,20 +37,23 @@ _VALID_AUTHOR_KINDS = frozenset(k.value for k in CommentAuthorKind)
 _SETTABLE_STATUSES = frozenset({CommentStatus.OPEN.value, CommentStatus.RESOLVED.value})
 
 
-def _author_display(c: Comment, s: Session) -> str | None:
-    """Human label for the comment's author: the user's name (or email) for a
-    user comment, "Agent" for an agent comment. Resolved on the open session so
-    the panel can show who wrote it instead of a generic "User"."""
+def _author_displays(s: Session, comments: Iterable[Comment]) -> dict[str, str]:
+    """Map each comment author's user id to a display string (name, or email
+    when unnamed), fetched for all distinct authors in one query."""
+    ids = {c.author_user_id for c in comments if c.author_user_id}
+    if not ids:
+        return {}
+    rows = s.execute(select(User.id, User.name, User.email).where(User.id.in_(ids))).all()
+    return {uid: (name or email) for uid, name, email in rows}
+
+
+def _to_dict(c: Comment, displays: dict[str, str]) -> dict[str, Any]:
     if c.author_user_id:
-        u = s.get(User, c.author_user_id)
-        if u is not None:
-            return u.name or u.email
-    if c.author_kind == CommentAuthorKind.AGENT.value:
-        return "Agent"
-    return None
-
-
-def _to_dict(c: Comment, s: Session) -> dict[str, Any]:
+        author_display = displays.get(c.author_user_id)
+    elif c.author_kind == CommentAuthorKind.AGENT.value:
+        author_display = "Agent"
+    else:
+        author_display = None
     return {
         "id": c.id,
         "doc_path": c.doc_path,
@@ -62,7 +66,7 @@ def _to_dict(c: Comment, s: Session) -> dict[str, Any]:
         "quoted_text": c.quoted_text,
         "author_kind": c.author_kind,
         "author_user_id": c.author_user_id,
-        "author_display": _author_display(c, s),
+        "author_display": author_display,
         "body": c.body,
         "status": c.status,
         "resolved_by_user_id": c.resolved_by_user_id,
@@ -132,7 +136,7 @@ def create_thread(
         )
         s.add(c)
         s.flush()
-        result = _to_dict(c, s)
+        result = _to_dict(c, _author_displays(s, [c]))
     log.info("comment thread created id=%s doc=%s", cid, doc_path)
     return result
 
@@ -175,7 +179,7 @@ def add_reply(
         )
         s.add(c)
         s.flush()
-        return _to_dict(c, s)
+        return _to_dict(c, _author_displays(s, [c]))
 
 
 # --------------------------------------------------------------------------- #
@@ -186,7 +190,7 @@ def add_reply(
 def get(comment_id: str) -> dict[str, Any] | None:
     with session() as s:
         c = s.get(Comment, comment_id)
-        return _to_dict(c, s) if c else None
+        return _to_dict(c, _author_displays(s, [c])) if c else None
 
 
 def list_for_doc(doc_path: str) -> list[dict[str, Any]]:
@@ -199,7 +203,8 @@ def list_for_doc(doc_path: str) -> list[dict[str, Any]]:
             .where(Comment.doc_path == doc_path)
             .order_by(Comment.created_at.asc())
         ).all()
-        return [_to_dict(c, s) for c in rows]
+        displays = _author_displays(s, rows)
+        return [_to_dict(c, displays) for c in rows]
 
 
 def list_thread(thread_root_id: str) -> list[dict[str, Any]]:
@@ -209,7 +214,8 @@ def list_thread(thread_root_id: str) -> list[dict[str, Any]]:
             .where(Comment.thread_root_id == thread_root_id)
             .order_by(Comment.created_at.asc())
         ).all()
-        return [_to_dict(c, s) for c in rows]
+        displays = _author_displays(s, rows)
+        return [_to_dict(c, displays) for c in rows]
 
 
 # --------------------------------------------------------------------------- #
@@ -225,7 +231,7 @@ def edit_body(comment_id: str, body: str) -> dict[str, Any] | None:
         c.body = body
         c.updated_at = _now_text(s)
         s.flush()
-        return _to_dict(c, s)
+        return _to_dict(c, _author_displays(s, [c]))
 
 
 def set_thread_status(
@@ -253,7 +259,7 @@ def set_thread_status(
             root.resolved_by_user_id = None
             root.resolved_at = None
         s.flush()
-        return _to_dict(root, s)
+        return _to_dict(root, _author_displays(s, [root]))
 
 
 def delete(comment_id: str) -> bool:
@@ -309,7 +315,8 @@ def roots_needing_remap(doc_path: str, head_sha: str) -> list[dict[str, Any]]:
                 Comment.anchor_sha != head_sha,
             )
         ).all()
-        return [_to_dict(c, s) for c in rows]
+        displays = _author_displays(s, rows)
+        return [_to_dict(c, displays) for c in rows]
 
 
 def apply_remap(

--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -19,8 +19,9 @@ import uuid
 from typing import Any
 
 from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session
 
-from app.db.models import Comment
+from app.db.models import Comment, User
 from app.db.session import execute_dml, session
 from app.models.comment import CommentAuthorKind, CommentScope, CommentStatus
 
@@ -35,7 +36,20 @@ _VALID_AUTHOR_KINDS = frozenset(k.value for k in CommentAuthorKind)
 _SETTABLE_STATUSES = frozenset({CommentStatus.OPEN.value, CommentStatus.RESOLVED.value})
 
 
-def _to_dict(c: Comment) -> dict[str, Any]:
+def _author_display(c: Comment, s: Session) -> str | None:
+    """Human label for the comment's author: the user's name (or email) for a
+    user comment, "Agent" for an agent comment. Resolved on the open session so
+    the panel can show who wrote it instead of a generic "User"."""
+    if c.author_user_id:
+        u = s.get(User, c.author_user_id)
+        if u is not None:
+            return u.name or u.email
+    if c.author_kind == CommentAuthorKind.AGENT.value:
+        return "Agent"
+    return None
+
+
+def _to_dict(c: Comment, s: Session) -> dict[str, Any]:
     return {
         "id": c.id,
         "doc_path": c.doc_path,
@@ -48,6 +62,7 @@ def _to_dict(c: Comment) -> dict[str, Any]:
         "quoted_text": c.quoted_text,
         "author_kind": c.author_kind,
         "author_user_id": c.author_user_id,
+        "author_display": _author_display(c, s),
         "body": c.body,
         "status": c.status,
         "resolved_by_user_id": c.resolved_by_user_id,
@@ -117,7 +132,7 @@ def create_thread(
         )
         s.add(c)
         s.flush()
-        result = _to_dict(c)
+        result = _to_dict(c, s)
     log.info("comment thread created id=%s doc=%s", cid, doc_path)
     return result
 
@@ -160,7 +175,7 @@ def add_reply(
         )
         s.add(c)
         s.flush()
-        return _to_dict(c)
+        return _to_dict(c, s)
 
 
 # --------------------------------------------------------------------------- #
@@ -171,7 +186,7 @@ def add_reply(
 def get(comment_id: str) -> dict[str, Any] | None:
     with session() as s:
         c = s.get(Comment, comment_id)
-        return _to_dict(c) if c else None
+        return _to_dict(c, s) if c else None
 
 
 def list_for_doc(doc_path: str) -> list[dict[str, Any]]:
@@ -184,7 +199,7 @@ def list_for_doc(doc_path: str) -> list[dict[str, Any]]:
             .where(Comment.doc_path == doc_path)
             .order_by(Comment.created_at.asc())
         ).all()
-        return [_to_dict(c) for c in rows]
+        return [_to_dict(c, s) for c in rows]
 
 
 def list_thread(thread_root_id: str) -> list[dict[str, Any]]:
@@ -194,7 +209,7 @@ def list_thread(thread_root_id: str) -> list[dict[str, Any]]:
             .where(Comment.thread_root_id == thread_root_id)
             .order_by(Comment.created_at.asc())
         ).all()
-        return [_to_dict(c) for c in rows]
+        return [_to_dict(c, s) for c in rows]
 
 
 # --------------------------------------------------------------------------- #
@@ -210,7 +225,7 @@ def edit_body(comment_id: str, body: str) -> dict[str, Any] | None:
         c.body = body
         c.updated_at = _now_text(s)
         s.flush()
-        return _to_dict(c)
+        return _to_dict(c, s)
 
 
 def set_thread_status(
@@ -238,7 +253,7 @@ def set_thread_status(
             root.resolved_by_user_id = None
             root.resolved_at = None
         s.flush()
-        return _to_dict(root)
+        return _to_dict(root, s)
 
 
 def delete(comment_id: str) -> bool:
@@ -294,7 +309,7 @@ def roots_needing_remap(doc_path: str, head_sha: str) -> list[dict[str, Any]]:
                 Comment.anchor_sha != head_sha,
             )
         ).all()
-        return [_to_dict(c) for c in rows]
+        return [_to_dict(c, s) for c in rows]
 
 
 def apply_remap(

--- a/backend/tests/test_comments_repo.py
+++ b/backend/tests/test_comments_repo.py
@@ -253,3 +253,33 @@ def test_orphan_all_for_doc_on_delete(tmp_db):
     got = comments.get(r2["id"])
     assert got is not None
     assert got["status"] == "orphaned"
+
+
+def test_author_display_resolves_name_then_email(tmp_db):
+    # The panel showed a generic "User"; the repo must surface the author's
+    # name (or email when unnamed) so others can be told apart.
+    named = seed_user(uid="u_named", email="n@x.com", name="Nora Dev")
+    unnamed = seed_user(uid="u_unnamed", email="bob@x.com")
+    r1 = _seed_root(named, sha="s1")
+    r2 = comments.create_thread(
+        doc_path=_DOC, body="hi", author_user_id=unnamed,
+        anchor_sha="s2", start_offset=1, end_offset=2, quoted_text="x",
+    )
+
+    # create return, get, and list (the panel path) all carry the display.
+    assert r1["author_display"] == "Nora Dev"
+    got = comments.get(r2["id"])
+    assert got is not None and got["author_display"] == "bob@x.com"
+    by_id = {c["id"]: c for c in comments.list_for_doc(_DOC)}
+    assert by_id[r1["id"]]["author_display"] == "Nora Dev"
+    assert by_id[r2["id"]]["author_display"] == "bob@x.com"
+
+
+def test_author_display_agent_comment(tmp_db):
+    c = comments.create_thread(
+        doc_path=_DOC, body="auto note", author_user_id=None,
+        anchor_sha="s3", start_offset=1, end_offset=2, quoted_text="x",
+        author_kind="agent",
+    )
+    got = comments.get(c["id"])
+    assert got is not None and got["author_display"] == "Agent"

--- a/backend/tests/test_comments_repo.py
+++ b/backend/tests/test_comments_repo.py
@@ -256,8 +256,7 @@ def test_orphan_all_for_doc_on_delete(tmp_db):
 
 
 def test_author_display_resolves_name_then_email(tmp_db):
-    # The panel showed a generic "User"; the repo must surface the author's
-    # name (or email when unnamed) so others can be told apart.
+    # author_display is the author's name, falling back to email when unnamed.
     named = seed_user(uid="u_named", email="n@x.com", name="Nora Dev")
     unnamed = seed_user(uid="u_unnamed", email="bob@x.com")
     r1 = _seed_root(named, sha="s1")

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -49,10 +49,11 @@ interface Props {
 
 function authorLabel(
   authorUserId: string | null,
+  authorDisplay: string | null,
   selfId: string | undefined,
 ): string {
   if (authorUserId && authorUserId === selfId) return "You";
-  return "User";
+  return authorDisplay ?? "User";
 }
 
 /** Backend timestamps are "YYYY-MM-DD HH:MM:SS" in UTC (not ISO). Normalize so
@@ -402,7 +403,7 @@ function Comment({
     <div className={styles.comment}>
       <div className={styles.metaRow}>
         <Text font="main-ui-action" color="text-04">
-          {authorLabel(comment.author_user_id, selfId)}
+          {authorLabel(comment.author_user_id, comment.author_display, selfId)}
         </Text>
         <span
           className={styles.time}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -54,6 +54,7 @@ export interface CommentView {
   quoted_text: string | null;
   author_kind: CommentAuthorKind;
   author_user_id: string | null;
+  author_display: string | null;
   body: string;
   status: CommentStatus;
   resolved_by_user_id: string | null;


### PR DESCRIPTION
## Problem

In the Comments panel, every comment written by someone other than the current viewer was labeled **"User"** — actual names never showed.

## Cause

The root cause was the backend, not just the label: the comment API (`CommentView` / repo `_to_dict`) only ever returned `author_kind` + `author_user_id` — **never a name**. So the frontend literally had nothing to render and fell back to `"User"` (`CommentsPanel.tsx:authorLabel` returned `"You"` for self, `"User"` for everyone else).

## Fix

- **Backend** — resolve the author's display in the comments repo on the already-open session (cheap PK lookup, no N+1 connections): the user's `name`, or `email` when unnamed; `"Agent"` for agent-authored comments. Exposed as `author_display` on `CommentView`. It flows through every read/return path (`get`, `list_for_doc`, `list_thread`, create/reply/edit/resolve).
- **Frontend** — `authorLabel` now renders `"You"` for self and `author_display` otherwise (falling back to `"User"` only when truly unresolved).

`author_display` is **display-only** — authorization still keys off `author_user_id` (the author/admin checks are unchanged).

## Testing

- New repo tests: `author_display` resolves to name → email fallback (via create-return, `get`, and the `list_for_doc` panel path), and `"Agent"` for an agent comment.
- `test_comments_repo` + `test_comments_api` pass (27). ruff + basedpyright + tsc clean.