### PR TITLE
feat(metrics): track cached vs uncached LLM input tokens; split token tiles

### DIFF
--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -22,7 +22,12 @@ from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
 from app.llm.client import ToolCall
 from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, apply_edits, batch_by_chars
-from app.metrics import ingest_reconciler_input_tokens, ingest_reconciler_output_tokens
+from app.metrics import (
+    ingest_reconciler_cached_input_tokens,
+    ingest_reconciler_input_tokens,
+    ingest_reconciler_output_tokens,
+    ingest_reconciler_uncached_input_tokens,
+)
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
 
@@ -195,6 +200,8 @@ def _reconcile_batch(
 
     try:
         ingest_reconciler_input_tokens.observe(result.usage.input_tokens)
+        ingest_reconciler_cached_input_tokens.observe(result.usage.cached_input_tokens)
+        ingest_reconciler_uncached_input_tokens.observe(result.usage.uncached_input_tokens)
         ingest_reconciler_output_tokens.observe(result.usage.output_tokens)
     except Exception:
         log.warning("ingest_batch_reconciler: could not observe token usage", exc_info=True)

--- a/backend/app/llm/agents/ingest_selector.py
+++ b/backend/app/llm/agents/ingest_selector.py
@@ -16,7 +16,13 @@ from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
 from app.llm.agents.common import batch_by_chars
 from app.llm.prompts import load_prompt
-from app.metrics import ingest_selector_calls_per_doc, ingest_selector_input_tokens, ingest_selector_output_tokens
+from app.metrics import (
+    ingest_selector_cached_input_tokens,
+    ingest_selector_calls_per_doc,
+    ingest_selector_input_tokens,
+    ingest_selector_output_tokens,
+    ingest_selector_uncached_input_tokens,
+)
 from app.tracing import trace_flow
 
 log = logging.getLogger(__name__)
@@ -104,6 +110,8 @@ def _select_batch(
         return batch
     try:
         ingest_selector_input_tokens.observe(result.usage.input_tokens)
+        ingest_selector_cached_input_tokens.observe(result.usage.cached_input_tokens)
+        ingest_selector_uncached_input_tokens.observe(result.usage.uncached_input_tokens)
         ingest_selector_output_tokens.observe(result.usage.output_tokens)
     except Exception:
         log.warning("ingest_selector: could not observe token usage", exc_info=True)

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -62,11 +62,21 @@ class ToolCall(BaseModel):
 
 
 class Usage(BaseModel):
-    """Token counts reported by the provider for a single completion."""
+    """Token counts reported by the provider for a single completion.
+
+    ``input_tokens`` is the provider's raw input count (kept as-is for
+    back-compat; note providers disagree on whether it includes cached tokens).
+    For a provider-consistent prompt-cache view, use the normalized pair:
+    ``cached_input_tokens`` (input served from the prompt cache) and
+    ``uncached_input_tokens`` (input processed fresh). Their sum is the total
+    input the model saw, across every provider.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
     reasoning_tokens: int = 0
+    cached_input_tokens: int = 0
+    uncached_input_tokens: int = 0
 
 
 class CompletionResult(BaseModel):

--- a/backend/app/llm/providers/anthropic.py
+++ b/backend/app/llm/providers/anthropic.py
@@ -136,12 +136,19 @@ class AnthropicProvider:
                 final = cast(Any, s.get_final_message())
             in_tok = cast(int, getattr(final.usage, "input_tokens", 0))
             out_tok = cast(int, getattr(final.usage, "output_tokens", 0))
+            # Anthropic's input_tokens EXCLUDES cached tokens; cache reads/writes
+            # are separate. Uncached = fresh input + cache writes (writes are
+            # full-price fresh input); cached = cache reads.
+            cache_read = cast(int, getattr(final.usage, "cache_read_input_tokens", 0) or 0)
+            cache_write = cast(int, getattr(final.usage, "cache_creation_input_tokens", 0) or 0)
             log.info(
-                "llm done provider=anthropic model=%s stop=%s tokens=%d/%d",
+                "llm done provider=anthropic model=%s stop=%s tokens=%d/%d cache_read=%d cache_write=%d",
                 model,
                 getattr(final, "stop_reason", "") or "",
                 in_tok,
                 out_tok,
+                cache_read,
+                cache_write,
             )
             yield {
                 "type": "done",
@@ -150,6 +157,8 @@ class AnthropicProvider:
                     "input_tokens": in_tok,
                     "output_tokens": out_tok,
                     "reasoning_tokens": 0,
+                    "cached_input_tokens": cache_read,
+                    "uncached_input_tokens": in_tok + cache_write,
                 },
             }
         except LLMError:

--- a/backend/app/llm/providers/custom.py
+++ b/backend/app/llm/providers/custom.py
@@ -167,12 +167,17 @@ class CustomProvider:
             out_tok = int(getattr(usage, "completion_tokens", 0) or 0)
             details = getattr(usage, "completion_tokens_details", None)
             reason_tok = int(getattr(details, "reasoning_tokens", 0) or 0)
+            # Chat Completions reports cached prompt tokens under
+            # prompt_tokens_details; prompt_tokens INCLUDES them (like OpenAI).
+            in_details = getattr(usage, "prompt_tokens_details", None)
+            cached_tok = int(getattr(in_details, "cached_tokens", 0) or 0)
             log.info(
-                "llm done provider=custom model=%s stop=%s tokens=%d/%d",
+                "llm done provider=custom model=%s stop=%s tokens=%d/%d cached=%d",
                 model,
                 stop_reason,
                 in_tok,
                 out_tok,
+                cached_tok,
             )
             yield {
                 "type": "done",
@@ -181,6 +186,8 @@ class CustomProvider:
                     "input_tokens": in_tok,
                     "output_tokens": out_tok,
                     "reasoning_tokens": reason_tok,
+                    "cached_input_tokens": cached_tok,
+                    "uncached_input_tokens": max(0, in_tok - cached_tok),
                 },
             }
         except LLMError:

--- a/backend/app/llm/providers/gemini.py
+++ b/backend/app/llm/providers/gemini.py
@@ -145,10 +145,15 @@ class GeminiProvider:
                             }
                 meta = getattr(chunk, "usage_metadata", None)
                 if meta is not None:
+                    prompt_tok = getattr(meta, "prompt_token_count", 0) or 0
+                    # Gemini's prompt_token_count INCLUDES cached context tokens.
+                    cached_tok = getattr(meta, "cached_content_token_count", 0) or 0
                     usage = {
-                        "input_tokens": getattr(meta, "prompt_token_count", 0) or 0,
+                        "input_tokens": prompt_tok,
                         "output_tokens": getattr(meta, "candidates_token_count", 0) or 0,
                         "reasoning_tokens": getattr(meta, "thoughts_token_count", 0) or 0,
+                        "cached_input_tokens": cached_tok,
+                        "uncached_input_tokens": max(0, prompt_tok - cached_tok),
                     }
             log.info(
                 "llm done provider=gemini model=%s stop=%s tokens=%d/%d",

--- a/backend/app/llm/providers/ollama.py
+++ b/backend/app/llm/providers/ollama.py
@@ -152,6 +152,9 @@ class OllamaProvider:
                         "input_tokens": in_tok,
                         "output_tokens": out_tok,
                         "reasoning_tokens": 0,
+                        # Ollama has no prompt cache: all input is uncached.
+                        "cached_input_tokens": 0,
+                        "uncached_input_tokens": in_tok,
                     }
             log.info(
                 "llm done provider=ollama model=%s stop=%s tokens=%d/%d",

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -143,13 +143,19 @@ class OpenAIProvider:
                     out_tok = getattr(usage, "output_tokens", 0) if usage else 0
                     details = getattr(usage, "output_tokens_details", None) if usage else None
                     reason_tok = getattr(details, "reasoning_tokens", 0) if details else 0
+                    # OpenAI's input_tokens INCLUDES cached tokens; the cached
+                    # portion is reported under input_tokens_details. Uncached =
+                    # input_tokens - cached.
+                    in_details = getattr(usage, "input_tokens_details", None) if usage else None
+                    cached_tok = getattr(in_details, "cached_tokens", 0) if in_details else 0
                     status = getattr(resp, "status", "") or ""
                     log.info(
-                        "llm done provider=openai model=%s status=%s tokens=%d/%d",
+                        "llm done provider=openai model=%s status=%s tokens=%d/%d cached=%d",
                         model,
                         status,
                         in_tok,
                         out_tok,
+                        cached_tok or 0,
                     )
                     yield {
                         "type": "done",
@@ -161,6 +167,8 @@ class OpenAIProvider:
                             "input_tokens": in_tok,
                             "output_tokens": out_tok,
                             "reasoning_tokens": reason_tok or 0,
+                            "cached_input_tokens": cached_tok or 0,
+                            "uncached_input_tokens": max(0, (in_tok or 0) - (cached_tok or 0)),
                         },
                     }
         except LLMError:

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -158,7 +158,21 @@ _TOKEN_BUCKETS = [128, 256, 512, 1024, 2048, 4096, 8192, 16384]
 
 ingest_selector_input_tokens = Histogram(
     "ingest_selector_input_tokens",
-    "Input tokens per selector batch call",
+    "Input tokens per selector batch call (provider-raw; _count drives call counts)",
+    buckets=_TOKEN_BUCKETS,
+)
+
+# Provider-consistent prompt-cache split of selector input tokens: cached =
+# served from the prompt cache, uncached = processed fresh. Sum ≈ total input.
+ingest_selector_cached_input_tokens = Histogram(
+    "ingest_selector_cached_input_tokens",
+    "Cached (prompt-cache hit) input tokens per selector batch call",
+    buckets=_TOKEN_BUCKETS,
+)
+
+ingest_selector_uncached_input_tokens = Histogram(
+    "ingest_selector_uncached_input_tokens",
+    "Uncached (freshly processed) input tokens per selector batch call",
     buckets=_TOKEN_BUCKETS,
 )
 
@@ -170,7 +184,19 @@ ingest_selector_output_tokens = Histogram(
 
 ingest_reconciler_input_tokens = Histogram(
     "ingest_reconciler_input_tokens",
-    "Input tokens per reconciler batch call",
+    "Input tokens per reconciler batch call (provider-raw; _count drives call counts)",
+    buckets=_TOKEN_BUCKETS,
+)
+
+ingest_reconciler_cached_input_tokens = Histogram(
+    "ingest_reconciler_cached_input_tokens",
+    "Cached (prompt-cache hit) input tokens per reconciler batch call",
+    buckets=_TOKEN_BUCKETS,
+)
+
+ingest_reconciler_uncached_input_tokens = Histogram(
+    "ingest_reconciler_uncached_input_tokens",
+    "Uncached (freshly processed) input tokens per reconciler batch call",
     buckets=_TOKEN_BUCKETS,
 )
 

--- a/backend/tests/test_custom_provider.py
+++ b/backend/tests/test_custom_provider.py
@@ -263,7 +263,13 @@ def test_stream_uses_usage_only_final_chunk(monkeypatch: pytest.MonkeyPatch) -> 
     assert events[-1] == {
         "type": "done",
         "stop_reason": "",
-        "usage": {"input_tokens": 11, "output_tokens": 7, "reasoning_tokens": 3},
+        "usage": {
+            "input_tokens": 11,
+            "output_tokens": 7,
+            "reasoning_tokens": 3,
+            "cached_input_tokens": 0,
+            "uncached_input_tokens": 11,
+        },
     }
 
 
@@ -289,7 +295,13 @@ def test_stream_emits_exactly_one_done_with_verbatim_stop_reason_and_usage_defau
     assert len(done_events) == 1
     assert done_events[0]["stop_reason"] == "gateway_stop"
     usage_dict = done_events[0]["usage"]
-    assert usage_dict == {"input_tokens": 4, "output_tokens": 6, "reasoning_tokens": 0}
+    assert usage_dict == {
+        "input_tokens": 4,
+        "output_tokens": 6,
+        "reasoning_tokens": 0,
+        "cached_input_tokens": 0,
+        "uncached_input_tokens": 4,
+    }
     assert all(isinstance(value, int) for value in usage_dict.values())
 
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -130,10 +130,17 @@ def _a_tool_use_events(*, index, id, name, arg_chunks):
     return events
 
 
-def _a_final(*, stop_reason="end_turn", input_tokens=10, output_tokens=20):
+def _a_final(
+    *, stop_reason="end_turn", input_tokens=10, output_tokens=20, cache_read=0, cache_write=0
+):
     return SimpleNamespace(
         stop_reason=stop_reason,
-        usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_write,
+        ),
     )
 
 
@@ -157,12 +164,16 @@ def _o_text_delta(text):
     return SimpleNamespace(type="response.output_text.delta", delta=text)
 
 
-def _o_completed(*, status="completed", input_tokens=10, output_tokens=20):
+def _o_completed(*, status="completed", input_tokens=10, output_tokens=20, cached=0):
     return SimpleNamespace(
         type="response.completed",
         response=SimpleNamespace(
             status=status,
-            usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
+            usage=SimpleNamespace(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                input_tokens_details=SimpleNamespace(cached_tokens=cached),
+            ),
         ),
     )
 
@@ -461,7 +472,13 @@ def test_anthropic_stream_yields_text_deltas_then_done(
     assert events[-1] == {
         "type": "done",
         "stop_reason": "end_turn",
-        "usage": {"input_tokens": 12, "output_tokens": 34, "reasoning_tokens": 0},
+        "usage": {
+            "input_tokens": 12,
+            "output_tokens": 34,
+            "reasoning_tokens": 0,
+            "cached_input_tokens": 0,
+            "uncached_input_tokens": 12,
+        },
     }
 
 
@@ -516,7 +533,24 @@ def test_anthropic_complete_drains_stream_into_dict(
         "input_tokens": 12,
         "output_tokens": 34,
         "reasoning_tokens": 0,
+        "cached_input_tokens": 0,
+        "uncached_input_tokens": 12,
     }
+
+
+def test_anthropic_usage_splits_cached_and_uncached(
+    configure_anthropic, fake_anthropic
+):
+    # Anthropic's input_tokens excludes cache; cache reads/writes are separate.
+    # cached = cache_read; uncached = input_tokens + cache_write.
+    fake_anthropic(
+        _a_text_block_events(["ok"], index=0),
+        _a_final(input_tokens=10, output_tokens=5, cache_read=200, cache_write=50),
+    )
+    out = llm_client.complete([{"role": "user", "content": "hi"}])
+    assert out.usage.input_tokens == 10
+    assert out.usage.cached_input_tokens == 200
+    assert out.usage.uncached_input_tokens == 60  # 10 fresh + 50 cache write
 
 
 # --------------------------------------------------------------------------- #
@@ -686,7 +720,13 @@ def test_openai_stream_yields_text_deltas(configure_openai, fake_openai):
         {
             "type": "done",
             "stop_reason": "completed",
-            "usage": {"input_tokens": 7, "output_tokens": 11, "reasoning_tokens": 0},
+            "usage": {
+                "input_tokens": 7,
+                "output_tokens": 11,
+                "reasoning_tokens": 0,
+                "cached_input_tokens": 0,
+                "uncached_input_tokens": 7,
+            },
         },
     ]
 
@@ -748,5 +788,20 @@ def test_openai_complete_handles_missing_usage(configure_openai, fake_openai):
 
     out = llm_client.complete([{"role": "user", "content": "hi"}])
 
-    assert out.usage.model_dump() == {"input_tokens": 0, "output_tokens": 0, "reasoning_tokens": 0}
+    assert out.usage.model_dump() == {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "reasoning_tokens": 0,
+        "cached_input_tokens": 0,
+        "uncached_input_tokens": 0,
+    }
     assert out.text == "ok"
+
+
+def test_openai_usage_splits_cached_and_uncached(configure_openai, fake_openai):
+    # OpenAI's input_tokens INCLUDES cached; uncached = input_tokens - cached.
+    fake_openai([_o_text_delta("ok"), _o_completed(input_tokens=100, output_tokens=5, cached=80)])
+    out = llm_client.complete([{"role": "user", "content": "hi"}])
+    assert out.usage.input_tokens == 100
+    assert out.usage.cached_input_tokens == 80
+    assert out.usage.uncached_input_tokens == 20

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.23
+version: 0.3.24
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -52,7 +52,7 @@
       "gridPos": {
         "x": 0,
         "y": 10,
-        "w": 4,
+        "w": 3,
         "h": 4
       },
       "id": 125,
@@ -106,9 +106,9 @@
         }
       },
       "gridPos": {
-        "x": 4,
+        "x": 3,
         "y": 10,
-        "w": 4,
+        "w": 3,
         "h": 4
       },
       "id": 126,
@@ -162,9 +162,9 @@
         }
       },
       "gridPos": {
-        "x": 8,
+        "x": 6,
         "y": 10,
-        "w": 4,
+        "w": 3,
         "h": 4
       },
       "id": 121,
@@ -179,11 +179,67 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(ingest_selector_input_tokens_sum[24h]))",
+          "expr": "sum(increase(ingest_selector_uncached_input_tokens_sum[24h]))",
           "refId": "A"
         }
       ],
-      "title": "Selector Input Tokens",
+      "title": "Selector Input (uncached)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "x": 9,
+        "y": 10,
+        "w": 3,
+        "h": 4
+      },
+      "id": 130,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(ingest_selector_cached_input_tokens_sum[24h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Selector Input (cached)",
       "type": "stat"
     },
     {
@@ -220,7 +276,7 @@
       "gridPos": {
         "x": 12,
         "y": 10,
-        "w": 4,
+        "w": 3,
         "h": 4
       },
       "id": 122,
@@ -274,9 +330,9 @@
         }
       },
       "gridPos": {
-        "x": 16,
+        "x": 15,
         "y": 10,
-        "w": 4,
+        "w": 3,
         "h": 4
       },
       "id": 123,
@@ -291,11 +347,11 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(ingest_reconciler_input_tokens_sum[24h]))",
+          "expr": "sum(increase(ingest_reconciler_uncached_input_tokens_sum[24h]))",
           "refId": "A"
         }
       ],
-      "title": "Reconciler Input Tokens",
+      "title": "Reconciler Input (uncached)",
       "type": "stat"
     },
     {
@@ -330,9 +386,65 @@
         }
       },
       "gridPos": {
-        "x": 20,
+        "x": 18,
         "y": 10,
-        "w": 4,
+        "w": 3,
+        "h": 4
+      },
+      "id": 131,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(ingest_reconciler_cached_input_tokens_sum[24h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Reconciler Input (cached)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "blue",
+            "mode": "fixed"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "x": 21,
+        "y": 10,
+        "w": 3,
         "h": 4
       },
       "id": 124,


### PR DESCRIPTION
## What
Capture the **prompt-cache token usage** every provider already returns (and we were discarding), and split the dashboard's two input-token tiles into **cached vs uncached**.

## Backend
- `Usage` gains `cached_input_tokens` (served from prompt cache) + `uncached_input_tokens` (processed fresh), normalized **consistently across providers** despite their differing conventions:
  - **Anthropic** — `input_tokens` *excludes* cache → uncached = input + cache_creation, cached = cache_read.
  - **OpenAI / custom / Gemini** — input *includes* cache → uncached = input − cached, cached = the reported cached portion.
  - **Ollama** — no cache → uncached = input, cached = 0.
  - `input_tokens` itself is left raw (back-compat; its `_count` still drives the 'LLM Calls' tiles).
- New per-stage histograms: `ingest_{selector,reconciler}_{cached,uncached}_input_tokens`, recorded in the selector + reconciler agents.

## Dashboard
- Split **Selector Input Tokens** → *Selector Input (uncached)* + *Selector Input (cached)*; same for **Reconciler Input Tokens**. Token Summary row re-tiled to 8 × w3. Chart 0.3.23 → 0.3.24.

## Notes
- **Zero added cost** — the cache counts ride along in the response `usage`; no extra calls/tokens. (Confirmed live: a cached system prompt reported cache_read on the repeat call.)
- It also makes our existing caching savings visible (Anthropic system prompt is cache_control'd today).

## Tests
`test_{anthropic,openai}_usage_splits_cached_and_uncached` + updated provider usage-shape assertions; 119 pass; basedpyright + ruff clean.