### PR TITLE
feat(llm): test-connection preflight for every provider

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -15,17 +15,15 @@ from app.auth import invites
 from app.auth.deps import require_admin
 from app.ingest import settings as ingest_settings
 from app.ingest.settings import IngestSettings
+from app.llm.errors import LLMError
 from app.llm import providers as llm_providers
 from app.llm import settings as llm_settings
-from app.llm.providers import custom as custom_provider
 from app.llm.settings import LLMSettings
 from app.models.admin import (
     AdminUserListResponse,
     AdminUserView,
     BraintrustConfigRequest,
     BraintrustView,
-    CustomProviderTestRequest,
-    CustomProviderTestResult,
     IngestConfigRequest,
     InviteUsersRequest,
     InvitedUserView,
@@ -34,6 +32,8 @@ from app.models.admin import (
     LLMConfigRequest,
     LLMView,
     OkResponse,
+    ProviderTestRequest,
+    ProviderTestResult,
     UpdateUserRequest,
     UserCounts,
     WebConfigRequest,
@@ -329,22 +329,32 @@ def put_llm(
     return _llm_view(llm_settings.get())
 
 
-@router.post("/llm/custom/test", response_model=CustomProviderTestResult)
-def test_custom_llm(
-    req: CustomProviderTestRequest,
+@router.post("/llm/{provider_name}/test", response_model=ProviderTestResult)
+def test_llm_provider(
+    provider_name: str,
+    req: ProviderTestRequest,
     _actor: User = Depends(require_admin),
-) -> CustomProviderTestResult:
-    """Preflight the SAVED custom-provider config. Interactive diagnostics —
+) -> ProviderTestResult:
+    """Preflight the SAVED provider config. Interactive diagnostics —
     bounded by the provider's preflight timeout, so it stays inline rather
     than going through a task queue."""
+    provider = llm_providers.get(provider_name)
+    if provider is None:
+        raise HTTPException(status_code=404, detail=f"unknown provider '{provider_name}'")
     s = llm_settings.get()
-    if not s.custom_base_url:
-        raise HTTPException(status_code=400, detail="custom provider is not configured")
-    saved_models = s.provider_models.get("custom", [])
-    model = (req.model or "").strip() or (saved_models[0] if saved_models else "") or s.model
+    try:
+        provider.check_configured(s)
+    except LLMError as exc:
+        raise HTTPException(status_code=400, detail=exc.message) from exc
+    saved_models = s.provider_models.get(provider_name, [])
+    model = (
+        (req.model or "").strip()
+        or (saved_models[0] if saved_models else "")
+        or (s.model if s.provider == provider_name else "")
+    )
     if not model:
         raise HTTPException(status_code=400, detail="add a model name before testing")
-    return CustomProviderTestResult(**custom_provider.test_connection(s, model=model))
+    return ProviderTestResult(**provider.test_connection(s, model=model))
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -17,12 +17,15 @@ from app.ingest import settings as ingest_settings
 from app.ingest.settings import IngestSettings
 from app.llm import providers as llm_providers
 from app.llm import settings as llm_settings
+from app.llm.providers import custom as custom_provider
 from app.llm.settings import LLMSettings
 from app.models.admin import (
     AdminUserListResponse,
     AdminUserView,
     BraintrustConfigRequest,
     BraintrustView,
+    CustomProviderTestRequest,
+    CustomProviderTestResult,
     IngestConfigRequest,
     InviteUsersRequest,
     InvitedUserView,
@@ -324,6 +327,24 @@ def put_llm(
         model,
     )
     return _llm_view(llm_settings.get())
+
+
+@router.post("/llm/custom/test", response_model=CustomProviderTestResult)
+def test_custom_llm(
+    req: CustomProviderTestRequest,
+    _actor: User = Depends(require_admin),
+) -> CustomProviderTestResult:
+    """Preflight the SAVED custom-provider config. Interactive diagnostics —
+    bounded by the provider's preflight timeout, so it stays inline rather
+    than going through a task queue."""
+    s = llm_settings.get()
+    if not s.custom_base_url:
+        raise HTTPException(status_code=400, detail="custom provider is not configured")
+    saved_models = s.provider_models.get("custom", [])
+    model = (req.model or "").strip() or (saved_models[0] if saved_models else "") or s.model
+    if not model:
+        raise HTTPException(status_code=400, detail="add a model name before testing")
+    return CustomProviderTestResult(**custom_provider.test_connection(s, model=model))
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -120,15 +120,11 @@ def update_user(
 
     if req.is_admin is not None and req.is_admin != was_admin:
         users_repo.set_admin(user_id, req.is_admin)
-        log.info(
-            "admin: %s set is_admin=%s on user %s", actor.id, req.is_admin, user_id
-        )
+        log.info("admin: %s set is_admin=%s on user %s", actor.id, req.is_admin, user_id)
 
     if req.is_active is not None and req.is_active != was_active:
         users_repo.set_active(user_id, req.is_active)
-        log.info(
-            "admin: %s set is_active=%s on user %s", actor.id, req.is_active, user_id
-        )
+        log.info("admin: %s set is_active=%s on user %s", actor.id, req.is_active, user_id)
 
     row = users_repo.get_by_id(user_id)
     assert row is not None
@@ -354,7 +350,7 @@ def test_llm_provider(
     )
     if not model:
         raise HTTPException(status_code=400, detail="add a model name before testing")
-    return ProviderTestResult(**provider.test_connection(s, model=model))
+    return ProviderTestResult.model_validate(provider.test_connection(s, model=model))
 
 
 # --------------------------------------------------------------------------- #
@@ -394,9 +390,7 @@ def put_web(
         return sent
 
     serper_key = _resolve("serper_api_key", req.serper_api_key, current.serper_api_key)
-    firecrawl_key = _resolve(
-        "firecrawl_api_key", req.firecrawl_api_key, current.firecrawl_api_key
-    )
+    firecrawl_key = _resolve("firecrawl_api_key", req.firecrawl_api_key, current.firecrawl_api_key)
 
     web_settings.upsert(
         serper_api_key=serper_key,

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -60,6 +60,14 @@ class Provider(Protocol):
         """
         ...
 
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the provider's SAVED credentials: a cheap listing probe when
+        the backend has one (non-fatal if unsupported) plus a minimal 1-token
+        completion against ``model``. Returns a redacted diagnostics dict (keys:
+        ok, base_url, auth_present, model, models_endpoint, completion) — NEVER
+        credentials."""
+        ...
+
     def stream(
         self,
         messages: list[dict[str, Any]],

--- a/backend/app/llm/providers/_common.py
+++ b/backend/app/llm/providers/_common.py
@@ -5,10 +5,16 @@ interface; they're translation utilities that more than one provider
 needs. If something here grows beyond translation glue, give it a
 proper home.
 """
+
 from __future__ import annotations
 
 import json
-from typing import Any, cast
+from typing import Any, Callable, cast
+
+from app.llm.errors import LLMError
+
+
+PREFLIGHT_TIMEOUT_SECONDS = 10.0
 
 
 def safe_json_loads(s: str) -> dict[str, Any]:
@@ -79,3 +85,34 @@ def stringify_tool_result(content: Any) -> str:
         return json.dumps(content)
     except (TypeError, ValueError):
         return str(content)
+
+
+def run_preflight(
+    *,
+    base_url: str,
+    auth_present: bool,
+    model: str,
+    listing: Callable[[], object],
+    completion: Callable[[], object],
+    translate: Callable[[Exception], LLMError],
+) -> dict[str, Any]:
+    """Shared preflight scaffold: non-fatal listing probe + decisive 1-token
+    completion. Failures surface as translated messages — never credentials."""
+    result: dict[str, Any] = {
+        "base_url": base_url,
+        "auth_present": auth_present,
+        "model": model,
+    }
+    try:
+        listing()
+        result["models_endpoint"] = "ok"
+    except Exception as exc:
+        result["models_endpoint"] = translate(exc).message
+    try:
+        completion()
+        result["completion"] = "ok"
+        result["ok"] = True
+    except Exception as exc:
+        result["completion"] = translate(exc).message
+        result["ok"] = False
+    return result

--- a/backend/app/llm/providers/anthropic.py
+++ b/backend/app/llm/providers/anthropic.py
@@ -1,4 +1,5 @@
 """Anthropic provider — Messages API streaming."""
+
 from __future__ import annotations
 
 import json
@@ -9,7 +10,12 @@ from typing import Any, Iterator, cast
 from anthropic import Anthropic
 
 from app.llm.errors import LLMError
-from app.llm.providers._common import safe_json_loads, split_system
+from app.llm.providers._common import (
+    PREFLIGHT_TIMEOUT_SECONDS,
+    run_preflight,
+    safe_json_loads,
+    split_system,
+)
 from app.llm.settings import LLMSettings
 
 log = logging.getLogger(__name__)
@@ -33,6 +39,26 @@ class AnthropicProvider:
                 "not_configured",
                 "Anthropic API key is not set. An admin needs to add it on the admin page.",
             )
+
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the saved Anthropic config without touching the cached client."""
+        client = Anthropic(
+            api_key=settings.anthropic_api_key,
+            timeout=PREFLIGHT_TIMEOUT_SECONDS,
+            max_retries=0,
+        )
+        return run_preflight(
+            base_url="",
+            auth_present=bool(settings.anthropic_api_key),
+            model=model,
+            listing=lambda: cast(Any, client).models.list(),
+            completion=lambda: cast(Any, client.messages).create(
+                model=model,
+                max_tokens=1,
+                messages=[{"role": "user", "content": "ping"}],
+            ),
+            translate=_translate_error,
+        )
 
     def stream(
         self,
@@ -67,7 +93,10 @@ class AnthropicProvider:
 
         log.info(
             "llm request provider=anthropic model=%s tools=%d max_tokens=%d msgs=%d",
-            model, len(tools or []), max_tokens, len(convo),
+            model,
+            len(tools or []),
+            max_tokens,
+            len(convo),
         )
         client = _client(settings.anthropic_api_key)
         try:
@@ -109,7 +138,10 @@ class AnthropicProvider:
             out_tok = cast(int, getattr(final.usage, "output_tokens", 0))
             log.info(
                 "llm done provider=anthropic model=%s stop=%s tokens=%d/%d",
-                model, getattr(final, "stop_reason", "") or "", in_tok, out_tok,
+                model,
+                getattr(final, "stop_reason", "") or "",
+                in_tok,
+                out_tok,
             )
             yield {
                 "type": "done",

--- a/backend/app/llm/providers/custom.py
+++ b/backend/app/llm/providers/custom.py
@@ -11,7 +11,12 @@ import openai
 from openai import OpenAI
 
 from app.llm.errors import LLMError
-from app.llm.providers._common import safe_json_loads, stringify_tool_result
+from app.llm.providers._common import (
+    PREFLIGHT_TIMEOUT_SECONDS,
+    run_preflight,
+    safe_json_loads,
+    stringify_tool_result,
+)
 from app.llm.providers._openai_errors import translate_openai_error
 from app.llm.settings import LLMSettings
 
@@ -41,45 +46,6 @@ def _create_stream(client: OpenAI, kwargs: dict[str, Any]) -> Any:
     return completions.create(**kwargs)
 
 
-_PREFLIGHT_TIMEOUT_SECONDS = 10.0
-
-
-def test_connection(settings: LLMSettings, *, model: str) -> dict[str, Any]:
-    """Preflight the saved gateway config: GET /models when the gateway has it,
-    plus a 1-token completion. Diagnostics are redacted — the key never leaves."""
-    client = OpenAI(
-        api_key=settings.custom_api_key or _KEYLESS_API_KEY,
-        base_url=settings.custom_base_url,
-        timeout=_PREFLIGHT_TIMEOUT_SECONDS,
-        max_retries=0,
-    )
-    result: dict[str, Any] = {
-        "base_url": settings.custom_base_url,
-        "auth_present": bool(settings.custom_api_key),
-        "model": model,
-    }
-    try:
-        cast(Any, client).models.list()
-        result["models_endpoint"] = "ok"
-    except Exception as exc:
-        # Non-fatal: plenty of gateways don't implement /models.
-        result["models_endpoint"] = translate_openai_error(
-            exc, provider_label=_PROVIDER_LABEL
-        ).message
-    try:
-        cast(Any, client.chat).completions.create(
-            model=model,
-            messages=[{"role": "user", "content": "ping"}],
-            max_tokens=1,
-        )
-        result["completion"] = "ok"
-        result["ok"] = True
-    except Exception as exc:
-        result["completion"] = translate_openai_error(exc, provider_label=_PROVIDER_LABEL).message
-        result["ok"] = False
-    return result
-
-
 class CustomProvider:
     name = "custom"
 
@@ -89,6 +55,27 @@ class CustomProvider:
                 "not_configured",
                 "Custom provider base URL is not set. An admin needs to add it on the admin page.",
             )
+
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the saved gateway config without touching the cached client."""
+        client = OpenAI(
+            api_key=settings.custom_api_key or _KEYLESS_API_KEY,
+            base_url=settings.custom_base_url,
+            timeout=PREFLIGHT_TIMEOUT_SECONDS,
+            max_retries=0,
+        )
+        return run_preflight(
+            base_url=settings.custom_base_url,
+            auth_present=bool(settings.custom_api_key),
+            model=model,
+            listing=lambda: cast(Any, client).models.list(),
+            completion=lambda: cast(Any, client.chat).completions.create(
+                model=model,
+                messages=[{"role": "user", "content": "ping"}],
+                max_tokens=1,
+            ),
+            translate=lambda exc: translate_openai_error(exc, provider_label=_PROVIDER_LABEL),
+        )
 
     def stream(
         self,

--- a/backend/app/llm/providers/custom.py
+++ b/backend/app/llm/providers/custom.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 StreamEvent = dict[str, Any]
 
+_PROVIDER_LABEL = "Custom provider"
 _KEYLESS_API_KEY = "EMPTY"  # vLLM/LM Studio allow keyless mode; the SDK still needs a value.
 
 
@@ -38,6 +39,45 @@ def _create_stream(client: OpenAI, kwargs: dict[str, Any]) -> Any:
         if "stream_options" not in msg and "include_usage" not in msg:
             raise
     return completions.create(**kwargs)
+
+
+_PREFLIGHT_TIMEOUT_SECONDS = 10.0
+
+
+def test_connection(settings: LLMSettings, *, model: str) -> dict[str, Any]:
+    """Preflight the saved gateway config: GET /models when the gateway has it,
+    plus a 1-token completion. Diagnostics are redacted — the key never leaves."""
+    client = OpenAI(
+        api_key=settings.custom_api_key or _KEYLESS_API_KEY,
+        base_url=settings.custom_base_url,
+        timeout=_PREFLIGHT_TIMEOUT_SECONDS,
+        max_retries=0,
+    )
+    result: dict[str, Any] = {
+        "base_url": settings.custom_base_url,
+        "auth_present": bool(settings.custom_api_key),
+        "model": model,
+    }
+    try:
+        cast(Any, client).models.list()
+        result["models_endpoint"] = "ok"
+    except Exception as exc:
+        # Non-fatal: plenty of gateways don't implement /models.
+        result["models_endpoint"] = translate_openai_error(
+            exc, provider_label=_PROVIDER_LABEL
+        ).message
+    try:
+        cast(Any, client.chat).completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "ping"}],
+            max_tokens=1,
+        )
+        result["completion"] = "ok"
+        result["ok"] = True
+    except Exception as exc:
+        result["completion"] = translate_openai_error(exc, provider_label=_PROVIDER_LABEL).message
+        result["ok"] = False
+    return result
 
 
 class CustomProvider:
@@ -160,7 +200,7 @@ class CustomProvider:
             raise
         except Exception as exc:
             log.exception("llm provider error provider=custom model=%s", model)
-            raise translate_openai_error(exc, provider_label="Custom provider") from exc
+            raise translate_openai_error(exc, provider_label=_PROVIDER_LABEL) from exc
 
 
 def _cc_message(m: dict[str, Any]) -> dict[str, Any]:

--- a/backend/app/llm/providers/gemini.py
+++ b/backend/app/llm/providers/gemini.py
@@ -51,7 +51,10 @@ class GeminiProvider:
 
     def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
         """Preflight the saved Gemini config without touching the cached client."""
-        client = genai.Client(api_key=settings.gemini_api_key)
+        client = genai.Client(
+            api_key=settings.gemini_api_key,
+            http_options=cast(Any, {"timeout": int(PREFLIGHT_TIMEOUT_SECONDS * 1000)}),
+        )
         return run_preflight(
             base_url="",
             auth_present=bool(settings.gemini_api_key),
@@ -60,13 +63,7 @@ class GeminiProvider:
             completion=lambda: cast(Any, client.models).generate_content(
                 model=model,
                 contents=cast(Any, "ping"),
-                config=cast(
-                    Any,
-                    {
-                        "max_output_tokens": 1,
-                        "http_options": {"timeout": int(PREFLIGHT_TIMEOUT_SECONDS * 1000)},
-                    },
-                ),
+                config=cast(Any, {"max_output_tokens": 1}),
             ),
             translate=_translate_error,
         )

--- a/backend/app/llm/providers/gemini.py
+++ b/backend/app/llm/providers/gemini.py
@@ -9,6 +9,7 @@ differs from Anthropic/OpenAI in two notable ways:
   so we resolve the name by walking earlier assistant turns
   (see ``tool_call_id_to_name``).
 """
+
 from __future__ import annotations
 
 import logging
@@ -19,6 +20,8 @@ from google import genai
 
 from app.llm.errors import LLMError
 from app.llm.providers._common import (
+    PREFLIGHT_TIMEOUT_SECONDS,
+    run_preflight,
     split_system,
     stringify_tool_result,
     tool_call_id_to_name,
@@ -45,6 +48,28 @@ class GeminiProvider:
                 "not_configured",
                 "Gemini API key is not set. An admin needs to add it on the admin page.",
             )
+
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the saved Gemini config without touching the cached client."""
+        client = genai.Client(api_key=settings.gemini_api_key)
+        return run_preflight(
+            base_url="",
+            auth_present=bool(settings.gemini_api_key),
+            model=model,
+            listing=lambda: cast(Any, client.models).list(),
+            completion=lambda: cast(Any, client.models).generate_content(
+                model=model,
+                contents=cast(Any, "ping"),
+                config=cast(
+                    Any,
+                    {
+                        "max_output_tokens": 1,
+                        "http_options": {"timeout": int(PREFLIGHT_TIMEOUT_SECONDS * 1000)},
+                    },
+                ),
+            ),
+            translate=_translate_error,
+        )
 
     def stream(
         self,
@@ -81,7 +106,10 @@ class GeminiProvider:
 
         log.info(
             "llm request provider=gemini model=%s tools=%d max_tokens=%d msgs=%d",
-            model, len(tools or []), max_tokens, len(convo),
+            model,
+            len(tools or []),
+            max_tokens,
+            len(convo),
         )
         client = _client(settings.gemini_api_key)
         try:
@@ -127,7 +155,10 @@ class GeminiProvider:
                     }
             log.info(
                 "llm done provider=gemini model=%s stop=%s tokens=%d/%d",
-                model, stop_reason, usage["input_tokens"], usage["output_tokens"],
+                model,
+                stop_reason,
+                usage["input_tokens"],
+                usage["output_tokens"],
             )
             yield {"type": "done", "stop_reason": stop_reason, "usage": usage}
         except LLMError:
@@ -152,18 +183,14 @@ def _content_for(m: dict[str, Any], id_to_name: dict[str, str]) -> dict[str, Any
             response_obj = {"result": stringify_tool_result(content)}
         return {
             "role": "user",
-            "parts": [
-                {"function_response": {"name": name, "response": response_obj}}
-            ],
+            "parts": [{"function_response": {"name": name, "response": response_obj}}],
         }
     if role == "assistant" and m.get("tool_calls"):
         parts: list[dict[str, Any]] = []
         if m.get("content"):
             parts.append({"text": m["content"]})
         for tc in m["tool_calls"]:
-            parts.append(
-                {"function_call": {"name": tc["name"], "args": tc["arguments"]}}
-            )
+            parts.append({"function_call": {"name": tc["name"], "args": tc["arguments"]}})
         return {"role": "model", "parts": parts}
     if role == "assistant":
         return {"role": "model", "parts": [{"text": m["content"] or ""}]}

--- a/backend/app/llm/providers/ollama.py
+++ b/backend/app/llm/providers/ollama.py
@@ -13,6 +13,7 @@ Differences from cloud providers:
 * Tool-call arguments come back as a dict already (no JSON-string
   reassembly).
 """
+
 from __future__ import annotations
 
 import logging
@@ -22,7 +23,11 @@ from typing import Any, Iterator, cast
 from ollama import Client
 
 from app.llm.errors import LLMError
-from app.llm.providers._common import stringify_tool_result
+from app.llm.providers._common import (
+    PREFLIGHT_TIMEOUT_SECONDS,
+    run_preflight,
+    stringify_tool_result,
+)
 from app.llm.settings import LLMSettings
 
 log = logging.getLogger(__name__)
@@ -44,6 +49,26 @@ class OllamaProvider:
         # to the SDK default (localhost). Nothing to validate here — model
         # presence is checked upstream in client.stream.
         return
+
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the saved Ollama config without touching the cached client."""
+        client = (
+            Client(host=settings.ollama_base_url, timeout=PREFLIGHT_TIMEOUT_SECONDS)
+            if settings.ollama_base_url
+            else Client(timeout=PREFLIGHT_TIMEOUT_SECONDS)
+        )
+        return run_preflight(
+            base_url=settings.ollama_base_url,
+            auth_present=False,
+            model=model,
+            listing=lambda: cast(Any, client).list(),
+            completion=lambda: cast(Any, client).chat(
+                model=model,
+                messages=[{"role": "user", "content": "ping"}],
+                options={"num_predict": 1},
+            ),
+            translate=_translate_error,
+        )
 
     def stream(
         self,
@@ -79,7 +104,10 @@ class OllamaProvider:
 
         log.info(
             "llm request provider=ollama model=%s tools=%d max_tokens=%d msgs=%d",
-            model, len(tools or []), max_tokens, len(ollama_messages),
+            model,
+            len(tools or []),
+            max_tokens,
+            len(ollama_messages),
         )
         client = _client(settings.ollama_base_url)
         try:
@@ -127,7 +155,10 @@ class OllamaProvider:
                     }
             log.info(
                 "llm done provider=ollama model=%s stop=%s tokens=%d/%d",
-                model, stop_reason, usage["input_tokens"], usage["output_tokens"],
+                model,
+                stop_reason,
+                usage["input_tokens"],
+                usage["output_tokens"],
             )
             yield {"type": "done", "stop_reason": stop_reason, "usage": usage}
         except LLMError:

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -1,4 +1,5 @@
 """OpenAI provider — Responses API streaming (NOT Chat Completions)."""
+
 from __future__ import annotations
 
 import json
@@ -9,7 +10,12 @@ from typing import Any, Iterator, cast
 from openai import OpenAI
 
 from app.llm.errors import LLMError
-from app.llm.providers._common import safe_json_loads, split_system
+from app.llm.providers._common import (
+    PREFLIGHT_TIMEOUT_SECONDS,
+    run_preflight,
+    safe_json_loads,
+    split_system,
+)
 from app.llm.providers._openai_errors import translate_openai_error
 from app.llm.settings import LLMSettings
 
@@ -33,6 +39,26 @@ class OpenAIProvider:
                 "not_configured",
                 "OpenAI API key is not set. An admin needs to add it on the admin page.",
             )
+
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the saved OpenAI config without touching the cached client."""
+        client = OpenAI(
+            api_key=settings.openai_api_key,
+            timeout=PREFLIGHT_TIMEOUT_SECONDS,
+            max_retries=0,
+        )
+        return run_preflight(
+            base_url="",
+            auth_present=bool(settings.openai_api_key),
+            model=model,
+            listing=lambda: cast(Any, client).models.list(),
+            completion=lambda: cast(Any, client.responses).create(
+                model=model,
+                input="ping",
+                max_output_tokens=16,
+            ),
+            translate=lambda exc: translate_openai_error(exc, provider_label="OpenAI"),
+        )
 
     def stream(
         self,
@@ -72,7 +98,10 @@ class OpenAIProvider:
 
         log.info(
             "llm request provider=openai model=%s tools=%d max_tokens=%d items=%d",
-            model, len(tools or []), max_tokens, len(input_items),
+            model,
+            len(tools or []),
+            max_tokens,
+            len(input_items),
         )
         client = _client(settings.openai_api_key)
         try:
@@ -117,7 +146,10 @@ class OpenAIProvider:
                     status = getattr(resp, "status", "") or ""
                     log.info(
                         "llm done provider=openai model=%s status=%s tokens=%d/%d",
-                        model, status, in_tok, out_tok,
+                        model,
+                        status,
+                        in_tok,
+                        out_tok,
                     )
                     yield {
                         "type": "done",

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -42,9 +42,9 @@ class LLMConfigRequest(BaseModel):
     ingest_selector_model: str | None = None
 
 
-class CustomProviderTestRequest(BaseModel):
-    """Model to preflight; empty/absent falls back to the first saved custom
-    model, then the active model."""
+class ProviderTestRequest(BaseModel):
+    """Model to preflight; empty/absent falls back to the first saved model
+    for that provider, then the active model."""
 
     # `model` is a real field, so silence pydantic's ``model_*`` namespace warning.
     model_config = ConfigDict(protected_namespaces=())
@@ -136,8 +136,8 @@ class LLMView(BaseModel):
     ingest_selector_model: str
 
 
-class CustomProviderTestResult(BaseModel):
-    """Redacted preflight diagnostics — never includes the key."""
+class ProviderTestResult(BaseModel):
+    """Redacted preflight diagnostics for any provider — never includes credentials."""
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -42,6 +42,16 @@ class LLMConfigRequest(BaseModel):
     ingest_selector_model: str | None = None
 
 
+class CustomProviderTestRequest(BaseModel):
+    """Model to preflight; empty/absent falls back to the first saved custom
+    model, then the active model."""
+
+    # `model` is a real field, so silence pydantic's ``model_*`` namespace warning.
+    model_config = ConfigDict(protected_namespaces=())
+
+    model: str | None = None
+
+
 class WebConfigRequest(BaseModel):
     serper_api_key: str | None = None
     firecrawl_api_key: str | None = None
@@ -124,6 +134,20 @@ class LLMView(BaseModel):
     custom_display_name: str
     provider_models: dict[str, list[str]]
     ingest_selector_model: str
+
+
+class CustomProviderTestResult(BaseModel):
+    """Redacted preflight diagnostics — never includes the key."""
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    ok: bool
+    base_url: str
+    auth_present: bool
+    model: str
+    # "ok" or a translated, redaction-safe error message.
+    models_endpoint: str
+    completion: str
 
 
 class WebView(BaseModel):

--- a/backend/tests/test_admin_llm_custom.py
+++ b/backend/tests/test_admin_llm_custom.py
@@ -145,7 +145,7 @@ def test_available_omits_custom_without_models(client, admin):
 def test_preflight_unconfigured_is_400(client, admin):
     r = client.post("/api/admin/llm/custom/test", json={})
     assert r.status_code == 400
-    assert "not configured" in r.json()["error"]
+    assert "base URL" in r.json()["error"]
 
 
 def test_preflight_without_any_model_is_400(client, admin):
@@ -170,9 +170,9 @@ def test_preflight_falls_back_to_first_saved_model(client, admin, monkeypatch):
             "completion": "ok",
         }
 
-    import app.api.admin as admin_api
-
-    monkeypatch.setattr(admin_api.custom_provider, "test_connection", fake_test)
+    provider = llm_providers.get("custom")
+    assert provider is not None
+    monkeypatch.setattr(provider, "test_connection", fake_test)
     r = client.post("/api/admin/llm/custom/test", json={})
     assert r.status_code == 200
     assert r.json()["ok"] is True
@@ -194,10 +194,48 @@ def test_preflight_explicit_model_wins(client, admin, monkeypatch):
             "completion": "Custom provider rejected the API key.",
         }
 
-    import app.api.admin as admin_api
-
-    monkeypatch.setattr(admin_api.custom_provider, "test_connection", fake_test)
+    provider = llm_providers.get("custom")
+    assert provider is not None
+    monkeypatch.setattr(provider, "test_connection", fake_test)
     r = client.post("/api/admin/llm/custom/test", json={"model": "other-model"})
     assert r.status_code == 200
     assert r.json()["ok"] is False
     assert seen["model"] == "other-model"
+
+
+def test_preflight_unknown_provider_is_404(client, admin):
+    r = client.post("/api/admin/llm/custom-bogus/test", json={})
+    assert r.status_code == 404
+    assert "unknown provider" in r.json()["error"]
+
+
+def test_preflight_builtin_provider_dispatches_via_registry(client, admin, monkeypatch):
+    _put(
+        client,
+        provider="anthropic",
+        model="claude-3-5-haiku-latest",
+        anthropic_api_key="sk-ant-test",
+        provider_models={"anthropic": ["claude-3-5-haiku-latest"]},
+    )
+    seen: dict[str, str] = {}
+
+    def fake_test(settings, *, model):
+        seen["model"] = model
+        return {
+            "ok": True,
+            "base_url": "",
+            "auth_present": bool(settings.anthropic_api_key),
+            "model": model,
+            "models_endpoint": "ok",
+            "completion": "ok",
+        }
+
+    provider = llm_providers.get("anthropic")
+    assert provider is not None
+    monkeypatch.setattr(provider, "test_connection", fake_test)
+
+    r = client.post("/api/admin/llm/anthropic/test", json={})
+
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    assert seen["model"] == "claude-3-5-haiku-latest"

--- a/backend/tests/test_admin_llm_custom.py
+++ b/backend/tests/test_admin_llm_custom.py
@@ -140,3 +140,64 @@ def test_available_omits_custom_without_models(client, admin):
     _configure_custom(client, provider_models={"custom": []})
     providers = client.get("/api/llm/available").json()["providers"]
     assert all(p["provider"] != "custom" for p in providers)
+
+
+def test_preflight_unconfigured_is_400(client, admin):
+    r = client.post("/api/admin/llm/custom/test", json={})
+    assert r.status_code == 400
+    assert "not configured" in r.json()["error"]
+
+
+def test_preflight_without_any_model_is_400(client, admin):
+    _put(client, custom_base_url="https://gw.example.com/v1")
+    r = client.post("/api/admin/llm/custom/test", json={})
+    assert r.status_code == 400
+    assert "model" in r.json()["error"]
+
+
+def test_preflight_falls_back_to_first_saved_model(client, admin, monkeypatch):
+    _configure_custom(client)
+    seen: dict[str, str] = {}
+
+    def fake_test(settings, *, model):
+        seen["model"] = model
+        return {
+            "ok": True,
+            "base_url": settings.custom_base_url,
+            "auth_present": True,
+            "model": model,
+            "models_endpoint": "ok",
+            "completion": "ok",
+        }
+
+    import app.api.admin as admin_api
+
+    monkeypatch.setattr(admin_api.custom_provider, "test_connection", fake_test)
+    r = client.post("/api/admin/llm/custom/test", json={})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    assert seen["model"] == "deepseek-chat"
+
+
+def test_preflight_explicit_model_wins(client, admin, monkeypatch):
+    _configure_custom(client)
+    seen: dict[str, str] = {}
+
+    def fake_test(settings, *, model):
+        seen["model"] = model
+        return {
+            "ok": False,
+            "base_url": settings.custom_base_url,
+            "auth_present": True,
+            "model": model,
+            "models_endpoint": "ok",
+            "completion": "Custom provider rejected the API key.",
+        }
+
+    import app.api.admin as admin_api
+
+    monkeypatch.setattr(admin_api.custom_provider, "test_connection", fake_test)
+    r = client.post("/api/admin/llm/custom/test", json={"model": "other-model"})
+    assert r.status_code == 200
+    assert r.json()["ok"] is False
+    assert seen["model"] == "other-model"

--- a/backend/tests/test_custom_provider.py
+++ b/backend/tests/test_custom_provider.py
@@ -430,3 +430,95 @@ def test_stream_wraps_tools_in_chat_completions_envelope(
             },
         }
     ]
+
+
+# --------------------------------------------------------------------------- #
+# Preflight (test_connection)                                                 #
+# --------------------------------------------------------------------------- #
+
+
+class _FakePreflightClient:
+    def __init__(self, models_exc: Exception | None, completion_exc: Exception | None):
+        outer = self
+
+        class _Models:
+            def list(self) -> list[object]:
+                if models_exc is not None:
+                    raise models_exc
+                return []
+
+        class _Completions:
+            def create(self, **kwargs: object) -> object:
+                outer.completion_kwargs = kwargs
+                if completion_exc is not None:
+                    raise completion_exc
+                return object()
+
+        class _Chat:
+            completions = _Completions()
+
+        self.models = _Models()
+        self.chat = _Chat()
+        self.completion_kwargs: dict[str, object] = {}
+
+
+def _patch_preflight_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    models_exc: Exception | None = None,
+    completion_exc: Exception | None = None,
+) -> tuple[_FakePreflightClient, dict[str, object]]:
+    fake = _FakePreflightClient(models_exc, completion_exc)
+    ctor_kwargs: dict[str, object] = {}
+
+    def factory(**kwargs: object) -> _FakePreflightClient:
+        ctor_kwargs.update(kwargs)
+        return fake
+
+    monkeypatch.setattr(custom_provider, "OpenAI", factory)
+    return fake, ctor_kwargs
+
+
+def test_preflight_all_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake, ctor = _patch_preflight_client(monkeypatch)
+    result = custom_provider.test_connection(
+        _settings(custom_api_key="sk-x"), model="m-1"
+    )
+    assert result["ok"] is True
+    assert result["models_endpoint"] == "ok"
+    assert result["completion"] == "ok"
+    assert result["auth_present"] is True
+    assert result["model"] == "m-1"
+    assert fake.completion_kwargs["model"] == "m-1"
+    assert fake.completion_kwargs["max_tokens"] == 1
+    assert ctor["max_retries"] == 0
+
+
+def test_preflight_models_endpoint_missing_is_nonfatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = httpx.Request("GET", "https://example.test/v1/models")
+    response = httpx.Response(status_code=404, request=request)
+    nf = openai.NotFoundError("nope", response=response, body=None)
+    _patch_preflight_client(monkeypatch, models_exc=nf)
+    result = custom_provider.test_connection(_settings(), model="m-1")
+    assert result["ok"] is True
+    assert result["models_endpoint"] != "ok"
+    assert "model name" in result["models_endpoint"]
+    assert result["completion"] == "ok"
+
+
+def test_preflight_completion_failure_reports_translated_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    request = httpx.Request("POST", "https://example.test/v1/chat/completions")
+    response = httpx.Response(status_code=401, request=request)
+    auth = openai.AuthenticationError("bad key", response=response, body=None)
+    _, ctor = _patch_preflight_client(monkeypatch, completion_exc=auth)
+    result = custom_provider.test_connection(
+        _settings(custom_api_key=""), model="m-1"
+    )
+    assert result["ok"] is False
+    assert "rejected the API key" in result["completion"]
+    assert result["auth_present"] is False
+    assert ctor["api_key"] == "EMPTY"

--- a/backend/tests/test_custom_provider.py
+++ b/backend/tests/test_custom_provider.py
@@ -481,9 +481,7 @@ def _patch_preflight_client(
 
 def test_preflight_all_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     fake, ctor = _patch_preflight_client(monkeypatch)
-    result = custom_provider.test_connection(
-        _settings(custom_api_key="sk-x"), model="m-1"
-    )
+    result = custom_provider.PROVIDER.test_connection(_settings(custom_api_key="sk-x"), model="m-1")
     assert result["ok"] is True
     assert result["models_endpoint"] == "ok"
     assert result["completion"] == "ok"
@@ -501,7 +499,7 @@ def test_preflight_models_endpoint_missing_is_nonfatal(
     response = httpx.Response(status_code=404, request=request)
     nf = openai.NotFoundError("nope", response=response, body=None)
     _patch_preflight_client(monkeypatch, models_exc=nf)
-    result = custom_provider.test_connection(_settings(), model="m-1")
+    result = custom_provider.PROVIDER.test_connection(_settings(), model="m-1")
     assert result["ok"] is True
     assert result["models_endpoint"] != "ok"
     assert "model name" in result["models_endpoint"]
@@ -515,9 +513,7 @@ def test_preflight_completion_failure_reports_translated_error(
     response = httpx.Response(status_code=401, request=request)
     auth = openai.AuthenticationError("bad key", response=response, body=None)
     _, ctor = _patch_preflight_client(monkeypatch, completion_exc=auth)
-    result = custom_provider.test_connection(
-        _settings(custom_api_key=""), model="m-1"
-    )
+    result = custom_provider.PROVIDER.test_connection(_settings(custom_api_key=""), model="m-1")
     assert result["ok"] is False
     assert "rejected the API key" in result["completion"]
     assert result["auth_present"] is False

--- a/backend/tests/test_provider_preflights.py
+++ b/backend/tests/test_provider_preflights.py
@@ -1,0 +1,382 @@
+"""Every provider preflight returns redacted diagnostics with ``ok`` gated on
+the completion probe and a non-fatal listing probe."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import anthropic
+import httpx
+import ollama
+import openai
+import pytest
+
+from app.llm.providers import anthropic as anthropic_provider
+from app.llm.providers import gemini as gemini_provider
+from app.llm.providers import ollama as ollama_provider
+from app.llm.providers import openai as openai_provider
+from app.llm.providers._common import PREFLIGHT_TIMEOUT_SECONDS
+from app.llm.settings import LLMSettings
+
+
+def _settings(**overrides: Any) -> LLMSettings:
+    base: dict[str, Any] = {
+        "provider": "openai",
+        "model": "base-model",
+        "anthropic_api_key": "sk-ant-test",
+        "openai_api_key": "sk-openai-test",
+        "gemini_api_key": "sk-gemini-test",
+        "ollama_base_url": "http://localhost:11434",
+        "custom_api_key": "",
+        "custom_base_url": "",
+        "custom_display_name": "",
+        "provider_models": {},
+        "ingest_selector_model": "",
+    }
+    base.update(overrides)
+    return LLMSettings(**base)
+
+
+class _FakeAnthropicClient:
+    def __init__(self, models_exc: Exception | None, completion_exc: Exception | None):
+        self._models_exc = models_exc
+        self._completion_exc = completion_exc
+        self.models = SimpleNamespace(list=self._list_models)
+        self.messages = SimpleNamespace(create=self._create_message)
+        self.completion_kwargs: dict[str, Any] = {}
+
+    def _list_models(self) -> list[object]:
+        if self._models_exc is not None:
+            raise self._models_exc
+        return []
+
+    def _create_message(self, **kwargs: Any) -> object:
+        self.completion_kwargs = kwargs
+        if self._completion_exc is not None:
+            raise self._completion_exc
+        return object()
+
+
+class _FakeOpenAIClient:
+    def __init__(self, models_exc: Exception | None, completion_exc: Exception | None):
+        self._models_exc = models_exc
+        self._completion_exc = completion_exc
+        self.models = SimpleNamespace(list=self._list_models)
+        self.responses = SimpleNamespace(create=self._create_response)
+        self.completion_kwargs: dict[str, Any] = {}
+
+    def _list_models(self) -> list[object]:
+        if self._models_exc is not None:
+            raise self._models_exc
+        return []
+
+    def _create_response(self, **kwargs: Any) -> object:
+        self.completion_kwargs = kwargs
+        if self._completion_exc is not None:
+            raise self._completion_exc
+        return object()
+
+
+class _FakeGeminiModels:
+    def __init__(self, models_exc: Exception | None, completion_exc: Exception | None):
+        self._models_exc = models_exc
+        self._completion_exc = completion_exc
+        self.completion_kwargs: dict[str, Any] = {}
+
+    def list(self) -> list[object]:
+        if self._models_exc is not None:
+            raise self._models_exc
+        return []
+
+    def generate_content(self, **kwargs: Any) -> object:
+        self.completion_kwargs = kwargs
+        if self._completion_exc is not None:
+            raise self._completion_exc
+        return object()
+
+
+class _FakeGeminiClient:
+    def __init__(self, models_exc: Exception | None, completion_exc: Exception | None):
+        self.models = _FakeGeminiModels(models_exc, completion_exc)
+
+
+class _FakeOllamaClient:
+    def __init__(self, models_exc: Exception | None, completion_exc: Exception | None):
+        self._models_exc = models_exc
+        self._completion_exc = completion_exc
+        self.completion_kwargs: dict[str, Any] = {}
+
+    def list(self) -> dict[str, Any]:
+        if self._models_exc is not None:
+            raise self._models_exc
+        return {"models": []}
+
+    def chat(self, **kwargs: Any) -> dict[str, Any]:
+        self.completion_kwargs = kwargs
+        if self._completion_exc is not None:
+            raise self._completion_exc
+        return {"message": {"content": "pong"}}
+
+
+def _patch_anthropic_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    models_exc: Exception | None = None,
+    completion_exc: Exception | None = None,
+) -> tuple[_FakeAnthropicClient, dict[str, Any]]:
+    fake = _FakeAnthropicClient(models_exc, completion_exc)
+    ctor_kwargs: dict[str, Any] = {}
+
+    def factory(**kwargs: Any) -> _FakeAnthropicClient:
+        ctor_kwargs.update(kwargs)
+        return fake
+
+    monkeypatch.setattr(anthropic_provider, "Anthropic", factory)
+    return fake, ctor_kwargs
+
+
+def _patch_openai_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    models_exc: Exception | None = None,
+    completion_exc: Exception | None = None,
+) -> tuple[_FakeOpenAIClient, dict[str, Any]]:
+    fake = _FakeOpenAIClient(models_exc, completion_exc)
+    ctor_kwargs: dict[str, Any] = {}
+
+    def factory(**kwargs: Any) -> _FakeOpenAIClient:
+        ctor_kwargs.update(kwargs)
+        return fake
+
+    monkeypatch.setattr(openai_provider, "OpenAI", factory)
+    return fake, ctor_kwargs
+
+
+def _patch_gemini_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    models_exc: Exception | None = None,
+    completion_exc: Exception | None = None,
+) -> tuple[_FakeGeminiClient, dict[str, Any]]:
+    fake = _FakeGeminiClient(models_exc, completion_exc)
+    ctor_kwargs: dict[str, Any] = {}
+
+    def factory(**kwargs: Any) -> _FakeGeminiClient:
+        ctor_kwargs.update(kwargs)
+        return fake
+
+    monkeypatch.setattr(gemini_provider.genai, "Client", factory)
+    return fake, ctor_kwargs
+
+
+def _patch_ollama_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    models_exc: Exception | None = None,
+    completion_exc: Exception | None = None,
+) -> tuple[_FakeOllamaClient, dict[str, Any]]:
+    fake = _FakeOllamaClient(models_exc, completion_exc)
+    ctor_kwargs: dict[str, Any] = {}
+
+    def factory(**kwargs: Any) -> _FakeOllamaClient:
+        ctor_kwargs.update(kwargs)
+        return fake
+
+    monkeypatch.setattr(ollama_provider, "Client", factory)
+    return fake, ctor_kwargs
+
+
+def _openai_auth_error() -> openai.AuthenticationError:
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(status_code=401, request=request)
+    return openai.AuthenticationError("bad key", response=response, body=None)
+
+
+def _openai_not_found_error() -> openai.NotFoundError:
+    request = httpx.Request("GET", "https://api.openai.com/v1/models")
+    response = httpx.Response(status_code=404, request=request)
+    return openai.NotFoundError("missing", response=response, body=None)
+
+
+def _anthropic_auth_error() -> anthropic.AuthenticationError:
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status_code=401, request=request)
+    return anthropic.AuthenticationError("bad key", response=response, body=None)
+
+
+def _anthropic_not_found_error() -> anthropic.NotFoundError:
+    request = httpx.Request("GET", "https://api.anthropic.com/v1/models")
+    response = httpx.Response(status_code=404, request=request)
+    return anthropic.NotFoundError("missing", response=response, body=None)
+
+
+class _GeminiAuthError(Exception):
+    def __init__(self) -> None:
+        super().__init__("API_KEY_INVALID")
+        self.code = 401
+
+
+class _GeminiNotFoundError(Exception):
+    def __init__(self) -> None:
+        super().__init__("NotFound")
+        self.code = 404
+
+
+class ConnectError(Exception):
+    pass
+
+
+def _assert_redacted_shape(result: dict[str, Any], *, model: str) -> None:
+    assert set(result) == {
+        "ok",
+        "base_url",
+        "auth_present",
+        "model",
+        "models_endpoint",
+        "completion",
+    }
+    assert result["model"] == model
+    assert "api_key" not in result
+    assert "sk-" not in str(result)
+
+
+def test_anthropic_preflight_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake, ctor = _patch_anthropic_client(monkeypatch)
+
+    result = anthropic_provider.PROVIDER.test_connection(_settings(), model="claude-3-5-haiku")
+
+    _assert_redacted_shape(result, model="claude-3-5-haiku")
+    assert result["ok"] is True
+    assert result["base_url"] == ""
+    assert result["auth_present"] is True
+    assert result["models_endpoint"] == "ok"
+    assert result["completion"] == "ok"
+    assert fake.completion_kwargs["max_tokens"] == 1
+    assert ctor["timeout"] == PREFLIGHT_TIMEOUT_SECONDS
+    assert ctor["max_retries"] == 0
+
+
+def test_anthropic_preflight_completion_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_anthropic_client(monkeypatch, completion_exc=_anthropic_auth_error())
+
+    result = anthropic_provider.PROVIDER.test_connection(_settings(), model="claude-3-5-haiku")
+
+    assert result["ok"] is False
+    assert "rejected the API key" in result["completion"]
+
+
+def test_anthropic_preflight_models_failure_is_nonfatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_anthropic_client(monkeypatch, models_exc=_anthropic_not_found_error())
+
+    result = anthropic_provider.PROVIDER.test_connection(_settings(), model="claude-3-5-haiku")
+
+    assert result["ok"] is True
+    assert result["models_endpoint"] != "ok"
+    assert result["completion"] == "ok"
+
+
+def test_openai_preflight_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake, ctor = _patch_openai_client(monkeypatch)
+
+    result = openai_provider.PROVIDER.test_connection(_settings(), model="gpt-4o-mini")
+
+    _assert_redacted_shape(result, model="gpt-4o-mini")
+    assert result["ok"] is True
+    assert result["base_url"] == ""
+    assert result["auth_present"] is True
+    assert result["models_endpoint"] == "ok"
+    assert result["completion"] == "ok"
+    assert fake.completion_kwargs["max_output_tokens"] == 16
+    assert ctor["timeout"] == PREFLIGHT_TIMEOUT_SECONDS
+    assert ctor["max_retries"] == 0
+
+
+def test_openai_preflight_completion_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_openai_client(monkeypatch, completion_exc=_openai_auth_error())
+
+    result = openai_provider.PROVIDER.test_connection(_settings(), model="gpt-4o-mini")
+
+    assert result["ok"] is False
+    assert "rejected the API key" in result["completion"]
+
+
+def test_openai_preflight_models_failure_is_nonfatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_openai_client(monkeypatch, models_exc=_openai_not_found_error())
+
+    result = openai_provider.PROVIDER.test_connection(_settings(), model="gpt-4o-mini")
+
+    assert result["ok"] is True
+    assert result["models_endpoint"] != "ok"
+    assert result["completion"] == "ok"
+
+
+def test_gemini_preflight_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake, ctor = _patch_gemini_client(monkeypatch)
+
+    result = gemini_provider.PROVIDER.test_connection(_settings(), model="gemini-2.5-flash")
+
+    _assert_redacted_shape(result, model="gemini-2.5-flash")
+    assert result["ok"] is True
+    assert result["base_url"] == ""
+    assert result["auth_present"] is True
+    assert result["models_endpoint"] == "ok"
+    assert result["completion"] == "ok"
+    assert ctor == {"api_key": "sk-gemini-test"}
+    assert fake.models.completion_kwargs["config"]["http_options"]["timeout"] == int(
+        PREFLIGHT_TIMEOUT_SECONDS * 1000
+    )
+
+
+def test_gemini_preflight_completion_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_gemini_client(monkeypatch, completion_exc=_GeminiAuthError())
+
+    result = gemini_provider.PROVIDER.test_connection(_settings(), model="gemini-2.5-flash")
+
+    assert result["ok"] is False
+    assert "rejected the API key" in result["completion"]
+
+
+def test_gemini_preflight_models_failure_is_nonfatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_gemini_client(monkeypatch, models_exc=_GeminiNotFoundError())
+
+    result = gemini_provider.PROVIDER.test_connection(_settings(), model="gemini-2.5-flash")
+
+    assert result["ok"] is True
+    assert result["models_endpoint"] != "ok"
+    assert result["completion"] == "ok"
+
+
+def test_ollama_preflight_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake, ctor = _patch_ollama_client(monkeypatch)
+
+    result = ollama_provider.PROVIDER.test_connection(_settings(), model="llama3.1")
+
+    _assert_redacted_shape(result, model="llama3.1")
+    assert result["ok"] is True
+    assert result["base_url"] == "http://localhost:11434"
+    assert result["auth_present"] is False
+    assert result["models_endpoint"] == "ok"
+    assert result["completion"] == "ok"
+    assert fake.completion_kwargs["options"] == {"num_predict": 1}
+    assert ctor["host"] == "http://localhost:11434"
+    assert ctor["timeout"] == PREFLIGHT_TIMEOUT_SECONDS
+
+
+def test_ollama_preflight_completion_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_ollama_client(monkeypatch, completion_exc=ConnectError("Connection refused"))
+
+    result = ollama_provider.PROVIDER.test_connection(_settings(), model="llama3.1")
+
+    assert result["ok"] is False
+    assert "Could not reach Ollama" in result["completion"]
+
+
+def test_ollama_preflight_models_failure_is_nonfatal(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_ollama_client(monkeypatch, models_exc=ollama.ResponseError("missing", status_code=404))
+
+    result = ollama_provider.PROVIDER.test_connection(_settings(), model="llama3.1")
+
+    assert result["ok"] is True
+    assert result["models_endpoint"] != "ok"
+    assert result["completion"] == "ok"

--- a/backend/tests/test_provider_preflights.py
+++ b/backend/tests/test_provider_preflights.py
@@ -322,10 +322,11 @@ def test_gemini_preflight_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["auth_present"] is True
     assert result["models_endpoint"] == "ok"
     assert result["completion"] == "ok"
-    assert ctor == {"api_key": "sk-gemini-test"}
-    assert fake.models.completion_kwargs["config"]["http_options"]["timeout"] == int(
-        PREFLIGHT_TIMEOUT_SECONDS * 1000
-    )
+    assert ctor == {
+        "api_key": "sk-gemini-test",
+        "http_options": {"timeout": 10000},
+    }
+    assert fake.models.completion_kwargs["config"] == {"max_output_tokens": 1}
 
 
 def test_gemini_preflight_completion_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -591,6 +591,15 @@ function ProviderForm({
   );
 }
 
+interface CustomTestResult {
+  ok: boolean;
+  base_url: string;
+  auth_present: boolean;
+  model: string;
+  models_endpoint: string;
+  completion: string;
+}
+
 function CustomProviderForm({
   settings,
   configured,
@@ -610,7 +619,26 @@ function CustomProviderForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<CustomTestResult | null>(null);
   const confirmDialog = useConfirm();
+
+  async function onTest() {
+    setTesting(true);
+    setTestResult(null);
+    setError(null);
+    try {
+      const r = await apiFetch<CustomTestResult>("/admin/llm/custom/test", {
+        method: "POST",
+        body: JSON.stringify({ model: models[0] ?? null }),
+      });
+      setTestResult(r);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "test failed");
+    } finally {
+      setTesting(false);
+    }
+  }
 
   function addModel() {
     const m = newModel.trim();
@@ -757,6 +785,45 @@ function CustomProviderForm({
           </div>
         </div>
       </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          disabled={testing || !configured}
+          onClick={() => void onTest()}
+        >
+          {testing ? "Testing…" : "Test connection"}
+        </Button>
+        <span className="text-xs text-(--text-03)">
+          Tests the saved configuration.
+        </span>
+      </div>
+      {testResult && (
+        <div className="flex flex-col gap-1 font-mono text-xs">
+          <div
+            className={
+              testResult.ok
+                ? "text-(--status-text-success-05)"
+                : "text-(--status-text-error-05)"
+            }
+          >
+            {testResult.ok
+              ? `✓ ${testResult.model} responded`
+              : `✗ ${testResult.completion}`}
+          </div>
+          <div className="text-(--text-03)">
+            {testResult.models_endpoint === "ok"
+              ? "✓ /models reachable"
+              : `• /models: ${testResult.models_endpoint}`}
+          </div>
+          <div className="text-(--text-03)">
+            {testResult.auth_present ? "auth: key sent" : "auth: keyless"} ·{" "}
+            {testResult.base_url}
+          </div>
+        </div>
+      )}
 
       <FormMessages error={error} saved={saved} />
       <FormActions saving={saving} configured={configured} onClear={onClear} />

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -585,19 +585,105 @@ function ProviderForm({
         </div>
       </div>
 
+      <TestConnection
+        provider={provider}
+        model={knownModels.find((m) => selectedModels.has(m)) ?? null}
+        configured={configured}
+      />
+
       <FormMessages error={error} saved={saved} />
       <FormActions saving={saving} configured={configured} onClear={onClear} />
     </form>
   );
 }
 
-interface CustomTestResult {
+interface ProviderTestResult {
   ok: boolean;
   base_url: string;
   auth_present: boolean;
   model: string;
   models_endpoint: string;
   completion: string;
+}
+
+function TestConnection({
+  provider,
+  model,
+  configured,
+}: {
+  provider: Provider;
+  model: string | null;
+  configured: boolean;
+}) {
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<ProviderTestResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onTest() {
+    setTesting(true);
+    setResult(null);
+    setError(null);
+    try {
+      const r = await apiFetch<ProviderTestResult>(
+        `/admin/llm/${provider}/test`,
+        {
+          method: "POST",
+          body: JSON.stringify({ model }),
+        },
+      );
+      setResult(r);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "test failed");
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          disabled={testing || !configured}
+          onClick={() => void onTest()}
+        >
+          {testing ? "Testing…" : "Test connection"}
+        </Button>
+        <span className="text-xs text-(--text-03)">
+          Tests the saved configuration.
+        </span>
+      </div>
+      {error && (
+        <div className="text-[13px] text-(--status-text-error-05)">{error}</div>
+      )}
+      {result && (
+        <div className="flex flex-col gap-1 font-mono text-xs">
+          <div
+            className={
+              result.ok
+                ? "text-(--status-text-success-05)"
+                : "text-(--status-text-error-05)"
+            }
+          >
+            {result.ok
+              ? `✓ ${result.model} responded`
+              : `✗ ${result.completion}`}
+          </div>
+          <div className="text-(--text-03)">
+            {result.models_endpoint === "ok"
+              ? "✓ models endpoint reachable"
+              : `• models endpoint: ${result.models_endpoint}`}
+          </div>
+          <div className="text-(--text-03)">
+            {result.auth_present ? "auth: key sent" : "auth: keyless"}
+            {result.base_url ? ` · ${result.base_url}` : ""}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function CustomProviderForm({
@@ -619,26 +705,7 @@ function CustomProviderForm({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
-  const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<CustomTestResult | null>(null);
   const confirmDialog = useConfirm();
-
-  async function onTest() {
-    setTesting(true);
-    setTestResult(null);
-    setError(null);
-    try {
-      const r = await apiFetch<CustomTestResult>("/admin/llm/custom/test", {
-        method: "POST",
-        body: JSON.stringify({ model: models[0] ?? null }),
-      });
-      setTestResult(r);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "test failed");
-    } finally {
-      setTesting(false);
-    }
-  }
 
   function addModel() {
     const m = newModel.trim();
@@ -786,44 +853,11 @@ function CustomProviderForm({
         </div>
       </div>
 
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          variant="default"
-          size="sm"
-          disabled={testing || !configured}
-          onClick={() => void onTest()}
-        >
-          {testing ? "Testing…" : "Test connection"}
-        </Button>
-        <span className="text-xs text-(--text-03)">
-          Tests the saved configuration.
-        </span>
-      </div>
-      {testResult && (
-        <div className="flex flex-col gap-1 font-mono text-xs">
-          <div
-            className={
-              testResult.ok
-                ? "text-(--status-text-success-05)"
-                : "text-(--status-text-error-05)"
-            }
-          >
-            {testResult.ok
-              ? `✓ ${testResult.model} responded`
-              : `✗ ${testResult.completion}`}
-          </div>
-          <div className="text-(--text-03)">
-            {testResult.models_endpoint === "ok"
-              ? "✓ /models reachable"
-              : `• /models: ${testResult.models_endpoint}`}
-          </div>
-          <div className="text-(--text-03)">
-            {testResult.auth_present ? "auth: key sent" : "auth: keyless"} ·{" "}
-            {testResult.base_url}
-          </div>
-        </div>
-      )}
+      <TestConnection
+        provider="custom"
+        model={models[0] ?? null}
+        configured={configured}
+      />
 
       <FormMessages error={error} saved={saved} />
       <FormActions saving={saving} configured={configured} onClear={onClear} />


### PR DESCRIPTION
## Description

Follow-up to #228, requested in #169's thread — and generalized per review feedback: every provider gets a preflight, not just custom.

- `Provider` protocol gains `test_connection(settings, *, model)`; all five providers implement it via a shared `run_preflight` scaffold (non-fatal models-listing probe + decisive 1-token completion, ~10s timeout, no retries)
- `POST /admin/llm/{provider}/test`: registry lookup (404 unknown), `check_configured` gate (400 with the provider's own message), model fallback request → saved[0] → active
- Diagnostics are redacted: per-probe status, auth mode, base URL where meaningful, translated error messages — never the key
- Admin UI: "Test connection" button on every provider card (shared component)
- 12 per-provider preflight tests + registry-dispatch route tests

## How Has This Been Tested?