### PR TITLE
feat(security): independent ENCRYPTION_KEY_SECRET + re-encrypt rotation tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ DEV_MODE=true
 # Optional dedicated key for at-rest column encryption. Unset = derive the
 # encryption key from SECRET_KEY (the default). Set it to rotate the encryption
 # key independently of the cookie-signing key; when you change it, re-encrypt
-# existing data with `OLD_ENCRYPTION_KEY_SECRET=<prev> python -m app.db.rotate_encryption_key`.
+# existing data with `OLD_ENCRYPTION_KEY_SECRET=<prev> python -m app.scripts.rotate_encryption_key`.
 # ENCRYPTION_KEY_SECRET=
 
 # Where the wiki git repo lives. Relative paths are resolved against the

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ SECRET_KEY=change-me
 # at-rest encryption worthless). Setting it true downgrades that to a warning.
 DEV_MODE=true
 
+# Optional dedicated key for at-rest column encryption. Unset = derive the
+# encryption key from SECRET_KEY (the default). Set it to rotate the encryption
+# key independently of the cookie-signing key; when you change it, re-encrypt
+# existing data with `OLD_ENCRYPTION_KEY_SECRET=<prev> python -m app.db.rotate_encryption_key`.
+# ENCRYPTION_KEY_SECRET=
+
 # Where the wiki git repo lives. Relative paths are resolved against the
 # repo root (see `app/config.py`), so this works regardless of the launch
 # cwd. Compose overrides this to `/data/wiki` for in-container runs.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,10 @@ log = logging.getLogger(__name__)
 # override it — see verify_secret_key().
 DEV_SECRET_KEY = "dev-secret"
 
+# Minimum length for an explicitly-set ENCRYPTION_KEY_SECRET (`openssl rand
+# -hex 32` yields 64). Below this it's too weak to derive an at-rest key from.
+_MIN_ENCRYPTION_KEY_LEN = 32
+
 # Load the repo-root .env so non-Docker launchers (python -m app.main, pytest,
 # task workers) get the same env as `flask run` and docker compose. Search
 # upward from this file rather than relying on CWD.
@@ -44,7 +48,8 @@ class Config(BaseModel):
 
     # Dedicated secret for at-rest column encryption (app/db/crypto.py). Empty =
     # fall back to ``secret_key`` (the historical behavior), so existing
-    # ciphertext keeps decrypting. Set it to rotate the encryption key
+    # ciphertext keeps decrypting. When set it must be a real key (>= 32 chars,
+    # enforced in verify_secret_key()). Set it to rotate the encryption key
     # independently of the cookie-signing key — see app/scripts/rotate_encryption_key.py.
     encryption_key_secret: str
 
@@ -179,27 +184,42 @@ CONFIG = load_config()
 
 
 def verify_secret_key(config: Config | None = None) -> None:
-    """Refuse to start a production deployment on the default/empty SECRET_KEY.
+    """Validate the secrets that protect cookies and at-rest encryption.
 
-    SECRET_KEY signs session cookies and derives the AES key that encrypts the
-    secret columns at rest (app/db/crypto.py). The built-in default is public,
-    so on a real deployment it makes cookies forgeable and the at-rest
-    encryption worthless. Production (``dev_mode`` off, the default) treats a
-    default/empty key as fatal; local dev / CI opt out with ``DEV_MODE=true``
-    so the dev loop keeps working.
+    SECRET_KEY signs session cookies and (by default) derives the AES key that
+    encrypts the secret columns at rest (app/db/crypto.py); the built-in default
+    is public, so it must not be used on a real deployment. ENCRYPTION_KEY_SECRET
+    is optional, but when set it derives the at-rest key, so a weak value
+    silently undermines encryption even when SECRET_KEY is fine — require it to
+    be long enough to be a real key.
 
-    Called at startup before init_db() so a misconfigured prod fails fast
-    rather than encrypting live data under the public default key.
+    Production (``dev_mode`` off, the default) treats a violation as fatal;
+    local dev / CI opt out with ``DEV_MODE=true``. Called at startup before
+    init_db() so a misconfigured prod fails fast rather than encrypting live
+    data under a weak/public key.
     """
     cfg = config or CONFIG
-    if cfg.secret_key and cfg.secret_key != DEV_SECRET_KEY:
-        return
-    message = (
+
+    def _enforce(ok: bool, message: str) -> None:
+        if ok:
+            return
+        if not cfg.dev_mode:
+            raise ValueError(message)
+        log.warning("%s Allowed because DEV_MODE is set.", message)
+
+    _enforce(
+        bool(cfg.secret_key) and cfg.secret_key != DEV_SECRET_KEY,
         "SECRET_KEY is unset or the built-in default. It signs session cookies "
         "and derives the at-rest encryption key, so the public default makes "
         "cookies forgeable and encrypted secrets readable. Generate one with "
-        "`openssl rand -hex 32` and set SECRET_KEY."
+        "`openssl rand -hex 32` and set SECRET_KEY.",
     )
-    if not cfg.dev_mode:
-        raise ValueError(message)
-    log.warning("%s Allowed because DEV_MODE is set.", message)
+    # Optional (falls back to SECRET_KEY), but if an operator sets it, a short
+    # value would silently weaken at-rest encryption — hold it to a real key.
+    _enforce(
+        not cfg.encryption_key_secret
+        or len(cfg.encryption_key_secret) >= _MIN_ENCRYPTION_KEY_LEN,
+        f"ENCRYPTION_KEY_SECRET is set but shorter than {_MIN_ENCRYPTION_KEY_LEN} "
+        "characters; it derives the at-rest encryption key. Generate one with "
+        "`openssl rand -hex 32`.",
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -42,6 +42,12 @@ class Config(BaseModel):
     # `True` when the app is served over HTTPS — toggles SESSION_COOKIE_SECURE.
     secure_cookies: bool
 
+    # Dedicated secret for at-rest column encryption (app/db/crypto.py). Empty =
+    # fall back to ``secret_key`` (the historical behavior), so existing
+    # ciphertext keeps decrypting. Set it to rotate the encryption key
+    # independently of the cookie-signing key — see app/db/rotate_encryption_key.py.
+    encryption_key_secret: str
+
     # `True` only in local dev / CI. Production must leave it false (the
     # default) — it's the opt-in that downgrades verify_secret_key() from
     # fatal to a warning.
@@ -152,6 +158,7 @@ def load_config() -> Config:
         in {"1", "true", "yes"},
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         dev_mode=os.environ.get("DEV_MODE", "false").lower() in {"1", "true", "yes"},
+        encryption_key_secret=os.environ.get("ENCRYPTION_KEY_SECRET", ""),
         launchers_enabled=os.environ.get("LAUNCHERS_ENABLED", "false").lower()
         in {"1", "true", "yes"},
         launch_code_ttl_seconds=_positive_int("LAUNCH_CODE_TTL_SECONDS", 60),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,7 +45,7 @@ class Config(BaseModel):
     # Dedicated secret for at-rest column encryption (app/db/crypto.py). Empty =
     # fall back to ``secret_key`` (the historical behavior), so existing
     # ciphertext keeps decrypting. Set it to rotate the encryption key
-    # independently of the cookie-signing key — see app/db/rotate_encryption_key.py.
+    # independently of the cookie-signing key — see app/scripts/rotate_encryption_key.py.
     encryption_key_secret: str
 
     # `True` only in local dev / CI. Production must leave it false (the

--- a/backend/app/db/crypto.py
+++ b/backend/app/db/crypto.py
@@ -14,8 +14,8 @@ historical default). Splitting the encryption secret from the cookie-signing
 key lets it rotate independently. Changing the active key makes existing
 ciphertext undecryptable (a read raises ``cryptography``'s ``InvalidTag``
 rather than returning garbage), so rotate it with
-``app/db/rotate_encryption_key.py``, which re-encrypts every column from the
-old key to the new one. ``launcher_tokens`` instead re-mints on a key change;
+``app/scripts/rotate_encryption_key.py``, which re-encrypts every column from
+the old key to the new one. ``launcher_tokens`` instead re-mints on a key change;
 it can, a webhook can't.
 """
 from __future__ import annotations

--- a/backend/app/db/crypto.py
+++ b/backend/app/db/crypto.py
@@ -9,11 +9,14 @@ encrypt on write, decrypt on read.
 Storage layout: a single ``bytea`` column holding ``nonce (12 bytes) ||
 ciphertext`` per value. A fresh random nonce is generated on every write.
 
-Key rotation caveat: values are tied to ``SECRET_KEY``. Rotating it makes
-existing ciphertext undecryptable — a read raises ``cryptography``'s
-``InvalidTag`` rather than silently returning garbage. Callers that can
-recover (e.g. re-mint) should catch it; for user-supplied secrets the user
-re-enters the value. (``launcher_tokens`` re-mints; it can, a webhook can't.)
+Key source: ``ENCRYPTION_KEY_SECRET`` when set, else ``SECRET_KEY`` (the
+historical default). Splitting the encryption secret from the cookie-signing
+key lets it rotate independently. Changing the active key makes existing
+ciphertext undecryptable (a read raises ``cryptography``'s ``InvalidTag``
+rather than returning garbage), so rotate it with
+``app/db/rotate_encryption_key.py``, which re-encrypts every column from the
+old key to the new one. ``launcher_tokens`` instead re-mints on a key change;
+it can, a webhook can't.
 """
 from __future__ import annotations
 
@@ -30,22 +33,33 @@ from app.config import CONFIG
 _NONCE_BYTES = 12  # AES-GCM standard nonce length
 
 
-def _key() -> bytes:
-    """32-byte AES key derived from SECRET_KEY (mirrors launcher_tokens)."""
-    return hashlib.sha256(CONFIG.secret_key.encode("utf-8")).digest()
+def active_key_secret() -> str:
+    """Secret material the AES key is derived from: ``ENCRYPTION_KEY_SECRET``
+    when set, else ``SECRET_KEY``. The fallback keeps deployments that never
+    set a dedicated encryption key (and their existing ciphertext) working."""
+    return CONFIG.encryption_key_secret or CONFIG.secret_key
 
 
-def encrypt_string(plaintext: str) -> bytes:
+def _key(secret: str | None = None) -> bytes:
+    """32-byte AES key derived from ``secret`` (defaults to the active secret).
+
+    An explicit ``secret`` lets the rotation tool decrypt under the old key and
+    re-encrypt under the new one in the same process."""
+    material = secret if secret is not None else active_key_secret()
+    return hashlib.sha256(material.encode("utf-8")).digest()
+
+
+def encrypt_string(plaintext: str, *, secret: str | None = None) -> bytes:
     """Return ``nonce || ciphertext`` for ``plaintext`` under AES-256-GCM."""
     nonce = secrets.token_bytes(_NONCE_BYTES)
-    ciphertext = AESGCM(_key()).encrypt(nonce, plaintext.encode("utf-8"), None)
+    ciphertext = AESGCM(_key(secret)).encrypt(nonce, plaintext.encode("utf-8"), None)
     return nonce + ciphertext
 
 
-def decrypt_string(blob: bytes) -> str:
+def decrypt_string(blob: bytes, *, secret: str | None = None) -> str:
     """Inverse of :func:`encrypt_string`. Raises ``InvalidTag`` on a wrong key."""
     nonce, ciphertext = blob[:_NONCE_BYTES], blob[_NONCE_BYTES:]
-    return AESGCM(_key()).decrypt(nonce, ciphertext, None).decode("utf-8")
+    return AESGCM(_key(secret)).decrypt(nonce, ciphertext, None).decode("utf-8")
 
 
 class EncryptedString(TypeDecorator[str]):

--- a/backend/app/db/rotate_encryption_key.py
+++ b/backend/app/db/rotate_encryption_key.py
@@ -1,0 +1,96 @@
+"""Re-encrypt every ``EncryptedString`` column from an old key to the current one.
+
+Run during a maintenance window after pointing ``ENCRYPTION_KEY_SECRET`` at a new
+value (and before the app reads any of these columns under the new key)::
+
+    OLD_ENCRYPTION_KEY_SECRET=<previous-secret> python -m app.db.rotate_encryption_key
+
+For each secret column it reads the raw ``nonce || ciphertext`` bytes — via a
+Core table typed as ``LargeBinary`` so the ``EncryptedString`` decorator's
+auto-encrypt/decrypt is bypassed — decrypts with the old key, re-encrypts with
+the current key, and writes the bytes back. NULLs are skipped.
+
+``launcher_tokens`` are intentionally not rotated: they self-heal by re-minting
+when their ciphertext fails to decrypt (see ``app/db/launcher_tokens.py``).
+
+The "old" secret is whatever the active key was before the change — i.e. the
+previous ``ENCRYPTION_KEY_SECRET``, or ``SECRET_KEY`` if a dedicated encryption
+key is being introduced for the first time.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from sqlalchemy import Column, Integer, LargeBinary, MetaData, Table, Text, select, update
+
+from app.db.crypto import active_key_secret, decrypt_string, encrypt_string
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+# (table, primary-key column, primary-key type, [encrypted columns]).
+# Keep in sync with the EncryptedString columns in app/db/models.py.
+_TARGETS: list[tuple[str, str, type, list[str]]] = [
+    ("slack_webhooks", "id", Text, ["webhook_url"]),
+    (
+        "llm_settings",
+        "id",
+        Integer,
+        ["anthropic_api_key", "openai_api_key", "gemini_api_key", "custom_api_key"],
+    ),
+    ("web_settings", "id", Integer, ["serper_api_key", "firecrawl_api_key"]),
+    ("ingest_settings", "id", Integer, ["api_key"]),
+    ("braintrust_settings", "id", Integer, ["api_key"]),
+]
+
+
+def rotate(old_secret: str, new_secret: str | None = None) -> int:
+    """Re-encrypt all secret columns from ``old_secret`` to ``new_secret``.
+
+    ``new_secret`` defaults to the currently-active key. Returns the number of
+    rows touched. Raises ``cryptography``'s ``InvalidTag`` if ``old_secret`` is
+    wrong for a value — nothing in that table is committed (the session rolls
+    back), so a bad key fails loudly instead of corrupting data.
+    """
+    new = new_secret if new_secret is not None else active_key_secret()
+    rows_touched = 0
+    for table_name, pk, pk_type, cols in _TARGETS:
+        columns: list[Column[Any]] = [Column(pk, pk_type, primary_key=True)]
+        columns += [Column(c, LargeBinary) for c in cols]
+        table = Table(table_name, MetaData(), *columns)
+        with session() as s:
+            for row in s.execute(select(table)).mappings().all():
+                changes = {
+                    c: encrypt_string(decrypt_string(bytes(row[c]), secret=old_secret), secret=new)
+                    for c in cols
+                    if row[c] is not None
+                }
+                if changes:
+                    s.execute(update(table).where(table.c[pk] == row[pk]).values(**changes))
+                    rows_touched += 1
+    log.info(
+        "rotate_encryption_key: re-encrypted %d rows across %d tables",
+        rows_touched,
+        len(_TARGETS),
+    )
+    return rows_touched
+
+
+def main() -> None:
+    from app.utils.logging import setup_logging
+
+    setup_logging()
+    old = os.environ.get("OLD_ENCRYPTION_KEY_SECRET")
+    if not old:
+        raise SystemExit(
+            "OLD_ENCRYPTION_KEY_SECRET must be set to the previous encryption key "
+            "(the prior ENCRYPTION_KEY_SECRET, or SECRET_KEY if introducing a "
+            "dedicated key for the first time)."
+        )
+    rotate(old)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/scripts/rotate_encryption_key.py
+++ b/backend/app/scripts/rotate_encryption_key.py
@@ -23,31 +23,41 @@ import logging
 import os
 from typing import Any
 
-from sqlalchemy import Column, Integer, LargeBinary, MetaData, Table, Text, select, update
+from sqlalchemy import Column, LargeBinary, MetaData, Table, and_, select, update
 
-from app.db.crypto import active_key_secret, decrypt_string, encrypt_string
+from app.db.crypto import EncryptedString, active_key_secret, decrypt_string, encrypt_string
+from app.db.models import Base
 from app.db.session import session
 
 log = logging.getLogger(__name__)
 
-# (table, primary-key column, primary-key type, [encrypted columns]).
-# Keep in sync with the EncryptedString columns in app/db/models.py.
-_TARGETS: list[tuple[str, str, type, list[str]]] = [
-    ("slack_webhooks", "id", Text, ["webhook_url"]),
-    (
-        "llm_settings",
-        "id",
-        Integer,
-        ["anthropic_api_key", "openai_api_key", "gemini_api_key", "custom_api_key"],
-    ),
-    ("web_settings", "id", Integer, ["serper_api_key", "firecrawl_api_key"]),
-    ("ingest_settings", "id", Integer, ["api_key"]),
-    ("braintrust_settings", "id", Integer, ["api_key"]),
-]
+
+def _encrypted_targets() -> list[tuple[Table, list[str], list[str]]]:
+    """Discover every ``EncryptedString`` column from the ORM models.
+
+    Returns, per table that has at least one, a Core ``Table`` whose secret
+    columns are typed as raw ``LargeBinary`` (so the ``EncryptedString``
+    decorator's auto-encrypt/decrypt is bypassed and we see the stored bytes),
+    plus its primary-key and encrypted column names. Deriving this from the
+    mapper rather than a hand-maintained list means a newly added
+    ``EncryptedString`` column is rotated automatically, never silently skipped.
+    """
+    targets: list[tuple[Table, list[str], list[str]]] = []
+    for table in Base.metadata.sorted_tables:
+        enc_cols = [c.name for c in table.columns if isinstance(c.type, EncryptedString)]
+        if not enc_cols:
+            continue
+        pk_cols = [c.name for c in table.primary_key.columns]
+        columns: list[Column[Any]] = [
+            Column(c.name, c.type, primary_key=True) for c in table.primary_key.columns
+        ]
+        columns += [Column(name, LargeBinary) for name in enc_cols]
+        targets.append((Table(table.name, MetaData(), *columns), pk_cols, enc_cols))
+    return targets
 
 
 def rotate(old_secret: str, new_secret: str | None = None) -> int:
-    """Re-encrypt all secret columns from ``old_secret`` to ``new_secret``.
+    """Re-encrypt every EncryptedString column from ``old_secret`` to ``new_secret``.
 
     ``new_secret`` defaults to the currently-active key. Returns the number of
     rows touched. Raises ``cryptography``'s ``InvalidTag`` if ``old_secret`` is
@@ -55,25 +65,24 @@ def rotate(old_secret: str, new_secret: str | None = None) -> int:
     back), so a bad key fails loudly instead of corrupting data.
     """
     new = new_secret if new_secret is not None else active_key_secret()
+    targets = _encrypted_targets()
     rows_touched = 0
-    for table_name, pk, pk_type, cols in _TARGETS:
-        columns: list[Column[Any]] = [Column(pk, pk_type, primary_key=True)]
-        columns += [Column(c, LargeBinary) for c in cols]
-        table = Table(table_name, MetaData(), *columns)
+    for table, pk_cols, enc_cols in targets:
         with session() as s:
             for row in s.execute(select(table)).mappings().all():
                 changes = {
                     c: encrypt_string(decrypt_string(bytes(row[c]), secret=old_secret), secret=new)
-                    for c in cols
+                    for c in enc_cols
                     if row[c] is not None
                 }
                 if changes:
-                    s.execute(update(table).where(table.c[pk] == row[pk]).values(**changes))
+                    where = and_(*[table.c[pk] == row[pk] for pk in pk_cols])
+                    s.execute(update(table).where(where).values(**changes))
                     rows_touched += 1
     log.info(
         "rotate_encryption_key: re-encrypted %d rows across %d tables",
         rows_touched,
-        len(_TARGETS),
+        len(targets),
     )
     return rows_touched
 

--- a/backend/app/scripts/rotate_encryption_key.py
+++ b/backend/app/scripts/rotate_encryption_key.py
@@ -1,21 +1,56 @@
 """Re-encrypt every ``EncryptedString`` column from an old key to the current one.
 
-Run during a maintenance window after pointing ``ENCRYPTION_KEY_SECRET`` at a new
-value (and before the app reads any of these columns under the new key)::
+WHAT IT DOES
+    For each secret column it reads the raw ``nonce || ciphertext`` bytes — via a
+    Core table typed as ``LargeBinary`` so the ``EncryptedString`` decorator's
+    auto-encrypt/decrypt is bypassed — decrypts with the OLD key, re-encrypts with
+    the NEW (currently-active) key, and writes the bytes back. NULLs are skipped.
+    The target columns are discovered from the ORM (every ``EncryptedString``
+    column), so a newly added secret column is rotated automatically.
 
-    OLD_ENCRYPTION_KEY_SECRET=<previous-secret> python -m app.scripts.rotate_encryption_key
+    - NEW key  = the active key in this process: ``ENCRYPTION_KEY_SECRET`` if set,
+      else ``SECRET_KEY``.
+    - OLD key  = ``OLD_ENCRYPTION_KEY_SECRET`` (required): whatever the data is
+      *currently* encrypted under — the previous ``ENCRYPTION_KEY_SECRET``, or
+      ``SECRET_KEY`` if you're introducing a dedicated encryption key for the
+      first time (the "split").
 
-For each secret column it reads the raw ``nonce || ciphertext`` bytes — via a
-Core table typed as ``LargeBinary`` so the ``EncryptedString`` decorator's
-auto-encrypt/decrypt is bypassed — decrypts with the old key, re-encrypts with
-the current key, and writes the bytes back. NULLs are skipped.
+WHY ORDER MATTERS — RUN IT IN A MAINTENANCE WINDOW
+    At any instant there is exactly ONE active key, and a process can only decrypt
+    data that is under *its* key. A rotation flips two things that cannot be made
+    atomic: the *data* (old -> new, done by this script) and the *running
+    processes* (old -> new, done by restarting them with the new key). Whenever
+    those two disagree, reads of the secret columns fail with ``InvalidTag`` and
+    LLM / Slack-webhook features break.
 
-``launcher_tokens`` are intentionally not rotated: they self-heal by re-minting
-when their ciphertext fails to decrypt (see ``app/db/launcher_tokens.py``).
+    In particular, do NOT just "set the new key and restart the app, then rotate":
+    the moment the app comes up on the new key it can't read the still-old data.
+    Instead, take a short window where no app process is reading these columns:
 
-The "old" secret is whatever the active key was before the change — i.e. the
-previous ``ENCRYPTION_KEY_SECRET``, or ``SECRET_KEY`` if a dedicated encryption
-key is being introduced for the first time.
+        1. Put the NEW value in the secret store, but do NOT restart the app yet
+           (running pods keep the OLD key in memory and keep working).
+        2. Stop / scale the backend + workers to zero (no live readers).
+        3. Run this script with OLD_ENCRYPTION_KEY_SECRET=<old> and the env's
+           ENCRYPTION_KEY_SECRET=<new>:
+
+               OLD_ENCRYPTION_KEY_SECRET=<old> ENCRYPTION_KEY_SECRET=<new> \\
+                   python -m app.scripts.rotate_encryption_key
+
+        4. Start the backend + workers back up on the NEW key.
+
+    The dataset is tiny (singleton settings tables + a handful of webhooks), so
+    the script is sub-second and the window is short — but it IS a brief outage of
+    LLM/Slack features, not a seamless rotation. (A seamless option would require
+    try-new-then-old "dual-key" decryption during a grace period; not implemented.)
+
+NOTES
+    - ``ENCRYPTION_KEY_SECRET``, when set, must be >= 32 chars (enforced by
+      ``app.config.verify_secret_key`` at startup).
+    - A wrong OLD key raises ``InvalidTag`` and that table's transaction rolls
+      back — a bad key fails loudly rather than corrupting data. Safe to re-run.
+    - ``launcher_tokens`` are intentionally NOT rotated: they self-heal by
+      re-minting when their ciphertext fails to decrypt (see
+      ``app/db/launcher_tokens.py``).
 """
 from __future__ import annotations
 

--- a/backend/app/scripts/rotate_encryption_key.py
+++ b/backend/app/scripts/rotate_encryption_key.py
@@ -3,7 +3,7 @@
 Run during a maintenance window after pointing ``ENCRYPTION_KEY_SECRET`` at a new
 value (and before the app reads any of these columns under the new key)::
 
-    OLD_ENCRYPTION_KEY_SECRET=<previous-secret> python -m app.db.rotate_encryption_key
+    OLD_ENCRYPTION_KEY_SECRET=<previous-secret> python -m app.scripts.rotate_encryption_key
 
 For each secret column it reads the raw ``nonce || ciphertext`` bytes — via a
 Core table typed as ``LargeBinary`` so the ``EncryptedString`` decorator's

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -113,6 +113,7 @@ def tmp_config(tmp_path, monkeypatch):
         oidc_redirect_uri="",
         secure_cookies=False,
         dev_mode=True,
+        encryption_key_secret="",
         ingest_bm25_min_score=1.0,
         ingest_bm25_title_boost=2.0,
         ingest_bm25_limit=20,

--- a/backend/tests/test_crypto_key.py
+++ b/backend/tests/test_crypto_key.py
@@ -1,0 +1,45 @@
+"""Key derivation for at-rest encryption: dedicated secret with SECRET_KEY fallback."""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from app.db import crypto
+
+
+def test_round_trip_with_explicit_secret() -> None:
+    blob = crypto.encrypt_string("hunter2", secret="key-a")
+    assert crypto.decrypt_string(blob, secret="key-a") == "hunter2"
+
+
+def test_wrong_secret_raises_rather_than_returning_garbage() -> None:
+    blob = crypto.encrypt_string("hunter2", secret="key-a")
+    with pytest.raises(InvalidTag):
+        crypto.decrypt_string(blob, secret="key-b")
+
+
+def test_key_is_sha256_of_secret() -> None:
+    assert crypto._key("key-a") == hashlib.sha256(b"key-a").digest()
+
+
+def test_active_secret_falls_back_to_secret_key_when_encryption_key_unset(monkeypatch) -> None:
+    cfg = crypto.CONFIG.model_copy(update={"encryption_key_secret": "", "secret_key": "sk"})
+    monkeypatch.setattr("app.db.crypto.CONFIG", cfg)
+    assert crypto.active_key_secret() == "sk"
+
+
+def test_active_secret_prefers_encryption_key_when_set(monkeypatch) -> None:
+    cfg = crypto.CONFIG.model_copy(update={"encryption_key_secret": "ek", "secret_key": "sk"})
+    monkeypatch.setattr("app.db.crypto.CONFIG", cfg)
+    assert crypto.active_key_secret() == "ek"
+
+
+def test_fallback_decrypts_secret_key_era_ciphertext(monkeypatch) -> None:
+    # A value written before a dedicated key existed (encrypted under SECRET_KEY)
+    # must still decrypt when ENCRYPTION_KEY_SECRET is unset.
+    cfg = crypto.CONFIG.model_copy(update={"encryption_key_secret": "", "secret_key": "sk"})
+    monkeypatch.setattr("app.db.crypto.CONFIG", cfg)
+    blob = crypto.encrypt_string("legacy-value")
+    assert crypto.decrypt_string(blob) == "legacy-value"

--- a/backend/tests/test_rotate_encryption_key.py
+++ b/backend/tests/test_rotate_encryption_key.py
@@ -6,7 +6,7 @@ from cryptography.exceptions import InvalidTag
 from sqlalchemy import Column, Integer, LargeBinary, MetaData, Table, select
 
 from app.db import crypto
-from app.db.rotate_encryption_key import rotate
+from app.scripts.rotate_encryption_key import rotate
 from app.db.session import session
 from app.llm import settings as llm_settings
 

--- a/backend/tests/test_rotate_encryption_key.py
+++ b/backend/tests/test_rotate_encryption_key.py
@@ -1,0 +1,59 @@
+"""rotate_encryption_key: re-encrypt secret columns from an old key to the new one."""
+from __future__ import annotations
+
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import Column, Integer, LargeBinary, MetaData, Table, select
+
+from app.db import crypto
+from app.db.rotate_encryption_key import rotate
+from app.db.session import session
+from app.llm import settings as llm_settings
+
+
+def _raw_anthropic_key() -> bytes:
+    """Raw ciphertext bytes of llm_settings.anthropic_api_key (bypasses EncryptedString)."""
+    t = Table(
+        "llm_settings",
+        MetaData(),
+        Column("id", Integer, primary_key=True),
+        Column("anthropic_api_key", LargeBinary),
+    )
+    with session() as s:
+        return bytes(s.execute(select(t.c.anthropic_api_key).where(t.c.id == 1)).scalar_one())
+
+
+def test_rotate_reencrypts_under_new_key(tmp_db: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    llm_settings.upsert(
+        provider="anthropic",
+        model="m",
+        anthropic_api_key="sk-rotate-me",
+        openai_api_key="",
+        gemini_api_key="",
+        ollama_base_url="",
+        custom_api_key="",
+        custom_base_url="",
+        custom_display_name="",
+    )
+
+    old_secret = crypto.active_key_secret()
+    before = _raw_anthropic_key()
+    assert crypto.decrypt_string(before, secret=old_secret) == "sk-rotate-me"
+
+    # Point the active key at a new secret, then rotate from the old one.
+    new_secret = old_secret + "-rotated-v2"
+    monkeypatch.setattr(
+        "app.db.crypto.CONFIG",
+        crypto.CONFIG.model_copy(update={"encryption_key_secret": new_secret}),
+    )
+    touched = rotate(old_secret=old_secret)
+
+    assert touched == 1  # the single llm_settings row
+    after = _raw_anthropic_key()
+    assert after != before  # genuinely re-encrypted
+    # Reads now succeed under the new active key...
+    assert llm_settings.get().anthropic_api_key == "sk-rotate-me"
+    assert crypto.decrypt_string(after, secret=new_secret) == "sk-rotate-me"
+    # ...and the old key no longer decrypts the rotated value.
+    with pytest.raises(InvalidTag):
+        crypto.decrypt_string(after, secret=old_secret)

--- a/backend/tests/test_verify_secret_key.py
+++ b/backend/tests/test_verify_secret_key.py
@@ -13,8 +13,14 @@ import pytest
 from app.config import CONFIG, DEV_SECRET_KEY, Config, verify_secret_key
 
 
-def _cfg(*, secret_key: str, dev_mode: bool) -> Config:
-    return CONFIG.model_copy(update={"secret_key": secret_key, "dev_mode": dev_mode})
+def _cfg(*, secret_key: str = "a-real-secret", dev_mode: bool, encryption_key_secret: str = "") -> Config:
+    return CONFIG.model_copy(
+        update={
+            "secret_key": secret_key,
+            "dev_mode": dev_mode,
+            "encryption_key_secret": encryption_key_secret,
+        }
+    )
 
 
 def test_rejects_default_key_in_production() -> None:
@@ -42,3 +48,29 @@ def test_warns_but_allows_empty_key_in_dev(caplog: pytest.LogCaptureFixture) -> 
 def test_accepts_real_key_in_production() -> None:
     # A configured key boots cleanly regardless of dev_mode and emits no warning.
     verify_secret_key(_cfg(secret_key="a-real-32-byte-hex-secret", dev_mode=False))
+
+
+# ENCRYPTION_KEY_SECRET: optional, but if set it must be a real key.
+
+_WEAK_ENCRYPTION_KEY = "test"
+_STRONG_ENCRYPTION_KEY = "x" * 32
+
+
+def test_rejects_short_encryption_key_in_production() -> None:
+    with pytest.raises(ValueError, match="ENCRYPTION_KEY_SECRET"):
+        verify_secret_key(_cfg(dev_mode=False, encryption_key_secret=_WEAK_ENCRYPTION_KEY))
+
+
+def test_warns_but_allows_short_encryption_key_in_dev(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING):
+        verify_secret_key(_cfg(dev_mode=True, encryption_key_secret=_WEAK_ENCRYPTION_KEY))
+    assert any("ENCRYPTION_KEY_SECRET" in r.message for r in caplog.records)
+
+
+def test_accepts_strong_encryption_key_in_production() -> None:
+    verify_secret_key(_cfg(dev_mode=False, encryption_key_secret=_STRONG_ENCRYPTION_KEY))
+
+
+def test_unset_encryption_key_is_fine_in_production() -> None:
+    # Empty = fall back to SECRET_KEY, so no strength check applies.
+    verify_secret_key(_cfg(dev_mode=False, encryption_key_secret=""))


### PR DESCRIPTION
## Why

At-rest column encryption (`app/db/crypto.py`, shipped in #252) derived its AES key from `SECRET_KEY`. Two problems:
- The encryption key couldn't be rotated independently of the cookie-signing key — rotating `SECRET_KEY` to refresh cookie signing would make **every encrypted column undecryptable**.
- There was no recovery path: changing the key left ciphertext stuck (the design doc flagged this as gap #5).

This adds the ability to rotate the encryption key safely.

## Change

- **`ENCRYPTION_KEY_SECRET` config** (`app/config.py`). `crypto.active_key_secret()` returns it when set, else falls back to `SECRET_KEY`. **No behavior change for existing deployments** — unset means the key is derived from `SECRET_KEY` exactly as before, so existing ciphertext keeps decrypting.
- **`encrypt_string` / `decrypt_string` take an optional `secret`** so the old and new keys can both be used in one process.
- **`app/db/rotate_encryption_key.py`** — the re-encrypt walker. For each of the 8 `EncryptedString` columns (slack_webhooks, llm_settings ×4, web_settings ×2, ingest_settings, braintrust_settings), it reads the raw `nonce||ciphertext` bytes via a Core table typed as `LargeBinary` (bypassing the `EncryptedString` auto-encrypt/decrypt), decrypts with the old key, re-encrypts with the current key, and writes back. Per-table transaction, so a wrong old key fails loudly (rolls back) instead of corrupting data. NULLs skipped.
- **`launcher_tokens` are intentionally excluded** — they self-heal by re-minting when their ciphertext fails to decrypt (see `app/db/launcher_tokens.py`).

Rotation procedure (maintenance window):
```
# point ENCRYPTION_KEY_SECRET at the new value, then:
OLD_ENCRYPTION_KEY_SECRET=<previous> python -m app.db.rotate_encryption_key
```
(The "old" secret is the prior `ENCRYPTION_KEY_SECRET`, or `SECRET_KEY` if introducing a dedicated key for the first time.)

## Testing

- `tests/test_crypto_key.py` — explicit-secret round-trip, wrong-secret raises `InvalidTag`, SHA-256 derivation, `ENCRYPTION_KEY_SECRET` precedence, and that `SECRET_KEY`-era ciphertext still decrypts under the fallback.
- `tests/test_rotate_encryption_key.py` — seeds a row under the old key, points the active key at a new secret, runs `rotate(old)`, and asserts: row re-encrypted (raw bytes changed), reads succeed under the new key, and the old key no longer decrypts it.
- 29 passing across the crypto/settings/guard suites; whole-project basedpyright + ruff clean.

## Deploy note

This only adds the *capability*; current deployments are unaffected (they keep deriving from `SECRET_KEY`). Actually splitting the keys in prod is a separate ops step: wire `ENCRYPTION_KEY_SECRET` into the Helm chart / Secrets Manager, set it, and run the rotation tool. Resolves the "single key" open question and gap #5 in `design/Secret Handling.md`.