### PR TITLE
fix(security): credential hints never reconstruct secrets; ingest key show-once

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -8,6 +8,17 @@ Use explicit type annotations for variables to enhance code clarity, especially 
 
 Prefer consistency with existing patterns, fix issues in code you touch, avoid tacking new features onto muddy interfaces, fail loudly instead of silently swallowing errors, keep code strictly typed, preserve clear state boundaries, remove duplicate or dead logic, break up overly long functions, avoid hidden import-time side effects, respect module boundaries, and favor correctness-by-construction over relying on callers to use an API correctly.
 
+## CRITICAL — Secrets Never Leave the Server
+
+API keys, tokens, and credentials must never appear in API responses, logs, traces, exception messages, or URLs. Any violation is a blocking finding regardless of severity elsewhere in the PR.
+
+- Response models expose credentials only as `*_set: bool` and `*_hint` (redacted) fields — never the raw value. A raw credential field in any read endpoint's response model is a blocking finding.
+- Show-once is the only exception: an endpoint that creates or rotates a credential may return it exactly once in that response; every subsequent read returns only set/hint.
+- Redaction must not reconstruct the secret: a first4…last4 hint is acceptable only for values long enough that it reveals a small fraction (≥16 chars); shorter values get fixed-width masking that reveals neither content nor length.
+- No credential values in `log.*` calls at any level, in tracing spans, in error/exception text returned to clients, or interpolated into URLs.
+- Flag any new code path that serializes a stored credential (`model_dump`, `JSONResponse`, f-string, `repr` in logs) outside the provider/SDK call that consumes it.
+- Frontend: credential inputs are write-only; never store a fetched raw credential in component state except the show-once response, and never render one outside that flow.
+
 ## TODOs
 
 Whenever a TODO is added, there must be an associated name or ticket in the form `TODO(name): ...` or `TODO(1234): ...`.

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -198,10 +198,12 @@ def delete_user(user_id: str, actor: User = Depends(require_admin)) -> OkRespons
 
 
 def _redact(key: str) -> str:
+    """First4…last4 only when the value is long enough that the hint can't
+    reconstruct it; fixed width below that so neither content nor length leak."""
     if not key:
         return ""
-    if len(key) <= 8:
-        return "•" * len(key)
+    if len(key) < 16:
+        return "••••••••"
     return f"{key[:4]}…{key[-4:]}"
 
 
@@ -390,7 +392,11 @@ _MAX_DOC_CHARS = 5_000_000
 
 
 def _ingest_view(s: IngestSettings) -> IngestView:
-    return IngestView(max_doc_chars=s.max_doc_chars, api_key=s.api_key)
+    return IngestView(
+        max_doc_chars=s.max_doc_chars,
+        api_key_set=bool(s.api_key),
+        api_key_hint=_redact(s.api_key or ""),
+    )
 
 
 @router.get("/ingest", response_model=IngestView)

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -138,8 +138,12 @@ class WebView(BaseModel):
 
 
 class IngestView(BaseModel):
+    """The raw ingest key is show-once via RegenerateKeyResponse — reads
+    only ever get set/hint."""
+
     max_doc_chars: int
-    api_key: str | None
+    api_key_set: bool
+    api_key_hint: str
 
 
 class RegenerateKeyResponse(BaseModel):

--- a/backend/tests/test_credential_masking.py
+++ b/backend/tests/test_credential_masking.py
@@ -1,0 +1,59 @@
+"""Credential masking: hints must not reconstruct short secrets, and the
+ingest API key is show-once — reads return only set/hint, never the raw key."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_db):
+    return TestClient(create_app())
+
+
+@pytest.fixture
+def admin(client):
+    uid = seed_user(uid="usr_adm", email="admin@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    return uid
+
+
+def test_short_key_hint_is_fixed_width(client, admin):
+    short = "sk-12345"  # 8 chars
+    medium = "sk-123456789"  # 12 chars — first4+last4 would expose 8/12
+    client.put("/api/admin/llm", json={"custom_api_key": medium})
+    got = client.get("/api/admin/llm").json()
+    assert got["custom_api_key_hint"] == "••••••••"
+    assert medium not in str(got)
+    assert short not in str(got)
+
+
+def test_long_key_hint_shows_edges_only(client, admin):
+    key = "sk-or-v1-" + "a" * 40
+    client.put("/api/admin/llm", json={"custom_api_key": key})
+    got = client.get("/api/admin/llm").json()
+    assert got["custom_api_key_hint"] == f"{key[:4]}…{key[-4:]}"
+    assert key not in str(got)
+
+
+def test_ingest_get_never_returns_raw_key(client, admin):
+    raw = client.post("/api/admin/ingest/regenerate-key").json()["api_key"]
+    assert raw  # show-once response carries the key
+
+    got = client.get("/api/admin/ingest").json()
+    assert "api_key" not in got
+    assert got["api_key_set"] is True
+    assert raw not in str(got)
+    assert got["api_key_hint"] != ""
+
+
+def test_ingest_get_before_any_key(client, admin):
+    got = client.get("/api/admin/ingest").json()
+    assert got["api_key_set"] is False
+    assert got["api_key_hint"] == ""

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -19,7 +19,8 @@ import { useIsMobile } from "@/lib/viewport";
 
 interface IngestSettings {
   max_doc_chars: number;
-  api_key: string | null;
+  api_key_set: boolean;
+  api_key_hint: string;
 }
 
 export default function AdminIngestPage() {
@@ -43,6 +44,8 @@ function IngestForm() {
   const [llmSettings, setLlmSettings] = useState<LLMSettings | null>(null);
   const [maxDocChars, setMaxDocChars] = useState("");
   const [keyVisible, setKeyVisible] = useState(false);
+  // Raw key exists client-side only in the regenerate response — show-once.
+  const [freshKey, setFreshKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -93,7 +96,7 @@ function IngestForm() {
 
   async function regenerateKey() {
     if (
-      settings?.api_key &&
+      (settings?.api_key_set || freshKey) &&
       !(await confirmDialog({
         title: "Regenerate the API key?",
         body: "The old key will stop working immediately.",
@@ -111,7 +114,8 @@ function IngestForm() {
           method: "POST",
         },
       );
-      setSettings((prev) => (prev ? { ...prev, api_key: r.api_key } : prev));
+      setFreshKey(r.api_key);
+      setSettings((prev) => (prev ? { ...prev, api_key_set: true } : prev));
       setKeyVisible(true);
       setSaved(
         "New API key generated. Copy it now — it will be masked after you leave this page.",
@@ -168,25 +172,31 @@ function IngestForm() {
               <input
                 readOnly
                 type={keyVisible ? "text" : "password"}
-                value={settings.api_key ?? ""}
+                value={freshKey ?? ""}
                 placeholder={
-                  settings.api_key ? undefined : "No key yet — click Regenerate"
+                  freshKey
+                    ? undefined
+                    : settings.api_key_set
+                      ? settings.api_key_hint
+                      : "No key yet — click Regenerate"
                 }
-                className={`box-border w-full flex-1 rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm${settings.api_key ? "font-mono" : ""}`}
+                className={`box-border w-full flex-1 rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm${freshKey ? "font-mono" : ""}`}
               />
-              {settings.api_key && keyVisible && (
+              {freshKey && keyVisible && (
                 <Button
                   type="button"
                   variant="default"
                   size="sm"
-                  onClick={() => void copyToClipboard(settings.api_key ?? "")}
+                  onClick={() => void copyToClipboard(freshKey)}
                 >
                   Copy
                 </Button>
               )}
               <Button
                 type="button"
-                variant={settings.api_key ? "default" : "action"}
+                variant={
+                  settings.api_key_set || freshKey ? "default" : "action"
+                }
                 size="sm"
                 disabled={saving}
                 onClick={() => void regenerateKey()}

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -180,7 +180,7 @@ function IngestForm() {
                       ? settings.api_key_hint
                       : "No key yet — click Regenerate"
                 }
-                className={`box-border w-full flex-1 rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm${freshKey ? "font-mono" : ""}`}
+                className={`box-border w-full flex-1 rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm ${freshKey ? "font-mono" : ""}`}
               />
               {freshKey && keyVisible && (
                 <Button


### PR DESCRIPTION
## Description

Key-masking audit findings (no LLM provider keys were exposed — these are the two gaps found):

**Bug 1:** `_redact` showed first4…last4 for any key >8 chars — a 9-char key exposed 8/9 characters — and `"•"*len` leaked the exact length.
**Fix:** hint only for values ≥16 chars; fixed-width mask below that.

**Bug 2:** `GET /admin/ingest` returned the raw ingest API key on every read (the page's own copy promises "masked after you leave this page").
**Fix:** reads return `api_key_set`/`api_key_hint`; the raw key appears only in the regenerate response — show-once, held in transient component state.

Also adds a **CRITICAL Greptile rule** ("Secrets Never Leave the Server"): raw credential fields in read responses, log/trace/error leakage, and reconstructable hints are blocking findings.

Tests pin all of it (`test_credential_masking.py`).

## How Has This Been Tested?