### PR TITLE
feat(mcp): expose add_comment as an MCP tool

### DIFF
--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -50,6 +50,7 @@ MCP_ALLOWED_TOOLS: frozenset[str] = frozenset(
         "apply_patch",
         "move_path",
         "create_directory",
+        "add_comment",
         # Write — async
         "update_doc_nl",
     }

--- a/backend/tests/test_mcp_server_tools.py
+++ b/backend/tests/test_mcp_server_tools.py
@@ -234,6 +234,28 @@ def test_list_history_blocked_when_user_lacks_read(client):
     assert "forbidden" in payload["error"]
 
 
+def test_add_comment_blocked_when_user_lacks_read(client):
+    """A stranger can't comment on a page they can't read — `add_comment`
+    gates on `require_can("read", path)` before it ever anchors."""
+    owner = seed_user(uid="owner", email="owner@x.com")
+    stranger = seed_user(uid="stranger", email="stranger@x.com")
+
+    wiki_git.commit_file("private.md", "# secrets\nthe secret value\n", "seed", author=None)
+    wiki_acl.set_owner("private.md", owner)
+
+    headers = _handshake(client, _mint(stranger))
+    rpc = _call_tool(
+        client,
+        headers,
+        "add_comment",
+        {"path": "private.md", "quoted_text": "the secret value", "body": "x"},
+    )
+    payload, is_error = _payload_from_call_response(rpc)
+    assert is_error is True
+    assert "forbidden" in payload["error"]
+    assert wiki_comments.list_for_doc("private.md") == []  # nothing created
+
+
 # --------------------------------------------------------------------------- #
 # Disallowed / unknown tools                                                  #
 # --------------------------------------------------------------------------- #
@@ -277,7 +299,7 @@ def test_call_with_missing_name_is_invalid_params(client):
 
 
 # --------------------------------------------------------------------------- #
-# Search                                                                      #
+# add_comment (write)                                                         #
 # --------------------------------------------------------------------------- #
 
 
@@ -305,6 +327,11 @@ def test_add_comment_via_mcp(client):
     assert rows[0]["author_kind"] == "agent"
     assert rows[0]["author_user_id"] == uid
     assert rows[0]["quoted_text"] == "The pool size is 20."
+
+
+# --------------------------------------------------------------------------- #
+# Search                                                                      #
+# --------------------------------------------------------------------------- #
 
 
 @needs_opensearch

--- a/backend/tests/test_mcp_server_tools.py
+++ b/backend/tests/test_mcp_server_tools.py
@@ -120,6 +120,7 @@ def test_tools_list_uses_mcp_shape_and_allow_list(client):
         "apply_patch",
         "move_path",
         "create_directory",
+        "add_comment",
     }
     # Tools not on the allow-list must NOT be exposed.
     assert "run_bash" not in names
@@ -278,6 +279,32 @@ def test_call_with_missing_name_is_invalid_params(client):
 # --------------------------------------------------------------------------- #
 # Search                                                                      #
 # --------------------------------------------------------------------------- #
+
+
+def test_add_comment_via_mcp(client):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    wiki_git.commit_file(
+        "guide.md", "# Guide\nThe pool size is 20.\nEnd.\n", "seed", author=None
+    )
+    headers = _handshake(client, _mint(uid))
+
+    rpc = _call_tool(
+        client,
+        headers,
+        "add_comment",
+        {"path": "guide.md", "quoted_text": "The pool size is 20.", "body": "confirm?"},
+    )
+    payload, is_error = _payload_from_call_response(rpc)
+    assert is_error is False
+    assert payload["comment_id"].startswith("cmt_")
+    assert payload["doc_path"] == "guide.md"
+
+    rows = wiki_comments.list_for_doc("guide.md")
+    assert len(rows) == 1
+    # Authored by the agent, attributed to the authenticated MCP user.
+    assert rows[0]["author_kind"] == "agent"
+    assert rows[0]["author_user_id"] == uid
+    assert rows[0]["quoted_text"] == "The pool size is 20."
 
 
 @needs_opensearch


### PR DESCRIPTION
## What

Add `add_comment` to `MCP_ALLOWED_TOOLS` so external/launcher agents (e.g. Claude Code over MCP) can leave inline comments on wiki pages — not just the in-app chat agent. Follows `search_comments` going MCP (#216); this is the **write** counterpart.

## Why it's OK to broaden writes here
- **Low blast radius:** a comment is *discussion*, not page content — ACL-scoped via `current_user()`, attributed (`author_kind="agent"` + the authenticated MCP user), and **reversible** (deletable). Very different from an autonomous content write.
- **Human-in-the-loop, one layer up:** an external agent calls this because *its* user asked it to — so the "only when asked" intent is preserved at the client layer.

## The one caveat (documented)
The "only when the user explicitly asks" steering lives in three places for the in-app agent — tool description, skill `.md`, chat prompt. External MCP clients use their own system prompt and don't load our skill md, so for them the guard rests on the **tool description** alone (which MCP surfaces via `tools/list`). The description already says "ONLY call this when the user explicitly asks … never proactively." Combined with reversibility + ACL scoping, the residual risk is small.

## Tests
`test_add_comment_via_mcp`: `tools/call` creates an agent-authored comment anchored to the quoted snippet, attributed to the authenticated MCP user. `tools/list` assertions stay consistent (`>=` and `== set(MCP_ALLOWED_TOOLS)`).

`ruff` + `basedpyright` clean.

## Now exposed over MCP
Read: `search_comments` (#216). Write: `add_comment` (this PR). Reply/resolve remain unbuilt (Phase 3 follow-ups).