### PR TITLE
feat(comments): agent reply_comment + resolve_comment tools (chat + MCP)

### DIFF
--- a/backend/app/llm/agents/skills/__init__.py
+++ b/backend/app/llm/agents/skills/__init__.py
@@ -64,8 +64,8 @@ SKILLS: dict[str, Skill] = {
     ),
     "comments": Skill(
         name="comments",
-        description="leave inline comments (agent-authored discussion) on wiki pages",
-        tool_names=("add_comment",),
+        description="comment on wiki pages — add inline comments, reply in threads, resolve threads",
+        tool_names=("add_comment", "reply_comment", "resolve_comment"),
         instructions=_load_md("comments"),
     ),
     "web_search": Skill(

--- a/backend/app/llm/agents/skills/comments.md
+++ b/backend/app/llm/agents/skills/comments.md
@@ -2,23 +2,31 @@ You can leave comments on wiki pages — threaded discussion that humans see,
 **separate from page content**. A comment does not change the page; to edit
 content, load the `modify_wiki` skill instead.
 
-Tool:
-- `add_comment(path, quoted_text, body)` — leave an inline comment anchored to a
+Tools:
+- `add_comment(path, quoted_text, body)` — start an inline comment anchored to a
   specific passage.
+- `reply_comment(comment_id, body)` — reply in an existing thread (no anchor
+  needed; it inherits the thread's).
+- `resolve_comment(comment_id)` — mark a thread resolved (done).
 
-How to anchor:
+To target an existing thread (reply/resolve), get its `comment_id` from a
+`search_comments` result.
+
+How to anchor a new comment:
 - `quoted_text` must be copied **verbatim** from the current page body and must
   appear **exactly once**. If you're unsure of the exact wording, `read_page`
   first and copy from it. If a short snippet isn't unique, quote a longer span.
 
-When to use it:
-- **Only when the user explicitly asks you to leave / post / add a comment.**
-  Do not comment proactively, as a side effect of another task, or on your own
-  initiative — even if you spot something worth flagging. If you think a comment
-  would help, *suggest* it in your reply and let the user decide; don't post one
-  unprompted.
-- Once the user asks, comment on the specific passage they mean (anchored to a
-  quoted snippet) and keep it concise.
+When to use these:
+- **Only when the user explicitly asks** you to comment, reply, or resolve. Do
+  not comment/reply/resolve proactively, as a side effect of another task, or on
+  your own initiative — even if you spot something worth flagging or a thread
+  that looks handled. If you think one would help, *suggest* it in your reply and
+  let the user decide; don't act unprompted.
+- **`resolve_comment` is the most sensitive** — it dismisses someone's feedback
+  as done. Only resolve a thread the user clearly tells you to resolve; never
+  infer it. (It's reversible — a human can reopen — but don't rely on that.)
+- Keep comments and replies concise and specific.
 
 After commenting, you may share the returned `link` so the human can jump
 straight to the thread. Keep comments concise and specific to the quoted span.

--- a/backend/app/llm/agents/tools/_links.py
+++ b/backend/app/llm/agents/tools/_links.py
@@ -1,0 +1,16 @@
+"""Shared link builders for the comment tools.
+
+Underscore-prefixed and paired with no `.json`, so the tool registry's loader
+(which imports `<name>.py` for each `<name>.json`) never treats it as a tool.
+"""
+from __future__ import annotations
+
+from urllib.parse import quote
+
+
+def thread_link(doc_path: str, thread_root_id: str) -> str:
+    """`/app/wiki/<encoded path>?comment=<root>` — the shipped deep-link route
+    that opens a page focused on a comment thread. Each path segment and the id
+    are url-encoded."""
+    encoded = "/".join(quote(seg) for seg in doc_path.split("/") if seg)
+    return f"/app/wiki/{encoded}?comment={quote(thread_root_id, safe='')}"

--- a/backend/app/llm/agents/tools/add_comment.py
+++ b/backend/app/llm/agents/tools/add_comment.py
@@ -15,17 +15,12 @@ user (`current_user()`), the same principal the chat request authenticated as.
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import quote
 
 from app.auth import PermissionDenied, current_user, require_can
+from app.llm.agents.tools._links import thread_link
 from app.llm.agents.tools.errors import ToolError
 from app.models.comment import CommentAuthorKind
 from app.wiki import comments as comments_repo, git as wiki_git, utils as wiki_utils
-
-
-def _thread_link(doc_path: str, thread_root_id: str) -> str:
-    encoded = "/".join(quote(seg) for seg in doc_path.split("/") if seg)
-    return f"/app/wiki/{encoded}?comment={quote(thread_root_id, safe='')}"
 
 
 def handle(args: dict[str, Any]) -> Any:
@@ -87,5 +82,5 @@ def handle(args: dict[str, Any]) -> Any:
     return {
         "comment_id": row["id"],
         "doc_path": path,
-        "link": _thread_link(path, row["thread_root_id"]),
+        "link": thread_link(path, row["thread_root_id"]),
     }

--- a/backend/app/llm/agents/tools/reply_comment.json
+++ b/backend/app/llm/agents/tools/reply_comment.json
@@ -1,0 +1,18 @@
+{
+  "name": "reply_comment",
+  "description": "Reply to an existing comment thread on a wiki page. This is *discussion* (it does NOT change the page). ONLY call this when the user explicitly asks you to reply / respond to a comment — never proactively. Pass the `comment_id` of any comment in the target thread (e.g. from a `search_comments` result) and your `body`. The reply inherits the thread's anchor, so no snippet is needed. Returns the new comment id and a link to the thread.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "comment_id": {
+        "type": "string",
+        "description": "Id of a comment in the thread to reply to (e.g. the `thread_root_id` or `comment_id` from a search_comments hit)."
+      },
+      "body": {
+        "type": "string",
+        "description": "The reply text."
+      }
+    },
+    "required": ["comment_id", "body"]
+  }
+}

--- a/backend/app/llm/agents/tools/reply_comment.py
+++ b/backend/app/llm/agents/tools/reply_comment.py
@@ -1,0 +1,61 @@
+"""Handler for the `reply_comment` tool. Spec lives in `reply_comment.json`.
+
+Lets an agent reply in an existing comment thread (agent-authored discussion).
+No anchoring: a reply inherits the thread's anchor and `doc_path` from its
+parent, so the only inputs are the `comment_id` to reply under (from a
+`search_comments` hit) and the `body`.
+
+Attributed to the user driving the chat (`author_user_id = current_user()`)
+with `author_kind="agent"` provenance — same model as `add_comment`. Permission
+mirrors human replying: read access to the parent's page, via
+`require_can("read", parent.doc_path)`.
+"""
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+from app.auth import PermissionDenied, current_user, require_can
+from app.models.comment import CommentAuthorKind
+from app.wiki import comments as comments_repo
+
+
+def _thread_link(doc_path: str, thread_root_id: str) -> str:
+    encoded = "/".join(quote(seg) for seg in doc_path.split("/") if seg)
+    return f"/app/wiki/{encoded}?comment={quote(thread_root_id, safe='')}"
+
+
+def handle(args: dict[str, Any]) -> Any:
+    comment_id = args.get("comment_id")
+    if not isinstance(comment_id, str) or not comment_id.strip():
+        return {"error": "comment_id is required — the id of a comment in the thread to reply to"}
+    comment_id = comment_id.strip()
+
+    body = args.get("body")
+    if not isinstance(body, str) or not body.strip():
+        return {"error": "body is required"}
+
+    parent = comments_repo.get(comment_id)
+    if parent is None:
+        return {"error": f"comment not found: {comment_id}"}
+
+    try:
+        require_can("read", parent["doc_path"])
+    except PermissionDenied as exc:
+        return {"error": str(exc)}
+
+    user = current_user()
+    reply = comments_repo.add_reply(
+        parent_id=comment_id,
+        body=body.strip(),
+        author_user_id=user.id if user else None,
+        author_kind=CommentAuthorKind.AGENT.value,
+    )
+    if reply is None:  # parent vanished between get() and add_reply()
+        return {"error": f"comment not found: {comment_id}"}
+    return {
+        "comment_id": reply["id"],
+        "thread_root_id": reply["thread_root_id"],
+        "doc_path": reply["doc_path"],
+        "link": _thread_link(reply["doc_path"], reply["thread_root_id"]),
+    }

--- a/backend/app/llm/agents/tools/reply_comment.py
+++ b/backend/app/llm/agents/tools/reply_comment.py
@@ -13,16 +13,11 @@ mirrors human replying: read access to the parent's page, via
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import quote
 
 from app.auth import PermissionDenied, current_user, require_can
+from app.llm.agents.tools._links import thread_link
 from app.models.comment import CommentAuthorKind
 from app.wiki import comments as comments_repo
-
-
-def _thread_link(doc_path: str, thread_root_id: str) -> str:
-    encoded = "/".join(quote(seg) for seg in doc_path.split("/") if seg)
-    return f"/app/wiki/{encoded}?comment={quote(thread_root_id, safe='')}"
 
 
 def handle(args: dict[str, Any]) -> Any:
@@ -57,5 +52,5 @@ def handle(args: dict[str, Any]) -> Any:
         "comment_id": reply["id"],
         "thread_root_id": reply["thread_root_id"],
         "doc_path": reply["doc_path"],
-        "link": _thread_link(reply["doc_path"], reply["thread_root_id"]),
+        "link": thread_link(reply["doc_path"], reply["thread_root_id"]),
     }

--- a/backend/app/llm/agents/tools/resolve_comment.json
+++ b/backend/app/llm/agents/tools/resolve_comment.json
@@ -1,0 +1,14 @@
+{
+  "name": "resolve_comment",
+  "description": "Mark a comment thread as resolved (done). ONLY call this when the user explicitly asks you to resolve a comment — never on your own judgment that a thread looks handled. Resolving dismisses someone's feedback, so it's the most sensitive comment action; it is reversible (a human can reopen). Pass the `comment_id` of any comment in the thread (e.g. from a `search_comments` result); the whole thread is resolved.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "comment_id": {
+        "type": "string",
+        "description": "Id of any comment in the thread to resolve (e.g. the `thread_root_id` or `comment_id` from a search_comments hit)."
+      }
+    },
+    "required": ["comment_id"]
+  }
+}

--- a/backend/app/llm/agents/tools/resolve_comment.py
+++ b/backend/app/llm/agents/tools/resolve_comment.py
@@ -1,0 +1,49 @@
+"""Handler for the `resolve_comment` tool. Spec lives in `resolve_comment.json`.
+
+Lets an agent mark a comment thread resolved. Resolving dismisses a thread as
+"handled", so this is the most delicate of the comment-write tools — the spec
+and the `comments` skill steer the agent to only resolve when the user
+*explicitly* asks, never on its own judgment. It's reversible (a human can
+reopen from the panel), which is the backstop.
+
+Operates on the whole thread: given any `comment_id` in the thread we resolve
+its root (`set_thread_status`). Permission mirrors human resolving — read access
+to the page (Google-Docs style, any reader can resolve).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.auth import PermissionDenied, current_user, require_can
+from app.models.comment import CommentStatus
+from app.wiki import comments as comments_repo
+
+
+def handle(args: dict[str, Any]) -> Any:
+    comment_id = args.get("comment_id")
+    if not isinstance(comment_id, str) or not comment_id.strip():
+        return {"error": "comment_id is required — a comment in the thread to resolve"}
+    comment_id = comment_id.strip()
+
+    comment = comments_repo.get(comment_id)
+    if comment is None:
+        return {"error": f"comment not found: {comment_id}"}
+
+    try:
+        require_can("read", comment["doc_path"])
+    except PermissionDenied as exc:
+        return {"error": str(exc)}
+
+    user = current_user()
+    root = comments_repo.set_thread_status(
+        comment["thread_root_id"],
+        CommentStatus.RESOLVED.value,
+        resolved_by_user_id=user.id if user else None,
+    )
+    if root is None:
+        return {"error": f"thread not found: {comment['thread_root_id']}"}
+    return {
+        "thread_root_id": root["id"],
+        "doc_path": root["doc_path"],
+        "status": root["status"],
+    }

--- a/backend/app/llm/agents/tools/resolve_comment.py
+++ b/backend/app/llm/agents/tools/resolve_comment.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.auth import PermissionDenied, current_user, require_can
+from app.llm.agents.tools._links import thread_link
 from app.models.comment import CommentStatus
 from app.wiki import comments as comments_repo
 
@@ -46,4 +47,5 @@ def handle(args: dict[str, Any]) -> Any:
         "thread_root_id": root["id"],
         "doc_path": root["doc_path"],
         "status": root["status"],
+        "link": thread_link(root["doc_path"], root["id"]),
     }

--- a/backend/app/llm/prompts/chat.system.md
+++ b/backend/app/llm/prompts/chat.system.md
@@ -32,7 +32,7 @@ You start with a small core toolset:
 - `load_skill(name)` — load a skill to gain access to additional tools. Call this once per skill you need; tools remain available for the rest of the conversation. The tool result returns instructions for how to use that skill's tools. Available skills:
     - `triggers` — create/update/list NL triggers on wiki pages and folders
     - `modify_wiki` — read/edit/create/move wiki pages and directories
-    - `comments` — leave inline comments (discussion) on a page, anchored to a quoted snippet; load only when the user explicitly asks you to comment
+    - `comments` — comment on a page: add an inline comment, reply in a thread, or resolve a thread; load only when the user explicitly asks you to comment / reply / resolve
     - `web_search` — search the public web and fetch page contents
     - `ux_explanation` — explain how Agent Wiki works or answer wiki Q&A via a sub-agent
     - `bash` — run read-only shell commands against the wiki tree

--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -51,6 +51,8 @@ MCP_ALLOWED_TOOLS: frozenset[str] = frozenset(
         "move_path",
         "create_directory",
         "add_comment",
+        "reply_comment",
+        "resolve_comment",
         # Write — async
         "update_doc_nl",
     }

--- a/backend/tests/test_mcp_server_tools.py
+++ b/backend/tests/test_mcp_server_tools.py
@@ -121,6 +121,8 @@ def test_tools_list_uses_mcp_shape_and_allow_list(client):
         "move_path",
         "create_directory",
         "add_comment",
+        "reply_comment",
+        "resolve_comment",
     }
     # Tools not on the allow-list must NOT be exposed.
     assert "run_bash" not in names
@@ -299,7 +301,7 @@ def test_call_with_missing_name_is_invalid_params(client):
 
 
 # --------------------------------------------------------------------------- #
-# add_comment (write)                                                         #
+# Comment write tools (add / reply / resolve)                                 #
 # --------------------------------------------------------------------------- #
 
 
@@ -327,6 +329,57 @@ def test_add_comment_via_mcp(client):
     assert rows[0]["author_kind"] == "agent"
     assert rows[0]["author_user_id"] == uid
     assert rows[0]["quoted_text"] == "The pool size is 20."
+
+
+def test_reply_comment_via_mcp(client):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    wiki_git.commit_file("guide.md", "# Guide\nbody\n", "seed", author=None)
+    root = wiki_comments.create_thread(
+        doc_path="guide.md",
+        body="is this current?",
+        author_user_id=uid,
+        anchor_sha="seed",
+        start_offset=0,
+        end_offset=4,
+        quoted_text="Guid",
+    )
+    headers = _handshake(client, _mint(uid))
+
+    rpc = _call_tool(
+        client, headers, "reply_comment", {"comment_id": root["id"], "body": "yes, confirmed"}
+    )
+    payload, is_error = _payload_from_call_response(rpc)
+    assert is_error is False
+    assert payload["thread_root_id"] == root["id"]
+
+    thread = wiki_comments.list_thread(root["id"])
+    assert len(thread) == 2
+    reply = next(c for c in thread if c["parent_id"])
+    assert reply["author_kind"] == "agent"
+    assert reply["author_user_id"] == uid
+
+
+def test_resolve_comment_via_mcp(client):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    wiki_git.commit_file("guide.md", "# Guide\nbody\n", "seed", author=None)
+    root = wiki_comments.create_thread(
+        doc_path="guide.md",
+        body="needs review",
+        author_user_id=uid,
+        anchor_sha="seed",
+        start_offset=0,
+        end_offset=4,
+        quoted_text="Guid",
+    )
+    headers = _handshake(client, _mint(uid))
+
+    rpc = _call_tool(client, headers, "resolve_comment", {"comment_id": root["id"]})
+    payload, is_error = _payload_from_call_response(rpc)
+    assert is_error is False
+    assert payload["status"] == "resolved"
+
+    refreshed = wiki_comments.get(root["id"])
+    assert refreshed is not None and refreshed["status"] == "resolved"
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_reply_resolve_tools.py
+++ b/backend/tests/test_reply_resolve_tools.py
@@ -1,0 +1,101 @@
+"""reply_comment + resolve_comment chat tools.
+
+DB-backed (`tmp_db`); `current_user` patched to a seeded user (the FK on
+`author_user_id` / `resolved_by_user_id` needs a real row). The page is
+implicit-public (no ACL rows), so `require_can("read", ...)` passes.
+"""
+from __future__ import annotations
+
+from app.auth import User
+from app.llm.agents.tools.reply_comment import handle as reply_handle
+from app.llm.agents.tools.resolve_comment import handle as resolve_handle
+from app.wiki import comments
+from tests._seed import seed_user
+
+_DOC = "guides/setup.md"
+
+
+def _root(author: str) -> dict:
+    return comments.create_thread(
+        doc_path=_DOC,
+        body="root question",
+        author_user_id=author,
+        anchor_sha="sha1",
+        start_offset=0,
+        end_offset=4,
+        quoted_text="root",
+    )
+
+
+def _as_user(monkeypatch) -> str:
+    uid = seed_user(uid="u_a", email="a@x.com")
+    user = User(id=uid, email="a@x.com", name=None, is_admin=False)
+    monkeypatch.setattr("app.auth.current_user", lambda: user)
+    monkeypatch.setattr("app.llm.agents.tools.reply_comment.current_user", lambda: user)
+    monkeypatch.setattr("app.llm.agents.tools.resolve_comment.current_user", lambda: user)
+    return uid
+
+
+# --- reply_comment -------------------------------------------------------- #
+
+
+def test_reply_attaches_to_thread(tmp_db, monkeypatch):
+    uid = _as_user(monkeypatch)
+    root = _root(uid)
+
+    out = reply_handle({"comment_id": root["id"], "body": "here's my answer"})
+    assert out["thread_root_id"] == root["id"]
+    assert out["doc_path"] == _DOC
+    assert out["link"] == f"/app/wiki/guides/setup.md?comment={root['id']}"
+
+    thread = comments.list_thread(root["id"])
+    assert len(thread) == 2
+    reply = next(c for c in thread if c["parent_id"])
+    assert reply["author_kind"] == "agent"
+    assert reply["author_user_id"] == uid
+    assert reply["body"] == "here's my answer"
+
+
+def test_reply_unknown_comment_errors(tmp_db, monkeypatch):
+    _as_user(monkeypatch)
+    out = reply_handle({"comment_id": "cmt_nope", "body": "x"})
+    assert "error" in out and "not found" in out["error"]
+
+
+def test_reply_requires_body_and_id(tmp_db, monkeypatch):
+    uid = _as_user(monkeypatch)
+    root = _root(uid)
+    assert "error" in reply_handle({"comment_id": root["id"], "body": "   "})
+    assert "error" in reply_handle({"comment_id": "  ", "body": "hi"})
+
+
+# --- resolve_comment ------------------------------------------------------ #
+
+
+def test_resolve_marks_thread_resolved(tmp_db, monkeypatch):
+    uid = _as_user(monkeypatch)
+    root = _root(uid)
+
+    out = resolve_handle({"comment_id": root["id"]})
+    assert out["status"] == "resolved"
+    assert out["thread_root_id"] == root["id"]
+    refreshed = comments.get(root["id"])
+    assert refreshed is not None and refreshed["status"] == "resolved"
+
+
+def test_resolve_via_reply_id_resolves_the_thread(tmp_db, monkeypatch):
+    uid = _as_user(monkeypatch)
+    root = _root(uid)
+    reply = comments.add_reply(parent_id=root["id"], body="r", author_user_id=uid)
+    assert reply is not None
+
+    out = resolve_handle({"comment_id": reply["id"]})
+    assert out["thread_root_id"] == root["id"]
+    refreshed = comments.get(root["id"])
+    assert refreshed is not None and refreshed["status"] == "resolved"
+
+
+def test_resolve_unknown_comment_errors(tmp_db, monkeypatch):
+    _as_user(monkeypatch)
+    out = resolve_handle({"comment_id": "cmt_nope"})
+    assert "error" in out and "not found" in out["error"]

--- a/backend/tests/test_reply_resolve_tools.py
+++ b/backend/tests/test_reply_resolve_tools.py
@@ -79,6 +79,7 @@ def test_resolve_marks_thread_resolved(tmp_db, monkeypatch):
     out = resolve_handle({"comment_id": root["id"]})
     assert out["status"] == "resolved"
     assert out["thread_root_id"] == root["id"]
+    assert out["link"] == f"/app/wiki/guides/setup.md?comment={root['id']}"
     refreshed = comments.get(root["id"])
     assert refreshed is not None and refreshed["status"] == "resolved"
 


### PR DESCRIPTION
## What

Completes Phase 3 "agent add/update/resolve a comment". The `comments` skill group now holds **`add_comment` + `reply_comment` + `resolve_comment`**, and all comment tools (read + write) are exposed over **MCP**. Follows merged `add_comment` (#215) and the MCP exposures of `search_comments`/`add_comment` (#216/#217).

## Tools (chat skill + MCP)
- **`reply_comment(comment_id, body)`** — reply in a thread. No anchoring (inherits the thread's anchor + `doc_path`); `comment_id` from a `search_comments` hit. `author_kind="agent"` + `author_user_id=current_user`.
- **`resolve_comment(comment_id)`** — resolve the whole thread (given any comment in it). The most sensitive action; steered to "only when the user explicitly asks," reversible via reopen.
- Both registered in the `comments` skill (chat) **and** added to `MCP_ALLOWED_TOOLS` (external/launcher agents).

## Safety / steering
- ACL = read access (Google-Docs style), via `current_user()` — works the same in chat and over MCP (MCP authenticates as a user).
- "Only when the user explicitly asks" lives in the tool descriptions, the `comments` skill md, and the chat prompt. For MCP clients the **description** carries the guard (they don't load our prompt/skill md); reversibility + ACL keep the blast radius low.

## Tests
- `test_reply_resolve_tools.py`: handler-level — reply attaches to thread (agent-authored, attributed) / resolve marks thread resolved (incl. via a reply id) / unknown-id + validation errors.
- `test_mcp_server_tools.py`: `tools/call` for reply + resolve over MCP; `tools/list` allow-list assertions extended.

`ruff` + `basedpyright` (strict) clean.

<img width="770" height="282" alt="Screenshot 2026-06-09 at 5 52 45 PM" src="https://github.com/user-attachments/assets/5a2dd358-4315-4a42-9638-dcad89e8eff3" />

<img width="402" height="232" alt="Screenshot 2026-06-09 at 5 53 23 PM" src="https://github.com/user-attachments/assets/5ffc4a38-1b29-4fbf-b909-35381327af07" />
<img width="407" height="345" alt="Screenshot 2026-06-09 at 5 53 16 PM" src="https://github.com/user-attachments/assets/fda2c9ad-3a1a-4472-9f36-9f92be18a14a" />

## Deferred

The richer "ask the agent to *address* this comment → it edits the doc → auto-resolves on commit" workflow (a `documents_queue` flow); `resolve_comment` is the when-asked subset.