### PR TITLE
security: scrub secrets from DEBUG LLM payload dumps

### DIFF
--- a/backend/app/llm/agents/chat.py
+++ b/backend/app/llm/agents/chat.py
@@ -22,6 +22,7 @@ from app.llm import client
 from app.llm.agents import skills as skill_registry
 from app.llm.agents import tools as tool_registry
 from app.llm.prompts import load_prompt
+from app.llm.redact import scrub_secrets
 from app.tracing import start_tool_span
 from app.wiki import agent_activity
 
@@ -34,14 +35,17 @@ CHAT_AGENT_NAME = "Wiki AI Assistant"
 
 
 def _debug_dump(label: str, obj: Any) -> None:
-    """Pretty-print ``obj`` to the log at DEBUG, untruncated."""
+    """Pretty-print ``obj`` to the log at DEBUG, untruncated (secrets scrubbed).
+
+    Tool-call arguments and tool results pass through here, so scrub before
+    logging — same as app/llm/client._debug_dump."""
     if not log.isEnabledFor(logging.DEBUG):
         return
     try:
         rendered = json.dumps(obj, indent=2, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         rendered = repr(obj)
-    log.debug("%s\n%s", label, rendered)
+    log.debug("%s\n%s", label, scrub_secrets(rendered))
 
 Message = dict[str, Any]
 ToolDispatch = Callable[[str, dict[str, Any]], Any]

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -37,13 +37,13 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from typing import Any, Iterator
 
 from pydantic import BaseModel, Field
 
 from app.llm import providers
 from app.llm.errors import LLMError
+from app.llm.redact import scrub_secrets
 from app.llm.settings import get as get_llm_settings
 from app.tracing import start_llm_span, to_openai_message_shape
 
@@ -79,43 +79,6 @@ class CompletionResult(BaseModel):
     usage: Usage = Field(default_factory=Usage)
 
 
-_REDACTED = "[redacted]"
-
-# Values under a secret-ish JSON key — "api_key": "...", "authorization": "...".
-# Matches the rendered JSON, so it catches secrets nested anywhere (message
-# content, tool args, tool results). Numbers (e.g. "input_tokens": 5) are
-# unquoted and don't match.
-_KEYED_SECRET_RE = re.compile(
-    r'("[a-z_]*(?:api[_-]?key|secret|token|password|authorization)[a-z_]*"\s*:\s*")[^"]+(")',
-    re.IGNORECASE,
-)
-# Recognizable credential token shapes — conservative, prefix-anchored so we
-# don't mangle ordinary prose. Keep the prefix for debuggability, redact the body.
-_TOKEN_RES = [
-    re.compile(r"(sk-ant-)[A-Za-z0-9_\-]{12,}"),  # Anthropic
-    re.compile(r"(sk-(?:proj-)?)[A-Za-z0-9_\-]{16,}"),  # OpenAI
-    re.compile(r"(AIza)[A-Za-z0-9_\-]{20,}"),  # Google / Gemini
-    re.compile(r"(AKIA)[0-9A-Z]{16}"),  # AWS access key id
-    re.compile(r"(xox[baprs]-)[A-Za-z0-9-]{8,}"),  # Slack
-    re.compile(r"(gh[pousr]_)[A-Za-z0-9]{20,}"),  # GitHub
-    re.compile(r"(Bearer\s+)[A-Za-z0-9._\-]{8,}", re.IGNORECASE),  # bearer tokens
-]
-
-
-def _scrub_secrets(text: str) -> str:
-    """Mask credentials in a debug payload before it hits the log.
-
-    DEBUG dumps the full LLM message history + tool defs/args/results, any of
-    which can carry a secret (a key pasted into a prompt, a tool result holding
-    a config value). This best-effort scrub catches secret-keyed JSON fields and
-    well-known token shapes; it is not a guarantee, so DEBUG remains an
-    operator-only level."""
-    text = _KEYED_SECRET_RE.sub(rf"\1{_REDACTED}\2", text)
-    for pat in _TOKEN_RES:
-        text = pat.sub(rf"\1{_REDACTED}", text)
-    return text
-
-
 def _debug_dump(label: str, obj: Any) -> None:
     """Pretty-print ``obj`` to the log at DEBUG, untruncated (secrets scrubbed).
 
@@ -128,7 +91,7 @@ def _debug_dump(label: str, obj: Any) -> None:
         rendered = json.dumps(obj, indent=2, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         rendered = repr(obj)
-    log.debug("%s\n%s", label, _scrub_secrets(rendered))
+    log.debug("%s\n%s", label, scrub_secrets(rendered))
 
 
 def stream(

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, Iterator
 
 from pydantic import BaseModel, Field
@@ -78,8 +79,45 @@ class CompletionResult(BaseModel):
     usage: Usage = Field(default_factory=Usage)
 
 
+_REDACTED = "[redacted]"
+
+# Values under a secret-ish JSON key — "api_key": "...", "authorization": "...".
+# Matches the rendered JSON, so it catches secrets nested anywhere (message
+# content, tool args, tool results). Numbers (e.g. "input_tokens": 5) are
+# unquoted and don't match.
+_KEYED_SECRET_RE = re.compile(
+    r'("[a-z_]*(?:api[_-]?key|secret|token|password|authorization)[a-z_]*"\s*:\s*")[^"]+(")',
+    re.IGNORECASE,
+)
+# Recognizable credential token shapes — conservative, prefix-anchored so we
+# don't mangle ordinary prose. Keep the prefix for debuggability, redact the body.
+_TOKEN_RES = [
+    re.compile(r"(sk-ant-)[A-Za-z0-9_\-]{12,}"),  # Anthropic
+    re.compile(r"(sk-(?:proj-)?)[A-Za-z0-9_\-]{16,}"),  # OpenAI
+    re.compile(r"(AIza)[A-Za-z0-9_\-]{20,}"),  # Google / Gemini
+    re.compile(r"(AKIA)[0-9A-Z]{16}"),  # AWS access key id
+    re.compile(r"(xox[baprs]-)[A-Za-z0-9-]{8,}"),  # Slack
+    re.compile(r"(gh[pousr]_)[A-Za-z0-9]{20,}"),  # GitHub
+    re.compile(r"(Bearer\s+)[A-Za-z0-9._\-]{8,}", re.IGNORECASE),  # bearer tokens
+]
+
+
+def _scrub_secrets(text: str) -> str:
+    """Mask credentials in a debug payload before it hits the log.
+
+    DEBUG dumps the full LLM message history + tool defs/args/results, any of
+    which can carry a secret (a key pasted into a prompt, a tool result holding
+    a config value). This best-effort scrub catches secret-keyed JSON fields and
+    well-known token shapes; it is not a guarantee, so DEBUG remains an
+    operator-only level."""
+    text = _KEYED_SECRET_RE.sub(rf"\1{_REDACTED}\2", text)
+    for pat in _TOKEN_RES:
+        text = pat.sub(rf"\1{_REDACTED}", text)
+    return text
+
+
 def _debug_dump(label: str, obj: Any) -> None:
-    """Pretty-print ``obj`` to the log at DEBUG, untruncated.
+    """Pretty-print ``obj`` to the log at DEBUG, untruncated (secrets scrubbed).
 
     Skips serialization entirely when DEBUG isn't enabled — no cost on the
     hot path. Use for full LLM payloads (messages, tools, responses).
@@ -90,7 +128,7 @@ def _debug_dump(label: str, obj: Any) -> None:
         rendered = json.dumps(obj, indent=2, ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         rendered = repr(obj)
-    log.debug("%s\n%s", label, rendered)
+    log.debug("%s\n%s", label, _scrub_secrets(rendered))
 
 
 def stream(

--- a/backend/app/llm/redact.py
+++ b/backend/app/llm/redact.py
@@ -1,0 +1,45 @@
+"""Best-effort secret scrubbing for DEBUG log payloads.
+
+Shared by every place that dumps full LLM payloads at ``LOG_LEVEL=DEBUG``
+(``app/llm/client.py`` and ``app/llm/agents/chat.py``) — the message history,
+tool definitions, tool-call arguments, and tool results, any of which can carry
+a secret (a key pasted into a prompt, a tool result holding a config value or
+HTTP headers). Centralised here so the two debug-dump paths can't drift.
+
+This is pattern matching, not a guarantee — it catches secret-keyed JSON fields
+and well-known credential token shapes, so DEBUG stays an operator-only level.
+"""
+from __future__ import annotations
+
+import re
+
+_REDACTED = "[redacted]"
+
+# Values under a secret-ish JSON key — "api_key": "...", "x-api-key": "...".
+# Matches the rendered JSON, so it catches secrets nested anywhere. The
+# surrounding class allows ``-`` so hyphenated header-style keys (x-api-key,
+# access-token) are covered. Numbers (e.g. "input_tokens": 5) are unquoted and
+# don't match.
+_KEYED_SECRET_RE = re.compile(
+    r'("[a-z_-]*(?:api[_-]?key|secret|token|password|authorization)[a-z_-]*"\s*:\s*")[^"]+(")',
+    re.IGNORECASE,
+)
+# Recognizable credential token shapes — conservative, prefix-anchored so we
+# don't mangle ordinary prose. Keep the prefix for debuggability, redact the body.
+_TOKEN_RES = [
+    re.compile(r"(sk-ant-)[A-Za-z0-9_\-]{12,}"),  # Anthropic
+    re.compile(r"(sk-(?:proj-)?)[A-Za-z0-9_\-]{16,}"),  # OpenAI
+    re.compile(r"(AIza)[A-Za-z0-9_\-]{20,}"),  # Google / Gemini
+    re.compile(r"(AKIA)[0-9A-Z]{16}"),  # AWS access key id
+    re.compile(r"(xox[baprs]-)[A-Za-z0-9-]{8,}"),  # Slack
+    re.compile(r"(gh[pousr]_)[A-Za-z0-9]{20,}"),  # GitHub
+    re.compile(r"(Bearer\s+)[A-Za-z0-9._\-]{8,}", re.IGNORECASE),  # bearer tokens
+]
+
+
+def scrub_secrets(text: str) -> str:
+    """Mask credentials in a rendered debug payload before it hits the log."""
+    text = _KEYED_SECRET_RE.sub(rf"\1{_REDACTED}\2", text)
+    for pat in _TOKEN_RES:
+        text = pat.sub(rf"\1{_REDACTED}", text)
+    return text

--- a/backend/tests/test_debug_scrub.py
+++ b/backend/tests/test_debug_scrub.py
@@ -1,0 +1,41 @@
+"""DEBUG LLM-payload dumps scrub secrets before logging (app/llm/client._debug_dump)."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from app.llm import client
+
+
+def test_scrubs_keyed_secret_fields() -> None:
+    out = client._scrub_secrets('{"anthropic_api_key": "sk-ant-abc123def456ghi789"}')
+    assert "sk-ant-abc123def456ghi789" not in out
+    assert '"anthropic_api_key": "[redacted]"' in out
+
+
+def test_scrubs_known_token_shapes_anywhere() -> None:
+    # A key pasted into free-text message content, not under a secret-y key.
+    out = client._scrub_secrets('{"content": "my key is sk-ant-abc123def456ghi789xyz please use it"}')
+    assert "abc123def456ghi789xyz" not in out
+    assert "sk-ant-[redacted]" in out
+
+
+def test_scrubs_bearer_and_aws() -> None:
+    assert "[redacted]" in client._scrub_secrets("Authorization: Bearer abcdef1234567890")
+    assert "AKIA[redacted]" in client._scrub_secrets("AKIAIOSFODNN7EXAMPLE")
+
+
+def test_leaves_ordinary_content_and_numbers_untouched() -> None:
+    payload = '{"role": "user", "content": "summarize the runbook", "input_tokens": 512}'
+    assert client._scrub_secrets(payload) == payload
+
+
+def test_debug_dump_logs_scrubbed(caplog: pytest.LogCaptureFixture) -> None:
+    obj = {"messages": [{"role": "user", "content": "token: sk-ant-SECRETSECRETSECRET123"}]}
+    with caplog.at_level(logging.DEBUG, logger="app.llm.client"):
+        client._debug_dump("llm request messages", obj)
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "llm request messages" in logged
+    assert "SECRETSECRETSECRET123" not in logged
+    assert "sk-ant-[redacted]" in logged

--- a/backend/tests/test_debug_scrub.py
+++ b/backend/tests/test_debug_scrub.py
@@ -1,4 +1,8 @@
-"""DEBUG LLM-payload dumps scrub secrets before logging (app/llm/client._debug_dump)."""
+"""DEBUG LLM-payload dumps scrub secrets before logging.
+
+Covers the shared scrubber (app/llm/redact.scrub_secrets) and both debug-dump
+paths that use it: app/llm/client and app/llm/agents/chat.
+"""
 from __future__ import annotations
 
 import logging
@@ -6,32 +10,43 @@ import logging
 import pytest
 
 from app.llm import client
+from app.llm.agents import chat
+from app.llm.redact import scrub_secrets
 
 
 def test_scrubs_keyed_secret_fields() -> None:
-    out = client._scrub_secrets('{"anthropic_api_key": "sk-ant-abc123def456ghi789"}')
+    out = scrub_secrets('{"anthropic_api_key": "sk-ant-abc123def456ghi789"}')
     assert "sk-ant-abc123def456ghi789" not in out
     assert '"anthropic_api_key": "[redacted]"' in out
 
 
+def test_scrubs_hyphenated_header_style_keys() -> None:
+    # Hyphenated keys (HTTP headers serialized into a tool result) must be covered.
+    out = scrub_secrets('{"x-api-key": "raw-secret-value", "access-token": "another-one"}')
+    assert "raw-secret-value" not in out
+    assert "another-one" not in out
+    assert '"x-api-key": "[redacted]"' in out
+    assert '"access-token": "[redacted]"' in out
+
+
 def test_scrubs_known_token_shapes_anywhere() -> None:
     # A key pasted into free-text message content, not under a secret-y key.
-    out = client._scrub_secrets('{"content": "my key is sk-ant-abc123def456ghi789xyz please use it"}')
+    out = scrub_secrets('{"content": "my key is sk-ant-abc123def456ghi789xyz please use it"}')
     assert "abc123def456ghi789xyz" not in out
     assert "sk-ant-[redacted]" in out
 
 
 def test_scrubs_bearer_and_aws() -> None:
-    assert "[redacted]" in client._scrub_secrets("Authorization: Bearer abcdef1234567890")
-    assert "AKIA[redacted]" in client._scrub_secrets("AKIAIOSFODNN7EXAMPLE")
+    assert "[redacted]" in scrub_secrets("Authorization: Bearer abcdef1234567890")
+    assert "AKIA[redacted]" in scrub_secrets("AKIAIOSFODNN7EXAMPLE")
 
 
 def test_leaves_ordinary_content_and_numbers_untouched() -> None:
     payload = '{"role": "user", "content": "summarize the runbook", "input_tokens": 512}'
-    assert client._scrub_secrets(payload) == payload
+    assert scrub_secrets(payload) == payload
 
 
-def test_debug_dump_logs_scrubbed(caplog: pytest.LogCaptureFixture) -> None:
+def test_client_debug_dump_logs_scrubbed(caplog: pytest.LogCaptureFixture) -> None:
     obj = {"messages": [{"role": "user", "content": "token: sk-ant-SECRETSECRETSECRET123"}]}
     with caplog.at_level(logging.DEBUG, logger="app.llm.client"):
         client._debug_dump("llm request messages", obj)
@@ -39,3 +54,15 @@ def test_debug_dump_logs_scrubbed(caplog: pytest.LogCaptureFixture) -> None:
     assert "llm request messages" in logged
     assert "SECRETSECRETSECRET123" not in logged
     assert "sk-ant-[redacted]" in logged
+
+
+def test_chat_debug_dump_scrubs_tool_results(caplog: pytest.LogCaptureFixture) -> None:
+    # Tool-call args/results flow through chat._debug_dump — the path the
+    # original PR missed. Model a tool result that serializes HTTP response
+    # headers (nested dict, the case the reviewer flagged).
+    tool_result = {"role": "tool", "content": {"headers": {"x-api-key": "secret-header-value-123"}}}
+    with caplog.at_level(logging.DEBUG, logger="app.llm.agents.chat"):
+        chat._debug_dump("chat tool result", tool_result)
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "secret-header-value-123" not in logged
+    assert '"x-api-key": "[redacted]"' in logged


### PR DESCRIPTION
## Why (gap #4 in design/Secret Handling.md)

`app/llm/client.py:_debug_dump` serializes the **full LLM message history + tool definitions/args/results** at `LOG_LEVEL=DEBUG`. Provider keys aren't in those payloads (they ride in HTTP headers), but any secret that lands in a prompt or tool result — a key pasted into a message, a tool returning a config value — was logged verbatim.

## Change

Add `_scrub_secrets()` and apply it to the rendered payload before logging. It masks:
- **secret-keyed JSON fields** — values under keys matching `api_key` / `secret` / `token` / `password` / `authorization` (catches secrets nested anywhere in the dump; numbers like `"input_tokens": 5` are unquoted and untouched).
- **well-known credential token shapes** — Anthropic (`sk-ant-…`), OpenAI (`sk-…`), Google (`AIza…`), AWS (`AKIA…`), Slack (`xox[baprs]-…`), GitHub (`gh[pousr]_…`), and `Bearer …` — prefix-anchored so ordinary prose isn't mangled; the prefix is kept for debuggability, the body replaced with `[redacted]`.

It's best-effort pattern matching, not a guarantee, so DEBUG remains an operator-only level — but it closes the obvious "secret in a prompt/tool-arg gets logged in the clear" hole.

## Testing

`tests/test_debug_scrub.py`: keyed-field redaction, free-text token redaction, Bearer/AWS, ordinary-content-and-numbers untouched, and an end-to-end `_debug_dump` test asserting the logged record contains the marker, not the raw secret. ruff + whole-project basedpyright clean.

Closes the last open item in `design/Secret Handling.md` (gap #4).