### PR TITLE
feat(wiki-ui): Update Policy on the folder view

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -203,6 +203,7 @@ function Explorer({ dir }: { dir: string }) {
   const [dragSource, setDragSource] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const [sharePath, setSharePath] = useState<string | null>(null);
+  const [policyOpen, setPolicyOpen] = useState(false);
 
   const { subdirs, files } = useMemo(() => {
     const prefix = dir ? dir + "/" : "";
@@ -385,6 +386,9 @@ function Explorer({ dir }: { dir: string }) {
             >
               Trigger
             </Button>
+            <Button prominence="tertiary" onClick={() => setPolicyOpen(true)}>
+              Update Policy
+            </Button>
             <Button
               prominence="tertiary"
               icon={SvgFolderPlus}
@@ -535,6 +539,25 @@ function Explorer({ dir }: { dir: string }) {
       </ul>
       {sharePath && (
         <ShareDialog path={sharePath} open onClose={() => setSharePath(null)} />
+      )}
+      {policyOpen && (
+        // Folder policy applies to every page under this folder. Shown as a
+        // right-side drawer (the folder listing isn't a flex row like the page
+        // view), reusing the same panel — ``dir`` is the folder path ("" = root).
+        <>
+          <div
+            onClick={() => setPolicyOpen(false)}
+            aria-hidden
+            className="fixed inset-0 z-[60] bg-(--mask-03)"
+          />
+          <div className="fixed top-0 right-0 bottom-0 z-[70] flex w-[min(400px,100vw)] shadow-(--shadow-panel)">
+            <UpdatePolicyPanel
+              path={dir}
+              onClose={() => setPolicyOpen(false)}
+              fullHeight
+            />
+          </div>
+        </>
       )}
     </main>
   );


### PR DESCRIPTION
Extends the Update Policy UI (page view shipped in #238) to **folders**, since a folder policy cascades to every page under it.

### Change
- Adds an **"Update Policy"** button to the folder listing header (`Explorer`).
- Opens the existing `UpdatePolicyPanel` as a right-side drawer (backdrop + fixed panel — the folder listing isn't a flex row like the page view), scoped to the folder path (`""` = wiki root).

Backend, API, and the panel component already accept folder paths and cascade folder → page (resolved server-side via `resolve_for_path`); only the folder-view entry point was missing. So an owner can now disable auto-update or set update instructions for a whole folder from the UI.

### Verification
`bun run typecheck` + prettier clean; frontend Docker image builds (`next build`) and serves. The panel/API round-trip (incl. folder cascade) was already verified end-to-end in the backend testing.

Page-only follow-ups still open: ingestion `update_instruction` injection, and the auto-update-enabled dashboard card.

<img width="1055" height="479" alt="Screenshot 2026-06-16 at 11 07 15 AM" src="https://github.com/user-attachments/assets/a09d50aa-1f78-40a2-ab7b-236170abaf74" />

