### PR TITLE
feat(wiki): show open doc name in the browser tab title

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -142,6 +142,16 @@ export default function WikiRoute() {
     if (isFile) void recordRecentDoc(slugPath);
   }, [slugPath, isFile]);
 
+  // Tab title tracks the open doc (or folder); falls back to the app name.
+  useEffect(() => {
+    const last = slugPath.split("/").pop() ?? "";
+    const label = isFile ? last.replace(/\.md$/i, "") : last;
+    document.title = label || "agent-wiki";
+    return () => {
+      document.title = "agent-wiki";
+    };
+  }, [slugPath, isFile]);
+
   if (loading || !user)
     return (
       <main className={isMobile ? "p-4" : "p-8"}>


### PR DESCRIPTION
## Description

The browser tab always showed `agent-wiki`. Viewing a doc now sets the tab title to the doc name (e.g. `10k wiki corpus and updates`); folder pages show the folder name; the wiki root and other pages keep the default. One effect in `WikiRoute`; restores the default title on unmount. Long names are ellipsized by the browser tab itself.