### PR TITLE
fix(forms): move setTouched to blur handler, fix spurious validation on first keystroke

### DIFF
--- a/frontend/src/hooks/formHooks.ts
+++ b/frontend/src/hooks/formHooks.ts
@@ -25,6 +25,7 @@ export function useOnChangeValue<T = any>(
   return useCallback(
     (value: T) => {
       helpers.setValue(value);
+      helpers.setTouched(true);
       f?.(value);
     },
     [helpers, f],
@@ -32,13 +33,12 @@ export function useOnChangeValue<T = any>(
 }
 
 export function useOnBlurEvent<T = any>(name: string, f?: (event: T) => void) {
-  const [field, , helpers] = useField<T>(name);
+  const [field] = useField<T>(name);
   return useCallback(
     (event: T) => {
       f?.(event);
       field.onBlur(event);
-      helpers.setTouched(true);
     },
-    [field, helpers, f],
+    [field, f],
   );
 }

--- a/frontend/src/hooks/formHooks.ts
+++ b/frontend/src/hooks/formHooks.ts
@@ -7,14 +7,13 @@ export function useOnChangeEvent<T = any>(
   name: string,
   f?: (event: T) => void,
 ) {
-  const [field, , helpers] = useField<T>(name);
+  const [field] = useField<T>(name);
   return useCallback(
     (event: T) => {
       field.onChange(event);
-      helpers.setTouched(true);
       f?.(event);
     },
-    [field, helpers, f],
+    [field, f],
   );
 }
 
@@ -26,7 +25,6 @@ export function useOnChangeValue<T = any>(
   return useCallback(
     (value: T) => {
       helpers.setValue(value);
-      helpers.setTouched(true);
       f?.(value);
     },
     [helpers, f],
@@ -34,12 +32,13 @@ export function useOnChangeValue<T = any>(
 }
 
 export function useOnBlurEvent<T = any>(name: string, f?: (event: T) => void) {
-  const [field] = useField<T>(name);
+  const [field, , helpers] = useField<T>(name);
   return useCallback(
     (event: T) => {
       f?.(event);
       field.onBlur(event);
+      helpers.setTouched(true);
     },
-    [field, f],
+    [field, helpers, f],
   );
 }


### PR DESCRIPTION
## Summary

`useOnChangeEvent` and `useOnChangeValue` were calling `helpers.setTouched(true)` in the change handler. This triggered a second Formik validation pass that read the pre-keystroke (stale) field value, producing a `required` error on the very first keystroke that disappeared on the second.

`setTouched(true)` is now only called in `useOnBlurEvent` — errors surface after the user leaves a field, which is the correct UX contract.

## Repro (before)
1. Open login or signup form
2. Click into the password field, type one character
3. "Password is required." appears immediately
4. Type a second character — error disappears