### PR TITLE
feat(ingest): eval-log selector- and BM25-filtered candidate pairs

### DIFF
--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -1,8 +1,12 @@
-"""Opt-in logging of ingest reconciler decisions to the ingest_eval_samples table.
+"""Opt-in logging of ingest candidate decisions to the ingest_eval_samples table.
 
-Enabled via INGEST_EVAL_LOGGING=true. Each row captures the source document,
-the wiki page before reconciliation, the unified diff of any edit, and the outcome.
-Intended for human review and building a regression test suite.
+Enabled via INGEST_EVAL_LOGGING=true. Each row captures the source document, a
+candidate wiki page, the unified diff of any edit, and the outcome — one row per
+(document, candidate page) pair. Besides the reconciler verdicts
+(committed/no_change/irrelevant) it also records pre-reconciler drops:
+``filtered_by_selector`` (weak-model selector) and ``filtered_by_bm25_score``
+(below the BM25 score threshold). Intended for human review and building a
+regression test suite.
 """
 from __future__ import annotations
 
@@ -25,7 +29,13 @@ def log_sample(
     source_content: str,
     wiki_path: str,
     wiki_body_before: str,
-    outcome: Literal["committed", "no_change", "irrelevant"],
+    outcome: Literal[
+        "committed",
+        "no_change",
+        "irrelevant",
+        "filtered_by_selector",
+        "filtered_by_bm25_score",
+    ],
     commit_sha: str | None,
 ) -> None:
     diff = wiki_git.diff_for_commit(commit_sha, wiki_path) if commit_sha is not None else None

--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -17,15 +17,11 @@ import re
 import logging
 from collections import Counter
 
+from pydantic import BaseModel
+
 from app.config import CONFIG
 from app.db.fts import SearchHit, search as fts_search
-from app.metrics import (
-    ingest_bm25_hits,
-    ingest_bm25_passed,
-    ingest_bm25_score,
-    ingest_bm25_score_by_outcome,
-    ingest_outcomes_total,
-)
+from app.metrics import ingest_bm25_hits, ingest_bm25_passed, ingest_bm25_score
 
 log = logging.getLogger(__name__)
 
@@ -59,11 +55,25 @@ def _jaccard(a: set[str], b: set[str]) -> float:
     return len(a & b) / len(a | b)
 
 
-def candidates(content: str, title: str | None) -> list[SearchHit]:
-    """Return BM25 candidates above the score threshold, most relevant first.
+class CandidateSearch(BaseModel):
+    """Result of a BM25 candidate search: pages above the score threshold
+    (`passed`, most relevant first) and those below it (`dropped`), both with
+    title-boosted scores. Pure data — the caller decides what to do with the
+    drops (outcome metric, eval logging) via a post-process step, so this
+    module stays free of git/DB/metadata concerns."""
 
-    Title similarity boosts the raw BM25 score before thresholding so
-    pages whose titles closely match the incoming document rank higher.
+    passed: list[SearchHit]
+    dropped: list[SearchHit]
+
+
+def candidates(content: str, title: str | None) -> CandidateSearch:
+    """Return the BM25 candidates split into `passed`/`dropped` by the score
+    threshold, most relevant first.
+
+    Title similarity boosts the raw BM25 score before thresholding so pages
+    whose titles closely match the incoming document rank higher. Emits only
+    search telemetry (hits/passed/raw-score); per-drop outcome accounting is the
+    caller's post-process (see ``wiki_update``).
     """
     try:
         hits = fts_search(
@@ -79,11 +89,12 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
         raise IngestSearchError(str(exc)) from exc
     if not hits:
         log.debug("ingest candidates: no BM25 hits for title=%r", title)
-        return []
+        return CandidateSearch(passed=[], dropped=[])
 
     query_title_tokens: set[str] = _tokens(title) if title else set()
 
     boosted: list[SearchHit] = []
+    dropped: list[SearchHit] = []
     for hit in hits:
         raw_score = hit.score
         score = raw_score
@@ -95,20 +106,11 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
             "ingest candidate: path=%r raw_bm25=%.3f boosted=%.3f threshold=%.3f pass=%s",
             hit.path, raw_score, score, CONFIG.ingest_bm25_min_score, score >= CONFIG.ingest_bm25_min_score,
         )
+        scored = hit.model_copy(update={"score": score})
         if score >= CONFIG.ingest_bm25_min_score:
-            boosted.append(hit.model_copy(update={"score": score}))
+            boosted.append(scored)
         else:
-            # Candidate page surfaced by BM25 but below the score threshold —
-            # dropped here, before the selector/reconciler ever see it. Record
-            # it as a per-pair outcome so the Ingest Outcomes breakdown accounts
-            # for this earliest filter stage (and the score-by-outcome histogram
-            # covers the drops too).
-            ingest_outcomes_total.labels(
-                outcome="filtered_by_bm25_score", wiki_path=hit.path
-            ).inc()
-            ingest_bm25_score_by_outcome.labels(
-                outcome="filtered_by_bm25_score"
-            ).observe(score)
+            dropped.append(scored)
 
     ingest_bm25_hits.observe(len(hits))
     ingest_bm25_passed.observe(len(boosted))
@@ -117,4 +119,4 @@ def candidates(content: str, title: str | None) -> list[SearchHit]:
         title, len(hits), len(boosted), CONFIG.ingest_bm25_min_score,
     )
     boosted.sort(key=lambda h: h.score, reverse=True)
-    return boosted
+    return CandidateSearch(passed=boosted, dropped=dropped)

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -306,9 +306,47 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
         ingest_outcomes_total.labels(outcome="filtered", wiki_path="").inc()
         return
 
+    _meta: dict[str, Any] = push.get("metadata") or {}
+    url: str = str(push.get("url") or _meta.get("url") or "")
+
+    def _record_bm25_drops(dropped: list[ingest_search.SearchHit]) -> None:
+        # Post-process the candidates the BM25 score threshold dropped: the
+        # per-pair outcome metric, and (when eval logging is on) an eval row —
+        # reading the page body here since this path never reads it otherwise.
+        for hit in dropped:
+            ingest_outcomes_total.labels(
+                outcome="filtered_by_bm25_score", wiki_path=hit.path
+            ).inc()
+            ingest_bm25_score_by_outcome.labels(
+                outcome="filtered_by_bm25_score"
+            ).observe(hit.score)
+            if not CONFIG.ingest_eval_logging:
+                continue
+            try:
+                body = wiki_git.read_file(hit.path)
+            except Exception:
+                continue
+            try:
+                ingest_eval_sample.log_sample(
+                    source_document_id=push.get("source_document_id"),
+                    source_type=source_type,
+                    source_title=title,
+                    source_url=url if url else None,
+                    source_content=content,
+                    wiki_path=hit.path,
+                    wiki_body_before=body,
+                    outcome="filtered_by_bm25_score",
+                    commit_sha=None,
+                )
+            except Exception:
+                log.warning(
+                    "ingest_eval_sample: failed to log filtered_by_bm25_score sample",
+                    exc_info=True,
+                )
+
     t_start = time.monotonic()
     try:
-        hits = ingest_search.candidates(content, title)
+        search_result = ingest_search.candidates(content, title)
     except ingest_search.IngestSearchError:
         # The candidate search failed — almost always because the full document
         # body exceeds OpenSearch's boolean-clause limit. Only large documents
@@ -330,7 +368,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             strategy, doc_id,
         )
         try:
-            hits = ingest_search.candidates(query, title)
+            search_result = ingest_search.candidates(query, title)
         except ingest_search.IngestSearchError:
             log.warning(
                 "process_pushed_document: candidate search FAILED after %s fallback "
@@ -338,6 +376,9 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                 strategy, doc_id, exc_info=True,
             )
             return
+
+    _record_bm25_drops(search_result.dropped)
+    hits = search_result.passed
     if not hits:
         log.info("process_pushed_document: no BM25 candidates above threshold, doc_id=%s", doc_id)
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()
@@ -345,8 +386,6 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
         return
 
     source_label = source_type or "external"
-    _meta: dict[str, Any] = push.get("metadata") or {}
-    url: str = str(push.get("url") or _meta.get("url") or "")
 
     # Read all candidate bodies upfront — needed by both the selector and the
     # main reconciler loop. Skip unreadable files early so the selector sees the
@@ -409,6 +448,24 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                 ).inc()
                 ingest_bm25_score_by_outcome.labels(outcome="filtered_by_selector").observe(c.hit.score)
                 log.debug("process_pushed_document: filtered_by_selector path=%s", c.hit.path)
+                if CONFIG.ingest_eval_logging:
+                    try:
+                        ingest_eval_sample.log_sample(
+                            source_document_id=push.get("source_document_id"),
+                            source_type=source_type,
+                            source_title=title,
+                            source_url=url if url else None,
+                            source_content=content,
+                            wiki_path=c.hit.path,
+                            wiki_body_before=c.body,
+                            outcome="filtered_by_selector",
+                            commit_sha=None,
+                        )
+                    except Exception:
+                        log.warning(
+                            "ingest_eval_sample: failed to log filtered_by_selector sample",
+                            exc_info=True,
+                        )
 
     # Stage 4: batch reconcile with the main model — one call decides and
     # produces new bodies for all candidates. Skipped when model is unset.

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -325,6 +325,11 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             try:
                 body = wiki_git.read_file(hit.path)
             except Exception:
+                log.warning(
+                    "ingest_eval_sample: failed to read %s for filtered_by_bm25_score sample",
+                    hit.path,
+                    exc_info=True,
+                )
                 continue
             try:
                 ingest_eval_sample.log_sample(
@@ -345,9 +350,11 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                 )
 
     t_start = time.monotonic()
+    used_fallback = False
     try:
         search_result = ingest_search.candidates(content, title)
     except ingest_search.IngestSearchError:
+        used_fallback = True
         # The candidate search failed — almost always because the full document
         # body exceeds OpenSearch's boolean-clause limit. Only large documents
         # reach here, so retry with a compact query (and pay the LLM cost only
@@ -377,7 +384,11 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             )
             return
 
-    _record_bm25_drops(search_result.dropped)
+    # Only record BM25 drops from the primary, full-content search. The fallback
+    # scores against a lossy summary query, so its below-threshold pages aren't
+    # comparable to the document and would mislabel the eval rows.
+    if not used_fallback:
+        _record_bm25_drops(search_result.dropped)
     hits = search_result.passed
     if not hits:
         log.info("process_pushed_document: no BM25 candidates above threshold, doc_id=%s", doc_id)

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -23,6 +23,7 @@ from app.ingest import search as ingest_search
 from app.ingest.source_tiers import is_filtered
 from app.llm.agents.common import IRRELEVANT_SENTINEL
 from app.llm.settings import _EMPTY as _EMPTY_LLM_SETTINGS, LLMSettings
+from app.wiki import git as wiki_git
 from app.wiki.utils import author_string
 
 
@@ -84,10 +85,17 @@ def _hit(path: str, title: str | None, score: float) -> SearchHit:
     return SearchHit(doc_id=path, path=path, title=title, snippet="", score=score)
 
 
+def _cs(
+    passed: list[SearchHit], dropped: list[SearchHit] | None = None
+) -> ingest_search.CandidateSearch:
+    """Build a CandidateSearch for mocking ingest_search.candidates()."""
+    return ingest_search.CandidateSearch(passed=passed, dropped=dropped or [])
+
+
 def test_candidates_empty_when_no_fts_results():
     with patch("app.ingest.search.fts_search", return_value=[]):
         result = ingest_search.candidates("some content", "Some Title")
-    assert result == []
+    assert result.passed == [] and result.dropped == []
 
 
 def _outcome_count(outcome: str, wiki_path: str) -> float:
@@ -97,17 +105,15 @@ def _outcome_count(outcome: str, wiki_path: str) -> float:
     ) or 0.0
 
 
-def test_candidates_drops_below_min_score(monkeypatch):
+def test_candidates_partitions_on_min_score(monkeypatch):
     monkeypatch.setattr(ingest_search, "CONFIG", CONFIG.model_copy(update={"ingest_bm25_min_score": 5.0}))
     hits = [_hit("a.md", "Alpha", 3.0), _hit("b.md", "Beta", 6.0)]
-    before = _outcome_count("filtered_by_bm25_score", "a.md")
     with patch("app.ingest.search.fts_search", return_value=hits):
         result = ingest_search.candidates("content", None)
-    assert len(result) == 1
-    assert result[0].path == "b.md"
-    # The below-threshold candidate is recorded as its own outcome so the
-    # Ingest Outcomes breakdown accounts for BM25-score drops.
-    assert _outcome_count("filtered_by_bm25_score", "a.md") - before == 1.0
+    # candidates() is pure: it partitions passed/dropped and emits no drop
+    # outcome metric — that's the caller's post-process.
+    assert [h.path for h in result.passed] == ["b.md"]
+    assert [h.path for h in result.dropped] == ["a.md"]
 
 
 def test_candidates_sorted_descending_by_score(monkeypatch):
@@ -115,7 +121,7 @@ def test_candidates_sorted_descending_by_score(monkeypatch):
     hits = [_hit("low.md", None, 1.0), _hit("high.md", None, 5.0), _hit("mid.md", None, 3.0)]
     with patch("app.ingest.search.fts_search", return_value=hits):
         result = ingest_search.candidates("content", None)
-    assert [h.path for h in result] == ["high.md", "mid.md", "low.md"]
+    assert [h.path for h in result.passed] == ["high.md", "mid.md", "low.md"]
 
 
 def test_title_boost_raises_score(monkeypatch):
@@ -124,8 +130,8 @@ def test_title_boost_raises_score(monkeypatch):
     hits = [_hit("deploy.md", "deploy guide", 2.0), _hit("other.md", "unrelated", 2.0)]
     with patch("app.ingest.search.fts_search", return_value=hits):
         result = ingest_search.candidates("content", "deploy guide")
-    assert result[0].path == "deploy.md"
-    assert result[0].score > result[1].score
+    assert result.passed[0].path == "deploy.md"
+    assert result.passed[0].score > result.passed[1].score
 
 
 def test_title_boost_zero_when_no_incoming_title(monkeypatch):
@@ -134,7 +140,7 @@ def test_title_boost_zero_when_no_incoming_title(monkeypatch):
     with patch("app.ingest.search.fts_search", return_value=hits):
         result = ingest_search.candidates("content", None)
     # no boost applied — sorted purely by BM25 score
-    assert result[0].path == "b.md"
+    assert result.passed[0].path == "b.md"
 
 
 def test_title_boost_threshold_interaction(monkeypatch):
@@ -143,7 +149,7 @@ def test_title_boost_threshold_interaction(monkeypatch):
     hits = [_hit("a.md", "deploy guide", 3.0)]
     with patch("app.ingest.search.fts_search", return_value=hits):
         result = ingest_search.candidates("content", "deploy guide")
-    assert len(result) == 1
+    assert len(result.passed) == 1
 
 
 # --------------------------------------------------------------------------- #
@@ -171,7 +177,7 @@ def _run(push: dict[str, Any]) -> None:
         process_pushed_document(push)
 
 
-@patch("app.tasks.wiki_update.ingest_search.candidates", return_value=[])
+@patch("app.tasks.wiki_update.ingest_search.candidates", return_value=_cs([]))
 def test_filtered_source_drops_silently(mock_search, monkeypatch):
     monkeypatch.setattr("app.ingest.source_tiers.FILTERED_SOURCES", frozenset({"git_commit"}))
     _run(_make_push(source="git_commit"))
@@ -185,7 +191,7 @@ def _doc_result_count(result: str) -> float:
     ) or 0.0
 
 
-@patch("app.tasks.wiki_update.ingest_search.candidates", return_value=[])
+@patch("app.tasks.wiki_update.ingest_search.candidates", return_value=_cs([]))
 def test_no_candidates_returns_early(mock_search):
     # No BM25 hit -> the doc still gets a per-document terminal result so the
     # "search filtered out" tile accounts for it (panel reconciles to ingested).
@@ -199,7 +205,7 @@ def test_no_candidates_returns_early(mock_search):
 @patch("app.tasks.wiki_update.ingest_search.candidates")
 def test_no_readable_candidates_records_search_filtered_out(mock_search, mock_read):
     # Hits exist but none are readable -> also recorded as no_candidates.
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     before = _doc_result_count("no_candidates")
     _run(_make_push())
     assert _doc_result_count("no_candidates") - before == 1.0
@@ -232,7 +238,7 @@ def test_search_error_is_caught_and_does_not_commit(mock_search, mock_commit):
 @patch("app.tasks.wiki_update.ingest_search.candidates")
 def test_new_body_commits(mock_search, mock_reconcile, mock_read, mock_commit, mock_notify, mock_head, monkeypatch):
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     mock_reconcile.return_value = (["new body"], 1)
     _run(_make_push())
     mock_commit.assert_called_once()
@@ -252,7 +258,7 @@ def test_commit_attributed_to_onyx_ingest(
     # otherwise fall back to "AI Wiki Helper". process_pushed_document binds the
     # Onyx Ingest identity for the run instead.
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     mock_reconcile.return_value = (["new body"], 1)
     _run(_make_push())
     assert mock_commit.call_args.kwargs["author"] == "Onyx Ingest <onyx-ingest@local>"
@@ -266,7 +272,7 @@ def test_commit_attributed_to_onyx_ingest(
 @patch("app.tasks.wiki_update.ingest_search.candidates")
 def test_no_change_does_not_commit(mock_search, mock_reconcile, mock_read, mock_commit, monkeypatch):
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     mock_reconcile.return_value = ([None], 1)
     _run(_make_push())
     mock_commit.assert_not_called()
@@ -278,7 +284,7 @@ def test_no_change_does_not_commit(mock_search, mock_reconcile, mock_read, mock_
 @patch("app.tasks.wiki_update.ingest_search.candidates")
 def test_irrelevant_does_not_commit(mock_search, mock_reconcile, mock_read, mock_commit, monkeypatch):
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     mock_reconcile.return_value = ([IRRELEVANT_SENTINEL], 1)
     _run(_make_push())
     mock_commit.assert_not_called()
@@ -299,7 +305,7 @@ def test_ingestion_disabled_skips_candidate_before_llm(
         "app.tasks.wiki_update.update_policy.resolve_for_paths",
         lambda paths: {"page.md": ResolvedPolicy(ingestion_auto_update_disabled=True)},
     )
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     _run(_make_push())
     mock_reconcile.assert_not_called()
     mock_commit.assert_not_called()
@@ -322,7 +328,7 @@ def test_update_instruction_passed_to_reconciler(
         "app.tasks.wiki_update.update_policy.resolve_for_paths",
         lambda paths: {"page.md": ResolvedPolicy(update_instruction="Keep it terse.")},
     )
-    mock_search.return_value = [_hit("page.md", "Page", 5.0)]
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     mock_reconcile.return_value = (["new body"], 1)
     _run(_make_push())
     candidates = mock_reconcile.call_args.kwargs["candidates"]
@@ -338,7 +344,7 @@ def test_n_consecutive_irrelevant_stops_loop(mock_search, mock_reconcile, mock_r
     monkeypatch.setattr("app.tasks.wiki_update.CONFIG", CONFIG.model_copy(update={"ingest_irrelevant_stop_n": 2}))
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
     # 5 candidates — first two are IRRELEVANT, rest would commit but never reached
-    mock_search.return_value = [_hit(f"p{i}.md", f"P{i}", float(5 - i)) for i in range(5)]
+    mock_search.return_value = _cs([_hit(f"p{i}.md", f"P{i}", float(5 - i)) for i in range(5)])
     mock_reconcile.return_value = ([IRRELEVANT_SENTINEL, IRRELEVANT_SENTINEL, "new", "new", "new"], 1)
     _run(_make_push())
     mock_commit.assert_not_called()
@@ -353,7 +359,7 @@ def test_no_change_resets_irrelevant_counter(mock_search, mock_reconcile, mock_r
     monkeypatch.setattr("app.tasks.wiki_update.CONFIG", CONFIG.model_copy(update={"ingest_irrelevant_stop_n": 2}))
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
     # IRRELEVANT, NO_CHANGE (resets counter), IRRELEVANT — should NOT stop early
-    mock_search.return_value = [_hit(f"p{i}.md", None, float(5 - i)) for i in range(3)]
+    mock_search.return_value = _cs([_hit(f"p{i}.md", None, float(5 - i)) for i in range(3)])
     mock_reconcile.return_value = ([IRRELEVANT_SENTINEL, None, IRRELEVANT_SENTINEL], 1)
     _run(_make_push())
     mock_commit.assert_not_called()
@@ -369,7 +375,7 @@ def test_commit_resets_irrelevant_counter(mock_search, mock_reconcile, mock_read
     monkeypatch.setattr("app.tasks.wiki_update.CONFIG", CONFIG.model_copy(update={"ingest_irrelevant_stop_n": 2}))
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
     # IRRELEVANT, new body (resets counter), IRRELEVANT — should NOT stop early
-    mock_search.return_value = [_hit(f"p{i}.md", None, float(5 - i)) for i in range(3)]
+    mock_search.return_value = _cs([_hit(f"p{i}.md", None, float(5 - i)) for i in range(3)])
     mock_reconcile.return_value = ([IRRELEVANT_SENTINEL, "new body", IRRELEVANT_SENTINEL], 1)
     _run(_make_push())
     mock_commit.assert_called_once()
@@ -381,10 +387,69 @@ def test_commit_resets_irrelevant_counter(mock_search, mock_reconcile, mock_read
 @patch("app.tasks.wiki_update.ingest_search.candidates")
 def test_missing_file_skipped(mock_search, mock_reconcile, mock_read, mock_commit, monkeypatch):
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
-    mock_search.return_value = [_hit("missing.md", None, 5.0)]
+    mock_search.return_value = _cs([_hit("missing.md", None, 5.0)])
     _run(_make_push())
     mock_reconcile.assert_not_called()
     mock_commit.assert_not_called()
+
+
+def _eval_rows(outcome: str) -> list[dict[str, Any]]:
+    from sqlalchemy import select as sa_select
+
+    from app.db.models import IngestEvalSample
+    from app.db.session import session
+
+    with session() as s:
+        return [
+            {"wiki_path": r.wiki_path, "source_document_id": r.source_document_id}
+            for r in s.execute(
+                sa_select(IngestEvalSample).where(IngestEvalSample.outcome == outcome)
+            ).scalars().all()
+        ]
+
+
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_bm25_drop_recorded_and_eval_logged(mock_search, tmp_repo, monkeypatch):
+    # The post-process records a below-threshold candidate: the
+    # filtered_by_bm25_score outcome metric + an eval row (body read here).
+    wiki_git.commit_file("low.md", "# Low\nbody\n", "seed", author=None)
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_logging": True}),
+    )
+    mock_search.return_value = _cs([], [_hit("low.md", "Low", 2.0)])
+    before = _outcome_count("filtered_by_bm25_score", "low.md")
+    _run(_make_push())
+    assert _outcome_count("filtered_by_bm25_score", "low.md") - before == 1.0
+    rows = _eval_rows("filtered_by_bm25_score")
+    assert len(rows) == 1
+    assert rows[0]["wiki_path"] == "low.md"
+    assert rows[0]["source_document_id"] == "doc-abc"
+
+
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile", return_value=([], 0))
+@patch("app.tasks.wiki_update.ingest_selector.select_candidates", return_value=[])
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_selector_drop_eval_logged(
+    mock_search, mock_select, mock_reconcile, tmp_repo, monkeypatch
+):
+    # The selector drops the only candidate; that (doc, page) pair is eval-logged.
+    wiki_git.commit_file("page.md", "# Page\nbody\n", "seed", author=None)
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.get_llm_settings",
+        lambda: _EMPTY_LLM_SETTINGS.model_copy(
+            update={"model": "main", "ingest_selector_model": "sel"}
+        ),
+    )
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_logging": True}),
+    )
+    mock_search.return_value = _cs([_hit("page.md", "Page", 6.0)])
+    _run(_make_push())
+    rows = _eval_rows("filtered_by_selector")
+    assert len(rows) == 1
+    assert rows[0]["wiki_path"] == "page.md"
 
 
 # --------------------------------------------------------------------------- #
@@ -459,7 +524,7 @@ def test_oversized_query_retries_with_llm_intent(
     monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_selector())
     # First candidate search blows the clause limit; retry with the distilled
     # query succeeds and the doc commits.
-    mock_search.side_effect = [ingest_search.IngestSearchError("maxClauseCount is set to 1024"), [_hit("page.md", "Page", 5.0)]]
+    mock_search.side_effect = [ingest_search.IngestSearchError("maxClauseCount is set to 1024"), _cs([_hit("page.md", "Page", 5.0)])]
     mock_reconcile.return_value = (["new body"], 1)
     _run(_make_push(content="x " * 5000))
     mock_intent.assert_called_once()
@@ -472,7 +537,7 @@ def test_oversized_query_retries_with_llm_intent(
 def test_oversized_query_falls_back_to_bounded_terms_when_no_model(mock_search, mock_bounded):
     # No selector model configured (autouse _EMPTY settings) → no LLM call,
     # fall back to bounded-terms query and retry.
-    mock_search.side_effect = [ingest_search.IngestSearchError("maxClauseCount is set to 1024"), []]
+    mock_search.side_effect = [ingest_search.IngestSearchError("maxClauseCount is set to 1024"), _cs([])]
     _run(_make_push(content="x " * 5000))
     mock_bounded.assert_called_once()
     assert mock_search.call_count == 2

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -452,6 +452,26 @@ def test_selector_drop_eval_logged(
     assert rows[0]["wiki_path"] == "page.md"
 
 
+@patch("app.tasks.wiki_update.ingest_search.bounded_query", return_value="term")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_fallback_bm25_drops_not_recorded(mock_search, mock_bounded, tmp_repo, monkeypatch):
+    # The oversized-query fallback scores against a lossy summary, so its drops
+    # must NOT be recorded — no filtered_by_bm25_score metric and no eval row.
+    wiki_git.commit_file("low.md", "# Low\nbody\n", "seed", author=None)
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_logging": True}),
+    )
+    mock_search.side_effect = [
+        ingest_search.IngestSearchError("maxClauseCount is set to 1024"),
+        _cs([], [_hit("low.md", "Low", 2.0)]),
+    ]
+    before = _outcome_count("filtered_by_bm25_score", "low.md")
+    _run(_make_push(content="x " * 5000))
+    assert _outcome_count("filtered_by_bm25_score", "low.md") - before == 0.0
+    assert _eval_rows("filtered_by_bm25_score") == []
+
+
 # --------------------------------------------------------------------------- #
 # oversized-query handling (LLM intent + bounded fallback)                    #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What
Extend the `ingest_eval_samples` DB capture (behind `INGEST_EVAL_LOGGING`) beyond reconciler verdicts to **pre-reconciler drops** — one row per (doc, candidate page) pair, same shape as today:
- `filtered_by_selector` — the weak-model selector dropped the candidate (the non-deterministic, label-worthy decision)
- `filtered_by_bm25_score` — candidate scored below the BM25 threshold

## How (design)
- **`candidates()` is now a pure function** returning `CandidateSearch(passed, dropped)` — no metrics, git, or DB. (Search-describing histograms stay; the per-drop outcome metric that #255 had put *inside* `candidates()` moves out.)
- **The caller post-processes the drops.** `_record_bm25_drops()` in `wiki_update` emits the `filtered_by_bm25_score` outcome metric **and** writes the eval row (reads the page body, since this path never reads it otherwise).
- **Selector drops** are logged in the existing selector-drop loop (the page body is already in hand).
- `log_sample`'s `outcome` `Literal` widened. All eval writes stay behind `INGEST_EVAL_LOGGING`, in try/except (best-effort, never breaks ingestion).

Rebased onto current `main`; supersedes the earlier callback version per review (keep `candidates()` a pure leaf, side-effects in a post-process step).

## Notes
- Backend-only — no migration (`outcome` is plain text), no dashboard change.
- Storage: per-pair rows; bounded (≤bm25_limit candidates/doc, TOAST-compressed). Prod DB is at 200 GiB, env flag is the kill switch. `created_at` retention task is the clean follow-up.

## Tests
`candidates()` partition test; `test_bm25_drop_recorded_and_eval_logged` + `test_selector_drop_eval_logged` (metric + eval row end-to-end); all existing pipeline tests updated to the `CandidateSearch` return shape. 34 pass; basedpyright + ruff clean.