### PR TITLE
fix(wiki): home page fills the layout slot (kills double scrollbar)

### DIFF
--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -3,8 +3,11 @@
    Section). These classes are layout-only — column width, the card grids, the
    gutter offset, and the masked markdown preview (which has no OPAL primitive). */
 
+/* Fill the RootLayout main slot (which sits below the pinned header), not the
+   whole viewport — otherwise this scroller + the slot's own overflow stack into
+   two scrollbars. */
 .scroll {
-  height: 100vh;
+  height: 100%;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Problem

The Wiki home (`WikiHome`) showed **two vertical scrollbars**.

`WikiHome`'s `.scroll` container was `height: 100vh; overflow-y: auto`, nested inside Opal's `RootLayout` main slot (`opal-root-layout__main`, itself `flex-1 overflow-auto`). Since the pinned `WikiHeader` now sits *above* that slot, `100vh` over-counts the available height by the header — so `.scroll` overflows the slot and **both** scroll: the slot (outer scrollbar) and `.scroll` (inner scrollbar).

## Fix

`height: 100vh` → `height: 100%` so `.scroll` fills the layout slot exactly. Only `.scroll` scrolls (one scrollbar, flush at the right edge); the slot no longer overflows.

This is the CSS-module twin of the `h-screen` → `h-full` change from #250 — same "fill the slot beneath the pinned header, don't assume the full viewport" rule.

## Testing

Built the frontend image and verified the home page renders with a single scrollbar; `/app/wiki` serves cleanly.

before fix
<img width="1375" height="920" alt="Screenshot 2026-06-17 at 12 29 18 PM" src="https://github.com/user-attachments/assets/41c15c84-c43e-4244-babe-923263f97d51" />
after fix 
<img width="1188" height="888" alt="Screenshot 2026-06-17 at 12 29 33 PM" src="https://github.com/user-attachments/assets/d3790782-9111-4127-bac2-ce85e00fc226" />
