### PR TITLE
feat(metrics): record BM25-score-filtered candidates as an ingest outcome

### DIFF
--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -19,7 +19,13 @@ from collections import Counter
 
 from app.config import CONFIG
 from app.db.fts import SearchHit, search as fts_search
-from app.metrics import ingest_bm25_hits, ingest_bm25_passed, ingest_bm25_score
+from app.metrics import (
+    ingest_bm25_hits,
+    ingest_bm25_passed,
+    ingest_bm25_score,
+    ingest_bm25_score_by_outcome,
+    ingest_outcomes_total,
+)
 
 log = logging.getLogger(__name__)
 
@@ -91,6 +97,18 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
         )
         if score >= CONFIG.ingest_bm25_min_score:
             boosted.append(hit.model_copy(update={"score": score}))
+        else:
+            # Candidate page surfaced by BM25 but below the score threshold —
+            # dropped here, before the selector/reconciler ever see it. Record
+            # it as a per-pair outcome so the Ingest Outcomes breakdown accounts
+            # for this earliest filter stage (and the score-by-outcome histogram
+            # covers the drops too).
+            ingest_outcomes_total.labels(
+                outcome="filtered_by_bm25_score", wiki_path=hit.path
+            ).inc()
+            ingest_bm25_score_by_outcome.labels(
+                outcome="filtered_by_bm25_score"
+            ).observe(score)
 
     ingest_bm25_hits.observe(len(hits))
     ingest_bm25_passed.observe(len(boosted))

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -63,7 +63,10 @@ ingest_outcomes_total = Counter(
     # wiki_path cardinality is bounded by the number of pages in the wiki git repo
     # (a finite set). Stale series from renamed/deleted pages expire with TSDB retention.
     # Add a recording rule to cap top-N if the wiki grows beyond ~500 pages.
-    ["outcome", "wiki_path"],  # committed, no_change, irrelevant, filtered, no_candidates
+    # committed, no_change, irrelevant, no_candidates, filtered (source type),
+    # filtered_by_bm25_score (below BM25 threshold), filtered_by_selector,
+    # ingestion_auto_update_disabled
+    ["outcome", "wiki_path"],
 )
 
 ingest_document_results_total = Counter(

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -90,13 +90,24 @@ def test_candidates_empty_when_no_fts_results():
     assert result == []
 
 
+def _outcome_count(outcome: str, wiki_path: str) -> float:
+    from prometheus_client import REGISTRY
+    return REGISTRY.get_sample_value(
+        "ingest_outcomes_total", {"outcome": outcome, "wiki_path": wiki_path}
+    ) or 0.0
+
+
 def test_candidates_drops_below_min_score(monkeypatch):
     monkeypatch.setattr(ingest_search, "CONFIG", CONFIG.model_copy(update={"ingest_bm25_min_score": 5.0}))
     hits = [_hit("a.md", "Alpha", 3.0), _hit("b.md", "Beta", 6.0)]
+    before = _outcome_count("filtered_by_bm25_score", "a.md")
     with patch("app.ingest.search.fts_search", return_value=hits):
         result = ingest_search.candidates("content", None)
     assert len(result) == 1
     assert result[0].path == "b.md"
+    # The below-threshold candidate is recorded as its own outcome so the
+    # Ingest Outcomes breakdown accounts for BM25-score drops.
+    assert _outcome_count("filtered_by_bm25_score", "a.md") - before == 1.0
 
 
 def test_candidates_sorted_descending_by_score(monkeypatch):


### PR DESCRIPTION
## Gap
The **Ingest Outcomes (total breakdown)** donut was missing a slice for candidate doc→page pairs dropped by the **BM25 score threshold**. Those are filtered inside `candidates()` (`app/ingest/search.py`) before the selector/reconciler ever see them, and were only counted in the `ingest_bm25_hits`/`ingest_bm25_passed` histograms — never as an `ingest_outcomes_total` outcome. So the earliest filter stage of the funnel was invisible in the breakdown.

## Change
In `candidates()`, for each hit whose (title-boosted) score is below `ingest_bm25_min_score`, emit:
- `ingest_outcomes_total{outcome="filtered_by_bm25_score", wiki_path=<page>}` — one per dropped pair, so it shows as its own donut slice (and appears in the per-path top-N breakdowns), and
- `ingest_bm25_score_by_outcome{outcome="filtered_by_bm25_score"}` — so the score-by-outcome histogram covers the drops too.

No dashboard change needed: the donut is `sum(...) by (outcome)` with palette-classic, so the new outcome auto-renders with its own color. (Backend-only → no chart version bump.)

## Tests
Extended `test_candidates_drops_below_min_score` to assert the `filtered_by_bm25_score` outcome increments for the dropped candidate. 32 pass; ruff + basedpyright clean.