### PR TITLE
feat(ingest): skip auto-update for pages with ingestion disabled

### DIFF
--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -352,9 +352,11 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     # the same set the reconciler will act on. Drop pages whose update policy
     # disables ingestion auto-update *before* any LLM call, so a protected page
     # is never rewritten by a connector push.
+    # Resolve every candidate's ingestion-disable in one query, not per-hit.
+    disabled = update_policy.disabled_paths([hit.path for hit in hits])
     readable: list[WikiUpdateCandidate] = []
     for hit in hits:
-        if update_policy.is_ingest_disabled(hit.path):
+        if hit.path in disabled:
             ingest_outcomes_total.labels(
                 outcome="ingestion_auto_update_disabled", wiki_path=hit.path
             ).inc()

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -52,7 +52,7 @@ from app.mcp_server import jobs as mcp_jobs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.auth import UserMissingError, load_user, set_current_user
 from app.tasks.queues import documents_queue
-from app.wiki import agent_activity, git as wiki_git
+from app.wiki import agent_activity, git as wiki_git, update_policy
 from app.models.wiki import ChangeKind, CommitMaxRetriesError
 
 
@@ -349,9 +349,20 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
 
     # Read all candidate bodies upfront — needed by both the selector and the
     # main reconciler loop. Skip unreadable files early so the selector sees
-    # the same set the reconciler will act on.
+    # the same set the reconciler will act on. Drop pages whose update policy
+    # disables ingestion auto-update *before* any LLM call, so a protected page
+    # is never rewritten by a connector push.
     readable: list[WikiUpdateCandidate] = []
     for hit in hits:
+        if update_policy.is_ingest_disabled(hit.path):
+            ingest_outcomes_total.labels(
+                outcome="ingestion_auto_update_disabled", wiki_path=hit.path
+            ).inc()
+            log.debug(
+                "process_pushed_document: ingestion auto-update disabled for %s, skipping",
+                hit.path,
+            )
+            continue
         try:
             readable.append(WikiUpdateCandidate(hit=hit, body=wiki_git.read_file(hit.path)))
         except Exception:

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from collections.abc import Iterable
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
@@ -179,6 +180,15 @@ def on_path_moved(moves: list[tuple[str, str]]) -> None:
             )
 
 
+def _scope_chain(norm: str) -> list[str]:
+    """The path itself then its ancestor folders, closest first (root last)."""
+    chain: list[str] = [norm]
+    for parent in filesystem.parent_dirs(norm):
+        if parent not in chain:
+            chain.append(parent)
+    return chain
+
+
 def resolve_for_path(path: str) -> ResolvedPolicy:
     """Effective policy for ``path``: most-granular scope that sets a field wins.
 
@@ -187,11 +197,7 @@ def resolve_for_path(path: str) -> ResolvedPolicy:
     re-enable ingestion under a disabled folder, and a folder instruction
     applies until a nearer scope overrides it.
     """
-    norm = normalize_path(path)
-    candidates: list[str] = [norm]
-    for parent in filesystem.parent_dirs(norm):
-        if parent not in candidates:
-            candidates.append(parent)
+    candidates = _scope_chain(normalize_path(path))
 
     with session() as s:
         rows = (
@@ -223,3 +229,38 @@ def resolve_for_path(path: str) -> ResolvedPolicy:
 def is_ingest_disabled(path: str) -> bool:
     """Convenience: is connector/ingest auto-update disabled for ``path``?"""
     return resolve_for_path(path).ingestion_auto_update_disabled
+
+
+def disabled_paths(paths: Iterable[str]) -> set[str]:
+    """Subset of ``paths`` whose effective policy disables ingestion auto-update.
+
+    One query for all paths and their ancestor folders, then resolve each in
+    Python — collapses N per-candidate lookups to a single round-trip. Keyed by
+    the *input* path strings so callers can test membership directly.
+    """
+    chains: dict[str, list[str]] = {}
+    scopes: set[str] = set()
+    for p in paths:
+        chain = _scope_chain(normalize_path(p))
+        chains[p] = chain
+        scopes.update(chain)
+    if not scopes:
+        return set()
+
+    with session() as s:
+        rows = (
+            s.execute(select(UpdatePolicy).where(UpdatePolicy.path.in_(scopes)))
+            .scalars()
+            .all()
+        )
+    by_path = {r.path: r for r in rows}
+
+    out: set[str] = set()
+    for orig, chain in chains.items():
+        for scope in chain:  # closest first
+            row = by_path.get(scope)
+            if row is not None and row.ingestion_auto_update_disabled is not None:
+                if row.ingestion_auto_update_disabled:
+                    out.add(orig)
+                break
+    return out

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -39,12 +39,12 @@ def _stub_llm_settings(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.fixture(autouse=True)
 def _stub_ingest_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The candidate loop calls update_policy.is_ingest_disabled, which opens a
-    DB session. These unit tests mock git/search and run without a DB, so
-    default to 'not disabled'. The policy-specific test overrides this."""
+    """The candidate loop calls update_policy.disabled_paths, which opens a DB
+    session. These unit tests mock git/search and run without a DB, so default
+    to 'none disabled'. The policy-specific test overrides this."""
     monkeypatch.setattr(
-        "app.tasks.wiki_update.update_policy.is_ingest_disabled",
-        lambda path: False,
+        "app.tasks.wiki_update.update_policy.disabled_paths",
+        lambda paths: set(),
     )
 
 
@@ -262,8 +262,8 @@ def test_ingestion_disabled_skips_candidate_before_llm(
     # any LLM call — the reconciler never sees it and nothing commits.
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
     monkeypatch.setattr(
-        "app.tasks.wiki_update.update_policy.is_ingest_disabled",
-        lambda path: path == "page.md",
+        "app.tasks.wiki_update.update_policy.disabled_paths",
+        lambda paths: {"page.md"},
     )
     mock_search.return_value = [_hit("page.md", "Page", 5.0)]
     _run(_make_push())

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -37,6 +37,17 @@ def _stub_llm_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@pytest.fixture(autouse=True)
+def _stub_ingest_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The candidate loop calls update_policy.is_ingest_disabled, which opens a
+    DB session. These unit tests mock git/search and run without a DB, so
+    default to 'not disabled'. The policy-specific test overrides this."""
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.update_policy.is_ingest_disabled",
+        lambda path: False,
+    )
+
+
 def _settings_with_model(model: str = "test-model") -> LLMSettings:
     return _EMPTY_LLM_SETTINGS.model_copy(update={"model": model})
 
@@ -238,6 +249,25 @@ def test_irrelevant_does_not_commit(mock_search, mock_reconcile, mock_read, mock
     mock_search.return_value = [_hit("page.md", "Page", 5.0)]
     mock_reconcile.return_value = ([IRRELEVANT_SENTINEL], 1)
     _run(_make_push())
+    mock_commit.assert_not_called()
+
+
+@patch("app.tasks.wiki_update.wiki_git.commit_file")
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_ingestion_disabled_skips_candidate_before_llm(
+    mock_search, mock_reconcile, mock_commit, monkeypatch
+):
+    # A page whose policy disables ingestion auto-update must be dropped before
+    # any LLM call — the reconciler never sees it and nothing commits.
+    monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.update_policy.is_ingest_disabled",
+        lambda path: path == "page.md",
+    )
+    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    _run(_make_push())
+    mock_reconcile.assert_not_called()
     mock_commit.assert_not_called()
 
 

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -51,6 +51,20 @@ def test_instruction_closest_scope_wins(tmp_db):
     assert update_policy.resolve_for_path("a/other.md").update_instruction == "folder rule"
 
 
+def test_disabled_paths_batch(tmp_db):
+    update_policy.set_policy("a", ingestion_auto_update_disabled=True)  # folder off
+    update_policy.set_policy("a/on.md", ingestion_auto_update_disabled=False)  # re-enabled
+    update_policy.set_policy("b.md", ingestion_auto_update_disabled=True)
+    result = update_policy.disabled_paths(["a/off.md", "a/on.md", "b.md", "c.md"])
+    # a/off.md inherits the folder disable; a/on.md overrides; b.md is explicit;
+    # c.md has no policy.
+    assert result == {"a/off.md", "b.md"}
+
+
+def test_disabled_paths_empty(tmp_db):
+    assert update_policy.disabled_paths([]) == set()
+
+
 def test_fields_resolve_independently(tmp_db):
     update_policy.set_policy("a", ingestion_auto_update_disabled=True)
     update_policy.set_policy("a/page.md", update_instruction="terse")


### PR DESCRIPTION
First half of update-policy **ingestion enforcement** — makes `ingestion_auto_update_disabled` actually take effect (until now it was stored/editable but never read at update time).

### Change
`process_pushed_document` (`app/tasks/wiki_update.py`) now resolves each BM25 candidate's policy via `update_policy.is_ingest_disabled(hit.path)` and **drops disabled pages before any LLM call** (selector or reconciler). Resolution is most-granular-wins, so a page is skipped if it — or any ancestor folder — disables ingestion auto-update, unless a nearer scope re-enables it. Records an `ingestion_auto_update_disabled` ingest outcome metric.

A connector push can no longer rewrite a page an owner has protected.

### Tests
- Unit: a disabled candidate is dropped before `batch_reconcile` and nothing commits (existing candidate-path tests get an autouse `is_ingest_disabled → False` stub so they stay DB-free).
- Resolver behavior (cascade/override) already covered by `tests/test_update_policy.py`.

`ruff` + `basedpyright` clean.

### Scope
Disable enforcement only. `update_instruction` injection into the reconciler + NL updater prompts is the next follow-up.