### PR TITLE
feat(comments): index comments for full-text search (separate index)

### DIFF
--- a/backend/app/db/comment_fts.py
+++ b/backend/app/db/comment_fts.py
@@ -1,0 +1,292 @@
+"""BM25 full-text search for comments via OpenSearch.
+
+A **separate** index from the document index (`wiki-docs`), one OpenSearch
+document per comment.  Keeping comments in their own index is deliberate: the
+document-ingestion candidate search (`app.db.fts.search`, field-scoped to
+`title`/`body` over `wiki-docs`) and its `INGEST_BM25_MIN_SCORE` calibration
+must stay untouched.  OpenSearch BM25 statistics are per-index, so a separate
+index can't perturb `wiki-docs` scoring, and nothing here writes to `wiki-docs`.
+
+The index name is derived from the doc index (`<opensearch_index>-comments`) so
+the per-test isolation the conftest already sets up for `wiki-docs` extends to
+comments for free.
+
+Like `app.db.fts`, writes are best-effort: failures log at WARNING and return
+without raising so a search-index glitch never aborts a comment mutation, and
+search degrades to an empty list on connection errors.  Visibility is filtered
+in Python by `doc_path` (comments inherit the page's read access).
+"""
+from __future__ import annotations
+
+import logging
+
+from opensearchpy import OpenSearch  # type: ignore[import-untyped]
+from opensearchpy.exceptions import NotFoundError  # type: ignore[import-untyped]
+from pydantic import BaseModel
+
+from app.db import fts
+
+log = logging.getLogger(__name__)
+
+# Tracks which index name we've ensured a mapping for. When CONFIG changes
+# (e.g. a new per-test index name), this differs from the current name and we
+# re-ensure — so no explicit reset hook is needed between tests.
+_ensured_index: str | None = None
+
+
+class CommentDoc(BaseModel):
+    comment_id: str
+    doc_path: str
+    thread_root_id: str
+    body: str
+    author_user_id: str | None
+    mentioned_user_ids: list[str]
+    status: str
+
+
+class CommentSearchHit(BaseModel):
+    comment_id: str
+    doc_path: str
+    thread_root_id: str
+    snippet: str
+    score: float
+
+
+_MAPPING = {
+    "settings": {
+        "index": {
+            "similarity": {"default": {"type": "BM25", "b": 0.75, "k1": 1.2}},
+        },
+    },
+    "mappings": {
+        "properties": {
+            "comment_id": {"type": "keyword"},
+            "doc_path": {"type": "keyword"},
+            "thread_root_id": {"type": "keyword"},
+            "body": {"type": "text"},
+            "author_user_id": {"type": "keyword"},
+            "mentioned_user_ids": {"type": "keyword"},
+            "status": {"type": "keyword"},
+        },
+    },
+}
+
+
+def _index_name() -> str:
+    from app.config import CONFIG
+
+    return f"{CONFIG.opensearch_index}-comments"
+
+
+def _client() -> object | None:
+    """The shared OpenSearch client (created/owned by ``app.db.fts``), with our
+    own index ensured once per index name."""
+    global _ensured_index
+    client = fts.get_client()  # reuse the singleton + its connection
+    if client is None:
+        return None
+    idx = _index_name()
+    if _ensured_index != idx:
+        try:
+            c: OpenSearch = client  # type: ignore[assignment]
+            if not c.indices.exists(index=idx):
+                c.indices.create(index=idx, body=_MAPPING)
+                log.info("comment_fts: created index %s", idx)
+            _ensured_index = idx
+        except Exception:
+            log.warning("comment_fts: failed to ensure index %s", idx, exc_info=True)
+            return None
+    return client
+
+
+def drop_index_for_tests() -> None:
+    """Delete the per-test comment index (mirrors ``fts.drop_index_for_tests``)."""
+    global _ensured_index
+    client = _client()
+    _ensured_index = None
+    if client is None:
+        return
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        try:
+            c.indices.delete(index=_index_name())
+        except NotFoundError:
+            pass
+    except Exception:
+        log.warning("comment_fts: drop_index_for_tests failed", exc_info=True)
+
+
+# --------------------------------------------------------------------------- #
+# Write operations                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def index_comment(doc: CommentDoc) -> None:
+    client = _client()
+    if client is None:
+        return
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        c.index(
+            index=_index_name(),
+            id=doc.comment_id,
+            body=doc.model_dump(),
+            refresh=True,  # type: ignore[call-arg]
+        )
+    except Exception:
+        log.warning("comment_fts: index_comment failed for %s", doc.comment_id, exc_info=True)
+
+
+def count() -> int | None:
+    """Number of indexed comments, or None if the index is unavailable."""
+    client = _client()
+    if client is None:
+        return None
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        return int(c.count(index=_index_name())["count"])
+    except Exception:
+        log.warning("comment_fts: count failed", exc_info=True)
+        return None
+
+
+def delete_comment(comment_id: str) -> None:
+    client = _client()
+    if client is None:
+        return
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        try:
+            c.delete(index=_index_name(), id=comment_id, refresh=True)  # type: ignore[call-arg]
+        except NotFoundError:
+            pass
+    except Exception:
+        log.warning("comment_fts: delete_comment failed for %s", comment_id, exc_info=True)
+
+
+def _delete_by(field: str, value: str) -> None:
+    client = _client()
+    if client is None:
+        return
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        c.delete_by_query(
+            index=_index_name(),
+            body={"query": {"term": {field: value}}},
+            refresh=True,  # type: ignore[call-arg]
+            conflicts="proceed",  # type: ignore[call-arg]
+        )
+    except Exception:
+        log.warning("comment_fts: delete_by %s=%s failed", field, value, exc_info=True)
+
+
+def delete_thread(thread_root_id: str) -> None:
+    """Remove every comment in a thread from the index (thread deleted or orphaned)."""
+    _delete_by("thread_root_id", thread_root_id)
+
+
+def delete_for_doc(doc_path: str) -> None:
+    """Remove every comment on a page from the index (page deleted)."""
+    _delete_by("doc_path", doc_path)
+
+
+def reassign_doc_path(old_path: str, new_path: str) -> None:
+    """Repoint a page's comment docs to a new path (page move/rename)."""
+    client = _client()
+    if client is None:
+        return
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        c.update_by_query(
+            index=_index_name(),
+            body={
+                "query": {"term": {"doc_path": old_path}},
+                "script": {
+                    "source": "ctx._source.doc_path = params.p",
+                    "params": {"p": new_path},
+                },
+            },
+            refresh=True,  # type: ignore[call-arg]
+            conflicts="proceed",  # type: ignore[call-arg]
+        )
+    except Exception:
+        log.warning(
+            "comment_fts: reassign_doc_path %s->%s failed", old_path, new_path, exc_info=True
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Search                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def search(
+    query: str,
+    limit: int = 20,
+    *,
+    user_id: str | None = None,
+    is_admin: bool = False,
+    apply_visibility: bool = True,
+) -> list[CommentSearchHit]:
+    client = _client()
+    if client is None:
+        return []
+
+    fetch_size = min(limit * 5, 200)
+    body = {
+        "query": {
+            "bool": {
+                "must": {"match": {"body": query}},
+                # Orphaned comments are removed from the index, but filter
+                # defensively so a stale doc never surfaces.
+                "filter": {"terms": {"status": ["open", "resolved"]}},
+            },
+        },
+        "highlight": {"fields": {"body": {"fragment_size": 200, "number_of_fragments": 1}}},
+        "_source": ["comment_id", "doc_path", "thread_root_id"],
+        "size": fetch_size,
+    }
+
+    try:
+        c: OpenSearch = client  # type: ignore[assignment]
+        resp = c.search(index=_index_name(), body=body)
+    except Exception:
+        log.warning("comment_fts: search failed for query %r", query, exc_info=True)
+        return []
+
+    hits = resp.get("hits", {}).get("hits", [])
+    if not hits:
+        return []
+
+    rows: list[tuple[str, str, str, str, float]] = []
+    for h in hits:
+        src = h.get("_source", {})
+        doc_path: str = src.get("doc_path", "")
+        if not doc_path:
+            continue
+        comment_id: str = src.get("comment_id", "") or h["_id"]
+        thread_root_id: str = src.get("thread_root_id", "")
+        hl: dict[str, list[str]] = h.get("highlight") or {}
+        snippet_parts: list[str] = hl.get("body") or []
+        rows.append(
+            (
+                comment_id,
+                doc_path,
+                thread_root_id,
+                snippet_parts[0] if snippet_parts else "",
+                float(h.get("_score", 0.0)),
+            )
+        )
+
+    if apply_visibility and not is_admin and rows:
+        from app.wiki import acl
+
+        visible = set(acl.filter_paths_in_python(user_id, is_admin, {r[1] for r in rows}))
+        rows = [r for r in rows if r[1] in visible]
+
+    return [
+        CommentSearchHit(
+            comment_id=cid, doc_path=dp, thread_root_id=trid, snippet=snip, score=score
+        )
+        for cid, dp, trid, snip, score in rows[:limit]
+    ]

--- a/backend/app/db/comment_fts.py
+++ b/backend/app/db/comment_fts.py
@@ -19,6 +19,8 @@ in Python by `doc_path` (comments inherit the page's read access).
 from __future__ import annotations
 
 import logging
+import re
+import threading
 
 from opensearchpy import OpenSearch  # type: ignore[import-untyped]
 from opensearchpy.exceptions import NotFoundError  # type: ignore[import-untyped]
@@ -30,8 +32,14 @@ log = logging.getLogger(__name__)
 
 # Tracks which index name we've ensured a mapping for. When CONFIG changes
 # (e.g. a new per-test index name), this differs from the current name and we
-# re-ensure — so no explicit reset hook is needed between tests.
+# re-ensure — so no explicit reset hook is needed between tests. Guarded by
+# ``_ensure_lock`` so concurrent cold-start requests don't race on create.
+_ensure_lock = threading.Lock()
 _ensured_index: str | None = None
+
+# OpenSearch highlight wraps matched terms in <em>…</em>; strip them so the
+# snippet is plain text (the surrounding fragment is otherwise unescaped source).
+_EM_TAG_RE = re.compile(r"</?em>")
 
 
 class CommentDoc(BaseModel):
@@ -48,7 +56,7 @@ class CommentSearchHit(BaseModel):
     comment_id: str
     doc_path: str
     thread_root_id: str
-    snippet: str
+    snippet: str  # plain text (highlight <em> tags stripped); render as text
     score: float
 
 
@@ -86,7 +94,11 @@ def _client() -> object | None:
     if client is None:
         return None
     idx = _index_name()
-    if _ensured_index != idx:
+    if _ensured_index == idx:
+        return client
+    with _ensure_lock:
+        if _ensured_index == idx:  # another thread ensured it while we waited
+            return client
         try:
             c: OpenSearch = client  # type: ignore[assignment]
             if not c.indices.exists(index=idx):
@@ -268,12 +280,13 @@ def search(
         thread_root_id: str = src.get("thread_root_id", "")
         hl: dict[str, list[str]] = h.get("highlight") or {}
         snippet_parts: list[str] = hl.get("body") or []
+        snippet = _EM_TAG_RE.sub("", snippet_parts[0]) if snippet_parts else ""
         rows.append(
             (
                 comment_id,
                 doc_path,
                 thread_root_id,
-                snippet_parts[0] if snippet_parts else "",
+                snippet,
                 float(h.get("_score", 0.0)),
             )
         )

--- a/backend/app/db/comment_fts.py
+++ b/backend/app/db/comment_fts.py
@@ -26,7 +26,9 @@ from opensearchpy import OpenSearch  # type: ignore[import-untyped]
 from opensearchpy.exceptions import NotFoundError  # type: ignore[import-untyped]
 from pydantic import BaseModel
 
+import app.config as _app_config
 from app.db import fts
+from app.wiki import acl
 
 log = logging.getLogger(__name__)
 
@@ -81,9 +83,9 @@ _MAPPING = {
 
 
 def _index_name() -> str:
-    from app.config import CONFIG
-
-    return f"{CONFIG.opensearch_index}-comments"
+    # Read the attribute at call time (not a top-level `from … import CONFIG`)
+    # so tests that monkeypatch `app.config.CONFIG` are honored.
+    return f"{_app_config.CONFIG.opensearch_index}-comments"
 
 
 def _client() -> object | None:
@@ -292,8 +294,6 @@ def search(
         )
 
     if apply_visibility and not is_admin and rows:
-        from app.wiki import acl
-
         visible = set(acl.filter_paths_in_python(user_id, is_admin, {r[1] for r in rows}))
         rows = [r for r in rows if r[1] in visible]
 

--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -94,6 +94,12 @@ def _get_client() -> object | None:
         _client_ready = True
     return _client
 
+def get_client() -> object | None:
+    """Public accessor for the shared OpenSearch client (used by sibling
+    index modules like ``comment_fts`` so they share one connection)."""
+    return _get_client()
+
+
 def reset_client_for_tests() -> None:
     """Drop the cached client.  Call between tests that change CONFIG."""
     global _client, _client_ready

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -55,7 +55,14 @@ from app.metrics import setup_prometheus
 from app.mcp_server import pubsub as mcp_pubsub
 from app.llm.errors import LLMError
 from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestError
+from app.db.session import init_db
+from app.tasks.agent_activity import schedule_all_pending_cleanups
 from app.tasks.queues import QueueFullError
+from app.triggers import repo as triggers_repo
+from app.utils.logging import setup_logging
+from app.wiki.git import ensure_wiki_repo
+from app.wiki.seed import seed_if_empty
+from app.wiki.templates import seed_starter_templates_if_empty
 
 log = logging.getLogger(__name__)
 
@@ -138,14 +145,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     without entering the context manager, so the lifespan body is
     skipped — fixtures (``tmp_db`` / ``tmp_repo``) own DB/wiki init.
     """
-    from app.db.session import init_db
-    from app.tasks.agent_activity import schedule_all_pending_cleanups
-    from app.triggers import repo as triggers_repo
-    from app.utils.logging import setup_logging
-    from app.wiki.git import ensure_wiki_repo
-    from app.wiki.seed import seed_if_empty
-    from app.wiki.templates import seed_starter_templates_if_empty
-
     setup_logging()
     log.info(
         "agent-wiki backend starting (database=%s)", _app_config.CONFIG.database_url.split("@")[-1]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -157,6 +157,14 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # Starter document templates seed once on a brand-new DB; users
     # who delete a starter will not see it re-appear after a reboot.
     seed_starter_templates_if_empty()
+    # One-time backfill: index existing comments when the comment search index
+    # is empty (first boot after the feature ships, or after an index reset).
+    # The index persists across reboots, so steady-state boots skip this.
+    from app.db import comment_fts
+    from app.wiki import comments as _comments_repo
+
+    if comment_fts.count() == 0:
+        _comments_repo.reindex_all_inline()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_repo.rebuild_from_filesystem()
     schedule_all_pending_cleanups()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,8 @@ from app.api import (
 from app.auth import PermissionDenied
 from app.auth.deps import CurrentUserMiddleware
 import app.config as _app_config
+from app.db import comment_fts
+from app.wiki import comments as _comments_repo
 from app.metrics import setup_prometheus
 from app.mcp_server import pubsub as mcp_pubsub
 from app.llm.errors import LLMError
@@ -160,9 +162,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # One-time backfill: index existing comments when the comment search index
     # is empty (first boot after the feature ships, or after an index reset).
     # The index persists across reboots, so steady-state boots skip this.
-    from app.db import comment_fts
-    from app.wiki import comments as _comments_repo
-
     if comment_fts.count() == 0:
         _comments_repo.reindex_all_inline()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")

--- a/backend/app/wiki/comment_mentions.py
+++ b/backend/app/wiki/comment_mentions.py
@@ -1,0 +1,31 @@
+"""@mention tokens inside a comment body (server-side mirror of the frontend's
+``lib/commentMentions.ts``).
+
+Mentions are stored inline in the comment ``body`` as a canonical token:
+
+    @[Display Name](mention:<user_id>)
+
+The frontend (de)tokenizes at the compose/edit boundary; the backend stores the
+body verbatim. For search indexing we need the body in human-readable form (so
+``@[Bo Yang](mention:cmt_x)`` is searched as "Bo Yang") plus the set of
+mentioned user ids (for a future "mentions of me" filter).
+"""
+from __future__ import annotations
+
+import re
+
+_TOKEN_RE = re.compile(r"@\[([^\]]+)\]\(mention:([^)]+)\)")
+
+
+def detokenize(body: str) -> str:
+    """Replace each mention token with its display form ``@Name`` so the text
+    indexes/searches naturally."""
+    return _TOKEN_RE.sub(lambda m: f"@{m.group(1)}", body)
+
+
+def mentioned_ids(body: str) -> list[str]:
+    """The distinct user ids mentioned in ``body`` (order-preserving)."""
+    seen: dict[str, None] = {}
+    for m in _TOKEN_RE.finditer(body):
+        seen.setdefault(m.group(2), None)
+    return list(seen)

--- a/backend/app/wiki/comments.py
+++ b/backend/app/wiki/comments.py
@@ -22,11 +22,49 @@ from typing import Any
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
+from app.db import comment_fts
 from app.db.models import Comment, User
 from app.db.session import execute_dml, session
 from app.models.comment import CommentAuthorKind, CommentScope, CommentStatus
+from app.wiki import comment_mentions
 
 log = logging.getLogger(__name__)
+
+
+def _index_thread(thread_root_id: str) -> None:
+    """Sync a thread to the comment search index after a change. Re-indexes
+    every comment in the thread with the thread's status (taken from the root),
+    or removes the thread from the index if its root is gone or orphaned.
+    Best-effort: never raises, so an index glitch can't fail a mutation."""
+    try:
+        with session() as s:
+            root = s.get(Comment, thread_root_id)
+            if root is None or root.status == CommentStatus.ORPHANED.value:
+                comment_fts.delete_thread(thread_root_id)
+                return
+            rows = s.scalars(
+                select(Comment).where(Comment.thread_root_id == thread_root_id)
+            ).all()
+            if not rows:
+                comment_fts.delete_thread(thread_root_id)
+                return
+            status = root.status
+            docs = [
+                comment_fts.CommentDoc(
+                    comment_id=c.id,
+                    doc_path=c.doc_path,
+                    thread_root_id=c.thread_root_id,
+                    body=comment_mentions.detokenize(c.body),
+                    author_user_id=c.author_user_id,
+                    mentioned_user_ids=comment_mentions.mentioned_ids(c.body),
+                    status=status,
+                )
+                for c in rows
+            ]
+        for doc in docs:
+            comment_fts.index_comment(doc)
+    except Exception:
+        log.warning("comment index: _index_thread failed for %s", thread_root_id, exc_info=True)
 
 # Derived from the enums in app/models/comment.py so they stay the single
 # source of truth (the DB CHECK constraints mirror the same values).
@@ -137,6 +175,7 @@ def create_thread(
         s.add(c)
         s.flush()
         result = _to_dict(c, _author_displays(s, [c]))
+    _index_thread(cid)
     log.info("comment thread created id=%s doc=%s", cid, doc_path)
     return result
 
@@ -179,7 +218,10 @@ def add_reply(
         )
         s.add(c)
         s.flush()
-        return _to_dict(c, _author_displays(s, [c]))
+        result = _to_dict(c, _author_displays(s, [c]))
+        thread_root_id = parent.thread_root_id
+    _index_thread(thread_root_id)
+    return result
 
 
 # --------------------------------------------------------------------------- #
@@ -231,7 +273,10 @@ def edit_body(comment_id: str, body: str) -> dict[str, Any] | None:
         c.body = body
         c.updated_at = _now_text(s)
         s.flush()
-        return _to_dict(c, _author_displays(s, [c]))
+        result = _to_dict(c, _author_displays(s, [c]))
+        thread_root_id = c.thread_root_id
+    _index_thread(thread_root_id)
+    return result
 
 
 def set_thread_status(
@@ -259,7 +304,9 @@ def set_thread_status(
             root.resolved_by_user_id = None
             root.resolved_at = None
         s.flush()
-        return _to_dict(root, _author_displays(s, [root]))
+        result = _to_dict(root, _author_displays(s, [root]))
+    _index_thread(thread_root_id)
+    return result
 
 
 def delete(comment_id: str) -> bool:
@@ -275,7 +322,9 @@ def delete(comment_id: str) -> bool:
         c = s.get(Comment, comment_id)
         if c is None:
             return False
-        if c.parent_id is not None:
+        is_root = c.parent_id is None
+        thread_root_id = c.thread_root_id
+        if not is_root:
             # Promote this comment's children to its parent, then delete only
             # this node (nothing references it anymore, so the cascade is a
             # no-op beyond the single row).
@@ -286,7 +335,12 @@ def delete(comment_id: str) -> bool:
                 .execution_options(synchronize_session=False)
             )
         s.delete(c)
-        return True
+    if is_root:
+        # Root delete cascades the whole thread → drop all its index docs.
+        comment_fts.delete_thread(thread_root_id)
+    else:
+        comment_fts.delete_comment(comment_id)
+    return True
 
 
 # --------------------------------------------------------------------------- #
@@ -351,29 +405,52 @@ def orphan(comment_id: str) -> None:
         if c is None:
             return
         c.status = CommentStatus.ORPHANED.value
+        thread_root_id = c.thread_root_id
+    # Orphaned threads drop out of search (their span is gone).
+    _index_thread(thread_root_id)
 
 
 def reassign_doc_path(old_path: str, new_path: str) -> int:
     """Re-key all comments from ``old_path`` to ``new_path`` (page move/rename).
     Returns the number of rows moved."""
     with session() as s:
-        return execute_dml(
+        moved = execute_dml(
             s,
             update(Comment)
             .where(Comment.doc_path == old_path)
             .values(doc_path=new_path)
             .execution_options(synchronize_session=False),
         )
+    comment_fts.reassign_doc_path(old_path, new_path)
+    return moved
 
 
 def orphan_all_for_doc(doc_path: str) -> int:
     """Orphan every still-anchored comment on a page (page deleted). Returns
     the number of rows orphaned."""
     with session() as s:
-        return execute_dml(
+        orphaned = execute_dml(
             s,
             update(Comment)
             .where(Comment.doc_path == doc_path, Comment.status != CommentStatus.ORPHANED.value)
             .values(status=CommentStatus.ORPHANED.value)
             .execution_options(synchronize_session=False),
         )
+    # Page deleted → its comments become tombstones in Postgres but leave search.
+    comment_fts.delete_for_doc(doc_path)
+    return orphaned
+
+
+def reindex_all_inline() -> None:
+    """Index every comment thread into the search index. Called at startup so
+    comments created before the feature (or while the index was down) become
+    searchable. Idempotent — re-indexing a thread is an upsert."""
+    with session() as s:
+        root_ids = s.scalars(
+            select(Comment.id).where(Comment.parent_id.is_(None))
+        ).all()
+    if not root_ids:
+        return
+    log.info("comment index: backfilling %d thread(s) at startup", len(root_ids))
+    for rid in root_ids:
+        _index_thread(rid)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -151,6 +151,9 @@ def tmp_config(tmp_path, monkeypatch):
 
     if _opensearch_up:
         _fts.drop_index_for_tests()  # delete the per-test index
+        from app.db import comment_fts as _comment_fts
+
+        _comment_fts.drop_index_for_tests()  # and the per-test comment index
     _fts.reset_client_for_tests()
     with psycopg.connect(_BASE_URL, autocommit=True) as conn:
         conn.execute(sql.SQL("DROP SCHEMA {} CASCADE").format(sql.Identifier(schema)))

--- a/backend/tests/test_comment_search.py
+++ b/backend/tests/test_comment_search.py
@@ -1,0 +1,114 @@
+"""Comment full-text search — the `wiki-comments` index and its lifecycle.
+
+The pure token helpers run anywhere; the index/search tests need OpenSearch and
+are skipped when it isn't reachable (``needs_opensearch``). Comment mutations
+index inline, so we assert against ``comment_fts.search`` right after writing.
+"""
+from __future__ import annotations
+
+from app.db import comment_fts
+from app.wiki import comment_mentions, comments
+from tests._seed import seed_user
+from tests.conftest import needs_opensearch
+
+_DOC = "guides/db.md"
+
+
+def _root(author: str, body: str, *, doc: str = _DOC) -> dict:
+    return comments.create_thread(
+        doc_path=doc,
+        body=body,
+        author_user_id=author,
+        anchor_sha="sha1",
+        start_offset=0,
+        end_offset=5,
+        quoted_text="pool ",
+    )
+
+
+# --- pure helpers (no OpenSearch) ----------------------------------------- #
+
+
+def test_detokenize_renders_mentions_as_names():
+    body = "hey @[Bo Yang](mention:cmt_abc) check @[Admin](mention:cmt_def)"
+    assert comment_mentions.detokenize(body) == "hey @Bo Yang check @Admin"
+
+
+def test_mentioned_ids_are_distinct_and_ordered():
+    body = "@[Bo](mention:u1) and @[Al](mention:u2) and @[Bo again](mention:u1)"
+    assert comment_mentions.mentioned_ids(body) == ["u1", "u2"]
+
+
+def test_detokenize_noop_without_mentions():
+    assert comment_mentions.detokenize("plain text, no mentions") == (
+        "plain text, no mentions"
+    )
+
+
+# --- index + search lifecycle (OpenSearch) -------------------------------- #
+
+
+@needs_opensearch
+def test_new_comment_is_searchable(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    _root(alice, "check the connection pool size in the config")
+
+    hits = comment_fts.search("connection pool", user_id=alice, is_admin=True)
+    assert len(hits) == 1
+    assert hits[0].doc_path == _DOC
+    # Non-matching query returns nothing.
+    assert comment_fts.search("kubernetes ingress", user_id=alice, is_admin=True) == []
+
+
+@needs_opensearch
+def test_reply_is_searchable_and_deep_links_to_thread(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _root(alice, "root about caching")
+    comments.add_reply(parent_id=root["id"], body="use a redis sidecar", author_user_id=alice)
+
+    hits = comment_fts.search("redis sidecar", user_id=alice, is_admin=True)
+    assert len(hits) == 1
+    # Replies point back at the thread root so the UI can deep-link.
+    assert hits[0].thread_root_id == root["id"]
+
+
+@needs_opensearch
+def test_resolved_searchable_orphaned_not(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _root(alice, "throttle the webhook retries")
+
+    comments.set_thread_status(root["id"], "resolved", resolved_by_user_id=alice)
+    assert len(comment_fts.search("throttle webhook", user_id=alice, is_admin=True)) == 1
+
+    comments.orphan(root["id"])
+    assert comment_fts.search("throttle webhook", user_id=alice, is_admin=True) == []
+
+
+@needs_opensearch
+def test_edit_updates_the_index(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _root(alice, "original wording about quotas")
+
+    comments.edit_body(root["id"], "rewritten to mention rate limiting")
+    assert comment_fts.search("rate limiting", user_id=alice, is_admin=True)
+    assert comment_fts.search("quotas", user_id=alice, is_admin=True) == []
+
+
+@needs_opensearch
+def test_delete_removes_from_index(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    root = _root(alice, "delete me about migrations")
+
+    assert comment_fts.search("migrations", user_id=alice, is_admin=True)
+    comments.delete(root["id"])
+    assert comment_fts.search("migrations", user_id=alice, is_admin=True) == []
+
+
+@needs_opensearch
+def test_mention_is_searchable_by_name(tmp_db):
+    alice = seed_user(uid="u_alice", email="alice@x.com")
+    _root(alice, "ping @[Bo Yang](mention:cmt_bo) about the schema")
+
+    # The token is detokenized before indexing, so the display name matches.
+    hits = comment_fts.search("Bo Yang", user_id=alice, is_admin=True)
+    assert len(hits) == 1


### PR DESCRIPTION
## What

**Write side** of searchable comments (Option A from the [one-pager](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/comments/searchable-comments.md)): comment bodies are indexed into a dedicated **`wiki-comments`** OpenSearch index (one doc per comment) and kept in sync as comments change. **Retrieval — the search endpoint + frontend — is a deliberate follow-up PR.** Indexing first lets the index populate and the lifecycle hooks prove out in prod before any search surface is exposed.

## Why a separate index (isolation from ingestion)

The document-push pipeline runs BM25 candidate retrieval over `wiki-docs` (`fts.search`, field-scoped to `title`/`body`) to pick which page to update. Comment indexing must not perturb that or the `INGEST_BM25_MIN_SCORE` calibration. A separate index guarantees it: OpenSearch BM25 stats are **per-index**, and nothing here writes to `wiki-docs`. (We rejected folding comment docs into `wiki-docs` — it would shift IDF and drift ingest scores.)

## How

- **`app/db/comment_fts.py`** — index/delete over `wiki-comments`, sharing the existing OpenSearch client via new `fts.get_client()`. Index name derived from the doc index (`<opensearch_index>-comments`) so the conftest's per-test isolation extends for free. Also holds `search()` — the read primitive the tests assert through (no HTTP caller yet; that's the follow-up).
- **`app/wiki/comment_mentions.py`** — server-side mirror of the mention tokens: `@[Name](mention:id)` → `@Name` for indexing, plus mentioned user-ids (for a future "mentions of me" filter).
- **`app/wiki/comments.py`** — `_index_thread` keeps the index in sync on create / reply / edit / resolve / reopen / delete / orphan / move / page-delete. Thread status comes from the root (open+resolved indexed; orphaned dropped). Resilient: an index hiccup never fails a comment write. `reindex_all_inline()` backfill.
- **`app/main.py`** — one-time backfill when the comment index is empty (steady-state boots skip it; the index persists).

## Tests
`tests/test_comment_search.py`: pure token helpers + `@needs_opensearch` lifecycle tests (new comment indexed, reply ties to thread, resolved kept / orphaned dropped, edit updates, delete removes, mention indexed by name) — all asserted via `comment_fts.search()`. conftest drops the per-test comment index on teardown.

`ruff` + `basedpyright` (strict) clean. OpenSearch/DB-backed tests run in CI.

## Follow-up PR (retrieval)
`GET /comments/search` endpoint + a "Comments" results section in the search UI, deep-linking to threads via `/app/wiki/<path>?comment=<id>`.