### PR TITLE
feat(wiki-ui): Update Policy panel on the page view

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -50,6 +50,7 @@ import {
 } from "@/lib/launchers";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
+import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { apiFetch, ApiError } from "@/lib/api";
 import { listComments } from "@/lib/comments";
 import {
@@ -1337,6 +1338,7 @@ function FileViewer({ path }: { path: string }) {
   // Comments (render-mode). `commentDraft` is a pending text selection being
   // composed; `selTool` is the floating "Comment" affordance shown on select.
   const [commentsOpen, setCommentsOpen] = useState(false);
+  const [policyOpen, setPolicyOpen] = useState(false);
   const [commentDraft, setCommentDraft] = useState<CommentDraft | null>(null);
   const [commentThreads, setCommentThreads] = useState<CommentThreadView[]>([]);
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
@@ -1357,6 +1359,7 @@ function FileViewer({ path }: { path: string }) {
   // auto-open, the selection "💬 Comment" tool).
   const openComments = useCallback(() => {
     setHistoryOpen(false);
+    setPolicyOpen(false);
     setCommentsOpen(true);
   }, []);
 
@@ -1826,8 +1829,9 @@ function FileViewer({ path }: { path: string }) {
       return;
     }
     setHistoryOpen(true);
-    // Mutual exclusion with the comments panel (see ``openComments``).
+    // Mutual exclusion with the comments + policy panels (see ``openComments``).
     setCommentsOpen(false);
+    setPolicyOpen(false);
     setCommentDraft(null);
     // Opening history: show the newest commit's diff immediately rather
     // than leaving the rendered body up until the user clicks a row.
@@ -2219,6 +2223,21 @@ function FileViewer({ path }: { path: string }) {
               >
                 Comments
               </SelectButton>
+              <SelectButton
+                state={policyOpen ? "selected" : "empty"}
+                onClick={() => {
+                  if (policyOpen) {
+                    setPolicyOpen(false);
+                    return;
+                  }
+                  setHistoryOpen(false);
+                  setCommentsOpen(false);
+                  setCommentDraft(null);
+                  setPolicyOpen(true);
+                }}
+              >
+                Update Policy
+              </SelectButton>
             </div>
             <Button variant="action" onClick={startEdit}>
               Edit
@@ -2533,6 +2552,12 @@ function FileViewer({ path }: { path: string }) {
               }}
             />
           )}
+          {policyOpen && !isMobile && (
+            <UpdatePolicyPanel
+              path={path}
+              onClose={() => setPolicyOpen(false)}
+            />
+          )}
         </div>
       )}
       {historyOpen && isMobile && (
@@ -2585,6 +2610,22 @@ function FileViewer({ path }: { path: string }) {
                 setCommentsOpen(false);
                 setCommentDraft(null);
               }}
+              fullHeight
+            />
+          </div>
+        </>
+      )}
+      {policyOpen && isMobile && (
+        <>
+          <div
+            onClick={() => setPolicyOpen(false)}
+            aria-hidden
+            className="fixed inset-0 z-[60] bg-(--mask-03)"
+          />
+          <div className="fixed top-0 right-0 bottom-0 z-[70] flex w-[min(360px,100vw)] shadow-(--shadow-panel)">
+            <UpdatePolicyPanel
+              path={path}
+              onClose={() => setPolicyOpen(false)}
               fullHeight
             />
           </div>

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -1,0 +1,115 @@
+/* Same chrome as CommentsPanel/HistoryPanel: a 400px rounded tint-01 card with
+   a titled header row, so the side panels read as one family. */
+.panel {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 400px;
+  min-height: 0;
+  background: var(--background-tint-01);
+  border-radius: var(--border-radius-12);
+  padding: 8px;
+  gap: 8px;
+}
+
+.fullHeight {
+  width: 100%;
+  height: 100%;
+  border-radius: 0;
+}
+
+.headerRow {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  flex-shrink: 0;
+}
+.headerTitle {
+  flex: 1;
+  min-width: 0;
+}
+
+.scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 4px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* One floating card holding both controls, matching the mockup. */
+.card {
+  border: 1px solid var(--border-01);
+  border-radius: var(--border-radius-12);
+  padding: 16px;
+  background: var(--background-tint-00);
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 12px;
+}
+.rowText {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.desc {
+  font-size: 13px;
+  line-height: 18px;
+  color: var(--text-03);
+}
+
+.instruction {
+  font-size: 13px;
+  color: var(--text-05);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 96px;
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-01);
+  border-radius: var(--border-radius-04);
+  background: var(--background-tint-00);
+  color: var(--text-05);
+}
+.textarea:focus {
+  outline: none;
+  border-color: var(--border-05);
+}
+
+.composeRow {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.muted {
+  font-size: 13px;
+  color: var(--text-03);
+  padding: 8px 4px;
+}
+.error {
+  color: var(--status-text-error-05);
+  font-size: 12px;
+  padding: 4px 0;
+}

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Button, Switch, Text } from "@onyx-ai/opal/components";
+import { SvgEdit, SvgX } from "@onyx-ai/opal/icons";
+import { useEffect, useState } from "react";
+
+import { ApiError } from "@/lib/api";
+import {
+  getUpdatePolicy,
+  setUpdatePolicy,
+  type UpdatePolicyResponse,
+} from "@/lib/updatePolicy";
+
+import styles from "./UpdatePolicyPanel.module.css";
+
+interface Props {
+  path: string;
+  onClose: () => void;
+  fullHeight?: boolean;
+}
+
+function errorMessage(e: unknown): string {
+  if (e instanceof ApiError && e.status === 403) {
+    return "You don't have permission to change this.";
+  }
+  return e instanceof Error ? e.message : "Something went wrong.";
+}
+
+export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
+  const kind = path.endsWith(".md") ? "page" : "folder";
+
+  const [loading, setLoading] = useState(true);
+  const [disabled, setDisabled] = useState(false); // effective ingestion-disable
+  const [instruction, setInstruction] = useState(""); // this path's own (explicit)
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function applyResponse(r: UpdatePolicyResponse) {
+    setDisabled(r.effective.ingestion_auto_update_disabled);
+    setInstruction(r.explicit?.update_instruction ?? "");
+  }
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setError(null);
+    setEditing(false);
+    getUpdatePolicy(path)
+      .then((r) => {
+        if (alive) applyResponse(r);
+      })
+      .catch((e) => {
+        if (alive) setError(errorMessage(e));
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [path]);
+
+  // The toggle reads as "Auto-Update Wiki" — ON means ingestion auto-update is
+  // enabled, i.e. NOT disabled. Saves instantly (settings-switch feel).
+  async function onToggle(on: boolean) {
+    const prev = disabled;
+    setDisabled(!on);
+    setSaving(true);
+    setError(null);
+    try {
+      const r = await setUpdatePolicy(path, {
+        ingestion_auto_update_disabled: !on,
+        update_instruction: instruction || null,
+      });
+      applyResponse(r);
+    } catch (e) {
+      setDisabled(prev); // revert optimistic flip
+      setError(errorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function saveInstruction() {
+    setSaving(true);
+    setError(null);
+    try {
+      const r = await setUpdatePolicy(path, {
+        ingestion_auto_update_disabled: disabled,
+        update_instruction: draft.trim() || null,
+      });
+      applyResponse(r);
+      setEditing(false);
+    } catch (e) {
+      setError(errorMessage(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
+      <div className={styles.headerRow}>
+        <div className={styles.headerTitle}>
+          <Text font="main-ui-action" color="text-04">
+            Update Policy
+          </Text>
+        </div>
+        <Button
+          icon={SvgX}
+          prominence="tertiary"
+          size="sm"
+          tooltip="Close"
+          onClick={onClose}
+        />
+      </div>
+
+      <div className={styles.scroll}>
+        {loading ? (
+          <div className={styles.muted}>Loading…</div>
+        ) : (
+          <div className={styles.card}>
+            <div className={styles.row}>
+              <div className={styles.rowText}>
+                <Text font="main-content-emphasis" color="text-04">
+                  Auto-Update Wiki
+                </Text>
+                <span className={styles.desc}>
+                  Onyx will periodically scan ingested data sources and update
+                  relevant wiki content.
+                </span>
+              </div>
+              <Switch
+                checked={!disabled}
+                disabled={saving}
+                onCheckedChange={onToggle}
+              />
+            </div>
+
+            <div className={styles.row}>
+              <div className={styles.rowText}>
+                <Text font="main-content-emphasis" color="text-04">
+                  Update Instructions
+                </Text>
+                <span className={styles.desc}>
+                  Add instructions on how this {kind} should be updated.
+                </span>
+              </div>
+              {!editing && (
+                <Button
+                  icon={SvgEdit}
+                  prominence="tertiary"
+                  size="sm"
+                  tooltip="Edit instructions"
+                  onClick={() => {
+                    setDraft(instruction);
+                    setEditing(true);
+                  }}
+                />
+              )}
+            </div>
+
+            {!editing && instruction && (
+              <div className={styles.instruction}>{instruction}</div>
+            )}
+
+            {editing && (
+              <div>
+                <textarea
+                  className={styles.textarea}
+                  value={draft}
+                  autoFocus
+                  placeholder={`How should this ${kind} be updated?`}
+                  onChange={(e) => setDraft(e.target.value)}
+                />
+                <div className={styles.composeRow}>
+                  <Button
+                    prominence="tertiary"
+                    size="sm"
+                    disabled={saving}
+                    onClick={() => setEditing(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    variant="action"
+                    size="sm"
+                    disabled={saving}
+                    onClick={() => void saveInstruction()}
+                  >
+                    {saving ? "Saving…" : "Save"}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+        {error && <div className={styles.error}>{error}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -30,6 +30,7 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
   const kind = path.endsWith(".md") ? "page" : "folder";
 
   const [loading, setLoading] = useState(true);
+  const [loaded, setLoaded] = useState(false); // first fetch succeeded
   const [disabled, setDisabled] = useState(false); // effective ingestion-disable
   const [instruction, setInstruction] = useState(""); // this path's own (explicit)
   const [editing, setEditing] = useState(false);
@@ -45,11 +46,15 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
   useEffect(() => {
     let alive = true;
     setLoading(true);
+    setLoaded(false);
     setError(null);
     setEditing(false);
     getUpdatePolicy(path)
       .then((r) => {
-        if (alive) applyResponse(r);
+        if (alive) {
+          applyResponse(r);
+          setLoaded(true);
+        }
       })
       .catch((e) => {
         if (alive) setError(errorMessage(e));
@@ -120,6 +125,12 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
       <div className={styles.scroll}>
         {loading ? (
           <div className={styles.muted}>Loading…</div>
+        ) : !loaded ? (
+          // Load failed: never render the card — its default values would
+          // overwrite a real policy if the user interacted with it.
+          <div className={styles.error}>
+            {error ?? "Couldn't load the update policy."}
+          </div>
         ) : (
           <div className={styles.card}>
             <div className={styles.row}>
@@ -197,7 +208,8 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
             )}
           </div>
         )}
-        {error && <div className={styles.error}>{error}</div>}
+        {/* Save errors sit below the card; load errors render in the slot above. */}
+        {loaded && error && <div className={styles.error}>{error}</div>}
       </div>
     </div>
   );

--- a/frontend/src/lib/updatePolicy.ts
+++ b/frontend/src/lib/updatePolicy.ts
@@ -1,0 +1,49 @@
+// Typed client for the per-page/per-folder update policy
+// (`/api/update-policy`). The policy has two fields — whether ingestion
+// auto-update is disabled, and a free-text update instruction — resolved
+// most-granular-wins on the server. `effective` is what's actually in force
+// (incl. inheritance); `explicit` is the row set on exactly this path.
+import { apiFetch } from "@/lib/api";
+
+export interface EffectivePolicy {
+  ingestion_auto_update_disabled: boolean;
+  update_instruction: string | null;
+}
+
+export interface ExplicitPolicy {
+  path: string;
+  kind: "page" | "folder";
+  ingestion_auto_update_disabled: boolean | null;
+  update_instruction: string | null;
+  updated_by_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpdatePolicyResponse {
+  explicit: ExplicitPolicy | null;
+  effective: EffectivePolicy;
+}
+
+export interface SetUpdatePolicyInput {
+  ingestion_auto_update_disabled: boolean | null;
+  update_instruction: string | null;
+}
+
+export function getUpdatePolicy(path: string): Promise<UpdatePolicyResponse> {
+  return apiFetch<UpdatePolicyResponse>(
+    `/update-policy?path=${encodeURIComponent(path)}`,
+  );
+}
+
+// PUT is full desired-state: both fields are sent every time, so callers pass
+// the complete intended policy (a missing field clears it on the server).
+export function setUpdatePolicy(
+  path: string,
+  input: SetUpdatePolicyInput,
+): Promise<UpdatePolicyResponse> {
+  return apiFetch<UpdatePolicyResponse>("/update-policy", {
+    method: "PUT",
+    body: JSON.stringify({ path, ...input }),
+  });
+}


### PR DESCRIPTION
Adds the first UI for the update policy (backend shipped in #233–#235). A **"Update Policy"** top-bar button on the wiki page view opens a right-side panel — mirroring the Comments panel — matching the mockup:

- **Auto-Update Wiki** toggle — saves instantly on flip. ON = ingestion auto-update enabled (`ingestion_auto_update_disabled = false`). Reflects the *effective* policy (incl. folder inheritance) and writes this path's explicit value.
- **Update Instructions** — an edit icon reveals a textarea with Save/Cancel; edits the page's *own* instruction.

### Changes
- `src/lib/updatePolicy.ts` — typed `getUpdatePolicy` / `setUpdatePolicy` over `apiFetch` (`/api/update-policy`).
- `src/components/wiki/UpdatePolicyPanel.tsx` (+ `.module.css`) — the panel (same chrome as `CommentsPanel`); busy/error states; a non-writer's 403 reverts the change with an inline message.
- `src/app/app/wiki/[[...slug]]/page.tsx` — `SelectButton` + state, mutually exclusive with History/Comments, desktop side-card + mobile overlay renders.

### Scope / notes
- **Page view only** (`.md`); folder-header button is a follow-up.
- PUT is full-replace, so the panel always sends both fields.
- This persists *intent* — ingestion doesn't honor the policy yet (separate enforcement PR).

### Verification
- `bun run typecheck` clean; prettier clean.
- Frontend Docker image builds (`next build`) and serves; round-trip against `/api/update-policy` already verified end-to-end on the backend.

<img width="652" height="481" alt="Screenshot 2026-06-15 at 5 53 27 PM" src="https://github.com/user-attachments/assets/8b93e841-bd76-4fc2-8ff5-57fb3e2f70bc" />


