### PR TITLE
feat(wiki): update policy read/write/update — repo + REST API (2/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,25 @@ Search and listing endpoints filter through
   `local_data/wiki/permissions/permissions.md` and the export warning in
   `local_data/wiki/running-locally.md`.
 
+### Update policy — `app/wiki/update_policy.py` (`update_policies` table)
+
+Per-page / per-folder control over how the wiki auto-updates, Postgres-only and
+path-keyed like the ACL tables. One row per `path` (a `.md` page, a folder, or
+`""` for root) with two fields, both resolved **most-granular-wins** via
+`update_policy.resolve_for_path(path)` (walks the path + ancestor folders, the
+closest scope that sets a field wins):
+
+- `ingestion_auto_update_disabled` (tri-state) — when set, connector/ingest
+  reconciliation skips the page. Ingestion-scoped: it does not gate the NL
+  updater, direct agent writes, or human edits.
+- `update_instruction` — author guidance for the updater LLM on *how* to edit.
+
+Don't read/write `update_policies` directly — go through
+`app/wiki/update_policy.py` (`get` / `set_policy` / `delete` / `resolve_for_path`).
+Manage over HTTP via `GET/PUT/DELETE /api/update-policy`, gated by
+`require_can("read"|"write", path)`. Design: the wiki page
+`Engineering Projects/Agent Wiki Project/design/Update Policy.md`.
+
 ### Database — SQLAlchemy 2.0 ORM, small repo modules
 
 Schema lives in `app/db/models.py` as `DeclarativeBase` subclasses with

--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -1,0 +1,78 @@
+"""FastAPI router for /api/update-policy — per-page / per-folder update policy.
+
+Thin HTTP layer over ``app/wiki/update_policy.py``. Reads/writes are gated by
+``require_can`` on the target path, the same permission as editing it.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from app.auth import User, require_can
+from app.auth.deps import require_user
+from app.models.update_policy import (
+    EffectivePolicy,
+    ExplicitPolicy,
+    SetUpdatePolicyRequest,
+    UpdatePolicyResponse,
+)
+from app.wiki import update_policy as policy_repo
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+
+def _normalize(path: str) -> str:
+    try:
+        return policy_repo.normalize_path(path)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from exc
+
+
+def _build_response(path: str) -> UpdatePolicyResponse:
+    explicit = policy_repo.get(path)
+    effective = policy_repo.resolve_for_path(path)
+    return UpdatePolicyResponse(
+        explicit=ExplicitPolicy(**explicit) if explicit is not None else None,
+        effective=EffectivePolicy(
+            ingestion_auto_update_disabled=effective.ingestion_auto_update_disabled,
+            update_instruction=effective.update_instruction,
+        ),
+    )
+
+
+@router.get("/update-policy")
+def get_update_policy(
+    path: str, user: User = Depends(require_user)
+) -> UpdatePolicyResponse:
+    norm = _normalize(path)
+    require_can("read", norm, user)
+    return _build_response(norm)
+
+
+@router.put("/update-policy")
+def put_update_policy(
+    req: SetUpdatePolicyRequest, user: User = Depends(require_user)
+) -> UpdatePolicyResponse:
+    norm = _normalize(req.path)
+    require_can("write", norm, user)
+    policy_repo.set_policy(
+        norm,
+        ingestion_auto_update_disabled=req.ingestion_auto_update_disabled,
+        update_instruction=req.update_instruction,
+        actor_user_id=user.id,
+    )
+    return _build_response(norm)
+
+
+@router.delete("/update-policy")
+def delete_update_policy(
+    path: str, user: User = Depends(require_user)
+) -> UpdatePolicyResponse:
+    norm = _normalize(path)
+    require_can("write", norm, user)
+    policy_repo.delete(norm)
+    return _build_response(norm)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -985,7 +985,7 @@ class UpdatePolicy(Base):
     setting; clearing every field deletes it (see ``app/wiki/update_policy.py``).
 
     Two independent settings, each resolved most-granular-wins by walking the
-    doc and its ancestor folders (``update_policy.resolve_for_doc``):
+    path and its ancestor folders (``update_policy.resolve_for_path``):
 
     - ``ingestion_auto_update_disabled`` — tri-state. ``NULL`` inherits from a
       broader scope; ``True`` keeps connector/ingest reconciliation from

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.api import (
     permissions,
     templates,
     triggers,
+    update_policy,
     user,
     users,
     webhooks,
@@ -217,6 +218,7 @@ def create_app() -> FastAPI:
     app.include_router(templates.admin_router, prefix="/api/admin/templates")
     app.include_router(templates.router, prefix="/api/templates")
     app.include_router(permissions.router, prefix="/api")
+    app.include_router(update_policy.router, prefix="/api")
     app.include_router(launchers.router, prefix="/api")
     app.include_router(installer.router, prefix="/api")
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -1,0 +1,42 @@
+"""HTTP shapes for /api/update-policy."""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class EffectivePolicy(BaseModel):
+    """The resolved policy for a path after the most-granular-wins cascade."""
+
+    ingestion_auto_update_disabled: bool
+    update_instruction: str | None = None
+
+
+class ExplicitPolicy(BaseModel):
+    """The policy row set on exactly this path (no cascade)."""
+
+    path: str
+    kind: Literal["page", "folder"]
+    ingestion_auto_update_disabled: bool | None = None
+    update_instruction: str | None = None
+    updated_by_user_id: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class UpdatePolicyResponse(BaseModel):
+    explicit: ExplicitPolicy | None = None
+    effective: EffectivePolicy
+
+
+class SetUpdatePolicyRequest(BaseModel):
+    """Full desired state for a path (PUT semantics).
+
+    Both fields default to ``null`` = inherit/clear. When the resulting row
+    carries no setting it is removed.
+    """
+
+    path: str
+    ingestion_auto_update_disabled: bool | None = None
+    update_instruction: str | None = None

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -1,0 +1,176 @@
+"""Update-policy repo — per-page / per-folder control over wiki auto-updates.
+
+Postgres-only governance metadata keyed by path (a ``.md`` page, a folder, or
+``""`` for the wiki root), mirroring ``app/wiki/acl.py``. Two independent
+settings — ``ingestion_auto_update_disabled`` (tri-state) and
+``update_instruction`` — are each resolved most-granular-wins by walking a path
+and its ancestor folders. See the design page
+``Engineering Projects/Agent Wiki Project/design/Update Policy.md``.
+
+Free functions over the ``UpdatePolicy`` model; each opens its own session and
+returns plain dicts so callers don't depend on the ORM.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+
+from app.db.models import UpdatePolicy
+from app.db.session import session
+from app.wiki import filesystem
+
+log = logging.getLogger(__name__)
+
+# Sentinel for "field not provided" in ``set_policy``. ``None`` and ``""`` are
+# meaningful (clear the field), so they can't double as the no-op marker. A
+# typed sentinel (not bare ``object()``) keeps call-site type checking intact.
+class _UnsetType:
+    """Sentinel type for a ``set_policy`` field that was not provided."""
+
+
+_UNSET = _UnsetType()
+
+
+class ResolvedPolicy(BaseModel):
+    """The effective policy for a path after the most-granular-wins cascade."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ingestion_auto_update_disabled: bool = False
+    update_instruction: str | None = None
+
+
+def _now() -> str:
+    """UTC timestamp matching the ``YYYY-MM-DD HH:MM:SS`` column format."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def kind_for_path(path: str) -> str:
+    """A ``.md`` path is a ``page``; everything else (incl. root) is a ``folder``."""
+    return "page" if path.endswith(".md") else "folder"
+
+
+def normalize_path(raw: str) -> str:
+    """Canonicalize a policy path. ``""`` and ``"/"`` both mean the wiki root."""
+    stripped = raw.strip()
+    if stripped in ("", "/"):
+        return ""
+    return filesystem.safe_rel_path(stripped.lstrip("/"))
+
+
+def _to_dict(row: UpdatePolicy) -> dict[str, Any]:
+    return {
+        "path": row.path,
+        "kind": row.kind,
+        "ingestion_auto_update_disabled": row.ingestion_auto_update_disabled,
+        "update_instruction": row.update_instruction,
+        "updated_by_user_id": row.updated_by_user_id,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+def get(path: str) -> dict[str, Any] | None:
+    """The explicit policy row for exactly this path, or ``None``."""
+    with session() as s:
+        row = s.get(UpdatePolicy, normalize_path(path))
+        return _to_dict(row) if row is not None else None
+
+
+def set_policy(
+    path: str,
+    *,
+    ingestion_auto_update_disabled: bool | None | _UnsetType = _UNSET,
+    update_instruction: str | None | _UnsetType = _UNSET,
+    actor_user_id: str | None = None,
+) -> dict[str, Any] | None:
+    """Upsert the policy for ``path`` with patch semantics.
+
+    Only fields passed (not ``_UNSET``) are changed. An empty-string
+    ``update_instruction`` clears it. When the row ends up carrying no setting
+    (both fields NULL/empty) it is deleted and ``None`` is returned.
+    """
+    norm = normalize_path(path)
+    with session() as s:
+        row = s.get(UpdatePolicy, norm)
+        existed = row is not None
+        if row is None:
+            row = UpdatePolicy(path=norm, kind=kind_for_path(norm))
+
+        if not isinstance(ingestion_auto_update_disabled, _UnsetType):
+            row.ingestion_auto_update_disabled = ingestion_auto_update_disabled
+        if not isinstance(update_instruction, _UnsetType):
+            row.update_instruction = update_instruction or None
+
+        if row.ingestion_auto_update_disabled is None and not row.update_instruction:
+            if existed:
+                s.delete(row)
+            return None
+
+        now = _now()
+        row.updated_by_user_id = actor_user_id
+        row.updated_at = now
+        if not existed:
+            row.created_at = now
+            s.add(row)
+        return _to_dict(row)
+
+
+def delete(path: str) -> bool:
+    """Remove the policy row for ``path``. Returns whether a row was deleted."""
+    with session() as s:
+        row = s.get(UpdatePolicy, normalize_path(path))
+        if row is None:
+            return False
+        s.delete(row)
+        return True
+
+
+def resolve_for_path(path: str) -> ResolvedPolicy:
+    """Effective policy for ``path``: most-granular scope that sets a field wins.
+
+    ``path`` may be a doc or a folder. Walks the path and its ancestor folders,
+    closest first, and resolves each field independently — so a page can
+    re-enable ingestion under a disabled folder, and a folder instruction
+    applies until a nearer scope overrides it.
+    """
+    norm = normalize_path(path)
+    candidates: list[str] = [norm]
+    for parent in filesystem.parent_dirs(norm):
+        if parent not in candidates:
+            candidates.append(parent)
+
+    with session() as s:
+        rows = (
+            s.execute(select(UpdatePolicy).where(UpdatePolicy.path.in_(candidates)))
+            .scalars()
+            .all()
+        )
+    by_path = {r.path: r for r in rows}
+
+    disabled: bool | None = None
+    instruction: str | None = None
+    for scope in candidates:  # closest first
+        row = by_path.get(scope)
+        if row is None:
+            continue
+        if disabled is None and row.ingestion_auto_update_disabled is not None:
+            disabled = row.ingestion_auto_update_disabled
+        if instruction is None and row.update_instruction:
+            instruction = row.update_instruction
+        if disabled is not None and instruction is not None:
+            break
+
+    return ResolvedPolicy(
+        ingestion_auto_update_disabled=bool(disabled),
+        update_instruction=instruction,
+    )
+
+
+def is_ingest_disabled(path: str) -> bool:
+    """Convenience: is connector/ingest auto-update disabled for ``path``?"""
+    return resolve_for_path(path).ingestion_auto_update_disabled

--- a/backend/tests/integration/test_update_policy_api.py
+++ b/backend/tests/integration/test_update_policy_api.py
@@ -1,0 +1,86 @@
+"""HTTP tests for /api/update-policy — CRUD round-trip, folder cascade, and
+the require_can write gate."""
+from __future__ import annotations
+
+
+def _strip_everyone(integration, path: str) -> None:
+    """Revoke the seeded ``everyone`` page grants so ``path`` becomes private."""
+    resp = integration.client.get(f"/api/wiki/acl?path={path}")
+    assert resp.status_code == 200, resp.text
+    for entry in resp.json()["entries"]:
+        if entry["principal_kind"] == "everyone" and entry["resource_kind"] == "page":
+            r = integration.client.delete(f"/api/wiki/acl/{entry['id']}")
+            assert r.status_code == 204
+
+
+def test_put_get_delete_roundtrip(integration):
+    integration.signup(email="admin@x.com")  # auto-admin (first user)
+    integration.put_doc("guide.md", "# Guide\n\nbody")
+
+    resp = integration.client.put(
+        "/api/update-policy",
+        json={
+            "path": "guide.md",
+            "ingestion_auto_update_disabled": True,
+            "update_instruction": "Keep it terse.",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["explicit"]["kind"] == "page"
+    assert body["explicit"]["ingestion_auto_update_disabled"] is True
+    assert body["explicit"]["update_instruction"] == "Keep it terse."
+    assert body["effective"]["ingestion_auto_update_disabled"] is True
+
+    resp = integration.client.get("/api/update-policy?path=guide.md")
+    assert resp.status_code == 200
+    assert resp.json()["effective"]["update_instruction"] == "Keep it terse."
+
+    resp = integration.client.delete("/api/update-policy?path=guide.md")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["explicit"] is None
+    assert body["effective"]["ingestion_auto_update_disabled"] is False
+
+
+def test_folder_policy_shows_in_doc_effective(integration):
+    integration.signup(email="admin@x.com")
+    integration.put_doc("team/guide.md", "# Guide")
+
+    resp = integration.client.put(
+        "/api/update-policy",
+        json={"path": "team", "ingestion_auto_update_disabled": True},
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = integration.client.get("/api/update-policy?path=team/guide.md")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["explicit"] is None  # no row on the doc itself
+    assert body["effective"]["ingestion_auto_update_disabled"] is True  # inherited
+
+
+def test_non_writer_forbidden(integration):
+    integration.signup(email="admin@x.com")  # auto-admin, owns the page
+    integration.put_doc("secret.md", "# Secret")
+    _strip_everyone(integration, "secret.md")
+
+    integration.signup(email="bob@x.com")  # session is now bob (non-admin)
+    resp = integration.client.put(
+        "/api/update-policy",
+        json={"path": "secret.md", "ingestion_auto_update_disabled": True},
+    )
+    assert resp.status_code == 403
+
+
+def test_non_admin_writer_allowed(integration):
+    integration.signup(email="admin@x.com")
+    integration.put_doc("open.md", "# Open")  # default-public: everyone read+write
+    integration.signup(email="carol@x.com")  # non-admin, has everyone write
+
+    resp = integration.client.put(
+        "/api/update-policy",
+        json={"path": "open.md", "update_instruction": "be brief"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["explicit"]["update_instruction"] == "be brief"

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -1,0 +1,103 @@
+"""Tests for app.wiki.update_policy — the per-page/per-folder update policy.
+
+Covers the most-granular-wins cascade and the patch/delete semantics of
+set_policy.
+"""
+from __future__ import annotations
+
+from app.wiki import update_policy
+
+
+# --------------------------------------------------------------------------- #
+# Resolver cascade                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_defaults_when_no_rows(tmp_db):
+    resolved = update_policy.resolve_for_path("a/b/page.md")
+    assert resolved.ingestion_auto_update_disabled is False
+    assert resolved.update_instruction is None
+
+
+def test_doc_level_disable(tmp_db):
+    update_policy.set_policy("a/page.md", ingestion_auto_update_disabled=True)
+    assert update_policy.is_ingest_disabled("a/page.md") is True
+
+
+def test_folder_disable_cascades_to_doc(tmp_db):
+    update_policy.set_policy("a", ingestion_auto_update_disabled=True)
+    assert update_policy.is_ingest_disabled("a/b/page.md") is True
+
+
+def test_granular_page_re_enables_under_disabled_folder(tmp_db):
+    update_policy.set_policy("a", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("a/page.md", ingestion_auto_update_disabled=False)
+    # Most-granular wins: the page opts back in even though the folder is off.
+    assert update_policy.is_ingest_disabled("a/page.md") is False
+    # A sibling with no own row still inherits the folder's disable.
+    assert update_policy.is_ingest_disabled("a/other.md") is True
+
+
+def test_root_scope_cascades_everywhere(tmp_db):
+    update_policy.set_policy("", ingestion_auto_update_disabled=True)
+    assert update_policy.is_ingest_disabled("anything/deep/page.md") is True
+
+
+def test_instruction_closest_scope_wins(tmp_db):
+    update_policy.set_policy("a", update_instruction="folder rule")
+    update_policy.set_policy("a/page.md", update_instruction="page rule")
+    assert update_policy.resolve_for_path("a/page.md").update_instruction == "page rule"
+    # A sibling without its own instruction falls back to the folder's.
+    assert update_policy.resolve_for_path("a/other.md").update_instruction == "folder rule"
+
+
+def test_fields_resolve_independently(tmp_db):
+    update_policy.set_policy("a", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("a/page.md", update_instruction="terse")
+    resolved = update_policy.resolve_for_path("a/page.md")
+    # disable inherited from the folder; instruction from the page.
+    assert resolved.ingestion_auto_update_disabled is True
+    assert resolved.update_instruction == "terse"
+
+
+# --------------------------------------------------------------------------- #
+# set_policy patch + delete semantics                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_set_policy_patches_only_given_fields(tmp_db):
+    update_policy.set_policy("a/page.md", ingestion_auto_update_disabled=True)
+    # Second call sets only the instruction; the disable flag is left intact.
+    update_policy.set_policy("a/page.md", update_instruction="keep")
+    row = update_policy.get("a/page.md")
+    assert row is not None
+    assert row["ingestion_auto_update_disabled"] is True
+    assert row["update_instruction"] == "keep"
+
+
+def test_clearing_both_fields_deletes_row(tmp_db):
+    update_policy.set_policy("a/page.md", ingestion_auto_update_disabled=True)
+    result = update_policy.set_policy(
+        "a/page.md", ingestion_auto_update_disabled=None, update_instruction=None
+    )
+    assert result is None
+    assert update_policy.get("a/page.md") is None
+
+
+def test_empty_instruction_is_cleared(tmp_db):
+    result = update_policy.set_policy("a/page.md", update_instruction="")
+    # Only field set is an empty instruction → nothing to store.
+    assert result is None
+    assert update_policy.get("a/page.md") is None
+
+
+def test_kind_inferred_from_path(tmp_db):
+    update_policy.set_policy("a/page.md", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("a", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("", ingestion_auto_update_disabled=True)
+    page = update_policy.get("a/page.md")
+    folder = update_policy.get("a")
+    root = update_policy.get("")
+    assert page is not None and page["kind"] == "page"
+    assert folder is not None and folder["kind"] == "folder"
+    assert root is not None and root["kind"] == "folder"


### PR DESCRIPTION
**2/3** — builds on #233 (merged). Read/write/update of the update-policy fields, both the repo and the HTTP surface. Enforcement (ingest skip + prompt injection) follows in a separate PR.

### Repo — `app/wiki/update_policy.py`
Read/write/update for both `ingestion_auto_update_disabled` and `update_instruction`:
- `get(path)` — the explicit row for a path.
- `set_policy(path, *, ingestion_auto_update_disabled=…, update_instruction=…)` — upsert with patch semantics (`_UNSET` sentinel); deletes the row when both fields end up empty.
- `delete(path)`.
- `resolve_for_doc(doc_path)` — effective policy via the most-granular-wins cascade (walks the doc + ancestor folders, closest scope that sets a field wins); `is_ingest_disabled(doc_path)` convenience.

Postgres-only, path-keyed like `app/wiki/acl.py`; returns plain dicts.

### REST API — `app/api/update_policy.py`
`GET/PUT/DELETE /api/update-policy?path=…`, gated by `require_can("read"|"write", path)` (same permission as editing the page/folder). `PUT` is full desired-state; clearing both fields removes the row. Responses return the **explicit** row plus the **effective** (resolved) policy. Shapes in `app/models/update_policy.py`; router registered in `app/main.py`.

### Tests
- Repo: most-granular-wins cascade (tri-state override, folder cascade, root scope, independent fields), `set_policy` patch/delete, kind inference.
- API: CRUD round-trip, folder→doc effective cascade, non-admin writer allowed, and the `require_can` write-gate (403).

`ruff` + `basedpyright` clean.

> Design page: `Engineering Projects/Agent Wiki Project/design/Update Policy.md` (in the wiki).