### PR TITLE
fix(wiki): remove double scrollbar on wiki views

### DIFF
--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -104,7 +104,7 @@ function AppContent({ children }: AppContentProps) {
           </RootLayout.Header>
         )}
         <RootLayout.MainContent>
-          <div className="mx-auto w-full max-w-[768px]">{children}</div>
+          <div className="mx-auto h-full w-full max-w-[768px]">{children}</div>
         </RootLayout.MainContent>
       </RootLayout.App>
     </WikiItemActionsProvider>

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -357,7 +357,7 @@ function Explorer({ dir }: { dir: string }) {
 
   return (
     <main
-      className={`h-screen overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      className={`h-full overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
     >
       <PageHeader
         title={
@@ -766,7 +766,7 @@ function NewDocView({ dir }: { dir: string }) {
 
   return (
     <main
-      className={`box-border flex h-screen flex-col gap-3 ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      className={`box-border flex h-full flex-col gap-3 ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
     >
       <PageHeader
         title="New document"
@@ -2191,7 +2191,7 @@ function FileViewer({ path }: { path: string }) {
 
   return (
     <main
-      className={`box-border flex h-screen min-h-0 flex-col ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      className={`box-border flex h-full min-h-0 flex-col ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
     >
       <header
         className={`mb-4 flex flex-wrap items-center ${isMobile ? "gap-2" : "gap-3"}`}


### PR DESCRIPTION
## Bug
Wiki page/folder/new-doc views showed **two vertical scrollbars** — an outer one and an inner one.

## Cause
The page roots used `h-screen` (100vh). They render inside Opal's `RootLayout` main slot (`.opal-root-layout__main` = `flex-1 overflow-auto`), which is already the bounded scroll area. A 100vh child overflows that slot → the slot scrolls (outer) **on top of** the page's own `<article overflow-y-auto>` (inner).

## Fix
Make the views fill the main slot with `h-full` instead of forcing `100vh`, propagated through an `h-full` content wrapper in the app layout. The main slot no longer overflows (outer scrollbar gone) and only the inner content scrolls — the breadcrumb/tabs stay pinned.

Changed: `h-screen`→`h-full` on the file view, folder view, and new-doc view; added `h-full` to the shared `max-w-[768px]` content wrapper. Frontend `tsc` clean.