### PR TITLE
feat(llm): add gpt-5.4-nano to suggested OpenAI models

### DIFF
--- a/backend/app/api/llm.py
+++ b/backend/app/api/llm.py
@@ -36,7 +36,7 @@ _PROVIDER_LABELS = {
 
 _PROVIDER_DEFAULT_MODELS: dict[str, list[str]] = {
     "anthropic": ["claude-sonnet-4-6", "claude-opus-4-7", "claude-opus-4-6", "claude-haiku-4-5"],
-    "openai": ["gpt-5.5", "gpt-5.4", "gpt-5.2"],
+    "openai": ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
     "gemini": ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
     "ollama": ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
 }

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -71,7 +71,7 @@ const PROVIDER_MODELS: Record<Provider, string[]> = {
     "claude-opus-4-6",
     "claude-haiku-4-5",
   ],
-  openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.2"],
+  openai: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
   gemini: ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
   ollama: ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
   custom: [],


### PR DESCRIPTION
Adds `gpt-5.4-nano` to the suggested OpenAI model dropdown (backend `_PROVIDER_DEFAULT_MODELS` + frontend admin list).

Also aligns the two lists: the backend was missing `gpt-5.4-mini` that the frontend already offered, so both now suggest the same set: `gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.2`.

These are suggested options only — the admin UI still accepts any custom model string. Backend basedpyright + frontend tsc clean.