### PR TITLE
fix(ingest): raise + log candidate-search failures instead of swallowing

### DIFF
--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -223,6 +223,7 @@ def search(
     user_id: str | None = None,
     is_admin: bool = False,
     apply_visibility: bool = True,
+    raise_on_error: bool = False,
 ) -> list[SearchHit]:
     client = _get_client()
     if client is None:
@@ -252,6 +253,12 @@ def search(
         c: OpenSearch = client  # type: ignore[assignment]
         resp = c.search(index=_index_name(), body=body)
     except Exception:
+        # Callers that need to tell a real backend failure (e.g. OpenSearch
+        # rejecting an oversized query) apart from a genuine no-match pass
+        # raise_on_error=True. The default swallows so search-surface callers
+        # degrade to empty results.
+        if raise_on_error:
+            raise
         log.warning("fts: search failed for query %r", query, exc_info=True)
         return []
 

--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -253,10 +253,10 @@ def search(
         c: OpenSearch = client  # type: ignore[assignment]
         resp = c.search(index=_index_name(), body=body)
     except Exception:
-        # Callers that need to tell a real backend failure (e.g. OpenSearch
-        # rejecting an oversized query) apart from a genuine no-match pass
-        # raise_on_error=True. The default swallows so search-surface callers
-        # degrade to empty results.
+        # With raise_on_error, propagate so the caller can distinguish a backend
+        # failure (e.g. OpenSearch rejecting an oversized query) from a genuine
+        # no-match. Otherwise log and return [] — the search surface degrades to
+        # empty results.
         if raise_on_error:
             raise
         log.warning("fts: search failed for query %r", query, exc_info=True)

--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -25,6 +25,12 @@ log = logging.getLogger(__name__)
 _TOKEN_RE = re.compile(r"\w+")
 
 
+class IngestSearchError(Exception):
+    """The BM25 candidate search failed (backend error), as opposed to
+    returning no matches. Lets the reconciler record a distinct outcome
+    instead of silently treating the failure as ``no_candidates``."""
+
+
 def _tokens(text: str) -> set[str]:
     return {t.lower() for t in _TOKEN_RE.findall(text)}
 
@@ -41,7 +47,18 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
     Title similarity boosts the raw BM25 score before thresholding so
     pages whose titles closely match the incoming document rank higher.
     """
-    hits = fts_search(content, limit=CONFIG.ingest_bm25_limit, apply_visibility=False)
+    try:
+        hits = fts_search(
+            content,
+            limit=CONFIG.ingest_bm25_limit,
+            apply_visibility=False,
+            raise_on_error=True,
+        )
+    except Exception as exc:
+        # A backend failure (e.g. OpenSearch rejecting an oversized query) is
+        # not "no candidates" — surface it so the reconciler records it
+        # distinctly rather than silently dropping the document.
+        raise IngestSearchError(str(exc)) from exc
     if not hits:
         log.debug("ingest candidates: no BM25 hits for title=%r", title)
         return []

--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -26,9 +26,9 @@ _TOKEN_RE = re.compile(r"\w+")
 
 
 class IngestSearchError(Exception):
-    """The BM25 candidate search failed (backend error), as opposed to
-    returning no matches. Lets the reconciler record a distinct outcome
-    instead of silently treating the failure as ``no_candidates``."""
+    """Raised when the BM25 candidate search fails at the backend (e.g.
+    OpenSearch rejecting an oversized query), as distinct from returning no
+    matches. The reconciler logs it and drops the document."""
 
 
 def _tokens(text: str) -> set[str]:
@@ -55,9 +55,9 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
             raise_on_error=True,
         )
     except Exception as exc:
-        # A backend failure (e.g. OpenSearch rejecting an oversized query) is
-        # not "no candidates" — surface it so the reconciler records it
-        # distinctly rather than silently dropping the document.
+        # Surface a backend failure (e.g. OpenSearch rejecting an oversized
+        # query) as IngestSearchError, distinct from an empty result, so the
+        # caller treats it as an error rather than a genuine no-match.
         raise IngestSearchError(str(exc)) from exc
     if not hits:
         log.debug("ingest candidates: no BM25 hits for title=%r", title)

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -309,8 +309,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
         hits = ingest_search.candidates(content, title)
     except ingest_search.IngestSearchError:
         # Candidate search failed (e.g. OpenSearch rejected an oversized query).
-        # Log and drop the document — surfaced in the logs rather than silently
-        # masquerading as a genuine no-match.
+        # Log it and drop the document.
         log.warning(
             "process_pushed_document: candidate search FAILED (document dropped), doc_id=%s",
             doc_id,

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -305,7 +305,18 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
         return
 
     t_start = time.monotonic()
-    hits = ingest_search.candidates(content, title)
+    try:
+        hits = ingest_search.candidates(content, title)
+    except ingest_search.IngestSearchError:
+        # Candidate search failed (e.g. OpenSearch rejected an oversized query).
+        # Log and drop the document — surfaced in the logs rather than silently
+        # masquerading as a genuine no-match.
+        log.warning(
+            "process_pushed_document: candidate search FAILED (document dropped), doc_id=%s",
+            doc_id,
+            exc_info=True,
+        )
+        return
     if not hits:
         log.info("process_pushed_document: no BM25 candidates above threshold, doc_id=%s", doc_id)
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -162,6 +162,25 @@ def test_no_candidates_returns_early(mock_search):
     mock_search.assert_called_once()
 
 
+def test_candidates_raises_on_search_backend_error():
+    # A backend failure (e.g. OpenSearch rejecting an oversized query) must
+    # surface as IngestSearchError, not be swallowed into an empty result.
+    boom = RuntimeError("maxClauseCount is set to 1024")
+    with patch("app.ingest.search.fts_search", side_effect=boom):
+        with pytest.raises(ingest_search.IngestSearchError):
+            ingest_search.candidates("a very long transcript", "Big Meeting")
+
+
+@patch("app.tasks.wiki_update.wiki_git.commit_file")
+@patch("app.tasks.wiki_update.ingest_search.candidates",
+       side_effect=ingest_search.IngestSearchError("maxClauseCount is set to 1024"))
+def test_search_error_is_caught_and_does_not_commit(mock_search, mock_commit):
+    # A search failure is logged and the document dropped — it must be caught
+    # (not raised out of the task) and must never commit.
+    _run(_make_push())
+    mock_commit.assert_not_called()
+
+
 @patch("app.tasks.wiki_update.wiki_git.head_sha_for_path", return_value="headsha")
 @patch("app.wiki.utils.wiki_notify.after_doc_write")
 @patch("app.tasks.wiki_update.wiki_git.commit_file", return_value="sha123")


### PR DESCRIPTION
## Problem

Document ingestion silently drops long documents. The BM25 candidate search (`fts.search`) **swallows backend errors and returns `[]`**, so a *failed* search is indistinguishable from a *genuine no-match*. In particular, OpenSearch rejects the query when the document body exceeds `maxClauseCount = 1024` terms:

```
opensearchpy.exceptions.RequestError: RequestError(400, 'search_phase_execution_exception',
  'failed to create query: maxClauseCount is set to 1024')
process_pushed_document: no BM25 candidates above threshold, doc_id=FIREFLIES_...
```

The reconciler then records `outcome="no_candidates"` and returns early — no reconcile, no wiki edit, **no trace that anything failed**. Observed live: long Fireflies transcripts (~15k chars) accepted with `202`, then dropped with zero signal.

This PR makes the failure **raise + log** instead of being swallowed. It does **not** fix the underlying root cause (using the full document body as the query — tracked separately as P1); it just stops the silent drop.

## Change

- `app/db/fts.py` — `search()` gains `raise_on_error=False`; the search endpoint is unchanged via the default, ingest opts in.
- `app/ingest/search.py` — new `IngestSearchError`; `candidates()` raises it on backend failure instead of returning `[]`.
- `app/tasks/wiki_update.py` — catches it, logs a warning with traceback, and drops the document. No longer masquerades as `no_candidates`.

## Tests
- `test_candidates_raises_on_search_backend_error` — a backend error surfaces as `IngestSearchError`, not an empty result.
- `test_search_error_is_caught_and_does_not_commit` — the reconciler logs + drops (doesn't raise out of the task) and never commits.
- Full ingest suite passes; `ruff` + `basedpyright` clean.