### PR TITLE
feat(comments): @mention typeahead in the comment composer

### DIFF
--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -155,6 +155,14 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
+/* @mention chip inside a rendered comment body. */
+.mention {
+  color: var(--text-05);
+  background: var(--background-tint-03);
+  border-radius: var(--border-radius-04);
+  padding: 0 3px;
+  font-weight: 500;
+}
 
 .actions {
   display: flex;

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -14,7 +14,7 @@ import {
   SvgTrash,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
 import {
@@ -26,9 +26,15 @@ import {
   resolveThread,
 } from "@/lib/comments";
 import type { CommentDraft } from "@/lib/commentAnchor";
+import {
+  detokenizeMentions,
+  parseBody,
+  tokenizeMentions,
+} from "@/lib/commentMentions";
 import { absoluteTime, relativeTime } from "@/lib/time";
 import type { CommentThreadView, CommentView } from "@/types";
 
+import { MentionTextarea } from "./MentionTextarea";
 import styles from "./CommentsPanel.module.css";
 
 export type { CommentDraft };
@@ -250,15 +256,20 @@ function DraftComposer({
   onCancel: () => void;
 }) {
   const [body, setBody] = useState("");
+  // "@Name" → userId for every mention picked this session; used to tokenize
+  // the body on submit.
+  const mentions = useRef<Record<string, string>>({});
   return (
     <div className={styles.draft}>
       <div className={styles.quote}>{draft.quotedText}</div>
-      <textarea
-        className={styles.textarea}
+      <MentionTextarea
         placeholder="Add a comment…"
         value={body}
         autoFocus
-        onChange={(e) => setBody(e.target.value)}
+        onChange={setBody}
+        onPickMention={(d, id) => {
+          mentions.current[d] = id;
+        }}
       />
       <div className={styles.composeRow}>
         <Button prominence="tertiary" size="sm" onClick={onCancel}>
@@ -268,7 +279,9 @@ function DraftComposer({
           variant="action"
           size="sm"
           disabled={disabled || !body.trim()}
-          onClick={() => onSubmit(body.trim())}
+          onClick={() =>
+            onSubmit(tokenizeMentions(body.trim(), mentions.current))
+          }
         >
           Comment
         </Button>
@@ -307,6 +320,7 @@ function Thread({
   const { root } = thread;
   const [replyOpen, setReplyOpen] = useState(false);
   const [replyBody, setReplyBody] = useState("");
+  const replyMentions = useRef<Record<string, string>>({});
   const resolved = root.status === "resolved";
 
   // One flat conversation (Google-Docs style): the root and every reply render
@@ -341,12 +355,14 @@ function Thread({
 
       {replyOpen ? (
         <div className={styles.replyBox}>
-          <textarea
-            className={styles.textarea}
+          <MentionTextarea
             placeholder="Reply…"
             value={replyBody}
             autoFocus
-            onChange={(e) => setReplyBody(e.target.value)}
+            onChange={setReplyBody}
+            onPickMention={(d, id) => {
+              replyMentions.current[d] = id;
+            }}
           />
           <div className={styles.composeRow}>
             <Button
@@ -362,8 +378,12 @@ function Thread({
               disabled={busy || !replyBody.trim()}
               onClick={async () => {
                 // Clear/close only on success so a failed reply isn't lost.
-                if (await onReply(replyBody.trim())) {
+                const ok = await onReply(
+                  tokenizeMentions(replyBody.trim(), replyMentions.current),
+                );
+                if (ok) {
                   setReplyBody("");
+                  replyMentions.current = {};
                   setReplyOpen(false);
                 }
               }}
@@ -425,9 +445,21 @@ function Comment({
   onDelete: (id: string) => void;
 }) {
   const [editing, setEditing] = useState(false);
-  const [draft, setDraft] = useState(comment.body);
+  const [draft, setDraft] = useState("");
+  const editMentions = useRef<Record<string, string>>({});
   const [menuOpen, setMenuOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+
+  // Edit in the readable display form; (de)tokenize at the boundary so the
+  // textarea shows "@Name" while storage keeps the mention's user id. Re-seed
+  // from the current stored body each time edit opens, so a re-edit after an
+  // external change starts from fresh content.
+  const openEdit = () => {
+    const d = detokenizeMentions(comment.body);
+    setDraft(d.text);
+    editMentions.current = d.map;
+    setEditing(true);
+  };
 
   // Copy a deep-link to this comment's thread (anchors live on the root, so all
   // comments in a thread share its link). Doesn't close the menu — the swapped
@@ -496,7 +528,7 @@ function Comment({
                           variant="section"
                           onClick={() => {
                             setMenuOpen(false);
-                            setEditing(true);
+                            openEdit();
                           }}
                         />
                         <LineItemButton
@@ -522,20 +554,19 @@ function Comment({
 
       {editing ? (
         <div>
-          <textarea
-            className={styles.textarea}
+          <MentionTextarea
             value={draft}
             autoFocus
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={setDraft}
+            onPickMention={(d, id) => {
+              editMentions.current[d] = id;
+            }}
           />
           <div className={styles.composeRow}>
             <Button
               prominence="tertiary"
               size="sm"
-              onClick={() => {
-                setDraft(comment.body);
-                setEditing(false);
-              }}
+              onClick={() => setEditing(false)}
             >
               Cancel
             </Button>
@@ -544,7 +575,11 @@ function Comment({
               size="sm"
               disabled={busy || !draft.trim()}
               onClick={async () => {
-                if (await onEdit(comment.id, draft.trim())) setEditing(false);
+                const next = tokenizeMentions(
+                  draft.trim(),
+                  editMentions.current,
+                );
+                if (await onEdit(comment.id, next)) setEditing(false);
               }}
             >
               Save
@@ -552,7 +587,17 @@ function Comment({
           </div>
         </div>
       ) : (
-        <div className={styles.body}>{comment.body}</div>
+        <div className={styles.body}>
+          {parseBody(comment.body).map((seg, i) =>
+            seg.kind === "mention" ? (
+              <span key={i} className={styles.mention}>
+                @{seg.name}
+              </span>
+            ) : (
+              <span key={i}>{seg.text}</span>
+            ),
+          )}
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/wiki/MentionTextarea.module.css
+++ b/frontend/src/components/wiki/MentionTextarea.module.css
@@ -1,0 +1,80 @@
+/* Comment textarea + @-mention typeahead. The textarea mirrors the shared
+   .textarea styling in CommentsPanel.module.css so the two read identically. */
+.wrap {
+  position: relative;
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 54px;
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-01);
+  border-radius: var(--border-radius-04);
+  background: var(--background-tint-00);
+  color: var(--text-05);
+}
+.textarea:focus {
+  outline: none;
+  border-color: var(--border-05);
+}
+
+/* Typeahead list, anchored under the textarea. */
+.menu {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 100%;
+  margin: 4px 0 0;
+  padding: 4px;
+  list-style: none;
+  max-height: 180px;
+  overflow-y: auto;
+  background: var(--background-tint-00);
+  border: 1px solid var(--border-01);
+  border-radius: var(--border-radius-08);
+  box-shadow: var(--shadow-modal);
+  z-index: var(--z-popover);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--border-radius-04);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-05);
+}
+.itemActive {
+  background: var(--background-tint-03);
+}
+
+/* Initials avatar — same muted chip used elsewhere for principals. */
+.avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--border-radius-round);
+  background: var(--background-tint-03);
+  color: var(--text-04);
+  font-size: 10px;
+  font-weight: 600;
+}
+.name {
+  flex-shrink: 0;
+}
+.email {
+  color: var(--text-03);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/components/wiki/MentionTextarea.tsx
+++ b/frontend/src/components/wiki/MentionTextarea.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import { activeMentionQuery } from "@/lib/commentMentions";
+import { displayName, initials, useUserSearch } from "@/lib/users";
+
+import styles from "./MentionTextarea.module.css";
+
+/** A comment textarea with a Google-Docs-style `@` people typeahead. The parent
+ * owns the (display-text) value; on each pick we report `("@Name", userId)` so
+ * the parent can tokenize the body on submit. Submit itself stays with the
+ * parent's buttons — we only intercept keys while the menu is open. */
+export function MentionTextarea({
+  value,
+  onChange,
+  onPickMention,
+  placeholder,
+  autoFocus,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onPickMention: (display: string, userId: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  // `query === null` means no active mention; "" means just typed "@".
+  const [query, setQuery] = useState<string | null>(null);
+  const [start, setStart] = useState(0);
+  const [sel, setSel] = useState(0);
+
+  const { users } = useUserSearch(query ?? "", query !== null);
+  const open = query !== null && users.length > 0;
+
+  // Recompute the active `@query` from the current caret position.
+  const sync = (v: string, caret: number) => {
+    const m = activeMentionQuery(v, caret);
+    if (m) {
+      setQuery(m.query);
+      setStart(m.start);
+      setSel(0);
+    } else {
+      setQuery(null);
+    }
+  };
+
+  const pick = (userId: string, display: string) => {
+    const el = ref.current;
+    const caret = el ? el.selectionStart : value.length;
+    const inserted = `@${display} `;
+    const next = value.slice(0, start) + inserted + value.slice(caret);
+    onChange(next);
+    onPickMention(`@${display}`, userId);
+    setQuery(null);
+    // Restore the caret just after the inserted mention once React re-renders.
+    const pos = start + inserted.length;
+    requestAnimationFrame(() => {
+      if (el) {
+        el.focus();
+        el.setSelectionRange(pos, pos);
+      }
+    });
+  };
+
+  return (
+    <div className={styles.wrap}>
+      <textarea
+        ref={ref}
+        className={styles.textarea}
+        placeholder={placeholder}
+        value={value}
+        autoFocus={autoFocus}
+        onChange={(e) => {
+          onChange(e.target.value);
+          sync(e.target.value, e.target.selectionStart);
+        }}
+        onClick={(e) => sync(value, e.currentTarget.selectionStart)}
+        onKeyUp={(e) => {
+          // Caret moved by arrows/home/end (when the menu isn't catching them).
+          if (!open) sync(value, e.currentTarget.selectionStart);
+        }}
+        onKeyDown={(e) => {
+          if (!open) return;
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setSel((s) => (s + 1) % users.length);
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setSel((s) => (s - 1 + users.length) % users.length);
+          } else if (e.key === "Enter" || e.key === "Tab") {
+            e.preventDefault();
+            const u = users[sel];
+            if (u) pick(u.id, displayName(u));
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            setQuery(null);
+          }
+        }}
+      />
+      {open && (
+        <ul className={styles.menu} role="listbox">
+          {users.map((u, i) => (
+            <li
+              key={u.id}
+              role="option"
+              aria-selected={i === sel}
+              className={`${styles.item} ${i === sel ? styles.itemActive : ""}`}
+              // onMouseDown (not onClick) so the textarea doesn't blur first.
+              onMouseDown={(e) => {
+                e.preventDefault();
+                pick(u.id, displayName(u));
+              }}
+              onMouseEnter={() => setSel(i)}
+            >
+              <span className={styles.avatar}>{initials(u)}</span>
+              <span className={styles.name}>{displayName(u)}</span>
+              {u.name && <span className={styles.email}>{u.email}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/commentMentions.ts
+++ b/frontend/src/lib/commentMentions.ts
@@ -39,7 +39,13 @@ export function tokenizeMentions(
   for (const disp of displays) {
     const id = map[disp];
     if (!id) continue;
-    out = out.split(disp).join(`@[${disp.slice(1)}](mention:${id})`);
+    // Only at a start-or-whitespace `@` boundary, so we never rewrite an `@name`
+    // that's part of something else (e.g. the local part of an email address).
+    const escaped = disp.slice(1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    out = out.replace(
+      new RegExp(`(?:^|(?<=\\s))@${escaped}(?=\\s|$)`, "g"),
+      `@[${disp.slice(1)}](mention:${id})`,
+    );
   }
   return out;
 }

--- a/frontend/src/lib/commentMentions.ts
+++ b/frontend/src/lib/commentMentions.ts
@@ -1,0 +1,78 @@
+/** @mentions inside a comment body.
+ *
+ * Mentions are persisted inline in the stored body as a canonical token:
+ *
+ *     @[Display Name](mention:<user_id>)
+ *
+ * The composer works in the human form ("@Display Name"); we (de)tokenize at
+ * the edit/save boundary so editing stays readable while storage keeps the
+ * user id. Rendering parses the tokens into chips. A later notification pass
+ * can recover the mentioned user ids by parsing the body — no separate store.
+ */
+
+const TOKEN_SOURCE = /@\[([^\]]+)\]\(mention:([^)]+)\)/g;
+
+/** Stored body → display text + a `"@Name" → userId` map. */
+export function detokenizeMentions(body: string): {
+  text: string;
+  map: Record<string, string>;
+} {
+  const map: Record<string, string> = {};
+  const text = body.replace(
+    new RegExp(TOKEN_SOURCE),
+    (_full, name: string, id: string) => {
+      map[`@${name}`] = id;
+      return `@${name}`;
+    },
+  );
+  return { text, map };
+}
+
+/** Display text + map → stored body, re-inserting a token for each known
+ * mention. Longest display names first so "@Bo" can't clobber "@Bo Yang". */
+export function tokenizeMentions(
+  text: string,
+  map: Record<string, string>,
+): string {
+  const displays = Object.keys(map).sort((a, b) => b.length - a.length);
+  let out = text;
+  for (const disp of displays) {
+    const id = map[disp];
+    if (!id) continue;
+    out = out.split(disp).join(`@[${disp.slice(1)}](mention:${id})`);
+  }
+  return out;
+}
+
+export type BodySegment =
+  | { kind: "text"; text: string }
+  | { kind: "mention"; name: string; userId: string };
+
+/** Split a stored body into text and mention segments for rendering. */
+export function parseBody(body: string): BodySegment[] {
+  const segs: BodySegment[] = [];
+  const re = new RegExp(TOKEN_SOURCE);
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    if (m.index > last)
+      segs.push({ kind: "text", text: body.slice(last, m.index) });
+    segs.push({ kind: "mention", name: m[1]!, userId: m[2]! });
+    last = m.index + m[0].length;
+  }
+  if (last < body.length) segs.push({ kind: "text", text: body.slice(last) });
+  return segs;
+}
+
+/** The in-progress `@query` immediately before the caret, or null if the caret
+ * isn't in a mention token. A mention starts at the string start or after
+ * whitespace, and runs up to the caret with no whitespace/`@` inside. */
+export function activeMentionQuery(
+  value: string,
+  caret: number,
+): { query: string; start: number } | null {
+  const before = value.slice(0, caret);
+  const m = /(?:^|\s)@([^\s@]*)$/.exec(before);
+  if (!m) return null;
+  return { query: m[1]!, start: caret - m[1]!.length - 1 };
+}


### PR DESCRIPTION
## What

Type `@` in a comment, reply, or edit to get a **Google-Docs-style people typeahead** and mention a teammate. Authoring + display only — actually *notifying* the person is a deliberate follow-up (no notification infra yet). First half of the Phase 2 @mention item from the [comments design doc](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/comments/design.md).

## How (frontend-only — no backend/schema change)

- **People search** reuses the existing `GET /users/search` (`useUserSearch`) — the same endpoint the share dialog uses. No new endpoint.
- **Storage**: mentions live inline in the existing comment `body` as a canonical token `@[Display Name](mention:<user_id>)`. The create/reply/edit endpoints already carry `body` and treat it as opaque text, so **no new column, migration, or model change**. A later notify pass parses the ids back out of the body.
- **`lib/commentMentions.ts`** — pure tokenize / detokenize / parse + active-`@`-query helper.
- **`MentionTextarea.tsx`** (+ CSS) — textarea with the `@` typeahead: ↑/↓ to move, Enter/Tab/click to pick, Esc to dismiss; avatar + name + email rows. Inserts the readable `@Name`; reports `(@Name, userId)` so the parent can tokenize on submit.
- **`CommentsPanel.tsx`** — wired into all three composers (new comment, reply, edit). Edit re-seeds from the current stored body each time it opens. Rendered comments show `@Name` as a chip.

## Notes / limitations (v1)
- The typeahead dropdown is anchored directly under the textarea — could clip at the very bottom of the panel; a portal would fix it later.
- No live chips *inside* the textarea while composing (you see `@Name` as plain text; chip on display) — that's the contenteditable/CodeMirror Phase 2 item.
- Opal-compatible: only existing tokens + `useUserSearch`; no raw colors.

## Test plan
<img width="1204" height="565" alt="Screenshot 2026-06-05 at 3 20 35 PM" src="https://github.com/user-attachments/assets/e64821a5-6df3-4404-938b-a98f6eb61c1f" />


- [ ] Type `@` in a new comment → dropdown of org users; filter by typing; pick with click and with ↑/↓+Enter.
- [ ] Submit → rendered comment shows the name as a chip.
- [ ] Reply and Edit composers get the same typeahead; editing an existing mention round-trips (shows `@Name`, saves back to a token).
- [ ] `@` with no match / Esc dismisses cleanly; a plain `email@x.com` in text isn't turned into a mention.

`bun run typecheck` + prettier clean (verified before commit).