### PR TITLE
feat(home): recent-page actions menu + active folder in directory sidebar

### DIFF
--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -224,6 +224,11 @@
   padding: 4px 4px 4px 12px;
 }
 
+/* Ref-forwarding wrapper for the OPAL Button inside Popover.Trigger asChild. */
+.menuTrigger {
+  display: inline-flex;
+}
+
 .cardPreview {
   flex: 1;
   min-height: 0;

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -29,6 +29,7 @@ import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
 import type { RecentPage } from "@/lib/wiki";
 
+import { WikiItemActionsProvider, WikiItemMenu } from "./WikiItemActions";
 import { WikiTree } from "./WikiTree";
 import styles from "./WikiHome.module.css";
 
@@ -82,109 +83,111 @@ export function WikiHome() {
         </div>
       </div>
 
-      <div className={styles.body}>
-        <div className={styles.sidebar}>
-          <WikiTree />
-        </div>
-
-        <div className={styles.column}>
-          {/* Hero */}
-          <div className={styles.hero}>
-            <span className={styles.heroMark}>
-              <SvgOnyxLogo size={32} />
-            </span>
-            <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
-          </div>
-          <div className={styles.dividerWrap}>
-            <Divider />
+      <WikiItemActionsProvider>
+        <div className={styles.body}>
+          <div className={styles.sidebar}>
+            <WikiTree />
           </div>
 
-          {/* Start a new page */}
-          <div className={styles.sectionHeader}>
-            <span className={styles.secHead}>Start a new page</span>
-          </div>
-          <div className={styles.templates}>
-            <div className={styles.templateCell}>
-              <TemplateCard
-                title="Blank page"
-                glyph={
-                  <span className={styles.blankGlyph}>
-                    <SvgPlusCircle size={22} />
-                  </span>
-                }
-                onClick={() => startNewPage()}
-              />
+          <div className={styles.column}>
+            {/* Hero */}
+            <div className={styles.hero}>
+              <span className={styles.heroMark}>
+                <SvgOnyxLogo size={32} />
+              </span>
+              <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
             </div>
-            {featured.map((t) => (
-              <div key={t.id} className={styles.templateCell}>
+            <div className={styles.dividerWrap}>
+              <Divider />
+            </div>
+
+            {/* Start a new page */}
+            <div className={styles.sectionHeader}>
+              <span className={styles.secHead}>Start a new page</span>
+            </div>
+            <div className={styles.templates}>
+              <div className={styles.templateCell}>
                 <TemplateCard
-                  title={t.name}
-                  description={t.description ?? ""}
-                  onClick={() => startNewPage(t.id)}
+                  title="Blank page"
+                  glyph={
+                    <span className={styles.blankGlyph}>
+                      <SvgPlusCircle size={22} />
+                    </span>
+                  }
+                  onClick={() => startNewPage()}
                 />
               </div>
-            ))}
-          </div>
-          <button
-            type="button"
-            className={styles.moreRow}
-            onClick={() => startNewPage()}
-          >
-            <span className={styles.moreLabel}>More Templates</span>
-            <SvgChevronRight size={18} className={styles.moreChevron} />
-          </button>
-
-          {/* Write with AI */}
-          <div className={styles.aiRow}>
-            <span className={styles.aiGutterIcon}>
-              <SvgOnyxOctagon size={18} />
-            </span>
-            <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
-              <InputTypeIn
-                value={aiPrompt}
-                onChange={(e) => setAiPrompt(e.target.value)}
-                placeholder="Start writing with AI…"
-                aria-label="Start writing with AI"
-                rightChildren={
-                  <Button
-                    type="submit"
-                    size="sm"
-                    prominence="tertiary"
-                    icon={SvgArrowUp}
-                    disabled={!aiPrompt.trim()}
-                    aria-label="Start writing"
-                  />
-                }
-              />
-            </form>
-          </div>
-
-          <div className={styles.midDividerWrap}>
-            <Divider />
-          </div>
-
-          {/* Recent Pages */}
-          <div className={styles.sectionHeader}>
-            <span className={styles.secHeadLg}>Recent Pages</span>
-          </div>
-          {recent.length === 0 ? (
-            <p className={styles.empty}>
-              No pages yet. Create one to get started.
-            </p>
-          ) : (
-            <div className={styles.recentGrid}>
-              {recent.map((p) => (
-                <div key={p.path} className={styles.recentCell}>
-                  <RecentCard
-                    page={p}
-                    onClick={() => router.push(`/app/wiki/${p.path}`)}
+              {featured.map((t) => (
+                <div key={t.id} className={styles.templateCell}>
+                  <TemplateCard
+                    title={t.name}
+                    description={t.description ?? ""}
+                    onClick={() => startNewPage(t.id)}
                   />
                 </div>
               ))}
             </div>
-          )}
+            <button
+              type="button"
+              className={styles.moreRow}
+              onClick={() => startNewPage()}
+            >
+              <span className={styles.moreLabel}>More Templates</span>
+              <SvgChevronRight size={18} className={styles.moreChevron} />
+            </button>
+
+            {/* Write with AI */}
+            <div className={styles.aiRow}>
+              <span className={styles.aiGutterIcon}>
+                <SvgOnyxOctagon size={18} />
+              </span>
+              <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
+                <InputTypeIn
+                  value={aiPrompt}
+                  onChange={(e) => setAiPrompt(e.target.value)}
+                  placeholder="Start writing with AI…"
+                  aria-label="Start writing with AI"
+                  rightChildren={
+                    <Button
+                      type="submit"
+                      size="sm"
+                      prominence="tertiary"
+                      icon={SvgArrowUp}
+                      disabled={!aiPrompt.trim()}
+                      aria-label="Start writing"
+                    />
+                  }
+                />
+              </form>
+            </div>
+
+            <div className={styles.midDividerWrap}>
+              <Divider />
+            </div>
+
+            {/* Recent Pages */}
+            <div className={styles.sectionHeader}>
+              <span className={styles.secHeadLg}>Recent Pages</span>
+            </div>
+            {recent.length === 0 ? (
+              <p className={styles.empty}>
+                No pages yet. Create one to get started.
+              </p>
+            ) : (
+              <div className={styles.recentGrid}>
+                {recent.map((p) => (
+                  <div key={p.path} className={styles.recentCell}>
+                    <RecentCard
+                      page={p}
+                      onClick={() => router.push(`/app/wiki/${p.path}`)}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      </WikiItemActionsProvider>
     </main>
   );
 }
@@ -238,6 +241,7 @@ function RecentCard({
   page: RecentPage;
   onClick: () => void;
 }) {
+  const [menuOpen, setMenuOpen] = useState(false);
   return (
     <SelectCard
       state="empty"
@@ -264,15 +268,28 @@ function RecentCard({
               ? `Updated ${relativeTime(page.updated_at, "long")}`
               : "—"}
           </Text>
-          <Button
-            size="sm"
-            prominence="tertiary"
-            icon={SvgMoreHorizontal}
-            aria-label="More"
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-          />
+          <WikiItemMenu
+            path={page.path}
+            isFolder={false}
+            open={menuOpen}
+            onOpenChange={setMenuOpen}
+            align="end"
+          >
+            {/* Plain span trigger — OPAL Button doesn't forward ref/onClick
+                into Popover.Trigger asChild; the span anchors the popover and
+                stops the click from navigating the card. */}
+            <span
+              className={styles.menuTrigger}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Button
+                size="sm"
+                prominence="tertiary"
+                icon={SvgMoreHorizontal}
+                aria-label="More"
+              />
+            </span>
+          </WikiItemMenu>
         </div>
       </div>
     </SelectCard>

--- a/frontend/src/components/wiki/WikiItemActions.module.css
+++ b/frontend/src/components/wiki/WikiItemActions.module.css
@@ -1,0 +1,35 @@
+/* Shared contextual-menu surface for wiki items (sidebar tree + recent cards).
+   Holds only the menu content + transient toast; per-surface trigger styling
+   (e.g. the tree's hover-revealed "⋯") stays with that surface. */
+
+/* Contextual menu (657:41564): fixed 160px width, line items in a column. */
+.menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 160px;
+  box-sizing: border-box;
+}
+
+/* Delete item — danger red (#dc2626 → --status-text-error-05) on icon + label.
+   !important to override OPAL LineItemButton's own text/icon color; scoped to
+   the single wrapped Delete item. */
+.danger,
+.danger :global(*) {
+  color: var(--status-text-error-05) !important;
+}
+
+/* Transient toast (e.g. "Link copied") — bottom-centre, auto-dismisses. */
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
+  z-index: var(--z-toast);
+  padding: 8px 14px;
+  border-radius: var(--border-radius-08);
+  background: var(--background-tint-04);
+  color: var(--text-05);
+  font-size: 13px;
+  box-shadow: var(--shadow-popover);
+}

--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -43,16 +43,31 @@ interface RowActions {
 }
 
 const ActionsContext = createContext<RowActions | null>(null);
-export const useRowActions = () => useContext(ActionsContext);
+export function useRowActions(): RowActions {
+  const ctx = useContext(ActionsContext);
+  if (!ctx)
+    throw new Error(
+      "useRowActions must be used within WikiItemActionsProvider",
+    );
+  return ctx;
+}
 
 /** The folder new pages/folders are created inside ("" = wiki root). Lives here
- * (not in WikiTree) so deletes — owned by this provider — can reset it. */
+ * (not in WikiTree) so deletes/renames/moves — owned by this provider — can
+ * keep it coherent. */
 interface ActiveFolder {
   activeFolder: string;
   setActiveFolder: (path: string) => void;
 }
 const ActiveFolderContext = createContext<ActiveFolder | null>(null);
-export const useActiveFolder = () => useContext(ActiveFolderContext);
+export function useActiveFolder(): ActiveFolder {
+  const ctx = useContext(ActiveFolderContext);
+  if (!ctx)
+    throw new Error(
+      "useActiveFolder must be used within WikiItemActionsProvider",
+    );
+  return ctx;
+}
 
 /** Every folder path in the tree (plus root ""), for the move-destination list. */
 function collectFolders(entries: Entry[]): string[] {
@@ -91,9 +106,9 @@ export function WikiItemMenu({
   children: ReactNode;
 }) {
   const actions = useRowActions();
-  const run = (fn?: (p: string) => void) => () => {
+  const run = (fn: (p: string) => void) => () => {
     onOpenChange(false);
-    fn?.(path);
+    fn(path);
   };
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -105,21 +120,21 @@ export function WikiItemMenu({
             sizePreset="main-ui"
             icon={SvgShare}
             title="Share"
-            onClick={run(actions?.share)}
+            onClick={run(actions.share)}
           />
           <LineItemButton
             variant="body"
             sizePreset="main-ui"
             icon={SvgEdit}
             title="Rename"
-            onClick={run(actions?.rename)}
+            onClick={run(actions.rename)}
           />
           <LineItemButton
             variant="body"
             sizePreset="main-ui"
             icon={SvgFolderIn}
             title="Move"
-            onClick={run(actions?.move)}
+            onClick={run(actions.move)}
           />
           <Divider />
           <LineItemButton
@@ -127,7 +142,7 @@ export function WikiItemMenu({
             sizePreset="main-ui"
             icon={SvgLink}
             title="Copy Link"
-            onClick={run(actions?.copyLink)}
+            onClick={run(actions.copyLink)}
           />
           {!isFolder && (
             <LineItemButton
@@ -135,7 +150,7 @@ export function WikiItemMenu({
               sizePreset="main-ui"
               icon={SvgSparkle}
               title="Launch Agent"
-              onClick={run(actions?.launchAgent)}
+              onClick={run(actions.launchAgent)}
             />
           )}
           <Divider />
@@ -147,7 +162,7 @@ export function WikiItemMenu({
               title="Delete"
               onClick={() => {
                 onOpenChange(false);
-                actions?.remove(path, isFolder);
+                actions.remove(path, isFolder);
               }}
             />
           </span>
@@ -189,6 +204,17 @@ export function WikiItemActionsProvider({ children }: { children: ReactNode }) {
       (key) => typeof key === "string" && key.startsWith("/wiki/recent"),
     );
   };
+
+  // Keep the active folder pointing at the right path after a rename/move of it
+  // (or an ancestor). No-op for file renames/moves (active folder never .md).
+  const remapActiveFolder = (oldPath: string, newPath: string) =>
+    setActiveFolder((prev) =>
+      prev === oldPath
+        ? newPath
+        : prev.startsWith(`${oldPath}/`)
+          ? newPath + prev.slice(oldPath.length)
+          : prev,
+    );
 
   const actions: RowActions = {
     share: setSharePath,
@@ -246,7 +272,8 @@ export function WikiItemActionsProvider({ children }: { children: ReactNode }) {
               <RenameModal
                 path={renamePath}
                 onClose={() => setRenamePath(null)}
-                onDone={() => {
+                onDone={(newPath) => {
+                  remapActiveFolder(renamePath, newPath);
                   setRenamePath(null);
                   refresh();
                 }}
@@ -257,7 +284,8 @@ export function WikiItemActionsProvider({ children }: { children: ReactNode }) {
                 path={movePath}
                 folders={collectFolders(entries)}
                 onClose={() => setMovePath(null)}
-                onDone={() => {
+                onDone={(newPath) => {
+                  remapActiveFolder(movePath, newPath);
                   setMovePath(null);
                   refresh();
                 }}

--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import useSWR, { useSWRConfig } from "swr";
+
+import { Divider, LineItemButton, Popover } from "@onyx-ai/opal/components";
+import {
+  SvgEdit,
+  SvgFolderIn,
+  SvgLink,
+  SvgShare,
+  SvgSparkle,
+  SvgTrash,
+} from "@onyx-ai/opal/icons";
+
+import { apiFetch } from "@/lib/api";
+import { RunAgentPanel } from "./RunAgentPanel";
+import { ShareDialog } from "./ShareDialog";
+import { MoveModal, RenameModal } from "./WikiItemModals";
+import styles from "./WikiItemActions.module.css";
+
+interface Entry {
+  path: string;
+  updated_at: string;
+}
+
+/** Per-item contextual-menu actions, owned by the provider and consumed by
+ * every WikiItemMenu via context (sidebar tree rows + recent-page cards). */
+interface RowActions {
+  share: (path: string) => void;
+  rename: (path: string) => void;
+  move: (path: string) => void;
+  copyLink: (path: string) => void;
+  launchAgent: (path: string) => void;
+  remove: (path: string, isFolder: boolean) => void;
+}
+
+const ActionsContext = createContext<RowActions | null>(null);
+export const useRowActions = () => useContext(ActionsContext);
+
+/** The folder new pages/folders are created inside ("" = wiki root). Lives here
+ * (not in WikiTree) so deletes — owned by this provider — can reset it. */
+interface ActiveFolder {
+  activeFolder: string;
+  setActiveFolder: (path: string) => void;
+}
+const ActiveFolderContext = createContext<ActiveFolder | null>(null);
+export const useActiveFolder = () => useContext(ActiveFolderContext);
+
+/** Every folder path in the tree (plus root ""), for the move-destination list. */
+function collectFolders(entries: Entry[]): string[] {
+  const set = new Set<string>([""]);
+  for (const e of entries) {
+    const parts = e.path.split("/");
+    parts.pop();
+    let cur = "";
+    for (const p of parts) {
+      cur = cur ? `${cur}/${p}` : p;
+      set.add(cur);
+    }
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Per-item "⋯" actions menu (contextual menu node 657:41564). Spec: 160px wide,
+ * compact line items, dividers, Delete in danger red. The first item navigates
+ * to the page (file) or folder view. Folders omit "Launch Agent" (it adds a doc
+ * to an agent run). The caller supplies the trigger as `children`.
+ */
+export function WikiItemMenu({
+  path,
+  isFolder,
+  open,
+  onOpenChange,
+  align = "start",
+  children,
+}: {
+  path: string;
+  isFolder: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  align?: "start" | "center" | "end";
+  children: ReactNode;
+}) {
+  const actions = useRowActions();
+  const run = (fn?: (p: string) => void) => () => {
+    onOpenChange(false);
+    fn?.(path);
+  };
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <Popover.Trigger asChild>{children}</Popover.Trigger>
+      <Popover.Content align={align} sideOffset={4} width="fit">
+        <div className={styles.menu}>
+          <LineItemButton
+            variant="body"
+            sizePreset="main-ui"
+            icon={SvgShare}
+            title="Share"
+            onClick={run(actions?.share)}
+          />
+          <LineItemButton
+            variant="body"
+            sizePreset="main-ui"
+            icon={SvgEdit}
+            title="Rename"
+            onClick={run(actions?.rename)}
+          />
+          <LineItemButton
+            variant="body"
+            sizePreset="main-ui"
+            icon={SvgFolderIn}
+            title="Move"
+            onClick={run(actions?.move)}
+          />
+          <Divider />
+          <LineItemButton
+            variant="body"
+            sizePreset="main-ui"
+            icon={SvgLink}
+            title="Copy Link"
+            onClick={run(actions?.copyLink)}
+          />
+          {!isFolder && (
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgSparkle}
+              title="Launch Agent"
+              onClick={run(actions?.launchAgent)}
+            />
+          )}
+          <Divider />
+          <span className={styles.danger}>
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgTrash}
+              title="Delete"
+              onClick={() => {
+                onOpenChange(false);
+                actions?.remove(path, isFolder);
+              }}
+            />
+          </span>
+        </div>
+      </Popover.Content>
+    </Popover>
+  );
+}
+
+/**
+ * Owns the contextual-menu actions (go to / share / rename / move / copy link /
+ * launch agent / delete) and renders the reused ShareDialog + RunAgentPanel and
+ * the Rename / Move modals once, portaled to <body>. Wrap any surface that hosts
+ * a WikiItemMenu (the directory sidebar and the recent-pages grid) in this so
+ * they share one set of overlays.
+ */
+export function WikiItemActionsProvider({ children }: { children: ReactNode }) {
+  const { mutate } = useSWRConfig();
+  const { data } = useSWR<{ entries: Entry[] }>("/wiki");
+  const entries = data?.entries ?? [];
+
+  const [sharePath, setSharePath] = useState<string | null>(null);
+  const [renamePath, setRenamePath] = useState<string | null>(null);
+  const [movePath, setMovePath] = useState<string | null>(null);
+  const [agentPath, setAgentPath] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const [activeFolder, setActiveFolder] = useState("");
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 2000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  // Revalidate the tree and every recent-pages grid after a write.
+  const refresh = () => {
+    void mutate("/wiki");
+    void mutate(
+      (key) => typeof key === "string" && key.startsWith("/wiki/recent"),
+    );
+  };
+
+  const actions: RowActions = {
+    share: setSharePath,
+    rename: setRenamePath,
+    move: setMovePath,
+    launchAgent: setAgentPath,
+    copyLink: (path) => {
+      const encoded = path.split("/").map(encodeURIComponent).join("/");
+      const url = `${window.location.origin}/app/wiki/${encoded}`;
+      navigator.clipboard
+        .writeText(url)
+        .then(() => setToast("Link copied"))
+        .catch(() => setToast("Couldn't copy link"));
+    },
+    remove: async (path, isFolder) => {
+      const label = path.replace(/\.md$/, "").split("/").pop() ?? path;
+      const message = isFolder
+        ? `Delete folder "${label}" and everything in it? This cannot be undone.`
+        : `Delete ${label}? This cannot be undone.`;
+      if (!window.confirm(message)) return;
+      try {
+        await apiFetch(`/wiki/file?path=${encodeURIComponent(path)}`, {
+          method: "DELETE",
+        });
+        // Clear the active folder if it (or an ancestor) was just deleted.
+        setActiveFolder((prev) =>
+          prev === path || prev.startsWith(`${path}/`) ? "" : prev,
+        );
+        refresh();
+      } catch (e) {
+        setToast(e instanceof Error ? e.message : "Delete failed");
+      }
+    },
+  };
+
+  return (
+    <ActionsContext.Provider value={actions}>
+      <ActiveFolderContext.Provider value={{ activeFolder, setActiveFolder }}>
+        {children}
+      </ActiveFolderContext.Provider>
+
+      {/* Overlays are portaled to <body> so they escape any sticky/sidebar
+          stacking context (otherwise page content paints over the scrim). */}
+      {typeof document !== "undefined" &&
+        createPortal(
+          <>
+            {sharePath !== null && (
+              <ShareDialog
+                path={sharePath}
+                open
+                onClose={() => setSharePath(null)}
+              />
+            )}
+            {renamePath !== null && (
+              <RenameModal
+                path={renamePath}
+                onClose={() => setRenamePath(null)}
+                onDone={() => {
+                  setRenamePath(null);
+                  refresh();
+                }}
+              />
+            )}
+            {movePath !== null && (
+              <MoveModal
+                path={movePath}
+                folders={collectFolders(entries)}
+                onClose={() => setMovePath(null)}
+                onDone={() => {
+                  setMovePath(null);
+                  refresh();
+                }}
+              />
+            )}
+            {/* RunAgentPanel renders its own scrim, so no separate backdrop. */}
+            <RunAgentPanel
+              open={agentPath !== null}
+              onClose={() => setAgentPath(null)}
+              wikiPath={agentPath}
+            />
+            {toast && <div className={styles.toast}>{toast}</div>}
+          </>,
+          document.body,
+        )}
+    </ActionsContext.Provider>
+  );
+}

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -66,17 +66,22 @@
   box-sizing: border-box;
 }
 
-/* Row wrapper — holds the SidebarTab plus the hover-revealed "⋯" menu, which
-   overlays the row's right edge (panel-coloured so it sits over the label). */
+/* Row wrapper — SidebarTab with the "⋯" menu overlaying its leading icon. */
 .rowWrap {
   position: relative;
   width: 100%;
 }
+.tab {
+  width: 100%;
+}
+/* "⋯" overlay — pinned over the leading icon slot (container p-2 = 8px + icon
+   box), hidden until the row is hovered or its menu is open. */
 .rowMenu {
   position: absolute;
-  right: 4px;
+  left: 6px;
   top: 50%;
   transform: translateY(-50%);
+  z-index: 1;
   opacity: 0;
   transition: opacity 0.12s ease;
 }
@@ -85,57 +90,31 @@
 .rowMenu[data-open] {
   opacity: 1;
 }
-/* "⋯" More button (657:29879): 24px, white surface (tint/00 → bg-page),
-   rounded-08 (md). Sits over the row's right edge. */
+/* Hide the file/folder icon while the "⋯" is showing, so it reads as a swap.
+   Scoped to .tab so the menu's own icon (in .rowMenu) is unaffected. */
+.rowWrap:hover .tab :global(svg),
+.rowWrap:has(.rowMenu[data-open]) .tab :global(svg) {
+  visibility: hidden;
+}
+/* "⋯" trigger — sized to sit in the icon slot, transparent so it reads as the
+   swapped-in icon (the real icon is hidden underneath while hovered). */
 .moreBtn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   padding: 0;
   border: none;
   border-radius: var(--border-radius-08);
-  background: var(--background-tint-00);
+  background: transparent;
   color: var(--text-03);
   cursor: pointer;
 }
 .moreBtn:hover {
-  background: var(--background-tint-03);
-  color: var(--text-04);
-}
-
-/* Contextual menu (657:41564): fixed 160px width, line items in a column. */
-.menu {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 160px;
-  box-sizing: border-box;
-}
-/* Delete item — danger red (#dc2626 → --status-text-error-05) on icon + label.
-   !important to override OPAL LineItemButton's own text/icon color; scoped to
-   the single wrapped Delete item. */
-.danger,
-.danger :global(*) {
-  color: var(--status-text-error-05) !important;
+  color: var(--text-05);
 }
 
 .empty {
   padding: 8px 12px;
-}
-
-/* Transient toast (e.g. "Link copied") — bottom-centre, auto-dismisses. */
-.toast {
-  position: fixed;
-  left: 50%;
-  bottom: 32px;
-  transform: translateX(-50%);
-  z-index: var(--z-toast);
-  padding: 8px 14px;
-  border-radius: var(--border-radius-08);
-  background: var(--background-tint-04);
-  color: var(--text-05);
-  font-size: 13px;
-  box-shadow: var(--shadow-popover);
 }

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -1,44 +1,26 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useState,
-  type FormEvent,
-} from "react";
-import { createPortal } from "react-dom";
+import { useEffect, useState, type FormEvent } from "react";
 import useSWR, { useSWRConfig } from "swr";
 
 import {
   Button,
-  Divider,
   InputTypeIn,
-  LineItemButton,
-  Popover,
   SidebarTab,
   Text,
 } from "@onyx-ai/opal/components";
 import {
-  SvgEdit,
   SvgFileText,
   SvgFolder,
-  SvgFolderIn,
   SvgFolderOpen,
   SvgFolderPlus,
-  SvgLink,
   SvgMoreHorizontal,
   SvgPlus,
-  SvgShare,
-  SvgSparkle,
-  SvgTrash,
 } from "@onyx-ai/opal/icons";
 
 import { apiFetch } from "@/lib/api";
-import { RunAgentPanel } from "./RunAgentPanel";
-import { ShareDialog } from "./ShareDialog";
-import { MoveModal, RenameModal } from "./WikiItemModals";
+import { useActiveFolder, WikiItemMenu } from "./WikiItemActions";
 import styles from "./WikiTree.module.css";
 
 interface Entry {
@@ -48,18 +30,6 @@ interface Entry {
 
 // Persist which folders are expanded so the tree restores on refresh.
 const EXPANDED_KEY = "wiki:expandedFolders";
-
-/** Per-row contextual-menu actions, provided once by WikiTree and consumed by
- * every RowMenu via context (avoids drilling through the recursive tree). */
-interface RowActions {
-  share: (path: string) => void;
-  rename: (path: string) => void;
-  move: (path: string) => void;
-  copyLink: (path: string) => void;
-  launchAgent: (path: string) => void;
-  remove: (path: string, isFolder: boolean) => void;
-}
-const ActionsContext = createContext<RowActions | null>(null);
 
 /** Direct child folders + files of `dir`, derived from the flat path list. */
 function childrenOf(entries: Entry[], dir: string) {
@@ -83,117 +53,7 @@ function childrenOf(entries: Entry[], dir: string) {
   };
 }
 
-/** Every folder path in the tree (plus root ""), for the move-destination list. */
-function collectFolders(entries: Entry[]): string[] {
-  const set = new Set<string>([""]);
-  for (const e of entries) {
-    const parts = e.path.split("/");
-    parts.pop();
-    let cur = "";
-    for (const p of parts) {
-      cur = cur ? `${cur}/${p}` : p;
-      set.add(cur);
-    }
-  }
-  return [...set].sort((a, b) => a.localeCompare(b));
-}
-
 type IconComponent = React.ComponentProps<typeof SidebarTab>["icon"];
-
-/**
- * Per-row "⋯" actions menu (contextual menu node 657:41564). Spec: 160px wide,
- * compact line items, two dividers, Delete in danger red. Folders omit
- * "Launch Agent" (it adds a doc to an agent run). The trigger stops propagation
- * so it doesn't navigate/expand the row.
- */
-function RowMenu({
-  path,
-  isFolder,
-  open,
-  onOpenChange,
-}: {
-  path: string;
-  isFolder: boolean;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-}) {
-  const actions = useContext(ActionsContext);
-  const run = (fn?: (p: string) => void) => () => {
-    onOpenChange(false);
-    fn?.(path);
-  };
-  return (
-    <div className={styles.rowMenu} data-open={open || undefined}>
-      <Popover open={open} onOpenChange={onOpenChange}>
-        <Popover.Trigger asChild>
-          <button
-            type="button"
-            className={styles.moreBtn}
-            aria-label="More actions"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <SvgMoreHorizontal size={16} />
-          </button>
-        </Popover.Trigger>
-        <Popover.Content align="start" sideOffset={4} width="fit">
-          <div className={styles.menu}>
-            <LineItemButton
-              variant="body"
-              sizePreset="main-ui"
-              icon={SvgShare}
-              title="Share"
-              onClick={run(actions?.share)}
-            />
-            <LineItemButton
-              variant="body"
-              sizePreset="main-ui"
-              icon={SvgEdit}
-              title="Rename"
-              onClick={run(actions?.rename)}
-            />
-            <LineItemButton
-              variant="body"
-              sizePreset="main-ui"
-              icon={SvgFolderIn}
-              title="Move"
-              onClick={run(actions?.move)}
-            />
-            <Divider />
-            <LineItemButton
-              variant="body"
-              sizePreset="main-ui"
-              icon={SvgLink}
-              title="Copy Link"
-              onClick={run(actions?.copyLink)}
-            />
-            {!isFolder && (
-              <LineItemButton
-                variant="body"
-                sizePreset="main-ui"
-                icon={SvgSparkle}
-                title="Launch Agent"
-                onClick={run(actions?.launchAgent)}
-              />
-            )}
-            <Divider />
-            <span className={styles.danger}>
-              <LineItemButton
-                variant="body"
-                sizePreset="main-ui"
-                icon={SvgTrash}
-                title="Delete"
-                onClick={() => {
-                  onOpenChange(false);
-                  actions?.remove(path, isFolder);
-                }}
-              />
-            </span>
-          </div>
-        </Popover.Content>
-      </Popover>
-    </div>
-  );
-}
 
 /**
  * One tree row: an OPAL SidebarTab plus the hover-/open-revealed "⋯" menu. The
@@ -205,31 +65,47 @@ function Row({
   label,
   path,
   isFolder,
+  active = false,
   onClick,
 }: {
   icon: IconComponent;
   label: string;
   path: string;
   isFolder: boolean;
+  active?: boolean;
   onClick: () => void;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
     <div className={styles.rowWrap}>
-      <SidebarTab
-        variant="sidebar-light"
-        icon={icon}
-        selected={menuOpen}
-        onClick={onClick}
-      >
-        {label}
-      </SidebarTab>
-      <RowMenu
-        path={path}
-        isFolder={isFolder}
-        open={menuOpen}
-        onOpenChange={setMenuOpen}
-      />
+      <div className={styles.tab}>
+        <SidebarTab
+          variant="sidebar-light"
+          icon={icon}
+          selected={menuOpen || active}
+          onClick={onClick}
+        >
+          {label}
+        </SidebarTab>
+      </div>
+      {/* "⋯" overlays the leading file/folder icon, revealed on hover. */}
+      <div className={styles.rowMenu} data-open={menuOpen || undefined}>
+        <WikiItemMenu
+          path={path}
+          isFolder={isFolder}
+          open={menuOpen}
+          onOpenChange={setMenuOpen}
+        >
+          <button
+            type="button"
+            className={styles.moreBtn}
+            aria-label="More actions"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <SvgMoreHorizontal size={16} />
+          </button>
+        </WikiItemMenu>
+      </div>
     </div>
   );
 }
@@ -243,6 +119,8 @@ function FolderNode({
   onOpenFile,
   expanded,
   onToggle,
+  activeFolder,
+  onSetActive,
 }: {
   entries: Entry[];
   dir: string;
@@ -250,6 +128,8 @@ function FolderNode({
   onOpenFile: (path: string) => void;
   expanded: Set<string>;
   onToggle: (path: string) => void;
+  activeFolder: string;
+  onSetActive: (path: string) => void;
 }) {
   const full = dir ? `${dir}/${name}` : name;
   const open = expanded.has(full);
@@ -263,7 +143,11 @@ function FolderNode({
         label={name}
         path={full}
         isFolder
-        onClick={() => onToggle(full)}
+        active={activeFolder === full}
+        onClick={() => {
+          onSetActive(full);
+          onToggle(full);
+        }}
       />
       {open && (folders.length > 0 || files.length > 0) && (
         <div className={styles.nested}>
@@ -276,6 +160,8 @@ function FolderNode({
               onOpenFile={onOpenFile}
               expanded={expanded}
               onToggle={onToggle}
+              activeFolder={activeFolder}
+              onSetActive={onSetActive}
             />
           ))}
           {files.map((f) => (
@@ -295,10 +181,9 @@ function FolderNode({
 }
 
 /**
- * Permanent directory sidebar — a nested, expandable tree. Owns the per-row
- * contextual-menu actions (share / rename / move / copy link / launch agent /
- * delete), rendering the reused ShareDialog + RunAgentPanel and the Rename /
- * Move modals once. The list scrolls rather than the panel growing.
+ * Permanent directory sidebar — a nested, expandable tree. Per-row contextual
+ * actions come from the surrounding WikiItemActionsProvider (shared with the
+ * recent-pages grid). The list scrolls rather than the panel growing.
  */
 export function WikiTree() {
   const router = useRouter();
@@ -313,12 +198,14 @@ export function WikiTree() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Contextual-menu targets — each holds the path of the row that opened it.
-  const [sharePath, setSharePath] = useState<string | null>(null);
-  const [renamePath, setRenamePath] = useState<string | null>(null);
-  const [movePath, setMovePath] = useState<string | null>(null);
-  const [agentPath, setAgentPath] = useState<string | null>(null);
-  const [toast, setToast] = useState<string | null>(null);
+  // The folder new pages/folders are created inside ("" = wiki root). State
+  // lives in the provider so deletes can reset it. Clicking a folder row makes
+  // it active; the active row is highlighted (`selected`).
+  const { activeFolder, setActiveFolder } = useActiveFolder() ?? {
+    activeFolder: "",
+    setActiveFolder: () => {},
+  };
+  const activeLabel = activeFolder.split("/").pop() ?? "";
 
   // Expanded folders, persisted to sessionStorage so they survive a refresh.
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -344,57 +231,45 @@ export function WikiTree() {
     });
   };
 
+  // Expand a folder (idempotent) so a freshly-created child is visible.
+  const expandFolder = (path: string) => {
+    if (!path) return;
+    setExpanded((prev) => {
+      if (prev.has(path)) return prev;
+      const next = new Set(prev).add(path);
+      try {
+        sessionStorage.setItem(EXPANDED_KEY, JSON.stringify([...next]));
+      } catch {
+        // ignore persistence failure
+      }
+      return next;
+    });
+  };
+
   const refresh = () => void mutate("/wiki");
 
-  useEffect(() => {
-    if (!toast) return;
-    const t = setTimeout(() => setToast(null), 2000);
-    return () => clearTimeout(t);
-  }, [toast]);
-
-  const actions: RowActions = {
-    share: setSharePath,
-    rename: setRenamePath,
-    move: setMovePath,
-    launchAgent: setAgentPath,
-    copyLink: (path) => {
-      const encoded = path.split("/").map(encodeURIComponent).join("/");
-      const url = `${window.location.origin}/app/wiki/${encoded}`;
-      navigator.clipboard
-        .writeText(url)
-        .then(() => setToast("Link copied"))
-        .catch(() => setToast("Couldn't copy link"));
-    },
-    remove: async (path, isFolder) => {
-      const label = path.replace(/\.md$/, "").split("/").pop() ?? path;
-      const message = isFolder
-        ? `Delete folder "${label}" and everything in it? This cannot be undone.`
-        : `Delete ${label}? This cannot be undone.`;
-      if (!window.confirm(message)) return;
-      try {
-        await apiFetch(`/wiki/file?path=${encodeURIComponent(path)}`, {
-          method: "DELETE",
-        });
-        refresh();
-      } catch (e) {
-        setToast(e instanceof Error ? e.message : "Delete failed");
-      }
-    },
-  };
+  // New pages route to NewDocView for the active folder; new folders create
+  // inside it. Both fall back to the wiki root when nothing is active.
+  const newPage = () =>
+    router.push(
+      activeFolder ? `/app/wiki/${activeFolder}?new=1` : "/app/wiki?new=1",
+    );
 
   async function createFolder(e: FormEvent) {
     e.preventDefault();
-    const name = folderName.trim().replace(/\/+$/, "");
+    const name = folderName.trim().replace(/^\/+|\/+$/g, "");
     if (!name) return;
+    const path = activeFolder ? `${activeFolder}/${name}` : name;
     setBusy(true);
     setError(null);
     try {
       await apiFetch("/wiki/folder", {
         method: "POST",
-        body: JSON.stringify({ path: name }),
+        body: JSON.stringify({ path }),
       });
       setFolderName("");
       setAddingFolder(false);
+      expandFolder(activeFolder);
       refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : "create failed");
@@ -404,118 +279,80 @@ export function WikiTree() {
   }
 
   return (
-    <ActionsContext.Provider value={actions}>
-      <div className={styles.panel}>
-        <div className={styles.header}>
-          <Text font="secondary-body" color="text-03">
-            Directory
-          </Text>
-          <div className={styles.actions}>
-            <Button
-              prominence="tertiary"
-              size="sm"
-              icon={SvgPlus}
-              tooltip="New page"
-              onClick={() => router.push("/app/wiki?new=1")}
-            />
-            <Button
-              prominence="tertiary"
-              size="sm"
-              icon={SvgFolderPlus}
-              tooltip="New folder"
-              onClick={() => setAddingFolder((v) => !v)}
-            />
-          </div>
-        </div>
-
-        {addingFolder && (
-          <form className={styles.folderForm} onSubmit={createFolder}>
-            <InputTypeIn
-              value={folderName}
-              onChange={(e) => setFolderName(e.target.value)}
-              placeholder="folder-name (or subdir/folder-name)"
-              aria-label="New folder name"
-              autoFocus
-            />
-          </form>
-        )}
-        {error && <div className={styles.folderError}>{error}</div>}
-
-        <div className={styles.list}>
-          {folders.map((f) => (
-            <FolderNode
-              key={f}
-              entries={entries}
-              dir=""
-              name={f}
-              onOpenFile={openFile}
-              expanded={expanded}
-              onToggle={toggleFolder}
-            />
-          ))}
-          {files.map((f) => (
-            <Row
-              key={f}
-              icon={SvgFileText}
-              label={f.replace(/\.md$/, "")}
-              path={f}
-              isFolder={false}
-              onClick={() => openFile(f)}
-            />
-          ))}
-          {folders.length === 0 && files.length === 0 && (
-            <div className={styles.empty}>
-              <Text font="secondary-body" color="text-03">
-                No pages yet
-              </Text>
-            </div>
-          )}
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <Text font="secondary-body" color="text-03">
+          Directory
+        </Text>
+        <div className={styles.actions}>
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgPlus}
+            tooltip={activeFolder ? `New page in ${activeLabel}` : "New page"}
+            onClick={newPage}
+          />
+          <Button
+            prominence="tertiary"
+            size="sm"
+            icon={SvgFolderPlus}
+            tooltip={
+              activeFolder ? `New folder in ${activeLabel}` : "New folder"
+            }
+            onClick={() => setAddingFolder((v) => !v)}
+          />
         </div>
       </div>
 
-      {/* Overlays are portaled to <body> so they escape the sticky sidebar's
-          stacking context (otherwise the page content paints over the scrim). */}
-      {typeof document !== "undefined" &&
-        createPortal(
-          <>
-            {sharePath !== null && (
-              <ShareDialog
-                path={sharePath}
-                open
-                onClose={() => setSharePath(null)}
-              />
-            )}
-            {renamePath !== null && (
-              <RenameModal
-                path={renamePath}
-                onClose={() => setRenamePath(null)}
-                onDone={() => {
-                  setRenamePath(null);
-                  refresh();
-                }}
-              />
-            )}
-            {movePath !== null && (
-              <MoveModal
-                path={movePath}
-                folders={collectFolders(entries)}
-                onClose={() => setMovePath(null)}
-                onDone={() => {
-                  setMovePath(null);
-                  refresh();
-                }}
-              />
-            )}
-            {/* RunAgentPanel renders its own scrim, so no separate backdrop. */}
-            <RunAgentPanel
-              open={agentPath !== null}
-              onClose={() => setAgentPath(null)}
-              wikiPath={agentPath}
-            />
-            {toast && <div className={styles.toast}>{toast}</div>}
-          </>,
-          document.body,
+      {addingFolder && (
+        <form className={styles.folderForm} onSubmit={createFolder}>
+          <InputTypeIn
+            value={folderName}
+            onChange={(e) => setFolderName(e.target.value)}
+            placeholder={
+              activeFolder
+                ? `folder-name (in ${activeLabel})`
+                : "folder-name (or subdir/folder-name)"
+            }
+            aria-label="New folder name"
+            autoFocus
+          />
+        </form>
+      )}
+      {error && <div className={styles.folderError}>{error}</div>}
+
+      <div className={styles.list}>
+        {folders.map((f) => (
+          <FolderNode
+            key={f}
+            entries={entries}
+            dir=""
+            name={f}
+            onOpenFile={openFile}
+            expanded={expanded}
+            onToggle={toggleFolder}
+            activeFolder={activeFolder}
+            onSetActive={setActiveFolder}
+          />
+        ))}
+        {files.map((f) => (
+          <Row
+            key={f}
+            icon={SvgFileText}
+            label={f.replace(/\.md$/, "")}
+            path={f}
+            isFolder={false}
+            onClick={() => openFile(f)}
+          />
+        ))}
+        {folders.length === 0 && files.length === 0 && (
+          <div className={styles.empty}>
+            <Text font="secondary-body" color="text-03">
+              No pages yet
+            </Text>
+          </div>
         )}
-    </ActionsContext.Provider>
+      </div>
+    </div>
   );
 }

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -201,10 +201,7 @@ export function WikiTree() {
   // The folder new pages/folders are created inside ("" = wiki root). State
   // lives in the provider so deletes can reset it. Clicking a folder row makes
   // it active; the active row is highlighted (`selected`).
-  const { activeFolder, setActiveFolder } = useActiveFolder() ?? {
-    activeFolder: "",
-    setActiveFolder: () => {},
-  };
+  const { activeFolder, setActiveFolder } = useActiveFolder();
   const activeLabel = activeFolder.split("/").pop() ?? "";
 
   // Expanded folders, persisted to sessionStorage so they survive a refresh.


### PR DESCRIPTION
## Description

- Extract `WikiItemActionsProvider` + `WikiItemMenu` so the directory sidebar and the recent-pages grid share one contextual menu and one set of overlays (Share / Rename / Move / Copy Link / Launch Agent / Delete).
- **Recent-page card ⋯** now opens that menu — it was previously inert. Wrapped in a `<span>` trigger because OPAL `Button` doesn't forward refs into `Popover.Trigger asChild`.
- **Sidebar ⋯** swaps in over the leading file/folder icon on hover (no extra column).
- **Active folder:** clicking a folder row marks it active (highlighted); new pages/folders are created inside it; the active folder resets when it (or an ancestor) is deleted. State lives in the provider so deletes can clear it.

## How Has This Been Tested?