### PR TITLE
fix(ingest): cap the distilled intent query length

### DIFF
--- a/backend/app/ingest/intent.py
+++ b/backend/app/ingest/intent.py
@@ -24,6 +24,12 @@ log = logging.getLogger(__name__)
 # without paying full-document token cost on this cheap call.
 _INTENT_CONTENT_CHARS = 20_000
 
+# Cap the composed query's term count so it can't re-trip OpenSearch's clause
+# limit when the model echoes many distinct tokens (e.g. an ID-heavy document).
+# multi_match expands across two fields, so 200 terms ≈ 400 clauses — well under
+# the 1024 default. Matches app.ingest.search.bounded_query's cap.
+_MAX_QUERY_TERMS = 200
+
 
 def generate_search_query(*, title: str | None, content: str, model: str) -> str | None:
     """Return a compact query (summary + candidate updates + entities) distilled
@@ -63,5 +69,5 @@ def generate_search_query(*, title: str | None, content: str, model: str) -> str
         log.warning("ingest_intent: failed to generate search query", exc_info=True)
         return None
 
-    query = " ".join(p.strip() for p in parts if p.strip())
+    query = " ".join(" ".join(parts).split()[:_MAX_QUERY_TERMS])
     return query or None

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -341,6 +341,19 @@ def test_generate_search_query_strips_markdown_fence():
     assert q is not None and "Acme call" in q and "Acme" in q
 
 
+def test_generate_search_query_caps_term_count():
+    import json as _json
+    from types import SimpleNamespace
+    from app.ingest import intent as ingest_intent
+    # Model echoes a huge entities list — the query must stay bounded so it can't
+    # re-trip the clause limit on retry.
+    payload = _json.dumps({"summary": "many ids", "candidate_updates": [], "entities": [f"id{i:05d}" for i in range(1000)]})
+    with patch("app.ingest.intent.client.complete", return_value=SimpleNamespace(text=payload)):
+        q = ingest_intent.generate_search_query(title="t", content="c", model="cheap")
+    assert q is not None
+    assert len(q.split()) <= 200
+
+
 def _settings_with_selector(model: str = "test-model") -> LLMSettings:
     return _EMPTY_LLM_SETTINGS.model_copy(update={"model": model, "ingest_selector_model": model})
 


### PR DESCRIPTION
## Problem

Follow-up to #204. The LLM-distilled intent query in `generate_search_query` was **not length-capped**. For a document whose intent still contains many distinct tokens (e.g. an ID/contact-heavy dump where the model echoes lots of entities), the retry query can itself exceed OpenSearch's clause limit and fail — so the document is still dropped, defeating the fix.

Found while verifying P1 in prod: a probe doc distilled to a 669-term intent, and `multi_match` spans two fields (`title` + `body`), so ~669 × 2 ≈ 1338 clauses > 1024 → retry re-failed.

## Fix

Cap the composed query to **200 terms** in `generate_search_query` (200 × 2 fields ≈ 400 clauses, safe margin), matching `bounded_query`'s existing cap. Normal transcripts are unaffected (their intent is far shorter); only pathological high-cardinality docs are truncated, keeping the summary (most important signal) first.

## Tests
- `test_generate_search_query_caps_term_count` — a 1000-entity model response yields a ≤200-term query.
- Full ingest suite passes (29); ruff + basedpyright clean.
- Verified in prod (probe): a 200-term-capped query retries successfully (20 candidates).