### PR TITLE
feat(settings): default a user's timezone to local instead of UTC

### DIFF
--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -25,7 +25,10 @@ class UserSettings(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     theme: Literal["light", "dark", "system"] = "system"
-    timezone: str = "UTC"
+    # None means "not chosen" — the frontend resolves it to the browser's local
+    # zone, so a user's times default to local rather than UTC. An explicit
+    # choice (including "UTC") is stored and honored.
+    timezone: str | None = None
     default_landing: Literal["wiki_home", "recent", "last_viewed"] = "wiki_home"
     # Preferred provider + model for chat. None = use the global agent settings.
     chat_provider: str | None = None
@@ -33,7 +36,9 @@ class UserSettings(BaseModel):
 
     @field_validator("timezone")
     @classmethod
-    def _validate_timezone(cls, value: str) -> str:
+    def _validate_timezone(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
         try:
             ZoneInfo(value)
         except ZoneInfoNotFoundError as exc:

--- a/backend/tests/integration/test_user_settings_flow.py
+++ b/backend/tests/integration/test_user_settings_flow.py
@@ -24,7 +24,7 @@ def test_settings_persist_across_logout_and_login(integration):
     # Defaults right after signup.
     me = integration.client.get("/api/auth/me").json()
     assert me["settings"]["theme"] == "system"
-    assert me["settings"]["timezone"] == "UTC"
+    assert me["settings"]["timezone"] is None
     assert me["settings"]["default_landing"] == "wiki_home"
 
     # Update each of the three fields.
@@ -158,7 +158,7 @@ def test_settings_isolated_between_users(integration):
     me = integration.client.get("/api/auth/me").json()
     # Bob is a new account — should see defaults, not Alice's values.
     assert me["settings"]["theme"] == "system"
-    assert me["settings"]["timezone"] == "UTC"
+    assert me["settings"]["timezone"] is None
 
     # And Bob's own update doesn't touch Alice's row.
     integration.client.put("/api/user/settings", json={"theme": "light"})

--- a/backend/tests/test_user_settings.py
+++ b/backend/tests/test_user_settings.py
@@ -22,7 +22,7 @@ def test_get_settings_returns_defaults_for_fresh_user(tmp_db):
     assert s is not None
     assert s == UserSettings().model_dump()
     assert s["theme"] == "system"
-    assert s["timezone"] == "UTC"
+    assert s["timezone"] is None
     assert s["default_landing"] == "wiki_home"
 
 
@@ -38,7 +38,7 @@ def test_update_settings_persists_partial(tmp_db):
     assert out is not None
     assert out["theme"] == "dark"
     # Other fields keep defaults.
-    assert out["timezone"] == "UTC"
+    assert out["timezone"] is None
 
     # Persisted across reads.
     again = users_repo.get_settings("usr_a")
@@ -88,6 +88,15 @@ def test_user_settings_accepts_iana_timezone():
     assert s.timezone == "America/Los_Angeles"
 
 
+def test_timezone_defaults_to_none_so_client_uses_local():
+    # An unset timezone is None (not "UTC"); the frontend resolves None to the
+    # browser's local zone, so times default to local rather than UTC.
+    assert UserSettings().timezone is None
+    assert UserSettings.model_validate({}).timezone is None
+    # None is explicitly valid (doesn't trip the IANA validator).
+    assert UserSettings.model_validate({"timezone": None}).timezone is None
+
+
 def test_user_settings_ignores_unknown_keys():
     """Stale JSON from an older app version shouldn't break login."""
     s = UserSettings.model_validate({"theme": "dark", "obsolete_key": True})
@@ -115,7 +124,7 @@ def test_get_settings_returns_defaults(client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["theme"] == "system"
-    assert body["timezone"] == "UTC"
+    assert body["timezone"] is None
     assert body["default_landing"] == "wiki_home"
 
 
@@ -124,7 +133,7 @@ def test_put_settings_persists_partial(client):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["theme"] == "dark"
-    assert body["timezone"] == "UTC"  # untouched
+    assert body["timezone"] is None  # untouched (resolves to local on the client)
 
     # Round-trip via GET.
     again = client.get("/api/user/settings").json()
@@ -164,4 +173,4 @@ def test_auth_me_payload_includes_settings(client):
     assert "settings" in body
     assert body["settings"]["theme"] == "dark"
     assert body["settings"]["default_landing"] == "recent"
-    assert body["settings"]["timezone"] == "UTC"
+    assert body["settings"]["timezone"] is None

--- a/frontend/src/app/app/events/page.tsx
+++ b/frontend/src/app/app/events/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@onyx-ai/opal/components";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { PageHeader } from "@/components/common/PageHeader";
 import { useRequireAuth } from "@/lib/auth";
-import { browserTimezone } from "@/lib/cron";
+import { effectiveTimezone } from "@/lib/cron";
 import { useEvents } from "@/lib/events";
 import { formatInTimezone, formatScopePath } from "@/lib/format";
 import { useIsMobile } from "@/lib/viewport";
@@ -12,9 +12,8 @@ import { useIsMobile } from "@/lib/viewport";
 export default function EventsPage() {
   const { user, loading } = useRequireAuth();
   const isMobile = useIsMobile();
-  // Prefer the user's configured wiki timezone; otherwise fall back to the
-  // browser's local zone rather than UTC, so timestamps read in local time.
-  const timezone = user?.settings.timezone ?? browserTimezone();
+  // The user's explicit timezone, else their browser's local zone.
+  const timezone = effectiveTimezone(user?.settings.timezone);
   const { events, error, isValidating, refresh } = useEvents({
     kind: "trigger.fire",
     limit: 200,

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -13,13 +13,14 @@ import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
+import { effectiveTimezone } from "@/lib/cron";
 import { setLocalThemePreview } from "@/lib/theme-provider";
 import type { DefaultLanding, ThemeSetting, UserSettings } from "@/types";
 import styles from "./page.module.css";
 
 const DEFAULT_SETTINGS: UserSettings = {
   theme: "system",
-  timezone: "UTC",
+  timezone: null,
   default_landing: "wiki_home",
   chat_provider: null,
   chat_model: null,
@@ -163,26 +164,32 @@ function SettingsForm({
   initial: UserSettings;
   updateSettings: (partial: Partial<UserSettings>) => Promise<UserSettings>;
 }) {
+  // An unset timezone (null) means "use my local zone" — show that concretely
+  // in the form so the field never reads UTC just because nothing was chosen.
+  const initialTz = effectiveTimezone(initial.timezone);
   const [draft, setDraft] = useState<UserSettings>({
     ...DEFAULT_SETTINGS,
     ...initial,
+    timezone: initialTz,
   });
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [tzCustom, setTzCustom] = useState<boolean>(
-    !COMMON_TIMEZONES.includes(initial.timezone),
+    !COMMON_TIMEZONES.includes(initialTz),
   );
 
   // Pull future updates (e.g. another tab) back into the form.
   useEffect(() => {
-    setDraft({ ...DEFAULT_SETTINGS, ...initial });
-    setTzCustom(!COMMON_TIMEZONES.includes(initial.timezone));
+    const tz = effectiveTimezone(initial.timezone);
+    setDraft({ ...DEFAULT_SETTINGS, ...initial, timezone: tz });
+    setTzCustom(!COMMON_TIMEZONES.includes(tz));
   }, [initial]);
 
   const dirty = useMemo(() => {
+    const cmp = { ...initial, timezone: effectiveTimezone(initial.timezone) };
     return (Object.keys(draft) as (keyof UserSettings)[]).some(
-      (k) => draft[k] !== initial[k],
+      (k) => draft[k] !== cmp[k],
     );
   }, [draft, initial]);
 
@@ -248,14 +255,14 @@ function SettingsForm({
         <div className={lblClass}>Timezone</div>
         {tzCustom ? (
           <input
-            value={draft.timezone}
+            value={draft.timezone ?? ""}
             onChange={(e) => update("timezone", e.target.value)}
             placeholder="e.g. America/Los_Angeles"
             className={inputClass}
           />
         ) : (
           <select
-            value={draft.timezone}
+            value={draft.timezone ?? ""}
             onChange={(e) => {
               if (e.target.value === "__custom__") {
                 setTzCustom(true);
@@ -282,7 +289,7 @@ function SettingsForm({
                 type="button"
                 onClick={() => {
                   setTzCustom(false);
-                  if (!COMMON_TIMEZONES.includes(draft.timezone)) {
+                  if (!COMMON_TIMEZONES.includes(draft.timezone ?? "")) {
                     update("timezone", "UTC");
                   }
                 }}

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -186,12 +186,21 @@ function SettingsForm({
     setTzCustom(!COMMON_TIMEZONES.includes(tz));
   }, [initial]);
 
+  // The baseline the form diffs against: identical to `initial`, but with the
+  // timezone resolved the same way the field displays it. Both `dirty` and the
+  // save diff use this, so a save that didn't touch the timezone never patches
+  // it — leaving an unset (null) timezone unset rather than pinning the local
+  // zone.
+  const baseline = useMemo<UserSettings>(
+    () => ({ ...initial, timezone: effectiveTimezone(initial.timezone) }),
+    [initial],
+  );
+
   const dirty = useMemo(() => {
-    const cmp = { ...initial, timezone: effectiveTimezone(initial.timezone) };
     return (Object.keys(draft) as (keyof UserSettings)[]).some(
-      (k) => draft[k] !== cmp[k],
+      (k) => draft[k] !== baseline[k],
     );
-  }, [draft, initial]);
+  }, [draft, baseline]);
 
   function update<K extends keyof UserSettings>(
     key: K,
@@ -218,7 +227,7 @@ function SettingsForm({
     try {
       const partial: Partial<UserSettings> = {};
       (Object.keys(draft) as (keyof UserSettings)[]).forEach((k) => {
-        if (draft[k] !== initial[k]) {
+        if (draft[k] !== baseline[k]) {
           (partial as Record<string, unknown>)[k] = draft[k];
         }
       });

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -15,7 +15,7 @@ import type { UserSettings, UserSettingsUpdate } from "@/types";
 
 const DEFAULT_USER_SETTINGS: UserSettings = {
   theme: "system",
-  timezone: "UTC",
+  timezone: null,
   default_landing: "wiki_home",
   chat_provider: null,
   chat_model: null,

--- a/frontend/src/lib/cron.ts
+++ b/frontend/src/lib/cron.ts
@@ -178,6 +178,12 @@ export function browserTimezone(): string {
   }
 }
 
+/** The timezone to render times in: the user's explicit choice, else their
+ * browser's local zone. `null`/undefined means "not chosen" → local. */
+export function effectiveTimezone(tz: string | null | undefined): string {
+  return tz ?? browserTimezone();
+}
+
 export function listTimezones(): string[] {
   try {
     if (typeof Intl.supportedValuesOf === "function") {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,7 +10,7 @@ export type DefaultLanding = "wiki_home" | "recent" | "last_viewed";
 
 export interface UserSettings {
   theme: ThemeSetting;
-  timezone: string;
+  timezone: string | null;
   default_landing: DefaultLanding;
   chat_provider: string | null;
   chat_model: string | null;


### PR DESCRIPTION
## Problem

A user who never picked a timezone had it default to **"UTC"**, so timestamps (e.g. the Events tab) rendered in UTC instead of their local time.

## Fix

Make the stored default **unset** rather than `"UTC"`, and resolve unset → the browser's local zone on the client. This way times default to local for everyone (new users and existing ones who never chose), while an **explicit** choice — including "UTC" — is stored and honored.

- **Backend:** `UserSettings.timezone: str | None = None` (validator passes `None` through; explicit values still IANA-checked). No DB migration — it's a JSONB blob, and existing rows that never set a timezone now read `None`.
- **Frontend:**
  - `effectiveTimezone(tz) = tz ?? browserTimezone()` helper (in `lib/cron.ts`).
  - Events page renders via `effectiveTimezone(...)`.
  - Settings page shows the **local** zone when unset (so the field never reads UTC just because nothing was chosen) and persists it on save. `auth` + settings defaults are `null`.

Distinguishing `null` ("never chose") from an explicit `"UTC"` is the reason for the nullable default — a string default couldn't tell them apart.

## Testing

- Backend: `timezone` defaults to `None`, accepts `None`, still validates explicit zones / rejects bad ones; updated the existing default-assertions. `test_user_settings` + integration flow pass (26).
- ruff + basedpyright clean; frontend `tsc` clean.

Note: backend + frontend change — needs both deployed to take full effect.