### PR TITLE
perf(triggers): patch trigger cache in place on move instead of full rebuild

### DIFF
--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -32,9 +32,9 @@ from typing import Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import croniter
-from sqlalchemy import delete as sa_delete, or_, select
+from sqlalchemy import delete as sa_delete, or_, select, update as sa_update
 
-from app.db.models import Event, Trigger
+from app.db.models import Event, Trigger, User
 from app.db.session import advisory_xact_lock, session
 from app.slack import webhooks as slack_webhooks
 from app.triggers import destinations as destinations_repo
@@ -466,6 +466,23 @@ def _is_trigger_file(path: str) -> bool:
     return name.startswith(".trigger_") and name.endswith(".yaml")
 
 
+def _recache_path(trigger_id: str, *, scope_path: str, file_path: str) -> None:
+    """Sync one trigger's cached ``scope_path``/``file_path`` after a move.
+
+    The YAML (source of truth) is already rewritten by the caller; this patches
+    just that cache row instead of reconverging the whole table. A no-op if the
+    id isn't cached (e.g. an orphaned-owner trigger the rebuild never loaded).
+    ``last_edited_at`` is left untouched — a relocation isn't a content edit,
+    matching what the full rebuild (which reads it from the YAML) preserves.
+    """
+    with session() as s:
+        s.execute(
+            sa_update(Trigger)
+            .where(Trigger.id == trigger_id)
+            .values(scope_path=scope_path, file_path=file_path)
+        )
+
+
 def repoint_scopes_for_moves(moves: list[tuple[str, str]], *, actor: str | None) -> None:
     """Rewrite trigger scopes after a path move so they don't dangle.
 
@@ -473,9 +490,10 @@ def repoint_scopes_for_moves(moves: list[tuple[str, str]], *, actor: str | None)
     YAML's filename/location is derived from that scope (``compute_path``). A
     plain ``git mv`` relocates files but never rewrites YAML content, so a
     rename leaves trigger scopes pointing at paths that no longer exist. Fix
-    the YAML files here; the caller (``after_path_move``) reconverges the
-    Postgres cache via ``rebuild_from_filesystem`` immediately after, so this
-    only touches the on-disk source of truth.
+    the YAML files here and patch the affected Postgres cache rows in step
+    (``scope_path``/``file_path`` are the only columns a move changes), so the
+    caller doesn't need a full ``rebuild_from_filesystem`` on the happy path —
+    the work is proportional to the triggers that actually moved.
 
     Two cases, read off the per-file ``(old, new)`` pairs:
       A. A trigger YAML rode along in a folder move (it's a tracked file under
@@ -505,10 +523,12 @@ def repoint_scopes_for_moves(moves: list[tuple[str, str]], *, actor: str | None)
         else:
             new_scope = new_dir
         handled_ids.add(data["id"])
-        if new_scope == old_scope:
-            continue
-        data["scope_path"] = new_scope
-        storage.write_trigger(data, file_path=new_p, actor=actor)
+        if new_scope != old_scope:
+            data["scope_path"] = new_scope
+            storage.write_trigger(data, file_path=new_p, actor=actor)
+        # The YAML physically moved to new_p, so the cached file_path is stale
+        # even when the scope string is unchanged — always re-point the row.
+        _recache_path(data["id"], scope_path=new_scope, file_path=new_p)
 
     # Case B — docs whose sibling doc-scoped trigger YAML stayed put.
     moved_yaml_olds = {old_p for old_p, _ in moves if _is_trigger_file(old_p)}
@@ -537,12 +557,11 @@ def repoint_scopes_for_moves(moves: list[tuple[str, str]], *, actor: str | None)
                 storage.move_trigger(
                     trig, old_file_path=old_file_path, new_file_path=new_file_path, actor=actor
                 )
+            _recache_path(trig["id"], scope_path=new_p, file_path=new_file_path)
 
 
 def rebuild_from_filesystem() -> int:
     """Repopulate the cache from on-disk trigger files. Returns count loaded."""
-    from app.db.models import User
-
     parsed: list[tuple[str, dict[str, Any]]] = []
     skipped = 0
     for file_path in storage.list_all_files():

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -206,17 +206,16 @@ def after_path_move(
             page_dirs.delete_all_for_page(old_p)
     # Triggers store their scope_path inside the moved YAML (and the YAML's
     # location is derived from it), so a git mv leaves scopes dangling. Rewrite
-    # the affected YAMLs, then reconverge the absolute file_path cache from
-    # disk. Both best-effort, in *separate* try blocks: a partial repoint
-    # failure must still let the rebuild run, or the cache would stay stale
-    # against the YAMLs that were rewritten until some later incidental rebuild.
+    # the affected YAMLs and patch their cache rows in step — proportional to
+    # what moved, not the whole table. If that raises partway, fall back to a
+    # full reconverge so a partial repoint can't leave the cache stale.
     try:
         triggers_repo.repoint_scopes_for_moves(moves, actor=actor)
     except Exception:
-        log.exception("trigger scope repoint after path move failed")
-    try:
-        triggers_repo.rebuild_from_filesystem()
-    except Exception:
-        log.exception("trigger cache rebuild after path move failed")
+        log.exception("trigger scope repoint after path move failed; reconverging cache")
+        try:
+            triggers_repo.rebuild_from_filesystem()
+        except Exception:
+            log.exception("fallback trigger cache rebuild after path move failed")
     if list_changed:
         mcp_pubsub.publish_list_changed()

--- a/backend/tests/test_move_notify.py
+++ b/backend/tests/test_move_notify.py
@@ -100,13 +100,31 @@ def test_after_path_move_repoints_update_policy(tmp_repo):
     assert update_policy.get("b.md") is not None
 
 
-def test_after_path_move_reconverges_trigger_cache(tmp_repo, monkeypatch):
-    # Reconvergence lives in the hook (not the API route) so the agent-tool
-    # move path — which also calls after_path_move — picks it up too.
+def test_after_path_move_patches_cache_without_full_rebuild(tmp_repo, monkeypatch):
+    # The move hook re-points trigger cache rows in step (repoint_scopes_for_moves);
+    # a clean move must NOT fall back to the whole-table rebuild_from_filesystem.
+    # (Correct repointing of scope_path/file_path is asserted end-to-end in
+    # test_triggers_repo.py.)
     calls: list[int] = []
-    monkeypatch.setattr(
-        notify.triggers_repo, "rebuild_from_filesystem", lambda: calls.append(1)
-    )
+    monkeypatch.setattr(notify.triggers_repo, "rebuild_from_filesystem", lambda: calls.append(1))
+    sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
+
+    notify.after_path_move([("a.md", "b.md")], sha, actor=None)
+
+    assert calls == []
+
+
+def test_after_path_move_falls_back_to_rebuild_when_repoint_raises(tmp_repo, monkeypatch):
+    # A partial repoint failure must not leave the cache stale — fall back to a
+    # full reconverge. Reconvergence lives in the hook (not the API route) so the
+    # agent-tool move path, which also calls after_path_move, gets it too.
+    calls: list[int] = []
+
+    def boom(*_a: object, **_k: object) -> None:
+        raise RuntimeError("repoint failed")
+
+    monkeypatch.setattr(notify.triggers_repo, "repoint_scopes_for_moves", boom)
+    monkeypatch.setattr(notify.triggers_repo, "rebuild_from_filesystem", lambda: calls.append(1))
     sha = wiki_git.commit_file("a.md", "body\n", "seed", author=None)
 
     notify.after_path_move([("a.md", "b.md")], sha, actor=None)


### PR DESCRIPTION
## Problem

On a page/folder move, `after_path_move` did two things for triggers:
1. `repoint_scopes_for_moves(moves, …)` — **targeted**: rewrites only the affected trigger YAML files (source of truth).
2. `rebuild_from_filesystem()` — **full**: `DELETE FROM triggers` + re-`INSERT` *every* trigger, purely to refresh the cached `scope_path`/`file_path`.

So a one-trigger move rebuilt the entire cache — O(all triggers) work and full-table churn for what's usually a single-row change.

## Change

`repoint_scopes_for_moves` already computes each moved trigger's `id`, new `scope_path`, and new `file_path`. Have it patch just those cache rows via a new `_recache_path()` helper as it rewrites each YAML, and drop the full rebuild from the move hook.

- **Case A** (trigger YAML rode along in a folder move): always re-point `file_path` — the file physically moved even when the scope string is unchanged.
- **Case B** (doc moved, sibling YAML relocated): re-point `scope_path` + `file_path` to the doc's new location.
- `last_edited_at` is left untouched — a relocation isn't a content edit (matches what the full rebuild, reading it from the YAML, preserved).
- **Fallback:** if `repoint_scopes_for_moves` raises partway, `after_path_move` falls back to a full `rebuild_from_filesystem()` so a partial repoint can't leave the cache stale.

Also hoists the `User` import in `repo.py` to module scope (it sits next to the existing `Event, Trigger` import from the same module).

## Testing

- Existing end-to-end repoint tests (`test_triggers_repo.py`: doc-scoped, folder-scoped, single-doc rename) already assert the cache row's `scope_path`/`file_path` after a move — they pass unchanged, confirming the targeted update produces the same rows the full rebuild did.
- `test_move_notify.py`: replaced the mechanism-asserting test with (a) a clean move does **not** call `rebuild_from_filesystem`, and (b) a repoint failure **does** fall back to it.
- ruff + whole-project basedpyright clean.

## Relationship to #254

Independent and complementary. #254 adds an advisory lock to serialize concurrent `rebuild_from_filesystem()` calls (the `--workers 2` boot race). This PR removes the full rebuild from the **move** path but the **boot** path still calls it, so #254 is still needed. They touch different parts of `repo.py`; a trivial rebase may be needed depending on merge order.