### PR TITLE
feat(comments): agent add_comment tool (Phase 3 — AI participates)

### DIFF
--- a/backend/app/llm/agents/skills/__init__.py
+++ b/backend/app/llm/agents/skills/__init__.py
@@ -62,6 +62,12 @@ SKILLS: dict[str, Skill] = {
         ),
         instructions=_load_md("modify_wiki"),
     ),
+    "comments": Skill(
+        name="comments",
+        description="leave inline comments (agent-authored discussion) on wiki pages",
+        tool_names=("add_comment",),
+        instructions=_load_md("comments"),
+    ),
     "web_search": Skill(
         name="web_search",
         description="search the public web and fetch page contents",

--- a/backend/app/llm/agents/skills/comments.md
+++ b/backend/app/llm/agents/skills/comments.md
@@ -12,11 +12,13 @@ How to anchor:
   first and copy from it. If a short snippet isn't unique, quote a longer span.
 
 When to use it:
-- Flag a problem ("this contradicts the runbook"), ask a question, or note
-  context for a specific passage — anything that's *feedback about* the page
-  rather than a change to it.
-- Prefer a comment over silently editing when you're unsure, when the call is a
-  human's to make, or when you want to leave a trail for review.
+- **Only when the user explicitly asks you to leave / post / add a comment.**
+  Do not comment proactively, as a side effect of another task, or on your own
+  initiative — even if you spot something worth flagging. If you think a comment
+  would help, *suggest* it in your reply and let the user decide; don't post one
+  unprompted.
+- Once the user asks, comment on the specific passage they mean (anchored to a
+  quoted snippet) and keep it concise.
 
 After commenting, you may share the returned `link` so the human can jump
 straight to the thread. Keep comments concise and specific to the quoted span.

--- a/backend/app/llm/agents/skills/comments.md
+++ b/backend/app/llm/agents/skills/comments.md
@@ -1,0 +1,22 @@
+You can leave comments on wiki pages — threaded discussion that humans see,
+**separate from page content**. A comment does not change the page; to edit
+content, load the `modify_wiki` skill instead.
+
+Tool:
+- `add_comment(path, quoted_text, body)` — leave an inline comment anchored to a
+  specific passage.
+
+How to anchor:
+- `quoted_text` must be copied **verbatim** from the current page body and must
+  appear **exactly once**. If you're unsure of the exact wording, `read_page`
+  first and copy from it. If a short snippet isn't unique, quote a longer span.
+
+When to use it:
+- Flag a problem ("this contradicts the runbook"), ask a question, or note
+  context for a specific passage — anything that's *feedback about* the page
+  rather than a change to it.
+- Prefer a comment over silently editing when you're unsure, when the call is a
+  human's to make, or when you want to leave a trail for review.
+
+After commenting, you may share the returned `link` so the human can jump
+straight to the thread. Keep comments concise and specific to the quoted span.

--- a/backend/app/llm/agents/tools/add_comment.json
+++ b/backend/app/llm/agents/tools/add_comment.json
@@ -1,0 +1,22 @@
+{
+  "name": "add_comment",
+  "description": "Leave an inline comment on a wiki page, anchored to an exact snippet you quote from the page. This is *discussion* (a thread humans will see) — it does NOT change the page; use the modify_wiki tools to edit content. Good for flagging an issue, asking a question, or noting context about a specific passage. Provide `path`, `quoted_text` (copy the exact text from the current page body to anchor to — it must appear verbatim and exactly once), and `body` (your comment). Returns the comment id and a link to the thread.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "Wiki-relative path of the page, ending in `.md`."
+      },
+      "quoted_text": {
+        "type": "string",
+        "description": "The exact snippet from the current page body to anchor the comment to. Must appear verbatim and exactly once — quote a longer span if a short one isn't unique. Read the page first if unsure of the exact text."
+      },
+      "body": {
+        "type": "string",
+        "description": "The comment text."
+      }
+    },
+    "required": ["path", "quoted_text", "body"]
+  }
+}

--- a/backend/app/llm/agents/tools/add_comment.json
+++ b/backend/app/llm/agents/tools/add_comment.json
@@ -1,6 +1,6 @@
 {
   "name": "add_comment",
-  "description": "Leave an inline comment on a wiki page, anchored to an exact snippet you quote from the page. This is *discussion* (a thread humans will see) — it does NOT change the page; use the modify_wiki tools to edit content. Good for flagging an issue, asking a question, or noting context about a specific passage. Provide `path`, `quoted_text` (copy the exact text from the current page body to anchor to — it must appear verbatim and exactly once), and `body` (your comment). Returns the comment id and a link to the thread.",
+  "description": "Leave an inline comment on a wiki page, anchored to an exact snippet you quote from the page. This is *discussion* (a thread humans will see) — it does NOT change the page; use the modify_wiki tools to edit content. ONLY call this when the user explicitly asks you to leave / post / add a comment — never proactively or as a side effect; if you think a comment would help, suggest it and let the user decide. Provide `path`, `quoted_text` (copy the exact text from the current page body to anchor to — it must appear verbatim and exactly once), and `body` (your comment). Returns the comment id and a link to the thread.",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/backend/app/llm/agents/tools/add_comment.py
+++ b/backend/app/llm/agents/tools/add_comment.py
@@ -4,8 +4,9 @@ Lets an agent leave an **inline** comment on a page (agent-authored discussion �
 it does not change page content). Agents can't pick character offsets, so the
 tool anchors by an exact `quoted_text` snippet: we read the page at HEAD, locate
 the snippet, and require it to appear *exactly once* (no guessing). The thread is
-stored with `author_kind="agent"` and no `author_user_id`, so it renders as
-"Agent" in the panel.
+attributed to the user driving the chat (`author_user_id = current_user()`) —
+the agent acts on their behalf, so it's their comment — with `author_kind="agent"`
+kept as provenance (the row records it was posted via an agent).
 
 Visibility/permission mirrors human commenting: read access to the page is
 enough to comment, resolved via `require_can("read", path)` against the calling
@@ -16,7 +17,7 @@ from __future__ import annotations
 from typing import Any
 from urllib.parse import quote
 
-from app.auth import PermissionDenied, require_can
+from app.auth import PermissionDenied, current_user, require_can
 from app.llm.agents.tools.errors import ToolError
 from app.models.comment import CommentAuthorKind
 from app.wiki import comments as comments_repo, git as wiki_git, utils as wiki_utils
@@ -67,10 +68,11 @@ def handle(args: dict[str, Any]) -> Any:
             "snippet so the comment anchors unambiguously"
         }
 
+    user = current_user()
     row = comments_repo.create_thread(
         doc_path=path,
         body=body.strip(),
-        author_user_id=None,
+        author_user_id=user.id if user else None,
         anchor_sha=head_sha,
         start_offset=idx,
         end_offset=idx + len(quoted),

--- a/backend/app/llm/agents/tools/add_comment.py
+++ b/backend/app/llm/agents/tools/add_comment.py
@@ -1,0 +1,84 @@
+"""Handler for the `add_comment` tool. Spec lives in `add_comment.json`.
+
+Lets an agent leave an **inline** comment on a page (agent-authored discussion —
+it does not change page content). Agents can't pick character offsets, so the
+tool anchors by an exact `quoted_text` snippet: we read the page at HEAD, locate
+the snippet, and require it to appear *exactly once* (no guessing). The thread is
+stored with `author_kind="agent"` and no `author_user_id`, so it renders as
+"Agent" in the panel.
+
+Visibility/permission mirrors human commenting: read access to the page is
+enough to comment, resolved via `require_can("read", path)` against the calling
+user (`current_user()`), the same principal the chat request authenticated as.
+"""
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+from app.auth import PermissionDenied, require_can
+from app.llm.agents.tools.errors import ToolError
+from app.models.comment import CommentAuthorKind
+from app.wiki import comments as comments_repo, git as wiki_git, utils as wiki_utils
+
+
+def _thread_link(doc_path: str, thread_root_id: str) -> str:
+    encoded = "/".join(quote(seg) for seg in doc_path.split("/") if seg)
+    return f"/app/wiki/{encoded}?comment={quote(thread_root_id, safe='')}"
+
+
+def handle(args: dict[str, Any]) -> Any:
+    try:
+        path = wiki_utils.validate_doc_path(args.get("path"))
+    except ToolError as exc:
+        return {"error": str(exc)}
+
+    body = args.get("body")
+    if not isinstance(body, str) or not body.strip():
+        return {"error": "body is required"}
+    quoted = args.get("quoted_text")
+    if not isinstance(quoted, str) or not quoted.strip():
+        return {"error": "quoted_text is required — the exact snippet to anchor the comment to"}
+
+    if not wiki_utils.file_exists(path):
+        return {"error": f"file not found: {path}"}
+
+    try:
+        require_can("read", path)
+    except PermissionDenied as exc:
+        return {"error": str(exc)}
+
+    head_sha = wiki_git.head_sha_for_path(path)
+    if not head_sha:
+        return {"error": f"could not resolve HEAD for {path}"}
+    page = wiki_git.read_file(path, ref="HEAD")
+
+    # Anchor to the quoted snippet — require an exact, unique occurrence so we
+    # never guess where the comment belongs.
+    idx = page.find(quoted)
+    if idx < 0:
+        return {
+            "error": "quoted_text not found verbatim on the page; copy an exact "
+            "snippet from the current body"
+        }
+    if page.find(quoted, idx + 1) != -1:
+        return {
+            "error": "quoted_text appears more than once; quote a longer, unique "
+            "snippet so the comment anchors unambiguously"
+        }
+
+    row = comments_repo.create_thread(
+        doc_path=path,
+        body=body.strip(),
+        author_user_id=None,
+        anchor_sha=head_sha,
+        start_offset=idx,
+        end_offset=idx + len(quoted),
+        quoted_text=quoted,
+        author_kind=CommentAuthorKind.AGENT.value,
+    )
+    return {
+        "comment_id": row["id"],
+        "doc_path": path,
+        "link": _thread_link(path, row["thread_root_id"]),
+    }

--- a/backend/app/llm/agents/tools/add_comment.py
+++ b/backend/app/llm/agents/tools/add_comment.py
@@ -40,6 +40,7 @@ def handle(args: dict[str, Any]) -> Any:
     quoted = args.get("quoted_text")
     if not isinstance(quoted, str) or not quoted.strip():
         return {"error": "quoted_text is required — the exact snippet to anchor the comment to"}
+    quoted = quoted.strip()
 
     if not wiki_utils.file_exists(path):
         return {"error": f"file not found: {path}"}
@@ -52,7 +53,11 @@ def handle(args: dict[str, Any]) -> Any:
     head_sha = wiki_git.head_sha_for_path(path)
     if not head_sha:
         return {"error": f"could not resolve HEAD for {path}"}
-    page = wiki_git.read_file(path, ref="HEAD")
+    # read_file_opt returns None (rather than raising UnknownSha) if the path
+    # isn't resolvable at HEAD — e.g. its latest commit was a deletion.
+    page = wiki_git.read_file_opt(path, ref="HEAD")
+    if page is None:
+        return {"error": f"could not read {path}"}
 
     # Anchor to the quoted snippet — require an exact, unique occurrence so we
     # never guess where the comment belongs.

--- a/backend/app/llm/prompts/chat.system.md
+++ b/backend/app/llm/prompts/chat.system.md
@@ -32,7 +32,7 @@ You start with a small core toolset:
 - `load_skill(name)` — load a skill to gain access to additional tools. Call this once per skill you need; tools remain available for the rest of the conversation. The tool result returns instructions for how to use that skill's tools. Available skills:
     - `triggers` — create/update/list NL triggers on wiki pages and folders
     - `modify_wiki` — read/edit/create/move wiki pages and directories
-    - `comments` — leave inline comments (discussion) on a page, anchored to a quoted snippet
+    - `comments` — leave inline comments (discussion) on a page, anchored to a quoted snippet; load only when the user explicitly asks you to comment
     - `web_search` — search the public web and fetch page contents
     - `ux_explanation` — explain how Agent Wiki works or answer wiki Q&A via a sub-agent
     - `bash` — run read-only shell commands against the wiki tree

--- a/backend/app/llm/prompts/chat.system.md
+++ b/backend/app/llm/prompts/chat.system.md
@@ -32,6 +32,7 @@ You start with a small core toolset:
 - `load_skill(name)` — load a skill to gain access to additional tools. Call this once per skill you need; tools remain available for the rest of the conversation. The tool result returns instructions for how to use that skill's tools. Available skills:
     - `triggers` — create/update/list NL triggers on wiki pages and folders
     - `modify_wiki` — read/edit/create/move wiki pages and directories
+    - `comments` — leave inline comments (discussion) on a page, anchored to a quoted snippet
     - `web_search` — search the public web and fetch page contents
     - `ux_explanation` — explain how Agent Wiki works or answer wiki Q&A via a sub-agent
     - `bash` — run read-only shell commands against the wiki tree

--- a/backend/tests/test_add_comment_tool.py
+++ b/backend/tests/test_add_comment_tool.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from app.auth import User
 from app.llm.agents.tools.add_comment import handle
 from app.wiki import comments, git as wiki_git
+from tests._seed import seed_user
 
 _PAGE = "guides/db.md"
 _BODY = "Intro line.\nThe connection pool size is 20.\nClosing line.\n"
@@ -20,9 +21,14 @@ def _commit(body: str = _BODY) -> None:
     wiki_git.commit_file(_PAGE, body, "seed", author=None)
 
 
-def _as_user(monkeypatch) -> None:
-    user = User(id="u_a", email="a@x.com", name=None, is_admin=True)
+def _as_user(monkeypatch) -> str:
+    """Seed a real user row (the comment FK needs it) and make the tool see it.
+    `add_comment` captured `current_user` at import, so patch that binding too."""
+    uid = seed_user(uid="u_a", email="a@x.com")
+    user = User(id=uid, email="a@x.com", name=None, is_admin=False)
     monkeypatch.setattr("app.auth.current_user", lambda: user)
+    monkeypatch.setattr("app.llm.agents.tools.add_comment.current_user", lambda: user)
+    return uid
 
 
 def test_add_comment_anchors_to_snippet(tmp_repo, monkeypatch):
@@ -38,7 +44,7 @@ def test_add_comment_anchors_to_snippet(tmp_repo, monkeypatch):
     assert len(rows) == 1
     c = rows[0]
     assert c["author_kind"] == "agent"
-    assert c["author_user_id"] is None
+    assert c["author_user_id"] == "u_a"  # attributed to the chatting user
     assert c["quoted_text"] == _SNIPPET
     start = _BODY.index(_SNIPPET)
     assert (c["start_offset"], c["end_offset"]) == (start, start + len(_SNIPPET))

--- a/backend/tests/test_add_comment_tool.py
+++ b/backend/tests/test_add_comment_tool.py
@@ -1,0 +1,73 @@
+"""The `add_comment` chat tool (app/llm/agents/tools/add_comment.py).
+
+Real wiki repo (`tmp_repo`) so the snippet anchoring runs against a real
+committed body, and a real DB so the agent-authored thread is created. Mirrors
+`test_comments_api.py`. `current_user` is patched to a seeded admin (the page is
+implicit-public anyway; this keeps `require_can` deterministic).
+"""
+from __future__ import annotations
+
+from app.auth import User
+from app.llm.agents.tools.add_comment import handle
+from app.wiki import comments, git as wiki_git
+
+_PAGE = "guides/db.md"
+_BODY = "Intro line.\nThe connection pool size is 20.\nClosing line.\n"
+_SNIPPET = "connection pool size is 20"
+
+
+def _commit(body: str = _BODY) -> None:
+    wiki_git.commit_file(_PAGE, body, "seed", author=None)
+
+
+def _as_user(monkeypatch) -> None:
+    user = User(id="u_a", email="a@x.com", name=None, is_admin=True)
+    monkeypatch.setattr("app.auth.current_user", lambda: user)
+
+
+def test_add_comment_anchors_to_snippet(tmp_repo, monkeypatch):
+    _commit()
+    _as_user(monkeypatch)
+
+    out = handle({"path": _PAGE, "quoted_text": _SNIPPET, "body": "still accurate?"})
+    assert out["doc_path"] == _PAGE
+    assert out["comment_id"].startswith("cmt_")
+    assert out["link"] == f"/app/wiki/guides/db.md?comment={out['comment_id']}"
+
+    rows = comments.list_for_doc(_PAGE)
+    assert len(rows) == 1
+    c = rows[0]
+    assert c["author_kind"] == "agent"
+    assert c["author_user_id"] is None
+    assert c["quoted_text"] == _SNIPPET
+    start = _BODY.index(_SNIPPET)
+    assert (c["start_offset"], c["end_offset"]) == (start, start + len(_SNIPPET))
+
+
+def test_rejects_missing_snippet(tmp_repo, monkeypatch):
+    _commit()
+    _as_user(monkeypatch)
+    out = handle({"path": _PAGE, "quoted_text": "not on the page", "body": "x"})
+    assert "error" in out and "not found" in out["error"]
+    assert comments.list_for_doc(_PAGE) == []
+
+
+def test_rejects_ambiguous_snippet(tmp_repo, monkeypatch):
+    _commit("the same line\nthe same line\n")
+    _as_user(monkeypatch)
+    out = handle({"path": _PAGE, "quoted_text": "the same line", "body": "x"})
+    assert "error" in out and "more than once" in out["error"]
+    assert comments.list_for_doc(_PAGE) == []
+
+
+def test_requires_body_and_quote(tmp_repo, monkeypatch):
+    _commit()
+    _as_user(monkeypatch)
+    assert "error" in handle({"path": _PAGE, "quoted_text": _SNIPPET, "body": "   "})
+    assert "error" in handle({"path": _PAGE, "quoted_text": "  ", "body": "hi"})
+
+
+def test_file_not_found(tmp_repo, monkeypatch):
+    _as_user(monkeypatch)
+    out = handle({"path": "no/such.md", "quoted_text": "x", "body": "hi"})
+    assert "error" in out and "not found" in out["error"]

--- a/backend/tests/test_skills_registry.py
+++ b/backend/tests/test_skills_registry.py
@@ -11,6 +11,7 @@ def test_expected_skills_present():
     assert set(skill_registry.SKILLS.keys()) == {
         "triggers",
         "modify_wiki",
+        "comments",
         "web_search",
         "ux_explanation",
         "bash",


### PR DESCRIPTION
## What

First slice of the Phase 3 **"agent add/update/resolve a comment"** item: the chat agent can now **leave an inline comment** on a page. It's agent-authored discussion (renders as "Agent") — it does **not** change page content.

## How
- **`tools/add_comment.{py,json}`** — wraps `comments.create_thread`. Inputs: `path`, `quoted_text`, `body`.
  - **Anchor by snippet** (agents can't pick char offsets): reads the page at HEAD, finds `quoted_text`, and requires it to appear **exactly once** — if it's missing or ambiguous, it errors and asks for a unique/longer quote. No guessing (same find-and-verify discipline as the citation-remap).
  - **Authorship:** `author_kind="agent"`, `author_user_id=None` → the existing panel renders it as **"Agent"** with no frontend change.
  - **Permissions:** `require_can("read", path)` — read access = can comment, same as humans; inherits the chat user's visibility.
  - Returns `comment_id` + a `?comment=` deep-link so the agent can point the human at the thread.
- **New `comments` skill** (`skills/comments.md`, registered in `SKILLS`, listed in `chat.system`). Writes stay behind `load_skill` (base tools are read-only); this skill will also hold `reply`/`resolve` later.
- **Inline-only** (page-scope is descoped). **Chat agent first**, MCP later — same staging as `search_comments`.

## Tests
`test_add_comment_tool.py` (real repo + DB): anchors to the snippet with correct offsets + agent authorship; rejects missing / ambiguous snippets; validates args; file-not-found. `test_skills_registry.py` updated for the new skill.

`ruff` + `basedpyright` (strict) clean; registry/skill tests green locally (DB-backed handler tests run in CI).
<img width="368" height="232" alt="Screenshot 2026-06-09 at 5 07 22 PM" src="https://github.com/user-attachments/assets/e45041f4-8b1c-4ecc-a475-7ba09c86bd7a" />
<img width="780" height="300" alt="Screenshot 2026-06-09 at 5 07 25 PM" src="https://github.com/user-attachments/assets/cd3290a3-4619-4544-9b04-78f0bc64f6fe" />

## Follow-ups (the rest of Phase 3)
- `reply` / `resolve` tools in the same skill (resolve gated to the human-initiated "address this" flow, not autonomous).
- Optional: attribute the triggering user (today `author_user_id` is null) + an "Agent" badge in the panel.