### PR TITLE
fix(triggers): serialize rebuild_from_filesystem under an advisory lock

### DIFF
--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, cast
 
-from sqlalchemy import Engine, Executable, create_engine
+from sqlalchemy import Engine, Executable, create_engine, text
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import Session, sessionmaker
 
@@ -168,3 +168,14 @@ def init_db() -> None:
                 sa.text("SELECT pg_advisory_unlock(:lock_key)"),
                 {"lock_key": _MIGRATION_ADVISORY_LOCK},
             )
+
+
+def advisory_xact_lock(s: Session, key: int) -> None:
+    """Take a transaction-scoped Postgres advisory lock on ``s``'s transaction.
+
+    Serialises writers that would otherwise race; the lock releases
+    automatically when the transaction commits or rolls back. Keeps the raw
+    advisory-lock SQL in this DB seam rather than in caller code (see
+    ``rebuild_from_filesystem``).
+    """
+    s.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": key})

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -32,7 +32,7 @@ from typing import Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
-from sqlalchemy import delete as sa_delete, or_, select
+from sqlalchemy import delete as sa_delete, or_, select, text
 
 from app.db.models import Event, Trigger
 from app.db.session import session
@@ -41,6 +41,14 @@ from app.triggers import destinations as destinations_repo
 from app.triggers import storage
 
 log = logging.getLogger(__name__)
+
+# Serialises concurrent rebuild_from_filesystem() callers. The rebuild clears
+# the triggers cache and re-inserts every row; two callers racing that (the boot
+# lifespan vs. an after_path_move, or overlapping backend processes) collide on
+# triggers_pkey with a UniqueViolation. A Postgres advisory lock makes the
+# second caller wait — same approach init_db() uses for concurrent migrations.
+# "trig" in ASCII; distinct from the migration lock key.
+_REBUILD_ADVISORY_LOCK = 0x74726967
 
 ALLOWED_KINDS = {"delta", "schedule"}
 
@@ -558,6 +566,12 @@ def rebuild_from_filesystem() -> int:
 
     fallback_now = _now_iso()
     with session() as s:
+        # Serialise concurrent rebuilds: a transaction-scoped advisory lock
+        # makes a second caller wait for this one to commit instead of racing
+        # the delete-all + re-insert into a triggers_pkey UniqueViolation. It
+        # releases automatically when this transaction ends (commit or rollback).
+        s.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
+
         # schedule_last_fired_at is runtime cursor state, intentionally not
         # stored in the YAML — so carry it across the rebuild instead of
         # nulling it, or every rebuild (boot, and per-move via after_path_move)

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -32,10 +32,10 @@ from typing import Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
-from sqlalchemy import delete as sa_delete, or_, select, text
+from sqlalchemy import delete as sa_delete, or_, select
 
 from app.db.models import Event, Trigger
-from app.db.session import session
+from app.db.session import advisory_xact_lock, session
 from app.slack import webhooks as slack_webhooks
 from app.triggers import destinations as destinations_repo
 from app.triggers import storage
@@ -570,7 +570,7 @@ def rebuild_from_filesystem() -> int:
         # makes a second caller wait for this one to commit instead of racing
         # the delete-all + re-insert into a triggers_pkey UniqueViolation. It
         # releases automatically when this transaction ends (commit or rollback).
-        s.execute(text("SELECT pg_advisory_xact_lock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
+        advisory_xact_lock(s, _REBUILD_ADVISORY_LOCK)
 
         # schedule_last_fired_at is runtime cursor state, intentionally not
         # stored in the YAML — so carry it across the rebuild instead of

--- a/backend/tests/test_trigger_rebuild_lock.py
+++ b/backend/tests/test_trigger_rebuild_lock.py
@@ -21,12 +21,6 @@ from app.triggers.repo import _REBUILD_ADVISORY_LOCK, rebuild_from_filesystem
 
 def test_rebuild_blocks_while_advisory_lock_is_held(tmp_repo: object) -> None:
     engine = get_engine()
-    # Hold the rebuild lock (session-scoped) on a dedicated connection. Session
-    # and xact advisory locks share one key space, so the rebuild's
-    # pg_advisory_xact_lock on the same key must wait for us to release it.
-    holder = engine.connect().execution_options(isolation_level="AUTOCOMMIT")
-    holder.execute(text("SELECT pg_advisory_lock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
-
     done = threading.Event()
     errors: list[BaseException] = []
 
@@ -38,16 +32,21 @@ def test_rebuild_blocks_while_advisory_lock_is_held(tmp_repo: object) -> None:
         finally:
             done.set()
 
-    worker = threading.Thread(target=run)
-    worker.start()
-    try:
-        # Blocked on the held lock — must not complete yet.
-        assert not done.wait(timeout=1.5), "rebuild did not wait on the advisory lock"
+    # Hold the rebuild lock (session-scoped) on a dedicated connection. Session
+    # and xact advisory locks share one key space, so the rebuild's
+    # pg_advisory_xact_lock on the same key must wait for us to release it. The
+    # `with` guarantees the connection (and thus the lock) is cleaned up.
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as holder:
+        holder.execute(text("SELECT pg_advisory_lock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
+        worker = threading.Thread(target=run)
+        worker.start()
+        try:
+            # Blocked on the held lock — must not complete yet.
+            assert not done.wait(timeout=1.5), "rebuild did not wait on the advisory lock"
 
-        # Release the lock; the rebuild should now proceed and finish.
-        holder.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
-        assert done.wait(timeout=10.0), "rebuild did not complete after lock release"
-        assert not errors, f"rebuild raised: {errors}"
-    finally:
-        holder.close()
-        worker.join(timeout=5)
+            # Release the lock; the rebuild should now proceed and finish.
+            holder.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
+            assert done.wait(timeout=10.0), "rebuild did not complete after lock release"
+            assert not errors, f"rebuild raised: {errors}"
+        finally:
+            worker.join(timeout=5)

--- a/backend/tests/test_trigger_rebuild_lock.py
+++ b/backend/tests/test_trigger_rebuild_lock.py
@@ -1,0 +1,53 @@
+"""rebuild_from_filesystem() serialises on a Postgres advisory lock.
+
+Concurrent rebuilds (boot lifespan vs. after_path_move, or overlapping backend
+processes) used to race the delete-all + re-insert into a triggers_pkey
+UniqueViolation and crash startup. The rebuild now takes a transaction-scoped
+advisory lock first, so a second caller waits instead of colliding.
+
+This proves it deterministically: hold that lock on a separate connection and
+assert the rebuild blocks until it's released, rather than trying to force the
+race.
+"""
+from __future__ import annotations
+
+import threading
+
+from sqlalchemy import text
+
+from app.db.session import get_engine
+from app.triggers.repo import _REBUILD_ADVISORY_LOCK, rebuild_from_filesystem
+
+
+def test_rebuild_blocks_while_advisory_lock_is_held(tmp_repo: object) -> None:
+    engine = get_engine()
+    # Hold the rebuild lock (session-scoped) on a dedicated connection. Session
+    # and xact advisory locks share one key space, so the rebuild's
+    # pg_advisory_xact_lock on the same key must wait for us to release it.
+    holder = engine.connect().execution_options(isolation_level="AUTOCOMMIT")
+    holder.execute(text("SELECT pg_advisory_lock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
+
+    done = threading.Event()
+    errors: list[BaseException] = []
+
+    def run() -> None:
+        try:
+            rebuild_from_filesystem()
+        except BaseException as e:  # noqa: BLE001 - surface to the test thread
+            errors.append(e)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=run)
+    worker.start()
+    try:
+        # Blocked on the held lock — must not complete yet.
+        assert not done.wait(timeout=1.5), "rebuild did not wait on the advisory lock"
+
+        # Release the lock; the rebuild should now proceed and finish.
+        holder.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": _REBUILD_ADVISORY_LOCK})
+        assert done.wait(timeout=10.0), "rebuild did not complete after lock release"
+        assert not errors, f"rebuild raised: {errors}"
+    finally:
+        holder.close()
+        worker.join(timeout=5)


### PR DESCRIPTION
## Problem

`rebuild_from_filesystem()` reconciles the Postgres trigger cache against the on-disk `.trigger_*.yaml` files by clearing the table (`DELETE FROM triggers`) and re-inserting every row in one transaction. It's called on backend **startup** (`app/main.py`) and after a **path move** (`app/wiki/notify.py`) — nothing serializes the two.

When two callers race the delete-all + re-insert (two backend processes booting at once, an old pod still finishing while the new one boots, or a boot overlapping a move), they collide on `triggers_pkey`:

```
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "triggers_pkey"
DETAIL:  Key (id)=(trg_...) already exists.
[SQL: INSERT INTO triggers (...) VALUES (...)]
ERROR:    Application startup failed. Exiting.
```

It self-heals (the process restarts and the next boot wins the race), so it's an intermittent startup blip rather than a hard outage — but it's a real crash, and it's the same race class the codebase already guards against elsewhere. Observed during a local rollout while backend + workers were recreated together.

## Fix

Take a **transaction-scoped Postgres advisory lock** (`pg_advisory_xact_lock`) as the first statement in the rebuild transaction, so a second caller waits for the first to commit instead of racing. Releases automatically when the transaction ends — no try/finally. This mirrors the advisory lock `init_db()` already uses to serialize concurrent migrations (uvicorn `--workers N` firing the lifespan per worker). The lock key is distinct from the migration key.

## Testing

- New `tests/test_trigger_rebuild_lock.py` proves it deterministically (no flaky race-forcing): hold the lock on a separate connection, assert the rebuild **blocks**, release, assert it **completes**. Removing the lock from the rebuild makes this test fail (the rebuild would finish immediately).
- Existing `test_triggers_api.py` + `test_schedule_triggers.py` (which exercise `rebuild_from_filesystem` heavily) still pass. ruff + basedpyright clean.

Unrelated to the secret-handling work — surfaced during that deploy, filed/fixed separately.