### PR TITLE
fix(api): set response_model on /api/update-policy routes

### DIFF
--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -44,7 +44,7 @@ def _build_response(path: str) -> UpdatePolicyResponse:
     )
 
 
-@router.get("/update-policy")
+@router.get("/update-policy", response_model=UpdatePolicyResponse)
 def get_update_policy(
     path: str, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:
@@ -53,7 +53,7 @@ def get_update_policy(
     return _build_response(norm)
 
 
-@router.put("/update-policy")
+@router.put("/update-policy", response_model=UpdatePolicyResponse)
 def put_update_policy(
     req: SetUpdatePolicyRequest, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:
@@ -68,7 +68,7 @@ def put_update_policy(
     return _build_response(norm)
 
 
-@router.delete("/update-policy")
+@router.delete("/update-policy", response_model=UpdatePolicyResponse)
 def delete_update_policy(
     path: str, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:


### PR DESCRIPTION
Follow-up to #234 (review comment). The three `/api/update-policy` routes used the return-annotation style only; the rest of the API (e.g. `permissions.py`) consistently sets `response_model=` on every route.

Adds `response_model=UpdatePolicyResponse` to the GET/PUT/DELETE decorators so FastAPI performs response-model validation/filtering (schema, extra-field exclusion) at the framework level, and stays consistent with the codebase convention.

No behavior change beyond framework-level response shaping. `ruff` + `basedpyright` clean.