### PR TITLE
feat(llm): support custom OpenAI-compatible providers

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -15,6 +15,7 @@ from app.auth import invites
 from app.auth.deps import require_admin
 from app.ingest import settings as ingest_settings
 from app.ingest.settings import IngestSettings
+from app.llm import providers as llm_providers
 from app.llm import settings as llm_settings
 from app.llm.settings import LLMSettings
 from app.models.admin import (
@@ -204,9 +205,6 @@ def _redact(key: str) -> str:
     return f"{key[:4]}…{key[-4:]}"
 
 
-_ALLOWED_PROVIDERS = ("anthropic", "openai", "gemini", "ollama", "custom")
-
-
 def _llm_view(s: LLMSettings) -> LLMView:
     return LLMView(
         provider=s.provider,
@@ -225,6 +223,22 @@ def _llm_view(s: LLMSettings) -> LLMView:
         provider_models=s.provider_models,
         ingest_selector_model=s.ingest_selector_model,
     )
+
+
+def _normalize_custom_base_url(raw: str) -> str:
+    url = raw.strip().rstrip("/")
+    if url:
+        if not url.startswith(("http://", "https://")):
+            raise HTTPException(
+                status_code=400,
+                detail="custom_base_url must start with http:// or https://",
+            )
+        if url.endswith("/chat/completions"):
+            raise HTTPException(
+                status_code=400,
+                detail="custom_base_url should be the API base (e.g. https://host/v1) — requests append /chat/completions automatically",
+            )
+    return url
 
 
 @router.get("/llm", response_model=LLMView)
@@ -246,11 +260,10 @@ def put_llm(
     if "provider" in sent_fields or "model" in sent_fields:
         provider = (req.provider or "").strip().lower()
         model = (req.model or "").strip()
-        if provider not in _ALLOWED_PROVIDERS:
-            allowed = ", ".join(f"'{p}'" for p in _ALLOWED_PROVIDERS)
-            raise HTTPException(
-                status_code=400, detail=f"provider must be one of {allowed}"
-            )
+        allowed = llm_providers.names()
+        if provider not in allowed:
+            allowed_str = ", ".join(f"'{p}'" for p in allowed)
+            raise HTTPException(status_code=400, detail=f"provider must be one of {allowed_str}")
         if not model:
             raise HTTPException(status_code=400, detail="model is required")
     else:
@@ -269,43 +282,22 @@ def put_llm(
     anthropic_key = _resolve_secret(
         "anthropic_api_key", req.anthropic_api_key, current.anthropic_api_key
     )
-    openai_key = _resolve_secret(
-        "openai_api_key", req.openai_api_key, current.openai_api_key
-    )
-    gemini_key = _resolve_secret(
-        "gemini_api_key", req.gemini_api_key, current.gemini_api_key
-    )
+    openai_key = _resolve_secret("openai_api_key", req.openai_api_key, current.openai_api_key)
+    gemini_key = _resolve_secret("gemini_api_key", req.gemini_api_key, current.gemini_api_key)
     ollama_base_url = _resolve_secret(
         "ollama_base_url", req.ollama_base_url, current.ollama_base_url
     )
-    custom_api_key = _resolve_secret(
-        "custom_api_key", req.custom_api_key, current.custom_api_key
-    )
-    custom_base_url = (
+    custom_api_key = _resolve_secret("custom_api_key", req.custom_api_key, current.custom_api_key)
+    custom_base_url = _normalize_custom_base_url(
         _resolve_secret("custom_base_url", req.custom_base_url, current.custom_base_url)
-        .strip()
-        .rstrip("/")
     )
-    if custom_base_url:
-        if not custom_base_url.startswith(("http://", "https://")):
-            raise HTTPException(
-                status_code=400,
-                detail="custom_base_url must start with http:// or https://",
-            )
-        if custom_base_url.endswith("/chat/completions"):
-            raise HTTPException(
-                status_code=400,
-                detail="custom_base_url should be the API base (e.g. https://host/v1) — requests append /chat/completions automatically",
-            )
 
     if "custom_display_name" in sent_fields:
         custom_display_name = (req.custom_display_name or "").strip()
     else:
         custom_display_name = current.custom_display_name
 
-    new_provider_models = (
-        req.provider_models if "provider_models" in sent_fields else None
-    )
+    new_provider_models = req.provider_models if "provider_models" in sent_fields else None
 
     if "ingest_selector_model" in sent_fields:
         ingest_selector_model = (req.ingest_selector_model or "").strip()

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -204,7 +204,7 @@ def _redact(key: str) -> str:
     return f"{key[:4]}…{key[-4:]}"
 
 
-_ALLOWED_PROVIDERS = ("anthropic", "openai", "gemini", "ollama")
+_ALLOWED_PROVIDERS = ("anthropic", "openai", "gemini", "ollama", "custom")
 
 
 def _llm_view(s: LLMSettings) -> LLMView:
@@ -218,6 +218,10 @@ def _llm_view(s: LLMSettings) -> LLMView:
         openai_api_key_hint=_redact(s.openai_api_key),
         gemini_api_key_hint=_redact(s.gemini_api_key),
         ollama_base_url=s.ollama_base_url,
+        custom_api_key_set=bool(s.custom_api_key),
+        custom_api_key_hint=_redact(s.custom_api_key),
+        custom_base_url=s.custom_base_url,
+        custom_display_name=s.custom_display_name,
         provider_models=s.provider_models,
         ingest_selector_model=s.ingest_selector_model,
     )
@@ -274,6 +278,30 @@ def put_llm(
     ollama_base_url = _resolve_secret(
         "ollama_base_url", req.ollama_base_url, current.ollama_base_url
     )
+    custom_api_key = _resolve_secret(
+        "custom_api_key", req.custom_api_key, current.custom_api_key
+    )
+    custom_base_url = (
+        _resolve_secret("custom_base_url", req.custom_base_url, current.custom_base_url)
+        .strip()
+        .rstrip("/")
+    )
+    if custom_base_url:
+        if not custom_base_url.startswith(("http://", "https://")):
+            raise HTTPException(
+                status_code=400,
+                detail="custom_base_url must start with http:// or https://",
+            )
+        if custom_base_url.endswith("/chat/completions"):
+            raise HTTPException(
+                status_code=400,
+                detail="custom_base_url should be the API base (e.g. https://host/v1) — requests append /chat/completions automatically",
+            )
+
+    if "custom_display_name" in sent_fields:
+        custom_display_name = (req.custom_display_name or "").strip()
+    else:
+        custom_display_name = current.custom_display_name
 
     new_provider_models = (
         req.provider_models if "provider_models" in sent_fields else None
@@ -291,6 +319,9 @@ def put_llm(
         openai_api_key=openai_key,
         gemini_api_key=gemini_key,
         ollama_base_url=ollama_base_url,
+        custom_api_key=custom_api_key,
+        custom_base_url=custom_base_url,
+        custom_display_name=custom_display_name,
         provider_models=new_provider_models,
         ingest_selector_model=ingest_selector_model,
     )

--- a/backend/app/api/llm.py
+++ b/backend/app/api/llm.py
@@ -52,6 +52,7 @@ def available(_user: User = Depends(require_user)) -> AvailableProvidersResponse
         ("openai", bool(s.openai_api_key)),
         ("gemini", bool(s.gemini_api_key)),
         ("ollama", bool(s.ollama_base_url)),
+        ("custom", bool(s.custom_base_url)),
     ]
     for name, has_creds in checks:
         if not has_creds:
@@ -62,6 +63,18 @@ def available(_user: User = Depends(require_user)) -> AvailableProvidersResponse
         try:
             p.check_configured(s)
         except LLMError:
+            continue
+        if name == "custom":
+            # Free-text models only — no built-in catalog; hide until ≥1 model saved.
+            models = s.provider_models.get("custom", [])
+            if not models:
+                continue
+            result.append(AvailableProvider(
+                provider=name,
+                label=s.custom_display_name or "Custom",
+                default_model=models[0],
+                models=models,
+            ))
             continue
         label, default_model = _PROVIDER_LABELS.get(name, (name, ""))
         saved = s.provider_models.get(name, [])

--- a/backend/app/db/migrations/versions/0029_custom_provider.py
+++ b/backend/app/db/migrations/versions/0029_custom_provider.py
@@ -1,0 +1,42 @@
+"""custom-provider
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-06-10 22:15:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0029"
+down_revision: str = "0028"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS custom_api_key TEXT NOT NULL DEFAULT ''"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS custom_base_url TEXT NOT NULL DEFAULT ''"
+        )
+    )
+    op.execute(
+        sa.text(
+            "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS custom_display_name TEXT NOT NULL DEFAULT ''"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("llm_settings", "custom_api_key")
+    op.drop_column("llm_settings", "custom_base_url")
+    op.drop_column("llm_settings", "custom_display_name")

--- a/backend/app/db/migrations/versions/0029_custom_provider.py
+++ b/backend/app/db/migrations/versions/0029_custom_provider.py
@@ -19,21 +19,18 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.execute(
-        sa.text(
-            "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS custom_api_key TEXT NOT NULL DEFAULT ''"
-        )
-    )
-    op.execute(
-        sa.text(
-            "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS custom_base_url TEXT NOT NULL DEFAULT ''"
-        )
-    )
-    op.execute(
-        sa.text(
-            "ALTER TABLE llm_settings ADD COLUMN IF NOT EXISTS custom_display_name TEXT NOT NULL DEFAULT ''"
-        )
-    )
+    # Guarded adds: the 0001 bootstrap creates the full current schema via
+    # create_all, so fresh installs already have these columns.
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("llm_settings")}
+
+    for name in ("custom_api_key", "custom_base_url", "custom_display_name"):
+        if name not in cols:
+            op.add_column(
+                "llm_settings",
+                sa.Column(name, sa.Text, nullable=False, server_default=sa.text("''")),
+            )
 
 
 def downgrade() -> None:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -684,6 +684,15 @@ class LLMSettings(Base):
     ollama_base_url: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("''")
     )
+    custom_api_key: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    custom_base_url: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    custom_display_name: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
     provider_models: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -25,6 +25,7 @@ relies on. Provider modules must:
 * Map SDK-specific exceptions to ``LLMError`` (raised by the SDK SDK,
   caught in the provider's ``stream``).
 """
+
 from __future__ import annotations
 
 from typing import Any, Iterator, Protocol
@@ -92,6 +93,7 @@ def names() -> list[str]:
 # actually compiled in. Keep imports at the bottom — each module references
 # `register` from this module.
 from app.llm.providers import anthropic as _anthropic  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
+from app.llm.providers import custom as _custom  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
 from app.llm.providers import gemini as _gemini  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
 from app.llm.providers import ollama as _ollama  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
 from app.llm.providers import openai as _openai  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]

--- a/backend/app/llm/providers/_openai_errors.py
+++ b/backend/app/llm/providers/_openai_errors.py
@@ -1,0 +1,39 @@
+# Shared provider-seam error mapping for OpenAI-SDK providers; keep the SDK import inside providers/.
+from __future__ import annotations
+
+import openai
+
+from app.llm.errors import LLMError
+
+
+def translate_openai_error(exc: Exception, *, provider_label: str) -> LLMError:
+    if isinstance(exc, openai.AuthenticationError):
+        return LLMError(
+            "auth",
+            f"{provider_label} rejected the API key. An admin needs to update it on the admin page.",
+        )
+    if isinstance(exc, openai.PermissionDeniedError):
+        return LLMError(
+            "auth",
+            f"{provider_label} denied access for the configured API key.",
+        )
+    if isinstance(exc, openai.RateLimitError):
+        return LLMError(
+            "rate_limit",
+            f"{provider_label} rate limit hit. Please retry in a moment.",
+        )
+    if isinstance(exc, openai.APIConnectionError):
+        return LLMError(
+            "network",
+            f"Could not reach {provider_label}. Check the backend's network access.",
+        )
+    if isinstance(exc, openai.NotFoundError):
+        return LLMError(
+            "config",
+            f"{provider_label} returned 'not found' — usually a bad model name. Check the configured model.",
+        )
+    if isinstance(exc, openai.BadRequestError):
+        return LLMError("bad_request", f"{provider_label} rejected the request: {exc}")
+    if isinstance(exc, openai.APIStatusError):
+        return LLMError("provider", f"{provider_label} error: {exc}")
+    return LLMError("unknown", f"Unexpected error talking to {provider_label}.")

--- a/backend/app/llm/providers/custom.py
+++ b/backend/app/llm/providers/custom.py
@@ -1,0 +1,237 @@
+"""Custom provider — OpenAI-compatible gateways via Chat Completions."""
+
+from __future__ import annotations
+
+import json
+import logging
+from functools import lru_cache
+from typing import Any, Iterator, cast
+
+from openai import OpenAI
+
+from app.llm.errors import LLMError
+from app.llm.providers._common import safe_json_loads, stringify_tool_result
+from app.llm.settings import LLMSettings
+
+log = logging.getLogger(__name__)
+
+StreamEvent = dict[str, Any]
+
+
+@lru_cache(maxsize=4)
+def _client(api_key: str, base_url: str) -> OpenAI:
+    """Cached OpenAI client for compat gateways."""
+    return OpenAI(api_key=api_key or "EMPTY", base_url=base_url)
+
+
+def _create_stream(client: OpenAI, kwargs: dict[str, Any]) -> Any:
+    """Retry once for gateways that reject stream usage metadata."""
+    import openai
+
+    completions = cast(Any, client.chat).completions
+    try:
+        return completions.create(**kwargs, stream_options={"include_usage": True})
+    except openai.BadRequestError as exc:
+        msg = str(exc).lower()
+        if "stream_options" not in msg and "include_usage" not in msg:
+            raise
+    return completions.create(**kwargs)
+
+
+class CustomProvider:
+    name = "custom"
+
+    def check_configured(self, settings: LLMSettings) -> None:
+        if not settings.custom_base_url:
+            raise LLMError(
+                "not_configured",
+                "Custom provider base URL is not set. An admin needs to add it on the admin page.",
+            )
+
+    def stream(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+        settings: LLMSettings,
+    ) -> Iterator[StreamEvent]:
+        cc_messages = [_cc_message(m) for m in messages]
+
+        kwargs: dict[str, Any] = {
+            "model": model,
+            "messages": cc_messages,
+            "max_tokens": max_tokens,
+            "stream": True,
+        }
+        if tools:
+            kwargs["tools"] = [_cc_tool(t) for t in tools]
+
+        log.info(
+            "llm request provider=custom model=%s tools=%d max_tokens=%d messages=%d",
+            model,
+            len(tools or []),
+            max_tokens,
+            len(cc_messages),
+        )
+        client = _client(settings.custom_api_key, settings.custom_base_url)
+        try:
+            stop_reason = ""
+            usage: Any = None
+            tool_chunks: dict[int, dict[str, Any]] = {}
+            chunks = _create_stream(client, kwargs)
+            for raw_chunk in chunks:
+                chunk = raw_chunk
+                if not chunk.choices:
+                    chunk_usage = getattr(chunk, "usage", None)
+                    if chunk_usage is not None:
+                        usage = chunk_usage
+                    continue
+
+                choice = chunk.choices[0]
+                delta = getattr(choice, "delta", None)
+                if delta is not None:
+                    if delta.content:
+                        yield {"type": "text_delta", "text": delta.content}
+                    raw_tool_calls = getattr(delta, "tool_calls", None)
+                    if raw_tool_calls:
+                        for raw_tc in raw_tool_calls:
+                            tc = raw_tc
+                            index = getattr(tc, "index", None)
+                            if index is None:
+                                continue
+                            rec = tool_chunks.setdefault(
+                                index,
+                                {"id": None, "name": None, "args_buf": ""},
+                            )
+                            tc_id = getattr(tc, "id", None)
+                            if rec["id"] is None and tc_id is not None:
+                                rec["id"] = tc_id
+                            fn = getattr(tc, "function", None)
+                            if fn is not None:
+                                fn_name = getattr(fn, "name", None)
+                                if rec["name"] is None and fn_name is not None:
+                                    rec["name"] = fn_name
+                                fn_args = getattr(fn, "arguments", None)
+                                if fn_args:
+                                    rec["args_buf"] += fn_args
+
+                finish_reason = getattr(choice, "finish_reason", None)
+                if finish_reason is not None:
+                    stop_reason = cast(str, finish_reason)
+
+                chunk_usage = getattr(chunk, "usage", None)
+                if chunk_usage is not None:
+                    usage = chunk_usage
+
+            for index in sorted(tool_chunks.keys()):
+                rec = tool_chunks[index]
+                yield {
+                    "type": "tool_call",
+                    "id": rec["id"] or f"call_{index}",
+                    "name": rec["name"] or "",
+                    "arguments": safe_json_loads(rec["args_buf"]),
+                }
+
+            in_tok = int(getattr(usage, "prompt_tokens", 0) or 0)
+            out_tok = int(getattr(usage, "completion_tokens", 0) or 0)
+            details = getattr(usage, "completion_tokens_details", None)
+            reason_tok = int(getattr(details, "reasoning_tokens", 0) or 0)
+            log.info(
+                "llm done provider=custom model=%s stop=%s tokens=%d/%d",
+                model,
+                stop_reason,
+                in_tok,
+                out_tok,
+            )
+            yield {
+                "type": "done",
+                "stop_reason": stop_reason,
+                "usage": {
+                    "input_tokens": in_tok,
+                    "output_tokens": out_tok,
+                    "reasoning_tokens": reason_tok,
+                },
+            }
+        except LLMError:
+            raise
+        except Exception as exc:
+            log.exception("llm provider error provider=custom model=%s", model)
+            raise _translate_error(exc) from exc
+
+
+def _cc_message(m: dict[str, Any]) -> dict[str, Any]:
+    role = m["role"]
+    if role == "assistant" and m.get("tool_calls"):
+        content = m.get("content") or None
+        return {
+            "role": "assistant",
+            "content": content,
+            "tool_calls": [
+                {
+                    "id": tc["id"],
+                    "type": "function",
+                    "function": {
+                        "name": tc["name"],
+                        "arguments": json.dumps(tc["arguments"]),
+                    },
+                }
+                for tc in m["tool_calls"]
+            ],
+        }
+    if role == "tool":
+        return {
+            "role": "tool",
+            "tool_call_id": m["tool_call_id"],
+            "content": stringify_tool_result(m["content"]),
+        }
+    return {"role": role, "content": m["content"]}
+
+
+def _cc_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": tool["name"],
+            "description": tool.get("description", ""),
+            "parameters": tool["input_schema"],
+        },
+    }
+
+
+def _translate_error(exc: Exception) -> LLMError:
+    import openai
+
+    if isinstance(exc, openai.AuthenticationError):
+        return LLMError(
+            "auth",
+            "Custom provider rejected the API key. An admin needs to update it on the admin page.",
+        )
+    if isinstance(exc, openai.PermissionDeniedError):
+        return LLMError("auth", "Custom provider denied access for the configured API key.")
+    if isinstance(exc, openai.RateLimitError):
+        return LLMError("rate_limit", "Custom provider rate limit hit. Please retry in a moment.")
+    if isinstance(exc, openai.APIConnectionError):
+        return LLMError(
+            "network",
+            "Could not reach the Custom provider. Check the backend's network access.",
+        )
+    if isinstance(exc, openai.NotFoundError):
+        return LLMError(
+            "config",
+            "Custom provider returned 'not found' — usually a bad model name. Check the configured model.",
+        )
+    if isinstance(exc, openai.BadRequestError):
+        return LLMError("bad_request", f"Custom provider rejected the request: {exc}")
+    if isinstance(exc, openai.APIStatusError):
+        return LLMError("provider", f"Custom provider error: {exc}")
+    return LLMError("unknown", "Unexpected error talking to Custom provider.")
+
+
+PROVIDER = CustomProvider()
+
+
+from app.llm.providers import register  # noqa: E402
+
+register(PROVIDER)  # pyright: ignore[reportUnknownMemberType]

--- a/backend/app/llm/providers/custom.py
+++ b/backend/app/llm/providers/custom.py
@@ -7,27 +7,29 @@ import logging
 from functools import lru_cache
 from typing import Any, Iterator, cast
 
+import openai
 from openai import OpenAI
 
 from app.llm.errors import LLMError
 from app.llm.providers._common import safe_json_loads, stringify_tool_result
+from app.llm.providers._openai_errors import translate_openai_error
 from app.llm.settings import LLMSettings
 
 log = logging.getLogger(__name__)
 
 StreamEvent = dict[str, Any]
 
+_KEYLESS_API_KEY = "EMPTY"  # vLLM/LM Studio allow keyless mode; the SDK still needs a value.
+
 
 @lru_cache(maxsize=4)
 def _client(api_key: str, base_url: str) -> OpenAI:
     """Cached OpenAI client for compat gateways."""
-    return OpenAI(api_key=api_key or "EMPTY", base_url=base_url)
+    return OpenAI(api_key=api_key or _KEYLESS_API_KEY, base_url=base_url)
 
 
 def _create_stream(client: OpenAI, kwargs: dict[str, Any]) -> Any:
     """Retry once for gateways that reject stream usage metadata."""
-    import openai
-
     completions = cast(Any, client.chat).completions
     try:
         return completions.create(**kwargs, stream_options={"include_usage": True})
@@ -158,7 +160,7 @@ class CustomProvider:
             raise
         except Exception as exc:
             log.exception("llm provider error provider=custom model=%s", model)
-            raise _translate_error(exc) from exc
+            raise translate_openai_error(exc, provider_label="Custom provider") from exc
 
 
 def _cc_message(m: dict[str, Any]) -> dict[str, Any]:
@@ -198,35 +200,6 @@ def _cc_tool(tool: dict[str, Any]) -> dict[str, Any]:
             "parameters": tool["input_schema"],
         },
     }
-
-
-def _translate_error(exc: Exception) -> LLMError:
-    import openai
-
-    if isinstance(exc, openai.AuthenticationError):
-        return LLMError(
-            "auth",
-            "Custom provider rejected the API key. An admin needs to update it on the admin page.",
-        )
-    if isinstance(exc, openai.PermissionDeniedError):
-        return LLMError("auth", "Custom provider denied access for the configured API key.")
-    if isinstance(exc, openai.RateLimitError):
-        return LLMError("rate_limit", "Custom provider rate limit hit. Please retry in a moment.")
-    if isinstance(exc, openai.APIConnectionError):
-        return LLMError(
-            "network",
-            "Could not reach the Custom provider. Check the backend's network access.",
-        )
-    if isinstance(exc, openai.NotFoundError):
-        return LLMError(
-            "config",
-            "Custom provider returned 'not found' — usually a bad model name. Check the configured model.",
-        )
-    if isinstance(exc, openai.BadRequestError):
-        return LLMError("bad_request", f"Custom provider rejected the request: {exc}")
-    if isinstance(exc, openai.APIStatusError):
-        return LLMError("provider", f"Custom provider error: {exc}")
-    return LLMError("unknown", "Unexpected error talking to Custom provider.")
 
 
 PROVIDER = CustomProvider()

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -10,6 +10,7 @@ from openai import OpenAI
 
 from app.llm.errors import LLMError
 from app.llm.providers._common import safe_json_loads, split_system
+from app.llm.providers._openai_errors import translate_openai_error
 from app.llm.settings import LLMSettings
 
 log = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ class OpenAIProvider:
             raise
         except Exception as exc:
             log.exception("llm provider error provider=openai model=%s", model)
-            raise _translate_error(exc) from exc
+            raise translate_openai_error(exc, provider_label="OpenAI") from exc
 
 
 def _input_items_for(m: dict[str, Any]) -> list[dict[str, Any]]:
@@ -145,9 +146,7 @@ def _input_items_for(m: dict[str, Any]) -> list[dict[str, Any]]:
     """
     role = m["role"]
     if role == "tool":
-        content = (
-            m["content"] if isinstance(m["content"], str) else json.dumps(m["content"])
-        )
+        content = m["content"] if isinstance(m["content"], str) else json.dumps(m["content"])
         return [
             {
                 "type": "function_call_output",
@@ -170,31 +169,6 @@ def _input_items_for(m: dict[str, Any]) -> list[dict[str, Any]]:
             )
         return items
     return [{"role": role, "content": m["content"]}]
-
-
-def _translate_error(exc: Exception) -> LLMError:
-    import openai
-
-    if isinstance(exc, openai.AuthenticationError):
-        return LLMError(
-            "auth", "OpenAI rejected the API key. An admin needs to update it on the admin page."
-        )
-    if isinstance(exc, openai.PermissionDeniedError):
-        return LLMError("auth", "OpenAI denied access for the configured API key.")
-    if isinstance(exc, openai.RateLimitError):
-        return LLMError("rate_limit", "OpenAI rate limit hit. Please retry in a moment.")
-    if isinstance(exc, openai.APIConnectionError):
-        return LLMError("network", "Could not reach OpenAI. Check the backend's network access.")
-    if isinstance(exc, openai.NotFoundError):
-        return LLMError(
-            "config",
-            "OpenAI returned 'not found' — usually a bad model name. Check the configured model.",
-        )
-    if isinstance(exc, openai.BadRequestError):
-        return LLMError("bad_request", f"OpenAI rejected the request: {exc}")
-    if isinstance(exc, openai.APIStatusError):
-        return LLMError("provider", f"OpenAI error: {exc}")
-    return LLMError("unknown", "Unexpected error talking to OpenAI.")
 
 
 PROVIDER = OpenAIProvider()

--- a/backend/app/llm/settings.py
+++ b/backend/app/llm/settings.py
@@ -1,10 +1,11 @@
 """DB-backed LLM settings. Configured via the admin page; no env-var fallback."""
+
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from app.db.models import LLMSettings as LLMSettingsRow
 from app.db.session import session
@@ -13,34 +14,26 @@ log = logging.getLogger(__name__)
 
 
 class LLMSettings(BaseModel):
-    model_config = ConfigDict(frozen=True, protected_namespaces=())
+    model_config = ConfigDict(
+        frozen=True,
+        protected_namespaces=(),
+        from_attributes=True,
+    )
 
-    provider: str
-    model: str
-    anthropic_api_key: str
-    openai_api_key: str
-    gemini_api_key: str
-    ollama_base_url: str
-    custom_api_key: str
-    custom_base_url: str
-    custom_display_name: str
-    provider_models: dict[str, list[str]]
-    ingest_selector_model: str  # empty or same as model → stage 3 skipped
+    provider: str = ""
+    model: str = ""
+    anthropic_api_key: str = ""
+    openai_api_key: str = ""
+    gemini_api_key: str = ""
+    ollama_base_url: str = ""
+    custom_api_key: str = ""
+    custom_base_url: str = ""
+    custom_display_name: str = ""
+    provider_models: dict[str, list[str]] = Field(default_factory=dict)
+    ingest_selector_model: str = ""  # empty or same as model → stage 3 skipped
 
 
-_EMPTY = LLMSettings(
-    provider="",
-    model="",
-    anthropic_api_key="",
-    openai_api_key="",
-    gemini_api_key="",
-    ollama_base_url="",
-    custom_api_key="",
-    custom_base_url="",
-    custom_display_name="",
-    provider_models={},
-    ingest_selector_model="",
-)
+_EMPTY = LLMSettings()
 
 
 def get() -> LLMSettings:
@@ -48,19 +41,7 @@ def get() -> LLMSettings:
         row = s.get(LLMSettingsRow, 1)
         if row is None:
             return _EMPTY
-        return LLMSettings(
-            provider=row.provider,
-            model=row.model,
-            anthropic_api_key=row.anthropic_api_key,
-            openai_api_key=row.openai_api_key,
-            gemini_api_key=row.gemini_api_key,
-            ollama_base_url=row.ollama_base_url,
-            custom_api_key=row.custom_api_key,
-            custom_base_url=row.custom_base_url,
-            custom_display_name=row.custom_display_name,
-            provider_models=row.provider_models or {},
-            ingest_selector_model=row.ingest_selector_model or "",
-        )
+        return LLMSettings.model_validate(row)
 
 
 def upsert(
@@ -81,36 +62,25 @@ def upsert(
     with session() as s:
         row = s.get(LLMSettingsRow, 1)
         if row is None:
-            s.add(
-                LLMSettingsRow(
-                    id=1,
-                    provider=provider,
-                    model=model,
-                    anthropic_api_key=anthropic_api_key,
-                    openai_api_key=openai_api_key,
-                    gemini_api_key=gemini_api_key,
-                    ollama_base_url=ollama_base_url,
-                    custom_api_key=custom_api_key,
-                    custom_base_url=custom_base_url,
-                    custom_display_name=custom_display_name,
-                    provider_models=provider_models or {},
-                    ingest_selector_model=ingest_selector_model or "",
-                    updated_at=now,
-                )
-            )
-        else:
-            row.provider = provider
-            row.model = model
-            row.anthropic_api_key = anthropic_api_key
-            row.openai_api_key = openai_api_key
-            row.gemini_api_key = gemini_api_key
-            row.ollama_base_url = ollama_base_url
-            row.custom_api_key = custom_api_key
-            row.custom_base_url = custom_base_url
-            row.custom_display_name = custom_display_name
-            if provider_models is not None:
-                row.provider_models = provider_models
-            if ingest_selector_model is not None:
-                row.ingest_selector_model = ingest_selector_model
-            row.updated_at = now
-    log.info("llm_settings upserted provider=%s model=%s ingest_selector_model=%s", provider, model, ingest_selector_model or "none")
+            row = LLMSettingsRow(id=1, provider_models={}, ingest_selector_model="")
+            s.add(row)
+        row.provider = provider
+        row.model = model
+        row.anthropic_api_key = anthropic_api_key
+        row.openai_api_key = openai_api_key
+        row.gemini_api_key = gemini_api_key
+        row.ollama_base_url = ollama_base_url
+        row.custom_api_key = custom_api_key
+        row.custom_base_url = custom_base_url
+        row.custom_display_name = custom_display_name
+        if provider_models is not None:
+            row.provider_models = provider_models
+        if ingest_selector_model is not None:
+            row.ingest_selector_model = ingest_selector_model
+        row.updated_at = now
+    log.info(
+        "llm_settings upserted provider=%s model=%s ingest_selector_model=%s",
+        provider,
+        model,
+        ingest_selector_model or "none",
+    )

--- a/backend/app/llm/settings.py
+++ b/backend/app/llm/settings.py
@@ -21,6 +21,9 @@ class LLMSettings(BaseModel):
     openai_api_key: str
     gemini_api_key: str
     ollama_base_url: str
+    custom_api_key: str
+    custom_base_url: str
+    custom_display_name: str
     provider_models: dict[str, list[str]]
     ingest_selector_model: str  # empty or same as model → stage 3 skipped
 
@@ -32,6 +35,9 @@ _EMPTY = LLMSettings(
     openai_api_key="",
     gemini_api_key="",
     ollama_base_url="",
+    custom_api_key="",
+    custom_base_url="",
+    custom_display_name="",
     provider_models={},
     ingest_selector_model="",
 )
@@ -49,6 +55,9 @@ def get() -> LLMSettings:
             openai_api_key=row.openai_api_key,
             gemini_api_key=row.gemini_api_key,
             ollama_base_url=row.ollama_base_url,
+            custom_api_key=row.custom_api_key,
+            custom_base_url=row.custom_base_url,
+            custom_display_name=row.custom_display_name,
             provider_models=row.provider_models or {},
             ingest_selector_model=row.ingest_selector_model or "",
         )
@@ -62,6 +71,9 @@ def upsert(
     openai_api_key: str,
     gemini_api_key: str,
     ollama_base_url: str,
+    custom_api_key: str,
+    custom_base_url: str,
+    custom_display_name: str,
     provider_models: dict[str, list[str]] | None = None,
     ingest_selector_model: str | None = None,
 ) -> None:
@@ -78,6 +90,9 @@ def upsert(
                     openai_api_key=openai_api_key,
                     gemini_api_key=gemini_api_key,
                     ollama_base_url=ollama_base_url,
+                    custom_api_key=custom_api_key,
+                    custom_base_url=custom_base_url,
+                    custom_display_name=custom_display_name,
                     provider_models=provider_models or {},
                     ingest_selector_model=ingest_selector_model or "",
                     updated_at=now,
@@ -90,6 +105,9 @@ def upsert(
             row.openai_api_key = openai_api_key
             row.gemini_api_key = gemini_api_key
             row.ollama_base_url = ollama_base_url
+            row.custom_api_key = custom_api_key
+            row.custom_base_url = custom_base_url
+            row.custom_display_name = custom_display_name
             if provider_models is not None:
                 row.provider_models = provider_models
             if ingest_selector_model is not None:

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -34,6 +34,10 @@ class LLMConfigRequest(BaseModel):
     openai_api_key: str | None = None
     gemini_api_key: str | None = None
     ollama_base_url: str | None = None
+    custom_api_key: str | None = None
+    custom_base_url: str | None = None
+    # Plain set-on-sent (not a secret) — "" clears, unlike the key fields.
+    custom_display_name: str | None = None
     provider_models: dict[str, list[str]] | None = None
     ingest_selector_model: str | None = None
 
@@ -114,6 +118,10 @@ class LLMView(BaseModel):
     gemini_api_key_hint: str
     # Ollama doesn't have an API key — surface the base URL directly.
     ollama_base_url: str
+    custom_api_key_set: bool
+    custom_api_key_hint: str
+    custom_base_url: str
+    custom_display_name: str
     provider_models: dict[str, list[str]]
     ingest_selector_model: str
 

--- a/backend/evals/_llm_override.py
+++ b/backend/evals/_llm_override.py
@@ -73,6 +73,9 @@ def build_settings(provider: str, model: str) -> LLMSettings:
         openai_api_key=_env_key("openai") if provider == "openai" else "",
         gemini_api_key=_env_key("gemini") if provider == "gemini" else "",
         ollama_base_url=os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434"),
+        custom_api_key="",
+        custom_base_url="",
+        custom_display_name="",
         provider_models={},
         ingest_selector_model="",
     )

--- a/backend/tests/test_admin_llm_custom.py
+++ b/backend/tests/test_admin_llm_custom.py
@@ -1,0 +1,131 @@
+"""Custom OpenAI-compatible provider settings: admin PUT/GET semantics
+(redaction, keep-vs-clear, base_url validation) and the user-facing
+/llm/status + /llm/available surfaces."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_db):
+    return TestClient(create_app())
+
+
+@pytest.fixture
+def admin(client):
+    uid = seed_user(uid="usr_adm", email="admin@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    return uid
+
+
+def _put(client, **body):
+    return client.put("/api/admin/llm", json=body)
+
+
+def _configure_custom(client, **overrides):
+    body = {
+        "provider": "custom",
+        "model": "deepseek-chat",
+        "custom_api_key": "sk-custom-secret-12345",
+        "custom_base_url": "https://gw.example.com/v1",
+        "custom_display_name": "DeepSeek",
+        "provider_models": {"custom": ["deepseek-chat"]},
+    }
+    body.update(overrides)
+    return _put(client, **body)
+
+
+def test_put_custom_persists_and_redacts(client, admin):
+    r = _configure_custom(client)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provider"] == "custom"
+    assert body["custom_api_key_set"] is True
+    assert body["custom_base_url"] == "https://gw.example.com/v1"
+    assert body["custom_display_name"] == "DeepSeek"
+    assert body["provider_models"]["custom"] == ["deepseek-chat"]
+
+    got = client.get("/api/admin/llm").json()
+    assert "sk-custom-secret-12345" not in str(got)
+    assert got["custom_api_key_hint"].startswith("sk-c")
+    assert "…" in got["custom_api_key_hint"]
+
+
+def test_custom_is_allowed_provider(client, admin):
+    r = _put(client, provider="custom", model="m")
+    assert r.status_code == 200
+
+
+def test_base_url_scheme_validated(client, admin):
+    r = _put(client, custom_base_url="gw.example.com/v1")
+    assert r.status_code == 400
+    assert "http" in r.json()["error"]
+
+
+def test_base_url_chat_completions_suffix_rejected(client, admin):
+    r = _put(client, custom_base_url="https://gw.example.com/v1/chat/completions")
+    assert r.status_code == 400
+
+
+def test_base_url_trailing_slash_stripped(client, admin):
+    r = _put(client, custom_base_url="https://gw.example.com/v1/")
+    assert r.status_code == 200
+    assert r.json()["custom_base_url"] == "https://gw.example.com/v1"
+
+
+def test_key_empty_string_keeps_null_clears_absent_keeps(client, admin):
+    _configure_custom(client)
+
+    # Absent field → keep.
+    r = _put(client, custom_display_name="renamed")
+    assert r.json()["custom_api_key_set"] is True
+
+    # Empty string → keep.
+    r = _put(client, custom_api_key="")
+    assert r.json()["custom_api_key_set"] is True
+
+    # Explicit null → clear.
+    r = _put(client, custom_api_key=None)
+    assert r.json()["custom_api_key_set"] is False
+
+
+def test_display_name_empty_string_clears(client, admin):
+    _configure_custom(client)
+    r = _put(client, custom_display_name="")
+    assert r.json()["custom_display_name"] == ""
+
+
+def test_status_configured_for_custom(client, admin):
+    _configure_custom(client)
+    body = client.get("/api/llm/status").json()
+    assert body["configured"] is True
+    assert body["provider"] == "custom"
+
+
+def test_available_includes_custom_with_label_and_models(client, admin):
+    _configure_custom(client, provider_models={"custom": ["deepseek-chat", "deepseek-reasoner"]})
+    providers = client.get("/api/llm/available").json()["providers"]
+    custom = next(p for p in providers if p["provider"] == "custom")
+    assert custom["label"] == "DeepSeek"
+    assert custom["models"] == ["deepseek-chat", "deepseek-reasoner"]
+    assert custom["default_model"] == "deepseek-chat"
+
+
+def test_available_label_falls_back_to_custom(client, admin):
+    _configure_custom(client, custom_display_name="")
+    providers = client.get("/api/llm/available").json()["providers"]
+    custom = next(p for p in providers if p["provider"] == "custom")
+    assert custom["label"] == "Custom"
+
+
+def test_available_omits_custom_without_models(client, admin):
+    _configure_custom(client, provider_models={"custom": []})
+    providers = client.get("/api/llm/available").json()["providers"]
+    assert all(p["provider"] != "custom" for p in providers)

--- a/backend/tests/test_admin_llm_custom.py
+++ b/backend/tests/test_admin_llm_custom.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
+from app.llm import providers as llm_providers
 from app.main import create_app
 
 from tests._auth import login_fastapi
@@ -61,6 +62,16 @@ def test_put_custom_persists_and_redacts(client, admin):
 def test_custom_is_allowed_provider(client, admin):
     r = _put(client, provider="custom", model="m")
     assert r.status_code == 200
+
+
+def test_allowlist_matches_registry() -> None:
+    assert set(llm_providers.names()) == {
+        "anthropic",
+        "openai",
+        "gemini",
+        "ollama",
+        "custom",
+    }
 
 
 def test_base_url_scheme_validated(client, admin):

--- a/backend/tests/test_custom_provider.py
+++ b/backend/tests/test_custom_provider.py
@@ -1,0 +1,432 @@
+"""Tests for the custom Chat Completions provider."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+
+import httpx
+import openai
+import pytest
+
+from app.llm.errors import LLMError
+from app.llm.providers import custom as custom_provider
+from app.llm.settings import LLMSettings
+
+
+def _settings(**overrides: Any) -> LLMSettings:
+    base: dict[str, Any] = {
+        "provider": "custom",
+        "model": "custom-model",
+        "anthropic_api_key": "",
+        "openai_api_key": "",
+        "gemini_api_key": "",
+        "ollama_base_url": "",
+        "custom_api_key": "",
+        "custom_base_url": "http://gateway.example/v1",
+        "custom_display_name": "Gateway",
+        "provider_models": {},
+        "ingest_selector_model": "",
+    }
+    base.update(overrides)
+    return LLMSettings(**base)
+
+
+class _FakeClient:
+    def __init__(self, responses: list[Any]):
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+        self.chat = SimpleNamespace(completions=SimpleNamespace(create=self._create))
+
+    def _create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if not self._responses:
+            return iter(())
+        result = self._responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return iter(result)
+
+
+def _chunk(
+    *,
+    content: str | None = None,
+    tool_calls: list[Any] | None = None,
+    finish_reason: str | None = None,
+    usage: Any = None,
+    choices: list[Any] | None = None,
+) -> Any:
+    if choices is None:
+        choices = [
+            SimpleNamespace(
+                delta=SimpleNamespace(content=content, tool_calls=tool_calls),
+                finish_reason=finish_reason,
+            )
+        ]
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+def _tool_delta(
+    *,
+    index: int,
+    id: str | None = None,
+    name: str | None = None,
+    arguments: str | None = None,
+) -> Any:
+    return SimpleNamespace(
+        index=index,
+        id=id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _bad_request(message: str) -> openai.BadRequestError:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx.Response(status_code=400, request=request)
+    return openai.BadRequestError(message, response=response, body={"message": message})
+
+
+def _collect(events: Any) -> list[dict[str, Any]]:
+    return list(events)
+
+
+def test_check_configured_raises_when_base_url_missing() -> None:
+    provider = custom_provider.CustomProvider()
+
+    with pytest.raises(LLMError) as excinfo:
+        provider.check_configured(_settings(custom_base_url=""))
+
+    assert excinfo.value.code == "not_configured"
+    assert "admin page" in excinfo.value.message
+
+
+def test_check_configured_allows_missing_api_key() -> None:
+    provider = custom_provider.CustomProvider()
+
+    assert provider.check_configured(_settings(custom_api_key="")) is None
+
+
+def test_stream_emits_text_deltas_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            [
+                _chunk(content="Hel"),
+                _chunk(content="lo"),
+                _chunk(finish_reason="stop"),
+            ]
+        ]
+    )
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    events = _collect(
+        provider.stream(
+            [{"role": "user", "content": "Hi"}],
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    assert [event for event in events if event["type"] == "text_delta"] == [
+        {"type": "text_delta", "text": "Hel"},
+        {"type": "text_delta", "text": "lo"},
+    ]
+
+
+def test_stream_reassembles_tool_call_fragments_even_when_finish_reason_is_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[
+                        _tool_delta(index=0, id="call_abc", name="lookup", arguments='{"city"')
+                    ]
+                ),
+                _chunk(tool_calls=[_tool_delta(index=0, arguments=':"SF"}')]),
+                _chunk(finish_reason="stop"),
+            ]
+        ]
+    )
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    events = _collect(
+        provider.stream(
+            [{"role": "user", "content": "Use tool"}],
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    assert events[0] == {
+        "type": "tool_call",
+        "id": "call_abc",
+        "name": "lookup",
+        "arguments": {"city": "SF"},
+    }
+    assert events[1]["type"] == "done"
+    assert events[1]["stop_reason"] == "stop"
+
+
+def test_stream_flushes_parallel_tool_calls_in_index_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[_tool_delta(index=1, id="call_b", name="second", arguments='{"b":')]
+                ),
+                _chunk(
+                    tool_calls=[_tool_delta(index=0, id="call_a", name="first", arguments='{"a":')]
+                ),
+                _chunk(tool_calls=[_tool_delta(index=1, arguments="2}")]),
+                _chunk(tool_calls=[_tool_delta(index=0, arguments="1}")]),
+                _chunk(finish_reason="stop"),
+            ]
+        ]
+    )
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    events = _collect(
+        provider.stream(
+            [{"role": "user", "content": "Use tools"}],
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    tool_events = [event for event in events if event["type"] == "tool_call"]
+    assert tool_events == [
+        {"type": "tool_call", "id": "call_a", "name": "first", "arguments": {"a": 1}},
+        {"type": "tool_call", "id": "call_b", "name": "second", "arguments": {"b": 2}},
+    ]
+
+
+def test_stream_handles_empty_tool_arguments(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient(
+        [
+            [
+                _chunk(
+                    tool_calls=[_tool_delta(index=0, id="call_empty", name="noop", arguments="")]
+                ),
+                _chunk(finish_reason="stop"),
+            ]
+        ]
+    )
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    events = _collect(
+        provider.stream(
+            [{"role": "user", "content": "No args"}],
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    assert events[0]["arguments"] == {}
+
+
+def test_stream_uses_usage_only_final_chunk(monkeypatch: pytest.MonkeyPatch) -> None:
+    usage = SimpleNamespace(
+        prompt_tokens=11,
+        completion_tokens=7,
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=3),
+    )
+    fake = _FakeClient([[_chunk(content="Hi"), _chunk(choices=[], usage=usage)]])
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    events = _collect(
+        provider.stream(
+            [{"role": "user", "content": "hello"}],
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    assert events[-1] == {
+        "type": "done",
+        "stop_reason": "",
+        "usage": {"input_tokens": 11, "output_tokens": 7, "reasoning_tokens": 3},
+    }
+
+
+def test_stream_emits_exactly_one_done_with_verbatim_stop_reason_and_usage_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    usage = SimpleNamespace(prompt_tokens=4, completion_tokens=6)
+    fake = _FakeClient([[_chunk(content="ok"), _chunk(finish_reason="gateway_stop", usage=usage)]])
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    events = _collect(
+        provider.stream(
+            [{"role": "user", "content": "hello"}],
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    done_events = [event for event in events if event["type"] == "done"]
+    assert len(done_events) == 1
+    assert done_events[0]["stop_reason"] == "gateway_stop"
+    usage_dict = done_events[0]["usage"]
+    assert usage_dict == {"input_tokens": 4, "output_tokens": 6, "reasoning_tokens": 0}
+    assert all(isinstance(value, int) for value in usage_dict.values())
+
+
+def test_create_stream_retries_once_without_stream_options() -> None:
+    fake = _FakeClient(
+        [
+            _bad_request("unsupported include_usage in stream_options"),
+            [_chunk(content="ok"), _chunk(finish_reason="stop")],
+        ]
+    )
+
+    stream = custom_provider._create_stream(
+        cast(Any, fake), {"model": "m", "messages": [], "stream": True}
+    )
+
+    events = list(stream)
+    assert len(fake.calls) == 2
+    assert fake.calls[0]["stream_options"] == {"include_usage": True}
+    assert "stream_options" not in fake.calls[1]
+    assert events[0].choices[0].delta.content == "ok"
+
+
+def test_stream_does_not_retry_unrelated_bad_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeClient([_bad_request("model is invalid")])
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+
+    with pytest.raises(LLMError) as excinfo:
+        _collect(
+            provider.stream(
+                [{"role": "user", "content": "hello"}],
+                model="custom-model",
+                tools=None,
+                max_tokens=32,
+                settings=_settings(),
+            )
+        )
+
+    assert excinfo.value.code == "bad_request"
+    assert len(fake.calls) == 1
+    assert fake.calls[0]["stream_options"] == {"include_usage": True}
+
+
+def test_client_uses_empty_placeholder_for_keyless_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[dict[str, Any]] = []
+
+    class _Recorder:
+        def __init__(self, *, api_key: str, base_url: str) -> None:
+            recorded.append({"api_key": api_key, "base_url": base_url})
+
+    custom_provider._client.cache_clear()
+    monkeypatch.setattr(custom_provider, "OpenAI", _Recorder)
+
+    custom_provider._client("", "http://gateway.example/v1")
+
+    assert recorded == [{"api_key": "EMPTY", "base_url": "http://gateway.example/v1"}]
+    custom_provider._client.cache_clear()
+
+
+def test_stream_translates_messages_to_chat_completions_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient([[_chunk(finish_reason="stop")]])
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+    messages = [
+        {"role": "system", "content": "You are helpful."},
+        {
+            "role": "assistant",
+            "content": "Calling tool",
+            "tool_calls": [{"id": "call_1", "name": "lookup", "arguments": {"q": "sf"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": {"result": 1}},
+        {"role": "user", "content": "Continue"},
+    ]
+
+    _collect(
+        provider.stream(
+            messages,
+            model="custom-model",
+            tools=None,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    assert fake.calls[0]["messages"] == [
+        {"role": "system", "content": "You are helpful."},
+        {
+            "role": "assistant",
+            "content": "Calling tool",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": json.dumps({"q": "sf"})},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": json.dumps({"result": 1})},
+        {"role": "user", "content": "Continue"},
+    ]
+
+
+def test_stream_wraps_tools_in_chat_completions_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeClient([[_chunk(finish_reason="stop")]])
+    monkeypatch.setattr(custom_provider, "_client", lambda api_key, base_url: fake)
+    provider = custom_provider.CustomProvider()
+    tools = [
+        {
+            "name": "lookup",
+            "description": "Find a record",
+            "input_schema": {"type": "object", "properties": {"q": {"type": "string"}}},
+        }
+    ]
+
+    _collect(
+        provider.stream(
+            [{"role": "user", "content": "Find it"}],
+            model="custom-model",
+            tools=tools,
+            max_tokens=32,
+            settings=_settings(),
+        )
+    )
+
+    assert fake.calls[0]["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "lookup",
+                "description": "Find a record",
+                "parameters": {"type": "object", "properties": {"q": {"type": "string"}}},
+            },
+        }
+    ]

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -44,6 +44,9 @@ def _upsert(**overrides: Any) -> None:
         "openai_api_key": "",
         "gemini_api_key": "",
         "ollama_base_url": "",
+        "custom_api_key": "",
+        "custom_base_url": "",
+        "custom_display_name": "",
     }
     base.update(overrides)
     llm_settings.upsert(**base)

--- a/backend/tests/test_llm_settings.py
+++ b/backend/tests/test_llm_settings.py
@@ -22,6 +22,9 @@ def _upsert(**overrides: Any) -> None:
         "openai_api_key": "",
         "gemini_api_key": "",
         "ollama_base_url": "",
+        "custom_api_key": "",
+        "custom_base_url": "",
+        "custom_display_name": "",
     }
     base.update(overrides)
     llm_settings.upsert(**base)

--- a/backend/tests/test_llm_settings.py
+++ b/backend/tests/test_llm_settings.py
@@ -1,4 +1,5 @@
 """Tests for app/llm/settings.py — DB-backed LLM configuration."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -38,6 +39,14 @@ def test_get_returns_empty_defaults_when_no_row(tmp_db):
     assert s.openai_api_key == ""
     assert s.gemini_api_key == ""
     assert s.ollama_base_url == ""
+
+
+def test_provider_models_defaults_to_empty_dict_not_none(tmp_db) -> None:
+    assert llm_settings.get().provider_models == {}
+
+    _upsert(provider="openai", model="gpt-4o")
+
+    assert llm_settings.get().provider_models == {}
 
 
 def test_upsert_then_get_round_trip(tmp_db):

--- a/backend/tests/test_openai_error_messages.py
+++ b/backend/tests/test_openai_error_messages.py
@@ -1,0 +1,86 @@
+# Guard the invariant that OpenAI-labeled translated SDK errors stay byte-identical.
+from __future__ import annotations
+
+import httpx
+import openai
+
+from app.llm.providers._openai_errors import translate_openai_error
+
+
+def _response(status_code: int) -> httpx.Response:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    return httpx.Response(status_code=status_code, request=request)
+
+
+def _authentication_error(message: str) -> openai.AuthenticationError:
+    return openai.AuthenticationError(
+        message,
+        response=_response(401),
+        body={"message": message},
+    )
+
+
+def _rate_limit_error(message: str) -> openai.RateLimitError:
+    return openai.RateLimitError(
+        message,
+        response=_response(429),
+        body={"message": message},
+    )
+
+
+def _api_connection_error(message: str) -> openai.APIConnectionError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    return openai.APIConnectionError(message=message, request=request)
+
+
+def _not_found_error(message: str) -> openai.NotFoundError:
+    return openai.NotFoundError(
+        message,
+        response=_response(404),
+        body={"message": message},
+    )
+
+
+def test_translate_openai_authentication_message() -> None:
+    err = translate_openai_error(
+        _authentication_error("bad key"),
+        provider_label="OpenAI",
+    )
+
+    assert err.code == "auth"
+    assert (
+        err.message == "OpenAI rejected the API key. An admin needs to update it on the admin page."
+    )
+
+
+def test_translate_openai_rate_limit_message() -> None:
+    err = translate_openai_error(
+        _rate_limit_error("slow down"),
+        provider_label="OpenAI",
+    )
+
+    assert err.code == "rate_limit"
+    assert err.message == "OpenAI rate limit hit. Please retry in a moment."
+
+
+def test_translate_openai_connection_message() -> None:
+    err = translate_openai_error(
+        _api_connection_error("network down"),
+        provider_label="OpenAI",
+    )
+
+    assert err.code == "network"
+    assert err.message == "Could not reach OpenAI. Check the backend's network access."
+
+
+def test_translate_openai_not_found_message() -> None:
+    err = translate_openai_error(
+        _not_found_error("missing model"),
+        provider_label="OpenAI",
+    )
+
+    assert err.code == "config"
+    assert (
+        err.message
+        == "OpenAI returned 'not found' — usually a bad model name. Check the configured model."
+    )

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -9,56 +9,17 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
+import {
+  ALL_PROVIDERS,
+  isConfigured,
+  providerLabel,
+  type LLMSettings,
+} from "@/lib/llm";
 import { useIsMobile } from "@/lib/viewport";
 
 interface IngestSettings {
   max_doc_chars: number;
   api_key: string | null;
-}
-
-type Provider = "anthropic" | "openai" | "gemini" | "ollama" | "custom";
-
-interface LLMSettings {
-  provider: Provider;
-  model: string;
-  anthropic_api_key_set: boolean;
-  openai_api_key_set: boolean;
-  gemini_api_key_set: boolean;
-  ollama_base_url: string;
-  custom_base_url: string;
-  custom_display_name: string;
-  provider_models: Record<string, string[]>;
-  ingest_selector_model: string;
-}
-
-const PROVIDER_LABEL: Record<Provider, string> = {
-  anthropic: "Anthropic",
-  openai: "OpenAI",
-  gemini: "Gemini",
-  ollama: "Ollama",
-  custom: "Custom",
-};
-
-const ALL_PROVIDERS: Provider[] = [
-  "anthropic",
-  "openai",
-  "gemini",
-  "ollama",
-  "custom",
-];
-
-function isConfigured(p: Provider, s: LLMSettings): boolean {
-  if (p === "anthropic") return s.anthropic_api_key_set;
-  if (p === "openai") return s.openai_api_key_set;
-  if (p === "gemini") return s.gemini_api_key_set;
-  if (p === "ollama") return !!s.ollama_base_url;
-  if (p === "custom") return !!s.custom_base_url;
-  return false;
-}
-
-function providerLabel(p: Provider, s: LLMSettings): string {
-  if (p === "custom") return s.custom_display_name || "Custom";
-  return PROVIDER_LABEL[p];
 }
 
 export default function AdminIngestPage() {

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -16,7 +16,7 @@ interface IngestSettings {
   api_key: string | null;
 }
 
-type Provider = "anthropic" | "openai" | "gemini" | "ollama";
+type Provider = "anthropic" | "openai" | "gemini" | "ollama" | "custom";
 
 interface LLMSettings {
   provider: Provider;
@@ -25,6 +25,8 @@ interface LLMSettings {
   openai_api_key_set: boolean;
   gemini_api_key_set: boolean;
   ollama_base_url: string;
+  custom_base_url: string;
+  custom_display_name: string;
   provider_models: Record<string, string[]>;
   ingest_selector_model: string;
 }
@@ -34,16 +36,29 @@ const PROVIDER_LABEL: Record<Provider, string> = {
   openai: "OpenAI",
   gemini: "Gemini",
   ollama: "Ollama",
+  custom: "Custom",
 };
 
-const ALL_PROVIDERS: Provider[] = ["anthropic", "openai", "gemini", "ollama"];
+const ALL_PROVIDERS: Provider[] = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "ollama",
+  "custom",
+];
 
 function isConfigured(p: Provider, s: LLMSettings): boolean {
   if (p === "anthropic") return s.anthropic_api_key_set;
   if (p === "openai") return s.openai_api_key_set;
   if (p === "gemini") return s.gemini_api_key_set;
   if (p === "ollama") return !!s.ollama_base_url;
+  if (p === "custom") return !!s.custom_base_url;
   return false;
+}
+
+function providerLabel(p: Provider, s: LLMSettings): string {
+  if (p === "custom") return s.custom_display_name || "Custom";
+  return PROVIDER_LABEL[p];
 }
 
 export default function AdminIngestPage() {
@@ -386,7 +401,7 @@ function SelectorModelSection({
                   <span
                     className={`shrink-0 text-[13px] font-medium ${isSelected ? "text-(--text-05)" : "text-(--text-04)"}`}
                   >
-                    {PROVIDER_LABEL[p]}
+                    {providerLabel(p, settings)}
                   </span>
                   <span
                     className={`font-mono text-[13px] ${isSelected ? "text-(--text-05)" : "text-(--text-03)"}`}

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { useEffect, useState, type FormEvent } from "react";
+import {
+  useEffect,
+  useState,
+  type FormEvent,
+  type InputHTMLAttributes,
+} from "react";
 import { mutate as globalMutate } from "swr";
 
 import { Button } from "@onyx-ai/opal/components";
@@ -10,12 +15,16 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
 import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
+import {
+  ALL_PROVIDERS,
+  isConfigured,
+  providerLabel,
+  type LLMSettings,
+  type Provider,
+} from "@/lib/llm";
 import { useIsMobile } from "@/lib/viewport";
 
-type Provider = "anthropic" | "openai" | "gemini" | "ollama" | "custom";
-
 interface ProviderMeta {
-  label: string;
   defaultModel: string;
   keyLabel: string;
   keyPlaceholder: string;
@@ -24,49 +33,36 @@ interface ProviderMeta {
 
 const PROVIDER_META: Record<Provider, ProviderMeta> = {
   anthropic: {
-    label: "Anthropic",
     defaultModel: "claude-sonnet-4-6",
     keyLabel: "API key",
     keyPlaceholder: "sk-ant-…",
     initial: "A",
   },
   openai: {
-    label: "OpenAI",
     defaultModel: "gpt-5.5",
     keyLabel: "API key",
     keyPlaceholder: "sk-…",
     initial: "O",
   },
   gemini: {
-    label: "Gemini",
     defaultModel: "gemini-3.1-pro-preview",
     keyLabel: "API key",
     keyPlaceholder: "AIza…",
     initial: "G",
   },
   ollama: {
-    label: "Ollama",
     defaultModel: "llama3.1",
     keyLabel: "Base URL",
     keyPlaceholder: "http://localhost:11434",
     initial: "L",
   },
   custom: {
-    label: "Custom",
     defaultModel: "",
     keyLabel: "API key",
     keyPlaceholder: "sk-…",
     initial: "C",
   },
 };
-
-const ALL_PROVIDERS: Provider[] = [
-  "anthropic",
-  "openai",
-  "gemini",
-  "ollama",
-  "custom",
-];
 
 const PROVIDER_MODELS: Record<Provider, string[]> = {
   anthropic: [
@@ -81,32 +77,6 @@ const PROVIDER_MODELS: Record<Provider, string[]> = {
   custom: [],
 };
 
-interface LLMSettings {
-  provider: Provider;
-  model: string;
-  anthropic_api_key_set: boolean;
-  openai_api_key_set: boolean;
-  gemini_api_key_set: boolean;
-  anthropic_api_key_hint: string;
-  openai_api_key_hint: string;
-  gemini_api_key_hint: string;
-  ollama_base_url: string;
-  custom_api_key_set: boolean;
-  custom_api_key_hint: string;
-  custom_base_url: string;
-  custom_display_name: string;
-  provider_models: Record<string, string[]>;
-}
-
-function isConfigured(p: Provider, s: LLMSettings): boolean {
-  if (p === "anthropic") return s.anthropic_api_key_set;
-  if (p === "openai") return s.openai_api_key_set;
-  if (p === "gemini") return s.gemini_api_key_set;
-  if (p === "ollama") return !!s.ollama_base_url;
-  if (p === "custom") return !!s.custom_base_url;
-  return false;
-}
-
 function keyHint(p: Provider, s: LLMSettings): string {
   if (p === "anthropic") return s.anthropic_api_key_hint;
   if (p === "openai") return s.openai_api_key_hint;
@@ -114,11 +84,6 @@ function keyHint(p: Provider, s: LLMSettings): string {
   if (p === "ollama") return s.ollama_base_url || "http://localhost:11434";
   if (p === "custom") return s.custom_base_url;
   return "";
-}
-
-function providerLabel(p: Provider, s: LLMSettings): string {
-  if (p === "custom") return s.custom_display_name || "Custom";
-  return PROVIDER_META[p].label;
 }
 
 export default function AdminLLMPage() {
@@ -474,7 +439,8 @@ function ProviderForm({
   configured,
   onSaved,
 }: {
-  provider: Provider;
+  // Custom routes to CustomProviderForm — encode that in the type.
+  provider: Exclude<Provider, "custom">;
   settings: LLMSettings;
   configured: boolean;
   onSaved: () => void;
@@ -543,7 +509,7 @@ function ProviderForm({
   async function onClear() {
     if (
       !(await confirmDialog({
-        title: `Remove ${meta.label} credentials?`,
+        title: `Remove ${providerLabel(provider, settings)} credentials?`,
         confirmLabel: "Remove",
       }))
     )
@@ -568,22 +534,19 @@ function ProviderForm({
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      <label>
-        <div className={lblClass}>{meta.keyLabel}</div>
-        <input
-          type={isOllama ? "text" : "password"}
-          value={keyValue}
-          onChange={(e) => setKeyValue(e.target.value)}
-          placeholder={
-            configured
-              ? isOllama
-                ? currentHint
-                : "leave blank to keep current"
-              : meta.keyPlaceholder
-          }
-          className={inputClass}
-        />
-      </label>
+      <Field
+        label={meta.keyLabel}
+        type={isOllama ? "text" : "password"}
+        value={keyValue}
+        onChange={(e) => setKeyValue(e.target.value)}
+        placeholder={
+          configured
+            ? isOllama
+              ? currentHint
+              : "leave blank to keep current"
+            : meta.keyPlaceholder
+        }
+      />
 
       <div>
         <div className="mb-2 flex items-baseline justify-between">
@@ -622,30 +585,8 @@ function ProviderForm({
         </div>
       </div>
 
-      {error && (
-        <div className="text-[13px] text-(--status-text-error-05)">{error}</div>
-      )}
-      {saved && (
-        <div className="text-[13px] text-(--status-text-success-05)">
-          Saved.
-        </div>
-      )}
-      <div className="flex gap-2">
-        <Button type="submit" variant="action" size="sm" disabled={saving}>
-          {saving ? "Saving…" : "Save"}
-        </Button>
-        {configured && (
-          <Button
-            type="button"
-            variant="danger"
-            size="sm"
-            disabled={saving}
-            onClick={onClear}
-          >
-            Remove
-          </Button>
-        )}
-      </div>
+      <FormMessages error={error} saved={saved} />
+      <FormActions saving={saving} configured={configured} onClear={onClear} />
     </form>
   );
 }
@@ -736,44 +677,32 @@ function CustomProviderForm({
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      <label>
-        <div className={lblClass}>Base URL</div>
-        <input
-          type="text"
-          value={baseUrl}
-          onChange={(e) => setBaseUrl(e.target.value)}
-          placeholder="https://openrouter.ai/api/v1"
-          className={inputClass}
-        />
-        <div className="mt-1 text-xs text-(--text-03)">
-          Any OpenAI-compatible endpoint. Requests go to /chat/completions under
-          this URL.
-        </div>
-      </label>
+      <Field
+        label="Base URL"
+        type="text"
+        value={baseUrl}
+        onChange={(e) => setBaseUrl(e.target.value)}
+        placeholder="https://openrouter.ai/api/v1"
+        hint="Any OpenAI-compatible endpoint. Requests go to /chat/completions under this URL."
+      />
 
-      <label>
-        <div className={lblClass}>API key (optional)</div>
-        <input
-          type="password"
-          value={keyValue}
-          onChange={(e) => setKeyValue(e.target.value)}
-          placeholder={
-            settings.custom_api_key_set ? "leave blank to keep current" : "sk-…"
-          }
-          className={inputClass}
-        />
-      </label>
+      <Field
+        label="API key (optional)"
+        type="password"
+        value={keyValue}
+        onChange={(e) => setKeyValue(e.target.value)}
+        placeholder={
+          settings.custom_api_key_set ? "leave blank to keep current" : "sk-…"
+        }
+      />
 
-      <label>
-        <div className={lblClass}>Display name (optional)</div>
-        <input
-          type="text"
-          value={displayName}
-          onChange={(e) => setDisplayName(e.target.value)}
-          placeholder="Custom"
-          className={inputClass}
-        />
-      </label>
+      <Field
+        label="Display name (optional)"
+        type="text"
+        value={displayName}
+        onChange={(e) => setDisplayName(e.target.value)}
+        placeholder="Custom"
+      />
 
       <div>
         <div className="mb-2 flex items-baseline justify-between">
@@ -829,6 +758,35 @@ function CustomProviderForm({
         </div>
       </div>
 
+      <FormMessages error={error} saved={saved} />
+      <FormActions saving={saving} configured={configured} onClear={onClear} />
+    </form>
+  );
+}
+
+function Field({
+  label,
+  hint,
+  ...inputProps
+}: { label: string; hint?: string } & InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <label>
+      <div className={lblClass}>{label}</div>
+      <input className={inputClass} {...inputProps} />
+      {hint && <div className="mt-1 text-xs text-(--text-03)">{hint}</div>}
+    </label>
+  );
+}
+
+function FormMessages({
+  error,
+  saved,
+}: {
+  error: string | null;
+  saved: boolean;
+}) {
+  return (
+    <>
       {error && (
         <div className="text-[13px] text-(--status-text-error-05)">{error}</div>
       )}
@@ -837,23 +795,36 @@ function CustomProviderForm({
           Saved.
         </div>
       )}
-      <div className="flex gap-2">
-        <Button type="submit" variant="action" size="sm" disabled={saving}>
-          {saving ? "Saving…" : "Save"}
+    </>
+  );
+}
+
+function FormActions({
+  saving,
+  configured,
+  onClear,
+}: {
+  saving: boolean;
+  configured: boolean;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex gap-2">
+      <Button type="submit" variant="action" size="sm" disabled={saving}>
+        {saving ? "Saving…" : "Save"}
+      </Button>
+      {configured && (
+        <Button
+          type="button"
+          variant="danger"
+          size="sm"
+          disabled={saving}
+          onClick={onClear}
+        >
+          Remove
         </Button>
-        {configured && (
-          <Button
-            type="button"
-            variant="danger"
-            size="sm"
-            disabled={saving}
-            onClick={onClear}
-          >
-            Remove
-          </Button>
-        )}
-      </div>
-    </form>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -12,7 +12,7 @@ import { RequireAdmin } from "@/components/RequireAdmin";
 import { apiFetch } from "@/lib/api";
 import { useIsMobile } from "@/lib/viewport";
 
-type Provider = "anthropic" | "openai" | "gemini" | "ollama";
+type Provider = "anthropic" | "openai" | "gemini" | "ollama" | "custom";
 
 interface ProviderMeta {
   label: string;
@@ -51,9 +51,22 @@ const PROVIDER_META: Record<Provider, ProviderMeta> = {
     keyPlaceholder: "http://localhost:11434",
     initial: "L",
   },
+  custom: {
+    label: "Custom",
+    defaultModel: "",
+    keyLabel: "API key",
+    keyPlaceholder: "sk-…",
+    initial: "C",
+  },
 };
 
-const ALL_PROVIDERS: Provider[] = ["anthropic", "openai", "gemini", "ollama"];
+const ALL_PROVIDERS: Provider[] = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "ollama",
+  "custom",
+];
 
 const PROVIDER_MODELS: Record<Provider, string[]> = {
   anthropic: [
@@ -65,6 +78,7 @@ const PROVIDER_MODELS: Record<Provider, string[]> = {
   openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2"],
   gemini: ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
   ollama: ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
+  custom: [],
 };
 
 interface LLMSettings {
@@ -77,6 +91,10 @@ interface LLMSettings {
   openai_api_key_hint: string;
   gemini_api_key_hint: string;
   ollama_base_url: string;
+  custom_api_key_set: boolean;
+  custom_api_key_hint: string;
+  custom_base_url: string;
+  custom_display_name: string;
   provider_models: Record<string, string[]>;
 }
 
@@ -85,6 +103,7 @@ function isConfigured(p: Provider, s: LLMSettings): boolean {
   if (p === "openai") return s.openai_api_key_set;
   if (p === "gemini") return s.gemini_api_key_set;
   if (p === "ollama") return !!s.ollama_base_url;
+  if (p === "custom") return !!s.custom_base_url;
   return false;
 }
 
@@ -93,7 +112,13 @@ function keyHint(p: Provider, s: LLMSettings): string {
   if (p === "openai") return s.openai_api_key_hint;
   if (p === "gemini") return s.gemini_api_key_hint;
   if (p === "ollama") return s.ollama_base_url || "http://localhost:11434";
+  if (p === "custom") return s.custom_base_url;
   return "";
+}
+
+function providerLabel(p: Provider, s: LLMSettings): string {
+  if (p === "custom") return s.custom_display_name || "Custom";
+  return PROVIDER_META[p].label;
 }
 
 export default function AdminLLMPage() {
@@ -268,7 +293,7 @@ function AgentModelSection({
             PROVIDER_META[settings.provider as Provider] ? (
               <>
                 <span className="text-sm font-medium">
-                  {PROVIDER_META[settings.provider as Provider].label}
+                  {providerLabel(settings.provider as Provider, settings)}
                 </span>
                 <span className="ml-2 text-sm text-(--text-03)">
                   {settings.model || "—"}
@@ -314,7 +339,7 @@ function AgentModelSection({
                   <span
                     className={`shrink-0 text-[13px] font-medium ${isSelected ? "text-(--text-05)" : "text-(--text-04)"}`}
                   >
-                    {PROVIDER_META[p].label}
+                    {providerLabel(p, settings)}
                   </span>
                   <span
                     className={`font-mono text-[13px] ${isSelected ? "text-(--text-05)" : "text-(--text-03)"}`}
@@ -388,7 +413,9 @@ function ProviderCard({
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">{meta.label}</span>
+            <span className="text-sm font-medium">
+              {providerLabel(provider, settings)}
+            </span>
             {isActive && (
               <span className="rounded-full border border-(--border-01) bg-(--background-tint-03) px-[6px] py-[2px] text-[11px] font-semibold text-(--text-05)">
                 Agent
@@ -421,12 +448,20 @@ function ProviderCard({
       {/* Expanded form */}
       {expanded && (
         <div className="border-t border-(--border-01) bg-(--background-tint-00) p-4">
-          <ProviderForm
-            provider={provider}
-            settings={settings}
-            configured={configured}
-            onSaved={onSaved}
-          />
+          {provider === "custom" ? (
+            <CustomProviderForm
+              settings={settings}
+              configured={configured}
+              onSaved={onSaved}
+            />
+          ) : (
+            <ProviderForm
+              provider={provider}
+              settings={settings}
+              configured={configured}
+              onSaved={onSaved}
+            />
+          )}
         </div>
       )}
     </div>
@@ -584,6 +619,212 @@ function ProviderForm({
               </button>
             );
           })}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-[13px] text-(--status-text-error-05)">{error}</div>
+      )}
+      {saved && (
+        <div className="text-[13px] text-(--status-text-success-05)">
+          Saved.
+        </div>
+      )}
+      <div className="flex gap-2">
+        <Button type="submit" variant="action" size="sm" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+        {configured && (
+          <Button
+            type="button"
+            variant="danger"
+            size="sm"
+            disabled={saving}
+            onClick={onClear}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+}
+
+function CustomProviderForm({
+  settings,
+  configured,
+  onSaved,
+}: {
+  settings: LLMSettings;
+  configured: boolean;
+  onSaved: () => void;
+}) {
+  const [baseUrl, setBaseUrl] = useState(settings.custom_base_url);
+  const [keyValue, setKeyValue] = useState("");
+  const [displayName, setDisplayName] = useState(settings.custom_display_name);
+  const [models, setModels] = useState<string[]>(
+    () => settings.provider_models["custom"] ?? [],
+  );
+  const [newModel, setNewModel] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const confirmDialog = useConfirm();
+
+  function addModel() {
+    const m = newModel.trim();
+    if (!m || models.includes(m)) return;
+    setModels((prev) => [...prev, m]);
+    setNewModel("");
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const body: Record<string, unknown> = {
+        custom_display_name: displayName.trim(),
+        provider_models: { ...settings.provider_models, custom: models },
+      };
+      // Empty string means "keep current" server-side; only send a real URL.
+      if (baseUrl.trim()) body.custom_base_url = baseUrl.trim();
+      if (keyValue) body.custom_api_key = keyValue;
+      await apiFetch("/admin/llm", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+      setKeyValue("");
+      setSaved(true);
+      onSaved();
+      void globalMutate("/llm/status");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onClear() {
+    if (
+      !(await confirmDialog({
+        title: "Remove custom provider credentials?",
+        confirmLabel: "Remove",
+      }))
+    )
+      return;
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch("/admin/llm", {
+        method: "PUT",
+        body: JSON.stringify({
+          custom_base_url: null,
+          custom_api_key: null,
+          custom_display_name: "",
+        }),
+      });
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to remove");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <label>
+        <div className={lblClass}>Base URL</div>
+        <input
+          type="text"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+          placeholder="https://openrouter.ai/api/v1"
+          className={inputClass}
+        />
+        <div className="mt-1 text-xs text-(--text-03)">
+          Any OpenAI-compatible endpoint. Requests go to /chat/completions under
+          this URL.
+        </div>
+      </label>
+
+      <label>
+        <div className={lblClass}>API key (optional)</div>
+        <input
+          type="password"
+          value={keyValue}
+          onChange={(e) => setKeyValue(e.target.value)}
+          placeholder={
+            settings.custom_api_key_set ? "leave blank to keep current" : "sk-…"
+          }
+          className={inputClass}
+        />
+      </label>
+
+      <label>
+        <div className={lblClass}>Display name (optional)</div>
+        <input
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Custom"
+          className={inputClass}
+        />
+      </label>
+
+      <div>
+        <div className="mb-2 flex items-baseline justify-between">
+          <div className={lblClass}>Models</div>
+          <div className="text-xs text-(--text-03)">
+            Add at least one model name
+          </div>
+        </div>
+        <div className="flex flex-col gap-1.5">
+          {models.map((id) => (
+            <div
+              key={id}
+              className="flex items-center justify-between rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) py-[6px] pr-2 pl-3"
+            >
+              <span className="font-mono text-[13px] text-(--text-05)">
+                {id}
+              </span>
+              <Button
+                type="button"
+                variant="default"
+                size="sm"
+                onClick={() =>
+                  setModels((prev) => prev.filter((m) => m !== id))
+                }
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newModel}
+              onChange={(e) => setNewModel(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addModel();
+                }
+              }}
+              placeholder="deepseek-chat"
+              className={inputClass}
+            />
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              onClick={addModel}
+            >
+              Add
+            </Button>
+          </div>
         </div>
       </div>
 

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -723,6 +723,7 @@ function CustomProviderForm({
           custom_base_url: null,
           custom_api_key: null,
           custom_display_name: "",
+          provider_models: { ...settings.provider_models, custom: [] },
         }),
       });
       onSaved();

--- a/frontend/src/lib/llm.ts
+++ b/frontend/src/lib/llm.ts
@@ -16,3 +16,54 @@ export function useLLMStatus(opts: { skip?: boolean } = {}) {
     refresh: mutate,
   };
 }
+
+export type Provider = "anthropic" | "openai" | "gemini" | "ollama" | "custom";
+
+export const ALL_PROVIDERS: Provider[] = [
+  "anthropic",
+  "openai",
+  "gemini",
+  "ollama",
+  "custom",
+];
+
+export const PROVIDER_LABELS: Record<Provider, string> = {
+  anthropic: "Anthropic",
+  openai: "OpenAI",
+  gemini: "Gemini",
+  ollama: "Ollama",
+  custom: "Custom",
+};
+
+// Shape of GET /admin/llm (LLMView) — shared by the admin pages that render it.
+export interface LLMSettings {
+  provider: Provider;
+  model: string;
+  anthropic_api_key_set: boolean;
+  openai_api_key_set: boolean;
+  gemini_api_key_set: boolean;
+  anthropic_api_key_hint: string;
+  openai_api_key_hint: string;
+  gemini_api_key_hint: string;
+  ollama_base_url: string;
+  custom_api_key_set: boolean;
+  custom_api_key_hint: string;
+  custom_base_url: string;
+  custom_display_name: string;
+  provider_models: Record<string, string[]>;
+  ingest_selector_model: string;
+}
+
+export function isConfigured(p: Provider, s: LLMSettings): boolean {
+  if (p === "anthropic") return s.anthropic_api_key_set;
+  if (p === "openai") return s.openai_api_key_set;
+  if (p === "gemini") return s.gemini_api_key_set;
+  if (p === "ollama") return !!s.ollama_base_url;
+  if (p === "custom") return !!s.custom_base_url;
+  return false;
+}
+
+export function providerLabel(p: Provider, s: LLMSettings): string {
+  if (p === "custom") return s.custom_display_name || PROVIDER_LABELS.custom;
+  return PROVIDER_LABELS[p];
+}


### PR DESCRIPTION
## Description

Closes #169 — adds a fifth provider slot **Custom** for any OpenAI-compatible gateway (OpenRouter, DeepSeek, vLLM, llama.cpp, internal proxies).

- `providers/custom.py`: Chat Completions streaming + tool calls via the openai SDK with configurable `base_url`. API key optional (keyless local routers). Tolerates gateway quirks: usage-only final chunks, `stream_options` rejection (one retry without), tool calls under `finish_reason: "stop"`.
- Migration `0029`: `custom_api_key` / `custom_base_url` / `custom_display_name` on `llm_settings`. Admin PUT keeps the existing keep-vs-clear secret semantics; validates http(s) scheme, strips trailing slash, rejects pasted `/chat/completions` URLs.
- `/llm/available` lists the custom provider under its display label with the admin's free-text model list (hidden until ≥1 model added).
- Admin Language Models page: Custom card — base URL, optional key, display name, add/remove model chips. Ingest selector follows.

Deliberately out of scope (follow-ups): multiple custom providers, test-connection preflight, per-model capability overrides.

## How Has This Been Tested?