### PR TITLE
feat(security): refuse to boot prod on the default/empty SECRET_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,11 @@
 FLASK_ENV=development
 SECRET_KEY=change-me
 
+# Local dev / CI only. Leave UNSET in production: with it off, the app refuses
+# to boot on an unset/default SECRET_KEY (which would make cookies forgeable and
+# at-rest encryption worthless). Setting it true downgrades that to a warning.
+DEV_MODE=true
+
 # Where the wiki git repo lives. Relative paths are resolved against the
 # repo root (see `app/config.py`), so this works regardless of the launch
 # cwd. Compose overrides this to `/data/wiki` for in-container runs.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,11 @@ class Config(BaseModel):
     # `True` when the app is served over HTTPS — toggles SESSION_COOKIE_SECURE.
     secure_cookies: bool
 
+    # `True` only in local dev / CI. Production must leave it false (the
+    # default) — it's the opt-in that downgrades verify_secret_key() from
+    # fatal to a warning.
+    dev_mode: bool
+
     # Ingest pipeline tuning
     ingest_bm25_min_score: float
     ingest_bm25_title_boost: float
@@ -146,6 +151,7 @@ def load_config() -> Config:
         ingest_eval_logging=os.environ.get("INGEST_EVAL_LOGGING", "false").lower()
         in {"1", "true", "yes"},
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
+        dev_mode=os.environ.get("DEV_MODE", "false").lower() in {"1", "true", "yes"},
         launchers_enabled=os.environ.get("LAUNCHERS_ENABLED", "false").lower()
         in {"1", "true", "yes"},
         launch_code_ttl_seconds=_positive_int("LAUNCH_CODE_TTL_SECONDS", 60),
@@ -171,9 +177,9 @@ def verify_secret_key(config: Config | None = None) -> None:
     SECRET_KEY signs session cookies and derives the AES key that encrypts the
     secret columns at rest (app/db/crypto.py). The built-in default is public,
     so on a real deployment it makes cookies forgeable and the at-rest
-    encryption worthless. ``secure_cookies`` (HTTPS) is the production signal:
-    when it's on, a default/empty key is fatal; otherwise (local dev) it's a
-    warning so the dev loop keeps working.
+    encryption worthless. Production (``dev_mode`` off, the default) treats a
+    default/empty key as fatal; local dev / CI opt out with ``DEV_MODE=true``
+    so the dev loop keeps working.
 
     Called at startup before init_db() so a misconfigured prod fails fast
     rather than encrypting live data under the public default key.
@@ -187,6 +193,6 @@ def verify_secret_key(config: Config | None = None) -> None:
         "cookies forgeable and encrypted secrets readable. Generate one with "
         "`openssl rand -hex 32` and set SECRET_KEY."
     )
-    if cfg.secure_cookies:
+    if not cfg.dev_mode:
         raise ValueError(message)
-    log.warning("%s Allowed because SECURE_COOKIES is off (dev mode).", message)
+    log.warning("%s Allowed because DEV_MODE is set.", message)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, field_validator
+
+log = logging.getLogger(__name__)
+
+# Built-in fallback used only for local dev. A production deployment must
+# override it — see verify_secret_key().
+DEV_SECRET_KEY = "dev-secret"
 
 # Load the repo-root .env so non-Docker launchers (python -m app.main, pytest,
 # task workers) get the same env as `flask run` and docker compose. Search
@@ -117,7 +124,7 @@ def _resolve_wiki_dir() -> str:
 
 def load_config() -> Config:
     return Config(
-        secret_key=os.environ.get("SECRET_KEY", "dev-secret"),
+        secret_key=os.environ.get("SECRET_KEY", DEV_SECRET_KEY),
         wiki_dir=_resolve_wiki_dir(),
         database_url=os.environ.get(
             "DATABASE_URL",
@@ -156,3 +163,30 @@ def load_config() -> Config:
 
 
 CONFIG = load_config()
+
+
+def verify_secret_key(config: Config | None = None) -> None:
+    """Refuse to start a production deployment on the default/empty SECRET_KEY.
+
+    SECRET_KEY signs session cookies and derives the AES key that encrypts the
+    secret columns at rest (app/db/crypto.py). The built-in default is public,
+    so on a real deployment it makes cookies forgeable and the at-rest
+    encryption worthless. ``secure_cookies`` (HTTPS) is the production signal:
+    when it's on, a default/empty key is fatal; otherwise (local dev) it's a
+    warning so the dev loop keeps working.
+
+    Called at startup before init_db() so a misconfigured prod fails fast
+    rather than encrypting live data under the public default key.
+    """
+    cfg = config or CONFIG
+    if cfg.secret_key and cfg.secret_key != DEV_SECRET_KEY:
+        return
+    message = (
+        "SECRET_KEY is unset or the built-in default. It signs session cookies "
+        "and derives the at-rest encryption key, so the public default makes "
+        "cookies forgeable and encrypted secrets readable. Generate one with "
+        "`openssl rand -hex 32` and set SECRET_KEY."
+    )
+    if cfg.secure_cookies:
+        raise ValueError(message)
+    log.warning("%s Allowed because SECURE_COOKIES is off (dev mode).", message)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -150,6 +150,9 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     log.info(
         "agent-wiki backend starting (database=%s)", _app_config.CONFIG.database_url.split("@")[-1]
     )
+    # Guard before init_db: a misconfigured prod must fail fast rather than
+    # encrypt live data under the public default SECRET_KEY.
+    _app_config.verify_secret_key()
     init_db()
     ensure_wiki_repo()
     # Seed-on-empty runs after the repo is initialized so writes go

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -22,6 +22,7 @@ import time
 from prometheus_client import start_http_server
 from sqlalchemy import text
 
+from app.config import verify_secret_key
 from app.tasks.queues import QUEUES
 from app.tasks.queue import run_consumer
 from app.utils.logging import setup_logging
@@ -97,6 +98,7 @@ def main() -> None:
     args = parser.parse_args()
 
     setup_logging()
+    verify_secret_key()
     start_http_server(_METRICS_PORT[args.queue])
     _wait_for_db()
     queue = QUEUES[args.queue]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -112,6 +112,7 @@ def tmp_config(tmp_path, monkeypatch):
         oidc_client_secret="",
         oidc_redirect_uri="",
         secure_cookies=False,
+        dev_mode=True,
         ingest_bm25_min_score=1.0,
         ingest_bm25_title_boost=2.0,
         ingest_bm25_limit=20,

--- a/backend/tests/test_verify_secret_key.py
+++ b/backend/tests/test_verify_secret_key.py
@@ -1,0 +1,38 @@
+"""verify_secret_key(): the production guard against the default/empty SECRET_KEY.
+
+SECRET_KEY signs session cookies and derives the at-rest encryption key, so the
+public built-in default must be fatal on a real (HTTPS / secure_cookies)
+deployment and a warning in local dev.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.config import CONFIG, DEV_SECRET_KEY, verify_secret_key
+
+
+def _cfg(*, secret_key: str, secure_cookies: bool):
+    return CONFIG.model_copy(update={"secret_key": secret_key, "secure_cookies": secure_cookies})
+
+
+def test_rejects_default_key_in_production() -> None:
+    with pytest.raises(ValueError, match="SECRET_KEY"):
+        verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, secure_cookies=True))
+
+
+def test_rejects_empty_key_in_production() -> None:
+    with pytest.raises(ValueError, match="SECRET_KEY"):
+        verify_secret_key(_cfg(secret_key="", secure_cookies=True))
+
+
+def test_warns_but_allows_default_key_in_dev(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, secure_cookies=False))
+    assert any("SECRET_KEY" in r.message for r in caplog.records)
+
+
+def test_accepts_real_key_in_production() -> None:
+    # A configured key boots cleanly and emits no warning.
+    verify_secret_key(_cfg(secret_key="a-real-32-byte-hex-secret", secure_cookies=True))

--- a/backend/tests/test_verify_secret_key.py
+++ b/backend/tests/test_verify_secret_key.py
@@ -1,8 +1,8 @@
 """verify_secret_key(): the production guard against the default/empty SECRET_KEY.
 
 SECRET_KEY signs session cookies and derives the at-rest encryption key, so the
-public built-in default must be fatal on a real (HTTPS / secure_cookies)
-deployment and a warning in local dev.
+public built-in default must be fatal on a real deployment (DEV_MODE off) and a
+warning in local dev / CI (DEV_MODE on).
 """
 from __future__ import annotations
 
@@ -13,32 +13,32 @@ import pytest
 from app.config import CONFIG, DEV_SECRET_KEY, Config, verify_secret_key
 
 
-def _cfg(*, secret_key: str, secure_cookies: bool) -> Config:
-    return CONFIG.model_copy(update={"secret_key": secret_key, "secure_cookies": secure_cookies})
+def _cfg(*, secret_key: str, dev_mode: bool) -> Config:
+    return CONFIG.model_copy(update={"secret_key": secret_key, "dev_mode": dev_mode})
 
 
 def test_rejects_default_key_in_production() -> None:
     with pytest.raises(ValueError, match="SECRET_KEY"):
-        verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, secure_cookies=True))
+        verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, dev_mode=False))
 
 
 def test_rejects_empty_key_in_production() -> None:
     with pytest.raises(ValueError, match="SECRET_KEY"):
-        verify_secret_key(_cfg(secret_key="", secure_cookies=True))
+        verify_secret_key(_cfg(secret_key="", dev_mode=False))
 
 
 def test_warns_but_allows_default_key_in_dev(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING):
-        verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, secure_cookies=False))
+        verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, dev_mode=True))
     assert any("SECRET_KEY" in r.message for r in caplog.records)
 
 
 def test_warns_but_allows_empty_key_in_dev(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING):
-        verify_secret_key(_cfg(secret_key="", secure_cookies=False))
+        verify_secret_key(_cfg(secret_key="", dev_mode=True))
     assert any("SECRET_KEY" in r.message for r in caplog.records)
 
 
 def test_accepts_real_key_in_production() -> None:
-    # A configured key boots cleanly and emits no warning.
-    verify_secret_key(_cfg(secret_key="a-real-32-byte-hex-secret", secure_cookies=True))
+    # A configured key boots cleanly regardless of dev_mode and emits no warning.
+    verify_secret_key(_cfg(secret_key="a-real-32-byte-hex-secret", dev_mode=False))

--- a/backend/tests/test_verify_secret_key.py
+++ b/backend/tests/test_verify_secret_key.py
@@ -10,10 +10,10 @@ import logging
 
 import pytest
 
-from app.config import CONFIG, DEV_SECRET_KEY, verify_secret_key
+from app.config import CONFIG, DEV_SECRET_KEY, Config, verify_secret_key
 
 
-def _cfg(*, secret_key: str, secure_cookies: bool):
+def _cfg(*, secret_key: str, secure_cookies: bool) -> Config:
     return CONFIG.model_copy(update={"secret_key": secret_key, "secure_cookies": secure_cookies})
 
 
@@ -30,6 +30,12 @@ def test_rejects_empty_key_in_production() -> None:
 def test_warns_but_allows_default_key_in_dev(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING):
         verify_secret_key(_cfg(secret_key=DEV_SECRET_KEY, secure_cookies=False))
+    assert any("SECRET_KEY" in r.message for r in caplog.records)
+
+
+def test_warns_but_allows_empty_key_in_dev(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        verify_secret_key(_cfg(secret_key="", secure_cookies=False))
     assert any("SECRET_KEY" in r.message for r in caplog.records)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
+      - DEV_MODE=true
     volumes:
       - ./local_data:/data
     expose:
@@ -101,6 +102,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
+      - DEV_MODE=true
     volumes:
       - ./local_data:/data
     depends_on:
@@ -123,6 +125,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
+      - DEV_MODE=true
     volumes:
       - ./local_data:/data
     depends_on:
@@ -145,6 +148,7 @@ services:
       - REDIS_URL=redis://redis:6379/0
       - OPENSEARCH_URL=http://opensearch:9200
       - WIKI_DIR=/data/wiki
+      - DEV_MODE=true
     volumes:
       - ./local_data:/data
     depends_on:


### PR DESCRIPTION
## Why

`SECRET_KEY` signs session cookies **and** derives the AES key that encrypts the secret columns at rest (shipped in #252). The built-in `"dev-secret"` default is public, so if a real deployment never sets `SECRET_KEY`:

- session cookies are signed with a known key → **forgeable** (auth bypass), and
- the at-rest encryption is **worthless** — anyone with the source can derive `SHA-256("dev-secret")` and decrypt every column.

This is the other half of "keys are actually protected": #252 built the lock; this ensures the key to it isn't a public default.

## Change

`verify_secret_key()` in `app/config.py`:
- If `SECRET_KEY` is set and not the default → OK.
- Else if `secure_cookies` is on (our prod/HTTPS signal) → **raise, refuse to boot** with a message pointing at `openssl rand -hex 32`.
- Else (local dev) → **warn and continue**, so the dev loop is unchanged.

Wired in two places:
- **Backend lifespan**, *before* `init_db()` — a misconfigured prod fails fast instead of running migration `0030` and encrypting live data under the public default key.
- **Worker entrypoint** (`run_worker.py`) — workers read encrypted columns too (doc-updater reads `llm_settings`, triggers read Slack webhooks), so they refuse to boot the same way.

Rejects both the `"dev-secret"` default and an empty value. Follows the Onyx precedent (`verify_user_auth_secret`): fatal in prod, warn in dev.

## Testing

- New `tests/test_verify_secret_key.py`: rejects default in prod, rejects empty in prod, warns-but-allows default in dev, accepts a real key in prod.
- Whole-project basedpyright clean, ruff clean. The guard runs only in the lifespan/worker entrypoints (skipped by `TestClient`), so the existing suite is unaffected.

## Note

Single `SECRET_KEY` is retained (not split into a separate `ENCRYPTION_KEY_SECRET`). Splitting buys independent rotation but has no payoff until rotation tooling exists; the design doc records the decision to revisit it as the first step of that work. On `agent-wiki-dev-wiki`, `SECRET_KEY` is already set and non-default, so this guard is satisfied there today — it converts "configured correctly" into "cannot boot misconfigured."