### PR TITLE
feat(ingest): raise BM25 candidate cap default 20 -> 100

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -152,7 +152,7 @@ def load_config() -> Config:
         max_queue_size=_positive_int("MAX_QUEUE_SIZE", 1000),
         ingest_bm25_min_score=_positive_float("INGEST_BM25_MIN_SCORE", 5.0),
         ingest_bm25_title_boost=_positive_float("INGEST_BM25_TITLE_BOOST", 2.0),
-        ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),
+        ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 100),
         ingest_irrelevant_stop_n=_positive_int("INGEST_IRRELEVANT_STOP_N", 2),
         auth_mode=os.environ.get("AUTH_MODE", "basic"),
         oidc_issuer=os.environ.get("OIDC_ISSUER", ""),

--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -8,7 +8,7 @@ Wraps ``app.db.fts.search`` with:
 Parameters are read from env vars so they can be tuned without a deploy:
   INGEST_BM25_MIN_SCORE    float, default 5.0
   INGEST_BM25_TITLE_BOOST  float, default 2.0
-  INGEST_BM25_LIMIT        int,   default 20  (candidates fetched from OS)
+  INGEST_BM25_LIMIT        int,   default 100 (candidates fetched from OS)
 """
 from __future__ import annotations
 


### PR DESCRIPTION
`INGEST_BM25_LIMIT` is the number of candidate pages the BM25 search fetches from OpenSearch per ingested document. Raise the default **20 → 100** so more candidates reach the selector/reconciler stages.

- Env-overridable as before; **not** pinned in Helm, so the new default applies on the next backend deploy.
- Backend-only (config default + docstring); no migration, no chart bump.

Heads-up (not in this PR):
- **Cost** — more candidates per doc means the selector/reconciler weigh more pages; watch `ingest_selector_*` / `ingest_reconciler_*` token metrics.
- **Histogram buckets** — `ingest_bm25_hits` / `ingest_bm25_passed` / `ingest_selector_candidates_filtered` top out at 20, so counts above 20 now land in the `+Inf` bucket and under-report on the dashboards. Worth extending the buckets (e.g. add 50/100) in a follow-up.