### PR TITLE
feat(comments): let agent @mention people in comments via find_user

### DIFF
--- a/backend/app/llm/agents/skills/__init__.py
+++ b/backend/app/llm/agents/skills/__init__.py
@@ -65,7 +65,7 @@ SKILLS: dict[str, Skill] = {
     "comments": Skill(
         name="comments",
         description="comment on wiki pages — add inline comments, reply in threads, resolve threads",
-        tool_names=("add_comment", "reply_comment", "resolve_comment"),
+        tool_names=("add_comment", "reply_comment", "resolve_comment", "find_user"),
         instructions=_load_md("comments"),
     ),
     "web_search": Skill(

--- a/backend/app/llm/agents/skills/comments.md
+++ b/backend/app/llm/agents/skills/comments.md
@@ -8,9 +8,22 @@ Tools:
 - `reply_comment(comment_id, body)` — reply in an existing thread (no anchor
   needed; it inherits the thread's).
 - `resolve_comment(comment_id)` — mark a thread resolved (done).
+- `find_user(query)` — look up a person's user id by name/email, to @mention them.
 
 To target an existing thread (reply/resolve), get its `comment_id` from a
 `search_comments` result.
+
+Mentioning someone (@mentions):
+- A real mention is a token in the body: `@[Display Name](mention:<user_id>)`.
+  The UI renders it as a chip and it's what lets the person be notified — a bare
+  "@Nik" is just text and does nothing.
+- So to ping someone, first `find_user("Nik")` to get their `id`, then put the
+  token in `body` where the mention belongs, e.g.
+  `body="@[Nik Garza](mention:u_ab12cd) — can you confirm the rollout date?"`.
+  Use the exact `name` and `id` that `find_user` returned.
+- If `find_user` returns more than one match, choose the one the user means; if
+  it's genuinely ambiguous, ask rather than guessing. If it returns nothing,
+  say so instead of inventing an id.
 
 How to anchor a new comment:
 - `quoted_text` must be copied **verbatim** from the current page body and must

--- a/backend/app/llm/agents/tools/add_comment.json
+++ b/backend/app/llm/agents/tools/add_comment.json
@@ -14,7 +14,7 @@
       },
       "body": {
         "type": "string",
-        "description": "The comment text."
+        "description": "The comment text. To @mention a person, resolve their id with find_user and include the token `@[Display Name](mention:<user_id>)` here — a bare \"@Name\" won't link or notify."
       }
     },
     "required": ["path", "quoted_text", "body"]

--- a/backend/app/llm/agents/tools/find_user.json
+++ b/backend/app/llm/agents/tools/find_user.json
@@ -1,0 +1,20 @@
+{
+  "name": "find_user",
+  "description": "Look up wiki users by name or email. Use this to resolve a person to their user id when you need to @mention them in a comment or reply — you can't guess the id. Returns matching users with `id`, `name`, and `email`. Once you have the id, include the token `@[Display Name](mention:<user_id>)` in the comment/reply `body` where the mention should appear (a bare \"@Nik\" is plain text — it won't link or notify). If several people match, pick the right one (ask the user if it's ambiguous).",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "description": "A name or email (or part of one) to search for, e.g. \"Nik\" or \"nik@\"."
+      },
+      "limit": {
+        "type": "integer",
+        "description": "Max results to return (default 10, max 20).",
+        "minimum": 1,
+        "maximum": 20
+      }
+    },
+    "required": ["query"]
+  }
+}

--- a/backend/app/llm/agents/tools/find_user.json
+++ b/backend/app/llm/agents/tools/find_user.json
@@ -1,6 +1,6 @@
 {
   "name": "find_user",
-  "description": "Look up wiki users by name or email. Use this to resolve a person to their user id when you need to @mention them in a comment or reply — you can't guess the id. Returns matching users with `id`, `name`, and `email`. Once you have the id, include the token `@[Display Name](mention:<user_id>)` in the comment/reply `body` where the mention should appear (a bare \"@Nik\" is plain text — it won't link or notify). If several people match, pick the right one (ask the user if it's ambiguous).",
+  "description": "Look up wiki users by name or email. Use this to resolve a person to their user id when you need to @mention them in a comment or reply — you can't guess the id. Returns matching users with `id` and `name`. Once you have the id, include the token `@[Display Name](mention:<user_id>)` in the comment/reply `body` where the mention should appear (a bare \"@Nik\" is plain text — it won't link or notify). If several people match, pick the right one (ask the user if it's ambiguous).",
   "input_schema": {
     "type": "object",
     "properties": {

--- a/backend/app/llm/agents/tools/find_user.py
+++ b/backend/app/llm/agents/tools/find_user.py
@@ -6,9 +6,11 @@ email here, then embeds the canonical token `@[Display Name](mention:<user_id>)`
 in the comment/reply body where the mention should appear.
 
 Case-insensitive substring match on name/email (same lookup the share
-typeahead uses). Returns only public-safe fields. Any signed-in user may
-search — the chat request is already authenticated as a real user — so there's
-no per-page ACL gate here (a user id isn't page-scoped).
+typeahead uses) — you can search *by* email, but the result only carries `id`
+and `name`: that's all the mention token needs, and keeping emails out of the
+model's context avoids them leaking back into chat or trace payloads. Any
+signed-in user may search — the chat request is already authenticated as a real
+user — so there's no per-page ACL gate here (a user id isn't page-scoped).
 """
 from __future__ import annotations
 
@@ -33,8 +35,4 @@ def handle(args: dict[str, Any]) -> Any:
     limit = max(1, min(limit, _MAX_LIMIT))
 
     rows = users_repo.search(query.strip(), limit)
-    return {
-        "users": [
-            {"id": r["id"], "name": r.get("name"), "email": r["email"]} for r in rows
-        ]
-    }
+    return {"users": [{"id": r["id"], "name": r.get("name")} for r in rows]}

--- a/backend/app/llm/agents/tools/find_user.py
+++ b/backend/app/llm/agents/tools/find_user.py
@@ -1,0 +1,40 @@
+"""Handler for the `find_user` tool. Spec lives in `find_user.json`.
+
+Resolves a person to their user id so the agent can @mention them in a comment
+or reply. The agent can't know a user's opaque id, so it searches by name or
+email here, then embeds the canonical token `@[Display Name](mention:<user_id>)`
+in the comment/reply body where the mention should appear.
+
+Case-insensitive substring match on name/email (same lookup the share
+typeahead uses). Returns only public-safe fields. Any signed-in user may
+search — the chat request is already authenticated as a real user — so there's
+no per-page ACL gate here (a user id isn't page-scoped).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.auth import users as users_repo
+
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 20
+
+
+def handle(args: dict[str, Any]) -> Any:
+    query = args.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return {"error": "query is required — a name or email to look up"}
+
+    raw_limit = args.get("limit")
+    try:
+        limit = int(raw_limit) if raw_limit is not None else _DEFAULT_LIMIT
+    except (TypeError, ValueError):
+        limit = _DEFAULT_LIMIT
+    limit = max(1, min(limit, _MAX_LIMIT))
+
+    rows = users_repo.search(query.strip(), limit)
+    return {
+        "users": [
+            {"id": r["id"], "name": r.get("name"), "email": r["email"]} for r in rows
+        ]
+    }

--- a/backend/app/llm/agents/tools/reply_comment.json
+++ b/backend/app/llm/agents/tools/reply_comment.json
@@ -10,7 +10,7 @@
       },
       "body": {
         "type": "string",
-        "description": "The reply text."
+        "description": "The reply text. To @mention a person, resolve their id with find_user and include the token `@[Display Name](mention:<user_id>)` here — a bare \"@Name\" won't link or notify."
       }
     },
     "required": ["comment_id", "body"]

--- a/backend/tests/test_find_user_tool.py
+++ b/backend/tests/test_find_user_tool.py
@@ -1,0 +1,55 @@
+"""`find_user` chat tool — resolves a person to their user id for @mentions.
+
+DB-backed (`tmp_db`): the tool searches real `users` rows via `users_repo`.
+"""
+from __future__ import annotations
+
+from app.llm.agents.tools.find_user import handle
+from tests._seed import seed_user
+
+_DOC_USERS = [
+    ("u_nik", "nik@onyx.app", "Nik Garza"),
+    ("u_dane", "dane@onyx.app", "Dane Liu"),
+    ("u_bo", "bo@onyx.app", "Bo Yang"),
+]
+
+
+def _seed_all() -> None:
+    for uid, email, name in _DOC_USERS:
+        seed_user(uid=uid, email=email, name=name)
+
+
+def test_finds_by_name(tmp_db):
+    _seed_all()
+    out = handle({"query": "Nik"})
+    assert out["users"] == [{"id": "u_nik", "name": "Nik Garza", "email": "nik@onyx.app"}]
+
+
+def test_finds_by_email_fragment(tmp_db):
+    _seed_all()
+    out = handle({"query": "bo@"})
+    assert [u["id"] for u in out["users"]] == ["u_bo"]
+
+
+def test_returns_multiple_matches(tmp_db):
+    _seed_all()
+    # Every seeded user is @onyx.app, so this matches all three.
+    out = handle({"query": "onyx.app"})
+    assert {u["id"] for u in out["users"]} == {"u_nik", "u_dane", "u_bo"}
+
+
+def test_no_match_returns_empty(tmp_db):
+    _seed_all()
+    out = handle({"query": "nobody-here"})
+    assert out["users"] == []
+
+
+def test_limit_is_clamped(tmp_db):
+    _seed_all()
+    out = handle({"query": "onyx.app", "limit": 1})
+    assert len(out["users"]) == 1
+
+
+def test_blank_query_errors(tmp_db):
+    assert "error" in handle({"query": "   "})
+    assert "error" in handle({})

--- a/backend/tests/test_find_user_tool.py
+++ b/backend/tests/test_find_user_tool.py
@@ -22,13 +22,20 @@ def _seed_all() -> None:
 def test_finds_by_name(tmp_db):
     _seed_all()
     out = handle({"query": "Nik"})
-    assert out["users"] == [{"id": "u_nik", "name": "Nik Garza", "email": "nik@onyx.app"}]
+    assert out["users"] == [{"id": "u_nik", "name": "Nik Garza"}]
 
 
 def test_finds_by_email_fragment(tmp_db):
     _seed_all()
+    # Searchable by email even though the result never carries it back.
     out = handle({"query": "bo@"})
     assert [u["id"] for u in out["users"]] == ["u_bo"]
+
+
+def test_result_omits_email(tmp_db):
+    _seed_all()
+    out = handle({"query": "Nik"})
+    assert out["users"] and all("email" not in u for u in out["users"])
 
 
 def test_returns_multiple_matches(tmp_db):


### PR DESCRIPTION
## Why

Agent-authored comments and replies could only ever write a plain `@Nik` string. That's just text — it doesn't render as a mention chip, isn't resolvable to a person, and won't fire a notification when that lands. So "ping Nik in a comment" produced a dead mention.

## What

Give the agent a way to resolve a person → their user id, then have it emit the **canonical mention token** the human composer already uses:

```
@[Display Name](mention:<user_id>)
```

That token renders as a chip in `CommentsPanel`, is detokenized for comment search, and is parseable by a future notify pass — so once the agent produces it, everything downstream already works.

- **`find_user` tool** (`find_user.{py,json}`) — looks up users by name/email (wraps `users_repo.search`, returns public-safe `{id, name, email}` only). Scoped to the `comments` skill, since that's where mentions happen.
- **`comments` skill** — `find_user` added to its tool set; `comments.md` documents the flow (resolve id → embed token; don't invent ids; ask if a name is ambiguous).
- **`add_comment` / `reply_comment`** — `body` descriptions note the token format so the model reaches for it.
- **Test** — `test_find_user_tool.py` (by-name, by-email fragment, multi-match, no-match, limit clamp, blank-query error).

No schema or frontend change: the user/agent distinction already lives in the DB as `comments.author_kind`, and the mention token format is already rendered + searched on the frontend.

## Notes

- Chat-only — `find_user` is **not** added to `MCP_ALLOWED_TOOLS` in this PR.
- Authorship is unchanged: agent comments are still attributed to the driving user (`author_user_id = current_user`) with `author_kind="agent"` as provenance.

## Test plan

- [x] `ruff` clean, `basedpyright` 0 errors
- [ ] CI runs `test_find_user_tool.py` (DB-backed; no local test DB)
- [ ] Local: ask the agent to "comment on X and ping Nik" → confirm a real mention chip renders