### PR TITLE
fix(wiki): render Markdown links whose target contains spaces

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -59,6 +59,7 @@ import {
   type CommentDraft,
 } from "@/lib/commentAnchor";
 import { rehypeSourcePos } from "@/lib/rehypeSourcePos";
+import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
 import { useRequireAuth } from "@/lib/auth";
 import { useDrafting } from "@/lib/drafting";
 import { rememberWikiPath } from "@/lib/lastViewed";
@@ -1387,7 +1388,7 @@ function FileViewer({ path }: { path: string }) {
   const renderedBody = useMemo(
     () => (
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}
         rehypePlugins={[rehypeSourcePos]}
       >
         {body}

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -11,6 +11,8 @@ import {
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
+
 import styles from "./ChatWidget.module.css";
 
 import { Button } from "@onyx-ai/opal/components";
@@ -888,7 +890,7 @@ function Bubble({
       >
         {renderMarkdown ? (
           <ReactMarkdown
-            remarkPlugins={[remarkGfm]}
+            remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}
             components={markdownComponents}
           >
             {content}

--- a/frontend/src/components/wiki/DiffHunk.tsx
+++ b/frontend/src/components/wiki/DiffHunk.tsx
@@ -2,6 +2,8 @@ import type { JSX } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
+
 import type { DiffHunk as DiffHunkData, DiffLine, WordDiff } from "@/lib/wiki";
 
 import styles from "./DiffHunk.module.css";
@@ -151,7 +153,7 @@ export function DiffHunk({ hunk }: { hunk: DiffHunkData }) {
         if (entry.kind === "context") {
           return (
             <div key={idx} className={`${styles.context} markdown`}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}>
                 {entry.text}
               </ReactMarkdown>
             </div>
@@ -161,7 +163,7 @@ export function DiffHunk({ hunk }: { hunk: DiffHunkData }) {
         return (
           <div key={idx} className={cls}>
             <div className={`${styles.blockContent} markdown`}>
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+              <ReactMarkdown remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}>
                 {entry.text}
               </ReactMarkdown>
             </div>

--- a/frontend/src/components/wiki/DiffView.tsx
+++ b/frontend/src/components/wiki/DiffView.tsx
@@ -3,6 +3,8 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
+import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
+
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { absoluteTime, relativeTime } from "@/lib/time";
 import type { FileDiffResponse } from "@/lib/wiki";
@@ -122,7 +124,7 @@ export function DiffView({
           </div>
         ) : (
           <article className={`${styles.doc} markdown`}>
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}>
               {body ?? ""}
             </ReactMarkdown>
           </article>

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState, type FormEvent } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+
+import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
 import useSWR from "swr";
 import {
   Button,
@@ -254,7 +256,7 @@ function RecentCard({
             {page.title}
           </Text>
           <div className={styles.cardPreview}>
-            <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            <ReactMarkdown remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}>
               {page.preview}
             </ReactMarkdown>
           </div>

--- a/frontend/src/lib/remarkBareSpaceLinks.ts
+++ b/frontend/src/lib/remarkBareSpaceLinks.ts
@@ -91,7 +91,13 @@ function transform(node: MdastNode): void {
         next.push(...replaced);
         continue;
       }
-    } else if (child.children) {
+    } else if (
+      child.children &&
+      child.type !== "link" &&
+      child.type !== "image"
+    ) {
+      // Don't recurse into a link/image: re-linkifying its label text would nest
+      // a link inside a link (invalid `<a><a>`).
       transform(child);
     }
     next.push(child);

--- a/frontend/src/lib/remarkBareSpaceLinks.ts
+++ b/frontend/src/lib/remarkBareSpaceLinks.ts
@@ -1,0 +1,101 @@
+/**
+ * Re-linkify Markdown link/image targets that contain spaces.
+ *
+ * CommonMark only linkifies `[text](dest)` when `dest` has no spaces (or is
+ * angle-bracketed), so internal wiki links — whose paths routinely contain
+ * spaces — render as literal text. This remark plugin rewrites such targets to
+ * `%20` form at render time, so authors never need angle brackets. Output still
+ * flows through react-markdown's `defaultUrlTransform`, so unsafe schemes stay
+ * neutralized.
+ *
+ * Runs on mdast `text` nodes only; `inlineCode` / `code` hold their content in
+ * `value`, not child text nodes, so link-like sequences in code are untouched.
+ */
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  children?: MdastNode[];
+  url?: string;
+  alt?: string | null;
+  title?: string | null;
+}
+
+// `[label](dest)` / `![alt](dest)` where dest holds >=1 space and no `()<>`. The
+// lookahead does the has-a-space test so the destination is a single bounded
+// quantifier with no inter-group backtracking (ReDoS-safe). Excluding `<` leaves
+// already-angle-bracketed destinations unmatched (CommonMark handles those).
+const SPACE_LINK =
+  /(!?)\[([^\]\n]{1,500})\]\((?=[^()<>\n]{0,2048}\s)([^()<>\n]{1,2048})\)/g;
+
+// A trailing CommonMark link title: ` "..."` or ` '...'`.
+const TRAILING_TITLE = /\s+(?:"([^"]*)"|'([^']*)')\s*$/;
+
+function encodeTarget(dest: string): string {
+  return dest.replace(/ /g, "%20");
+}
+
+function relinkify(value: string): MdastNode[] | null {
+  // No inline-link syntax → skip the regex entirely (the common case, and bounds
+  // adversarial text that has no `](`).
+  if (!value.includes("](")) return null;
+  SPACE_LINK.lastIndex = 0;
+  const out: MdastNode[] = [];
+  let cursor = 0;
+  let matched = false;
+  let match: RegExpExecArray | null;
+  while ((match = SPACE_LINK.exec(value)) !== null) {
+    matched = true;
+    const [full, bang, label, rawDest] = match;
+    if (match.index > cursor) {
+      out.push({ type: "text", value: value.slice(cursor, match.index) });
+    }
+    let dest = rawDest.trim();
+    let title: string | null = null;
+    const titleMatch = TRAILING_TITLE.exec(dest);
+    if (titleMatch) {
+      dest = dest.slice(0, titleMatch.index).trim();
+      title = titleMatch[1] ?? titleMatch[2];
+    }
+    const url = encodeTarget(dest);
+    if (bang === "!") {
+      out.push({ type: "image", url, alt: label, title });
+    } else {
+      out.push({
+        type: "link",
+        url,
+        title,
+        children: [{ type: "text", value: label }],
+      });
+    }
+    cursor = match.index + full.length;
+  }
+  if (!matched) return null;
+  if (cursor < value.length) {
+    out.push({ type: "text", value: value.slice(cursor) });
+  }
+  return out;
+}
+
+function transform(node: MdastNode): void {
+  const children = node.children;
+  if (!children) return;
+  const next: MdastNode[] = [];
+  for (const child of children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      const replaced = relinkify(child.value);
+      if (replaced) {
+        next.push(...replaced);
+        continue;
+      }
+    } else if (child.children) {
+      transform(child);
+    }
+    next.push(child);
+  }
+  node.children = next;
+}
+
+export function remarkBareSpaceLinks() {
+  return (tree: MdastNode): void => transform(tree);
+}

--- a/frontend/src/lib/remarkBareSpaceLinks.ts
+++ b/frontend/src/lib/remarkBareSpaceLinks.ts
@@ -32,7 +32,10 @@ const SPACE_LINK =
 const TRAILING_TITLE = /\s+(?:"([^"]*)"|'([^']*)')\s*$/;
 
 function encodeTarget(dest: string): string {
-  return dest.replace(/ /g, "%20");
+  // encodeURI handles spaces + non-ASCII + unsafe chars while preserving path
+  // structure and `#`/`?` (so heading-anchor / query links keep working); the
+  // trailing replace restores any already-valid %XX escape it double-encoded.
+  return encodeURI(dest).replace(/%25([0-9A-Fa-f]{2})/g, "%$1");
 }
 
 function relinkify(value: string): MdastNode[] | null {


### PR DESCRIPTION
## Description

**Bug:** internal wiki links whose path contains spaces (e.g. `[doc](Some Page.md)`) render as literal `[doc](...)` text, not clickable links.

**Why:** CommonMark (react-markdown) only linkifies a destination with spaces if it's angle-bracketed; wiki paths routinely have spaces.

**Fix:** a remark plugin (`remarkBareSpaceLinks`) re-linkifies link/image targets containing spaces to `%20` form at render time, wired into all five react-markdown surfaces (wiki page, diff view, diff hunk, wiki home, chat). Existing pages are fixed with no re-saving; authors never need angle brackets.

- text-nodes only → code spans/blocks untouched
- ReDoS-safe (lookahead + bounded quantifier, no inter-group backtracking)
- still flows through `defaultUrlTransform` → unsafe schemes stay neutralized
- preserves an optional trailing link title

## How Has This Been Tested?

- `bun run typecheck` + `prettier --check` clean; pre-commit (prettier + tsc) green. No `.py` changed.
- react-markdown render checks: space links → `%20` href; code spans stay `<code>`; images, `../` parent paths, titled links all correct.
- Adversarial review (GPT-5.4) caught a ReDoS in the first regex (43s freeze on an unclosed `(`); fixed — same inputs now 28–150 ms.