### PR TITLE
feat(update-policy): per-field PATCH + inherited/override UI

### DIFF
--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -68,6 +68,9 @@ def patch_update_policy(
         patch["ingestion_auto_update_disabled"] = req.ingestion_auto_update_disabled
     if "update_instruction" in req.model_fields_set:
         patch["update_instruction"] = req.update_instruction
+    # Nothing to change — don't touch the row (would falsify updated_by/_at).
+    if not patch:
+        return _build_response(norm)
     policy_repo.set_policy(norm, actor_user_id=user.id, **patch)
     return _build_response(norm)
 

--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -6,6 +6,7 @@ Thin HTTP layer over ``app/wiki/update_policy.py``. Reads/writes are gated by
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
@@ -14,7 +15,7 @@ from app.auth.deps import require_user
 from app.models.update_policy import (
     EffectivePolicy,
     ExplicitPolicy,
-    SetUpdatePolicyRequest,
+    PatchUpdatePolicyRequest,
     UpdatePolicyResponse,
 )
 from app.wiki import update_policy as policy_repo
@@ -53,18 +54,21 @@ def get_update_policy(
     return _build_response(norm)
 
 
-@router.put("/update-policy", response_model=UpdatePolicyResponse)
-def put_update_policy(
-    req: SetUpdatePolicyRequest, user: User = Depends(require_user)
+@router.patch("/update-policy", response_model=UpdatePolicyResponse)
+def patch_update_policy(
+    req: PatchUpdatePolicyRequest, user: User = Depends(require_user)
 ) -> UpdatePolicyResponse:
     norm = _normalize(req.path)
     require_can("write", norm, user)
-    policy_repo.set_policy(
-        norm,
-        ingestion_auto_update_disabled=req.ingestion_auto_update_disabled,
-        update_instruction=req.update_instruction,
-        actor_user_id=user.id,
-    )
+    # Patch only the fields actually present in the body; omitted fields keep
+    # their inherited state (``model_fields_set`` distinguishes "omitted" from an
+    # explicit ``null`` clear).
+    patch: dict[str, Any] = {}
+    if "ingestion_auto_update_disabled" in req.model_fields_set:
+        patch["ingestion_auto_update_disabled"] = req.ingestion_auto_update_disabled
+    if "update_instruction" in req.model_fields_set:
+        patch["update_instruction"] = req.update_instruction
+    policy_repo.set_policy(norm, actor_user_id=user.id, **patch)
     return _build_response(norm)
 
 

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -30,11 +30,14 @@ class UpdatePolicyResponse(BaseModel):
     effective: EffectivePolicy
 
 
-class SetUpdatePolicyRequest(BaseModel):
-    """Full desired state for a path (PUT semantics).
+class PatchUpdatePolicyRequest(BaseModel):
+    """Partial update for a path (PATCH semantics).
 
-    Both fields default to ``null`` = inherit/clear. When the resulting row
-    carries no setting it is removed.
+    Only fields present in the request body are changed; omitted fields are left
+    as-is, so setting one field never disturbs the other's inherited state. A
+    field sent as ``null`` clears it (back to inherit); when the row ends up with
+    no setting it is removed. The router keys off ``model_fields_set`` to tell
+    "omitted" from an explicit ``null``.
     """
 
     path: str

--- a/backend/tests/integration/test_update_policy_api.py
+++ b/backend/tests/integration/test_update_policy_api.py
@@ -91,6 +91,23 @@ def test_patch_null_resets_field_to_inherited(integration):
     assert body["effective"]["ingestion_auto_update_disabled"] is True  # folder again
 
 
+def test_empty_patch_is_noop_and_preserves_audit(integration):
+    integration.signup(email="admin@x.com")
+    integration.put_doc("open.md", "# Open")  # default-public: everyone write
+    set_by_admin = integration.client.patch(
+        "/api/update-policy",
+        json={"path": "open.md", "update_instruction": "x"},
+    ).json()
+    admin_id = set_by_admin["explicit"]["updated_by_user_id"]
+
+    integration.signup(email="carol@x.com")  # now carol (non-admin, can write)
+    # Empty patch (only path) must not touch the row — otherwise updated_by would
+    # flip to carol even though no policy field changed.
+    resp = integration.client.patch("/api/update-policy", json={"path": "open.md"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["explicit"]["updated_by_user_id"] == admin_id
+
+
 def test_folder_policy_shows_in_doc_effective(integration):
     integration.signup(email="admin@x.com")
     integration.put_doc("team/guide.md", "# Guide")

--- a/backend/tests/integration/test_update_policy_api.py
+++ b/backend/tests/integration/test_update_policy_api.py
@@ -1,5 +1,5 @@
-"""HTTP tests for /api/update-policy — CRUD round-trip, folder cascade, and
-the require_can write gate."""
+"""HTTP tests for /api/update-policy — PATCH partial semantics, folder cascade,
+and the require_can write gate."""
 from __future__ import annotations
 
 
@@ -13,11 +13,11 @@ def _strip_everyone(integration, path: str) -> None:
             assert r.status_code == 204
 
 
-def test_put_get_delete_roundtrip(integration):
+def test_patch_get_delete_roundtrip(integration):
     integration.signup(email="admin@x.com")  # auto-admin (first user)
     integration.put_doc("guide.md", "# Guide\n\nbody")
 
-    resp = integration.client.put(
+    resp = integration.client.patch(
         "/api/update-policy",
         json={
             "path": "guide.md",
@@ -43,11 +43,59 @@ def test_put_get_delete_roundtrip(integration):
     assert body["effective"]["ingestion_auto_update_disabled"] is False
 
 
+def test_patch_one_field_preserves_the_other(integration):
+    integration.signup(email="admin@x.com")
+    integration.put_doc("guide.md", "# Guide")
+
+    # Set only the instruction — disable stays inherited (no explicit value).
+    resp = integration.client.patch(
+        "/api/update-policy",
+        json={"path": "guide.md", "update_instruction": "Keep it terse."},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["explicit"]["ingestion_auto_update_disabled"] is None
+
+    # Now disable — the instruction must survive (not clobbered to null).
+    resp = integration.client.patch(
+        "/api/update-policy",
+        json={"path": "guide.md", "ingestion_auto_update_disabled": True},
+    )
+    body = resp.json()
+    assert body["explicit"]["ingestion_auto_update_disabled"] is True
+    assert body["explicit"]["update_instruction"] == "Keep it terse."
+
+
+def test_patch_null_resets_field_to_inherited(integration):
+    integration.signup(email="admin@x.com")
+    integration.put_doc("team/guide.md", "# Guide")
+    # Folder disables ingestion; page overrides to enabled.
+    integration.client.patch(
+        "/api/update-policy",
+        json={"path": "team", "ingestion_auto_update_disabled": True},
+    )
+    integration.client.patch(
+        "/api/update-policy",
+        json={"path": "team/guide.md", "ingestion_auto_update_disabled": False},
+    )
+    resp = integration.client.get("/api/update-policy?path=team/guide.md")
+    assert resp.json()["effective"]["ingestion_auto_update_disabled"] is False
+
+    # Reset the page's override to inherited (null) -> falls back to the folder.
+    resp = integration.client.patch(
+        "/api/update-policy",
+        json={"path": "team/guide.md", "ingestion_auto_update_disabled": None},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["explicit"] is None  # both fields empty -> row removed
+    assert body["effective"]["ingestion_auto_update_disabled"] is True  # folder again
+
+
 def test_folder_policy_shows_in_doc_effective(integration):
     integration.signup(email="admin@x.com")
     integration.put_doc("team/guide.md", "# Guide")
 
-    resp = integration.client.put(
+    resp = integration.client.patch(
         "/api/update-policy",
         json={"path": "team", "ingestion_auto_update_disabled": True},
     )
@@ -66,7 +114,7 @@ def test_non_writer_forbidden(integration):
     _strip_everyone(integration, "secret.md")
 
     integration.signup(email="bob@x.com")  # session is now bob (non-admin)
-    resp = integration.client.put(
+    resp = integration.client.patch(
         "/api/update-policy",
         json={"path": "secret.md", "ingestion_auto_update_disabled": True},
     )
@@ -78,7 +126,7 @@ def test_non_admin_writer_allowed(integration):
     integration.put_doc("open.md", "# Open")  # default-public: everyone read+write
     integration.signup(email="carol@x.com")  # non-admin, has everyone write
 
-    resp = integration.client.put(
+    resp = integration.client.patch(
         "/api/update-policy",
         json={"path": "open.md", "update_instruction": "be brief"},
     )

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -103,6 +103,31 @@
   gap: 8px;
 }
 
+/* Small "Inherited / Set here" status line + reset affordance. */
+.origin {
+  display: block;
+  font-size: 12px;
+  color: var(--text-03);
+  margin-top: 2px;
+}
+.linkBtn {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-04);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.linkBtn:hover {
+  color: var(--text-05);
+}
+.linkBtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
 .muted {
   font-size: 13px;
   color: var(--text-03);

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -110,22 +110,11 @@
   color: var(--text-03);
   margin-top: 2px;
 }
-.linkBtn {
-  border: none;
-  background: none;
-  padding: 0;
-  font: inherit;
-  font-size: 12px;
-  color: var(--text-04);
-  text-decoration: underline;
-  cursor: pointer;
-}
-.linkBtn:hover {
-  color: var(--text-05);
-}
-.linkBtn:disabled {
-  opacity: 0.5;
-  cursor: default;
+.originRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
 }
 
 .muted {

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -134,27 +134,27 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
                   Onyx will periodically scan ingested data sources and update
                   relevant wiki content.
                 </span>
-                <span className={styles.origin}>
-                  {disableSetHere ? (
-                    <>
-                      Set on this {kind} ·{" "}
-                      <button
-                        type="button"
-                        className={styles.linkBtn}
-                        disabled={saving}
-                        onClick={() =>
-                          save({ ingestion_auto_update_disabled: null })
-                        }
-                      >
-                        Reset to inherited
-                      </button>
-                    </>
-                  ) : effDisabled ? (
-                    "Inherited — off (from a parent folder)"
-                  ) : (
-                    "Inherited — on (default)"
-                  )}
-                </span>
+                {disableSetHere ? (
+                  <div className={styles.originRow}>
+                    <span className={styles.origin}>Set on this {kind}</span>
+                    <Button
+                      prominence="tertiary"
+                      size="sm"
+                      disabled={saving}
+                      onClick={() =>
+                        save({ ingestion_auto_update_disabled: null })
+                      }
+                    >
+                      Reset to inherited
+                    </Button>
+                  </div>
+                ) : (
+                  <span className={styles.origin}>
+                    {effDisabled
+                      ? "Inherited — off (from a parent folder)"
+                      : "Inherited — on (default)"}
+                  </span>
+                )}
               </div>
               <Switch
                 checked={switchOn}

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { ApiError } from "@/lib/api";
 import {
   getUpdatePolicy,
-  setUpdatePolicy,
+  patchUpdatePolicy,
   type UpdatePolicyResponse,
 } from "@/lib/updatePolicy";
 
@@ -31,17 +31,12 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
 
   const [loading, setLoading] = useState(true);
   const [loaded, setLoaded] = useState(false); // first fetch succeeded
-  const [disabled, setDisabled] = useState(false); // effective ingestion-disable
-  const [instruction, setInstruction] = useState(""); // this path's own (explicit)
+  const [policy, setPolicy] = useState<UpdatePolicyResponse | null>(null);
+  const [pendingOn, setPendingOn] = useState<boolean | null>(null); // optimistic toggle
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  function applyResponse(r: UpdatePolicyResponse) {
-    setDisabled(r.effective.ingestion_auto_update_disabled);
-    setInstruction(r.explicit?.update_instruction ?? "");
-  }
 
   useEffect(() => {
     let alive = true;
@@ -52,7 +47,7 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
     getUpdatePolicy(path)
       .then((r) => {
         if (alive) {
-          applyResponse(r);
+          setPolicy(r);
           setLoaded(true);
         }
       })
@@ -67,43 +62,40 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
     };
   }, [path]);
 
-  // The toggle reads as "Auto-Update Wiki" — ON means ingestion auto-update is
-  // enabled, i.e. NOT disabled. Saves instantly (settings-switch feel).
-  async function onToggle(on: boolean) {
-    const prev = disabled;
-    setDisabled(!on);
+  // Effective = what's actually in force (incl. inheritance); explicit = the row
+  // set on exactly this path. A field is "set here" only when explicit carries a
+  // value for it; otherwise it's inherited from an ancestor / the default.
+  const effDisabled = policy?.effective.ingestion_auto_update_disabled ?? false;
+  const disableSetHere =
+    policy?.explicit?.ingestion_auto_update_disabled != null;
+  const ownInstruction = policy?.explicit?.update_instruction ?? "";
+  const effInstruction = policy?.effective.update_instruction ?? "";
+
+  async function save(
+    patch: Parameters<typeof patchUpdatePolicy>[1],
+    after?: () => void,
+  ) {
     setSaving(true);
     setError(null);
     try {
-      const r = await setUpdatePolicy(path, {
-        ingestion_auto_update_disabled: !on,
-        update_instruction: instruction || null,
-      });
-      applyResponse(r);
+      setPolicy(await patchUpdatePolicy(path, patch));
+      after?.();
     } catch (e) {
-      setDisabled(prev); // revert optimistic flip
       setError(errorMessage(e));
     } finally {
       setSaving(false);
+      setPendingOn(null);
     }
   }
 
-  async function saveInstruction() {
-    setSaving(true);
-    setError(null);
-    try {
-      const r = await setUpdatePolicy(path, {
-        ingestion_auto_update_disabled: disabled,
-        update_instruction: draft.trim() || null,
-      });
-      applyResponse(r);
-      setEditing(false);
-    } catch (e) {
-      setError(errorMessage(e));
-    } finally {
-      setSaving(false);
-    }
+  // "Auto-Update Wiki" ON = ingestion auto-update enabled (NOT disabled).
+  // Patches only the disable field, so the instruction's inheritance is untouched.
+  function onToggle(on: boolean) {
+    setPendingOn(on);
+    void save({ ingestion_auto_update_disabled: !on });
   }
+
+  const switchOn = pendingOn ?? !effDisabled;
 
   return (
     <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
@@ -142,9 +134,30 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
                   Onyx will periodically scan ingested data sources and update
                   relevant wiki content.
                 </span>
+                <span className={styles.origin}>
+                  {disableSetHere ? (
+                    <>
+                      Set on this {kind} ·{" "}
+                      <button
+                        type="button"
+                        className={styles.linkBtn}
+                        disabled={saving}
+                        onClick={() =>
+                          save({ ingestion_auto_update_disabled: null })
+                        }
+                      >
+                        Reset to inherited
+                      </button>
+                    </>
+                  ) : effDisabled ? (
+                    "Inherited — off (from a parent folder)"
+                  ) : (
+                    "Inherited — on (default)"
+                  )}
+                </span>
               </div>
               <Switch
-                checked={!disabled}
+                checked={switchOn}
                 disabled={saving}
                 onCheckedChange={onToggle}
               />
@@ -166,15 +179,24 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
                   size="sm"
                   tooltip="Edit instructions"
                   onClick={() => {
-                    setDraft(instruction);
+                    setDraft(ownInstruction);
                     setEditing(true);
                   }}
                 />
               )}
             </div>
 
-            {!editing && instruction && (
-              <div className={styles.instruction}>{instruction}</div>
+            {!editing && ownInstruction && (
+              <div className={styles.instruction}>{ownInstruction}</div>
+            )}
+            {!editing && !ownInstruction && effInstruction && (
+              // No instruction of its own — show the one inherited from a parent.
+              <div className={styles.instruction}>
+                <span className={styles.origin}>
+                  Inherited from a parent folder
+                </span>
+                {effInstruction}
+              </div>
             )}
 
             {editing && (
@@ -199,7 +221,12 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
                     variant="action"
                     size="sm"
                     disabled={saving}
-                    onClick={() => void saveInstruction()}
+                    onClick={() =>
+                      void save(
+                        { update_instruction: draft.trim() || null },
+                        () => setEditing(false),
+                      )
+                    }
                   >
                     {saving ? "Saving…" : "Save"}
                   </Button>

--- a/frontend/src/lib/updatePolicy.ts
+++ b/frontend/src/lib/updatePolicy.ts
@@ -25,9 +25,13 @@ export interface UpdatePolicyResponse {
   effective: EffectivePolicy;
 }
 
-export interface SetUpdatePolicyInput {
-  ingestion_auto_update_disabled: boolean | null;
-  update_instruction: string | null;
+// Partial update: include only the field(s) you want to change. Omitted fields
+// keep their (possibly inherited) state; sending a field as `null` clears it
+// back to inherit. So toggling auto-update never disturbs the instruction, and
+// vice versa.
+export interface UpdatePolicyPatch {
+  ingestion_auto_update_disabled?: boolean | null;
+  update_instruction?: string | null;
 }
 
 export function getUpdatePolicy(path: string): Promise<UpdatePolicyResponse> {
@@ -36,14 +40,12 @@ export function getUpdatePolicy(path: string): Promise<UpdatePolicyResponse> {
   );
 }
 
-// PUT is full desired-state: both fields are sent every time, so callers pass
-// the complete intended policy (a missing field clears it on the server).
-export function setUpdatePolicy(
+export function patchUpdatePolicy(
   path: string,
-  input: SetUpdatePolicyInput,
+  patch: UpdatePolicyPatch,
 ): Promise<UpdatePolicyResponse> {
   return apiFetch<UpdatePolicyResponse>("/update-policy", {
-    method: "PUT",
-    body: JSON.stringify({ path, ...input }),
+    method: "PATCH",
+    body: JSON.stringify({ path, ...patch }),
   });
 }


### PR DESCRIPTION
Makes the update policy behave like a proper inherit-with-overrides model (à la Google Drive sharing): editing one field never freezes the other's inheritance, and the panel makes inherited-vs-set-here legible.

### Why
The old full-replace `PUT` sent both fields every save, so e.g. **adding an instruction to a page under a disabled folder silently froze the inherited `disabled=true` into an explicit override** — later re-enabling the folder wouldn't reach that page. Toggling/saving each clobbered the other field's inherited state.

### API
- `PUT /api/update-policy` → **`PATCH`**. Only fields present in the body change (via `model_fields_set`); omitted fields keep their (possibly inherited) state. A field sent as `null` clears it back to inherit; the row is deleted once both fields are empty. (`SetUpdatePolicyRequest` → `PatchUpdatePolicyRequest`.)

### UI
- Panel patches only the field the user changed (toggle → `ingestion_auto_update_disabled`; editor → `update_instruction`).
- Per-field **inherited vs set-here** indicator; inherited folder instruction shown read-only.
- **"Reset to inherited"** on an explicit disable override (PATCH `null`).

### Tests
- API: PATCH round-trip; **patch one field preserves the other**; **null resets to inherited** (falls back to the folder); folder cascade; require_can 403.
- `ruff` + `basedpyright` + `bun run typecheck` + prettier clean.

<img width="410" height="323" alt="Screenshot 2026-06-16 at 12 30 09 PM" src="https://github.com/user-attachments/assets/908c643f-aa0e-47da-8dd2-32e40e4ff28c" />
