### PR TITLE
feat(wiki): update policy follows page/folder moves & deletes

### DIFF
--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -44,7 +44,7 @@ def _build_response(path: str) -> UpdatePolicyResponse:
     )
 
 
-@router.get("/update-policy")
+@router.get("/update-policy", response_model=UpdatePolicyResponse)
 def get_update_policy(
     path: str, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:
@@ -53,7 +53,7 @@ def get_update_policy(
     return _build_response(norm)
 
 
-@router.put("/update-policy")
+@router.put("/update-policy", response_model=UpdatePolicyResponse)
 def put_update_policy(
     req: SetUpdatePolicyRequest, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:
@@ -68,7 +68,7 @@ def put_update_policy(
     return _build_response(norm)
 
 
-@router.delete("/update-policy")
+@router.delete("/update-policy", response_model=UpdatePolicyResponse)
 def delete_update_policy(
     path: str, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -44,6 +44,7 @@ from sqlalchemy import (
 from app.auth import groups as groups_repo
 from app.db.models import AclEntry, WikiOwner
 from app.db.session import session
+from app.wiki.filesystem import common_folder_rename
 
 log = logging.getLogger(__name__)
 
@@ -735,7 +736,7 @@ def on_path_moved(moves: list[tuple[str, str]]) -> None:
         # directory yields one tuple per nested file all sharing the
         # same prefix swap, so this catches it without the caller having
         # to tell us.
-        old_prefix, new_prefix = _common_folder_rename(moves)
+        old_prefix, new_prefix = common_folder_rename(moves)
         if old_prefix is not None and new_prefix is not None:
             # Folder ACL at the renamed folder itself.
             s.execute(
@@ -760,39 +761,6 @@ def on_path_moved(moves: list[tuple[str, str]]) -> None:
                     )
                 )
             )
-
-
-def _common_folder_rename(
-    moves: list[tuple[str, str]],
-) -> tuple[str | None, str | None]:
-    """If every move shares a common (old_prefix, new_prefix) directory
-    swap, return it; else (None, None). Used to catch directory renames
-    so we can rewrite folder-level ACLs in one query."""
-    if not moves:
-        return None, None
-    first_old, first_new = moves[0]
-    if "/" not in first_old or "/" not in first_new:
-        return None, None
-    old_prefix = first_old.rsplit("/", 1)[0]
-    new_prefix = first_new.rsplit("/", 1)[0]
-    while old_prefix and new_prefix:
-        suffix_old = first_old[len(old_prefix) :]
-        suffix_new = first_new[len(new_prefix) :]
-        if suffix_old != suffix_new:
-            return None, None
-        if all(
-            o.startswith(old_prefix + "/")
-            and n.startswith(new_prefix + "/")
-            and o[len(old_prefix) :] == n[len(new_prefix) :]
-            for o, n in moves
-        ):
-            return old_prefix, new_prefix
-        # Walk up one level and retry — handles nested rename detection.
-        if "/" not in old_prefix or "/" not in new_prefix:
-            return None, None
-        old_prefix = old_prefix.rsplit("/", 1)[0]
-        new_prefix = new_prefix.rsplit("/", 1)[0]
-    return None, None
 
 
 # Re-export for type-stability of ``Document`` import — keeps pyright happy

--- a/backend/app/wiki/filesystem.py
+++ b/backend/app/wiki/filesystem.py
@@ -34,3 +34,41 @@ def parent_dirs(rel_path: str) -> list[str]:
         out.append(str(Path(*parts[:i])))
     out.append("")
     return out
+
+
+def common_folder_rename(
+    moves: list[tuple[str, str]],
+) -> tuple[str | None, str | None]:
+    """If every move shares a common ``(old_prefix, new_prefix)`` directory
+    swap, return it; else ``(None, None)``.
+
+    ``move_path`` of a directory yields one ``(old, new)`` tuple per nested
+    file, all sharing the same prefix swap, so this recovers the directory
+    rename without the caller having to flag it. Move handlers use it to
+    rewrite folder-scoped rows (ACL grants, update policies) in one pass.
+    """
+    if not moves:
+        return None, None
+    first_old, first_new = moves[0]
+    if "/" not in first_old or "/" not in first_new:
+        return None, None
+    old_prefix = first_old.rsplit("/", 1)[0]
+    new_prefix = first_new.rsplit("/", 1)[0]
+    while old_prefix and new_prefix:
+        suffix_old = first_old[len(old_prefix):]
+        suffix_new = first_new[len(new_prefix):]
+        if suffix_old != suffix_new:
+            return None, None
+        if all(
+            o.startswith(old_prefix + "/")
+            and n.startswith(new_prefix + "/")
+            and o[len(old_prefix):] == n[len(new_prefix):]
+            for o, n in moves
+        ):
+            return old_prefix, new_prefix
+        # Walk up one level and retry — handles nested rename detection.
+        if "/" not in old_prefix or "/" not in new_prefix:
+            return None, None
+        old_prefix = old_prefix.rsplit("/", 1)[0]
+        new_prefix = new_prefix.rsplit("/", 1)[0]
+    return None, None

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -36,7 +36,7 @@ from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
 from app.triggers import repo as triggers_repo
-from app.wiki import acl, agent_activity, comments, drafts
+from app.wiki import acl, agent_activity, comments, drafts, update_policy
 from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind
 
@@ -125,6 +125,7 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
         return
     fts.delete_document(rel_path)
     acl.on_page_deleted(rel_path)
+    update_policy.on_page_deleted(rel_path)
     # The body is gone, so there's nothing to re-anchor against — orphan the
     # page's comments (keeps them as tombstones) rather than dropping them.
     comments.orphan_all_for_doc(rel_path)
@@ -171,6 +172,7 @@ def after_path_move(
     tree shape changed once, even if many paths moved).
     """
     acl.on_path_moved(moves)
+    update_policy.on_path_moved(moves)
     list_changed = False
     for old_p, new_p in moves:
         old_is_md = old_p.endswith(".md")

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -17,7 +17,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 
 from app.db.models import UpdatePolicy
 from app.db.session import session
@@ -128,6 +128,55 @@ def delete(path: str) -> bool:
             return False
         s.delete(row)
         return True
+
+
+def on_page_deleted(path: str) -> None:
+    """Drop the policy row for a deleted page (mirrors ``acl.on_page_deleted``).
+
+    Called per ``.md`` page from ``app.wiki.notify.after_doc_delete``. Folder
+    policy rows are left alone — a folder grant can outlive any single page in
+    it, matching the ACL convention.
+    """
+    delete(path)
+
+
+def on_path_moved(moves: list[tuple[str, str]]) -> None:
+    """Re-key policy rows so a page/folder policy follows a move/rename.
+
+    For each ``(old, new)`` pair the exact row at ``old`` is repointed to
+    ``new`` (page rows). When the pairs describe a directory rename, the
+    folder's own row and every row nested under it are repointed too — so
+    renaming ``a`` to ``b`` carries ``a`` and ``a/sub`` along. Mirrors
+    ``acl.on_path_moved``; the row volume is tiny in practice.
+    """
+    if not moves:
+        return
+    with session() as s:
+        for old_p, new_p in moves:
+            s.execute(
+                update(UpdatePolicy)
+                .where(UpdatePolicy.path == old_p)
+                .values(path=new_p)
+            )
+        old_prefix, new_prefix = filesystem.common_folder_rename(moves)
+        if old_prefix is not None and new_prefix is not None:
+            # The renamed folder's own policy row.
+            s.execute(
+                update(UpdatePolicy)
+                .where(UpdatePolicy.path == old_prefix)
+                .values(path=new_prefix)
+            )
+            # Policy rows nested under the renamed folder.
+            s.execute(
+                update(UpdatePolicy)
+                .where(UpdatePolicy.path.like(old_prefix + "/%"))
+                .values(
+                    path=func.concat(
+                        new_prefix,
+                        func.substr(UpdatePolicy.path, len(old_prefix) + 1),
+                    )
+                )
+            )
 
 
 def resolve_for_path(path: str) -> ResolvedPolicy:

--- a/backend/tests/test_delete_notify.py
+++ b/backend/tests/test_delete_notify.py
@@ -14,7 +14,7 @@ from app.db import page_dirs
 from app.db.models import DocumentTemplate
 from app.db.session import session
 from app.main import create_app
-from app.wiki import agent_activity, drafts, notify
+from app.wiki import agent_activity, drafts, notify, update_policy
 from app.wiki import git as wiki_git
 
 from tests._auth import login_fastapi
@@ -46,6 +46,15 @@ def test_after_doc_delete_drops_page_scoped_state(tmp_repo):
     assert agent_activity.list_for_doc("a.md") == []
     assert drafts.get("a.md") is None
     assert page_dirs.get_for_page(user_id=user, machine_id="m1", wiki_path="a.md") is None
+
+
+def test_after_doc_delete_drops_update_policy(tmp_repo):
+    update_policy.set_policy("a.md", ingestion_auto_update_disabled=True)
+    sha = wiki_git.commit_file("a.md", "# A\n", "seed", author=None)
+
+    notify.after_doc_delete("a.md", sha, actor=None)
+
+    assert update_policy.get("a.md") is None
 
 
 def test_delete_folder_fans_out_to_nested_pages(tmp_repo):

--- a/backend/tests/test_move_notify.py
+++ b/backend/tests/test_move_notify.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from app.db import page_dirs
 from app.db.models import DocumentTemplate
 from app.db.session import session
-from app.wiki import agent_activity, drafts, notify
+from app.wiki import agent_activity, drafts, notify, update_policy
 from app.wiki import git as wiki_git
 
 from tests._seed import seed_user
@@ -88,6 +88,16 @@ def test_after_path_move_out_of_md_space_clears_activity_and_drafts(tmp_repo):
     assert drafts.get("a.md") is None
     # No-TTL working-dir binding must be dropped too, or a future a.md inherits it.
     assert page_dirs.get_for_page(user_id=user, machine_id="m1", wiki_path="a.md") is None
+
+
+def test_after_path_move_repoints_update_policy(tmp_repo):
+    update_policy.set_policy("a.md", ingestion_auto_update_disabled=True)
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert update_policy.get("a.md") is None
+    assert update_policy.get("b.md") is not None
 
 
 def test_after_path_move_reconverges_trigger_cache(tmp_repo, monkeypatch):

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -101,3 +101,42 @@ def test_kind_inferred_from_path(tmp_db):
     assert page is not None and page["kind"] == "page"
     assert folder is not None and folder["kind"] == "folder"
     assert root is not None and root["kind"] == "folder"
+
+
+# --------------------------------------------------------------------------- #
+# Lifecycle — policy follows page/folder move + drops on delete               #
+# --------------------------------------------------------------------------- #
+
+
+def test_on_path_moved_rekeys_page(tmp_db):
+    update_policy.set_policy(
+        "a.md", ingestion_auto_update_disabled=True, update_instruction="x"
+    )
+    update_policy.on_path_moved([("a.md", "b.md")])
+    assert update_policy.get("a.md") is None
+    moved = update_policy.get("b.md")
+    assert moved is not None
+    assert moved["ingestion_auto_update_disabled"] is True
+    assert moved["update_instruction"] == "x"
+    assert moved["kind"] == "page"
+
+
+def test_on_path_moved_folder_rename_carries_subtree(tmp_db):
+    update_policy.set_policy("proj", update_instruction="folder rule")
+    update_policy.set_policy("proj/sub", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("proj/x.md", ingestion_auto_update_disabled=True)
+    # A directory rename surfaces as one move pair per nested file.
+    update_policy.on_path_moved([("proj/x.md", "work/x.md")])
+    assert update_policy.get("proj") is None
+    assert update_policy.get("proj/sub") is None
+    assert update_policy.get("proj/x.md") is None
+    work = update_policy.get("work")
+    assert work is not None and work["update_instruction"] == "folder rule"
+    assert update_policy.get("work/sub") is not None
+    assert update_policy.get("work/x.md") is not None
+
+
+def test_on_page_deleted_drops_row(tmp_db):
+    update_policy.set_policy("a.md", ingestion_auto_update_disabled=True)
+    update_policy.on_page_deleted("a.md")
+    assert update_policy.get("a.md") is None


### PR DESCRIPTION
**3/3** — builds on #233 + #234 (both merged). Keeps the policy key in sync with the wiki tree: whenever a page or folder is **renamed/moved or deleted**, the matching `update_policies` rows follow, mirroring how ACL/owners/comments already behave.

### Changes
- `app/wiki/update_policy.py`
  - `on_path_moved(moves)` — repoints the exact row per `(old, new)` pair (page moves); on a directory rename (detected from the per-file move pairs) repoints the folder's own row **and** every row nested under it.
  - `on_page_deleted(path)` — drops the page's policy row. Folder rows are left (they can outlive any single page, same convention as folder ACL grants).
- `app/wiki/notify.py` — calls both hooks from `after_path_move` / `after_doc_delete`, right alongside the ACL hooks.
- `app/wiki/filesystem.py` — extracted the folder-rename detector as `common_folder_rename`; `acl.py` now imports it instead of keeping a private duplicate.

### Tests
- Repo: page re-key, folder-rename carries the subtree (folder row + nested folder + nested page), delete drops the row.
- Wiring: `after_path_move` repoints and `after_doc_delete` drops the policy row; `test_acl` still green after the helper extraction.

> Scope note: this PR covers **only** the move/delete lifecycle. Ingestion enforcement + prompt injection (the original "enforce" idea) is a separate follow-up.