### PR TITLE
feat(mcp): expose search_comments as an MCP tool

### DIFF
--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -40,6 +40,7 @@ MCP_ALLOWED_TOOLS: frozenset[str] = frozenset(
         # Read
         "read_doc",
         "search_wiki",
+        "search_comments",
         "list_history",
         "ask_nl_question",
         # Write — sync

--- a/backend/tests/test_mcp_server_tools.py
+++ b/backend/tests/test_mcp_server_tools.py
@@ -19,6 +19,7 @@ from app.mcp_server import session as mcp_session
 from app.mcp_server import tools as mcp_tools
 from app.wiki import acl as wiki_acl
 from tests.conftest import needs_opensearch
+from app.wiki import comments as wiki_comments
 from app.wiki import git as wiki_git
 
 from tests._seed import seed_user
@@ -282,11 +283,10 @@ def test_call_with_missing_name_is_invalid_params(client):
 @needs_opensearch
 def test_search_comments_returns_results_via_mcp(client):
     uid = seed_user(uid="u1", email="u1@x.com")
-    from app.wiki import comments
 
     # A comment indexes inline on create (no queue), so it's searchable at once.
     wiki_git.commit_file("guide.md", "# Guide\nsome text here\n", "seed", author=None)
-    comments.create_thread(
+    wiki_comments.create_thread(
         doc_path="guide.md",
         body="we chose distributed tracing for the rollout",
         author_user_id=uid,

--- a/backend/tests/test_mcp_server_tools.py
+++ b/backend/tests/test_mcp_server_tools.py
@@ -110,6 +110,7 @@ def test_tools_list_uses_mcp_shape_and_allow_list(client):
     assert names >= {
         "read_doc",
         "search_wiki",
+        "search_comments",
         "list_history",
         "ask_nl_question",
         "edit_doc",
@@ -276,6 +277,31 @@ def test_call_with_missing_name_is_invalid_params(client):
 # --------------------------------------------------------------------------- #
 # Search                                                                      #
 # --------------------------------------------------------------------------- #
+
+
+@needs_opensearch
+def test_search_comments_returns_results_via_mcp(client):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    from app.wiki import comments
+
+    # A comment indexes inline on create (no queue), so it's searchable at once.
+    wiki_git.commit_file("guide.md", "# Guide\nsome text here\n", "seed", author=None)
+    comments.create_thread(
+        doc_path="guide.md",
+        body="we chose distributed tracing for the rollout",
+        author_user_id=uid,
+        anchor_sha="seed",
+        start_offset=0,
+        end_offset=4,
+        quoted_text="some",
+    )
+
+    headers = _handshake(client, _mint(uid))
+    rpc = _call_tool(client, headers, "search_comments", {"query": "distributed tracing"})
+    payload, is_error = _payload_from_call_response(rpc)
+    assert is_error is False
+    paths = [r["doc_path"] for r in payload["results"]]
+    assert "guide.md" in paths
 
 
 @needs_opensearch


### PR DESCRIPTION
## What

Add `search_comments` to `MCP_ALLOWED_TOOLS` so external/launcher agents (e.g. Claude Code over MCP) can search wiki **comment discussion** directly — precise hits with `doc_path`/`thread_root_id` + the `?comment=` deep-link — rather than only indirectly through `ask_nl_question`.

## Why this is safe to broaden (read-only)
- **ACL-scoped:** the handler filters by `current_user()`; MCP requests authenticate as a user, so a caller only ever sees comments it can read — same guarantee as the other exposed read tools (`read_doc`, `search_wiki`).
- **Consistency:** every other read tool is already on the allow-list; `search_comments` is the same kind of tool.
- **Already validated:** shipped + tested in #214 (chat + the `ask_nl_question` engine); this just upgrades the existing indirect path to a direct, precise one.

## Scope
- **Reads broaden, writes don't.** `add_comment` (#215) stays chat-only — its "only when the user asks" steering lives in the chat prompt/skill md, which external clients don't load, so a write tool over MCP is a separate, more deliberate decision.

## Tests
`test_search_comments_returns_results_via_mcp`: a seeded comment is found via `tools/call`. The `tools/list` allow-list assertions already use `>=` / `== set(MCP_ALLOWED_TOOLS)`, so they stay consistent automatically.

`ruff` + `basedpyright` clean.