### PR TITLE
feat(ingest): inject update_instruction into the updaters

### DIFF
--- a/backend/app/ingest/models.py
+++ b/backend/app/ingest/models.py
@@ -9,3 +9,6 @@ from app.db.fts import SearchHit
 class WikiUpdateCandidate(BaseModel):
     hit: SearchHit
     body: str
+    # Resolved per-page update instruction (most-granular scope wins), rendered
+    # into the reconciler prompt. ``None`` when no policy applies.
+    update_instruction: str | None = None

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -150,15 +150,17 @@ def _reconcile_batch(
     batch: list[WikiUpdateCandidate],
     model: str,
 ) -> list[str | None]:
-    def _fmt(i: int, c: WikiUpdateCandidate) -> str:
-        header = f"[{i + 1}] {c.hit.path}"
+    def _format_candidate(index: int, c: WikiUpdateCandidate) -> str:
+        header = f"[{index + 1}] {c.hit.path}"
         # Per-page update instruction (from the page's update policy) constrains
         # *how* to edit this candidate; it never forces an edit.
         if c.update_instruction:
             header += f"\n(Update instruction for this page: {c.update_instruction})"
         return f"{header}\n{c.body}"
 
-    candidate_text = "\n\n".join(_fmt(i, c) for i, c in enumerate(batch))
+    candidate_text = "\n\n".join(
+        _format_candidate(i, c) for i, c in enumerate(batch)
+    )
 
     system = load_prompt("ingest_batch_reconciler.system")
     user = load_prompt("ingest_batch_reconciler.input").format(

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -150,9 +150,15 @@ def _reconcile_batch(
     batch: list[WikiUpdateCandidate],
     model: str,
 ) -> list[str | None]:
-    candidate_text = "\n\n".join(
-        f"[{i + 1}] {c.hit.path}\n{c.body}" for i, c in enumerate(batch)
-    )
+    def _fmt(i: int, c: WikiUpdateCandidate) -> str:
+        header = f"[{i + 1}] {c.hit.path}"
+        # Per-page update instruction (from the page's update policy) constrains
+        # *how* to edit this candidate; it never forces an edit.
+        if c.update_instruction:
+            header += f"\n(Update instruction for this page: {c.update_instruction})"
+        return f"{header}\n{c.body}"
+
+    candidate_text = "\n\n".join(_fmt(i, c) for i, c in enumerate(batch))
 
     system = load_prompt("ingest_batch_reconciler.system")
     user = load_prompt("ingest_batch_reconciler.input").format(

--- a/backend/app/llm/agents/nl_updater.py
+++ b/backend/app/llm/agents/nl_updater.py
@@ -13,6 +13,7 @@ from app.llm import client
 from app.llm.agents.common import NO_CHANGE_SENTINEL, strip_outer_fence
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
+from app.wiki import update_policy
 
 log = logging.getLogger(__name__)
 
@@ -24,14 +25,35 @@ def process_instruction(wiki_path: str, current_body: str, payload: dict[str, An
     full new page body. Returns ``None`` if no change is needed.
 
     Caller (a background task or the ``update_doc_nl`` tool) is responsible for
-    committing the result. This function does no I/O beyond the LLM call.
+    committing the result. This function does a best-effort policy lookup (one DB
+    read) and one LLM call; it does no other I/O.
     """
+    # Per-page update instruction is advisory — if the policy store is
+    # unreachable (e.g. the offline eval harness with no DB) proceed without it
+    # rather than failing the update.
+    try:
+        instruction = update_policy.resolve_for_path(wiki_path).update_instruction
+    except Exception:
+        log.warning(
+            "nl_updater: update policy lookup failed for %s; proceeding without it",
+            wiki_path,
+            exc_info=True,
+        )
+        instruction = None
+    instruction_section = (
+        "--- Update instruction for this page ---\n"
+        f"{instruction}\n"
+        "--- End instruction ---\n\n"
+        if instruction
+        else ""
+    )
     system = load_prompt("wiki_updater.mcp.system")
     input = load_prompt("wiki_updater.mcp.input").format(
         wiki_path=wiki_path,
         source=source,
         current_body=current_body,
         payload=payload,
+        update_instruction=instruction_section,
     )
     with trace_flow("agent.nl_updater", wiki_path=wiki_path, source=source):
         result = client.complete(

--- a/backend/app/llm/agents/nl_updater.py
+++ b/backend/app/llm/agents/nl_updater.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sqlalchemy.exc import OperationalError
+
 from app.llm import client
 from app.llm.agents.common import NO_CHANGE_SENTINEL, strip_outer_fence
 from app.llm.prompts import load_prompt
@@ -33,9 +35,12 @@ def process_instruction(wiki_path: str, current_body: str, payload: dict[str, An
     # rather than failing the update.
     try:
         instruction = update_policy.resolve_for_path(wiki_path).update_instruction
-    except Exception:
+    except OperationalError:
+        # DB unreachable (e.g. the offline eval harness with no DB). The
+        # instruction is advisory, so proceed without it rather than fail the
+        # update. Other exceptions are real bugs and propagate.
         log.warning(
-            "nl_updater: update policy lookup failed for %s; proceeding without it",
+            "nl_updater: update policy DB unreachable for %s; proceeding without it",
             wiki_path,
             exc_info=True,
         )

--- a/backend/app/llm/agents/tools/read_doc.py
+++ b/backend/app/llm/agents/tools/read_doc.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
-from app.wiki import agent_activity, git as wiki_git
+from app.wiki import agent_activity, git as wiki_git, update_policy
 
 
 def handle(args: dict[str, Any]) -> Any:
@@ -54,10 +54,16 @@ def handle(args: dict[str, Any]) -> Any:
         wiki_utils.mark_doc_read(path)
         agents = [r.model_dump() for r in agent_activity.list_for_doc(path)]
 
-    return {
+    result: dict[str, Any] = {
         "path": path,
         "body": body,
         "sha": sha or head_sha,
         "is_head": is_head,
         "agents": agents,
     }
+    # Surface the page's effective update instruction (incl. inherited from a
+    # parent folder) so an agent editing this page can follow it.
+    instruction = update_policy.resolve_for_path(path).update_instruction
+    if instruction:
+        result["update_instruction"] = instruction
+    return result

--- a/backend/app/llm/agents/tools/read_page.py
+++ b/backend/app/llm/agents/tools/read_page.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
-from app.wiki import agent_activity, git as wiki_git
+from app.wiki import agent_activity, git as wiki_git, update_policy
 
 
 def handle(args: dict[str, Any]) -> Any:
@@ -37,12 +37,18 @@ def handle(args: dict[str, Any]) -> Any:
 
     wiki_utils.mark_doc_read(path)
 
-    return {
+    result: dict[str, Any] = {
         "path": path,
         "title": _derive_title(path, body),
         "body": body,
         "agents": [r.model_dump() for r in agent_activity.list_for_doc(path)],
     }
+    # Surface the page's effective update instruction (incl. inherited from a
+    # parent folder) so an agent editing this page can follow it.
+    instruction = update_policy.resolve_for_path(path).update_instruction
+    if instruction:
+        result["update_instruction"] = instruction
+    return result
 
 
 def _derive_title(path: str, body: str) -> str:

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -65,6 +65,14 @@ expand it to a full sentence or paragraph just because the source provides
 more context. If the edit cannot be expressed at the existing grain, use
 `no_change`.
 
+## Per-page update instructions
+
+A candidate may include a line `(Update instruction for this page: …)` right
+after its path. That is author-provided guidance on *how* this page should be
+maintained — honor it when you do edit. It never overrides the relevance,
+scope, or granularity rules above: if the source doesn't warrant a change,
+still return `no_change` or `irrelevant` even when an instruction is present.
+
 ## Editing rules (only apply if relevant)
 
 - Surgical edits beat full rewrites. Change only what the external doc

--- a/backend/app/llm/prompts/wiki_updater.mcp.input.md
+++ b/backend/app/llm/prompts/wiki_updater.mcp.input.md
@@ -9,5 +9,5 @@ Update source: {source}
 {payload}
 --- End payload ---
 
-Decide whether the page should change. If yes, return the full new body. If no,
+{update_instruction}Decide whether the page should change. If yes, return the full new body. If no,
 return NO_CHANGE.

--- a/backend/app/llm/prompts/wiki_updater.mcp.input.md
+++ b/backend/app/llm/prompts/wiki_updater.mcp.input.md
@@ -9,5 +9,6 @@ Update source: {source}
 {payload}
 --- End payload ---
 
-{update_instruction}Decide whether the page should change. If yes, return the full new body. If no,
+{update_instruction}
+Decide whether the page should change. If yes, return the full new body. If no,
 return NO_CHANGE.

--- a/backend/app/llm/prompts/wiki_updater.mcp.system.md
+++ b/backend/app/llm/prompts/wiki_updater.mcp.system.md
@@ -14,6 +14,13 @@ information the page already covers OR information that the page's structure
 clearly calls for. Tangentially related content at a different level of
 detail does not belong. When in doubt, return NO_CHANGE.
 
+## Per-page update instruction
+
+The input may include an "Update instruction for this page" block — author-provided
+guidance on how this page should be maintained. Honor it when you do edit, but it
+does not override the scope check: if the payload warrants no change, still return
+NO_CHANGE.
+
 ## Editing rules
 
 - **Surgical edits over rewrites.** Touch only the lines that need to change.

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -348,15 +348,16 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     url: str = str(push.get("url") or _meta.get("url") or "")
 
     # Read all candidate bodies upfront — needed by both the selector and the
-    # main reconciler loop. Skip unreadable files early so the selector sees
-    # the same set the reconciler will act on. Drop pages whose update policy
-    # disables ingestion auto-update *before* any LLM call, so a protected page
-    # is never rewritten by a connector push.
-    # Resolve every candidate's ingestion-disable in one query, not per-hit.
-    disabled = update_policy.disabled_paths([hit.path for hit in hits])
+    # main reconciler loop. Skip unreadable files early so the selector sees the
+    # same set the reconciler will act on. Resolve every candidate's update
+    # policy in one query: drop pages whose policy disables ingestion
+    # auto-update *before* any LLM call, and carry each kept page's resolved
+    # update instruction onto its candidate for the reconciler prompt.
+    policies = update_policy.resolve_for_paths([hit.path for hit in hits])
     readable: list[WikiUpdateCandidate] = []
     for hit in hits:
-        if hit.path in disabled:
+        policy = policies.get(hit.path)
+        if policy is not None and policy.ingestion_auto_update_disabled:
             ingest_outcomes_total.labels(
                 outcome="ingestion_auto_update_disabled", wiki_path=hit.path
             ).inc()
@@ -366,9 +367,17 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             )
             continue
         try:
-            readable.append(WikiUpdateCandidate(hit=hit, body=wiki_git.read_file(hit.path)))
+            body = wiki_git.read_file(hit.path)
         except Exception:
             log.debug("process_pushed_document: skipping unreadable %s", hit.path)
+            continue
+        readable.append(
+            WikiUpdateCandidate(
+                hit=hit,
+                body=body,
+                update_instruction=policy.update_instruction if policy else None,
+            )
+        )
 
     if not readable:
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -189,27 +189,11 @@ def _scope_chain(norm: str) -> list[str]:
     return chain
 
 
-def resolve_for_path(path: str) -> ResolvedPolicy:
-    """Effective policy for ``path``: most-granular scope that sets a field wins.
-
-    ``path`` may be a doc or a folder. Walks the path and its ancestor folders,
-    closest first, and resolves each field independently — so a page can
-    re-enable ingestion under a disabled folder, and a folder instruction
-    applies until a nearer scope overrides it.
-    """
-    candidates = _scope_chain(normalize_path(path))
-
-    with session() as s:
-        rows = (
-            s.execute(select(UpdatePolicy).where(UpdatePolicy.path.in_(candidates)))
-            .scalars()
-            .all()
-        )
-    by_path = {r.path: r for r in rows}
-
+def _resolve_chain(chain: list[str], by_path: dict[str, UpdatePolicy]) -> ResolvedPolicy:
+    """Resolve one scope chain (closest first) against pre-fetched rows."""
     disabled: bool | None = None
     instruction: str | None = None
-    for scope in candidates:  # closest first
+    for scope in chain:
         row = by_path.get(scope)
         if row is None:
             continue
@@ -219,33 +203,23 @@ def resolve_for_path(path: str) -> ResolvedPolicy:
             instruction = row.update_instruction
         if disabled is not None and instruction is not None:
             break
-
     return ResolvedPolicy(
         ingestion_auto_update_disabled=bool(disabled),
         update_instruction=instruction,
     )
 
 
-def is_ingest_disabled(path: str) -> bool:
-    """Convenience: is connector/ingest auto-update disabled for ``path``?"""
-    return resolve_for_path(path).ingestion_auto_update_disabled
+def resolve_for_paths(paths: Iterable[str]) -> dict[str, ResolvedPolicy]:
+    """Effective policy for many paths in a single query.
 
-
-def disabled_paths(paths: Iterable[str]) -> set[str]:
-    """Subset of ``paths`` whose effective policy disables ingestion auto-update.
-
-    One query for all paths and their ancestor folders, then resolve each in
-    Python — collapses N per-candidate lookups to a single round-trip. Keyed by
-    the *input* path strings so callers can test membership directly.
+    Fetches the union of every path's scope chain once, then resolves each path
+    most-granular-wins (each field independently). Keyed by the *input* path
+    strings. Use this on the ingest hot path instead of per-candidate calls.
     """
-    chains: dict[str, list[str]] = {}
-    scopes: set[str] = set()
-    for p in paths:
-        chain = _scope_chain(normalize_path(p))
-        chains[p] = chain
-        scopes.update(chain)
+    chains = {p: _scope_chain(normalize_path(p)) for p in paths}
+    scopes = {scope for chain in chains.values() for scope in chain}
     if not scopes:
-        return set()
+        return {}
 
     with session() as s:
         rows = (
@@ -254,13 +228,28 @@ def disabled_paths(paths: Iterable[str]) -> set[str]:
             .all()
         )
     by_path = {r.path: r for r in rows}
+    return {orig: _resolve_chain(chain, by_path) for orig, chain in chains.items()}
 
-    out: set[str] = set()
-    for orig, chain in chains.items():
-        for scope in chain:  # closest first
-            row = by_path.get(scope)
-            if row is not None and row.ingestion_auto_update_disabled is not None:
-                if row.ingestion_auto_update_disabled:
-                    out.add(orig)
-                break
-    return out
+
+def resolve_for_path(path: str) -> ResolvedPolicy:
+    """Effective policy for a single ``path`` (convenience over
+    :func:`resolve_for_paths`): most-granular scope that sets a field wins,
+    walking the path then its ancestor folders, each field resolved
+    independently — so a page can re-enable ingestion under a disabled folder.
+    """
+    return resolve_for_paths([path]).get(path, ResolvedPolicy())
+
+
+def is_ingest_disabled(path: str) -> bool:
+    """Convenience: is connector/ingest auto-update disabled for ``path``?"""
+    return resolve_for_path(path).ingestion_auto_update_disabled
+
+
+def disabled_paths(paths: Iterable[str]) -> set[str]:
+    """Subset of ``paths`` whose effective policy disables ingestion auto-update
+    (one query, via :func:`resolve_for_paths`). Keyed by the input path strings."""
+    return {
+        p
+        for p, r in resolve_for_paths(paths).items()
+        if r.ingestion_auto_update_disabled
+    }

--- a/backend/tests/test_doc_tools.py
+++ b/backend/tests/test_doc_tools.py
@@ -314,3 +314,34 @@ def test_multi_edit_rejects_no_op(repo_with_doc):
         }
     )
     assert "error" in out
+
+
+# --------------------------------------------------------------------------- #
+# read_doc surfaces the page's update instruction                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_read_doc_surfaces_own_update_instruction(repo_with_doc):
+    from app.llm.agents.tools.read_doc import handle
+    from app.wiki import update_policy
+
+    update_policy.set_policy("guide.md", update_instruction="Keep it terse.")
+    out = handle({"path": "guide.md"})
+    assert out["update_instruction"] == "Keep it terse."
+
+
+def test_read_doc_surfaces_inherited_update_instruction(repo_with_doc):
+    from app.llm.agents.tools.read_doc import handle
+    from app.wiki import git as wiki_git, update_policy
+
+    wiki_git.commit_file("team/sub.md", "# Sub\n", "seed", author=None)
+    update_policy.set_policy("team", update_instruction="folder rule")
+    out = handle({"path": "team/sub.md"})
+    assert out["update_instruction"] == "folder rule"  # inherited from the folder
+
+
+def test_read_doc_omits_update_instruction_when_none(repo_with_doc):
+    from app.llm.agents.tools.read_doc import handle
+
+    out = handle({"path": "guide.md"})
+    assert "update_instruction" not in out

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -334,3 +334,37 @@ def test_reconcile_passes_tool_to_client(mock_client, _mock_prompt):
     call_kwargs = mock_client.complete.call_args.kwargs
     assert call_kwargs.get("tools") is not None
     assert call_kwargs["tools"][0]["name"] == "submit_results"
+
+
+# --------------------------------------------------------------------------- #
+# Per-page update instruction rendering (real prompt)                          #
+# --------------------------------------------------------------------------- #
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_update_instruction_rendered_in_prompt(mock_client):
+    # Real load_prompt so the {candidates} block is actually rendered.
+    mock_client.complete.return_value = _llm_response(
+        {"results": [{"candidate_index": 1, "action": "no_change"}]}
+    )
+    cand = WikiUpdateCandidate(
+        hit=_hit("page.md"), body="body", update_instruction="Keep it terse."
+    )
+    batch_reconcile(
+        title="T", url="", content="doc", source="s", candidates=[cand], model="m"
+    )
+    user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
+    assert "Update instruction for this page: Keep it terse." in user_msg
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_no_instruction_line_when_absent(mock_client):
+    mock_client.complete.return_value = _llm_response(
+        {"results": [{"candidate_index": 1, "action": "no_change"}]}
+    )
+    batch_reconcile(
+        title="T", url="", content="doc", source="s",
+        candidates=[_candidate("page.md")], model="m",
+    )
+    user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
+    assert "Update instruction for this page" not in user_msg

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -38,13 +38,13 @@ def _stub_llm_settings(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _stub_ingest_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The candidate loop calls update_policy.disabled_paths, which opens a DB
-    session. These unit tests mock git/search and run without a DB, so default
-    to 'none disabled'. The policy-specific test overrides this."""
+def _stub_resolve_policies(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The candidate loop calls update_policy.resolve_for_paths, which opens a DB
+    session. These unit tests mock git/search and run without a DB, so default to
+    "no policy" (enabled, no instruction). Policy-specific tests override this."""
     monkeypatch.setattr(
-        "app.tasks.wiki_update.update_policy.disabled_paths",
-        lambda paths: set(),
+        "app.tasks.wiki_update.update_policy.resolve_for_paths",
+        lambda paths: {},
     )
 
 
@@ -261,14 +261,40 @@ def test_ingestion_disabled_skips_candidate_before_llm(
     # A page whose policy disables ingestion auto-update must be dropped before
     # any LLM call — the reconciler never sees it and nothing commits.
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
+    from app.wiki.update_policy import ResolvedPolicy
+
     monkeypatch.setattr(
-        "app.tasks.wiki_update.update_policy.disabled_paths",
-        lambda paths: {"page.md"},
+        "app.tasks.wiki_update.update_policy.resolve_for_paths",
+        lambda paths: {"page.md": ResolvedPolicy(ingestion_auto_update_disabled=True)},
     )
     mock_search.return_value = [_hit("page.md", "Page", 5.0)]
     _run(_make_push())
     mock_reconcile.assert_not_called()
     mock_commit.assert_not_called()
+
+
+@patch("app.tasks.wiki_update.wiki_git.head_sha_for_path", return_value="headsha")
+@patch("app.wiki.utils.wiki_notify.after_doc_write")
+@patch("app.tasks.wiki_update.wiki_git.commit_file", return_value="sha123")
+@patch("app.tasks.wiki_update.wiki_git.read_file", return_value="old body")
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_update_instruction_passed_to_reconciler(
+    mock_search, mock_reconcile, mock_read, mock_commit, mock_notify, mock_head, monkeypatch
+):
+    # The resolved per-page instruction rides onto the candidate the reconciler sees.
+    monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
+    from app.wiki.update_policy import ResolvedPolicy
+
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.update_policy.resolve_for_paths",
+        lambda paths: {"page.md": ResolvedPolicy(update_instruction="Keep it terse.")},
+    )
+    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_reconcile.return_value = (["new body"], 1)
+    _run(_make_push())
+    candidates = mock_reconcile.call_args.kwargs["candidates"]
+    assert candidates[0].update_instruction == "Keep it terse."
 
 
 @patch("app.wiki.utils.wiki_notify.after_doc_write")

--- a/backend/tests/test_read_page.py
+++ b/backend/tests/test_read_page.py
@@ -55,3 +55,19 @@ def test_read_page_falls_back_to_filename_when_no_h1(tmp_repo, tmp_config):
     wiki_git.commit_file("notes/raw.md", "Just a paragraph.\n", "seed", author=None)
     out = handle({"path": "notes/raw.md"})
     assert out["title"] == "raw"
+
+
+def test_read_page_surfaces_update_instruction(repo_with_doc):
+    from app.llm.agents.tools.read_page import handle
+    from app.wiki import update_policy
+
+    update_policy.set_policy("guide.md", update_instruction="Keep it terse.")
+    out = handle({"path": "guide.md"})
+    assert out["update_instruction"] == "Keep it terse."
+
+
+def test_read_page_omits_update_instruction_when_none(repo_with_doc):
+    from app.llm.agents.tools.read_page import handle
+
+    out = handle({"path": "guide.md"})
+    assert "update_instruction" not in out

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -5,6 +5,8 @@ set_policy.
 """
 from __future__ import annotations
 
+from typing import Any
+
 from app.wiki import update_policy
 
 
@@ -63,6 +65,84 @@ def test_disabled_paths_batch(tmp_db):
 
 def test_disabled_paths_empty(tmp_db):
     assert update_policy.disabled_paths([]) == set()
+
+
+def test_resolve_for_paths_batch(tmp_db):
+    update_policy.set_policy("a", update_instruction="folder rule")
+    update_policy.set_policy("a/p.md", ingestion_auto_update_disabled=True)
+    res = update_policy.resolve_for_paths(["a/p.md", "a/q.md", "c.md"])
+    # a/p.md: own disable + inherited instruction
+    assert res["a/p.md"].ingestion_auto_update_disabled is True
+    assert res["a/p.md"].update_instruction == "folder rule"
+    # a/q.md: inherits the folder instruction, enabled by default
+    assert res["a/q.md"].ingestion_auto_update_disabled is False
+    assert res["a/q.md"].update_instruction == "folder rule"
+    # c.md: nothing applies
+    assert res["c.md"].ingestion_auto_update_disabled is False
+    assert res["c.md"].update_instruction is None
+
+
+def test_nl_updater_injects_inherited_instruction(tmp_db, monkeypatch):
+    from app.llm.agents import nl_updater
+    from app.llm.client import CompletionResult
+
+    update_policy.set_policy("team", update_instruction="Keep it terse.")  # folder
+    captured: dict[str, Any] = {}
+
+    def fake_complete(*, messages, **kwargs):
+        captured["messages"] = messages
+        return CompletionResult(text="NO_CHANGE", tool_calls=[], stop_reason="end_turn")
+
+    monkeypatch.setattr(nl_updater.client, "complete", fake_complete)
+    nl_updater.process_instruction(
+        wiki_path="team/page.md", current_body="# P", payload={"instruction": "x"},
+        source="test",
+    )
+    user_msg = captured["messages"][1]["content"]
+    assert "Update instruction for this page" in user_msg
+    assert "Keep it terse." in user_msg  # inherited from the folder
+
+
+def test_nl_updater_omits_section_when_no_policy(tmp_db, monkeypatch):
+    from app.llm.agents import nl_updater
+    from app.llm.client import CompletionResult
+
+    captured: dict[str, Any] = {}
+
+    def fake_complete(*, messages, **kwargs):
+        captured["messages"] = messages
+        return CompletionResult(text="NO_CHANGE", tool_calls=[], stop_reason="end_turn")
+
+    monkeypatch.setattr(nl_updater.client, "complete", fake_complete)
+    nl_updater.process_instruction(
+        wiki_path="a/page.md", current_body="# A", payload={"instruction": "x"},
+        source="test",
+    )
+    assert "Update instruction for this page" not in captured["messages"][1]["content"]
+
+
+def test_nl_updater_proceeds_when_policy_store_unavailable(monkeypatch):
+    """No DB (offline eval): the advisory policy lookup must not fail the update."""
+    from app.llm.agents import nl_updater
+    from app.llm.client import CompletionResult
+
+    def boom(_path):
+        raise RuntimeError("no database")
+
+    monkeypatch.setattr(nl_updater.update_policy, "resolve_for_path", boom)
+    captured: dict[str, Any] = {}
+
+    def fake_complete(*, messages, **kwargs):
+        captured["messages"] = messages
+        return CompletionResult(text="NO_CHANGE", tool_calls=[], stop_reason="end_turn")
+
+    monkeypatch.setattr(nl_updater.client, "complete", fake_complete)
+    result = nl_updater.process_instruction(
+        wiki_path="a/page.md", current_body="# A", payload={"instruction": "x"},
+        source="test",
+    )
+    assert result is None
+    assert "Update instruction for this page" not in captured["messages"][1]["content"]
 
 
 def test_fields_resolve_independently(tmp_db):

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -122,12 +122,14 @@ def test_nl_updater_omits_section_when_no_policy(tmp_db, monkeypatch):
 
 
 def test_nl_updater_proceeds_when_policy_store_unavailable(monkeypatch):
-    """No DB (offline eval): the advisory policy lookup must not fail the update."""
+    """No DB (offline eval): an unreachable policy store must not fail the update."""
+    from sqlalchemy.exc import OperationalError
+
     from app.llm.agents import nl_updater
     from app.llm.client import CompletionResult
 
     def boom(_path):
-        raise RuntimeError("no database")
+        raise OperationalError("SELECT 1", {}, Exception("could not connect"))
 
     monkeypatch.setattr(nl_updater.update_policy, "resolve_for_path", boom)
     captured: dict[str, Any] = {}


### PR DESCRIPTION
Final functional half of update-policy enforcement — make **`update_instruction`** actually influence updates (disable-skip landed in #239).

### Resolver
- **`resolve_for_paths(paths)`** — batched effective-policy resolver `{path: ResolvedPolicy}` (disable + instruction) in one query, sharing `_resolve_chain`. `resolve_for_path` / `is_ingest_disabled` / `disabled_paths` now delegate to it.

### Where the instruction is now honored
- **Ingestion** (`process_pushed_document`) — one `resolve_for_paths` call drives both the disable-skip and carrying each kept candidate's instruction onto `WikiUpdateCandidate`; the reconciler renders it per-candidate.
- **NL update** (`nl_updater.process_instruction`, shared by **chat + MCP `update_doc_nl`**) — injects the resolved instruction; guarded by `except OperationalError` (DB unreachable, e.g. offline evals) so it degrades without masking real bugs.
- **Reads** (`read_doc` + `read_page`, chat + MCP) — return the effective `update_instruction` (incl. inherited) when set, so agents using the **direct-edit** tools (`write_doc`/`edit_doc`/…) can follow it.
- Prompt notes added to both updater system prompts (honor it; never forces an edit / overrides the scope check).

### Tests
`resolve_for_paths` batch; instruction reaches candidate + renders in reconciler prompt; NL-updater injects (own + inherited), omits when none, degrades on `OperationalError`; `read_doc`/`read_page` surface own + inherited, omit when none. `ruff` + `basedpyright` clean; verified end-to-end on local Docker.

Remaining update-policy item after this: the **"Wiki Pages (Auto-update)" Grafana card**.