### PR TITLE
feat(comments): shareable per-comment link

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -1338,6 +1338,8 @@ function FileViewer({ path }: { path: string }) {
   // Page owns the comment threads (so highlights render even with the panel
   // closed). Auto-open the panel once per path when a page has comments.
   const autoOpenedPathRef = useRef<string | null>(null);
+  // A `?comment=<id>` deep-link is focused once per id (reset on path change).
+  const focusedCommentRef = useRef<string | null>(null);
 
   // The history and comments side panels are mutually exclusive — every
   // path that opens one closes the other (toolbar toggles, the comments
@@ -1362,6 +1364,7 @@ function FileViewer({ path }: { path: string }) {
 
   useEffect(() => {
     autoOpenedPathRef.current = null;
+    focusedCommentRef.current = null;
     setCommentThreads([]);
     void refreshComments();
   }, [refreshComments]);
@@ -1488,6 +1491,49 @@ function FileViewer({ path }: { path: string }) {
     },
     [commentThreads, body, editing, viewingSha],
   );
+
+  // Deep-link: `?comment=<id>` opens the panel, selects that thread, and scrolls
+  // to its anchored span — the shareable-link counterpart to click-to-focus.
+  // Runs once per id (focusedCommentRef), and only once the thread is loaded.
+  // The scroll retries per-frame because on a fresh load react-markdown commits
+  // its text nodes a tick after this effect runs (same reason the highlight
+  // paint retries).
+  useEffect(() => {
+    const target = searchParams.get("comment");
+    if (!target || loading || editing || viewingSha) return;
+    if (focusedCommentRef.current === target) return;
+    const root = commentThreads.find((t) => t.root.id === target)?.root;
+    if (!root) return; // not loaded yet, or not a thread on this page
+    focusedCommentRef.current = target;
+    setActiveCommentId(target);
+    openComments();
+    if (
+      root.status === "orphaned" ||
+      root.status === "resolved" ||
+      root.start_offset === null ||
+      root.end_offset === null
+    )
+      return; // selected, but no live span to scroll to
+    const el = articleRef.current;
+    if (!el) return;
+    let raf = 0;
+    let attempts = 0;
+    const tick = () => {
+      if (scrollCommentIntoView(el, body, root.start_offset!, root.end_offset!))
+        return;
+      if (++attempts < 60) raf = requestAnimationFrame(tick);
+    };
+    tick();
+    return () => cancelAnimationFrame(raf);
+  }, [
+    searchParams,
+    commentThreads,
+    loading,
+    editing,
+    viewingSha,
+    body,
+    openComments,
+  ]);
 
   // On a text selection in the rendered article, offer a floating "Comment"
   // affordance anchored above the selection (render mode only).

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -14,7 +14,7 @@ import {
   SvgTrash,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { type MouseEvent, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
 import {
@@ -307,23 +307,8 @@ function Thread({
   const { root } = thread;
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyBody, setReplyBody] = useState("");
-  const [copied, setCopied] = useState(false);
   const resolved = root.status === "resolved";
 
-  // Copy a deep-link to this thread. Stop propagation so it doesn't also
-  // activate the thread (which would scroll the doc out from under the click).
-  const copyLink = (e: MouseEvent) => {
-    e.stopPropagation();
-    void navigator.clipboard
-      .writeText(commentLink(path, root.id))
-      .then(() => {
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1500);
-      })
-      .catch(() => {
-        /* clipboard blocked — no-op */
-      });
-  };
   // One flat conversation (Google-Docs style): the root and every reply render
   // uniformly, appended in order — no nesting/indentation.
   const conversation = [root, ...thread.replies];
@@ -344,6 +329,7 @@ function Thread({
           <Comment
             key={c.id}
             comment={c}
+            path={path}
             canModify={isAdmin || c.author_user_id === selfId}
             selfId={selfId}
             busy={busy}
@@ -415,13 +401,6 @@ function Thread({
               Resolve
             </Button>
           )}
-          <Button
-            icon={copied ? SvgCheck : SvgLink}
-            prominence="tertiary"
-            size="sm"
-            tooltip={copied ? "Link copied" : "Copy link to comment"}
-            onClick={copyLink}
-          />
         </div>
       )}
     </div>
@@ -430,6 +409,7 @@ function Thread({
 
 function Comment({
   comment,
+  path,
   canModify,
   selfId,
   busy,
@@ -437,6 +417,7 @@ function Comment({
   onDelete,
 }: {
   comment: CommentView;
+  path: string;
   canModify: boolean;
   selfId: string | undefined;
   busy: boolean;
@@ -446,6 +427,22 @@ function Comment({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(comment.body);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Copy a deep-link to this comment's thread (anchors live on the root, so all
+  // comments in a thread share its link). Doesn't close the menu — the swapped
+  // title/icon is the "done" feedback.
+  const copyLink = () => {
+    void navigator.clipboard
+      .writeText(commentLink(path, comment.thread_root_id))
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* clipboard blocked — no-op */
+      });
+  };
 
   return (
     <div className={styles.comment}>
@@ -462,9 +459,11 @@ function Comment({
           </Text>
         </span>
         <span className={styles.metaRight}>
-          {canModify && !editing && (
-            // Overflow menu (Google-Docs style) keeps Edit/Delete off the card
-            // until hovered, so comments stay compact. Forced visible while open.
+          {!editing && (
+            // Overflow menu (Google-Docs style) keeps actions off the card until
+            // hovered, so comments stay compact. Forced visible while open.
+            // "Copy link" is available to everyone (read access); Edit/Delete
+            // only to the author/admin.
             <span
               className={`${styles.kebab} ${menuOpen ? styles.kebabOpen : ""}`}
             >
@@ -482,26 +481,37 @@ function Comment({
                 <Popover.Content width="fit" align="end">
                   <Popover.Menu>
                     <LineItemButton
-                      title="Edit"
-                      icon={SvgEdit}
+                      title={copied ? "Link copied" : "Copy link"}
+                      icon={copied ? SvgCheck : SvgLink}
                       sizePreset="main-ui"
                       variant="section"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        setEditing(true);
-                      }}
+                      onClick={copyLink}
                     />
-                    <LineItemButton
-                      title="Delete"
-                      color="danger"
-                      icon={SvgTrash}
-                      sizePreset="main-ui"
-                      variant="section"
-                      onClick={() => {
-                        setMenuOpen(false);
-                        onDelete(comment.id);
-                      }}
-                    />
+                    {canModify && (
+                      <>
+                        <LineItemButton
+                          title="Edit"
+                          icon={SvgEdit}
+                          sizePreset="main-ui"
+                          variant="section"
+                          onClick={() => {
+                            setMenuOpen(false);
+                            setEditing(true);
+                          }}
+                        />
+                        <LineItemButton
+                          title="Delete"
+                          color="danger"
+                          icon={SvgTrash}
+                          sizePreset="main-ui"
+                          variant="section"
+                          onClick={() => {
+                            setMenuOpen(false);
+                            onDelete(comment.id);
+                          }}
+                        />
+                      </>
+                    )}
                   </Popover.Menu>
                 </Popover.Content>
               </Popover>

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -7,12 +7,14 @@ import {
   Text,
 } from "@onyx-ai/opal/components";
 import {
+  SvgCheck,
   SvgEdit,
+  SvgLink,
   SvgMoreHorizontal,
   SvgTrash,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { useCallback, useState } from "react";
+import { type MouseEvent, useCallback, useEffect, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
 import {
@@ -60,6 +62,18 @@ function authorLabel(
  * Date parses them as UTC, not local. */
 function toIso(ts: string): string {
   return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}
+
+/** Deep-link to a specific thread: the page route reads `?comment=<id>`, opens
+ * the panel, and scrolls to the thread's anchored span. Each path segment is
+ * encoded since wiki paths contain spaces. */
+function commentLink(path: string, rootId: string): string {
+  const encoded = path
+    .split("/")
+    .filter(Boolean)
+    .map((s) => encodeURIComponent(s))
+    .join("/");
+  return `${window.location.origin}/app/wiki/${encoded}?comment=${rootId}`;
 }
 
 export function CommentsPanel({
@@ -122,10 +136,19 @@ export function CommentsPanel({
     (t) => t.root.status === "resolved",
   );
 
+  // If the active thread (clicked, or arrived via a `?comment=` deep-link) is
+  // resolved, expand the resolved section so it's actually visible — otherwise
+  // activating it would silently do nothing.
+  const activeIsResolved = resolvedThreads.some((t) => t.root.id === activeId);
+  useEffect(() => {
+    if (activeIsResolved) setShowResolved(true);
+  }, [activeIsResolved]);
+
   const renderThread = (t: CommentThreadView) => (
     <Thread
       key={t.root.id}
       thread={t}
+      path={path}
       selfId={user?.id}
       isAdmin={!!user?.is_admin}
       busy={busy}
@@ -256,6 +279,7 @@ function DraftComposer({
 
 function Thread({
   thread,
+  path,
   selfId,
   isAdmin,
   busy,
@@ -268,6 +292,7 @@ function Thread({
   onDelete,
 }: {
   thread: CommentThreadView;
+  path: string;
   selfId: string | undefined;
   isAdmin: boolean;
   busy: boolean;
@@ -282,7 +307,23 @@ function Thread({
   const { root } = thread;
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyBody, setReplyBody] = useState("");
+  const [copied, setCopied] = useState(false);
   const resolved = root.status === "resolved";
+
+  // Copy a deep-link to this thread. Stop propagation so it doesn't also
+  // activate the thread (which would scroll the doc out from under the click).
+  const copyLink = (e: MouseEvent) => {
+    e.stopPropagation();
+    void navigator.clipboard
+      .writeText(commentLink(path, root.id))
+      .then(() => {
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => {
+        /* clipboard blocked — no-op */
+      });
+  };
   // One flat conversation (Google-Docs style): the root and every reply render
   // uniformly, appended in order — no nesting/indentation.
   const conversation = [root, ...thread.replies];
@@ -374,6 +415,13 @@ function Thread({
               Resolve
             </Button>
           )}
+          <Button
+            icon={copied ? SvgCheck : SvgLink}
+            prominence="tertiary"
+            size="sm"
+            tooltip={copied ? "Link copied" : "Copy link to comment"}
+            onClick={copyLink}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## What

Each inline comment now has a **copyable share link** in its overflow (⋮) menu. Copying yields `…/app/wiki/<path>?comment=<id>`; opening that link loads the page, opens the comments panel, selects the thread, and scrolls to its anchored span. Second Phase 2 feature from the [comments design doc](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/comments/design.md); builds on click-to-focus (#199).

## How

**Copy affordance — `CommentsPanel.tsx`**
- "Copy link" lives in each comment's kebab (⋮) menu — on the root **and every reply**, so it's discoverable per-comment. Available to anyone with read access; Edit/Delete stay author/admin-only. (The kebab now renders for everyone, not just modifiers.)
- The link targets the **thread root** (`thread_root_id`), since the anchor lives on the root — all comments in a thread share one link/span.
- Copying swaps the menu item to "Link copied" (check icon) for 1.5s without closing the menu; URL-encodes each path segment like `ShareDialog`/`WikiItemActions`.

**Deep-link — `page.tsx`**
- `?comment=<id>` → open panel + select + scroll, reusing `scrollCommentIntoView`.
- Retries the scroll per-frame (~1s cap) because react-markdown commits text nodes a tick after the effect on a fresh load.
- Fires once per id (`focusedCommentRef`), reset on path change so it re-arms after client-side nav.
- Resolved threads auto-expand the "Show resolved" section when activated, so a link to one isn't a silent no-op.

## Notes / edge cases
- A link to an **orphaned** comment selects it but can't scroll (no live span).
- A stale/deleted comment id is ignored (no thread to focus).
- No new UI tokens/colors — Opal `Button`/`LineItemButton` + `SvgLink`/`SvgCheck`.

## Test plan
- [ ] Open a comment's ⋮ menu (root and a reply) → "Copy link" present; non-author sees it too.
- [ ] Copy, open the link in a new tab → page scrolls to the span, thread selected (orange), panel open.
- [ ] Deep-link to a resolved comment → resolved section auto-expands.
- [ ] Deep-link with a bogus `?comment=` id → no error, page loads normally.
<img width="424" height="224" alt="Screenshot 2026-06-05 at 11 45 38 AM" src="https://github.com/user-attachments/assets/852104b9-c039-47f6-b16c-1dea94557368" />

`bun run typecheck` + prettier clean.