### PR TITLE
feat(craft): schema — migration 0031 + ORM models (stack 1/7)

### DIFF
--- a/backend/app/db/migrations/versions/0031_craft_integration.py
+++ b/backend/app/db/migrations/versions/0031_craft_integration.py
@@ -1,0 +1,108 @@
+"""Craft integration: agent_sessions external fields, user_onyx_connections,
+craft_connect_states, notifications, ingest_settings.onyx_base_url
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-06-09 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "0031"
+down_revision: str = "0030"
+branch_labels = None
+depends_on = None
+
+_NOW = sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    session_cols = {c["name"] for c in insp.get_columns("agent_sessions")}
+    if "external_session_id" not in session_cols:
+        op.add_column("agent_sessions", sa.Column("external_session_id", sa.Text, nullable=True))
+    if "external_url" not in session_cols:
+        op.add_column("agent_sessions", sa.Column("external_url", sa.Text, nullable=True))
+    if "failure_reason" not in session_cols:
+        op.add_column("agent_sessions", sa.Column("failure_reason", sa.Text, nullable=True))
+
+    ingest_cols = {c["name"] for c in insp.get_columns("ingest_settings")}
+    if "onyx_base_url" not in ingest_cols:
+        op.add_column("ingest_settings", sa.Column("onyx_base_url", sa.Text, nullable=True))
+
+    if not insp.has_table("user_onyx_connections"):
+        op.create_table(
+            "user_onyx_connections",
+            sa.Column(
+                "user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column("onyx_pat", sa.LargeBinary, nullable=False),
+            sa.Column("token_display", sa.Text, nullable=False),
+            sa.Column("onyx_user_email", sa.Text, nullable=True),
+            sa.Column("expires_at", sa.Text, nullable=True),
+            sa.Column("onyx_base_url", sa.Text, nullable=False),
+            sa.Column("created_at", sa.Text, nullable=False, server_default=_NOW),
+            sa.Column("updated_at", sa.Text, nullable=False, server_default=_NOW),
+        )
+
+    if not insp.has_table("craft_connect_states"):
+        op.create_table(
+            "craft_connect_states",
+            sa.Column("state", sa.Text, primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("code_verifier", sa.LargeBinary, nullable=False),
+            sa.Column("return_to", sa.Text, nullable=True),
+            sa.Column("expires_at", sa.Text, nullable=False),
+            sa.Column("consumed_at", sa.Text, nullable=True),
+        )
+
+    if not insp.has_table("notifications"):
+        op.create_table(
+            "notifications",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+            sa.Column(
+                "user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("notif_type", sa.Text, nullable=False),
+            sa.Column("title", sa.Text, nullable=False),
+            sa.Column("description", sa.Text, nullable=True),
+            sa.Column("dismissed", sa.Boolean, nullable=False, server_default=sa.text("FALSE")),
+            sa.Column("first_shown", sa.Text, nullable=False, server_default=_NOW),
+            sa.Column("last_shown", sa.Text, nullable=False, server_default=_NOW),
+            sa.Column("data", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+            sa.UniqueConstraint(
+                "user_id", "notif_type", "data", name="uq_notifications_user_type_data"
+            ),
+        )
+        op.create_index(
+            "idx_notifications_user_dismissed",
+            "notifications",
+            ["user_id", "dismissed"],
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("notifications")
+    op.drop_table("craft_connect_states")
+    op.drop_table("user_onyx_connections")
+    op.drop_column("ingest_settings", "onyx_base_url")
+    op.drop_column("agent_sessions", "failure_reason")
+    op.drop_column("agent_sessions", "external_url")
+    op.drop_column("agent_sessions", "external_session_id")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -302,6 +302,13 @@ class AgentSession(Base):
     )
     spawn_ok_at: Mapped[str | None] = mapped_column(Text)  # beacon timestamp
     closed_at: Mapped[str | None] = mapped_column(Text)
+    # in_app (Onyx Craft) launches only; local_cli rows leave these null.
+    # Craft rows use the extra ``status`` values 'provisioning' | 'ready' —
+    # distinct from the local_cli lifecycle so the idle/spawn sweepers
+    # (which filter on pending/active/idle) never touch them.
+    external_session_id: Mapped[str | None] = mapped_column(Text)
+    external_url: Mapped[str | None] = mapped_column(Text)
+    failure_reason: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (
         Index("idx_agent_sessions_user_status", "user_id", "status"),
@@ -724,6 +731,10 @@ class IngestSettings(Base):
     )
     # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
     api_key: Mapped[str | None] = mapped_column(EncryptedString(), nullable=True)
+    # Outbound half of the admin "Onyx Connection" page: the public Onyx
+    # origin used for Craft build-API calls, connect redirects, and
+    # "Open Craft" deep links. Null = Craft launches unavailable.
+    onyx_base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     updated_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
@@ -1146,3 +1157,91 @@ class IngestEvalSample(Base):
     diff: Mapped[str | None] = mapped_column(Text)
     outcome: Mapped[str] = mapped_column(Text, nullable=False)
     commit_sha: Mapped[str | None] = mapped_column(Text)
+
+
+# --------------------------------------------------------------------------- #
+# Onyx Craft integration — per-user Onyx connection (encrypted PAT), the      #
+# single-use connect-handshake state, and the general notification center.   #
+# See local_data/wiki + "Engineering Projects/Craft Integration" on the wiki. #
+# --------------------------------------------------------------------------- #
+
+
+class UserOnyxConnection(Base):
+    """One per user: the Onyx PAT minted by "Connect Onyx".
+
+    The PAT is AES-GCM encrypted at rest via ``EncryptedString``. There is
+    no refresh token — Onyx PATs don't refresh; on expiry or a 401 the row
+    is dropped and the user re-connects.
+    """
+
+    __tablename__ = "user_onyx_connections"
+
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    onyx_pat: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    # Masked form for display (e.g. "onyx_pat_abc1…xyz9") — never the raw token.
+    token_display: Mapped[str] = mapped_column(Text, nullable=False)
+    onyx_user_email: Mapped[str | None] = mapped_column(Text)
+    expires_at: Mapped[str | None] = mapped_column(Text)
+    # The Onyx origin this PAT was minted against. If the admin re-points
+    # onyx_base_url at a different instance, stored PATs are invalid there —
+    # the mismatch surfaces as needs_onyx_connect.
+    onyx_base_url: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+
+
+class CraftConnectState(Base):
+    """Single-use CSRF/PKCE state for the Connect-Onyx handshake.
+
+    Mirrors ``LaunchCode``: minted at /connect/start, consumed exactly once
+    at /connect/callback, short TTL. The PKCE ``code_verifier`` lives only
+    here server-side — it never rides a browser-visible URL.
+    """
+
+    __tablename__ = "craft_connect_states"
+
+    state: Mapped[str] = mapped_column(Text, primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    # AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString) — same
+    # treatment as the PAT, since it's a single-use secret.
+    code_verifier: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    # Relative path to bounce the browser back to after the callback.
+    return_to: Mapped[str | None] = mapped_column(Text)
+    expires_at: Mapped[str] = mapped_column(Text, nullable=False)
+    consumed_at: Mapped[str | None] = mapped_column(Text)
+
+
+class Notification(Base):
+    """Persistent per-user notification (header bell / inbox).
+
+    General subsystem — Craft launch outcomes are the first producer.
+    ``data`` is normalized to ``{}`` (never null) so the dedup unique index
+    is a plain column tuple; ``dismissed`` is the read flag. Follows Onyx's
+    notification semantics: re-creating an existing undismissed
+    (user, type, data) bumps ``last_shown``; a dismissed one is left alone.
+    """
+
+    __tablename__ = "notifications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    notif_type: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    dismissed: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
+    first_shown: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    last_shown: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    data: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "notif_type", "data", name="uq_notifications_user_type_data"),
+        Index("idx_notifications_user_dismissed", "user_id", "dismissed"),
+    )


### PR DESCRIPTION
## Description

**Stacked PR 1/7 — schema + models.** First layer of the Onyx Craft integration (splitting #259).

Schema only — migration `0031_craft_integration` + matching ORM models:
- `user_onyx_connections` (encrypted per-user PAT), `craft_connect_states`, `notifications`
- `agent_sessions`: `external_session_id`, `external_url`, `failure_reason`
- `ingest_settings`: `onyx_base_url`

`0031` stacks after main's `0030_encrypt_secret_columns` (single alembic head).

Stack: **1 schema** → 2 backend-logic → 3 backend-api → 4 fe-api → 5 settings → 6 notifications → 7 side-panel.

## How Has This Been Tested?

<!--- filled in on the top branch -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check