### PR TITLE
feat(metrics): Wiki Pages (Auto-update) dashboard card

### DIFF
--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -202,6 +202,33 @@ def count_documents() -> int | None:
         log.warning("fts: count_documents failed", exc_info=True)
         return None
 
+
+def paths_under(prefix: str) -> list[str]:
+    """Indexed page paths under a folder ``prefix`` (e.g. ``"team/"``).
+
+    ``path`` is a keyword field, so a prefix term matches the stored value.
+    ``prefix=""`` matches every page. Bounded to the first 10k matches (the
+    realistic ceiling).
+
+    Returns ``[]`` only when OpenSearch isn't configured. A backend error
+    (e.g. the search endpoint is down while ``count`` still answers) **raises**
+    rather than returning ``[]`` — an empty result must mean "genuinely no
+    pages here", so callers can't mistake a partial outage for an empty folder.
+    """
+    client = _get_client()
+    if client is None:
+        return []
+    c: OpenSearch = client  # type: ignore[assignment]
+    resp = c.search(
+        index=_index_name(),
+        body={
+            "size": 10_000,
+            "query": {"prefix": {"path": prefix}},
+            "_source": ["path"],
+        },
+    )
+    return [h["_source"]["path"] for h in resp["hits"]["hits"]]
+
 def delete_document(doc_id: str) -> None:
     """Remove a page from the index.  ``doc_id`` is the path when called
     from ``app.wiki.notify`` (the only callers)."""

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -11,12 +11,16 @@ Ingest pipeline metrics must be updated manually at each pipeline stage.
 """
 from __future__ import annotations
 
+import logging
+
 from fastapi import FastAPI
 from prometheus_client import Counter, Gauge, Histogram, REGISTRY
 from prometheus_client.core import GaugeMetricFamily  # type: ignore[import-untyped]
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.db import fts
+
+log = logging.getLogger(__name__)
 
 # --------------------------------------------------------------------------- #
 # Ingest pipeline                                                              #
@@ -99,6 +103,26 @@ class _WikiPagesCollector:
         yield g
 
 REGISTRY.register(_WikiPagesCollector())
+
+
+class _WikiAutoUpdateCollector:
+    def collect(self):
+        from app.wiki import update_policy
+
+        total = fts.count_documents() or 0
+        try:
+            enabled = update_policy.count_ingest_enabled_pages(total, fts.paths_under)
+        except Exception:
+            log.warning("metrics: auto-update-enabled count failed", exc_info=True)
+            enabled = total
+        g = GaugeMetricFamily(
+            "wiki_pages_auto_update_enabled",
+            "Wiki pages with ingestion auto-update enabled (effective policy)",
+        )
+        g.add_metric([], enabled)
+        yield g
+
+REGISTRY.register(_WikiAutoUpdateCollector())
 
 ingest_selector_candidates_filtered = Histogram(
     "ingest_selector_candidates_filtered",

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
@@ -253,3 +253,48 @@ def disabled_paths(paths: Iterable[str]) -> set[str]:
         for p, r in resolve_for_paths(paths).items()
         if r.ingestion_auto_update_disabled
     }
+
+
+def _disabled_true_scopes() -> list[str]:
+    """Paths that *explicitly* disable ingestion auto-update (the True rows).
+
+    Small — only managed scopes, not pages. Drives the auto-update-enabled
+    metric without enumerating every wiki page.
+    """
+    with session() as s:
+        rows = s.execute(
+            select(UpdatePolicy.path).where(
+                UpdatePolicy.ingestion_auto_update_disabled.is_(True)
+            )
+        ).scalars().all()
+    return list(rows)
+
+
+def count_ingest_enabled_pages(
+    total_pages: int, list_pages_under: Callable[[str], list[str]]
+) -> int:
+    """Number of pages with ingestion auto-update **enabled** (effective).
+
+    Driven by the small set of explicitly-disabled scopes, not by enumerating
+    every page: only the protected subtrees are listed (via
+    ``list_pages_under(prefix)``, injected to keep the search index out of this
+    module), then resolved most-granular-wins so re-enabled children are counted
+    back as enabled. Pages under no disabled scope are enabled by definition.
+
+    Clamped to ``[0, total_pages]``: a disabled *page* scope is counted even if
+    that path isn't indexed (a stale or pre-index policy row), so the subtracted
+    set can exceed ``total_pages`` when the policy table and the index disagree —
+    the gauge must never read negative.
+    """
+    scopes = _disabled_true_scopes()
+    if not scopes:
+        return total_pages
+    candidates: set[str] = set()
+    for scope in scopes:
+        if kind_for_path(scope) == "page":
+            candidates.add(scope)
+        else:
+            candidates.update(list_pages_under(f"{scope}/" if scope else ""))
+    if not candidates:
+        return total_pages
+    return max(0, total_pages - len(disabled_paths(candidates)))

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 from app.wiki import update_policy
 
 
@@ -65,6 +67,47 @@ def test_disabled_paths_batch(tmp_db):
 
 def test_disabled_paths_empty(tmp_db):
     assert update_policy.disabled_paths([]) == set()
+
+
+def test_count_ingest_enabled_pages(tmp_db):
+    # No policy at all -> every page is enabled (no enumeration).
+    assert update_policy.count_ingest_enabled_pages(10, lambda prefix: []) == 10
+
+    update_policy.set_policy("team", ingestion_auto_update_disabled=True)  # folder off
+    update_policy.set_policy("team/keep.md", ingestion_auto_update_disabled=False)  # re-enabled
+    update_policy.set_policy("solo.md", ingestion_auto_update_disabled=True)  # page off
+
+    pages = {"team/": ["team/a.md", "team/b.md", "team/keep.md"]}
+
+    # total=10; disabled = team/a, team/b (inherit), solo.md = 3; keep.md re-enabled.
+    enabled = update_policy.count_ingest_enabled_pages(10, lambda prefix: pages.get(prefix, []))
+    assert enabled == 7
+
+
+def test_count_ingest_enabled_pages_never_negative(tmp_db):
+    # A disabled page-scope row can reference a path not in the index (stale or
+    # pre-index): subtracting it plus a cascading root disable could exceed
+    # total_pages. The gauge must clamp to 0, never go negative.
+    update_policy.set_policy("", ingestion_auto_update_disabled=True)  # root: all off
+    update_policy.set_policy("ghost.md", ingestion_auto_update_disabled=True)  # not indexed
+    # Index reports 1 page; naive subtraction (root page + ghost) would be -1.
+    enabled = update_policy.count_ingest_enabled_pages(
+        1, lambda prefix: ["only.md"] if prefix == "" else []
+    )
+    assert enabled == 0
+
+
+def test_count_ingest_enabled_pages_propagates_lookup_failure(tmp_db):
+    # A disabled folder scope whose page listing fails (e.g. OpenSearch search
+    # endpoint down) must propagate, not silently return total_pages as if the
+    # folder were empty — the collector logs a warning and falls back to total.
+    update_policy.set_policy("team", ingestion_auto_update_disabled=True)
+
+    def boom(_prefix: str) -> list[str]:
+        raise RuntimeError("search endpoint down")
+
+    with pytest.raises(RuntimeError):
+        update_policy.count_ingest_enabled_pages(10, boom)
 
 
 def test_resolve_for_paths_batch(tmp_db):

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.21
+version: 0.3.22
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -494,6 +494,65 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 1
+      },
+      "id": 53,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(wiki_pages_auto_update_enabled{job=\"agent-wiki-agent-workspace-backend\"})",
+          "legendFormat": "Auto-update",
+          "refId": "A"
+        }
+      ],
+      "title": "Wiki Pages (Auto-update)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "mappings": [],
@@ -568,7 +627,7 @@
       "gridPos": {
         "h": 4,
         "w": 3,
-        "x": 6,
+        "x": 9,
         "y": 1
       },
       "id": 51,
@@ -666,8 +725,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 15,
-        "x": 9,
+        "w": 12,
+        "x": 12,
         "y": 1
       },
       "id": 52,


### PR DESCRIPTION
Adds a **"Wiki Pages (Auto-update)"** stat to the Grafana Ingest Pipeline row (right of "Wiki Pages"), showing how many wiki pages have ingestion auto-update **enabled**.

### Metric
- New `wiki_pages_auto_update_enabled` gauge via a custom collector (same pattern as `wiki_pages_total`), computed on scrape.
- **Scales — no per-page enumeration.** `update_policy.count_ingest_enabled_pages(total, list_pages_under)` drives off the *small* set of explicitly-disabled scopes: only protected subtrees are listed (new `fts.paths_under(prefix)`), then resolved most-granular-wins via `disabled_paths` so re-enabled children count back as enabled. Pages under no disabled scope are enabled by definition → `enabled = total` in the common case (zero index work).
- The `list_pages_under` dependency is injected, so the computation is unit-tested without the search index.

### Dashboard
`wiki-ingest-dashboard.json`: new stat at `x=6,w=3`; Wiki Updates shifts to `x=9`, Document Update Results to `x=12,w=12`. Row stays contiguous (0–24).
<img width="1086" height="378" alt="Screenshot 2026-06-16 at 1 55 26 PM" src="https://github.com/user-attachments/assets/250d750e-47d3-48a1-9fd2-bb200714b164" />




### Tests / verification
- Unit: `count_ingest_enabled_pages` (no policy → total; folder-disabled with a re-enabled child + a disabled page → correct count).
- `ruff` + `basedpyright` clean; JSON validated (unique ids, contiguous row).
- Verified live on Docker: `/metrics` emits `wiki_pages_auto_update_enabled`; adding a disabled page keeps the enabled count flat.

This is the last remaining update-policy item.