### PR TITLE
feat(activities-panel): activities panel + Opal 0.1.12 sidebar migration

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -19,6 +19,7 @@
         "diff": "^9.0.0",
         "formik": "^2.2.9",
         "next": "^16.2.7",
+        "next-themes": "^0.4.6",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-markdown": "^9.0.1",
@@ -896,6 +897,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "next": ["next@16.2.7", "", { "dependencies": { "@next/env": "16.2.7", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.7", "@next/swc-darwin-x64": "16.2.7", "@next/swc-linux-arm64-gnu": "16.2.7", "@next/swc-linux-arm64-musl": "16.2.7", "@next/swc-linux-x64-gnu": "16.2.7", "@next/swc-linux-x64-musl": "16.2.7", "@next/swc-win32-arm64-msvc": "16.2.7", "@next/swc-win32-x64-msvc": "16.2.7", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w=="],
+
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -9,7 +9,7 @@
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@onyx-ai/opal": "0.1.9",
+        "@onyx-ai/opal": "file:../../onyx/web/lib/opal/onyx-ai-opal-0.1.10.tgz",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.2.4",
@@ -177,7 +177,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@onyx-ai/opal": ["@onyx-ai/opal@0.1.9", "", { "dependencies": { "clsx": "^2.0.0", "copy-to-clipboard": "^3.3.3", "tailwind-merge": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.0", "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0", "@dnd-kit/sortable": "^8.0.0", "@dnd-kit/utilities": "^3.0.0", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-separator": "^1.0.0", "@radix-ui/react-slot": "^1.0.0", "@radix-ui/react-tabs": "^1.0.0", "@radix-ui/react-tooltip": "^1.0.0", "@tanstack/react-table": "^8.0.0", "formik": "^2.0.0", "next": ">=14.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-markdown": "^9.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.0" } }, "sha512-T7maKH8NXQPIS+dnwVPphFYYexcs7G5XICgmFE4ToGRaV6ibUroseIrvZQix4lfRZ0e05L9MwMySiOWv97CKfQ=="],
+    "@onyx-ai/opal": ["@onyx-ai/opal@../../onyx/web/lib/opal/onyx-ai-opal-0.1.10.tgz", { "dependencies": { "clsx": "^2.0.0", "copy-to-clipboard": "^3.3.3", "tailwind-merge": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.0", "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0", "@dnd-kit/sortable": "^8.0.0", "@dnd-kit/utilities": "^3.0.0", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-separator": "^1.0.0", "@radix-ui/react-slot": "^1.0.0", "@radix-ui/react-tabs": "^1.0.0", "@radix-ui/react-tooltip": "^1.0.0", "@tanstack/react-table": "^8.0.0", "formik": "^2.0.0", "next": ">=14.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-markdown": "^9.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.0" } }, "sha512-rnrUmQfJqjLI4QorwxdytTiBt7V4zoe6E4nlRj5D7+U/4dCRcjfgJOxHbTnVXbUhTjQyqn3TwARH38z81fOmPQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -9,7 +9,7 @@
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@onyx-ai/opal": "file:../../onyx/web/lib/opal/onyx-ai-opal-0.1.10.tgz",
+        "@onyx-ai/opal": "^0.1.12",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.2.4",
@@ -177,7 +177,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@onyx-ai/opal": ["@onyx-ai/opal@../../onyx/web/lib/opal/onyx-ai-opal-0.1.10.tgz", { "dependencies": { "clsx": "^2.0.0", "copy-to-clipboard": "^3.3.3", "tailwind-merge": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.0", "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0", "@dnd-kit/sortable": "^8.0.0", "@dnd-kit/utilities": "^3.0.0", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-separator": "^1.0.0", "@radix-ui/react-slot": "^1.0.0", "@radix-ui/react-tabs": "^1.0.0", "@radix-ui/react-tooltip": "^1.0.0", "@tanstack/react-table": "^8.0.0", "formik": "^2.0.0", "next": ">=14.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-markdown": "^9.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.0" } }, "sha512-rnrUmQfJqjLI4QorwxdytTiBt7V4zoe6E4nlRj5D7+U/4dCRcjfgJOxHbTnVXbUhTjQyqn3TwARH38z81fOmPQ=="],
+    "@onyx-ai/opal": ["@onyx-ai/opal@0.1.12", "", { "dependencies": { "clsx": "^2.0.0", "copy-to-clipboard": "^3.3.3", "tailwind-merge": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.0", "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0", "@dnd-kit/sortable": "^8.0.0", "@dnd-kit/utilities": "^3.0.0", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-separator": "^1.0.0", "@radix-ui/react-slot": "^1.0.0", "@radix-ui/react-tabs": "^1.0.0", "@radix-ui/react-tooltip": "^1.0.0", "@tanstack/react-table": "^8.0.0", "formik": "^2.0.0", "next": ">=14.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-markdown": "^9.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.0" } }, "sha512-rFWg1X//v5hB5gC94hLCAQwj8iC9WbzukKRJJcJie7qW0AkcBG64RmDjS9p5ae5At9D9YvswjLeBbajtDZer1A=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@onyx-ai/opal": "^0.1.9",
+    "@onyx-ai/opal": "file:../../onyx/web/lib/opal/onyx-ai-opal-0.1.10.tgz",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "diff": "^9.0.0",
     "formik": "^2.2.9",
     "next": "^16.2.7",
+    "next-themes": "^0.4.6",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-markdown": "^9.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@onyx-ai/opal": "file:../../onyx/web/lib/opal/onyx-ai-opal-0.1.10.tgz",
+    "@onyx-ai/opal": "^0.1.12",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.2.4",

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import type { ReactNode } from "react";
+import { SidebarStateProvider } from "@onyx-ai/opal/layouts";
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="flex min-h-screen bg-(--background-tint-01)">
-      <AdminSidebar />
-      <div className="min-w-0 flex-1">{children}</div>
-    </div>
+    <SidebarStateProvider>
+      <div className="flex min-h-screen bg-(--background-tint-01)">
+        <AdminSidebar />
+        <div className="min-w-0 flex-1">{children}</div>
+      </div>
+    </SidebarStateProvider>
   );
 }

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { SidebarStateProvider } from "@onyx-ai/opal/layouts";
+import { RootLayout, SidebarStateProvider } from "@onyx-ai/opal/layouts";
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
     <SidebarStateProvider>
-      <div className="flex min-h-screen bg-(--background-tint-01)">
+      <RootLayout.Root>
         <AdminSidebar />
-        <div className="min-w-0 flex-1">{children}</div>
-      </div>
+        <RootLayout.App>
+          <RootLayout.MainContent>{children}</RootLayout.MainContent>
+        </RootLayout.App>
+      </RootLayout.Root>
     </SidebarStateProvider>
   );
 }

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -9,7 +9,7 @@ import { WikiItemActionsProvider } from "@/providers/WikiItemActionsProvider";
 import { LeftPanelProvider, useLeftPanel } from "@/providers/LeftPanelProvider";
 import { WikiTree } from "@/components/wiki/WikiTree";
 import { WikiHeader } from "@/components/wiki/WikiHeader";
-import { ActivitiesPanel } from "@/components/wiki/ActivitiesPanel";
+import ActivitiesPanel from "@/components/wiki/ActivitiesPanel";
 import { useAuth } from "@/lib/auth";
 import { useHealth } from "@/lib/health";
 import { useLLMStatus } from "@/lib/llm";
@@ -112,7 +112,6 @@ function AppContent({ children }: AppContentProps) {
     </WikiItemActionsProvider>
   );
 }
-
 
 interface LayoutProps {
   children: ReactNode;

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, type ReactNode } from "react";
-import { RootLayout } from "@onyx-ai/opal/layouts";
+import { RootLayout, SidebarStateProvider } from "@onyx-ai/opal/layouts";
 import { MessageCard } from "@onyx-ai/opal/components";
 import { markdown } from "@onyx-ai/opal/utils";
 import AppSidebar from "@/sections/sidebar/AppSidebar";
@@ -118,7 +118,7 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const [folded, setFolded] = useState<boolean>(() => {
+  const [defaultFolded] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     const stored = window.localStorage.getItem(COLLAPSED_KEY);
     if (stored === "1") return true;
@@ -126,22 +126,19 @@ export default function Layout({ children }: LayoutProps) {
     return window.innerWidth < 724;
   });
 
-  function toggle() {
-    setFolded((prev) => {
-      const next = !prev;
-      window.localStorage.setItem(COLLAPSED_KEY, next ? "1" : "0");
-      return next;
-    });
-  }
-
   return (
     <LeftPanelProvider>
-      <RootLayout.Root>
-        <RootLayout.Sidebar folded={folded} onFoldToggle={toggle}>
-          <AppSidebar folded={folded} onFoldToggle={toggle} />
-        </RootLayout.Sidebar>
-        <AppContent>{children}</AppContent>
-      </RootLayout.Root>
+      <SidebarStateProvider
+        defaultFolded={defaultFolded}
+        onFoldedChange={(folded) => {
+          window.localStorage.setItem(COLLAPSED_KEY, folded ? "1" : "0");
+        }}
+      >
+        <RootLayout.Root>
+          <AppSidebar />
+          <AppContent>{children}</AppContent>
+        </RootLayout.Root>
+      </SidebarStateProvider>
     </LeftPanelProvider>
   );
 }

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -89,7 +89,11 @@ function AppContent({ children }: AppContentProps) {
       {view !== null && (
         <RootLayout.LeftPanel>
           {view === "wiki-tree" && <WikiTree />}
-          {view === "activities" && <ActivitiesPanel />}
+          {view === "activities" && (
+            <div className="p-1">
+              <ActivitiesPanel />
+            </div>
+          )}
         </RootLayout.LeftPanel>
       )}
       <RootLayout.App>

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -9,6 +9,7 @@ import { WikiItemActionsProvider } from "@/providers/WikiItemActionsProvider";
 import { LeftPanelProvider, useLeftPanel } from "@/providers/LeftPanelProvider";
 import { WikiTree } from "@/components/wiki/WikiTree";
 import { WikiHeader } from "@/components/wiki/WikiHeader";
+import { ActivitiesPanel } from "@/components/wiki/ActivitiesPanel";
 import { useAuth } from "@/lib/auth";
 import { useHealth } from "@/lib/health";
 import { useLLMStatus } from "@/lib/llm";
@@ -108,13 +109,6 @@ function AppContent({ children }: AppContentProps) {
   );
 }
 
-function ActivitiesPanel() {
-  return (
-    <div className="flex h-full items-center justify-center p-4">
-      <p className="text-sm text-(--text-03)">Activities coming soon.</p>
-    </div>
-  );
-}
 
 interface LayoutProps {
   children: ReactNode;

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -104,9 +104,7 @@ function AppContent({ children }: AppContentProps) {
           </RootLayout.Header>
         )}
         <RootLayout.MainContent>
-          <div className="mx-auto w-full max-w-[768px]">
-            {children}
-          </div>
+          <div className="mx-auto w-full max-w-[768px]">{children}</div>
         </RootLayout.MainContent>
       </RootLayout.App>
     </WikiItemActionsProvider>

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -90,7 +90,7 @@ function AppContent({ children }: AppContentProps) {
         <RootLayout.LeftPanel>
           {view === "wiki-tree" && <WikiTree />}
           {view === "activities" && (
-            <div className="p-1">
+            <div className="h-full p-1">
               <ActivitiesPanel />
             </div>
           )}

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -104,7 +104,7 @@ function AppContent({ children }: AppContentProps) {
           </RootLayout.Header>
         )}
         <RootLayout.MainContent>
-          <div className="mx-auto w-full max-w-(--breakpoint-content-md)">
+          <div className="mx-auto w-full max-w-[768px]">
             {children}
           </div>
         </RootLayout.MainContent>

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -14,7 +14,7 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
 import { effectiveTimezone } from "@/lib/cron";
-import { setLocalThemePreview } from "@/lib/theme-provider";
+import { useTheme } from "next-themes";
 import type { DefaultLanding, ThemeSetting, UserSettings } from "@/types";
 import styles from "./page.module.css";
 
@@ -196,6 +196,8 @@ function SettingsForm({
     [initial],
   );
 
+  const { setTheme } = useTheme();
+
   const dirty = useMemo(() => {
     return (Object.keys(draft) as (keyof UserSettings)[]).some(
       (k) => draft[k] !== baseline[k],
@@ -215,7 +217,7 @@ function SettingsForm({
     update("theme", theme);
     // Apply immediately so the user sees the change without waiting for
     // the round-trip — Save still needs to hit the server to persist.
-    setLocalThemePreview(theme);
+    setTheme(theme);
   }
 
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
@@ -236,7 +238,7 @@ function SettingsForm({
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to save");
       // Revert the optimistic theme apply if the server rejected.
-      setLocalThemePreview(initial.theme);
+      setTheme(initial.theme);
     } finally {
       setSaving(false);
     }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -19,16 +19,9 @@ body {
   }
 }
 
-/* Tell the browser which color scheme is active so native UI (scrollbars,
-   autofill, date pickers) uses matching light/dark variants. */
 :root {
-  color-scheme: light;
-  --breakpoint-content-md: 768px;
   /* agent-wiki layout tokens — not part of Opal */
   --activities-view: 22rem;
-}
-.dark {
-  color-scheme: dark;
 }
 
 /* ── Shadow tokens ────────────────────────────────────────────────────────

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -24,6 +24,8 @@ body {
 :root {
   color-scheme: light;
   --breakpoint-content-md: 768px;
+  /* agent-wiki layout tokens — not part of Opal */
+  --activities-view: 22rem;
 }
 .dark {
   color-scheme: dark;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,7 +3,6 @@ import "./globals.css";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { cn } from "@onyx-ai/opal/utils";
 import { DM_Mono, Hanken_Grotesk } from "next/font/google";
-import { cookies } from "next/headers";
 import type { ReactNode } from "react";
 
 import { ChatWidget } from "@/components/chat/ChatWidget";
@@ -11,11 +10,7 @@ import { ConfirmProvider } from "@/components/common/ConfirmDialog";
 import { AuthProvider } from "@/lib/auth";
 import { DraftingProvider } from "@/lib/drafting";
 import { SWRProvider } from "@/lib/swr";
-import {
-  THEME_COOKIE_KEY,
-  ThemeProvider,
-  type ResolvedTheme,
-} from "@/lib/theme-provider";
+import { ThemeProvider } from "@/lib/theme-provider";
 
 const hankenGrotesk = Hanken_Grotesk({
   subsets: ["latin"],
@@ -58,24 +53,16 @@ export const viewport = {
   initialScale: 1,
 };
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  const cookieStore = await cookies();
-  const theme: ResolvedTheme =
-    cookieStore.get(THEME_COOKIE_KEY)?.value === "dark" ? "dark" : "light";
-
   return (
     <html
       lang="en"
-      className={cn(
-        hankenGrotesk.variable,
-        dmMono.variable,
-        theme === "dark" && "dark",
-      )}
-      data-theme={theme}
+      className={cn(hankenGrotesk.variable, dmMono.variable)}
+      suppressHydrationWarning
     >
       <head />
       <body

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -53,11 +53,7 @@ export const viewport = {
   initialScale: 1,
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: ReactNode;
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html
       lang="en"

--- a/frontend/src/components/form/LabeledCheckboxField.tsx
+++ b/frontend/src/components/form/LabeledCheckboxField.tsx
@@ -46,18 +46,19 @@ export const LabeledCheckboxField: React.FC<LabeledCheckboxFieldProps> = ({
 
   const checkboxContent = (
     <div className="flex w-fit items-start space-x-2">
-      <Checkbox
-        id={name}
-        aria-labelledby={labelId}
-        checked={field.value}
-        onCheckedChange={(checked) => {
-          helpers.setValue(Boolean(checked));
-          onChange?.(Boolean(checked));
-        }}
-        className={cn(sizeClasses[size])}
-        disabled={disabled}
-        {...props}
-      />
+      <div className={cn(sizeClasses[size])}>
+        <Checkbox
+          id={name}
+          aria-labelledby={labelId}
+          checked={field.value}
+          onCheckedChange={(checked) => {
+            helpers.setValue(Boolean(checked));
+            onChange?.(Boolean(checked));
+          }}
+          disabled={disabled}
+          {...props}
+        />
+      </div>
       <div className="flex flex-col">
         <label
           id={labelId}

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -6,7 +6,6 @@ import {
   Divider,
   InputTypeIn,
   Tag,
-  Text,
 } from "@onyx-ai/opal/components";
 import { SvgEmpty, SvgNotFound } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
@@ -92,7 +91,7 @@ export default function ActivitiesPanel() {
   const olderEvents = filtered.filter((ev) => !isNewActivity(ev.ts));
 
   return (
-    <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01 p-1">
+    <div className="flex h-full w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) p-1">
       {/* Header */}
       <Section
         flexDirection="row"

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -60,7 +60,7 @@ export function ActivitiesPanel() {
   const olderEvents = events.filter((ev) => !isNewActivity(ev.ts));
 
   return (
-    <div className="flex h-full w-full max-w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
+    <div className="flex h-full w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
       <div className="flex items-center justify-between border-b border-(--border-01) px-3 py-2">
         <span className="text-sm font-semibold text-(--text-05)">Activities</span>
         <Button

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -84,7 +84,7 @@ export default function ActivitiesPanel() {
   const olderEvents = filtered.filter((ev) => !isNewActivity(ev.ts));
 
   return (
-    <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01">
+    <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01 p-1">
       {/* Header */}
       <Section
         flexDirection="row"

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Divider, InputTypeIn, Tag, Text } from "@onyx-ai/opal/components";
-import { SvgEmpty } from "@onyx-ai/opal/illustrations";
+import {
+  Button,
+  Divider,
+  InputTypeIn,
+  Tag,
+  Text,
+} from "@onyx-ai/opal/components";
+import { SvgEmpty, SvgNotFound } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
-import { IllustrationContent, Section } from "@onyx-ai/opal/layouts";
+import { Content, IllustrationContent, Section } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import {
@@ -12,7 +18,7 @@ import {
   toEventIso,
   useEvents,
   type AppEvent,
-} from "@/lib/events";
+} from "@/lib/activities";
 import { formatScopePath } from "@/lib/format";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 
@@ -39,13 +45,15 @@ function ActivityCard({ event }: ActivityCardProps) {
           <em className="text-xs text-(--text-02)">(no path)</em>
         )}
         {p.change_kind && (
-          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold uppercase tracking-[0.3px] text-(--text-05)">
+          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
             {p.change_kind}
           </span>
         )}
       </div>
       {p.reason && (
-        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">{p.reason}</p>
+        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
+          {p.reason}
+        </p>
       )}
       <div className="flex items-center justify-between">
         <span className="text-[11px] text-(--text-02)">
@@ -93,15 +101,20 @@ export default function ActivitiesPanel() {
         height="fit"
         padding={0.5}
       >
-        <Section flexDirection="row" alignItems="center" gap={0.5} height="fit">
-          <SvgActivity size={16} />
-          <span className="text-sm font-semibold text-(--text-05)">
-            Activity History
-          </span>
-        </Section>
-        <Section flexDirection="row" alignItems="center" gap={0.5} height="fit">
+        <Content
+          icon={SvgActivity}
+          title="Activity History"
+          variant="section"
+          sizePreset="main-ui"
+        />
+        <Section
+          flexDirection="row"
+          justifyContent="end"
+          gap={0.5}
+          height="fit"
+        >
           {unreadCount > 0 && (
-            <Tag title={`${unreadCount} new`} color="blue" />
+            <Tag title={`${unreadCount} new`} color="blue" size="md" />
           )}
           <Button
             icon={SvgX}
@@ -140,8 +153,11 @@ export default function ActivitiesPanel() {
         )}
 
         {!isLoading && events.length > 0 && filtered.length === 0 && (
-          <div className="px-3 pt-4">
-            <Text font="secondary-body" color="text-03">No matching activity.</Text>
+          <div className="flex h-full items-center justify-center">
+            <IllustrationContent
+              illustration={SvgNotFound}
+              title="No matching activity found."
+            />
           </div>
         )}
 

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Button, Divider } from "@onyx-ai/opal/components";
-import { SvgX } from "@onyx-ai/opal/icons";
+import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
+import { ContentAction } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { isNewActivity, toEventIso, useEvents, type AppEvent } from "@/lib/events";
@@ -61,14 +62,21 @@ export function ActivitiesPanel() {
 
   return (
     <div className="flex h-full w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
-      <div className="flex items-center justify-between border-b border-(--border-01) px-3 py-2">
-        <span className="text-sm font-semibold text-(--text-05)">Activities</span>
-        <Button
-          icon={SvgX}
-          prominence="tertiary"
-          size="sm"
-          tooltip="Close"
-          onClick={toggleActivities}
+      <div className="border-b border-(--border-01)">
+        <ContentAction
+          variant="section"
+          icon={SvgActivity}
+          title="Activity History"
+          padding="sm"
+          rightChildren={
+            <Button
+              icon={SvgX}
+              prominence="tertiary"
+              size="sm"
+              tooltip="Close"
+              onClick={toggleActivities}
+            />
+          }
         />
       </div>
 

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -60,7 +60,7 @@ export function ActivitiesPanel() {
   const olderEvents = events.filter((ev) => !isNewActivity(ev.ts));
 
   return (
-    <div className="flex h-full flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
+    <div className="flex h-full w-full max-w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
       <div className="flex items-center justify-between border-b border-(--border-01) px-3 py-2">
         <span className="text-sm font-semibold text-(--text-05)">Activities</span>
         <Button

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -2,10 +2,15 @@
 
 import { Button, Divider } from "@onyx-ai/opal/components";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
-import { ContentAction } from "@onyx-ai/opal/layouts";
+import { ContentAction, Section } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
-import { isNewActivity, toEventIso, useEvents, type AppEvent } from "@/lib/events";
+import {
+  isNewActivity,
+  toEventIso,
+  useEvents,
+  type AppEvent,
+} from "@/lib/events";
 import { formatScopePath } from "@/lib/format";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 
@@ -32,25 +37,29 @@ function ActivityCard({ event }: ActivityCardProps) {
           <em className="text-xs text-(--text-02)">(no path)</em>
         )}
         {p.change_kind && (
-          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold uppercase tracking-[0.3px] text-(--text-05)">
+          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
             {p.change_kind}
           </span>
         )}
       </div>
       {p.reason && (
-        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">{p.reason}</p>
+        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
+          {p.reason}
+        </p>
       )}
       <div className="flex items-center justify-between">
         <span className="text-[11px] text-(--text-02)">
           trigger {event.target ?? "?"}
         </span>
-        <span className="text-[11px] text-(--text-02)">{timeAgo(toEventIso(event.ts))}</span>
+        <span className="text-[11px] text-(--text-02)">
+          {timeAgo(toEventIso(event.ts))}
+        </span>
       </div>
     </div>
   );
 }
 
-export function ActivitiesPanel() {
+export default function ActivitiesPanel() {
   const { toggleActivities } = useLeftPanel();
   const { events, isLoading } = useEvents(
     { kind: "trigger.fire", limit: 100 },
@@ -61,31 +70,29 @@ export function ActivitiesPanel() {
   const olderEvents = events.filter((ev) => !isNewActivity(ev.ts));
 
   return (
-    <div className="flex h-full w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
-      <div className="border-b border-(--border-01)">
-        <ContentAction
-          variant="body"
-          sizePreset="main-ui"
-          icon={SvgActivity}
-          title="Activity History"
-          padding="sm"
-          rightChildren={
-            <Button
-              icon={SvgX}
-              prominence="tertiary"
-              size="sm"
-              tooltip="Close"
-              onClick={toggleActivities}
-            />
-          }
-        />
-      </div>
+    <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01">
+      <ContentAction
+        variant="body"
+        sizePreset="main-ui"
+        icon={SvgActivity}
+        title="Activity History"
+        padding="sm"
+        rightChildren={
+          <Button
+            icon={SvgX}
+            prominence="tertiary"
+            size="sm"
+            tooltip="Close"
+            onClick={toggleActivities}
+          />
+        }
+      />
 
       <div className="flex-1 overflow-y-auto py-1">
         {isLoading && <LoadingSpinner center />}
 
         {!isLoading && events.length === 0 && (
-          <p className="px-3 pt-4 text-sm text-(--text-03)">No activity yet.</p>
+          <p className="px-3 pt-4 text-sm text-text-03">No activity yet.</p>
         )}
 
         {newEvents.length > 0 && (

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -4,25 +4,14 @@ import { Button, Divider } from "@onyx-ai/opal/components";
 import { SvgX } from "@onyx-ai/opal/icons";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
-import { useEvents, type AppEvent } from "@/lib/events";
+import { isNewActivity, toEventIso, useEvents, type AppEvent } from "@/lib/events";
 import { formatScopePath } from "@/lib/format";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
-
-const NEW_CUTOFF_MS = 24 * 60 * 60 * 1000;
 
 interface TriggerFirePayload {
   doc_path?: string;
   change_kind?: string;
   reason?: string;
-}
-
-// SQLite's datetime('now') omits the T and Z; treat as UTC.
-function toIso(ts: string): string {
-  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
-}
-
-function isNew(ts: string): boolean {
-  return Date.now() - new Date(toIso(ts)).getTime() < NEW_CUTOFF_MS;
 }
 
 interface ActivityCardProps {
@@ -54,7 +43,7 @@ function ActivityCard({ event }: ActivityCardProps) {
         <span className="text-[11px] text-(--text-02)">
           trigger {event.target ?? "?"}
         </span>
-        <span className="text-[11px] text-(--text-02)">{timeAgo(toIso(event.ts))}</span>
+        <span className="text-[11px] text-(--text-02)">{timeAgo(toEventIso(event.ts))}</span>
       </div>
     </div>
   );
@@ -67,8 +56,8 @@ export function ActivitiesPanel() {
     { refreshInterval: 30_000 },
   );
 
-  const newEvents = events.filter((ev) => isNew(ev.ts));
-  const olderEvents = events.filter((ev) => !isNew(ev.ts));
+  const newEvents = events.filter((ev) => isNewActivity(ev.ts));
+  const olderEvents = events.filter((ev) => !isNewActivity(ev.ts));
 
   return (
     <div className="flex h-full flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Button, Divider } from "@onyx-ai/opal/components";
+import { useState } from "react";
+import { Button, Divider, InputTypeIn, Tag } from "@onyx-ai/opal/components";
+import { SvgEmpty } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
-import { ContentAction, Section } from "@onyx-ai/opal/layouts";
+import { IllustrationContent, Section } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import {
@@ -37,15 +39,13 @@ function ActivityCard({ event }: ActivityCardProps) {
           <em className="text-xs text-(--text-02)">(no path)</em>
         )}
         {p.change_kind && (
-          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
+          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold uppercase tracking-[0.3px] text-(--text-05)">
             {p.change_kind}
           </span>
         )}
       </div>
       {p.reason && (
-        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
-          {p.reason}
-        </p>
+        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">{p.reason}</p>
       )}
       <div className="flex items-center justify-between">
         <span className="text-[11px] text-(--text-02)">
@@ -61,38 +61,87 @@ function ActivityCard({ event }: ActivityCardProps) {
 
 export default function ActivitiesPanel() {
   const { toggleActivities } = useLeftPanel();
+  const [query, setQuery] = useState("");
   const { events, isLoading } = useEvents(
     { kind: "trigger.fire", limit: 100 },
     { refreshInterval: 30_000 },
   );
 
-  const newEvents = events.filter((ev) => isNewActivity(ev.ts));
-  const olderEvents = events.filter((ev) => !isNewActivity(ev.ts));
+  const unreadCount = events.filter((ev) => isNewActivity(ev.ts)).length;
+
+  const filtered = query
+    ? events.filter((ev) => {
+        const p = ev.payload as TriggerFirePayload;
+        const haystack = [p.doc_path, p.change_kind, p.reason, ev.target]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase();
+        return haystack.includes(query.toLowerCase());
+      })
+    : events;
+
+  const newEvents = filtered.filter((ev) => isNewActivity(ev.ts));
+  const olderEvents = filtered.filter((ev) => !isNewActivity(ev.ts));
 
   return (
     <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01">
-      <ContentAction
-        variant="body"
-        sizePreset="main-ui"
-        icon={SvgActivity}
-        title="Activity History"
-        padding="sm"
-        rightChildren={
+      {/* Header */}
+      <Section
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="between"
+        padding={0.5}
+      >
+        <Section flexDirection="row" alignItems="center" gap={0.5}>
+          <SvgActivity size={16} />
+          <span className="text-sm font-semibold text-(--text-05)">
+            Activity History
+          </span>
+        </Section>
+        <Section flexDirection="row" alignItems="center" gap={0.5}>
+          {unreadCount > 0 && (
+            <Tag title={`${unreadCount} new`} color="blue" />
+          )}
           <Button
             icon={SvgX}
             prominence="tertiary"
-            size="sm"
+            size="lg"
             tooltip="Close"
             onClick={toggleActivities}
           />
-        }
-      />
+        </Section>
+      </Section>
 
+      {/* Search — hidden when there are no events at all */}
+      {!isLoading && events.length > 0 && (
+        <div className="px-2 pb-2">
+          <InputTypeIn
+            searchIcon
+            placeholder="Search activity history..."
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            clearButton
+          />
+        </div>
+      )}
+
+      {/* Body */}
       <div className="flex-1 overflow-y-auto py-1">
         {isLoading && <LoadingSpinner center />}
 
         {!isLoading && events.length === 0 && (
-          <p className="px-3 pt-4 text-sm text-text-03">No activity yet.</p>
+          <div className="flex h-full items-center justify-center">
+            <IllustrationContent
+              illustration={SvgEmpty}
+              title="No activity yet."
+            />
+          </div>
+        )}
+
+        {!isLoading && events.length > 0 && filtered.length === 0 && (
+          <p className="px-3 pt-4 text-sm text-(--text-03)">
+            No matching activity.
+          </p>
         )}
 
         {newEvents.length > 0 && (

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -96,23 +96,19 @@ export default function ActivitiesPanel() {
       {/* Header */}
       <Section
         flexDirection="row"
-        alignItems="center"
         justifyContent="between"
         height="fit"
-        padding={0.5}
+        gap={0.25}
       >
-        <Content
-          icon={SvgActivity}
-          title="Activity History"
-          variant="section"
-          sizePreset="main-ui"
-        />
-        <Section
-          flexDirection="row"
-          justifyContent="end"
-          gap={0.5}
-          height="fit"
-        >
+        <div className="p-2">
+          <Content
+            icon={SvgActivity}
+            title="Activity History"
+            variant="section"
+            sizePreset="main-ui"
+          />
+        </div>
+        <Section flexDirection="row" justifyContent="end" width="fit">
           {unreadCount > 0 && (
             <Tag title={`${unreadCount} new`} color="blue" size="md" />
           )}

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { Button, Divider } from "@onyx-ai/opal/components";
+import { SvgX } from "@onyx-ai/opal/icons";
+import { timeAgo } from "@onyx-ai/opal/time";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { useEvents, type AppEvent } from "@/lib/events";
+import { formatScopePath } from "@/lib/format";
+import { useLeftPanel } from "@/providers/LeftPanelProvider";
+
+const NEW_CUTOFF_MS = 24 * 60 * 60 * 1000;
+
+interface TriggerFirePayload {
+  doc_path?: string;
+  change_kind?: string;
+  reason?: string;
+}
+
+// SQLite's datetime('now') omits the T and Z; treat as UTC.
+function toIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}
+
+function isNew(ts: string): boolean {
+  return Date.now() - new Date(toIso(ts)).getTime() < NEW_CUTOFF_MS;
+}
+
+interface ActivityCardProps {
+  event: AppEvent;
+}
+
+function ActivityCard({ event }: ActivityCardProps) {
+  const p = event.payload as TriggerFirePayload;
+  return (
+    <div className="mx-3 my-1.5 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-3 py-2.5">
+      <div className="mb-1 flex items-start justify-between gap-2">
+        {p.doc_path ? (
+          <span className="truncate font-mono text-xs text-(--text-04)">
+            {formatScopePath(p.doc_path)}
+          </span>
+        ) : (
+          <em className="text-xs text-(--text-02)">(no path)</em>
+        )}
+        {p.change_kind && (
+          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold uppercase tracking-[0.3px] text-(--text-05)">
+            {p.change_kind}
+          </span>
+        )}
+      </div>
+      {p.reason && (
+        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">{p.reason}</p>
+      )}
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] text-(--text-02)">
+          trigger {event.target ?? "?"}
+        </span>
+        <span className="text-[11px] text-(--text-02)">{timeAgo(toIso(event.ts))}</span>
+      </div>
+    </div>
+  );
+}
+
+export function ActivitiesPanel() {
+  const { toggleActivities } = useLeftPanel();
+  const { events, isLoading } = useEvents(
+    { kind: "trigger.fire", limit: 100 },
+    { refreshInterval: 30_000 },
+  );
+
+  const newEvents = events.filter((ev) => isNew(ev.ts));
+  const olderEvents = events.filter((ev) => !isNew(ev.ts));
+
+  return (
+    <div className="flex h-full flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
+      <div className="flex items-center justify-between border-b border-(--border-01) px-3 py-2">
+        <span className="text-sm font-semibold text-(--text-05)">Activities</span>
+        <Button
+          icon={SvgX}
+          prominence="tertiary"
+          size="sm"
+          tooltip="Close"
+          onClick={toggleActivities}
+        />
+      </div>
+
+      <div className="flex-1 overflow-y-auto py-1">
+        {isLoading && <LoadingSpinner center />}
+
+        {!isLoading && events.length === 0 && (
+          <p className="px-3 pt-4 text-sm text-(--text-03)">No activity yet.</p>
+        )}
+
+        {newEvents.length > 0 && (
+          <>
+            <div className="px-3 pt-1">
+              <Divider title="New" />
+            </div>
+            {newEvents.map((ev) => (
+              <ActivityCard key={ev.id} event={ev} />
+            ))}
+          </>
+        )}
+
+        {olderEvents.length > 0 && (
+          <>
+            <div className="px-3 pt-1">
+              <Divider title="Older" />
+            </div>
+            {olderEvents.map((ev) => (
+              <ActivityCard key={ev.id} event={ev} />
+            ))}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button, Divider, InputTypeIn, Tag } from "@onyx-ai/opal/components";
 import { SvgEmpty } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
-import { IllustrationContent, Section } from "@onyx-ai/opal/layouts";
+import { IllustrationContent } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import {
@@ -86,19 +86,14 @@ export default function ActivitiesPanel() {
   return (
     <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01">
       {/* Header */}
-      <Section
-        flexDirection="row"
-        alignItems="center"
-        justifyContent="between"
-        padding={0.5}
-      >
-        <Section flexDirection="row" alignItems="center" gap={0.5}>
+      <div className="flex shrink-0 items-center justify-between px-2 py-1">
+        <div className="flex items-center gap-2">
           <SvgActivity size={16} />
           <span className="text-sm font-semibold text-(--text-05)">
             Activity History
           </span>
-        </Section>
-        <Section flexDirection="row" alignItems="center" gap={0.5}>
+        </div>
+        <div className="flex items-center gap-1.5">
           {unreadCount > 0 && (
             <Tag title={`${unreadCount} new`} color="blue" />
           )}
@@ -109,8 +104,8 @@ export default function ActivitiesPanel() {
             tooltip="Close"
             onClick={toggleActivities}
           />
-        </Section>
-      </Section>
+        </div>
+      </div>
 
       {/* Search — hidden when there are no events at all */}
       {!isLoading && events.length > 0 && (

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,12 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import {
-  Button,
-  Divider,
-  InputTypeIn,
-  Tag,
-} from "@onyx-ai/opal/components";
+import { Button, Divider, InputTypeIn, Tag } from "@onyx-ai/opal/components";
 import { SvgEmpty, SvgNotFound } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
 import { Content, IllustrationContent, Section } from "@onyx-ai/opal/layouts";

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button, Divider, InputTypeIn, Tag } from "@onyx-ai/opal/components";
 import { SvgEmpty } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
-import { IllustrationContent } from "@onyx-ai/opal/layouts";
+import { IllustrationContent, Section } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import {
@@ -86,14 +86,20 @@ export default function ActivitiesPanel() {
   return (
     <div className="flex h-full w-(--activities-view) flex-col rounded-12 border border-border-01">
       {/* Header */}
-      <div className="flex shrink-0 items-center justify-between px-2 py-1">
-        <div className="flex items-center gap-2">
+      <Section
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="between"
+        height="fit"
+        padding={0.5}
+      >
+        <Section flexDirection="row" alignItems="center" gap={0.5} height="fit">
           <SvgActivity size={16} />
           <span className="text-sm font-semibold text-(--text-05)">
             Activity History
           </span>
-        </div>
-        <div className="flex items-center gap-1.5">
+        </Section>
+        <Section flexDirection="row" alignItems="center" gap={0.5} height="fit">
           {unreadCount > 0 && (
             <Tag title={`${unreadCount} new`} color="blue" />
           )}
@@ -104,8 +110,8 @@ export default function ActivitiesPanel() {
             tooltip="Close"
             onClick={toggleActivities}
           />
-        </div>
-      </div>
+        </Section>
+      </Section>
 
       {/* Search — hidden when there are no events at all */}
       {!isLoading && events.length > 0 && (

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -64,7 +64,8 @@ export function ActivitiesPanel() {
     <div className="flex h-full w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) bg-transparent">
       <div className="border-b border-(--border-01)">
         <ContentAction
-          variant="section"
+          variant="body"
+          sizePreset="main-ui"
           icon={SvgActivity}
           title="Activity History"
           padding="sm"

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Divider, InputTypeIn, Tag } from "@onyx-ai/opal/components";
+import { Button, Divider, InputTypeIn, Tag, Text } from "@onyx-ai/opal/components";
 import { SvgEmpty } from "@onyx-ai/opal/illustrations";
 import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
 import { IllustrationContent, Section } from "@onyx-ai/opal/layouts";
@@ -140,9 +140,9 @@ export default function ActivitiesPanel() {
         )}
 
         {!isLoading && events.length > 0 && filtered.length === 0 && (
-          <p className="px-3 pt-4 text-sm text-(--text-03)">
-            No matching activity.
-          </p>
+          <div className="px-3 pt-4">
+            <Text font="secondary-body" color="text-03">No matching activity.</Text>
+          </div>
         )}
 
         {newEvents.length > 0 && (

--- a/frontend/src/lib/activities/hooks.ts
+++ b/frontend/src/lib/activities/hooks.ts
@@ -1,24 +1,5 @@
 import useSWR from "swr";
-
-export const NEW_ACTIVITY_CUTOFF_MS = 24 * 60 * 60 * 1000;
-
-// SQLite's datetime('now') omits the T and Z; treat as UTC.
-export function toEventIso(ts: string): string {
-  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
-}
-
-export function isNewActivity(ts: string): boolean {
-  return Date.now() - new Date(toEventIso(ts)).getTime() < NEW_ACTIVITY_CUTOFF_MS;
-}
-
-export interface AppEvent {
-  id: number;
-  ts: string;
-  kind: string;
-  actor: string | null;
-  target: string | null;
-  payload: Record<string, unknown>;
-}
+import type { AppEvent } from "./types";
 
 function eventsPath(opts: { kind?: string; limit?: number }): string {
   const qs = new URLSearchParams();

--- a/frontend/src/lib/activities/index.ts
+++ b/frontend/src/lib/activities/index.ts
@@ -1,0 +1,3 @@
+export type { AppEvent } from "./types";
+export { NEW_ACTIVITY_CUTOFF_MS, isNewActivity, toEventIso } from "./utils";
+export { useEvents } from "./hooks";

--- a/frontend/src/lib/activities/types.ts
+++ b/frontend/src/lib/activities/types.ts
@@ -1,0 +1,8 @@
+export interface AppEvent {
+  id: number;
+  ts: string;
+  kind: string;
+  actor: string | null;
+  target: string | null;
+  payload: Record<string, unknown>;
+}

--- a/frontend/src/lib/activities/utils.ts
+++ b/frontend/src/lib/activities/utils.ts
@@ -1,0 +1,10 @@
+export const NEW_ACTIVITY_CUTOFF_MS = 24 * 60 * 60 * 1000;
+
+// SQLite's datetime('now') omits the T and Z; treat as UTC.
+export function toEventIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}
+
+export function isNewActivity(ts: string): boolean {
+  return Date.now() - new Date(toEventIso(ts)).getTime() < NEW_ACTIVITY_CUTOFF_MS;
+}

--- a/frontend/src/lib/activities/utils.ts
+++ b/frontend/src/lib/activities/utils.ts
@@ -6,5 +6,7 @@ export function toEventIso(ts: string): string {
 }
 
 export function isNewActivity(ts: string): boolean {
-  return Date.now() - new Date(toEventIso(ts)).getTime() < NEW_ACTIVITY_CUTOFF_MS;
+  return (
+    Date.now() - new Date(toEventIso(ts)).getTime() < NEW_ACTIVITY_CUTOFF_MS
+  );
 }

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -1,5 +1,16 @@
 import useSWR from "swr";
 
+export const NEW_ACTIVITY_CUTOFF_MS = 24 * 60 * 60 * 1000;
+
+// SQLite's datetime('now') omits the T and Z; treat as UTC.
+export function toEventIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}
+
+export function isNewActivity(ts: string): boolean {
+  return Date.now() - new Date(toEventIso(ts)).getTime() < NEW_ACTIVITY_CUTOFF_MS;
+}
+
 export interface AppEvent {
   id: number;
   ts: string;

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -16,10 +16,13 @@ function eventsPath(opts: { kind?: string; limit?: number }): string {
   return `/events${qs.toString() ? `?${qs}` : ""}`;
 }
 
-export function useEvents(opts: { kind?: string; limit?: number } = {}) {
+export function useEvents(
+  opts: { kind?: string; limit?: number } = {},
+  swrConfig?: { refreshInterval?: number },
+) {
   const { data, error, isLoading, isValidating, mutate } = useSWR<{
     events: AppEvent[];
-  }>(eventsPath(opts));
+  }>(eventsPath(opts), swrConfig);
   return {
     events: data?.events ?? [],
     error: error as Error | undefined,

--- a/frontend/src/lib/theme-provider.tsx
+++ b/frontend/src/lib/theme-provider.tsx
@@ -1,128 +1,30 @@
 "use client";
 
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react";
-
+import { ThemeProvider as NextThemesProvider, useTheme } from "next-themes";
+import { useEffect, type ReactNode } from "react";
 import { useAuth } from "@/lib/auth";
 
 export type ThemeSetting = "light" | "dark" | "system";
 export type ResolvedTheme = "light" | "dark";
 
-interface ThemeContextValue {
-  setting: ThemeSetting;
-  resolved: ResolvedTheme;
-}
-
-const ThemeContext = createContext<ThemeContextValue>({
-  setting: "system",
-  resolved: "light",
-});
-
-const STORAGE_KEY = "agent-wiki:theme";
-// Separate cookie key (no colon — RFC 6265 token-safe) so the server can
-// read the resolved theme for SSR without relying on localStorage.
-export const THEME_COOKIE_KEY = "agent-wiki-theme";
-
-function readStoredSetting(): ThemeSetting {
-  if (typeof window === "undefined") return "system";
-  try {
-    const v = window.localStorage.getItem(STORAGE_KEY);
-    if (v === "light" || v === "dark" || v === "system") return v;
-  } catch {
-    /* ignore */
-  }
-  return "system";
-}
-
-function applyTheme(resolved: ResolvedTheme) {
-  if (typeof document !== "undefined") {
-    document.documentElement.setAttribute("data-theme", resolved);
-    document.documentElement.classList.toggle("dark", resolved === "dark");
-  }
-}
-
-function resolveSystem(): ResolvedTheme {
-  if (typeof window === "undefined") return "light";
-  return window.matchMedia("(prefers-color-scheme: dark)").matches
-    ? "dark"
-    : "light";
+function ThemeSync() {
+  const { user } = useAuth();
+  const { setTheme } = useTheme();
+  useEffect(() => {
+    if (user?.settings?.theme) setTheme(user.settings.theme);
+  }, [user?.settings?.theme, setTheme]);
+  return null;
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const { user } = useAuth();
-  // Pre-auth render: lazy-init from localStorage so the inline bootstrap
-  // and React's first paint agree.
-  const [setting, setSetting] = useState<ThemeSetting>(readStoredSetting);
-  const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() =>
-    resolveSystem(),
-  );
-
-  // Once the user logs in, prefer the server-side preference.
-  const userSetting = user?.settings?.theme ?? null;
-  useEffect(() => {
-    if (userSetting && userSetting !== setting) {
-      setSetting(userSetting);
-    }
-  }, [userSetting, setting]);
-
-  // Persist locally so logged-out routes (login, signup) keep the choice.
-  useEffect(() => {
-    try {
-      window.localStorage.setItem(STORAGE_KEY, setting);
-    } catch {
-      /* ignore */
-    }
-  }, [setting]);
-
-  // Track OS preference when the user has chosen "system".
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const onChange = () => setSystemTheme(mq.matches ? "dark" : "light");
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
-  }, []);
-
-  const resolved: ResolvedTheme = setting === "system" ? systemTheme : setting;
-
-  useEffect(() => {
-    applyTheme(resolved);
-    // Persist resolved theme in a cookie so the server can render the
-    // correct data-theme on <html> before React hydrates.
-    document.cookie = `${THEME_COOKIE_KEY}=${resolved};path=/;max-age=${365 * 24 * 60 * 60};SameSite=Lax;Secure`;
-  }, [resolved]);
-
-  const value = useMemo<ThemeContextValue>(
-    () => ({ setting, resolved }),
-    [setting, resolved],
-  );
-
   return (
-    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableColorScheme
+    >
+      <ThemeSync />
+      {children}
+    </NextThemesProvider>
   );
 }
-
-export function useTheme(): ThemeContextValue {
-  return useContext(ThemeContext);
-}
-
-// Direct setter used by the settings page when it eagerly applies the
-// new value before the round-trip completes (so "Save" feels instant).
-export function setLocalThemePreview(setting: ThemeSetting) {
-  try {
-    window.localStorage.setItem(STORAGE_KEY, setting);
-  } catch {
-    /* ignore */
-  }
-  const resolved = setting === "system" ? resolveSystem() : setting;
-  applyTheme(resolved);
-}
-
-// Re-export the storage key for tests / explicit cleanup.
-export const THEME_STORAGE_KEY = STORAGE_KEY;

--- a/frontend/src/sections/sidebar/AdminSidebar.tsx
+++ b/frontend/src/sections/sidebar/AdminSidebar.tsx
@@ -34,7 +34,6 @@ export default function AdminSidebar() {
         />
       </SidebarLayouts.Header>
       <SidebarLayouts.Body scrollKey="admin-sidebar">
-
         {filteredGroups.map((group) => (
           <SidebarLayouts.Section
             key={group.label ?? "__ungrouped"}

--- a/frontend/src/sections/sidebar/AdminSidebar.tsx
+++ b/frontend/src/sections/sidebar/AdminSidebar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { InputTypeIn, SidebarTab, Text } from "@onyx-ai/opal/components";
+import { InputTypeIn, SidebarTab } from "@onyx-ai/opal/components";
 import { SvgX } from "@onyx-ai/opal/icons";
-import { SidebarLayouts, SidebarWrapper } from "@onyx-ai/opal/layouts";
+import { SidebarLayouts } from "@onyx-ai/opal/layouts";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import { ADMIN_NAV_GROUPS } from "@/lib/nav/registry";
@@ -22,49 +22,37 @@ export default function AdminSidebar() {
   })).filter((group) => group.entries.length > 0);
 
   return (
-    <SidebarWrapper logo={sidebarLogo}>
+    <SidebarLayouts.Root>
+      <SidebarLayouts.Header logo={sidebarLogo}>
+        <InputTypeIn
+          variant="internal"
+          searchIcon
+          clearButton
+          placeholder="Search…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </SidebarLayouts.Header>
       <SidebarLayouts.Body scrollKey="admin-sidebar">
-        <div className="relative w-full">
-          <InputTypeIn
-            variant="internal"
-            searchIcon
-            clearButton
-            placeholder="Search…"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-          />
-        </div>
 
-        <div className="flex flex-col gap-3">
-          {filteredGroups.map((group) => (
-            <div
-              key={group.label ?? "__ungrouped"}
-              className="flex flex-col gap-px"
-            >
-              {group.label && (
-                <div className="px-2 pt-1 pb-0.5">
-                  <Text font="secondary-body" color="text-02">
-                    {group.label}
-                  </Text>
-                </div>
-              )}
-              {group.entries.map((item) => {
-                const active = pathname?.startsWith(item.href) ?? false;
-                return (
-                  <SidebarTab
-                    key={item.href}
-                    href={item.href}
-                    selected={active}
-                    folded={false}
-                    icon={item.icon}
-                  >
-                    {item.label}
-                  </SidebarTab>
-                );
-              })}
-            </div>
-          ))}
-        </div>
+        {filteredGroups.map((group) => (
+          <SidebarLayouts.Section
+            key={group.label ?? "__ungrouped"}
+            title={group.label ?? undefined}
+          >
+            {group.entries.map((item) => (
+              <SidebarTab
+                key={item.href}
+                href={item.href}
+                selected={pathname?.startsWith(item.href) ?? false}
+                folded={false}
+                icon={item.icon}
+              >
+                {item.label}
+              </SidebarTab>
+            ))}
+          </SidebarLayouts.Section>
+        ))}
       </SidebarLayouts.Body>
 
       {/* Footer: exit + account — same slot order as AppSidebar so the
@@ -75,6 +63,6 @@ export default function AdminSidebar() {
         </SidebarTab>
         <UserMenu />
       </SidebarLayouts.Footer>
-    </SidebarWrapper>
+    </SidebarLayouts.Root>
   );
 }

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Button, SidebarTab, Text } from "@onyx-ai/opal/components";
 import {
+  SvgActivity,
   SvgDocFile,
   SvgNotificationBubble,
   SvgSearch,
@@ -32,6 +33,7 @@ import { NAV_ENTRIES } from "@/lib/nav/registry";
 import { useIsMobile } from "@/lib/viewport";
 import { useAppFocus } from "@/hooks/useAppFocus";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
+import { isNewActivity, useEvents } from "@/lib/events";
 
 function useRecentPages() {
   const { data } = useSWR(
@@ -62,6 +64,11 @@ export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
   const isMobile = useIsMobile();
   const focus = useAppFocus();
   const { isActivitiesOpen, toggleActivities } = useLeftPanel();
+  const { events: activityEvents } = useEvents(
+    { kind: "trigger.fire", limit: 100 },
+    { refreshInterval: 30_000 },
+  );
+  const hasNewActivities = activityEvents.some((ev) => isNewActivity(ev.ts));
   const starred = useStarredPages();
   const starredSet = new Set(starred);
   const recents = useRecentPages();
@@ -200,11 +207,16 @@ export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
 
       <SidebarLayouts.Footer>
         <SidebarTab
-          icon={SvgNotificationBubble}
+          icon={SvgActivity}
           folded={effectiveFolded}
           tooltip={effectiveFolded ? "Activities" : undefined}
           selected={isActivitiesOpen}
           onClick={toggleActivities}
+          rightChildren={
+            hasNewActivities ? (
+              <SvgNotificationBubble size={14} />
+            ) : undefined
+          }
         >
           Activities
         </SidebarTab>

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -104,7 +104,6 @@ export default function AppSidebar() {
       </SidebarLayouts.Header>
 
       <SidebarLayouts.Body scrollKey="app-sidebar">
-
         {starred.length > 0 && (
           <SidebarLayouts.Section title="Starred">
             <StarredList paths={starred} onNavigate={closeMobile} />

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -33,7 +33,7 @@ import { NAV_ENTRIES } from "@/lib/nav/registry";
 import { useIsMobile } from "@/lib/viewport";
 import { useAppFocus } from "@/hooks/useAppFocus";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
-import { isNewActivity, useEvents } from "@/lib/events";
+import { isNewActivity, useEvents } from "@/lib/activities";
 
 function useRecentPages() {
   const { data } = useSWR(

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -9,13 +9,8 @@ import {
   SvgSettings,
   SvgStar,
 } from "@onyx-ai/opal/icons";
-import {
-  SidebarLayouts,
-  SidebarWrapper,
-  useSidebarFolded,
-} from "@onyx-ai/opal/layouts";
+import { SidebarLayouts, useSidebarState } from "@onyx-ai/opal/layouts";
 import { sidebarLogo } from "@/sections/sidebar/shared";
-import { usePathname } from "next/navigation";
 import { useRef } from "react";
 import useSWR from "swr";
 import {
@@ -53,14 +48,8 @@ function useStarredPages() {
   return data?.paths ?? [];
 }
 
-interface AppSidebarProps {
-  folded: boolean;
-  onFoldToggle: () => void;
-}
-
-export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
+export default function AppSidebar() {
   const { user } = useAuth();
-  const pathname = usePathname();
   const isMobile = useIsMobile();
   const focus = useAppFocus();
   const { isActivitiesOpen, toggleActivities } = useLeftPanel();
@@ -74,25 +63,21 @@ export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
   const recents = useRecentPages();
   const pages = recents.filter((p) => !starredSet.has(p));
   const searchRef = useRef<WikiSearchHandle>(null);
+  const { folded, setFolded } = useSidebarState();
 
-  // effectiveFolded is always false on mobile — content renders expanded,
-  // RootLayout.Sidebar handles the slide-in/out overlay instead.
-  const effectiveFolded = useSidebarFolded();
+  const closeMobile = () => {
+    if (isMobile) setFolded(true);
+  };
 
   function expandAndFocusSearch() {
-    if (folded) onFoldToggle();
+    if (folded) setFolded(false);
     setTimeout(() => searchRef.current?.focus(), 0);
   }
 
   return (
-    <SidebarWrapper
-      folded={folded}
-      onFoldClick={onFoldToggle}
-      logo={sidebarLogo}
-    >
-      <SidebarLayouts.Body scrollKey="app-sidebar">
-        {/* Search */}
-        {effectiveFolded ? (
+    <SidebarLayouts.Root foldable>
+      <SidebarLayouts.Header logo={sidebarLogo}>
+        {folded ? (
           <Button
             icon={SvgSearch}
             prominence="tertiary"
@@ -101,121 +86,84 @@ export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
             onClick={expandAndFocusSearch}
           />
         ) : (
-          <WikiSearch
-            ref={searchRef}
-            onNavigate={() => {
-              if (isMobile) onFoldToggle();
-            }}
-          />
+          <WikiSearch ref={searchRef} onNavigate={closeMobile} />
+        )}
+        {NAV_ENTRIES.map((item) => (
+          <SidebarTab
+            key={item.href}
+            href={item.href}
+            selected={focus.matchesHref(item.href)}
+            folded={folded}
+            icon={item.icon}
+            tooltip={folded ? item.label : undefined}
+            onClick={closeMobile}
+          >
+            {item.label}
+          </SidebarTab>
+        ))}
+      </SidebarLayouts.Header>
+
+      <SidebarLayouts.Body scrollKey="app-sidebar">
+
+        {starred.length > 0 && (
+          <SidebarLayouts.Section title="Starred">
+            <StarredList paths={starred} onNavigate={closeMobile} />
+          </SidebarLayouts.Section>
         )}
 
-        {/* Top nav */}
-        <div className="flex flex-col gap-px">
-          {NAV_ENTRIES.map((item) => (
-            <SidebarTab
-              key={item.href}
-              href={item.href}
-              selected={focus.matchesHref(item.href)}
-              folded={effectiveFolded}
-              icon={item.icon}
-              tooltip={effectiveFolded ? item.label : undefined}
-              onClick={() => {
-                if (isMobile) onFoldToggle();
-              }}
-            >
-              {item.label}
-            </SidebarTab>
-          ))}
-        </div>
-
-        {/* Starred + Recents — scrollable, hidden when folded */}
-        {!effectiveFolded && (
-          <div className="flex-1 overflow-x-hidden overflow-y-auto">
-            {starred.length > 0 && (
-              <>
-                <div className="sticky top-0 z-10 mr-1.5 flex min-h-8 items-center bg-background-tint-02 py-1 pl-2">
-                  <div className="p-0.5">
-                    <Text font="secondary-body" color="text-02">
-                      Starred
-                    </Text>
-                  </div>
-                </div>
-                <StarredList
-                  paths={starred}
-                  onNavigate={() => {
-                    if (isMobile) onFoldToggle();
-                  }}
-                />
-              </>
-            )}
-            <div className="sticky top-0 z-10 mr-1.5 flex min-h-8 items-center bg-background-tint-02 py-1 pl-2">
-              <div className="p-0.5">
-                <Text font="secondary-body" color="text-02">
-                  Recents
-                </Text>
+        <SidebarLayouts.Section title="Recents">
+          {recents.length === 0 && (
+            <div className="px-2.5">
+              <Text font="secondary-body" color="text-01" as="p">
+                No recent pages. Create a page to get started.
+              </Text>
+            </div>
+          )}
+          {pages.map((path) => {
+            const href = `/app/wiki/${path}`;
+            return (
+              <div key={path} className="group/recent">
+                <SidebarTab
+                  href={href}
+                  selected={focus.matchesWikiPath(path)}
+                  folded={folded}
+                  icon={SvgDocFile}
+                  nested
+                  onClick={closeMobile}
+                  rightChildren={
+                    <span className="opacity-0 group-hover/recent:opacity-100">
+                      <Button
+                        icon={SvgStar}
+                        prominence="tertiary"
+                        size="sm"
+                        tooltip="Star"
+                        tooltipSide="right"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          void starDoc(path);
+                        }}
+                      />
+                    </span>
+                  }
+                >
+                  {docLabel(path)}
+                </SidebarTab>
               </div>
-            </div>
-            <div className="flex flex-col gap-px">
-              {recents.length === 0 && (
-                <div className="px-2.5">
-                  <Text font="secondary-body" color="text-01" as="p">
-                    No recent pages. Create a page to get started.
-                  </Text>
-                </div>
-              )}
-              {pages.map((path) => {
-                const href = `/app/wiki/${path}`;
-                const active = focus.matchesWikiPath(path);
-                return (
-                  <div key={path} className="group/recent">
-                    <SidebarTab
-                      href={href}
-                      selected={active}
-                      folded={effectiveFolded}
-                      icon={SvgDocFile}
-                      tooltip={undefined}
-                      nested
-                      onClick={() => {
-                        if (isMobile) onFoldToggle();
-                      }}
-                      rightChildren={
-                        <span className="opacity-0 group-hover/recent:opacity-100">
-                          <Button
-                            icon={SvgStar}
-                            prominence="tertiary"
-                            size="sm"
-                            tooltip="Star"
-                            tooltipSide="right"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                              void starDoc(path);
-                            }}
-                          />
-                        </span>
-                      }
-                    >
-                      {docLabel(path)}
-                    </SidebarTab>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
+            );
+          })}
+        </SidebarLayouts.Section>
       </SidebarLayouts.Body>
 
       <SidebarLayouts.Footer>
         <SidebarTab
           icon={SvgActivity}
-          folded={effectiveFolded}
-          tooltip={effectiveFolded ? "Activities" : undefined}
+          folded={folded}
+          tooltip={folded ? "Activities" : undefined}
           selected={isActivitiesOpen}
           onClick={toggleActivities}
           rightChildren={
-            hasNewActivities ? (
-              <SvgNotificationBubble size={14} />
-            ) : undefined
+            hasNewActivities ? <SvgNotificationBubble size={14} /> : undefined
           }
         >
           Activities
@@ -223,20 +171,15 @@ export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
         {user?.is_admin && (
           <SidebarTab
             icon={SvgSettings}
-            folded={effectiveFolded}
-            tooltip={effectiveFolded ? "Admin Panel" : undefined}
+            folded={folded}
+            tooltip={folded ? "Admin Panel" : undefined}
             href="/admin"
           >
             Admin Panel
           </SidebarTab>
         )}
-        <UserMenu
-          folded={effectiveFolded}
-          onNavigate={() => {
-            if (isMobile) onFoldToggle();
-          }}
-        />
+        <UserMenu folded={folded} onNavigate={closeMobile} />
       </SidebarLayouts.Footer>
-    </SidebarWrapper>
+    </SidebarLayouts.Root>
   );
 }

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -2,8 +2,8 @@
 
 import { Button, SidebarTab, Text } from "@onyx-ai/opal/components";
 import {
-  SvgActivity,
   SvgDocFile,
+  SvgNotificationBubble,
   SvgSearch,
   SvgSettings,
   SvgStar,
@@ -200,7 +200,7 @@ export default function AppSidebar({ folded, onFoldToggle }: AppSidebarProps) {
 
       <SidebarLayouts.Footer>
         <SidebarTab
-          icon={SvgActivity}
+          icon={SvgNotificationBubble}
           folded={effectiveFolded}
           tooltip={effectiveFolded ? "Activities" : undefined}
           selected={isActivitiesOpen}


### PR DESCRIPTION
## Summary

- **Activities panel** — new `ActivitiesPanel` component rendered in the left panel slot when the Activities tab is toggled from the sidebar footer. Shows trigger-fire events as a notification list with unread count badge, search filter, and empty state. Notification bubble on the Activities tab when new events are present.
- **`lib/activities/`** — split `lib/events.ts` into a typed `lib/activities/` folder (`hooks.ts`, `types.ts`, `utils.ts`, `index.ts`) for cleaner imports.
- **Opal 0.1.12 upgrade** — bumped `@onyx-ai/opal` to `^0.1.12`. Migrated both sidebars off the removed `SidebarWrapper`/`useSidebarFolded` API to the new `SidebarLayouts.Root/Header/Body/Footer/Section` primitives and `useSidebarState`. Fold state is now owned by `SidebarStateProvider` in the app layout; `RootLayout.Sidebar` removed. All hand-rolled layout divs (sticky headers, overflow wrappers, `flex-col gap-px`) replaced with `SidebarLayouts.Section`.