### PR TITLE
feat(comments): click a comment to scroll to its anchored content

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -47,6 +47,7 @@ import { apiFetch, ApiError } from "@/lib/api";
 import { listComments } from "@/lib/comments";
 import {
   paintCommentHighlights,
+  scrollCommentIntoView,
   selectionToAnchor,
   type CommentDraft,
 } from "@/lib/commentAnchor";
@@ -1398,6 +1399,33 @@ function FileViewer({ path }: { path: string }) {
     // with no paint (highlights only appeared after a click). Re-run on mount.
   }, [commentThreads, body, editing, viewingSha, activeCommentId, loading]);
 
+  // Select a thread (its span gets the orange highlight) and scroll the doc to
+  // bring that span into view. Only an explicit click runs this — keying a
+  // scroll off `activeCommentId` alone would also re-scroll on every comment
+  // refetch while a thread stays selected. Deferred a frame so the layout (and
+  // the active repaint) settles before we measure the range.
+  const activateComment = useCallback(
+    (id: string | null) => {
+      setActiveCommentId(id);
+      if (!id || editing || viewingSha) return;
+      const el = articleRef.current;
+      if (!el) return;
+      const root = commentThreads.find((t) => t.root.id === id)?.root;
+      if (
+        !root ||
+        root.status === "orphaned" ||
+        root.status === "resolved" ||
+        root.start_offset === null ||
+        root.end_offset === null
+      )
+        return;
+      requestAnimationFrame(() => {
+        scrollCommentIntoView(el, body, root.start_offset!, root.end_offset!);
+      });
+    },
+    [commentThreads, body, editing, viewingSha],
+  );
+
   // On a text selection in the rendered article, offer a floating "Comment"
   // affordance anchored above the selection (render mode only).
   const onArticleMouseUp = useCallback(() => {
@@ -2377,7 +2405,7 @@ function FileViewer({ path }: { path: string }) {
               threads={commentThreads}
               onChanged={refreshComments}
               activeId={activeCommentId}
-              onActivate={setActiveCommentId}
+              onActivate={activateComment}
               onDraftConsumed={() => setCommentDraft(null)}
               onClose={() => {
                 setCommentsOpen(false);
@@ -2431,7 +2459,7 @@ function FileViewer({ path }: { path: string }) {
               threads={commentThreads}
               onChanged={refreshComments}
               activeId={activeCommentId}
-              onActivate={setActiveCommentId}
+              onActivate={activateComment}
               onDraftConsumed={() => setCommentDraft(null)}
               onClose={() => {
                 setCommentsOpen(false);

--- a/frontend/src/lib/commentAnchor.ts
+++ b/frontend/src/lib/commentAnchor.ts
@@ -346,3 +346,80 @@ export function paintCommentHighlights(
 
   return painted;
 }
+
+// --------------------------------------------------------------------------- //
+// Scroll-to-anchor — bring a comment's referenced span into view on click.    //
+// --------------------------------------------------------------------------- //
+
+/** First rendered DOM Range for an anchored span, scanning top-level blocks in
+ * document order (same mapping as `paintCommentHighlights`, but stops at the
+ * first overlapping block). Null if the span maps to nothing rendered. */
+function firstRenderedRange(
+  article: HTMLElement,
+  body: string,
+  startOffset: number,
+  endOffset: number,
+): Range | null {
+  const starts = lineStartOffsets(body);
+  const els = Array.from(
+    article.querySelectorAll<HTMLElement>("[data-sourcepos]"),
+  );
+  for (const el of els) {
+    if (!isTopLevelBlock(el, article)) continue;
+    const a = alignBlock(el, body, starts);
+    if (!a) continue;
+    if (a.blockEnd <= startOffset || a.blockStart >= endOffset) continue;
+    let lo = -1;
+    let hi = -1;
+    for (let i = 0; i < a.rawAt.length; i++) {
+      const off = a.rawAt[i]!;
+      if (off >= startOffset && off < endOffset) {
+        if (lo < 0) lo = i;
+        hi = i;
+      }
+    }
+    if (lo < 0) continue;
+    const range = rangeForRenderedSpan(a.el, lo, hi + 1);
+    if (range) return range;
+  }
+  return null;
+}
+
+/** Nearest scrollable ancestor (inclusive). Defaults to `el` if none is found —
+ * the rendered article carries `overflow-y-auto`, so it's usually the scroller
+ * itself. */
+function scrollableAncestor(el: HTMLElement): HTMLElement {
+  let cur: HTMLElement | null = el;
+  while (cur) {
+    const oy = getComputedStyle(cur).overflowY;
+    if (/(auto|scroll|overlay)/.test(oy) && cur.scrollHeight > cur.clientHeight)
+      return cur;
+    cur = cur.parentElement;
+  }
+  return el;
+}
+
+/** Scroll the article's container so a comment's anchored span is centered in
+ * view. No-op (returns false) when the span maps to nothing rendered — e.g. an
+ * orphaned comment whose text was deleted. Pairs with the active highlight:
+ * the caller sets the thread active (orange) and calls this to bring it on
+ * screen. */
+export function scrollCommentIntoView(
+  article: HTMLElement,
+  body: string,
+  startOffset: number,
+  endOffset: number,
+): boolean {
+  const range = firstRenderedRange(article, body, startOffset, endOffset);
+  if (!range) return false;
+  const scroller = scrollableAncestor(article);
+  const rect = range.getBoundingClientRect();
+  const sRect = scroller.getBoundingClientRect();
+  const top =
+    scroller.scrollTop +
+    (rect.top - sRect.top) -
+    scroller.clientHeight / 2 +
+    rect.height / 2;
+  scroller.scrollTo({ top: Math.max(0, top), behavior: "smooth" });
+  return true;
+}


### PR DESCRIPTION
## What

Clicking a comment thread now scrolls the wiki page to bring its anchored span into view (centered, smooth scroll). This is the first **Phase 2** comment feature — *click-to-focus* — from the [comments design doc](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/comments/design.md).

Clicking a thread already selected it and painted its span orange; this adds the missing navigation — jumping the reader to the referenced text.

## How

- **`src/lib/commentAnchor.ts`** — new `scrollCommentIntoView(article, body, startOffset, endOffset)`. Reuses the same top-level-block alignment + `rangeForRenderedSpan` mapping as `paintCommentHighlights`, so it lands on exactly where the highlight is painted. Finds the first rendered range, resolves the scroll container, and centers it. Returns `false` (no-op) when the span maps to nothing rendered.
- **`src/app/app/wiki/[[...slug]]/page.tsx`** — new `activateComment` callback: sets the active thread (existing orange highlight) and scrolls. Wired into both panel instances (desktop + mobile).

## Notes

- Scroll runs on the **activation click**, not a `useEffect` on `activeCommentId` — otherwise a comment refetch (e.g. after posting a reply) would re-scroll while a thread stays selected.
- Skips orphaned/resolved threads (no live span) and edit/history mode; deferred one frame so the active repaint + layout settle before measuring.

## Test plan
<img width="1652" height="954" alt="Screenshot 2026-06-05 at 11 16 22 AM" src="https://github.com/user-attachments/assets/b93aed23-0395-4fac-a551-640d8e199144" />

- [ ] Open a page with anchored comments; click a thread whose span is off-screen → page scrolls to center it, span turns orange.
- [ ] Click a resolved/orphaned thread → no scroll, no error.
- [ ] Post a reply on a selected thread → no spurious re-scroll.
- [ ] Verify in edit mode the panel click doesn't scroll the (absent) article.

`bun run typecheck` passes; prettier clean.