### PR TITLE
feat(comments): comment search retrieval (endpoint + search-UI section)

### DIFF
--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -15,14 +15,17 @@ import logging
 from collections import defaultdict
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.auth import User, require_can
 from app.auth.deps import require_user
+from app.db import comment_fts
 from app.db.models import Event
 from app.db.session import session
 from app.models.comment import (
     CommentListResponse,
+    CommentSearchHit,
+    CommentSearchResponse,
     CommentStatus,
     CommentThreadView,
     CommentView,
@@ -131,6 +134,37 @@ def list_comments(
     except Exception:
         log.exception("comment remap backstop failed for %s", rel_path)
     return CommentListResponse(threads=_group_threads(comments_repo.list_for_doc(rel_path)))
+
+
+@router.get("/search", response_model=CommentSearchResponse)
+def search_comments(
+    user: User = Depends(require_user),
+    q: str = "",
+    limit: int = Query(10, ge=1, le=50),
+) -> CommentSearchResponse:
+    """Full-text search across comment bodies. Cross-page; results are filtered
+    to pages the caller can read (comments inherit page read access). A hit
+    carries ``doc_path`` + ``thread_root_id`` so the UI can deep-link to the
+    thread via ``/app/wiki/<path>?comment=<id>``."""
+    query = q.strip()
+    if not query:
+        return CommentSearchResponse(query="", hits=[])
+    hits = comment_fts.search(
+        query, limit=limit, user_id=user.id, is_admin=user.is_admin
+    )
+    return CommentSearchResponse(
+        query=query,
+        hits=[
+            CommentSearchHit(
+                comment_id=h.comment_id,
+                doc_path=h.doc_path,
+                thread_root_id=h.thread_root_id,
+                snippet=h.snippet,
+                score=h.score,
+            )
+            for h in hits
+        ],
+    )
 
 
 @router.post("", response_model=CommentView, status_code=status.HTTP_201_CREATED)

--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -101,3 +101,20 @@ class CommentThreadView(BaseModel):
 
 class CommentListResponse(BaseModel):
     threads: list[CommentThreadView]
+
+
+class CommentSearchHit(BaseModel):
+    """A comment matched by full-text search. ``doc_path`` + ``thread_root_id``
+    let the UI deep-link to the thread via ``/app/wiki/<path>?comment=<id>``.
+    ``snippet`` is plain text (highlight tags stripped) — render as text."""
+
+    comment_id: str
+    doc_path: str
+    thread_root_id: str
+    snippet: str
+    score: float
+
+
+class CommentSearchResponse(BaseModel):
+    query: str
+    hits: list[CommentSearchHit]

--- a/backend/tests/test_comments_api.py
+++ b/backend/tests/test_comments_api.py
@@ -14,6 +14,7 @@ from app.main import create_app
 from app.wiki import git as wiki_git
 from tests._auth import login_fastapi
 from tests._seed import list_events, seed_user
+from tests.conftest import needs_opensearch
 
 _PATH = "guides/setup.md"
 _BODY = "Intro line here.\nThe target sentence to comment on.\nClosing line.\n"
@@ -45,6 +46,32 @@ def _create(client: TestClient, sha: str, phrase: str = "target sentence", *, pa
 
 def test_unauthenticated_is_401(client):
     assert client.get(f"/api/comments?path={_PATH}").status_code == 401
+
+
+def test_search_empty_query_returns_empty(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    r = client.get("/api/comments/search?q=")
+    assert r.status_code == 200
+    assert r.json() == {"query": "", "hits": []}
+
+
+@needs_opensearch
+def test_search_returns_indexed_comment(client):
+    uid = seed_user(email="a@x.com")
+    login_fastapi(client, uid)
+    sha = _commit_page()
+    _create(client, sha)  # body: "is this still accurate?"
+
+    r = client.get("/api/comments/search?q=accurate")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["query"] == "accurate"
+    assert len(data["hits"]) == 1
+    hit = data["hits"][0]
+    assert hit["doc_path"] == _PATH
+    assert hit["thread_root_id"]  # present so the UI can deep-link to the thread
+    assert "<em>" not in hit["snippet"]  # highlight tags stripped → plain text
 
 
 def test_create_then_list_as_thread(client):

--- a/frontend/src/components/wiki/WikiSearch.tsx
+++ b/frontend/src/components/wiki/WikiSearch.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { InputTypeIn } from "@onyx-ai/opal/components";
-import { SvgFolder } from "@onyx-ai/opal/icons";
+import { SvgBubbleText, SvgFolder } from "@onyx-ai/opal/icons";
 import { useRouter } from "next/navigation";
 import {
   forwardRef,
@@ -37,18 +37,35 @@ interface FolderHit {
   path: string;
 }
 
+interface CommentHit {
+  comment_id: string;
+  doc_path: string;
+  thread_root_id: string;
+  snippet: string;
+  score: number;
+}
+
 interface SearchResponse {
   query: string;
   hits: SearchHit[];
   folders?: FolderHit[];
 }
 
+interface CommentSearchResponse {
+  query: string;
+  hits: CommentHit[];
+}
+
 type Row =
   | { kind: "folder"; folder: FolderHit }
-  | { kind: "doc"; hit: SearchHit };
+  | { kind: "doc"; hit: SearchHit }
+  | { kind: "comment"; hit: CommentHit };
 
 const DEBOUNCE_MS = 150;
 const RESULT_LIMIT = 10;
+// Comments are secondary to docs in the dropdown — cap them lower so the
+// combined list stays scannable.
+const COMMENT_RESULT_LIMIT = 5;
 
 interface WikiSearchProps {
   // Called after a result is picked — the sidebar uses this to collapse
@@ -62,6 +79,7 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
     const [query, setQuery] = useState("");
     const [hits, setHits] = useState<SearchHit[]>([]);
     const [folders, setFolders] = useState<FolderHit[]>([]);
+    const [comments, setComments] = useState<CommentHit[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [open, setOpen] = useState(false);
@@ -92,6 +110,7 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
       if (!trimmed) {
         setHits([]);
         setFolders([]);
+        setComments([]);
         setLoading(false);
         setError(null);
         return;
@@ -118,6 +137,18 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
           .finally(() => {
             if (seq === requestSeq.current) setLoading(false);
           });
+        // Comment search runs alongside docs and is best-effort chrome — a
+        // failure (e.g. search backend down) silently yields no comment rows
+        // rather than surfacing an error over the doc results.
+        apiFetch<CommentSearchResponse>(
+          `/comments/search?q=${encodeURIComponent(trimmed)}&limit=${COMMENT_RESULT_LIMIT}`,
+        )
+          .then((r) => {
+            if (seq === requestSeq.current) setComments(r.hits);
+          })
+          .catch(() => {
+            if (seq === requestSeq.current) setComments([]);
+          });
       }, DEBOUNCE_MS);
       return () => clearTimeout(handle);
     }, [query]);
@@ -136,21 +167,32 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
       return () => window.removeEventListener("mousedown", handleClick);
     }, [open]);
 
-    // Folders render first; both groups share one keyboard cursor.
+    // Folders first, then docs, then comments; all groups share one keyboard
+    // cursor.
     const rows = useMemo<Row[]>(
       () => [
         ...folders.map<Row>((f) => ({ kind: "folder", folder: f })),
         ...hits.map<Row>((h) => ({ kind: "doc", hit: h })),
+        ...comments.map<Row>((h) => ({ kind: "comment", hit: h })),
       ],
-      [folders, hits],
+      [folders, hits, comments],
     );
 
     const pick = useCallback(
       (row: Row) => {
         setOpen(false);
         setQuery("");
-        const path = row.kind === "folder" ? row.folder.path : row.hit.path;
-        router.push(`/app/wiki/${path}`);
+        if (row.kind === "comment") {
+          // Deep-link to the thread via its root id (the page handler matches
+          // `?comment=` against thread roots; a matched reply resolves to its
+          // root). Reuses the shipped click-to-focus/share-link route.
+          router.push(
+            `/app/wiki/${row.hit.doc_path}?comment=${row.hit.thread_root_id}`,
+          );
+        } else {
+          const path = row.kind === "folder" ? row.folder.path : row.hit.path;
+          router.push(`/app/wiki/${path}`);
+        }
         onNavigate?.();
       },
       [router, onNavigate],
@@ -262,7 +304,9 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
                     const key =
                       row.kind === "folder"
                         ? `f:${row.folder.path}`
-                        : `d:${row.hit.doc_id}`;
+                        : row.kind === "doc"
+                          ? `d:${row.hit.doc_id}`
+                          : `c:${row.hit.comment_id}`;
                     return (
                       <li key={key}>
                         <button
@@ -277,8 +321,10 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
                         >
                           {row.kind === "folder" ? (
                             <FolderRow folder={row.folder} />
-                          ) : (
+                          ) : row.kind === "doc" ? (
                             <DocRow hit={row.hit} />
+                          ) : (
+                            <CommentRow hit={row.hit} />
                           )}
                         </button>
                       </li>
@@ -333,6 +379,28 @@ function DocRow({ hit }: { hit: SearchHit }) {
         </div>
       )}
     </>
+  );
+}
+
+function CommentRow({ hit }: { hit: CommentHit }) {
+  const leaf = hit.doc_path.split("/").pop() || hit.doc_path;
+  return (
+    <div className="flex min-w-0 items-start gap-2">
+      <span className="mt-0.5 flex shrink-0 text-(--text-03)">
+        <SvgBubbleText size={16} />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="overflow-hidden text-[13px] text-ellipsis whitespace-nowrap text-(--text-04)">
+          Comment in{" "}
+          <span className="font-semibold text-(--text-05)">{leaf}</span>
+        </div>
+        {hit.snippet && (
+          <div className="mt-1 line-clamp-2 text-xs leading-[1.4] text-(--text-04)">
+            <SnippetText text={hit.snippet} />
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## What

The **retrieval** follow-up to #208 (which indexed comments). Comment matches now show up in the wiki search box and deep-link to the thread. Completes Option A from the [one-pager](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/comments/searchable-comments.md).

## Backend
- **`GET /comments/search?q=`** (`require_user`) — cross-page full-text search over comment bodies via `comment_fts.search`, results filtered to pages the caller can read (comments inherit page read access). Each hit carries `doc_path` + `thread_root_id`. Re-adds the `CommentSearchHit` / `CommentSearchResponse` DTOs (pulled from #208 when it was scoped to indexing-only).

## Frontend (`WikiSearch.tsx`)
- Fetches `/comments/search` **alongside** `/wiki/search`, best-effort: a comment-search failure silently yields no comment rows rather than blanking the doc results or surfacing an error.
- Renders a third row group — **"Comment in `<page>`"** with a bubble icon and the snippet — after folders and docs, sharing the same keyboard cursor (↑/↓/Enter).
- Picking a comment routes to `/app/wiki/<path>?comment=<thread_root_id>`, reusing the shipped click-to-focus / share-link deep-link. Uses the **thread root id** (the page handler matches `?comment=` against roots), so a matched reply resolves to its thread. Capped at 5 comment results to keep the dropdown scannable.

## Tests
`test_comments_api.py`: empty query → empty; an indexed comment is found via the endpoint, with `thread_root_id` present and a plain-text snippet (no `<em>`). `bun run typecheck` + `ruff` + `basedpyright` clean. OpenSearch/DB-backed tests run in CI.
<img width="406" height="232" alt="Screenshot 2026-06-09 at 12 36 39 PM" src="https://github.com/user-attachments/assets/2a6aa8c3-a8a3-4eb6-8c68-64079ac01b7e" />


## Depends on
#208 (merged) — `comment_fts.search()` and the `wiki-comments` index.