### PR TITLE
feat(metrics): "search filtered out" tile in Document Update Results (24h)

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -70,8 +70,11 @@ ingest_document_results_total = Counter(
     "ingest_document_results_total",
     "Per-document terminal outcome of ingest reconciliation, one increment per "
     "document. A document is 'committed' if any candidate page was committed, "
-    "else 'no_change' if any candidate resolved to no-change, else 'irrelevant'.",
-    ["result"],  # committed, no_change, irrelevant
+    "else 'no_change' if any candidate resolved to no-change, else 'irrelevant'. "
+    "'no_candidates' is recorded when search yields no usable candidate page "
+    "(no BM25 hit above threshold, or none readable), so this metric accounts "
+    "for every ingested document, not just those that reached reconciliation.",
+    ["result"],  # committed, no_change, irrelevant, no_candidates
 )
 
 ingest_document_chars = Histogram(

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -341,6 +341,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     if not hits:
         log.info("process_pushed_document: no BM25 candidates above threshold, doc_id=%s", doc_id)
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()
+        ingest_document_results_total.labels(result="no_candidates").inc()
         return
 
     source_label = source_type or "external"
@@ -381,6 +382,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
 
     if not readable:
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()
+        ingest_document_results_total.labels(result="no_candidates").inc()
         return
 
     # Stage 3: weak-model pre-filter (skipped when selector_model is unset or

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -167,10 +167,31 @@ def test_filtered_source_drops_silently(mock_search, monkeypatch):
     mock_search.assert_not_called()
 
 
+def _doc_result_count(result: str) -> float:
+    from prometheus_client import REGISTRY
+    return REGISTRY.get_sample_value(
+        "ingest_document_results_total", {"result": result}
+    ) or 0.0
+
+
 @patch("app.tasks.wiki_update.ingest_search.candidates", return_value=[])
 def test_no_candidates_returns_early(mock_search):
+    # No BM25 hit -> the doc still gets a per-document terminal result so the
+    # "search filtered out" tile accounts for it (panel reconciles to ingested).
+    before = _doc_result_count("no_candidates")
     _run(_make_push())
     mock_search.assert_called_once()
+    assert _doc_result_count("no_candidates") - before == 1.0
+
+
+@patch("app.tasks.wiki_update.wiki_git.read_file", side_effect=OSError("unreadable"))
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_no_readable_candidates_records_search_filtered_out(mock_search, mock_read):
+    # Hits exist but none are readable -> also recorded as no_candidates.
+    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    before = _doc_result_count("no_candidates")
+    _run(_make_push())
+    assert _doc_result_count("no_candidates") - before == 1.0
 
 
 def test_candidates_raises_on_search_backend_error():

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.22
+version: 0.3.23
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -665,7 +665,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Per-document terminal outcome over the last 24h (ingest_document_results_total), one count per ingested document. Priority: a document is 'committed' if it produced any wiki commit, else 'no_change' if any candidate resolved to no-change, else 'irrelevant'. Unlike \"Wiki Updates\", which counts page commits \u2014 one document can update several pages.",
+      "description": "Per-document terminal outcome over the last 24h (ingest_document_results_total), one count per ingested document. Priority: a document is 'committed' if it produced any wiki commit, else 'no_change' if any candidate resolved to no-change, else 'irrelevant'. 'search filtered out' (no_candidates) means search returned no usable candidate page (no BM25 hit above threshold, or none readable). These tiles together account for every ingested document, so they sum to \"Documents Ingested\". Unlike \"Wiki Updates\", which counts page commits \u2014 one document can update several pages.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -718,6 +718,25 @@
                   "fixedColor": "orange",
                   "mode": "fixed"
                 }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "no_candidates"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "search filtered out"
               }
             ]
           }


### PR DESCRIPTION
## What

Adds a **"search filtered out"** tile to the **Document Update Results (24h)** panel for documents that produce no per-document result because search returned no usable candidate.

## Why

`ingest_requests_total` (→ "Documents Ingested") counts every push up front, but `ingest_document_results_total` (→ "Document Update Results") was only emitted at the *end* of reconciliation. Documents that returned early — **no BM25 hit above threshold**, or **no readable candidate** — were counted as ingested but had no result tile. The gap (`ingested − results`, ~20/24h in dev) was only inferable by subtracting the two panels.

## Change

- `_reconcile_pushed_document`: record `ingest_document_results_total{result="no_candidates"}` on both early-return paths (`not hits`, `not readable`), so the metric accounts for **every** ingested document.
- Dashboard: purple **"search filtered out"** tile (color + `displayName` override on the `no_candidates` series; the panel already renders one tile per `result` via `by (result)`). Updated panel description; the tiles now sum to "Documents Ingested".
- Chart `0.3.22 → 0.3.23` so chart-releaser republishes the dashboard.

## Verification

- `test_no_candidates_returns_early` (no-hit) and `test_no_readable_candidates_records_search_filtered_out` assert the increment; 32 pass.
- basedpyright (whole-project) + ruff clean.
- Live: rebuilt backend image, drove a real no-hit ingest against OpenSearch → `ingest_document_results_total{result="no_candidates"}` delta = 1.0.

Note: the new tile shows data once a worker/backend image carrying this metric deploys (next nightly after merge), same as #244.