### PR TITLE
fix(theme): eliminate hydration mismatch by SSR-ing theme from cookie

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 
 import * as Tooltip from "@radix-ui/react-tooltip";
+import clsx from "clsx";
 import { DM_Mono, Hanken_Grotesk } from "next/font/google";
 import { cookies } from "next/headers";
 import type { ReactNode } from "react";
@@ -9,8 +10,11 @@ import { ConfirmProvider } from "@/components/common/ConfirmDialog";
 import { AuthProvider } from "@/lib/auth";
 import { DraftingProvider } from "@/lib/drafting";
 import { SWRProvider } from "@/lib/swr";
-import { THEME_COOKIE_KEY, ThemeProvider } from "@/lib/theme-provider";
-import type { ResolvedTheme } from "@/lib/theme-provider";
+import {
+  THEME_COOKIE_KEY,
+  ThemeProvider,
+  type ResolvedTheme,
+} from "@/lib/theme-provider";
 
 const hankenGrotesk = Hanken_Grotesk({
   subsets: ["latin"],
@@ -65,7 +69,11 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`${hankenGrotesk.variable} ${dmMono.variable}${theme === "dark" ? " dark" : ""}`}
+      className={clsx(
+        hankenGrotesk.variable,
+        dmMono.variable,
+        theme === "dark" && "dark",
+      )}
       data-theme={theme}
     >
       <head />

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "./globals.css";
 
 import * as Tooltip from "@radix-ui/react-tooltip";
-import clsx from "clsx";
+import { cn } from "@onyx-ai/opal/utils";
 import { DM_Mono, Hanken_Grotesk } from "next/font/google";
 import { cookies } from "next/headers";
 import type { ReactNode } from "react";
@@ -69,7 +69,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={clsx(
+      className={cn(
         hankenGrotesk.variable,
         dmMono.variable,
         theme === "dark" && "dark",

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,14 +2,15 @@ import "./globals.css";
 
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { DM_Mono, Hanken_Grotesk } from "next/font/google";
+import { cookies } from "next/headers";
 import type { ReactNode } from "react";
 
 import { ConfirmProvider } from "@/components/common/ConfirmDialog";
 import { AuthProvider } from "@/lib/auth";
 import { DraftingProvider } from "@/lib/drafting";
 import { SWRProvider } from "@/lib/swr";
-import { ThemeBootstrapScript } from "@/lib/theme-bootstrap-script";
-import { ThemeProvider } from "@/lib/theme-provider";
+import { THEME_COOKIE_KEY, ThemeProvider } from "@/lib/theme-provider";
+import type { ResolvedTheme } from "@/lib/theme-provider";
 
 const hankenGrotesk = Hanken_Grotesk({
   subsets: ["latin"],
@@ -52,14 +53,22 @@ export const viewport = {
   initialScale: 1,
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const cookieStore = await cookies();
+  const theme: ResolvedTheme =
+    cookieStore.get(THEME_COOKIE_KEY)?.value === "dark" ? "dark" : "light";
+
   return (
-    <html lang="en" className={`${hankenGrotesk.variable} ${dmMono.variable}`}>
-      <head>
-        {/* Sets data-theme attribute and .dark class on <html> before React
-            hydrates so dark-mode users don't see a light-mode flash. */}
-        <ThemeBootstrapScript />
-      </head>
+    <html
+      lang="en"
+      className={`${hankenGrotesk.variable} ${dmMono.variable}${theme === "dark" ? " dark" : ""}`}
+      data-theme={theme}
+    >
+      <head />
       <body
         style={{
           margin: 0,

--- a/frontend/src/lib/theme-bootstrap-script.tsx
+++ b/frontend/src/lib/theme-bootstrap-script.tsx
@@ -1,7 +1,0 @@
-const STORAGE_KEY = "agent-wiki:theme";
-
-const bootstrapSource = `(()=>{try{var k=${JSON.stringify(STORAGE_KEY)};var s=localStorage.getItem(k);if(s!=='light'&&s!=='dark'&&s!=='system')s='system';var r=s;if(s==='system')r=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';var el=document.documentElement;el.setAttribute('data-theme',r);el.classList.toggle('dark',r==='dark');}catch(e){}})();`;
-
-export function ThemeBootstrapScript() {
-  return <script dangerouslySetInnerHTML={{ __html: bootstrapSource }} />;
-}

--- a/frontend/src/lib/theme-provider.tsx
+++ b/frontend/src/lib/theme-provider.tsx
@@ -95,7 +95,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     applyTheme(resolved);
     // Persist resolved theme in a cookie so the server can render the
     // correct data-theme on <html> before React hydrates.
-    document.cookie = `${THEME_COOKIE_KEY}=${resolved};path=/;max-age=${365 * 24 * 60 * 60};SameSite=Lax`;
+    document.cookie = `${THEME_COOKIE_KEY}=${resolved};path=/;max-age=${365 * 24 * 60 * 60};SameSite=Lax;Secure`;
   }, [resolved]);
 
   const value = useMemo<ThemeContextValue>(

--- a/frontend/src/lib/theme-provider.tsx
+++ b/frontend/src/lib/theme-provider.tsx
@@ -25,6 +25,9 @@ const ThemeContext = createContext<ThemeContextValue>({
 });
 
 const STORAGE_KEY = "agent-wiki:theme";
+// Separate cookie key (no colon — RFC 6265 token-safe) so the server can
+// read the resolved theme for SSR without relying on localStorage.
+export const THEME_COOKIE_KEY = "agent-wiki-theme";
 
 function readStoredSetting(): ThemeSetting {
   if (typeof window === "undefined") return "system";
@@ -90,6 +93,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     applyTheme(resolved);
+    // Persist resolved theme in a cookie so the server can render the
+    // correct data-theme on <html> before React hydrates.
+    document.cookie = `${THEME_COOKIE_KEY}=${resolved};path=/;max-age=${365 * 24 * 60 * 60};SameSite=Lax`;
   }, [resolved]);
 
   const value = useMemo<ThemeContextValue>(


### PR DESCRIPTION
## Summary

- Replaces the `ThemeBootstrapScript` inline-script approach with proper server-side theme rendering
- `ThemeProvider` writes the resolved theme (`light`/`dark`) to a cookie (`agent-wiki-theme`) whenever it changes
- `RootLayout` is now async and reads that cookie to render `<html data-theme="..." class="... dark">` from the server — server and client agree on initial DOM state, React hydration never sees a mismatch
- Deletes `theme-bootstrap-script.tsx` which only existed to patch up the DOM pre-hydration

**Edge case:** first-time visitors with no cookie default to light. A system-dark user will see a brief flash on their very first load; subsequent loads are correct.

## Test plan

- [ ] Visit the app as a returning dark-mode user — no flash, no hydration warning in console
- [ ] Visit as a new user (clear cookies) — loads in light mode
- [ ] Toggle theme in settings — preference persists across hard refresh
- [ ] Check browser DevTools: `<html>` should have `data-theme` and `dark` class set correctly on the initial server-rendered HTML