### PR TITLE
fix(wiki): single Opal header + docked right panel for the doc view

### DIFF
--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -7,6 +7,10 @@ import { markdown } from "@onyx-ai/opal/utils";
 import AppSidebar from "@/sections/sidebar/AppSidebar";
 import { WikiItemActionsProvider } from "@/providers/WikiItemActionsProvider";
 import { LeftPanelProvider, useLeftPanel } from "@/providers/LeftPanelProvider";
+import {
+  WikiHeaderActionsProvider,
+  useRightPanelHost,
+} from "@/providers/WikiHeaderActionsProvider";
 import { WikiTree } from "@/components/wiki/WikiTree";
 import { WikiHeader } from "@/components/wiki/WikiHeader";
 import ActivitiesPanel from "@/components/wiki/ActivitiesPanel";
@@ -82,32 +86,49 @@ interface AppContentProps {
   children: ReactNode;
 }
 
+// Full-height right column. Wiki routes portal their side panels (History /
+// Comments / Update Policy) into this host instead of squeezing the document
+// column. We use Opal's `RootLayout.RightPanel` for the panel chrome: with no
+// slot-context provider it renders inline as a flex-row sibling of the app
+// (Root is a flex row), so it docks at the far right and is zero-width when
+// empty. Its children are a stable host div (portal target), so the panel never
+// re-renders itself into a loop the way teleporting live content would.
+function RightPanelHost() {
+  const host = useRightPanelHost();
+  return (
+    <RootLayout.RightPanel>
+      <div ref={host?.setEl} className="flex h-full" />
+    </RootLayout.RightPanel>
+  );
+}
+
 function AppContent({ children }: AppContentProps) {
   const { view, isOnWikiRoute } = useLeftPanel();
   return (
-    <WikiItemActionsProvider active={isOnWikiRoute}>
-      {view !== null && (
-        <RootLayout.LeftPanel>
-          {view === "wiki-tree" && <WikiTree />}
-          {view === "activities" && (
-            <div className="h-full p-1">
-              <ActivitiesPanel />
-            </div>
-          )}
-        </RootLayout.LeftPanel>
-      )}
-      <RootLayout.App>
-        <StatusBanner />
-        {isOnWikiRoute && (
-          <RootLayout.Header>
-            <WikiHeader />
-          </RootLayout.Header>
+    <WikiHeaderActionsProvider>
+      <WikiItemActionsProvider active={isOnWikiRoute}>
+        {view !== null && (
+          <RootLayout.LeftPanel>
+            {view === "wiki-tree" && <WikiTree />}
+            {view === "activities" && (
+              <div className="h-full p-1">
+                <ActivitiesPanel />
+              </div>
+            )}
+          </RootLayout.LeftPanel>
         )}
-        <RootLayout.MainContent>
-          <div className="mx-auto w-full max-w-[768px]">{children}</div>
-        </RootLayout.MainContent>
-      </RootLayout.App>
-    </WikiItemActionsProvider>
+        <RootLayout.App>
+          <StatusBanner />
+          {isOnWikiRoute && (
+            <RootLayout.Header>
+              <WikiHeader />
+            </RootLayout.Header>
+          )}
+          <RootLayout.MainContent>{children}</RootLayout.MainContent>
+        </RootLayout.App>
+        <RightPanelHost />
+      </WikiItemActionsProvider>
+    </WikiHeaderActionsProvider>
   );
 }
 

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import {
   useCallback,
@@ -10,6 +9,7 @@ import {
   useState,
   type FormEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import { diffLines } from "diff";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -23,21 +23,23 @@ import {
   SelectButton,
 } from "@onyx-ai/opal/components";
 import {
-  SvgArrowLeft,
+  SvgBubbleText,
   SvgChevronLeft,
   SvgChevronRight,
   SvgDocFile,
   SvgEdit,
   SvgFolder,
   SvgFolderPlus,
+  SvgHistory,
   SvgPlus,
   SvgShare,
+  SvgShield,
+  SvgSparkle,
   SvgTrash,
   SvgWorkflow,
 } from "@onyx-ai/opal/icons";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
-import { PageHeader } from "@/components/common/PageHeader";
 import { TriggerModal } from "@/components/triggers/TriggerModal";
 import { DiffView } from "@/components/wiki/DiffView";
 import { HistoryPanel } from "@/components/wiki/HistoryPanel";
@@ -62,6 +64,10 @@ import {
 import { rehypeSourcePos } from "@/lib/rehypeSourcePos";
 import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
 import { useRequireAuth } from "@/lib/auth";
+import {
+  useHeaderActionsHost,
+  useRightPanelHost,
+} from "@/providers/WikiHeaderActionsProvider";
 import { useDrafting } from "@/lib/drafting";
 import { rememberWikiPath } from "@/lib/lastViewed";
 import { recordRecentDoc } from "@/lib/recents";
@@ -172,6 +178,7 @@ export default function WikiRoute() {
 function Explorer({ dir }: { dir: string }) {
   const router = useRouter();
   const isMobile = useIsMobile();
+  const host = useHeaderActionsHost();
   const {
     data,
     error: listError,
@@ -246,8 +253,6 @@ function Explorer({ dir }: { dir: string }) {
       files: fileList.sort(cmp),
     };
   }, [entries, dir, sort]);
-
-  const segments = dir ? dir.split("/") : [];
 
   async function onCreate(e: FormEvent) {
     e.preventDefault();
@@ -355,60 +360,46 @@ function Explorer({ dir }: { dir: string }) {
     }
   }
 
+  // Folder-level actions portal into the single pinned header as icon buttons;
+  // the breadcrumb there is the shared one (WikiHeader), so this view renders
+  // no header of its own.
+  const headerActions = (
+    <>
+      <Button
+        icon={SvgWorkflow}
+        prominence="tertiary"
+        tooltip="Trigger"
+        onClick={() => setTriggerModalOpen(true)}
+      />
+      <Button
+        icon={SvgShield}
+        prominence="tertiary"
+        tooltip="Update Policy"
+        onClick={() => setPolicyOpen(true)}
+      />
+      <Button
+        icon={SvgFolderPlus}
+        prominence="tertiary"
+        tooltip="New folder"
+        onClick={() => {
+          setNewName("");
+          setCreating((v) => (v === "folder" ? null : "folder"));
+        }}
+      />
+      <Button
+        icon={SvgPlus}
+        variant="action"
+        tooltip="New document"
+        onClick={() => router.push(`/app/wiki/${dir}?new=1`)}
+      />
+    </>
+  );
+
   return (
     <main
-      className={`h-screen overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      className={`h-full overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
     >
-      <PageHeader
-        title={
-          <Breadcrumbs
-            segments={segments}
-            onDropToCrumb={(crumbPath) => {
-              if (dragSource && crumbPath !== dir)
-                onMove(dragSource, crumbPath);
-              setDragSource(null);
-              setDropTarget(null);
-            }}
-            dropTarget={dropTarget}
-            onCrumbDragOver={(crumbPath) => setDropTarget(crumbPath)}
-            onCrumbDragLeave={() => setDropTarget(null)}
-            currentDir={dir}
-          />
-        }
-        actions={
-          <>
-            {/* Same language as the doc-view header: quiet ghost buttons
-                with a single solid CTA (New document). */}
-            <Button
-              prominence="tertiary"
-              icon={SvgWorkflow}
-              onClick={() => setTriggerModalOpen(true)}
-            >
-              Trigger
-            </Button>
-            <Button prominence="tertiary" onClick={() => setPolicyOpen(true)}>
-              Update Policy
-            </Button>
-            <Button
-              prominence="tertiary"
-              icon={SvgFolderPlus}
-              onClick={() => {
-                setNewName("");
-                setCreating((v) => (v === "folder" ? null : "folder"));
-              }}
-            >
-              New folder
-            </Button>
-            <Button
-              variant="action"
-              icon={SvgPlus}
-              onClick={() => router.push(`/app/wiki/${dir}?new=1`)}
-            >
-              New document
-            </Button>
-          </>
-        }
-      />
+      {host?.el && createPortal(headerActions, host.el)}
 
       <TriggerModal
         open={triggerModalOpen}
@@ -567,6 +558,7 @@ function NewDocView({ dir }: { dir: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const isMobile = useIsMobile();
+  const host = useHeaderActionsHost();
   const { setDrafting, requestExpand, registerDraftBridge } = useDrafting();
   // "Start writing with AI" hands a generated draft (+ the prompt) here via
   // sessionStorage, paired with ?ai=1. Read it synchronously so the editor and
@@ -764,35 +756,31 @@ function NewDocView({ dir }: { dir: string }) {
     (isBlank || matchesApplied) && templates !== null && templates.length > 0;
   const parentSlug = destDir;
 
+  // Cancel / Create portal into the single pinned header; the breadcrumb there
+  // shows the destination folder, so this view renders no header of its own.
+  const headerActions = (
+    <>
+      <Button onClick={() => router.push(`/app/wiki/${dir}`)} disabled={saving}>
+        Cancel
+      </Button>
+      <Button
+        variant="action"
+        onClick={() => void onCreate()}
+        disabled={!canCreate}
+        tooltip={
+          !filenameValid && !saving ? "Give the file a name first." : undefined
+        }
+      >
+        {saving ? "Creating…" : "Create"}
+      </Button>
+    </>
+  );
+
   return (
     <main
-      className={`box-border flex h-screen flex-col gap-3 ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      className={`box-border flex h-full flex-col gap-3 ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
     >
-      <PageHeader
-        title="New document"
-        actions={
-          <>
-            <Button
-              onClick={() => router.push(`/app/wiki/${dir}`)}
-              disabled={saving}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="action"
-              onClick={() => void onCreate()}
-              disabled={!canCreate}
-              title={
-                !filenameValid && !saving
-                  ? "Give the file a name first."
-                  : undefined
-              }
-            >
-              {saving ? "Creating…" : "Create"}
-            </Button>
-          </>
-        }
-      />
+      {host?.el && createPortal(headerActions, host.el)}
 
       <div className="flex shrink-0 items-center gap-2">
         <span className="text-[13px] text-(--text-04)">Folder</span>
@@ -1259,83 +1247,12 @@ function Row({
   );
 }
 
-function Breadcrumbs({
-  segments,
-  onDropToCrumb,
-  onCrumbDragOver,
-  onCrumbDragLeave,
-  dropTarget,
-  currentDir,
-}: {
-  segments: string[];
-  onDropToCrumb?: (crumbPath: string) => void;
-  onCrumbDragOver?: (crumbPath: string) => void;
-  onCrumbDragLeave?: () => void;
-  dropTarget?: string | null;
-  currentDir?: string;
-}) {
-  // Use a sentinel for the root crumb so we can track its drop state without
-  // collision with a real path of "".
-  const ROOT = "__root__";
-  const crumbs = [{ label: "Wiki", href: "/app/wiki", path: "" }];
-  segments.forEach((seg, i) => {
-    const path = segments.slice(0, i + 1).join("/");
-    crumbs.push({ label: seg, href: `/app/wiki/${path}`, path });
-  });
-  return (
-    <nav className="flex flex-wrap items-center gap-1.5 text-sm">
-      {crumbs.map((c, i) => {
-        const last = i === crumbs.length - 1;
-        const targetKey = c.path === "" ? ROOT : c.path;
-        const droppable = onDropToCrumb && c.path !== currentDir;
-        const active = !!droppable && dropTarget === targetKey;
-        const dropHandlers: Record<string, unknown> = droppable
-          ? {
-              onDragOver: (e: React.DragEvent) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                onCrumbDragOver?.(targetKey);
-              },
-              onDragLeave: () => onCrumbDragLeave?.(),
-              onDrop: (e: React.DragEvent) => {
-                e.preventDefault();
-                onDropToCrumb?.(c.path);
-              },
-            }
-          : {};
-        const activeClass = active
-          ? "bg-(--background-tint-03) outline outline-2 outline-(--background-tint-inverted-00) rounded-(--border-radius-04) py-[2px] px-[6px]"
-          : "";
-        return (
-          <span key={c.href} className="flex items-center gap-1.5">
-            {i > 0 && <span className="text-(--text-02)">/</span>}
-            {last ? (
-              <span
-                className={`font-semibold ${activeClass}`}
-                {...dropHandlers}
-              >
-                {c.label}
-              </span>
-            ) : (
-              <Link
-                href={c.href}
-                className={`text-(--text-05) underline ${activeClass}`}
-                {...dropHandlers}
-              >
-                {c.label}
-              </Link>
-            )}
-          </span>
-        );
-      })}
-    </nav>
-  );
-}
-
 function FileViewer({ path }: { path: string }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const isMobile = useIsMobile();
+  const host = useHeaderActionsHost();
+  const rightHost = useRightPanelHost();
   const { setDrafting, requestExpand } = useDrafting();
   const [body, setBody] = useState("");
   const [draft, setDraft] = useState("");
@@ -1390,7 +1307,13 @@ function FileViewer({ path }: { path: string }) {
     try {
       const t = await listComments(path);
       setCommentThreads(t);
-      if (t.length > 0 && autoOpenedPathRef.current !== path) {
+      // Auto-open once per page only when something needs attention — i.e. an
+      // unresolved thread (open or orphaned, matching the panel's main list).
+      // A page whose comments are all resolved stays closed.
+      const hasUnresolved = t.some(
+        (thread) => thread.root.status !== "resolved",
+      );
+      if (hasUnresolved && autoOpenedPathRef.current !== path) {
         autoOpenedPathRef.current = path;
         openComments();
       }
@@ -1883,7 +1806,6 @@ function FileViewer({ path }: { path: string }) {
 
   const segments = path.split("/");
   const parentSlug = segments.slice(0, -1).join("/");
-  const backHref = parentSlug ? `/app/wiki/${parentSlug}` : "/app/wiki";
   const currentBasename = segments[segments.length - 1] ?? path;
   const currentBasenameNoExt = currentBasename.replace(/\.md$/i, "");
   const trimmedFilename = filenameDraft.trim().replace(/^\/+|\/+$/g, "");
@@ -2189,99 +2111,81 @@ function FileViewer({ path }: { path: string }) {
     }).catch(() => {});
   }
 
+  // Page actions live in the single pinned header (WikiHeader), not a second
+  // header inside the scroll area — they portal into its right-aligned slot.
+  // The panel toggles are icon SelectButtons so the open panel shows the
+  // selected tint; the others are tertiary icon Buttons with the lone solid
+  // CTA (Edit). Editing swaps in labelled Cancel / Save for clarity.
+  const headerActions = editing ? (
+    <>
+      <Button onClick={onCancel} disabled={saving}>
+        Cancel
+      </Button>
+      <Button variant="action" onClick={onSave} disabled={saving || !dirty}>
+        {saving ? "Saving…" : "Save"}
+      </Button>
+    </>
+  ) : !loading && !error ? (
+    <>
+      <Button
+        icon={SvgSparkle}
+        prominence="tertiary"
+        tooltip="Run Agent"
+        onClick={() => setRunAgentOpen(true)}
+      />
+      <Button
+        icon={SvgWorkflow}
+        prominence="tertiary"
+        tooltip="Trigger"
+        onClick={() => setTriggerModalOpen(true)}
+      />
+      <Button
+        icon={SvgShare}
+        prominence="tertiary"
+        tooltip="Share"
+        onClick={() => setShareOpen(true)}
+      />
+      <SelectButton
+        icon={SvgHistory}
+        state={historyOpen ? "selected" : "empty"}
+        tooltip="History"
+        onClick={toggleHistory}
+      />
+      <SelectButton
+        icon={SvgBubbleText}
+        state={commentsOpen ? "selected" : "empty"}
+        tooltip="Comments"
+        onClick={() => (commentsOpen ? setCommentsOpen(false) : openComments())}
+      />
+      <SelectButton
+        icon={SvgShield}
+        state={policyOpen ? "selected" : "empty"}
+        tooltip="Update Policy"
+        onClick={() => {
+          if (policyOpen) {
+            setPolicyOpen(false);
+            return;
+          }
+          setHistoryOpen(false);
+          setCommentsOpen(false);
+          setCommentDraft(null);
+          setPolicyOpen(true);
+        }}
+      />
+      <Button
+        icon={SvgEdit}
+        variant="action"
+        tooltip="Edit"
+        onClick={startEdit}
+      />
+    </>
+  ) : null;
+
   return (
     <main
-      className={`box-border flex h-screen min-h-0 flex-col ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      className={`box-border flex h-full min-h-0 flex-col ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
     >
-      <header
-        className={`mb-4 flex flex-wrap items-center ${isMobile ? "gap-2" : "gap-3"}`}
-      >
-        <Link
-          href={backHref}
-          title="Back"
-          aria-label="Back"
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-(--border-radius-08) border border-(--border-01) text-(--text-04) no-underline"
-        >
-          <SvgArrowLeft size={18} />
-        </Link>
-        <Breadcrumbs segments={segments} />
-        <div className="flex-1" />
-        {!editing && !loading && !error && (
-          <>
-            {/* Ghost buttons: transparent at rest, tint-02 on hover — the
-                one solid CTA in the header is Edit. The two panel toggles
-                are SelectButtons so the open panel shows the selected tint;
-                empty-state SelectButton hovers identically to a tertiary
-                Button, so the row reads as one style. */}
-            <div className="flex gap-2">
-              <Button
-                prominence="tertiary"
-                onClick={() => setRunAgentOpen(true)}
-              >
-                Run Agent
-              </Button>
-              <Button
-                prominence="tertiary"
-                icon={SvgWorkflow}
-                onClick={() => setTriggerModalOpen(true)}
-              >
-                Trigger
-              </Button>
-            </div>
-            <div className="flex gap-2">
-              <Button prominence="tertiary" onClick={() => setShareOpen(true)}>
-                Share
-              </Button>
-              <SelectButton
-                state={historyOpen ? "selected" : "empty"}
-                onClick={toggleHistory}
-              >
-                History
-              </SelectButton>
-              <SelectButton
-                state={commentsOpen ? "selected" : "empty"}
-                onClick={() =>
-                  commentsOpen ? setCommentsOpen(false) : openComments()
-                }
-              >
-                Comments
-              </SelectButton>
-              <SelectButton
-                state={policyOpen ? "selected" : "empty"}
-                onClick={() => {
-                  if (policyOpen) {
-                    setPolicyOpen(false);
-                    return;
-                  }
-                  setHistoryOpen(false);
-                  setCommentsOpen(false);
-                  setCommentDraft(null);
-                  setPolicyOpen(true);
-                }}
-              >
-                Update Policy
-              </SelectButton>
-            </div>
-            <Button variant="action" onClick={startEdit}>
-              Edit
-            </Button>
-          </>
-        )}
-        {editing && (
-          <>
-            <Button onClick={onCancel} disabled={saving}>
-              Cancel
-            </Button>
-            <Button
-              variant="action"
-              onClick={onSave}
-              disabled={saving || !dirty}
-            >
-              {saving ? "Saving…" : "Save"}
-            </Button>
-          </>
-        )}
-      </header>
+      {host?.el && headerActions && createPortal(headerActions, host.el)}
 
       {!editing && (
         <ActiveAgentsBar
@@ -2477,111 +2381,151 @@ function FileViewer({ path }: { path: string }) {
       {loading && <LoadingSpinner />}
 
       {!loading && !error && (
-        <div className="flex min-h-0 flex-1 gap-4">
-          <div className="flex min-w-0 flex-1 flex-col gap-3">
-            {editing ? (
-              <>
-                <FilenameRow
-                  parent={parentSlug}
-                  value={filenameDraft}
-                  onChange={setFilenameDraft}
-                  disabled={saving}
-                />
-                {(() => {
-                  // Cards visible while the body is still "empty enough"
-                  // to discard without losing user work: truly blank, or
-                  // still verbatim equal to the template the user just
-                  // applied (so they can keep swapping templates).
-                  const isBlank = draft.trim() === "";
-                  const matchesApplied =
-                    appliedTemplateBody !== null &&
-                    draft === appliedTemplateBody;
-                  const showGallery =
-                    (isBlank || matchesApplied) &&
-                    templates !== null &&
-                    templates.length > 0;
-                  if (!showGallery) return null;
-                  return (
-                    <TemplateGallery
-                      templates={templates!}
-                      activeId={matchesApplied ? appliedTemplateId : null}
-                      applyingId={applyingTemplateId}
-                      blankActive={isBlank && appliedTemplateId === null}
-                      onPick={(t) => void onPickTemplate(t)}
-                      onBlank={() => void onPickBlank()}
+        <>
+          {editing || (viewingVersion && diffData) ? (
+            // Editor / diff: fixed-height, capped + centered column with its own
+            // internal scroll (you edit against a pinned viewport, not a growing
+            // page).
+            <div className="flex min-h-0 flex-1 justify-center">
+              <div className="flex w-full max-w-[768px] min-w-0 flex-col gap-3">
+                {editing ? (
+                  <>
+                    <FilenameRow
+                      parent={parentSlug}
+                      value={filenameDraft}
+                      onChange={setFilenameDraft}
+                      disabled={saving}
                     />
-                  );
-                })()}
-                <textarea
-                  value={draft}
-                  onChange={(e) => setDraft(e.target.value)}
-                  spellCheck={false}
-                  placeholder="Start typing, or pick a template above…"
-                  className="box-border min-h-0 w-full flex-1 resize-none rounded-(--border-radius-08) border border-(--border-01) p-4 font-mono text-sm leading-[1.6] outline-none"
-                />
-              </>
-            ) : viewingVersion && diffData ? (
-              <div className="flex min-h-0 flex-1 overflow-hidden">
-                <DiffView
-                  data={diffData}
-                  commit={
-                    commits?.find((c) => c.sha === viewingSha) ?? undefined
-                  }
-                  loadBody={async () => {
-                    const sha = viewingSha;
-                    if (!sha) return "";
-                    const r = await apiFetch<FileResponse>(
-                      `/wiki/file?path=${encodeURIComponent(
-                        path,
-                      )}&ref=${encodeURIComponent(sha)}`,
-                    );
-                    return r.body;
-                  }}
-                />
+                    {(() => {
+                      // Cards visible while the body is still "empty enough"
+                      // to discard without losing user work: truly blank, or
+                      // still verbatim equal to the template the user just
+                      // applied (so they can keep swapping templates).
+                      const isBlank = draft.trim() === "";
+                      const matchesApplied =
+                        appliedTemplateBody !== null &&
+                        draft === appliedTemplateBody;
+                      const showGallery =
+                        (isBlank || matchesApplied) &&
+                        templates !== null &&
+                        templates.length > 0;
+                      if (!showGallery) return null;
+                      return (
+                        <TemplateGallery
+                          templates={templates!}
+                          activeId={matchesApplied ? appliedTemplateId : null}
+                          applyingId={applyingTemplateId}
+                          blankActive={isBlank && appliedTemplateId === null}
+                          onPick={(t) => void onPickTemplate(t)}
+                          onBlank={() => void onPickBlank()}
+                        />
+                      );
+                    })()}
+                    <textarea
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      spellCheck={false}
+                      placeholder="Start typing, or pick a template above…"
+                      className="box-border min-h-0 w-full flex-1 resize-none rounded-(--border-radius-08) border border-(--border-01) p-4 font-mono text-sm leading-[1.6] outline-none"
+                    />
+                  </>
+                ) : (
+                  <div className="flex min-h-0 flex-1 overflow-hidden">
+                    <DiffView
+                      data={diffData!}
+                      commit={
+                        commits?.find((c) => c.sha === viewingSha) ?? undefined
+                      }
+                      loadBody={async () => {
+                        const sha = viewingSha;
+                        if (!sha) return "";
+                        const r = await apiFetch<FileResponse>(
+                          `/wiki/file?path=${encodeURIComponent(
+                            path,
+                          )}&ref=${encodeURIComponent(sha)}`,
+                        );
+                        return r.body;
+                      }}
+                    />
+                  </div>
+                )}
               </div>
-            ) : (
+            </div>
+          ) : (
+            // Render mode: the whole main-content area scrolls with the
+            // scrollbar flush at the far right edge (the negative margin cancels
+            // <main>'s horizontal padding, re-applied inside so the text keeps
+            // its gutter); the article text stays capped + centered.
+            <div
+              className={`min-h-0 flex-1 overflow-y-auto ${isMobile ? "-mx-3 px-3" : "-mx-8 px-8"}`}
+            >
               <article
                 ref={articleRef}
-                className="markdown min-h-0 flex-1 overflow-y-auto"
+                className="markdown mx-auto w-full max-w-[768px]"
                 onMouseUp={onArticleMouseUp}
               >
                 {renderedBody}
               </article>
+            </div>
+          )}
+          {/* Desktop side panels dock at the app's right edge (full height,
+              beside the header) by portaling into the shell's right-panel host,
+              so they never eat into the reading column above. Mobile keeps the
+              fixed sheet rendered below. */}
+          {historyOpen &&
+            !isMobile &&
+            rightHost?.el &&
+            createPortal(
+              <div className="flex h-full w-[400px] border-l border-(--border-01)">
+                <HistoryPanel
+                  commits={commits}
+                  error={historyError}
+                  headSha={headSha}
+                  viewingSha={viewingSha}
+                  onPick={onPickCommit}
+                  onClose={closeHistory}
+                  fullHeight
+                />
+              </div>,
+              rightHost.el,
             )}
-          </div>
-          {historyOpen && !isMobile && (
-            <HistoryPanel
-              commits={commits}
-              error={historyError}
-              headSha={headSha}
-              viewingSha={viewingSha}
-              onPick={onPickCommit}
-              onClose={closeHistory}
-            />
-          )}
-          {commentsOpen && !isMobile && (
-            <CommentsPanel
-              path={path}
-              headSha={headSha}
-              draft={commentDraft}
-              threads={commentThreads}
-              onChanged={refreshComments}
-              activeId={activeCommentId}
-              onActivate={activateComment}
-              onDraftConsumed={() => setCommentDraft(null)}
-              onClose={() => {
-                setCommentsOpen(false);
-                setCommentDraft(null);
-              }}
-            />
-          )}
-          {policyOpen && !isMobile && (
-            <UpdatePolicyPanel
-              path={path}
-              onClose={() => setPolicyOpen(false)}
-            />
-          )}
-        </div>
+          {commentsOpen &&
+            !isMobile &&
+            rightHost?.el &&
+            createPortal(
+              <div className="flex h-full w-[400px] border-l border-(--border-01)">
+                <CommentsPanel
+                  path={path}
+                  headSha={headSha}
+                  draft={commentDraft}
+                  threads={commentThreads}
+                  onChanged={refreshComments}
+                  activeId={activeCommentId}
+                  onActivate={activateComment}
+                  onDraftConsumed={() => setCommentDraft(null)}
+                  onClose={() => {
+                    setCommentsOpen(false);
+                    setCommentDraft(null);
+                  }}
+                  fullHeight
+                />
+              </div>,
+              rightHost.el,
+            )}
+          {policyOpen &&
+            !isMobile &&
+            rightHost?.el &&
+            createPortal(
+              <div className="flex h-full w-[400px] border-l border-(--border-01)">
+                <UpdatePolicyPanel
+                  path={path}
+                  onClose={() => setPolicyOpen(false)}
+                  fullHeight
+                />
+              </div>,
+              rightHost.el,
+            )}
+        </>
       )}
       {historyOpen && isMobile && (
         // Mobile: render history as a fixed slide-in sheet over the

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -5,6 +5,7 @@ import { Button } from "@onyx-ai/opal/components";
 import { SvgFolder } from "@onyx-ai/opal/icons";
 import { useAppFocus } from "@/hooks/useAppFocus";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
+import { useHeaderActionsHost } from "@/providers/WikiHeaderActionsProvider";
 
 function segmentLabel(segment: string): string {
   return segment.replace(/\.md$/, "").replace(/_/g, " ");
@@ -14,6 +15,7 @@ export function WikiHeader() {
   const { view, toggleTree } = useLeftPanel();
   const treeVisible = view === "wiki-tree";
   const { wikiPath } = useAppFocus();
+  const host = useHeaderActionsHost();
 
   const segments = wikiPath ? wikiPath.split("/") : [];
   const crumbs: Array<{ label: string; href: string }> = [
@@ -54,6 +56,10 @@ export function WikiHeader() {
           );
         })}
       </nav>
+      {/* Page-level actions portal here from the active wiki route (see
+          WikiHeaderActionsProvider). Pushed right by the flex spacer. */}
+      <div className="flex-1" />
+      <div ref={host?.setEl} className="flex items-center gap-1" />
     </div>
   );
 }

--- a/frontend/src/providers/WikiHeaderActionsProvider.tsx
+++ b/frontend/src/providers/WikiHeaderActionsProvider.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+// Lets a wiki route render page-level chrome into the shared app shell instead
+// of duplicating it inside the scrollable content:
+//
+//   - header actions  → the single pinned header (`WikiHeader`)
+//   - side panels     → a permanent right column (sibling of the main content)
+//
+// Each surface exposes a host DOM element through context; routes portal their
+// content into it (see `useHeaderActionsHost` / `useRightPanelHost`). A portal —
+// rather than passing the nodes up as context state — keeps the content
+// re-rendering live with the route's own state without bouncing updates back
+// through the provider (which would loop).
+interface ChromeHost {
+  /** The host element, or null before it mounts. */
+  el: HTMLElement | null;
+  /** Ref callback the shell passes to its host element. */
+  setEl: (el: HTMLElement | null) => void;
+}
+
+const HeaderActionsContext = createContext<ChromeHost | null>(null);
+const RightPanelContext = createContext<ChromeHost | null>(null);
+
+export function WikiHeaderActionsProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [headerEl, setHeaderEl] = useState<HTMLElement | null>(null);
+  const [rightEl, setRightEl] = useState<HTMLElement | null>(null);
+  return (
+    <HeaderActionsContext.Provider value={{ el: headerEl, setEl: setHeaderEl }}>
+      <RightPanelContext.Provider value={{ el: rightEl, setEl: setRightEl }}>
+        {children}
+      </RightPanelContext.Provider>
+    </HeaderActionsContext.Provider>
+  );
+}
+
+/** Read the pinned-header actions host. Null outside the provider. */
+export function useHeaderActionsHost(): ChromeHost | null {
+  return useContext(HeaderActionsContext);
+}
+
+/** Read the right-column panel host. Null outside the provider. */
+export function useRightPanelHost(): ChromeHost | null {
+  return useContext(RightPanelContext);
+}


### PR DESCRIPTION
## Problem

The Opal `RootLayout` migration wrapped every wiki route in a centered `max-w-[768px]` column. But `FileViewer` is a full-bleed surface whose History/Comments/Update-Policy panels were **flex siblings of the article**, so capping that whole row produced a large empty gap on the left and **truncated the document** whenever a 400px panel opened. The pinned `WikiHeader` also showed a breadcrumb that **duplicated** `FileViewer`'s own header.

| Before | |
|---|---|
| Big left gap; doc text cut off under the History panel; two breadcrumbs. | |

## Changes

**Single pinned header.** Page actions (Run Agent, Trigger, Share, History, Comments, Update Policy, Edit) now live in the one pinned `WikiHeader` as Opal **icon `Button`/`SelectButton`s** (panel toggles show the selected tint). They travel there from each route via a small `WikiHeaderActionsProvider` portal host — the same loop-free pattern in both directions. `FileViewer`, `Explorer`, and `NewDocView` drop their own headers/breadcrumbs (and the now-dead `Breadcrumbs` component + `PageHeader`/`Link`/`SvgArrowLeft` imports).

**Docked right column.** History / Comments / Update Policy dock as a **full-height right column** using Opal's `RootLayout.RightPanel` (rendered inline with a *stable* host `<div>`; routes `createPortal` their live panel content into it, so the panel never re-renders itself into a loop). They no longer eat into the reading column.

**Full-width scroll, capped text.** In render mode the **whole main-content area scrolls with the scrollbar flush at the right edge**, while the article text stays capped at 768px and centered. `h-screen` → `h-full` so the main fills the slot beneath the new pinned header instead of over-counting its height. Editor/diff modes keep their fixed-height internal-scroll column.

**Comments auto-open.** On load the Comments panel auto-opens **only when a thread is unresolved** (open or orphaned — matching the panel's main list). Pages whose comments are all resolved stay closed.

## Opal leverage

All actionable UI uses Opal: `Button`/`SelectButton` (+ tooltips), `RootLayout` shell (`App`/`Header`/`MainContent`/`LeftPanel`/**`RightPanel`**), and design tokens throughout. The only custom pieces are two structural portal hosts (header actions + right panel), which is what lets live route state render into the shared shell without a render loop.

## Notes / follow-ups

- **Mobile** keeps the existing fixed slide-in sheet for panels (a docked column would swallow a phone screen); only desktop docks.
- **Minor regression:** Explorer's old breadcrumb was a drag-drop target (drop a row onto a parent crumb to move it up). Dropping the breadcrumb removes that target; dragging onto folder rows still works. Easy to restore if wanted.
- `Update Policy` uses a shield icon — happy to swap.

## Testing
<img width="960" height="500" alt="Screenshot 2026-06-17 at 11 36 57 AM" src="https://github.com/user-attachments/assets/adff80a8-2651-496c-b4ff-2ef37b09c676" />
<img width="1900" height="1028" alt="Screenshot 2026-06-17 at 11 36 46 AM" src="https://github.com/user-attachments/assets/5578b6ed-8062-4052-bcdc-b7c94ce50ecf" />
<img width="940" height="506" alt="Screenshot 2026-06-17 at 11 38 19 AM" src="https://github.com/user-attachments/assets/1c2f6e5b-b458-452c-9a09-b06e47e89bf9" />


`bun run typecheck` passes; prettier clean. Built the frontend image and verified the app serves cleanly (no runtime errors) at all wiki routes. Visual confirmation done in-browser against the running stack.

