### PR TITLE
feat(home): AI draft generation, destination picker, and chat-driven live editing

### DIFF
--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -368,8 +368,9 @@ async def drafting_init(
         # "Start writing with AI": the prompt is the user's real first turn
         # (shown), preceded by a hidden instruction — a draft for it is already
         # in the editor, so the agent just acknowledges and offers to refine.
+        prompt = req.prompt
         await run_in_threadpool(lambda: _append(_compose_ai_followup_instruction(), hidden=True))
-        await run_in_threadpool(lambda: _append(req.prompt or "", hidden=False))
+        await run_in_threadpool(lambda: _append(prompt, hidden=False))
     else:
         seed_text = (
             _compose_drafting_seed_message(tmpl)

--- a/backend/app/api/chat.py
+++ b/backend/app/api/chat.py
@@ -5,6 +5,7 @@ endpoint ``POST /api/chat/messages`` lands here in Phase 4 — async
 streaming so the model worker isn't pinned to one OS thread per
 in-flight chat the way the Flask sync-worker setup is today.
 """
+
 from __future__ import annotations
 
 import json
@@ -73,7 +74,8 @@ def create_session(user: User = Depends(require_user)) -> ChatSessionOut:
 
 @router.get("/sessions/{session_id}", response_model=ChatSessionDetail)
 def get_session(
-    session_id: str, user: User = Depends(require_user),
+    session_id: str,
+    user: User = Depends(require_user),
 ) -> ChatSessionDetail:
     row = sessions_repo.get(session_id, user.id)
     if row is None:
@@ -101,7 +103,8 @@ def get_session(
 
 @router.delete("/sessions/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
 def delete_session(
-    session_id: str, user: User = Depends(require_user),
+    session_id: str,
+    user: User = Depends(require_user),
 ) -> Response:
     if not sessions_repo.delete(session_id, user.id):
         raise HTTPException(status_code=404, detail="session not found")
@@ -110,7 +113,9 @@ def delete_session(
 
 @router.post("/messages")
 async def send_message(
-    req: SendChatRequest, request: Request, user: User = Depends(require_user),
+    req: SendChatRequest,
+    request: Request,
+    user: User = Depends(require_user),
 ) -> Response:
     """Run one user turn through the chat agent, streaming JSON-RPC-like
     SSE frames back to the client.
@@ -121,7 +126,9 @@ async def send_message(
     ``run_in_threadpool`` for the same reason.
     """
     sess = await run_in_threadpool(
-        sessions_repo.get, req.session_id, user.id,
+        sessions_repo.get,
+        req.session_id,
+        user.id,
     )
     if sess is None:
         raise HTTPException(status_code=404, detail="session not found")
@@ -129,7 +136,8 @@ async def send_message(
     # First turn? Used after the stream finishes to decide whether to
     # enqueue title generation.
     prior_count = await run_in_threadpool(
-        sessions_repo.count_messages, req.session_id,
+        sessions_repo.count_messages,
+        req.session_id,
     )
     is_first_turn = prior_count == 0
 
@@ -137,7 +145,10 @@ async def send_message(
     # halfway, the user's turn is still on the timeline.
     await run_in_threadpool(
         lambda: sessions_repo.append_message(
-            req.session_id, role="user", content=req.content, events=None,
+            req.session_id,
+            role="user",
+            content=req.content,
+            events=None,
         ),
     )
 
@@ -156,12 +167,15 @@ async def send_message(
         events: list[dict[str, Any]] = []
         text_parts: list[str] = []
         try:
-            with trace_flow(
-                "chat.send_message",
-                chat_session_id=session_id,
-                user_id=user_id,
-                is_first_turn=is_first_turn,
-            ), chat_agent_scope():
+            with (
+                trace_flow(
+                    "chat.send_message",
+                    chat_session_id=session_id,
+                    user_id=user_id,
+                    is_first_turn=is_first_turn,
+                ),
+                chat_agent_scope(),
+            ):
                 raw_settings = await run_in_threadpool(users_repo.get_settings, user_id)
                 user_prefs = UserSettings.model_validate(raw_settings or {})
                 gen = run_chat_stream(
@@ -230,7 +244,9 @@ async def send_message(
         "X-Accel-Buffering": "no",
     }
     return StreamingResponse(
-        stream(), media_type="text/event-stream", headers=headers,
+        stream(),
+        media_type="text/event-stream",
+        headers=headers,
     )
 
 
@@ -247,12 +263,25 @@ def _compose_blank_seed_message() -> str:
             "",
             "Reply in a very short response — just a couple of sentences total. "
             "Do not lecture or list options. Open with one short, welcoming line "
-            "like \"Great, what would you like to work on?\" and briefly mention "
+            'like "Great, what would you like to work on?" and briefly mention '
             "that I can describe topics or sections I care about (a project I "
             "want to track, recurring updates, a running list) and the wiki "
             "will fill those in and keep them updated over time. Keep the "
             "overall response short.",
         ]
+    )
+
+
+def _compose_ai_followup_instruction() -> str:
+    """Hidden turn for the "Start writing with AI" flow. The user's real prompt
+    follows this; a complete first draft for it is already in the editor."""
+    return (
+        "The user's request follows. A complete first draft for it has already "
+        "been generated and placed in the editor for them to review. When you "
+        "reply, do NOT reproduce the draft and do NOT call any tools. Just give "
+        "one short, welcoming sentence acknowledging the draft is ready in the "
+        "editor, then invite them to tell you any changes (tone, length, "
+        "sections, title). Keep it to 1-2 sentences."
     )
 
 
@@ -285,15 +314,15 @@ def _compose_drafting_seed_message(template: dict[str, Any]) -> str:
             "",
             "Reply in a very short response — just a couple of sentences total. "
             "Do not summarize, describe, or comment on the template itself. "
-            f"Open with one short sentence like \"Great, let's build out this {name} together\" "
+            f'Open with one short sentence like "Great, let\'s build out this {name} together" '
             "and then ask 1 or 2 specific guiding questions to help me start filling "
             "in the most important parts. The goal is to help me complete the doc with "
             "as little effort as possible.",
             "",
             "Also mention, in one line, that I can have future agents fill in any section "
             "later by leaving a short note in the doc itself describing what belongs there "
-            "(for example, \"This section auto-fills with new updates over time\" or "
-            "\"Log every mention of this project here with context\") — the wiki will pick "
+            '(for example, "This section auto-fills with new updates over time" or '
+            '"Log every mention of this project here with context") — the wiki will pick '
             "that up. Keep the overall response short.",
         ]
     )
@@ -326,20 +355,28 @@ async def drafting_init(
     session_id = sess["id"]
     user_id = user.id
 
-    seed_text = (
-        _compose_drafting_seed_message(tmpl)
-        if tmpl is not None
-        else _compose_blank_seed_message()
-    )
-    await run_in_threadpool(
-        lambda: sessions_repo.append_message(
+    def _append(content: str, *, hidden: bool) -> None:
+        sessions_repo.append_message(
             session_id,
             role="user",
-            content=seed_text,
+            content=content,
             events=None,
-            hidden=True,
-        ),
-    )
+            hidden=hidden,
+        )
+
+    if req.prompt is not None and tmpl is None:
+        # "Start writing with AI": the prompt is the user's real first turn
+        # (shown), preceded by a hidden instruction — a draft for it is already
+        # in the editor, so the agent just acknowledges and offers to refine.
+        await run_in_threadpool(lambda: _append(_compose_ai_followup_instruction(), hidden=True))
+        await run_in_threadpool(lambda: _append(req.prompt or "", hidden=False))
+    else:
+        seed_text = (
+            _compose_drafting_seed_message(tmpl)
+            if tmpl is not None
+            else _compose_blank_seed_message()
+        )
+        await run_in_threadpool(lambda: _append(seed_text, hidden=True))
 
     history = await run_in_threadpool(
         lambda: sessions_repo.get_messages(session_id, include_hidden=True),
@@ -353,12 +390,15 @@ async def drafting_init(
         events: list[dict[str, Any]] = []
         text_parts: list[str] = []
         try:
-            with trace_flow(
-                "chat.drafting_init",
-                chat_session_id=session_id,
-                user_id=user_id,
-                template_id=tmpl["id"] if tmpl is not None else None,
-            ), chat_agent_scope():
+            with (
+                trace_flow(
+                    "chat.drafting_init",
+                    chat_session_id=session_id,
+                    user_id=user_id,
+                    template_id=tmpl["id"] if tmpl is not None else None,
+                ),
+                chat_agent_scope(),
+            ):
                 gen = run_chat_stream(messages)
                 async for ev in iterate_in_threadpool(gen):
                     if await request.is_disconnected():
@@ -393,7 +433,8 @@ async def drafting_init(
             await run_in_threadpool(sessions_repo.touch, session_id)
         except Exception:
             log.exception(
-                "failed to persist drafting kickoff turn session_id=%s", session_id,
+                "failed to persist drafting kickoff turn session_id=%s",
+                session_id,
             )
 
     headers = {
@@ -402,5 +443,7 @@ async def drafting_init(
         "X-Accel-Buffering": "no",
     }
     return StreamingResponse(
-        stream(), media_type="text/event-stream", headers=headers,
+        stream(),
+        media_type="text/event-stream",
+        headers=headers,
     )

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -45,6 +45,8 @@ from app.models.file_system import (
     ReindexRequest,
     ReindexResponse,
     ReorderStarredRequest,
+    ReviseDraftRequest,
+    ReviseDraftResponse,
     SearchHitView,
     SearchResponse,
     SetDocumentDraftRequest,
@@ -412,6 +414,17 @@ def generate_draft(
 
     result = draft_generator.generate(req.prompt)
     return GenerateDraftResponse(title=result["title"], body=result["body"])
+
+
+@router.post("/revise", response_model=ReviseDraftResponse)
+def revise_draft(
+    req: ReviseDraftRequest,
+    user: User = Depends(require_user),
+) -> ReviseDraftResponse:
+    """Apply an instruction to an unsaved draft body; return the revised body."""
+    from app.llm.agents import draft_reviser
+
+    return ReviseDraftResponse(body=draft_reviser.revise(req.body, req.instruction))
 
 
 @router.get("/search", response_model=SearchResponse)

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -25,6 +25,8 @@ from app.models.file_system import (
     FileDiffResponse,
     FileHistoryResponse,
     FolderHitView,
+    GenerateDraftRequest,
+    GenerateDraftResponse,
     GetDocumentResponse,
     ListDocumentsResponse,
     ListRecentPagesResponse,
@@ -398,6 +400,18 @@ def reindex_document_by_path(
     require_can("read", rel, user)
     index_path(rel)
     return ReindexResponse(path=rel, queued=True)
+
+
+@router.post("/generate", response_model=GenerateDraftResponse)
+def generate_draft(
+    req: GenerateDraftRequest,
+    user: User = Depends(require_user),
+) -> GenerateDraftResponse:
+    """Generate a draft (title + body) from a free-text prompt for review."""
+    from app.llm.agents import draft_generator
+
+    result = draft_generator.generate(req.prompt)
+    return GenerateDraftResponse(title=result["title"], body=result["body"])
 
 
 @router.get("/search", response_model=SearchResponse)

--- a/backend/app/llm/agents/draft_generator.py
+++ b/backend/app/llm/agents/draft_generator.py
@@ -1,0 +1,44 @@
+"""One-shot draft generator backing the home "Start writing with AI" input.
+
+Turns a free-text prompt into a complete Markdown draft plus a title, for the
+user to review and create. Non-conversational: a single ``complete`` call, no
+tools, no chat loop. Tests patch ``app.llm.client.complete``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from app.llm import client
+from app.llm.prompts import load_prompt
+from app.tracing import trace_flow
+
+log = logging.getLogger(__name__)
+
+_MAX_TOKENS = 4000
+_TITLE_RE = re.compile(r"^\s*#\s+(.+?)\s*$", re.MULTILINE)
+
+
+def generate(prompt: str, *, model: str | None = None) -> dict[str, str]:
+    """Generate a draft for ``prompt``. Returns ``{title, body}``."""
+    messages = [
+        {"role": "system", "content": load_prompt("draft_generator.system")},
+        {"role": "user", "content": prompt},
+    ]
+    with trace_flow("agent.draft_generator", prompt=prompt):
+        result = client.complete(messages, model=model, max_tokens=_MAX_TOKENS)
+    body = result.text.strip()
+    return {"title": _title_from(body), "body": body}
+
+
+def _title_from(body: str) -> str:
+    """The first ``# `` heading, else the first non-empty line, else fallback."""
+    match = _TITLE_RE.search(body)
+    if match:
+        return match.group(1).strip()
+    for line in body.splitlines():
+        stripped = line.strip().lstrip("#").strip()
+        if stripped:
+            return stripped
+    return "Untitled"

--- a/backend/app/llm/agents/draft_reviser.py
+++ b/backend/app/llm/agents/draft_reviser.py
@@ -1,0 +1,42 @@
+"""One-shot draft reviser backing the drafting chat's live edits.
+
+Stateless: given the current (unsaved) draft body and an instruction, returns
+the full revised body. The editor's content is the only state, so iterative
+edits compose without conversation memory. Tests patch ``app.llm.client.complete``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.llm import client
+from app.llm.prompts import load_prompt
+from app.tracing import trace_flow
+
+log = logging.getLogger(__name__)
+
+_MAX_TOKENS = 4000
+
+
+def revise(body: str, instruction: str, *, model: str | None = None) -> str:
+    """Apply ``instruction`` to ``body``; return the full revised document."""
+    user = "\n".join(
+        [
+            "Current document:",
+            "",
+            "```markdown",
+            body,
+            "```",
+            "",
+            "Instruction:",
+            "",
+            instruction,
+        ]
+    )
+    messages = [
+        {"role": "system", "content": load_prompt("draft_reviser.system")},
+        {"role": "user", "content": user},
+    ]
+    with trace_flow("agent.draft_reviser", instruction=instruction):
+        result = client.complete(messages, model=model, max_tokens=_MAX_TOKENS)
+    return result.text.strip()

--- a/backend/app/llm/prompts/draft_generator.system.md
+++ b/backend/app/llm/prompts/draft_generator.system.md
@@ -1,0 +1,12 @@
+You generate a complete first-draft wiki page from a short user prompt.
+
+The user describes what they want to write about. Produce a single, ready-to-review Markdown document — not a question, not a clarification, not a conversation. The user will review and edit it before saving, so give them real content to work from rather than an empty skeleton.
+
+Rules:
+
+- Output **only** the Markdown document. No preamble, no "Here is…", no surrounding code fences.
+- Begin with a single `# Title` heading on the first line. Pick a clear, specific title from the prompt.
+- Follow with well-structured Markdown: short intro, then `##` sections with concrete, useful content. Use lists, tables, and checklists where they fit the topic.
+- Infer reasonable structure and placeholder detail when the prompt is sparse, so the page is genuinely useful as a starting point. Use `_italic placeholder_` text where the user clearly needs to fill in specifics.
+- Keep it focused and proportionate to the prompt — a few hundred words for a normal request, not an essay.
+- Never ask the user a question. Always commit to a draft.

--- a/backend/app/llm/prompts/draft_reviser.system.md
+++ b/backend/app/llm/prompts/draft_reviser.system.md
@@ -1,0 +1,11 @@
+You revise a Markdown wiki document according to the user's instruction.
+
+You are given the current document and one instruction describing a change (e.g. "change the title to X", "make it longer", "add a section on Y", "make the tone more formal"). Apply it and return the **complete, updated document**.
+
+Rules:
+
+- Output **only** the full revised Markdown document. No preamble, no "Here is…", no commentary, no surrounding code fences.
+- Preserve everything the instruction doesn't ask to change. Make the smallest edit that satisfies the request — don't rewrite untouched sections.
+- Keep a single `# Title` heading on the first line. If the instruction changes the title, change that heading.
+- If the current document is empty, treat the instruction as a request to draft a new document from scratch.
+- Never ask a question. Always return a document.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from app.auth.deps import CurrentUserMiddleware
 import app.config as _app_config
 from app.metrics import setup_prometheus
 from app.mcp_server import pubsub as mcp_pubsub
+from app.llm.errors import LLMError
 from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestError
 from app.tasks.queues import QueueFullError
 
@@ -59,7 +60,11 @@ log = logging.getLogger(__name__)
 
 def _on_http_exception(_request: Request, exc: Exception) -> JSONResponse:
     assert isinstance(exc, FastAPIHTTPException)
-    content = exc.detail if isinstance(exc.detail, dict) else ErrorResponse(error=str(exc.detail)).model_dump()
+    content = (
+        exc.detail
+        if isinstance(exc.detail, dict)
+        else ErrorResponse(error=str(exc.detail)).model_dump()
+    )
     return JSONResponse(status_code=exc.status_code, content=content)
 
 
@@ -100,6 +105,18 @@ def _on_request_error(_request: Request, exc: Exception) -> JSONResponse:
     )
 
 
+# LLMError.code → HTTP status, per the contract documented on the class.
+_LLM_ERROR_STATUS = {"not_configured": 503, "auth": 502, "rate_limit": 429}
+
+
+def _on_llm_error(_request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, LLMError)
+    return JSONResponse(
+        status_code=_LLM_ERROR_STATUS.get(exc.code, 502),
+        content=ErrorResponse(error=exc.message).model_dump(),
+    )
+
+
 def _install_error_handlers(app: FastAPI) -> None:
     """Translate domain exceptions into the standard
     ``{"error": "..."}`` envelope the frontend's ``ApiError`` parses."""
@@ -107,6 +124,7 @@ def _install_error_handlers(app: FastAPI) -> None:
     app.add_exception_handler(RequestValidationError, _on_validation_error)
     app.add_exception_handler(PermissionDenied, _on_permission_denied)
     app.add_exception_handler(QueueFullError, _on_queue_full)
+    app.add_exception_handler(LLMError, _on_llm_error)
     app.add_exception_handler(RequestError, _on_request_error)
 
 

--- a/backend/app/models/chat.py
+++ b/backend/app/models/chat.py
@@ -1,4 +1,5 @@
 """HTTP shapes for /api/chat."""
+
 from __future__ import annotations
 
 from typing import Any, Literal
@@ -39,6 +40,10 @@ class DraftingInitRequest(BaseModel):
     """
 
     template_id: str | None = Field(default=None, min_length=1)
+    # The "Start writing with AI" prompt. When set, it becomes a VISIBLE first
+    # user turn (a draft was already generated into the editor for it) instead
+    # of the generic blank prime.
+    prompt: str | None = Field(default=None, min_length=1)
 
 
 class ChatSessionOut(BaseModel):

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -61,6 +61,20 @@ class GenerateDraftResponse(BaseModel):
     body: str
 
 
+class ReviseDraftRequest(BaseModel):
+    """Live edit of an unsaved draft from the drafting chat. ``body`` is the
+    current editor content (may be empty); ``instruction`` is what to change."""
+
+    body: str
+    instruction: str = Field(min_length=1)
+
+
+class ReviseDraftResponse(BaseModel):
+    """The full revised document body to drop back into the editor."""
+
+    body: str
+
+
 class IngestRequest(BaseModel):
     """Inbound document push from external systems (e.g. Onyx connectors)."""
 

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -48,6 +48,19 @@ class ReindexRequest(BaseModel):
     path: str = Field(min_length=1)
 
 
+class GenerateDraftRequest(BaseModel):
+    """Free-text prompt from the home "Start writing with AI" input."""
+
+    prompt: str = Field(min_length=1)
+
+
+class GenerateDraftResponse(BaseModel):
+    """An auto-generated draft for the user to review before creating."""
+
+    title: str
+    body: str
+
+
 class IngestRequest(BaseModel):
     """Inbound document push from external systems (e.g. Onyx connectors)."""
 

--- a/backend/tests/test_draft_generator.py
+++ b/backend/tests/test_draft_generator.py
@@ -79,7 +79,7 @@ def test_generate_endpoint_returns_draft(mock_client: MagicMock, client: TestCli
 def test_generate_endpoint_422_on_empty_prompt(client: TestClient) -> None:
     uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
     login_fastapi(client, uid)
-    assert client.post("/api/wiki/generate", json={"prompt": ""}).status_code == 422
+    assert client.post("/api/wiki/generate", json={"prompt": ""}).status_code == 400
 
 
 @patch("app.llm.agents.draft_generator.client")

--- a/backend/tests/test_draft_generator.py
+++ b/backend/tests/test_draft_generator.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.auth import users as users_repo
 from app.llm.agents import draft_generator
+from app.llm.errors import LLMError
 from app.main import create_app
 from tests._auth import login_fastapi
 
@@ -79,3 +80,16 @@ def test_generate_endpoint_422_on_empty_prompt(client: TestClient) -> None:
     uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
     login_fastapi(client, uid)
     assert client.post("/api/wiki/generate", json={"prompt": ""}).status_code == 422
+
+
+@patch("app.llm.agents.draft_generator.client")
+def test_generate_endpoint_surfaces_llm_error(mock_client: MagicMock, client: TestClient) -> None:
+    # Unconfigured / failing LLM must surface a clean {error} envelope, not a 500.
+    mock_client.complete.side_effect = LLMError("not_configured", "LLM is not configured.")
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+
+    resp = client.post("/api/wiki/generate", json={"prompt": "anything"})
+
+    assert resp.status_code == 503
+    assert resp.json()["error"] == "LLM is not configured."

--- a/backend/tests/test_draft_generator.py
+++ b/backend/tests/test_draft_generator.py
@@ -1,0 +1,81 @@
+"""Tests for the AI draft generator agent + POST /api/wiki/generate."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.llm.agents import draft_generator
+from app.main import create_app
+from tests._auth import login_fastapi
+
+
+def _llm_response(text: str) -> MagicMock:
+    m = MagicMock(text=text)
+    m.usage.input_tokens = 10
+    m.usage.output_tokens = 20
+    return m
+
+
+# --------------------------------------------------------------------------- #
+# draft_generator.generate                                                     #
+# --------------------------------------------------------------------------- #
+
+
+@patch("app.llm.agents.draft_generator.client")
+def test_generate_extracts_title_from_heading(mock_client: MagicMock) -> None:
+    mock_client.complete.return_value = _llm_response("# My Plan\n\nintro\n")
+    out = draft_generator.generate("plan something")
+    assert out["title"] == "My Plan"
+    assert out["body"] == "# My Plan\n\nintro"
+
+
+@patch("app.llm.agents.draft_generator.client")
+def test_generate_falls_back_to_first_line(mock_client: MagicMock) -> None:
+    mock_client.complete.return_value = _llm_response("Just a line\nmore\n")
+    assert draft_generator.generate("x")["title"] == "Just a line"
+
+
+@patch("app.llm.agents.draft_generator.client")
+def test_generate_untitled_when_empty(mock_client: MagicMock) -> None:
+    mock_client.complete.return_value = _llm_response("   \n\n")
+    out = draft_generator.generate("x")
+    assert out["title"] == "Untitled"
+    assert out["body"] == ""
+
+
+# --------------------------------------------------------------------------- #
+# POST /api/wiki/generate                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def client(tmp_db: None, tmp_repo: None) -> TestClient:
+    return TestClient(create_app())
+
+
+def test_generate_endpoint_unauthenticated_is_401(client: TestClient) -> None:
+    assert client.post("/api/wiki/generate", json={"prompt": "hi"}).status_code == 401
+
+
+@patch("app.llm.agents.draft_generator.client")
+def test_generate_endpoint_returns_draft(mock_client: MagicMock, client: TestClient) -> None:
+    mock_client.complete.return_value = _llm_response("# Title\n\nbody text\n")
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+
+    resp = client.post("/api/wiki/generate", json={"prompt": "write about cats"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Title"
+    assert body["body"] == "# Title\n\nbody text"
+
+
+def test_generate_endpoint_422_on_empty_prompt(client: TestClient) -> None:
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+    assert client.post("/api/wiki/generate", json={"prompt": ""}).status_code == 422

--- a/backend/tests/test_draft_reviser.py
+++ b/backend/tests/test_draft_reviser.py
@@ -60,8 +60,9 @@ def test_revise_endpoint_returns_body(mock_client: MagicMock, client: TestClient
     assert resp.json()["body"] == "# Revised\n\nnew"
 
 
-def test_revise_endpoint_422_on_empty_instruction(client: TestClient) -> None:
+def test_revise_endpoint_400_on_empty_instruction(client: TestClient) -> None:
     uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
     login_fastapi(client, uid)
     resp = client.post("/api/wiki/revise", json={"body": "x", "instruction": ""})
-    assert resp.status_code == 422
+    # This app's validation handler returns 400, not FastAPI's default 422.
+    assert resp.status_code == 400

--- a/backend/tests/test_draft_reviser.py
+++ b/backend/tests/test_draft_reviser.py
@@ -1,0 +1,67 @@
+"""Tests for the draft reviser agent + POST /api/wiki/revise."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.llm.agents import draft_reviser
+from app.main import create_app
+from tests._auth import login_fastapi
+
+
+def _llm_response(text: str) -> MagicMock:
+    m = MagicMock(text=text)
+    m.usage.input_tokens = 10
+    m.usage.output_tokens = 20
+    return m
+
+
+@patch("app.llm.agents.draft_reviser.client")
+def test_revise_returns_trimmed_body(mock_client: MagicMock) -> None:
+    mock_client.complete.return_value = _llm_response("# New Title\n\nbody\n")
+    assert draft_reviser.revise("# Old\n", "rename it") == "# New Title\n\nbody"
+
+
+@patch("app.llm.agents.draft_reviser.client")
+def test_revise_passes_body_and_instruction(mock_client: MagicMock) -> None:
+    mock_client.complete.return_value = _llm_response("out")
+    draft_reviser.revise("# Doc\n\ncontent", "make it formal")
+    sent = mock_client.complete.call_args.args[0]
+    user_turn = sent[-1]["content"]
+    assert "# Doc" in user_turn and "make it formal" in user_turn
+
+
+@pytest.fixture
+def client(tmp_db: None, tmp_repo: None) -> TestClient:
+    return TestClient(create_app())
+
+
+def test_revise_endpoint_unauthenticated_is_401(client: TestClient) -> None:
+    resp = client.post("/api/wiki/revise", json={"body": "x", "instruction": "y"})
+    assert resp.status_code == 401
+
+
+@patch("app.llm.agents.draft_reviser.client")
+def test_revise_endpoint_returns_body(mock_client: MagicMock, client: TestClient) -> None:
+    mock_client.complete.return_value = _llm_response("# Revised\n\nnew\n")
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+
+    resp = client.post(
+        "/api/wiki/revise",
+        json={"body": "# Orig\n", "instruction": "rewrite"},
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["body"] == "# Revised\n\nnew"
+
+
+def test_revise_endpoint_422_on_empty_instruction(client: TestClient) -> None:
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+    resp = client.post("/api/wiki/revise", json={"body": "x", "instruction": ""})
+    assert resp.status_code == 422

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -14,7 +14,14 @@ import { diffLines } from "diff";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import useSWR from "swr";
-import { Button, SelectButton } from "@onyx-ai/opal/components";
+import {
+  Button,
+  LineItemButton,
+  OpenButton,
+  Popover,
+  PopoverMenu,
+  SelectButton,
+} from "@onyx-ai/opal/components";
 import {
   SvgArrowLeft,
   SvgChevronLeft,
@@ -524,9 +531,26 @@ function NewDocView({ dir }: { dir: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const isMobile = useIsMobile();
-  const { setDrafting, requestExpand } = useDrafting();
-  const [filename, setFilename] = useState("");
-  const [draft, setDraft] = useState("");
+  const { setDrafting, requestExpand, registerDraftBridge } = useDrafting();
+  // "Start writing with AI" hands a generated draft (+ the prompt) here via
+  // sessionStorage, paired with ?ai=1. Read it synchronously so the editor and
+  // the drafting chat seed on the first render (no blank→ai re-init flash).
+  const isAiSeed = searchParams?.get("ai") === "1";
+  const [aiSeed] = useState<{
+    title?: string;
+    body?: string;
+    prompt?: string;
+  } | null>(() => {
+    if (!isAiSeed || typeof window === "undefined") return null;
+    try {
+      const raw = sessionStorage.getItem(AI_DRAFT_KEY);
+      return raw ? JSON.parse(raw) : null;
+    } catch {
+      return null;
+    }
+  });
+  const [filename, setFilename] = useState(aiSeed?.title ?? "");
+  const [draft, setDraft] = useState(aiSeed?.body ?? "");
   const [templates, setTemplates] = useState<DocumentTemplateSummary[] | null>(
     null,
   );
@@ -542,34 +566,39 @@ function NewDocView({ dir }: { dir: string }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Home "Start writing with AI" hands off a generated draft via sessionStorage
-  // (paired with ?ai=1). Seed the composer with it once, then drop the flag so
-  // it doesn't re-apply on re-render or override later edits.
-  const isAiSeed = searchParams?.get("ai") === "1";
-  const aiSeededRef = useRef(false);
+  // Destination folder for the new doc — defaults to the route's folder but is
+  // user-selectable (the AI flow lands at root, so the picker is how you place it).
+  const [destDir, setDestDir] = useState(dir);
+  const { data: tree } = useSWR<ListResponse>("/wiki");
+  const folders = useMemo(() => collectFolders(tree?.entries ?? []), [tree]);
+
+  // Drop the stash once consumed so it doesn't re-apply on remount / back-nav.
   useEffect(() => {
-    if (aiSeededRef.current || !isAiSeed) return;
-    aiSeededRef.current = true;
-    try {
-      const raw = sessionStorage.getItem(AI_DRAFT_KEY);
-      sessionStorage.removeItem(AI_DRAFT_KEY);
-      if (!raw) return;
-      const draft = JSON.parse(raw) as { title?: string; body?: string };
-      if (draft.title) setFilename(draft.title);
-      if (draft.body) setDraft(draft.body);
-    } catch {
-      // malformed/unavailable stash — fall back to an empty composer
+    if (aiSeed && typeof window !== "undefined") {
+      try {
+        sessionStorage.removeItem(AI_DRAFT_KEY);
+      } catch {
+        // ignore
+      }
     }
-  }, [isAiSeed]);
+  }, [aiSeed]);
+
+  // Bridge the editor to the drafting chat so it can live-edit this unsaved
+  // draft. Keep a ref of the latest body so the chat reads current content.
+  const draftRef = useRef(draft);
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+  useEffect(() => {
+    registerDraftBridge({ get: () => draftRef.current, set: setDraft });
+    return () => registerDraftBridge(null);
+  }, [registerDraftBridge]);
 
   // Pop the chat widget open once on mount — the assistant can help while the
-  // user picks a template / drafts initial content. Skip it for an AI-seeded
-  // draft: there's already content to review, so the generic "what would you
-  // like to work on" prime would be noise.
+  // user drafts. For an AI-seeded draft the chat seeds with the user's prompt.
   useEffect(() => {
-    if (isAiSeed) return;
     requestExpand();
-  }, [requestExpand, isAiSeed]);
+  }, [requestExpand]);
 
   useEffect(() => {
     let cancelled = false;
@@ -601,9 +630,9 @@ function NewDocView({ dir }: { dir: string }) {
         templateName: t?.name ?? null,
       });
     } else {
-      setDrafting({ kind: "blank", path: null });
+      setDrafting({ kind: "blank", path: null, prompt: aiSeed?.prompt });
     }
-  }, [appliedTemplateId, templates, setDrafting]);
+  }, [appliedTemplateId, templates, setDrafting, aiSeed]);
   // Clear drafting on unmount (cancel, sidebar nav, …) — the chat widget
   // tears its drafting session down synchronously on null, so the collapse
   // happens in the same paint as the page change. The one exception is
@@ -672,7 +701,7 @@ function NewDocView({ dir }: { dir: string }) {
     setError(null);
     try {
       const name = filenameNoExt + ".md";
-      const fullPath = (dir ? dir + "/" : "") + name;
+      const fullPath = (destDir ? destDir + "/" : "") + name;
       await apiFetch("/wiki/file", {
         method: "PUT",
         body: JSON.stringify({ path: fullPath, body: draft }),
@@ -697,7 +726,7 @@ function NewDocView({ dir }: { dir: string }) {
     appliedTemplateBody !== null && draft === appliedTemplateBody;
   const showGallery =
     (isBlank || matchesApplied) && templates !== null && templates.length > 0;
-  const parentSlug = dir;
+  const parentSlug = destDir;
 
   return (
     <main
@@ -728,6 +757,16 @@ function NewDocView({ dir }: { dir: string }) {
           </>
         }
       />
+
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="text-[13px] text-(--text-04)">Folder</span>
+        <DestinationSelect
+          value={destDir}
+          folders={folders}
+          onChange={setDestDir}
+          disabled={saving}
+        />
+      </div>
 
       <FilenameRow
         parent={parentSlug}
@@ -2651,6 +2690,72 @@ function ActiveSessionRow({
         Close
       </Button>
     </li>
+  );
+}
+
+/** Every folder path in the tree (plus root ""), for the destination picker. */
+function collectFolders(entries: DocEntry[]): string[] {
+  const set = new Set<string>([""]);
+  for (const e of entries) {
+    const parts = e.path.split("/");
+    parts.pop();
+    let cur = "";
+    for (const p of parts) {
+      cur = cur ? `${cur}/${p}` : p;
+      set.add(cur);
+    }
+  }
+  return [...set].sort((a, b) => a.localeCompare(b));
+}
+
+/** Folder picker for the new-doc destination. "" is the wiki root ("Home"). */
+function DestinationSelect({
+  value,
+  folders,
+  onChange,
+  disabled,
+}: {
+  value: string;
+  folders: string[];
+  onChange: (v: string) => void;
+  disabled: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <span className="inline-flex max-w-full">
+          <OpenButton
+            variant="select-light"
+            size="md"
+            rounding="sm"
+            disabled={disabled}
+          >
+            {value === "" ? "Home" : value}
+          </OpenButton>
+        </span>
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="start" sideOffset={4}>
+        <div className="max-h-[320px] max-w-[360px] min-w-[200px] overflow-y-auto">
+          <PopoverMenu>
+            {folders.map((f) => (
+              <LineItemButton
+                key={f || "__root__"}
+                icon={SvgFolder}
+                title={f === "" ? "Home" : f}
+                sizePreset="main-ui"
+                variant="body"
+                state={value === f ? "selected" : "empty"}
+                onClick={() => {
+                  onChange(f);
+                  setOpen(false);
+                }}
+              />
+            ))}
+          </PopoverMenu>
+        </div>
+      </Popover.Content>
+    </Popover>
   );
 }
 

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -65,6 +65,7 @@ import {
 import { absoluteTime, relativeTime } from "@/lib/time";
 import { useIsMobile } from "@/lib/viewport";
 import {
+  AI_DRAFT_KEY,
   type CommitInfo,
   fetchFileDiff,
   fetchFileHistory,
@@ -541,11 +542,34 @@ function NewDocView({ dir }: { dir: string }) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Pop the chat widget open once on mount — the assistant can help
-  // while the user picks a template / drafts initial content.
+  // Home "Start writing with AI" hands off a generated draft via sessionStorage
+  // (paired with ?ai=1). Seed the composer with it once, then drop the flag so
+  // it doesn't re-apply on re-render or override later edits.
+  const isAiSeed = searchParams?.get("ai") === "1";
+  const aiSeededRef = useRef(false);
   useEffect(() => {
+    if (aiSeededRef.current || !isAiSeed) return;
+    aiSeededRef.current = true;
+    try {
+      const raw = sessionStorage.getItem(AI_DRAFT_KEY);
+      sessionStorage.removeItem(AI_DRAFT_KEY);
+      if (!raw) return;
+      const draft = JSON.parse(raw) as { title?: string; body?: string };
+      if (draft.title) setFilename(draft.title);
+      if (draft.body) setDraft(draft.body);
+    } catch {
+      // malformed/unavailable stash — fall back to an empty composer
+    }
+  }, [isAiSeed]);
+
+  // Pop the chat widget open once on mount — the assistant can help while the
+  // user picks a template / drafts initial content. Skip it for an AI-seeded
+  // draft: there's already content to review, so the generic "what would you
+  // like to work on" prime would be noise.
+  useEffect(() => {
+    if (isAiSeed) return;
     requestExpand();
-  }, [requestExpand]);
+  }, [requestExpand, isAiSeed]);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -39,6 +39,7 @@ import {
 import { useDrafting, type DraftingState } from "@/lib/drafting";
 import { ChatHistoryPanel } from "@/components/chat/ChatHistoryPanel";
 import { presentTool } from "@/lib/tools";
+import { reviseDraft } from "@/lib/wiki";
 
 // Items in the chat transcript. Tool calls are first-class entries
 // (rather than a transient hint) so they stay visible in the scrollback
@@ -75,7 +76,7 @@ const MIN_EXPANDED_WIDTH = 280;
 
 export function ChatWidget() {
   const { user } = useAuth();
-  const { drafting, expandTick } = useDrafting();
+  const { drafting, expandTick, getDraftBody, applyDraftBody } = useDrafting();
   const [mode, setMode] = useState<Mode>("closed");
   const [expandedWidth, setExpandedWidth] = useState<number>(
     DEFAULT_EXPANDED_WIDTH,
@@ -274,7 +275,9 @@ export function ChatWidget() {
       ? null
       : drafting.kind === "template"
         ? `tpl:${drafting.templateId ?? "deleted"}`
-        : "blank";
+        : drafting.prompt
+          ? `ai:${drafting.prompt}`
+          : "blank";
 
   // Keep the banner in sync while drafting is active (path/template name
   // can refine on the NewDocView → FileViewer hand-off). When ``drafting``
@@ -295,26 +298,32 @@ export function ChatWidget() {
       setDraftingKey(desiredKey);
       setError(null);
       setSessionId(null);
-      // Start empty; the reducer will push items as events arrive
-      // (text_delta creates an assistant bubble, tool_call pushes a
-      // tool status line, etc.).
-      setItems([]);
-      setSending(true);
       const tidForInit =
         drafting.kind === "template" ? drafting.templateId : null;
+      const promptForInit =
+        drafting.kind === "blank" ? (drafting.prompt ?? null) : null;
+      // For the AI flow, show the user's prompt as the first turn; the reducer
+      // then pushes the assistant's reply as events arrive. Otherwise start
+      // empty (the hidden seed primes a kickoff that lands as a text_delta).
+      setItems(promptForInit ? [{ kind: "user", content: promptForInit }] : []);
+      setSending(true);
       void (async () => {
         try {
-          await streamDraftingInit(tidForInit, (raw) => {
-            const ev = raw as StreamEvent;
-            if (ev.type === "session_created") {
-              setSessionId(ev.session_id);
-            } else if (ev.type === "error") {
-              setError(ev.message);
-              setItems((prev) => markRunningToolsAsError(prev));
-            } else {
-              setItems((prev) => reduceEvent(prev, ev));
-            }
-          });
+          await streamDraftingInit(
+            tidForInit,
+            (raw) => {
+              const ev = raw as StreamEvent;
+              if (ev.type === "session_created") {
+                setSessionId(ev.session_id);
+              } else if (ev.type === "error") {
+                setError(ev.message);
+                setItems((prev) => markRunningToolsAsError(prev));
+              } else {
+                setItems((prev) => reduceEvent(prev, ev));
+              }
+            },
+            { prompt: promptForInit },
+          );
         } catch (e) {
           setError(formatError(e));
           setItems((prev) => markRunningToolsAsError(prev));
@@ -383,6 +392,34 @@ export function ChatWidget() {
       // arrives. Until then, the "…" placeholder below covers the gap.
       setItems((prev) => [...prev, { kind: "user", content: text }]);
 
+      // Unsaved new-doc drafting (kind "blank", no path) with content in the
+      // editor: live-edit it via the stateless reviser and write the result
+      // straight back to the editor — no saved-doc chat session involved.
+      const body = getDraftBody();
+      if (
+        drafting?.kind === "blank" &&
+        drafting.path === null &&
+        body !== null &&
+        body.trim() !== ""
+      ) {
+        try {
+          const res = await reviseDraft(body, text);
+          applyDraftBody(res.body);
+          setItems((prev) => [
+            ...prev,
+            {
+              kind: "assistant",
+              content: "Done — I've updated the draft in the editor.",
+            },
+          ]);
+        } catch (err) {
+          setError(formatError(err));
+        } finally {
+          setSending(false);
+        }
+        return;
+      }
+
       // Lazily create a server-side session on first send so empty
       // sessions don't pile up if the user opens and closes the widget.
       let activeId = sessionId;
@@ -436,7 +473,7 @@ export function ChatWidget() {
         }
       }
     },
-    [sessionId],
+    [sessionId, drafting, getDraftBody, applyDraftBody],
   );
 
   const onSend = useCallback(

--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -182,6 +182,12 @@
   width: 100%;
   min-width: 0;
 }
+.aiError {
+  margin: 0;
+  padding: 0 8px 4px;
+  font-size: 13px;
+  color: var(--status-text-error-05);
+}
 
 /* Recent Pages grid */
 .recentGrid {

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -66,9 +66,13 @@ export function WikiHome() {
     setAiError(null);
     try {
       // Generate a full draft up front, then drop the user into the New
-      // Document composer with it pre-filled to review and create.
+      // Document composer with it pre-filled to review and create. The prompt
+      // rides along so the drafting chat can show it as the first user turn.
       const draft = await generateDraft(prompt);
-      sessionStorage.setItem(AI_DRAFT_KEY, JSON.stringify(draft));
+      sessionStorage.setItem(
+        AI_DRAFT_KEY,
+        JSON.stringify({ ...draft, prompt }),
+      );
       router.push("/app/wiki?new=1&ai=1");
     } catch (err) {
       setAiError(

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -24,22 +24,21 @@ import {
 } from "@onyx-ai/opal/icons";
 import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { relativeTime } from "@/lib/time";
 import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
-import type { RecentPage } from "@/lib/wiki";
+import { AI_DRAFT_KEY, generateDraft, type RecentPage } from "@/lib/wiki";
 
 import { WikiItemActionsProvider, WikiItemMenu } from "./WikiItemActions";
 import { WikiTree } from "./WikiTree";
 import styles from "./WikiHome.module.css";
 
-// Stash key for the typed "write with AI" prompt; the new-page composer
-// picks it up to seed the assistant.
-const AI_PROMPT_KEY = "wiki:aiPrompt";
-
 export function WikiHome() {
   const router = useRouter();
   const [aiPrompt, setAiPrompt] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [aiError, setAiError] = useState<string | null>(null);
 
   const { data: recentData } = useSWR<{ pages: RecentPage[] }>(
     "/wiki/recent?limit=12",
@@ -59,16 +58,24 @@ export function WikiHome() {
     router.push(`/app/wiki${qs}`);
   }
 
-  function onAiSubmit(e: FormEvent) {
+  async function onAiSubmit(e: FormEvent) {
     e.preventDefault();
     const prompt = aiPrompt.trim();
-    if (!prompt) return;
+    if (!prompt || generating) return;
+    setGenerating(true);
+    setAiError(null);
     try {
-      sessionStorage.setItem(AI_PROMPT_KEY, prompt);
-    } catch {
-      // sessionStorage may be unavailable (private mode).
+      // Generate a full draft up front, then drop the user into the New
+      // Document composer with it pre-filled to review and create.
+      const draft = await generateDraft(prompt);
+      sessionStorage.setItem(AI_DRAFT_KEY, JSON.stringify(draft));
+      router.push("/app/wiki?new=1&ai=1");
+    } catch (err) {
+      setAiError(
+        err instanceof Error ? err.message : "Couldn't generate a draft",
+      );
+      setGenerating(false);
     }
-    router.push("/app/wiki?new=1");
   }
 
   return (
@@ -139,7 +146,11 @@ export function WikiHome() {
             {/* Write with AI */}
             <div className={styles.aiRow}>
               <span className={styles.aiGutterIcon}>
-                <SvgOnyxOctagon size={18} />
+                {generating ? (
+                  <LoadingSpinner size={18} />
+                ) : (
+                  <SvgOnyxOctagon size={18} />
+                )}
               </span>
               <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
                 <InputTypeIn
@@ -153,13 +164,14 @@ export function WikiHome() {
                       size="sm"
                       prominence="tertiary"
                       icon={SvgArrowUp}
-                      disabled={!aiPrompt.trim()}
+                      disabled={!aiPrompt.trim() || generating}
                       aria-label="Start writing"
                     />
                   }
                 />
               </form>
             </div>
+            {aiError && <p className={styles.aiError}>{aiError}</p>}
 
             <div className={styles.midDividerWrap}>
               <Divider />

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -69,10 +69,15 @@ export function WikiHome() {
       // Document composer with it pre-filled to review and create. The prompt
       // rides along so the drafting chat can show it as the first user turn.
       const draft = await generateDraft(prompt);
-      sessionStorage.setItem(
-        AI_DRAFT_KEY,
-        JSON.stringify({ ...draft, prompt }),
-      );
+      try {
+        sessionStorage.setItem(
+          AI_DRAFT_KEY,
+          JSON.stringify({ ...draft, prompt }),
+        );
+      } catch {
+        // sessionStorage unavailable (Safari private mode / quota). Navigate
+        // anyway — NewDocView just opens an empty new-doc composer.
+      }
       router.push("/app/wiki?new=1&ai=1");
     } catch (err) {
       setAiError(

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -70,13 +70,16 @@ export function streamMessage(
 export function streamDraftingInit(
   templateId: string | null,
   onEvent: (data: unknown) => void,
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal; prompt?: string | null },
 ): Promise<void> {
   return apiStream(
     "/chat/drafting/init",
     {
       method: "POST",
-      body: JSON.stringify({ template_id: templateId }),
+      body: JSON.stringify({
+        template_id: templateId,
+        prompt: options?.prompt ?? null,
+      }),
     },
     onEvent,
     options?.signal,

--- a/frontend/src/lib/drafting.tsx
+++ b/frontend/src/lib/drafting.tsx
@@ -5,9 +5,17 @@ import {
   useCallback,
   useContext,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
+
+/** Read/write access to the in-progress (unsaved) doc editor, registered by
+ *  NewDocView so the drafting chat can live-edit the draft before it's saved. */
+export interface DraftBridge {
+  get: () => string;
+  set: (body: string) => void;
+}
 
 /** Active drafting state. Discriminated on ``kind``:
  *
@@ -31,6 +39,9 @@ export type DraftingState =
   | {
       kind: "blank";
       path: string | null;
+      /** "Start writing with AI" prompt — shown as the first user turn when the
+       *  chat seeds, instead of the generic blank prime. */
+      prompt?: string;
     };
 
 interface DraftingContextValue {
@@ -42,6 +53,12 @@ interface DraftingContextValue {
   expandTick: number;
   /** Bump to fire the expand request. */
   requestExpand: () => void;
+  /** NewDocView registers its editor here (null to unregister on unmount). */
+  registerDraftBridge: (bridge: DraftBridge | null) => void;
+  /** Current unsaved draft body, or null when no editor is bridged. */
+  getDraftBody: () => string | null;
+  /** Replace the unsaved draft body. Returns false when no editor is bridged. */
+  applyDraftBody: (body: string) => boolean;
 }
 
 const DraftingContext = createContext<DraftingContextValue | null>(null);
@@ -52,9 +69,39 @@ export function DraftingProvider({ children }: { children: ReactNode }) {
 
   const requestExpand = useCallback(() => setExpandTick((t) => t + 1), []);
 
+  // A ref (not state) so registering / reading the editor doesn't re-render.
+  const draftBridge = useRef<DraftBridge | null>(null);
+  const registerDraftBridge = useCallback((b: DraftBridge | null) => {
+    draftBridge.current = b;
+  }, []);
+  const getDraftBody = useCallback(
+    () => draftBridge.current?.get() ?? null,
+    [],
+  );
+  const applyDraftBody = useCallback((body: string) => {
+    if (!draftBridge.current) return false;
+    draftBridge.current.set(body);
+    return true;
+  }, []);
+
   const value = useMemo(
-    () => ({ drafting, setDrafting, expandTick, requestExpand }),
-    [drafting, expandTick, requestExpand],
+    () => ({
+      drafting,
+      setDrafting,
+      expandTick,
+      requestExpand,
+      registerDraftBridge,
+      getDraftBody,
+      applyDraftBody,
+    }),
+    [
+      drafting,
+      expandTick,
+      requestExpand,
+      registerDraftBridge,
+      getDraftBody,
+      applyDraftBody,
+    ],
   );
 
   return (

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -65,6 +65,17 @@ export async function generateDraft(prompt: string): Promise<GeneratedDraft> {
   });
 }
 
+/** Apply an instruction to an unsaved draft body; returns the revised body. */
+export async function reviseDraft(
+  body: string,
+  instruction: string,
+): Promise<{ body: string }> {
+  return apiFetch<{ body: string }>("/wiki/revise", {
+    method: "POST",
+    body: JSON.stringify({ body, instruction }),
+  });
+}
+
 export async function fetchFileDiff(
   path: string,
   sha: string,

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -48,6 +48,23 @@ export interface FileDiffResponse {
   is_creation: boolean;
 }
 
+/** An auto-generated draft for the home "Start writing with AI" flow. */
+export interface GeneratedDraft {
+  title: string;
+  body: string;
+}
+
+/** sessionStorage key handing a generated draft from the home input to the
+ * New Document composer (paired with the `?ai=1` query flag). */
+export const AI_DRAFT_KEY = "wiki:aiDraft";
+
+export async function generateDraft(prompt: string): Promise<GeneratedDraft> {
+  return apiFetch<GeneratedDraft>("/wiki/generate", {
+    method: "POST",
+    body: JSON.stringify({ prompt }),
+  });
+}
+
 export async function fetchFileDiff(
   path: string,
   sha: string,


### PR DESCRIPTION
## Description

Turns the home "Start writing with AI" input into an end-to-end drafting flow.

- **Generate:** `POST /wiki/generate` runs a one-shot `draft_generator` agent (prompt → full Markdown doc + title), and the input drops you into the New Document composer pre-filled to review and Create.
- **Destination picker:** the composer gets a Folder dropdown (root = "Home") so the doc lands where you choose instead of always at root.
- **Prompt in chat:** `drafting/init` takes an optional `prompt`, so the drafting chat shows your request as the first turn instead of the generic blank prime.
- **Live editing:** chat edit-turns on the unsaved draft route to a stateless `POST /wiki/revise` (current body + instruction → revised body) and write straight back to the editor via a draft "bridge" in the drafting context. Stateless-on-current-body means iterative edits compose. Template / saved-doc chat flows are unchanged.
- **Error surfacing:** added a global `LLMError` handler → clean `{error}` envelope (503/502/429) instead of a raw 500 when the LLM is unconfigured or fails.

New agents are non-conversational `complete()` calls (no tools); tests patch `app.llm.client.complete`.

## How Has This Been Tested?