### PR TITLE
feat(security): encrypt LLM/web/braintrust/ingest API keys at rest

### DIFF
--- a/backend/app/db/migrations/versions/0030_encrypt_secret_columns.py
+++ b/backend/app/db/migrations/versions/0030_encrypt_secret_columns.py
@@ -1,0 +1,117 @@
+"""encrypt provider/secret columns at rest
+
+Converts the plaintext secret columns on the singleton settings tables from
+``text`` to AES-GCM-encrypted ``bytea`` (``app/db/crypto.py:EncryptedString``):
+
+- ``llm_settings``: anthropic_api_key, openai_api_key, gemini_api_key, custom_api_key
+- ``web_settings``: serper_api_key, firecrawl_api_key
+- ``ingest_settings``: api_key (nullable)
+- ``braintrust_settings``: api_key
+
+Each column is migrated in place — its name is preserved. Because Postgres can't
+cast ``text`` -> ``bytea`` with the per-value encrypt step inline, we add a
+scratch ``bytea`` column, encrypt every existing value into it in Python, drop
+the old column, and rename the scratch column back. The settings tables are
+singletons (one row at most), so the data step is trivial in volume.
+
+Fresh installs get these columns as ``bytea`` directly from ``0001_initial``'s
+``Base.metadata.create_all`` against the current model registry, so each column
+is guarded on the live inspector and skipped when it's already ``bytea`` (same
+no-op-on-fresh-DB pattern as the other post-0001 migrations).
+
+Encryption is keyed by ``SECRET_KEY`` (see ``app/db/crypto.py``); it must be set
+and stable across this migration and all later reads, exactly as for the
+already-encrypted ``slack_webhooks.webhook_url``.
+
+Revision ID: 0030
+Revises: 4322ff468239
+Create Date: 2026-06-17 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.crypto import decrypt_string, encrypt_string
+
+
+revision: str = "0030"
+down_revision: str | None = "4322ff468239"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# (table, column, nullable) for every secret column being encrypted.
+_SECRET_COLUMNS: list[tuple[str, str, bool]] = [
+    ("llm_settings", "anthropic_api_key", False),
+    ("llm_settings", "openai_api_key", False),
+    ("llm_settings", "gemini_api_key", False),
+    ("llm_settings", "custom_api_key", False),
+    ("web_settings", "serper_api_key", False),
+    ("web_settings", "firecrawl_api_key", False),
+    ("ingest_settings", "api_key", True),
+    ("braintrust_settings", "api_key", False),
+]
+
+
+def _column_is_bytea(bind: sa.engine.Connection, table: str, column: str) -> bool:
+    inspector = sa.inspect(bind)
+    if table not in inspector.get_table_names():
+        # Table not created yet — nothing for this migration to do.
+        return True
+    for col in inspector.get_columns(table):
+        if col["name"] == column:
+            return isinstance(col["type"], sa.LargeBinary)
+    return True  # column absent — leave it to create_all
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    for table, column, nullable in _SECRET_COLUMNS:
+        if _column_is_bytea(bind, table, column):
+            continue  # fresh install already has bytea
+
+        scratch = f"_{column}_enc"
+        op.add_column(table, sa.Column(scratch, sa.LargeBinary, nullable=True))
+        rows = bind.execute(
+            sa.text(f'SELECT id, "{column}" AS val FROM {table}')
+        ).fetchall()
+        for row_id, value in rows:
+            if value is None:
+                continue  # preserve NULL (nullable columns)
+            bind.execute(
+                sa.text(f'UPDATE {table} SET "{scratch}" = :v WHERE id = :id'),
+                {"v": encrypt_string(value), "id": row_id},
+            )
+        op.drop_column(table, column)
+        op.alter_column(table, scratch, new_column_name=column)
+        if not nullable:
+            op.alter_column(table, column, nullable=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    for table, column, nullable in _SECRET_COLUMNS:
+        if not _column_is_bytea(bind, table, column):
+            continue  # already text (or absent)
+
+        scratch = f"_{column}_txt"
+        op.add_column(table, sa.Column(scratch, sa.Text, nullable=True))
+        rows = bind.execute(
+            sa.text(f'SELECT id, "{column}" AS val FROM {table}')
+        ).fetchall()
+        for row_id, value in rows:
+            if value is None:
+                continue
+            bind.execute(
+                sa.text(f'UPDATE {table} SET "{scratch}" = :v WHERE id = :id'),
+                {"v": decrypt_string(bytes(value)), "id": row_id},
+            )
+        op.drop_column(table, column)
+        op.alter_column(table, scratch, new_column_name=column)
+        if not nullable:
+            op.alter_column(
+                table, column, nullable=False, server_default=sa.text("''")
+            )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -673,8 +673,8 @@ class LLMSettings(Base):
     provider: Mapped[str] = mapped_column(Text, nullable=False)
     model: Mapped[str] = mapped_column(Text, nullable=False)
     # Secrets — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
-    # No server_default: the ``bytea`` storage can't carry a text '' default;
-    # ``upsert`` always supplies a value (same shape as SlackWebhook.webhook_url).
+    # No server_default: bytea can't carry a text '' default; every upsert path
+    # supplies all four key columns explicitly before the session commits.
     anthropic_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     openai_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     gemini_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -672,21 +672,16 @@ class LLMSettings(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
     provider: Mapped[str] = mapped_column(Text, nullable=False)
     model: Mapped[str] = mapped_column(Text, nullable=False)
-    anthropic_api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
-    openai_api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
-    gemini_api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
+    # Secrets — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+    # No server_default: the ``bytea`` storage can't carry a text '' default;
+    # ``upsert`` always supplies a value (same shape as SlackWebhook.webhook_url).
+    anthropic_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    openai_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    gemini_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     ollama_base_url: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("''")
     )
-    custom_api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
+    custom_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     custom_base_url: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("''")
     )
@@ -710,12 +705,9 @@ class WebSettings(Base):
     __tablename__ = "web_settings"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
-    serper_api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
-    firecrawl_api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
+    # Secrets — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+    serper_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    firecrawl_api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     updated_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
@@ -730,7 +722,8 @@ class IngestSettings(Base):
     max_doc_chars: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("100000")
     )
-    api_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+    api_key: Mapped[str | None] = mapped_column(EncryptedString(), nullable=True)
     updated_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
@@ -745,9 +738,8 @@ class BraintrustSettings(Base):
     project: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("''")
     )
-    api_key: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=text("''")
-    )
+    # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+    api_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
     )

--- a/backend/tests/test_encrypt_secret_columns_migration.py
+++ b/backend/tests/test_encrypt_secret_columns_migration.py
@@ -1,0 +1,74 @@
+"""0030 data migration: existing plaintext secret columns are encrypted in place.
+
+Normal test schemas get the secret columns as ``bytea`` straight from
+``0001_initial``'s ``create_all``, so the text->bytea conversion branch never
+runs there. This test reproduces a pre-0030 database — text columns holding
+plaintext — by rewinding ``llm_settings`` and the alembic stamp, then runs the
+real ``init_db()`` (``alembic upgrade head``) so ``0030`` actually converts the
+data.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from app.db.crypto import decrypt_string
+from app.db.session import init_db, session
+from app.llm import settings as llm_settings
+
+_PLAINTEXT = "sk-ant-PLAINTEXTKEY-0123456789abcdef"
+
+
+def _rewind_to_text_with_plaintext() -> None:
+    """Drop the encrypted columns, re-add them as text, seed plaintext, and
+    move the alembic stamp back to the pre-0030 revision."""
+    with session() as s:
+        for col in (
+            "anthropic_api_key",
+            "openai_api_key",
+            "gemini_api_key",
+            "custom_api_key",
+        ):
+            s.execute(sa.text(f"ALTER TABLE llm_settings DROP COLUMN {col}"))
+            s.execute(
+                sa.text(
+                    f"ALTER TABLE llm_settings ADD COLUMN {col} text NOT NULL DEFAULT ''"
+                )
+            )
+        s.execute(
+            sa.text("UPDATE llm_settings SET anthropic_api_key = :v WHERE id = 1"),
+            {"v": _PLAINTEXT},
+        )
+        s.execute(sa.text("UPDATE alembic_version SET version_num = '4322ff468239'"))
+
+
+def test_existing_plaintext_is_encrypted_in_place(tmp_db: object) -> None:
+    # Seed a configured row (encrypted columns), then rewind to the pre-0030
+    # plaintext-text shape.
+    llm_settings.upsert(
+        provider="anthropic",
+        model="claude-opus-4-8",
+        anthropic_api_key="placeholder",
+        openai_api_key="",
+        gemini_api_key="",
+        ollama_base_url="",
+        custom_api_key="",
+        custom_base_url="",
+        custom_display_name="",
+    )
+    _rewind_to_text_with_plaintext()
+
+    # Re-run the bootstrapper — only 0030 is pending now.
+    init_db()
+
+    # Stored bytes are ciphertext, not the plaintext, and decrypt back to it.
+    with session() as s:
+        raw = s.execute(
+            sa.text("SELECT anthropic_api_key FROM llm_settings WHERE id = 1")
+        ).scalar_one()
+    raw_bytes = bytes(raw)
+    assert raw_bytes != _PLAINTEXT.encode()
+    assert len(raw_bytes) > len(_PLAINTEXT)  # nonce + GCM tag overhead
+    assert decrypt_string(raw_bytes) == _PLAINTEXT
+
+    # And the repo reads the original value back transparently.
+    assert llm_settings.get().anthropic_api_key == _PLAINTEXT


### PR DESCRIPTION
## Problem

The provider API keys on the singleton settings tables were stored as **plaintext `text` columns** in Postgres. A DB dump, read replica, backup, or any `SELECT` exposed them verbatim — the only protection was the API-layer redaction hint on `GET`. The sibling incident [Cloud LLM API Key Leak (2026-06-16)](https://github.com/onyx-dot-app/agent-wiki) is a reminder these keys are actively targeted; this closes the at-rest gap with defense-in-depth.

## Change

Switch the eight secret columns to `EncryptedString()` (AES-256-GCM, the same machinery already used for `slack_webhooks.webhook_url`):

- `llm_settings`: `anthropic_api_key`, `openai_api_key`, `gemini_api_key`, `custom_api_key`
- `web_settings`: `serper_api_key`, `firecrawl_api_key`
- `braintrust_settings`: `api_key`
- `ingest_settings`: `api_key`

`ollama_base_url` / `custom_base_url` stay `text` (not secrets). The `''` server-defaults are dropped — `bytea` can't carry a text default, and every insert path supplies a value anyway.

**Migration `0030_encrypt_secret_columns`** converts existing rows in place (`text` → encrypted `bytea`, encrypting each value in Python, **column names preserved**), guarded per-column to no-op on fresh installs where `0001`'s `create_all` already produced `bytea`. Symmetric `downgrade` decrypts back to `text`; NULLs preserved for the nullable `ingest_settings.api_key`.

Repos (`app/llm/settings.py`, `app/web/settings.py`, `app/tracing/settings.py`, `app/ingest/settings.py`) and the admin redaction layer are **unchanged** — encryption is transparent at the column boundary.

## Testing

- New `tests/test_encrypt_secret_columns_migration.py` reproduces a real pre-0030 DB (rewinds `llm_settings` to `text` + plaintext, resets the alembic stamp) then runs `init_db()` so the actual conversion executes — asserts ciphertext at rest, decrypt round-trip, and transparent repo read.
- Whole-project basedpyright clean, ruff clean, 110 tests pass (settings / admin / credential-masking / ingest / slack / web / tracing + the new migration test).

## Deploy note

`0030` encrypts using `SECRET_KEY`, so it must be set and stable before the migration runs — same caveat that already governs `slack_webhooks`. A startup guard rejecting the `dev-secret` default in prod is the planned follow-up (Change 2 in `design/Secret Handling.md`).