### PR TITLE
fix(wiki): sidebar folder click navigates the main view

### DIFF
--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -118,6 +118,7 @@ function FolderNode({
   dir,
   name,
   onOpenFile,
+  onOpenFolder,
   expanded,
   onToggle,
   activeFolder,
@@ -127,6 +128,7 @@ function FolderNode({
   dir: string;
   name: string;
   onOpenFile: (path: string) => void;
+  onOpenFolder: (path: string) => void;
   expanded: Set<string>;
   onToggle: (path: string) => void;
   activeFolder: string;
@@ -146,6 +148,7 @@ function FolderNode({
         isFolder
         active={activeFolder === full}
         onClick={() => {
+          onOpenFolder(full);
           onSetActive(full);
           onToggle(full);
         }}
@@ -159,6 +162,7 @@ function FolderNode({
               dir={full}
               name={f}
               onOpenFile={onOpenFile}
+              onOpenFolder={onOpenFolder}
               expanded={expanded}
               onToggle={onToggle}
               activeFolder={activeFolder}
@@ -193,6 +197,9 @@ export function WikiTree() {
   const entries = data?.entries ?? [];
   const { folders, files } = childrenOf(entries, "");
   const openFile = (path: string) => router.push(`/app/wiki/${path}`);
+  // Clicking a folder also navigates the main view to its folder listing (the
+  // same route renders the directory). It still expands inline in the tree.
+  const openFolder = (path: string) => router.push(`/app/wiki/${path}`);
 
   const [addingFolder, setAddingFolder] = useState(false);
   const [folderName, setFolderName] = useState("");
@@ -327,6 +334,7 @@ export function WikiTree() {
             dir=""
             name={f}
             onOpenFile={openFile}
+            onOpenFolder={openFolder}
             expanded={expanded}
             onToggle={toggleFolder}
             activeFolder={activeFolder}

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -118,7 +118,6 @@ function FolderNode({
   dir,
   name,
   onOpenFile,
-  onOpenFolder,
   expanded,
   onToggle,
   activeFolder,
@@ -128,7 +127,6 @@ function FolderNode({
   dir: string;
   name: string;
   onOpenFile: (path: string) => void;
-  onOpenFolder: (path: string) => void;
   expanded: Set<string>;
   onToggle: (path: string) => void;
   activeFolder: string;
@@ -148,7 +146,7 @@ function FolderNode({
         isFolder
         active={activeFolder === full}
         onClick={() => {
-          onOpenFolder(full);
+          onOpenFile(full); // navigate the main view to the folder listing
           onSetActive(full);
           onToggle(full);
         }}
@@ -162,7 +160,6 @@ function FolderNode({
               dir={full}
               name={f}
               onOpenFile={onOpenFile}
-              onOpenFolder={onOpenFolder}
               expanded={expanded}
               onToggle={onToggle}
               activeFolder={activeFolder}
@@ -196,10 +193,9 @@ export function WikiTree() {
   const { data } = useSWR<{ entries: Entry[] }>("/wiki");
   const entries = data?.entries ?? [];
   const { folders, files } = childrenOf(entries, "");
+  // Navigates to a page or a folder — the same /app/wiki/<path> route renders
+  // both (a folder shows its directory listing).
   const openFile = (path: string) => router.push(`/app/wiki/${path}`);
-  // Clicking a folder also navigates the main view to its folder listing (the
-  // same route renders the directory). It still expands inline in the tree.
-  const openFolder = (path: string) => router.push(`/app/wiki/${path}`);
 
   const [addingFolder, setAddingFolder] = useState(false);
   const [folderName, setFolderName] = useState("");
@@ -334,7 +330,6 @@ export function WikiTree() {
             dir=""
             name={f}
             onOpenFile={openFile}
-            onOpenFolder={openFolder}
             expanded={expanded}
             onToggle={toggleFolder}
             activeFolder={activeFolder}


### PR DESCRIPTION
## Bug
Clicking a folder in the directory **sidebar** only expanded it inline and marked it active — the main content pane didn't change. Files navigate (`openFile` → `router.push`), folders didn't.

## Fix
Folder rows now also navigate to the folder's listing (`/app/wiki/<path>` — the same route that renders the directory view), while still expanding inline in the tree. Threaded an `onOpenFolder` handler through `FolderNode` alongside the existing `onOpenFile`.

Frontend `tsc` clean.
<img width="1568" height="713" alt="Screenshot 2026-06-16 at 3 01 52 PM" src="https://github.com/user-attachments/assets/35643420-51b9-40e2-a84d-63c2ac157d8b" />

