### PR TITLE
feat(auth): AuthCard submit slot, Formik outside card, validateOnMount

### DIFF
--- a/frontend/src/views/auth/LoginPage.tsx
+++ b/frontend/src/views/auth/LoginPage.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Formik, Form } from "formik";
 import { Button, Text } from "@onyx-ai/opal/components";
+import { SvgSimpleLoader } from "@onyx-ai/opal/icons";
 import { useAuth } from "@/lib/auth";
 import {
   AuthCard,
@@ -53,57 +54,64 @@ function LoginForm() {
 
   return (
     <AuthLayout>
-      <AuthCard>
-        {oidcErrorMessage && (
-          <div className="mb-4">
-            <AuthErrorBanner message={oidcErrorMessage} />
-          </div>
-        )}
-        {isOidc ? (
-          // Full-page navigation is required for the OIDC handshake, so
-          // this uses a native <a> styled to look like the primary action button.
-          <a
-            href="/api/auth/oidc/login"
-            className="box-border block w-full rounded-(--border-radius-08) border border-(--background-tint-inverted-00) bg-(--background-tint-inverted-00) px-3.5 py-2 text-center text-[13px] leading-[1.2] font-semibold text-(--text-inverted-05) no-underline"
-          >
-            Sign in with Google
-          </a>
-        ) : (
-          <Formik<LoginValues>
-            initialValues={INITIAL_VALUES}
-            validationSchema={LOGIN_VALIDATION_SCHEMA}
-            onSubmit={async (values, { setStatus }) => {
-              setStatus(null);
-              try {
-                await login(values.email, values.password);
-                router.replace(next ?? "/");
-              } catch (err) {
-                setStatus({
-                  error: err instanceof Error ? err.message : "login failed",
-                });
-              }
-            }}
-          >
-            {({ isSubmitting, status }) => (
-              <Form className="flex flex-col gap-2">
+      {isOidc ? (
+        <AuthCard
+          submit={
+            // Full-page navigation is required for the OIDC handshake, so
+            // this uses a native <a> styled to look like the primary action button.
+            <a
+              href="/api/auth/oidc/login"
+              className="box-border block w-full rounded-(--border-radius-08) border border-(--background-tint-inverted-00) bg-(--background-tint-inverted-00) px-3.5 py-2 text-center text-[13px] leading-[1.2] font-semibold text-(--text-inverted-05) no-underline"
+            >
+              Sign in with Google
+            </a>
+          }
+        >
+          {oidcErrorMessage && <AuthErrorBanner message={oidcErrorMessage} />}
+        </AuthCard>
+      ) : (
+        <Formik<LoginValues>
+          initialValues={INITIAL_VALUES}
+          validationSchema={LOGIN_VALIDATION_SCHEMA}
+          validateOnMount
+          onSubmit={async (values, { setStatus }) => {
+            setStatus(null);
+            try {
+              await login(values.email, values.password);
+              router.replace(next ?? "/");
+            } catch (err) {
+              setStatus({
+                error: err instanceof Error ? err.message : "login failed",
+              });
+            }
+          }}
+        >
+          {({ isSubmitting, status, isValid }) => (
+            <Form>
+              <AuthCard
+                submit={
+                  <Button
+                    type="submit"
+                    width="full"
+                    disabled={isSubmitting || !isValid}
+                    icon={isSubmitting ? SvgSimpleLoader : undefined}
+                  >
+                    Sign in
+                  </Button>
+                }
+              >
+                {oidcErrorMessage && (
+                  <AuthErrorBanner message={oidcErrorMessage} />
+                )}
                 <AuthEmailField autoFocus />
                 <AuthPasswordField />
                 {status?.error && <AuthErrorBanner message={status.error} />}
-                <div className="mt-1">
-                  <Button
-                    type="submit"
-                    variant="action"
-                    width="full"
-                    disabled={isSubmitting}
-                  >
-                    {isSubmitting ? "Signing in…" : "Sign in"}
-                  </Button>
-                </div>
-              </Form>
-            )}
-          </Formik>
-        )}
-      </AuthCard>
+              </AuthCard>
+            </Form>
+          )}
+        </Formik>
+      )}
+
       {!isOidc && (
         <div className="flex w-full items-baseline justify-center">
           {config?.signup_open === false ? (

--- a/frontend/src/views/auth/SignupPage.tsx
+++ b/frontend/src/views/auth/SignupPage.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Formik, Form } from "formik";
 import { Button, Text } from "@onyx-ai/opal/components";
 import { InputVertical } from "@onyx-ai/opal/layouts";
+import { SvgSimpleLoader } from "@onyx-ai/opal/icons";
 import { useAuth } from "@/lib/auth";
 import InputTypeInField from "@/components/form/InputTypeInField";
 import {
@@ -50,48 +51,50 @@ function SignupForm() {
 
   return (
     <AuthLayout>
-      <AuthCard>
-        <Formik<SignupValues>
-          initialValues={INITIAL_VALUES}
-          validationSchema={SIGNUP_VALIDATION_SCHEMA}
-          onSubmit={async (values, { setStatus }) => {
-            setStatus(null);
-            try {
-              await signup(
-                values.email,
-                values.password,
-                values.name || undefined,
-              );
-              router.replace(next ?? "/");
-            } catch (err) {
-              setStatus({
-                error: err instanceof Error ? err.message : "signup failed",
-              });
-            }
-          }}
-        >
-          {({ isSubmitting, status }) => (
-            <Form className="flex flex-col gap-2">
+      <Formik<SignupValues>
+        initialValues={INITIAL_VALUES}
+        validationSchema={SIGNUP_VALIDATION_SCHEMA}
+        validateOnMount
+        onSubmit={async (values, { setStatus }) => {
+          setStatus(null);
+          try {
+            await signup(
+              values.email,
+              values.password,
+              values.name || undefined,
+            );
+            router.replace(next ?? "/");
+          } catch (err) {
+            setStatus({
+              error: err instanceof Error ? err.message : "signup failed",
+            });
+          }
+        }}
+      >
+        {({ isSubmitting, status, isValid }) => (
+          <Form>
+            <AuthCard
+              submit={
+                <Button
+                  type="submit"
+                  width="full"
+                  disabled={isSubmitting || !isValid}
+                  icon={isSubmitting ? SvgSimpleLoader : undefined}
+                >
+                  Create account
+                </Button>
+              }
+            >
               <AuthEmailField autoFocus />
               <InputVertical title="Name" suffix="optional" withLabel>
                 <InputTypeInField name="name" type="text" />
               </InputVertical>
               <AuthPasswordField lengthHint />
               {status?.error && <AuthErrorBanner message={status.error} />}
-              <div className="mt-1">
-                <Button
-                  type="submit"
-                  variant="action"
-                  width="full"
-                  disabled={isSubmitting}
-                >
-                  {isSubmitting ? "Creating…" : "Create account"}
-                </Button>
-              </div>
-            </Form>
-          )}
-        </Formik>
-      </AuthCard>
+            </AuthCard>
+          </Form>
+        )}
+      </Formik>
       <div className="flex w-full items-baseline justify-center">
         <Text font="secondary-body" color="text-03">
           Already have an account?

--- a/frontend/src/views/auth/shared.tsx
+++ b/frontend/src/views/auth/shared.tsx
@@ -70,8 +70,12 @@ export function AuthCard({ children, submit }: AuthCardProps) {
         title="Welcome to Agent Wiki"
         description="Your open source AI agent collaboration platform"
       />
-      <Spacer rem={1} />
-      <div className="flex flex-col gap-2">{children}</div>
+      {children != null && (
+        <>
+          <Spacer rem={1} />
+          <div className="flex flex-col gap-2">{children}</div>
+        </>
+      )}
       <Spacer rem={1} />
       {submit}
     </Card>

--- a/frontend/src/views/auth/shared.tsx
+++ b/frontend/src/views/auth/shared.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, type ReactNode } from "react";
 import * as Yup from "yup";
-import { Card } from "@onyx-ai/opal/components";
+import { Card, Spacer } from "@onyx-ai/opal/components";
 import { Content, InputVertical } from "@onyx-ai/opal/layouts";
 import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 import { SvgSimpleLoader } from "@onyx-ai/opal/icons";
@@ -59,19 +59,21 @@ export function AuthLayout({ children }: AuthLayoutProps) {
 
 export interface AuthCardProps {
   children: ReactNode;
+  submit: ReactNode;
 }
 
-export function AuthCard({ children }: AuthCardProps) {
+export function AuthCard({ children, submit }: AuthCardProps) {
   return (
     <Card padding="lg" border="solid" rounding="lg">
-      <div className="mb-6">
-        <Content
-          icon={SvgOnyxLogo}
-          title="Welcome to Agent Wiki"
-          description="Your open source AI agent collaboration platform"
-        />
-      </div>
-      {children}
+      <Content
+        icon={SvgOnyxLogo}
+        title="Welcome to Agent Wiki"
+        description="Your open source AI agent collaboration platform"
+      />
+      <Spacer rem={1} />
+      <div className="flex flex-col gap-2">{children}</div>
+      <Spacer rem={1} />
+      {submit}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary

- `AuthCard` now accepts a required `submit` slot — the button renders below the fields with consistent spacing via `Spacer`
- `<Formik>` moved outside `<AuthCard>` on both pages; `<Form>` wraps the card so the entire card is the form element
- `validateOnMount` added to both forms so the submit button is disabled on initial render (empty required fields)
- Submit buttons: `isValid` guard, `SvgSimpleLoader` icon while submitting, removed `variant="action"` and dynamic loading text