### PR TITLE
feat(wiki-db): add update_policies table (1/3)

### DIFF
--- a/backend/app/db/migrations/versions/4322ff468239_update_policies.py
+++ b/backend/app/db/migrations/versions/4322ff468239_update_policies.py
@@ -1,0 +1,45 @@
+"""update policies
+
+Revision ID: 4322ff468239
+Revises: 0029
+Create Date: 2026-06-15 16:49:12.672004+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '4322ff468239'
+down_revision: str | None = '0029'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Fresh installs get the table from 0001's ``create_all`` — guard so this
+    # migration is a no-op there (same pattern as 0025/0026).
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "update_policies" in set(inspector.get_table_names()):
+        return
+
+    op.create_table(
+        'update_policies',
+        sa.Column('path', sa.Text(), nullable=False),
+        sa.Column('kind', sa.Text(), nullable=False),
+        sa.Column('ingestion_auto_update_disabled', sa.Boolean(), nullable=True),
+        sa.Column('update_instruction', sa.Text(), nullable=True),
+        sa.Column('updated_by_user_id', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.Text(), server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"), nullable=False),
+        sa.Column('updated_at', sa.Text(), server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"), nullable=False),
+        sa.CheckConstraint("kind IN ('page', 'folder')", name='update_policies_kind_check'),
+        sa.ForeignKeyConstraint(['updated_by_user_id'], ['users.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('path'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('update_policies')

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -972,6 +972,55 @@ class AclEntry(Base):
 
 
 # --------------------------------------------------------------------------- #
+# Update policy — per-page / per-folder control over auto-updates (PG-only)   #
+# --------------------------------------------------------------------------- #
+
+
+class UpdatePolicy(Base):
+    """Per-page / per-folder control over how the wiki auto-updates.
+
+    **Postgres-only** governance metadata keyed by path — like ``acl_entries``
+    it is never written to the wiki git repo. One row per scope: a ``.md`` page,
+    a folder, or ``""`` (the wiki root). A row exists only while it carries a
+    setting; clearing every field deletes it (see ``app/wiki/update_policy.py``).
+
+    Two independent settings, each resolved most-granular-wins by walking the
+    doc and its ancestor folders (``update_policy.resolve_for_doc``):
+
+    - ``ingestion_auto_update_disabled`` — tri-state. ``NULL`` inherits from a
+      broader scope; ``True`` keeps connector/ingest reconciliation from
+      touching the page; ``False`` explicitly re-enables it, so a page can opt
+      back in under a disabled folder. Ingestion-only — it does not gate the NL
+      updater, direct agent writes, or human edits.
+    - ``update_instruction`` — free-text guidance injected into the updater LLM
+      prompts. ``NULL``/empty means none.
+    """
+
+    __tablename__ = "update_policies"
+
+    path: Mapped[str] = mapped_column(Text, primary_key=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # "page" | "folder"
+    ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
+    update_instruction: Mapped[str | None] = mapped_column(Text)
+    updated_by_user_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('page', 'folder')",
+            name="update_policies_kind_check",
+        ),
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Comments — human discussion anchored to wiki pages (Postgres-only)          #
 # --------------------------------------------------------------------------- #
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,7 +23,12 @@ dependencies = [
     "opensearch-py>=2.4",  # BM25 full-text search
     "prometheus_client>=0.21",
     "prometheus-fastapi-instrumentator>=7.1",
-    "fastapi>=0.110",
+    # Pin FastAPI <0.137: 0.137's lazy router inclusion puts `_IncludedRouter`
+    # objects in `app.routes`, which prometheus-fastapi-instrumentator's route
+    # walker (get_route_name) can't read (AttributeError: no `.path`). uv.lock is
+    # gitignored, so CI resolves fresh — without this bound it floats to the
+    # broken 0.137 set. Remove once the instrumentator handles lazy includes.
+    "fastapi>=0.110,<0.137",
     "uvicorn[standard]>=0.27",  # ASGI server — production entry via Dockerfile CMD
     "itsdangerous>=2.1", # Starlette SessionMiddleware signs the session cookie
 ]


### PR DESCRIPTION
**Stack 1/3** — followed by #234 (resolver + enforcement) and #235 (REST API).

### `update_policies` table (schema only)
Per-page / per-folder control over how the wiki auto-updates. Postgres-only and path-keyed like the ACL tables. One row per `path` (a `.md` page, a folder, or `""` = root):

- **`ingestion_auto_update_disabled`** (tri-state: inherit / on / off) — exclude a page or folder from connector ingest auto-update.
- **`update_instruction`** — author guidance for the updater LLM.

Schema only — resolver, enforcement, and REST API land in the follow-up PRs. Migration is guarded for fresh-install `create_all` (same pattern as `0025`/`0026`).

### Also: CI dependency fix (`fastapi<0.137`)
`uv.lock` is gitignored, so CI resolves dependencies fresh every run and floated onto **FastAPI 0.137**, whose lazy router inclusion puts `_IncludedRouter` objects in `app.routes`. `prometheus-fastapi-instrumentator`'s route walker can't read those (`AttributeError: '_IncludedRouter' object has no attribute 'path'`), failing requests through the instrumented app — surfacing as unrelated test failures (`test_launch_api`, `test_wiki_drafts`, `test_admin_llm_custom`, `test_mcp_server_tools`). This is environmental, not caused by the feature (it reproduced on this schema-only PR).

Capped `fastapi>=0.110,<0.137` to hold the known-good set (fastapi 0.136.x / starlette 0.52.x / instrumentator 7.1.0). Included here so the whole stack inherits it.

**Long-term fix (recommended, separate):** commit `uv.lock` and install with `uv sync --frozen` so builds are reproducible and dependency upgrades are explicit, reviewable PRs — which would prevent this class of failure entirely.