### PR TITLE
refactor(layout): move WikiTree into RootLayout.LeftPanel

### DIFF
--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -40,25 +40,8 @@
   color: var(--text-04);
 }
 
-.body {
-  display: flex;
-  align-items: flex-start;
-  /* Gap kept wider than the AI-input gutter icon's -28px hang so the centered
-     column can never sit close enough for that icon to overlap the sidebar. */
-  gap: 40px;
-  padding: 0 16px 64px;
-}
-
-/* Permanent directory sidebar — sticky; its list scrolls rather than growing. */
-.sidebar {
-  flex: 0 0 240px;
-  width: 240px;
-  position: sticky;
-  top: 8px;
-  align-self: flex-start;
-}
-
 .column {
+  padding: 0 16px 64px;
   flex: 1;
   max-width: 672px;
   margin: 0 auto;

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -107,107 +107,107 @@ export function WikiHome() {
       </div>
 
       <div className={styles.column}>
-          {/* Hero */}
-          <div className={styles.hero}>
-            <span className={styles.heroMark}>
-              <SvgOnyxLogo size={32} />
-            </span>
-            <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
-          </div>
-          <div className={styles.dividerWrap}>
-            <Divider />
-          </div>
+        {/* Hero */}
+        <div className={styles.hero}>
+          <span className={styles.heroMark}>
+            <SvgOnyxLogo size={32} />
+          </span>
+          <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
+        </div>
+        <div className={styles.dividerWrap}>
+          <Divider />
+        </div>
 
-          {/* Start a new page */}
-          <div className={styles.sectionHeader}>
-            <span className={styles.secHead}>Start a new page</span>
+        {/* Start a new page */}
+        <div className={styles.sectionHeader}>
+          <span className={styles.secHead}>Start a new page</span>
+        </div>
+        <div className={styles.templates}>
+          <div className={styles.templateCell}>
+            <TemplateCard
+              title="Blank page"
+              glyph={
+                <span className={styles.blankGlyph}>
+                  <SvgPlusCircle size={22} />
+                </span>
+              }
+              onClick={() => startNewPage()}
+            />
           </div>
-          <div className={styles.templates}>
-            <div className={styles.templateCell}>
+          {featured.map((t) => (
+            <div key={t.id} className={styles.templateCell}>
               <TemplateCard
-                title="Blank page"
-                glyph={
-                  <span className={styles.blankGlyph}>
-                    <SvgPlusCircle size={22} />
-                  </span>
-                }
-                onClick={() => startNewPage()}
+                title={t.name}
+                description={t.description ?? ""}
+                onClick={() => startNewPage(t.id)}
               />
             </div>
-            {featured.map((t) => (
-              <div key={t.id} className={styles.templateCell}>
-                <TemplateCard
-                  title={t.name}
-                  description={t.description ?? ""}
-                  onClick={() => startNewPage(t.id)}
+          ))}
+        </div>
+        <button
+          type="button"
+          className={styles.moreRow}
+          onClick={() => startNewPage()}
+        >
+          <span className={styles.moreLabel}>More Templates</span>
+          <SvgChevronRight size={18} className={styles.moreChevron} />
+        </button>
+
+        {/* Write with AI */}
+        <div className={styles.aiRow}>
+          <span className={styles.aiGutterIcon}>
+            {generating ? (
+              <LoadingSpinner size={18} />
+            ) : (
+              <SvgOnyxOctagon size={18} />
+            )}
+          </span>
+          <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
+            <InputTypeIn
+              value={aiPrompt}
+              onChange={(e) => setAiPrompt(e.target.value)}
+              placeholder="Start writing with AI…"
+              aria-label="Start writing with AI"
+              rightChildren={
+                <Button
+                  type="submit"
+                  size="sm"
+                  prominence="tertiary"
+                  icon={SvgArrowUp}
+                  disabled={!aiPrompt.trim() || generating}
+                  aria-label="Start writing"
+                />
+              }
+            />
+          </form>
+        </div>
+        {aiError && <p className={styles.aiError}>{aiError}</p>}
+
+        <div className={styles.midDividerWrap}>
+          <Divider />
+        </div>
+
+        {/* Recent Pages */}
+        <div className={styles.sectionHeader}>
+          <span className={styles.secHeadLg}>Recent Pages</span>
+        </div>
+        {recent.length === 0 ? (
+          <p className={styles.empty}>
+            No pages yet. Create one to get started.
+          </p>
+        ) : (
+          <div className={styles.recentGrid}>
+            {recent.map((p) => (
+              <div key={p.path} className={styles.recentCell}>
+                <RecentCard
+                  page={p}
+                  onClick={() => router.push(`/app/wiki/${p.path}`)}
                 />
               </div>
             ))}
           </div>
-          <button
-            type="button"
-            className={styles.moreRow}
-            onClick={() => startNewPage()}
-          >
-            <span className={styles.moreLabel}>More Templates</span>
-            <SvgChevronRight size={18} className={styles.moreChevron} />
-          </button>
-
-          {/* Write with AI */}
-          <div className={styles.aiRow}>
-            <span className={styles.aiGutterIcon}>
-              {generating ? (
-                <LoadingSpinner size={18} />
-              ) : (
-                <SvgOnyxOctagon size={18} />
-              )}
-            </span>
-            <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
-              <InputTypeIn
-                value={aiPrompt}
-                onChange={(e) => setAiPrompt(e.target.value)}
-                placeholder="Start writing with AI…"
-                aria-label="Start writing with AI"
-                rightChildren={
-                  <Button
-                    type="submit"
-                    size="sm"
-                    prominence="tertiary"
-                    icon={SvgArrowUp}
-                    disabled={!aiPrompt.trim() || generating}
-                    aria-label="Start writing"
-                  />
-                }
-              />
-            </form>
-          </div>
-          {aiError && <p className={styles.aiError}>{aiError}</p>}
-
-          <div className={styles.midDividerWrap}>
-            <Divider />
-          </div>
-
-          {/* Recent Pages */}
-          <div className={styles.sectionHeader}>
-            <span className={styles.secHeadLg}>Recent Pages</span>
-          </div>
-          {recent.length === 0 ? (
-            <p className={styles.empty}>
-              No pages yet. Create one to get started.
-            </p>
-          ) : (
-            <div className={styles.recentGrid}>
-              {recent.map((p) => (
-                <div key={p.path} className={styles.recentCell}>
-                  <RecentCard
-                    page={p}
-                    onClick={() => router.push(`/app/wiki/${p.path}`)}
-                  />
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        )}
+      </div>
     </main>
   );
 }

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -43,11 +43,7 @@ export function WikiHome() {
   const { setLeftPanelContent, clearLeftPanelContent } = useAppLayout();
 
   useEffect(() => {
-    setLeftPanelContent(
-      <WikiItemActionsProvider>
-        <WikiTree />
-      </WikiItemActionsProvider>,
-    );
+    setLeftPanelContent(<WikiTree />);
     return () => clearLeftPanelContent();
   }, [setLeftPanelContent, clearLeftPanelContent]);
 
@@ -110,8 +106,7 @@ export function WikiHome() {
         </div>
       </div>
 
-      <WikiItemActionsProvider>
-        <div className={styles.column}>
+      <div className={styles.column}>
           {/* Hero */}
           <div className={styles.hero}>
             <span className={styles.heroMark}>
@@ -213,7 +208,6 @@ export function WikiHome() {
             </div>
           )}
         </div>
-      </WikiItemActionsProvider>
     </main>
   );
 }

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -31,7 +31,7 @@ import type { DocumentTemplateSummary } from "@/lib/templates";
 import { AI_DRAFT_KEY, generateDraft, type RecentPage } from "@/lib/wiki";
 import { useAppLayout } from "@/sections/app/AppLayoutContext";
 
-import { WikiItemActionsProvider, WikiItemMenu } from "./WikiItemActions";
+import { WikiItemMenu } from "./WikiItemActions";
 import { WikiTree } from "./WikiTree";
 import styles from "./WikiHome.module.css";
 

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import useSWR from "swr";
@@ -29,6 +29,7 @@ import { relativeTime } from "@/lib/time";
 import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
 import { AI_DRAFT_KEY, generateDraft, type RecentPage } from "@/lib/wiki";
+import { useAppLayout } from "@/sections/app/AppLayoutContext";
 
 import { WikiItemActionsProvider, WikiItemMenu } from "./WikiItemActions";
 import { WikiTree } from "./WikiTree";
@@ -39,6 +40,16 @@ export function WikiHome() {
   const [aiPrompt, setAiPrompt] = useState("");
   const [generating, setGenerating] = useState(false);
   const [aiError, setAiError] = useState<string | null>(null);
+  const { setLeftPanelContent, clearLeftPanelContent } = useAppLayout();
+
+  useEffect(() => {
+    setLeftPanelContent(
+      <WikiItemActionsProvider>
+        <WikiTree />
+      </WikiItemActionsProvider>,
+    );
+    return () => clearLeftPanelContent();
+  }, [setLeftPanelContent, clearLeftPanelContent]);
 
   const { data: recentData } = useSWR<{ pages: RecentPage[] }>(
     "/wiki/recent?limit=12",
@@ -89,7 +100,7 @@ export function WikiHome() {
 
   return (
     <main className={styles.scroll}>
-      {/* Top header — breadcrumb (Home root; tree self-navigates by expanding) */}
+      {/* Top header — breadcrumb */}
       <div className={styles.topHeader}>
         <div className={styles.breadcrumb}>
           <span className={styles.modeBox}>
@@ -100,113 +111,107 @@ export function WikiHome() {
       </div>
 
       <WikiItemActionsProvider>
-        <div className={styles.body}>
-          <div className={styles.sidebar}>
-            <WikiTree />
+        <div className={styles.column}>
+          {/* Hero */}
+          <div className={styles.hero}>
+            <span className={styles.heroMark}>
+              <SvgOnyxLogo size={32} />
+            </span>
+            <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
+          </div>
+          <div className={styles.dividerWrap}>
+            <Divider />
           </div>
 
-          <div className={styles.column}>
-            {/* Hero */}
-            <div className={styles.hero}>
-              <span className={styles.heroMark}>
-                <SvgOnyxLogo size={32} />
-              </span>
-              <h1 className={styles.heroTitle}>Welcome to Onyx Wiki</h1>
+          {/* Start a new page */}
+          <div className={styles.sectionHeader}>
+            <span className={styles.secHead}>Start a new page</span>
+          </div>
+          <div className={styles.templates}>
+            <div className={styles.templateCell}>
+              <TemplateCard
+                title="Blank page"
+                glyph={
+                  <span className={styles.blankGlyph}>
+                    <SvgPlusCircle size={22} />
+                  </span>
+                }
+                onClick={() => startNewPage()}
+              />
             </div>
-            <div className={styles.dividerWrap}>
-              <Divider />
-            </div>
-
-            {/* Start a new page */}
-            <div className={styles.sectionHeader}>
-              <span className={styles.secHead}>Start a new page</span>
-            </div>
-            <div className={styles.templates}>
-              <div className={styles.templateCell}>
+            {featured.map((t) => (
+              <div key={t.id} className={styles.templateCell}>
                 <TemplateCard
-                  title="Blank page"
-                  glyph={
-                    <span className={styles.blankGlyph}>
-                      <SvgPlusCircle size={22} />
-                    </span>
-                  }
-                  onClick={() => startNewPage()}
+                  title={t.name}
+                  description={t.description ?? ""}
+                  onClick={() => startNewPage(t.id)}
                 />
               </div>
-              {featured.map((t) => (
-                <div key={t.id} className={styles.templateCell}>
-                  <TemplateCard
-                    title={t.name}
-                    description={t.description ?? ""}
-                    onClick={() => startNewPage(t.id)}
+            ))}
+          </div>
+          <button
+            type="button"
+            className={styles.moreRow}
+            onClick={() => startNewPage()}
+          >
+            <span className={styles.moreLabel}>More Templates</span>
+            <SvgChevronRight size={18} className={styles.moreChevron} />
+          </button>
+
+          {/* Write with AI */}
+          <div className={styles.aiRow}>
+            <span className={styles.aiGutterIcon}>
+              {generating ? (
+                <LoadingSpinner size={18} />
+              ) : (
+                <SvgOnyxOctagon size={18} />
+              )}
+            </span>
+            <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
+              <InputTypeIn
+                value={aiPrompt}
+                onChange={(e) => setAiPrompt(e.target.value)}
+                placeholder="Start writing with AI…"
+                aria-label="Start writing with AI"
+                rightChildren={
+                  <Button
+                    type="submit"
+                    size="sm"
+                    prominence="tertiary"
+                    icon={SvgArrowUp}
+                    disabled={!aiPrompt.trim() || generating}
+                    aria-label="Start writing"
+                  />
+                }
+              />
+            </form>
+          </div>
+          {aiError && <p className={styles.aiError}>{aiError}</p>}
+
+          <div className={styles.midDividerWrap}>
+            <Divider />
+          </div>
+
+          {/* Recent Pages */}
+          <div className={styles.sectionHeader}>
+            <span className={styles.secHeadLg}>Recent Pages</span>
+          </div>
+          {recent.length === 0 ? (
+            <p className={styles.empty}>
+              No pages yet. Create one to get started.
+            </p>
+          ) : (
+            <div className={styles.recentGrid}>
+              {recent.map((p) => (
+                <div key={p.path} className={styles.recentCell}>
+                  <RecentCard
+                    page={p}
+                    onClick={() => router.push(`/app/wiki/${p.path}`)}
                   />
                 </div>
               ))}
             </div>
-            <button
-              type="button"
-              className={styles.moreRow}
-              onClick={() => startNewPage()}
-            >
-              <span className={styles.moreLabel}>More Templates</span>
-              <SvgChevronRight size={18} className={styles.moreChevron} />
-            </button>
-
-            {/* Write with AI */}
-            <div className={styles.aiRow}>
-              <span className={styles.aiGutterIcon}>
-                {generating ? (
-                  <LoadingSpinner size={18} />
-                ) : (
-                  <SvgOnyxOctagon size={18} />
-                )}
-              </span>
-              <form className={styles.aiInputWrap} onSubmit={onAiSubmit}>
-                <InputTypeIn
-                  value={aiPrompt}
-                  onChange={(e) => setAiPrompt(e.target.value)}
-                  placeholder="Start writing with AI…"
-                  aria-label="Start writing with AI"
-                  rightChildren={
-                    <Button
-                      type="submit"
-                      size="sm"
-                      prominence="tertiary"
-                      icon={SvgArrowUp}
-                      disabled={!aiPrompt.trim() || generating}
-                      aria-label="Start writing"
-                    />
-                  }
-                />
-              </form>
-            </div>
-            {aiError && <p className={styles.aiError}>{aiError}</p>}
-
-            <div className={styles.midDividerWrap}>
-              <Divider />
-            </div>
-
-            {/* Recent Pages */}
-            <div className={styles.sectionHeader}>
-              <span className={styles.secHeadLg}>Recent Pages</span>
-            </div>
-            {recent.length === 0 ? (
-              <p className={styles.empty}>
-                No pages yet. Create one to get started.
-              </p>
-            ) : (
-              <div className={styles.recentGrid}>
-                {recent.map((p) => (
-                  <div key={p.path} className={styles.recentCell}>
-                    <RecentCard
-                      page={p}
-                      onClick={() => router.push(`/app/wiki/${p.path}`)}
-                    />
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+          )}
         </div>
       </WikiItemActionsProvider>
     </main>

--- a/frontend/src/sections/app/AppContentLayout.tsx
+++ b/frontend/src/sections/app/AppContentLayout.tsx
@@ -7,10 +7,17 @@ import { StatusBanner } from "./StatusBanner";
 import { useAppLayout } from "./AppLayoutContext";
 
 export function AppContentLayout({ children }: { children: ReactNode }) {
-  const { headerContent, actionSidebarContent, isActionSidebarOpen } =
-    useAppLayout();
+  const {
+    headerContent,
+    leftPanelContent,
+    actionSidebarContent,
+    isActionSidebarOpen,
+  } = useAppLayout();
   return (
     <>
+      {leftPanelContent && (
+        <RootLayout.LeftPanel>{leftPanelContent}</RootLayout.LeftPanel>
+      )}
       <RootLayout.App>
         <StatusBanner />
         <RootLayout.Header>

--- a/frontend/src/sections/app/AppContentLayout.tsx
+++ b/frontend/src/sections/app/AppContentLayout.tsx
@@ -5,6 +5,7 @@ import { RootLayout } from "@onyx-ai/opal/layouts";
 import styles from "./AppContentLayout.module.css";
 import { StatusBanner } from "./StatusBanner";
 import { useAppLayout } from "./AppLayoutContext";
+import { WikiItemActionsProvider } from "@/components/wiki/WikiItemActions";
 
 export function AppContentLayout({ children }: { children: ReactNode }) {
   const {
@@ -14,7 +15,7 @@ export function AppContentLayout({ children }: { children: ReactNode }) {
     isActionSidebarOpen,
   } = useAppLayout();
   return (
-    <>
+    <WikiItemActionsProvider>
       {leftPanelContent && (
         <RootLayout.LeftPanel>{leftPanelContent}</RootLayout.LeftPanel>
       )}
@@ -32,6 +33,6 @@ export function AppContentLayout({ children }: { children: ReactNode }) {
           {actionSidebarContent}
         </RootLayout.RightPanel>
       )}
-    </>
+    </WikiItemActionsProvider>
   );
 }

--- a/frontend/src/sections/app/AppLayoutContext.tsx
+++ b/frontend/src/sections/app/AppLayoutContext.tsx
@@ -11,6 +11,7 @@ import {
 
 interface AppLayoutState {
   headerContent: ReactNode;
+  leftPanelContent: ReactNode | null;
   actionSidebarContent: ReactNode | null;
   isActionSidebarOpen: boolean;
 }
@@ -18,6 +19,8 @@ interface AppLayoutState {
 interface AppLayoutContextValue extends AppLayoutState {
   setHeaderContent: (node: ReactNode) => void;
   clearHeaderContent: () => void;
+  setLeftPanelContent: (node: ReactNode) => void;
+  clearLeftPanelContent: () => void;
   openActionSidebar: (content: ReactNode) => void;
   closeActionSidebar: () => void;
 }
@@ -26,11 +29,18 @@ const AppLayoutContext = createContext<AppLayoutContextValue | null>(null);
 
 export function AppLayoutProvider({ children }: { children: ReactNode }) {
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
+  const [leftPanelContent, setLeftPanelContent] = useState<ReactNode | null>(
+    null,
+  );
   const [actionSidebarContent, setActionSidebarContent] =
     useState<ReactNode | null>(null);
   const [isActionSidebarOpen, setIsActionSidebarOpen] = useState(false);
 
   const clearHeaderContent = useCallback(() => setHeaderContent(null), []);
+  const clearLeftPanelContent = useCallback(
+    () => setLeftPanelContent(null),
+    [],
+  );
   const openActionSidebar = useCallback((content: ReactNode) => {
     setActionSidebarContent(content);
     setIsActionSidebarOpen(true);
@@ -43,18 +53,23 @@ export function AppLayoutProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AppLayoutContextValue>(
     () => ({
       headerContent,
+      leftPanelContent,
       actionSidebarContent,
       isActionSidebarOpen,
       setHeaderContent,
       clearHeaderContent,
+      setLeftPanelContent,
+      clearLeftPanelContent,
       openActionSidebar,
       closeActionSidebar,
     }),
     [
       headerContent,
+      leftPanelContent,
       actionSidebarContent,
       isActionSidebarOpen,
       clearHeaderContent,
+      clearLeftPanelContent,
       openActionSidebar,
       closeActionSidebar,
     ],


### PR DESCRIPTION
## Summary

- Adds `leftPanelContent` / `setLeftPanelContent` / `clearLeftPanelContent` to `AppLayoutContext`, following the same pattern as `actionSidebarContent`
- Wires `RootLayout.LeftPanel` in `AppContentLayout` — renders when content is present, absent otherwise
- `WikiHome` mounts `<WikiItemActionsProvider><WikiTree /></WikiItemActionsProvider>` into the left panel via `useEffect` (cleared on unmount), removing the old internal flex sidebar layout and its CSS

## Screenshots + Videos

<img width="1663" height="1842" alt="image" src="https://github.com/user-attachments/assets/1bf0a4a6-abce-4813-9384-79523f873512" />