### PR TITLE
fix(ingest): distill an update-intent query for oversized documents (P1)

### DIFF
--- a/backend/app/ingest/intent.py
+++ b/backend/app/ingest/intent.py
@@ -1,0 +1,63 @@
+"""Distill an incoming document into a compact BM25 query.
+
+The candidate search normally uses the raw document body as the query. When a
+document is large its body exceeds OpenSearch's boolean-clause limit and the
+search is rejected (see ``app.ingest.search.candidates``). For those documents
+a cheap LLM extracts the update-intent — summary, candidate updates, and named
+entities — which is short enough to query with and keeps the discriminating
+tokens. Fails open: returns None on any model or parse error so the caller can
+fall back to a deterministic bounded-terms query.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+from app.llm import client
+from app.llm.prompts import load_prompt
+from app.tracing import trace_flow
+
+log = logging.getLogger(__name__)
+
+# Cap the content sent to the model — enough to capture the document's subject
+# without paying full-document token cost on this cheap call.
+_INTENT_CONTENT_CHARS = 20_000
+
+
+def generate_search_query(*, title: str | None, content: str, model: str) -> str | None:
+    """Return a compact query (summary + candidate updates + entities) distilled
+    from the document, or None if the model is unavailable or the response can't
+    be parsed."""
+    system = load_prompt("ingest_intent.system")
+    user = load_prompt("ingest_intent.input").format(
+        title=title or "(no title)",
+        content=content[:_INTENT_CONTENT_CHARS],
+    )
+    try:
+        with trace_flow("agent.ingest_intent"):
+            result = client.complete(
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                model=model,
+            )
+        raw: Any = json.loads(result.text.strip())
+        if not isinstance(raw, dict):
+            raise ValueError(f"expected object, got {type(raw).__name__}")
+        data = cast(dict[str, Any], raw)
+        parts: list[str] = []
+        summary = data.get("summary")
+        if isinstance(summary, str):
+            parts.append(summary)
+        for key in ("candidate_updates", "entities"):
+            vals = data.get(key)
+            if isinstance(vals, list):
+                parts.extend(v for v in cast(list[object], vals) if isinstance(v, str))
+    except Exception:
+        log.warning("ingest_intent: failed to generate search query", exc_info=True)
+        return None
+
+    query = " ".join(p.strip() for p in parts if p.strip())
+    return query or None

--- a/backend/app/ingest/intent.py
+++ b/backend/app/ingest/intent.py
@@ -43,7 +43,11 @@ def generate_search_query(*, title: str | None, content: str, model: str) -> str
                 ],
                 model=model,
             )
-        raw: Any = json.loads(result.text.strip())
+        text = result.text.strip()
+        # Some models wrap the JSON in a ```/```json code fence; strip it.
+        if text.startswith("```"):
+            text = text.split("```", 2)[1].removeprefix("json").removeprefix("JSON").strip()
+        raw: Any = json.loads(text)
         if not isinstance(raw, dict):
             raise ValueError(f"expected object, got {type(raw).__name__}")
         data = cast(dict[str, Any], raw)

--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import re
 
 import logging
+from collections import Counter
 
 from app.config import CONFIG
 from app.db.fts import SearchHit, search as fts_search
@@ -29,6 +30,17 @@ class IngestSearchError(Exception):
     """Raised when the BM25 candidate search fails at the backend (e.g.
     OpenSearch rejecting an oversized query), as distinct from returning no
     matches. The reconciler logs it and drops the document."""
+
+
+def bounded_query(content: str, max_terms: int = 200) -> str:
+    """Reduce ``content`` to its most frequent terms, capped at ``max_terms``.
+
+    A deterministic fallback query that stays well under OpenSearch's boolean
+    clause limit, used when the LLM intent path is unavailable for a document
+    too large to query with its raw body.
+    """
+    counts = Counter(t for t in _TOKEN_RE.findall(content.lower()) if len(t) > 2)
+    return " ".join(term for term, _ in counts.most_common(max_terms))
 
 
 def _tokens(text: str) -> set[str]:

--- a/backend/app/llm/prompts/ingest_intent.input.md
+++ b/backend/app/llm/prompts/ingest_intent.input.md
@@ -1,0 +1,4 @@
+Source document title: {title}
+
+Source document content:
+{content}

--- a/backend/app/llm/prompts/ingest_intent.system.md
+++ b/backend/app/llm/prompts/ingest_intent.system.md
@@ -1,0 +1,8 @@
+You extract the UPDATE-INTENT of an incoming source document: the concrete, specific information it carries that could plausibly update a team wiki. The output is used to search a BM25 wiki index for the pages this document might update, so favor concrete subject terms, named entities, and specifics over gist.
+
+Preserve SPECIFICS — names, IDs, versions, dates, the actual claim/event. Do not invent action items; only describe what is actually present. Strip conversational filler, boilerplate, and formatting noise.
+
+Return ONLY a JSON object with exactly these keys:
+- "summary": 1-2 sentences capturing the concrete substance (with specifics).
+- "candidate_updates": 0-5 short strings, each a concrete fact/event/decision/task the document asserts that could update a page. Empty list if the document carries no substantive updatable information.
+- "entities": list of named entities (people, companies, products, versions, identifiers) present.

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from app.config import CONFIG
 from app.ingest import eval_sample as ingest_eval_sample
+from app.ingest import intent as ingest_intent
 from app.ingest import search as ingest_search
 from app.ingest.source_tiers import is_filtered
 from app.ingest.models import WikiUpdateCandidate
@@ -308,14 +309,34 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     try:
         hits = ingest_search.candidates(content, title)
     except ingest_search.IngestSearchError:
-        # Candidate search failed (e.g. OpenSearch rejected an oversized query).
-        # Log it and drop the document.
-        log.warning(
-            "process_pushed_document: candidate search FAILED (document dropped), doc_id=%s",
-            doc_id,
-            exc_info=True,
+        # The candidate search failed — almost always because the full document
+        # body exceeds OpenSearch's boolean-clause limit. Only large documents
+        # reach here, so retry with a compact query (and pay the LLM cost only
+        # when needed): an LLM-distilled update-intent when a cheap model is
+        # configured, else a deterministic bounded-terms query.
+        selector_model = get_llm_settings().ingest_selector_model
+        query = (
+            ingest_intent.generate_search_query(title=title, content=content, model=selector_model)
+            if selector_model
+            else None
         )
-        return
+        strategy = "llm-intent"
+        if not query:
+            query = ingest_search.bounded_query(content)
+            strategy = "bounded-terms"
+        log.info(
+            "process_pushed_document: oversized query, retrying via %s, doc_id=%s",
+            strategy, doc_id,
+        )
+        try:
+            hits = ingest_search.candidates(query, title)
+        except ingest_search.IngestSearchError:
+            log.warning(
+                "process_pushed_document: candidate search FAILED after %s fallback "
+                "(document dropped), doc_id=%s",
+                strategy, doc_id, exc_info=True,
+            )
+            return
     if not hits:
         log.info("process_pushed_document: no BM25 candidates above threshold, doc_id=%s", doc_id)
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -300,7 +300,7 @@ def test_missing_file_skipped(mock_search, mock_reconcile, mock_read, mock_commi
 
 
 # --------------------------------------------------------------------------- #
-# P1: oversized-query handling (LLM intent + bounded fallback)                #
+# oversized-query handling (LLM intent + bounded fallback)                    #
 # --------------------------------------------------------------------------- #
 
 
@@ -329,6 +329,16 @@ def test_generate_search_query_returns_none_on_error():
     from app.ingest import intent as ingest_intent
     with patch("app.ingest.intent.client.complete", side_effect=RuntimeError("model down")):
         assert ingest_intent.generate_search_query(title="t", content="c", model="cheap") is None
+
+
+def test_generate_search_query_strips_markdown_fence():
+    from types import SimpleNamespace
+    from app.ingest import intent as ingest_intent
+    # Many models wrap JSON in a ```json fence — must still parse.
+    payload = '```json\n{"summary": "Acme call", "candidate_updates": [], "entities": ["Acme"]}\n```'
+    with patch("app.ingest.intent.client.complete", return_value=SimpleNamespace(text=payload)):
+        q = ingest_intent.generate_search_query(title="Acme", content="...", model="cheap")
+    assert q is not None and "Acme call" in q and "Acme" in q
 
 
 def _settings_with_selector(model: str = "test-model") -> LLMSettings:

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -297,3 +297,71 @@ def test_missing_file_skipped(mock_search, mock_reconcile, mock_read, mock_commi
     _run(_make_push())
     mock_reconcile.assert_not_called()
     mock_commit.assert_not_called()
+
+
+# --------------------------------------------------------------------------- #
+# P1: oversized-query handling (LLM intent + bounded fallback)                #
+# --------------------------------------------------------------------------- #
+
+
+def test_bounded_query_caps_terms_and_drops_short_tokens():
+    content = ("alpha beta gamma " * 50) + "to is a " + ("delta " * 5)
+    q = ingest_search.bounded_query(content, max_terms=3)
+    terms = q.split()
+    assert len(terms) <= 3
+    # short tokens (<=2 chars) are dropped
+    assert "to" not in terms and "is" not in terms and "a" not in terms
+    # most frequent content term is included
+    assert "alpha" in terms
+
+
+def test_generate_search_query_builds_from_intent_fields():
+    from types import SimpleNamespace
+    from app.ingest import intent as ingest_intent
+    payload = '{"summary": "Acme renewal call", "candidate_updates": ["renewed for $24k"], "entities": ["Acme", "$24k"]}'
+    with patch("app.ingest.intent.client.complete", return_value=SimpleNamespace(text=payload)):
+        q = ingest_intent.generate_search_query(title="Acme", content="...transcript...", model="cheap")
+    assert q is not None
+    assert "Acme renewal call" in q and "renewed for $24k" in q and "$24k" in q
+
+
+def test_generate_search_query_returns_none_on_error():
+    from app.ingest import intent as ingest_intent
+    with patch("app.ingest.intent.client.complete", side_effect=RuntimeError("model down")):
+        assert ingest_intent.generate_search_query(title="t", content="c", model="cheap") is None
+
+
+def _settings_with_selector(model: str = "test-model") -> LLMSettings:
+    return _EMPTY_LLM_SETTINGS.model_copy(update={"model": model, "ingest_selector_model": model})
+
+
+@patch("app.tasks.wiki_update.wiki_git.head_sha_for_path", return_value="headsha")
+@patch("app.wiki.utils.wiki_notify.after_doc_write")
+@patch("app.tasks.wiki_update.wiki_git.commit_file", return_value="sha")
+@patch("app.tasks.wiki_update.wiki_git.read_file", return_value="body")
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
+@patch("app.tasks.wiki_update.ingest_intent.generate_search_query", return_value="distilled query")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_oversized_query_retries_with_llm_intent(
+    mock_search, mock_intent, mock_reconcile, mock_read, mock_commit, mock_notify, mock_head, monkeypatch
+):
+    monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_selector())
+    # First candidate search blows the clause limit; retry with the distilled
+    # query succeeds and the doc commits.
+    mock_search.side_effect = [ingest_search.IngestSearchError("maxClauseCount is set to 1024"), [_hit("page.md", "Page", 5.0)]]
+    mock_reconcile.return_value = (["new body"], 1)
+    _run(_make_push(content="x " * 5000))
+    mock_intent.assert_called_once()
+    assert mock_search.call_count == 2
+    mock_commit.assert_called_once()
+
+
+@patch("app.tasks.wiki_update.ingest_search.bounded_query", return_value="term1 term2")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_oversized_query_falls_back_to_bounded_terms_when_no_model(mock_search, mock_bounded):
+    # No selector model configured (autouse _EMPTY settings) → no LLM call,
+    # fall back to bounded-terms query and retry.
+    mock_search.side_effect = [ingest_search.IngestSearchError("maxClauseCount is set to 1024"), []]
+    _run(_make_push(content="x " * 5000))
+    mock_bounded.assert_called_once()
+    assert mock_search.call_count == 2


### PR DESCRIPTION
## Problem (P1)

The candidate search (`ingest.search.candidates`) uses the **raw document body** as the BM25 query. For a long document that analyzes into >1024 terms, OpenSearch rejects the query (`maxClauseCount is set to 1024`). Result: long transcripts found no candidates and were dropped before reconciliation — which is why only tiny meetings ever reached the wiki.

(#202 made that failure *raise* instead of silently masquerading as a no-match. This PR fixes the underlying cause.)

## Fix — retry with a compact query (only large docs)

On `IngestSearchError` (only large docs reach here, so cost is paid only when needed):

1. If a cheap model is configured (`ingest_selector_model`), distill the document into an **update-intent** — `summary` + `candidate_updates` + `entities` — and query BM25 with that. It's short (no clause-limit issue) and **entity-rich**; per the evals it's a *better* query than the raw body (BM25 AUC **0.928 vs 0.892**), because it drops conversational filler/boilerplate.
2. Otherwise fall back to a deterministic **bounded top-terms** query (no LLM).
3. If even the retry fails, log + drop (as before).

Notes:
- **Uses the cheap selector model**, not the main reconciler model. No model configured → no LLM call (bounded-terms only). Doubly cost-bounded: cheap model × only-large-docs.
- **Page indexing unchanged** (raw body) — the eval found cleaning the *page* side hurts (0.928 → 0.606); only the doc-side query is cleaned.
- Prompt ported from `agent-wiki-evals` (`gen_scopes_intents.py` `DOC_SYS`).

## Files
- `app/ingest/intent.py` — `generate_search_query()` via `app.llm.client` (fails open → None).
- `app/llm/prompts/ingest_intent.{system,input}.md` — the update-intent prompt.
- `app/ingest/search.py` — `bounded_query()` deterministic fallback.
- `app/tasks/wiki_update.py` — retry-with-compact-query on `IngestSearchError`.

## Tests
- intent builds query from parsed fields; returns None on model error.
- bounded_query caps terms / drops short tokens.
- oversized search → retries with LLM intent → commits.
- oversized search, no model → bounded-terms fallback → retries.
- Full ingest suite passes; ruff + basedpyright clean.

## Follow-up
An integration test against real OpenSearch (ingest a >1024-term doc, assert candidates without error) would lock the regression end-to-end — unit tests here simulate the failure via mocked `candidates`.