### PR TITLE
feat(craft): backend api — connect/launch routers, gate, models (stack 3/7)

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -39,6 +39,7 @@ from app.models.admin import (
     WebConfigRequest,
     WebView,
 )
+from app.onyx.client import validate_onyx_base_url
 from app.tracing import settings as braintrust_settings
 from app.tracing.settings import BraintrustSettings
 from app.web import settings as web_settings
@@ -421,6 +422,7 @@ def _ingest_view(s: IngestSettings) -> IngestView:
         max_doc_chars=s.max_doc_chars,
         api_key_set=bool(s.api_key),
         api_key_hint=_redact(s.api_key or ""),
+        onyx_base_url=s.onyx_base_url,
     )
 
 
@@ -439,11 +441,23 @@ def put_ingest(
             status_code=400,
             detail=f"max_doc_chars must be between {_MIN_DOC_CHARS} and {_MAX_DOC_CHARS}",
         )
-    ingest_settings.upsert(max_doc_chars=req.max_doc_chars)
+    # Omitted (None) preserves the stored URL; an explicit empty string clears
+    # it. Otherwise validate and set. Avoids a max_doc_chars-only PUT wiping it.
+    if req.onyx_base_url is None:
+        onyx_base_url = ingest_settings.get().onyx_base_url
+    else:
+        onyx_base_url = req.onyx_base_url.strip() or None
+        if onyx_base_url is not None:
+            try:
+                validate_onyx_base_url(onyx_base_url)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+    ingest_settings.upsert(max_doc_chars=req.max_doc_chars, onyx_base_url=onyx_base_url)
     log.info(
-        "admin: %s updated ingest settings max_doc_chars=%d",
+        "admin: %s updated ingest settings max_doc_chars=%d onyx_base_url_set=%s",
         actor.id,
         req.max_doc_chars,
+        bool(onyx_base_url),
     )
     return _ingest_view(ingest_settings.get())
 

--- a/backend/app/api/agent_sessions.py
+++ b/backend/app/api/agent_sessions.py
@@ -78,6 +78,8 @@ def list_sessions(
                 last_activity_at=r["last_activity_at"],
                 closed_at=r["closed_at"],
                 cli_session_id=r["cli_session_id"],
+                external_url=r["external_url"],
+                failure_reason=r["failure_reason"],
             )
             for r in rows
         ]

--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -1,0 +1,270 @@
+"""HTTP API for Onyx Craft launches + the Connect-Onyx account link.
+
+Routes mounted under ``/api/craft`` from ``app.main:create_app``:
+
+- ``POST /api/craft/launch``            — idempotent launch (enqueues the worker)
+- ``GET  /api/craft/connect``           — connection status for the current user
+- ``POST /api/craft/connect``           — manual-PAT connect (v0): validate + store
+- ``DELETE /api/craft/connect``         — disconnect (best-effort revoke on Onyx)
+- ``GET  /api/craft/connect/start``     — redirect-mint connect (dormant; awaits Onyx Phase 1)
+- ``GET  /api/craft/connect/callback``  — redirect-mint return leg (dormant)
+
+Connect (v0) is **manual PAT paste**: the user mints an Onyx Personal Access
+Token and pastes it; we validate via ``GET /api/me`` and store it per-user.
+Each user's PAT means their Craft runs execute as them, so their Onyx
+knowledge ACLs + LLM access are respected. The redirect-mint flow
+(``connect/start`` + ``connect/callback``) is the future no-copy-paste UX and
+stays dormant until the Onyx ``/connect/agent-wiki`` endpoints ship.
+
+All gated on ``CONFIG.craft_enabled`` AND an admin-configured Onyx base URL
+(``ingest_settings.onyx_base_url``) — availability is computed, not a toggle,
+so the feature merges dark. See "Engineering Projects/Craft Integration".
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import RedirectResponse
+
+from app.auth import User
+from app.auth.deps import require_user
+from app.config import CONFIG
+from app.db import agent_sessions as sessions_repo
+from app.ingest import settings as ingest_settings
+from app.launchers import prompt_builder
+from app.launchers.registry import get_registry
+from app.models.craft import (
+    CraftConnectRequest,
+    CraftConnectStatus,
+    CraftLaunchRequest,
+    CraftLaunchResponse,
+)
+from app.onyx import connect as connect_flow
+from app.onyx import connections
+from app.onyx.client import OnyxAuthError, OnyxClient, OnyxError, exchange_connect_code
+from app.tasks.craft import attachment_filename, craft_launch
+from app.tasks.queues import QueueFullError
+from app.wiki import acl as wiki_acl
+from app.wiki import filesystem as wiki_fs
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_TOOL_ID = "onyx-craft"
+# Modest per-user backstop on concurrent sandbox provisioning — the
+# idempotency probe already dedups per-page double-clicks.
+_MAX_PROVISIONING_PER_USER = 3
+
+
+def _require_available() -> str:
+    """404 when the feature is dark; otherwise the Onyx origin."""
+    if not CONFIG.craft_enabled:
+        raise HTTPException(status_code=404, detail="craft launches disabled")
+    base = ingest_settings.get_onyx_base_url()
+    if not base:
+        raise HTTPException(status_code=404, detail="onyx connection not configured")
+    return base
+
+
+def _callback_url() -> str:
+    return f"{CONFIG.public_base_url}/api/craft/connect/callback"
+
+
+def _connect_start_url(return_to: str | None) -> str:
+    url = f"{CONFIG.public_base_url}/api/craft/connect/start"
+    if return_to:
+        url += f"?return_to={quote(return_to, safe='/')}"
+    return url
+
+
+def _bounce(return_to: str | None, *, outcome: str) -> RedirectResponse:
+    """Send the browser back into the app after the connect flow."""
+    path = connect_flow.normalize_return_to(return_to) or "/"
+    sep = "&" if "?" in path else "?"
+    return RedirectResponse(
+        f"{CONFIG.public_base_url}{path}{sep}onyx_connect={outcome}", status_code=302
+    )
+
+
+# --------------------------------------------------------------------------- #
+# POST /api/craft/launch                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@router.post("/launch", response_model=CraftLaunchResponse)
+def post_launch(req: CraftLaunchRequest, user: User = Depends(require_user)) -> CraftLaunchResponse:
+    base = _require_available()
+
+    manifest = get_registry().get(_TOOL_ID)
+    if manifest is None or manifest.kind != "in_app":
+        raise HTTPException(status_code=500, detail="onyx-craft manifest missing or not in_app")
+
+    if connections.get_with_pat(user.id, onyx_base_url=base) is None:
+        # Structured signal, not an error state — the frontend renders a
+        # "Connect Onyx" call-to-action and sends the browser to /connect/start.
+        raise HTTPException(status_code=409, detail="needs_onyx_connect")
+
+    # ACL-gate + canonicalize the source page before anything is created.
+    wiki_path: str | None = None
+    if req.wiki_path is not None:
+        try:
+            wiki_path = wiki_fs.safe_rel_path(req.wiki_path)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="invalid wiki_path") from exc
+        if not wiki_acl.can(user.id, bool(user.is_admin), "read", wiki_path):
+            raise HTTPException(status_code=403, detail="forbidden")
+
+    # Idempotency: an in-flight launch for the same (user, page) is returned
+    # as-is — no second sandbox.
+    existing = sessions_repo.find_in_flight(user.id, tool_id=_TOOL_ID, wiki_path=wiki_path)
+    if existing is not None:
+        return CraftLaunchResponse(agent_session_id=existing["id"], status=existing["status"])
+
+    if sessions_repo.count_provisioning(user.id, tool_id=_TOOL_ID) >= _MAX_PROVISIONING_PER_USER:
+        raise HTTPException(status_code=429, detail="rate_limited")
+
+    seed = prompt_builder.build_craft_seed_prompt(
+        wiki_path=wiki_path,
+        attachment_filename=attachment_filename(wiki_path) if wiki_path else None,
+        user_message=req.message,
+    )
+    sid = sessions_repo.create(
+        user_id=user.id,
+        tool_id=_TOOL_ID,
+        first_turn_prompt=seed,
+        wiki_path=wiki_path,
+        working_dir=None,
+        status="provisioning",
+    )
+    try:
+        craft_launch(sid)
+    except Exception as exc:
+        # The 'provisioning' row is already committed; a failed enqueue means the
+        # worker never runs, so mark it failed rather than stranding find_in_flight
+        # on a session that can never progress.
+        sessions_repo.mark_craft_failed(sid, reason="provisioning_failed")
+        if isinstance(exc, QueueFullError):
+            raise
+        log.exception("craft launch enqueue failed session=%s", sid)
+        raise HTTPException(status_code=503, detail="failed to enqueue craft launch") from exc
+    log.info("craft launch enqueued session=%s user=%s page=%s", sid, user.id, wiki_path)
+    return CraftLaunchResponse(agent_session_id=sid, status="provisioning")
+
+
+# --------------------------------------------------------------------------- #
+# Connect-Onyx                                                                #
+# --------------------------------------------------------------------------- #
+
+
+@router.get("/connect", response_model=CraftConnectStatus)
+def get_connect_status(
+    return_to: str | None = None,
+    user: User = Depends(require_user),
+) -> CraftConnectStatus:
+    base = _require_available()
+    row = connections.status(user.id)
+    connected = row is not None and row["onyx_base_url"] == base
+    return CraftConnectStatus(
+        connected=connected,
+        onyx_user_email=row["onyx_user_email"] if connected and row else None,
+        token_hint=row["token_display"] if connected and row else None,
+        expires_at=row["expires_at"] if connected and row else None,
+        onyx_base_url=base,
+        connect_url=_connect_start_url(return_to),
+    )
+
+
+@router.post("/connect", response_model=CraftConnectStatus)
+def connect_with_pat(
+    req: CraftConnectRequest,
+    user: User = Depends(require_user),
+) -> CraftConnectStatus:
+    """Manual-PAT connect (v0). Validate the pasted token against the
+    configured Onyx instance, then store it as this user's credential."""
+    base = _require_available()
+    pat = req.pat.strip()
+    client = OnyxClient(base, pat)  # also re-validates the base URL
+    try:
+        me = client.whoami()
+    except OnyxAuthError as exc:
+        raise HTTPException(status_code=401, detail="invalid_onyx_pat") from exc
+    except OnyxError as exc:
+        raise HTTPException(status_code=502, detail="onyx_unreachable") from exc
+    connections.upsert(
+        user_id=user.id,
+        onyx_pat=pat,
+        onyx_user_email=me.get("email"),
+        expires_at=None,  # manual PATs carry no expiry hint; re-connect on 401
+        onyx_base_url=base,
+    )
+    row = connections.status(user.id)
+    return CraftConnectStatus(
+        connected=True,
+        onyx_user_email=row["onyx_user_email"] if row else me.get("email"),
+        token_hint=row["token_display"] if row else None,
+        expires_at=row["expires_at"] if row else None,
+        onyx_base_url=base,
+        connect_url=None,
+    )
+
+
+@router.get("/connect/start")
+def connect_start(
+    return_to: str | None = None,
+    user: User = Depends(require_user),
+) -> RedirectResponse:
+    base = _require_available()
+    state, code_challenge = connect_flow.mint_state(user_id=user.id, return_to=return_to)
+    return RedirectResponse(
+        connect_flow.build_authorize_url(
+            base,
+            redirect_uri=_callback_url(),
+            state=state,
+            code_challenge=code_challenge,
+        ),
+        status_code=302,
+    )
+
+
+@router.get("/connect/callback")
+def connect_callback(
+    code: str,
+    state: str,
+    user: User = Depends(require_user),
+) -> RedirectResponse:
+    base = _require_available()
+    claimed = connect_flow.consume_state(state, user_id=user.id)
+    if claimed is None:
+        log.warning("craft connect callback rejected (bad state) user=%s", user.id)
+        return _bounce(None, outcome="error")
+    return_to = claimed["return_to"]
+    try:
+        body = exchange_connect_code(base, code=code, code_verifier=claimed["code_verifier"])
+    except OnyxError:
+        log.exception("craft connect exchange failed user=%s", user.id)
+        return _bounce(return_to, outcome="error")
+    connections.upsert(
+        user_id=user.id,
+        onyx_pat=body["pat"],
+        onyx_user_email=body.get("onyx_user_email"),
+        expires_at=body.get("expires_at"),
+        onyx_base_url=base,
+    )
+    return _bounce(return_to, outcome="ok")
+
+
+@router.delete("/connect")
+def disconnect(user: User = Depends(require_user)) -> dict[str, bool]:
+    base = ingest_settings.get_onyx_base_url()
+    row = connections.get_with_pat(user.id, onyx_base_url=base) if base else None
+    if row is not None:
+        try:
+            OnyxClient(row["onyx_base_url"], row["onyx_pat"]).revoke_pat()
+        except OnyxError:
+            log.warning("craft disconnect: best-effort revoke failed user=%s", user.id)
+    removed = connections.remove(user.id)
+    return {"disconnected": removed}

--- a/backend/app/api/launchers.py
+++ b/backend/app/api/launchers.py
@@ -30,6 +30,7 @@ from app.db import (
     launcher_tokens,
     page_dirs,
 )
+from app.ingest import settings as ingest_settings
 from app.launchers import prompt_builder
 from app.launchers.registry import Manifest, get_registry
 from app.models.launchers import (
@@ -58,9 +59,15 @@ def _check_flag() -> None:
 
 
 def _entry_available(m: Manifest) -> bool:
-    """— frontend filters by this flag. in_app tools without a
-    backend launch path are not yet wired."""
-    return m.kind == "local_cli"
+    """Frontend filters the Run-Agent picker by this flag. local_cli tools
+    are always launchable; onyx-craft (in_app) is launchable only when Craft
+    is enabled AND an admin has configured the Onyx instance URL — otherwise
+    the launch endpoint would 404."""
+    if m.kind == "local_cli":
+        return True
+    if m.id == "onyx-craft":
+        return CONFIG.craft_enabled and bool(ingest_settings.get_onyx_base_url())
+    return False
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/api/notifications.py
+++ b/backend/app/api/notifications.py
@@ -1,0 +1,46 @@
+"""HTTP API for the per-user notification center (header bell / inbox).
+
+Routes mounted under ``/api/notifications`` from ``app.main:create_app``:
+
+- ``GET  /api/notifications``               — newest-first page + badge counts
+- ``POST /api/notifications/{id}/dismiss``  — mark one read
+- ``POST /api/notifications/dismiss-all``   — mark everything read
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.auth import User
+from app.auth.deps import require_user
+from app.db import notifications as notifications_repo
+from app.models.notifications import DismissAllResponse, NotificationList, NotificationView
+
+router = APIRouter()
+
+
+@router.get("", response_model=NotificationList)
+def list_notifications(
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    user: User = Depends(require_user),
+) -> NotificationList:
+    page = notifications_repo.list_for_user(user.id, limit=limit, offset=offset)
+    return NotificationList(
+        notifications=[NotificationView(**n) for n in page["notifications"]],
+        total_items=page["total_items"],
+        undismissed_count=page["undismissed_count"],
+        has_more=page["has_more"],
+    )
+
+
+@router.post("/{notification_id}/dismiss")
+def dismiss(notification_id: int, user: User = Depends(require_user)) -> dict[str, bool]:
+    if not notifications_repo.dismiss(notification_id, user_id=user.id):
+        raise HTTPException(status_code=404, detail="notification not found")
+    return {"ok": True}
+
+
+@router.post("/dismiss-all", response_model=DismissAllResponse)
+def dismiss_all(user: User = Depends(require_user)) -> DismissAllResponse:
+    return DismissAllResponse(dismissed=notifications_repo.dismiss_all(user.id))

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,6 +76,12 @@ class Config(BaseModel):
     # external_url, Sentry system.url-prefix, Mattermost SiteURL).
     public_base_url: str
 
+    # Onyx Craft launches (Run Agent → Onyx Craft). Kill-switch only —
+    # the Onyx base URL itself is admin-configured in the DB
+    # (ingest_settings.onyx_base_url, the "Onyx Connection" admin page).
+    # The feature is live only when BOTH this flag and that URL are set.
+    craft_enabled: bool
+
     # Coding-tool launchers (Run Agent button) — see
     # local_data/wiki/Wiki Project/Specific Features/coding_tool_launchers/.
     launchers_enabled: bool
@@ -164,6 +170,7 @@ def load_config() -> Config:
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         dev_mode=os.environ.get("DEV_MODE", "false").lower() in {"1", "true", "yes"},
         encryption_key_secret=os.environ.get("ENCRYPTION_KEY_SECRET", ""),
+        craft_enabled=os.environ.get("CRAFT_ENABLED", "false").lower() in {"1", "true", "yes"},
         launchers_enabled=os.environ.get("LAUNCHERS_ENABLED", "false").lower()
         in {"1", "true", "yes"},
         launch_code_ttl_seconds=_positive_int("LAUNCH_CODE_TTL_SECONDS", 60),

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -38,16 +38,17 @@ def get_onyx_base_url() -> str | None:
     return get().onyx_base_url
 
 
-def upsert(*, max_doc_chars: int) -> None:
+def upsert(*, max_doc_chars: int, onyx_base_url: str | None) -> None:
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            s.add(IngestSettingsRow(id=1, max_doc_chars=max_doc_chars, updated_at=now))
+            s.add(IngestSettingsRow(id=1, max_doc_chars=max_doc_chars, onyx_base_url=onyx_base_url, updated_at=now))
         else:
             row.max_doc_chars = max_doc_chars
+            row.onyx_base_url = onyx_base_url
             row.updated_at = now
-    log.info("ingest_settings upserted max_doc_chars=%d", max_doc_chars)
+    log.info("ingest_settings upserted max_doc_chars=%d onyx_base_url_set=%s", max_doc_chars, bool(onyx_base_url))
 
 
 def regenerate_key() -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.api import (
     auth,
     chat,
     comments,
+    craft,
     documents,
     wiki,
     events,
@@ -39,6 +40,7 @@ from app.api import (
     mcp_connections,
     mcp_server,
     mcp_tokens,
+    notifications,
     permissions,
     templates,
     triggers,
@@ -223,6 +225,8 @@ def create_app() -> FastAPI:
     app.include_router(permissions.router, prefix="/api")
     app.include_router(update_policy.router, prefix="/api")
     app.include_router(launchers.router, prefix="/api")
+    app.include_router(craft.router, prefix="/api/craft")
+    app.include_router(notifications.router, prefix="/api/notifications")
     app.include_router(installer.router, prefix="/api")
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")
     app.include_router(triggers.router, prefix="/api/triggers")

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -59,6 +59,9 @@ class WebConfigRequest(BaseModel):
 
 class IngestConfigRequest(BaseModel):
     max_doc_chars: int
+    # Outbound Onyx origin for Craft launches. Omit to preserve the stored
+    # value; an explicit empty string clears it.
+    onyx_base_url: str | None = None
 
 
 class BraintrustConfigRequest(BaseModel):
@@ -168,6 +171,7 @@ class IngestView(BaseModel):
     max_doc_chars: int
     api_key_set: bool
     api_key_hint: str
+    onyx_base_url: str | None
 
 
 class RegenerateKeyResponse(BaseModel):

--- a/backend/app/models/craft.py
+++ b/backend/app/models/craft.py
@@ -1,0 +1,40 @@
+"""HTTP request/response shapes for the Craft launch + Connect-Onyx routes."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CraftConnectRequest(BaseModel):
+    """Manual-PAT connect (v0): the user pastes an Onyx Personal Access Token.
+    We validate it against the configured Onyx instance and store it as that
+    user's credential. Capped to bound abuse; real PATs are ~250 chars."""
+
+    pat: str = Field(..., min_length=8, max_length=1024)
+
+
+class CraftLaunchRequest(BaseModel):
+    wiki_path: str | None = None
+    # Same cap as the CLI launch path — bounds first_turn_prompt padding.
+    message: str = Field(..., max_length=16_384)
+
+
+class CraftLaunchResponse(BaseModel):
+    agent_session_id: str
+    status: str
+
+
+class CraftConnectStatus(BaseModel):
+    """GET /api/craft/connect — is this user linked to Onyx, and as whom."""
+
+    connected: bool
+    onyx_user_email: str | None = None
+    # Redacted display hint only (see connections.mask_token); never the raw PAT.
+    token_hint: str | None = None
+    expires_at: str | None = None
+    # The configured Onyx origin — lets the FE link the user to where they
+    # mint a PAT ({base}/... Settings → Accounts & Access). Present whenever
+    # Craft is available (i.e. the endpoint didn't 404).
+    onyx_base_url: str | None = None
+    # Dormant redirect-mint URL (future no-copy-paste connect); unused in v0.
+    connect_url: str | None = None

--- a/backend/app/models/launchers.py
+++ b/backend/app/models/launchers.py
@@ -121,6 +121,10 @@ class AgentSessionSummary(BaseModel):
     last_activity_at: str
     closed_at: str | None
     cli_session_id: str | None
+    # in_app (Onyx Craft) sessions only — the "Open Craft" deep link and
+    # the structured failure taxonomy value. Null on local_cli rows.
+    external_url: str | None = None
+    failure_reason: str | None = None
 
 
 class AgentSessionList(BaseModel):

--- a/backend/app/models/notifications.py
+++ b/backend/app/models/notifications.py
@@ -1,0 +1,29 @@
+"""HTTP shapes for the notification center (/api/notifications)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class NotificationView(BaseModel):
+    id: int
+    notif_type: str
+    title: str
+    description: str | None
+    dismissed: bool
+    first_shown: str
+    last_shown: str
+    data: dict[str, Any]
+
+
+class NotificationList(BaseModel):
+    notifications: list[NotificationView]
+    total_items: int
+    undismissed_count: int
+    has_more: bool
+
+
+class DismissAllResponse(BaseModel):
+    dismissed: int

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,6 +119,7 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
         ingest_eval_logging=False,
+        craft_enabled=True,
         launchers_enabled=True,
         launch_code_ttl_seconds=60,
         agent_session_idle_seconds=300,
@@ -135,6 +136,7 @@ def tmp_config(tmp_path, monkeypatch):
     # earlier local runs.
     monkeypatch.setattr("app.api.launchers.CONFIG", cfg)
     monkeypatch.setattr("app.api.agent_sessions.CONFIG", cfg)
+    monkeypatch.setattr("app.api.craft.CONFIG", cfg)
 
     # Reset the lazy OpenSearch client so it re-reads CONFIG on next use.
     from app.db import fts as _fts

--- a/backend/tests/test_craft_connect.py
+++ b/backend/tests/test_craft_connect.py
@@ -1,0 +1,337 @@
+"""Connect-Onyx handshake + availability gate + admin Onyx Connection config."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db.session import init_db
+from app.ingest import settings as ingest_settings
+from app.main import create_app
+from app.onyx import connections
+from app.onyx.client import OnyxAuthError, OnyxError, validate_onyx_base_url
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+ONYX = "https://onyx.example.com"
+
+
+@pytest.fixture
+def client(tmp_config):
+    init_db()
+    return TestClient(create_app())
+
+
+def _configure_onyx(base: str | None = ONYX) -> None:
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url=base)
+
+
+# --------------------------------------------------------------------------- #
+# Availability gate                                                           #
+# --------------------------------------------------------------------------- #
+
+
+def test_craft_routes_dark_without_base_url(client):
+    uid = seed_user()
+    login_fastapi(client, uid)
+    res = client.get("/api/craft/connect")
+    assert res.status_code == 404
+
+
+def test_craft_routes_dark_when_disabled(client, tmp_config, monkeypatch):
+    _configure_onyx()
+    monkeypatch.setattr(
+        "app.api.craft.CONFIG", tmp_config.model_copy(update={"craft_enabled": False})
+    )
+    uid = seed_user()
+    login_fastapi(client, uid)
+    assert client.get("/api/craft/connect").status_code == 404
+    assert client.post("/api/craft/launch", json={"message": "x"}).status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Manual-PAT connect (v0)                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _patch_onyx_client(monkeypatch, *, email: str | None = None, error: Exception | None = None):
+    """Patch app.api.craft.OnyxClient so whoami() returns/raises as configured."""
+
+    class Fake:
+        def __init__(self, base_url: str, pat: str):
+            self.pat = pat
+
+        def whoami(self) -> dict:
+            if error is not None:
+                raise error
+            return {"email": email}
+
+    monkeypatch.setattr("app.api.craft.OnyxClient", Fake)
+
+
+def test_connect_with_valid_pat_stores_connection(client, monkeypatch):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    _patch_onyx_client(monkeypatch, email="nik@onyx.app")
+
+    res = client.post("/api/craft/connect", json={"pat": "onyx_pat_" + "z" * 40})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["connected"] is True
+    assert body["onyx_user_email"] == "nik@onyx.app"
+    assert "z" * 40 not in (body["token_hint"] or "")
+
+    stored = connections.status(uid)
+    assert stored is not None and stored["onyx_user_email"] == "nik@onyx.app"
+    # Stored PAT must round-trip (decrypts) and be usable by the launcher.
+    full = connections.get_with_pat(uid, onyx_base_url=ONYX)
+    assert full is not None and full["onyx_pat"] == "onyx_pat_" + "z" * 40
+
+
+def test_connect_with_invalid_pat_rejected(client, monkeypatch):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    _patch_onyx_client(monkeypatch, error=OnyxAuthError("401"))
+
+    res = client.post("/api/craft/connect", json={"pat": "onyx_pat_bad"})
+    assert res.status_code == 401
+    assert res.json()["error"] == "invalid_onyx_pat"
+    assert connections.status(uid) is None
+
+
+def test_connect_requires_available(client, tmp_config, monkeypatch):
+    # No onyx_base_url configured → 404 even with a would-be-valid PAT.
+    uid = seed_user()
+    login_fastapi(client, uid)
+    _patch_onyx_client(monkeypatch, email="nik@onyx.app")
+    assert client.post("/api/craft/connect", json={"pat": "onyx_pat_x"}).status_code == 404
+
+
+def test_connect_status_drops_expired_connection(client):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    # Seed an expired connection (expires_at strictly in the past).
+    connections.upsert(
+        user_id=uid,
+        onyx_pat="onyx_pat_" + "d" * 40,
+        onyx_user_email="nik@onyx.app",
+        expires_at="2000-01-01 00:00:00",
+        onyx_base_url=ONYX,
+    )
+
+    res = client.get("/api/craft/connect")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["connected"] is False
+    # The expired row is removed so the user is prompted to reconnect.
+    assert connections.status(uid) is None
+
+
+# --------------------------------------------------------------------------- #
+# Connect start → Onyx authorize redirect (dormant redirect-mint flow)        #
+# --------------------------------------------------------------------------- #
+
+
+def test_connect_start_redirects_with_state_and_pkce(client):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    res = client.get(
+        "/api/craft/connect/start",
+        params={"return_to": "/app/wiki/Some%20Page.md"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    loc = urlparse(res.headers["location"])
+    assert f"{loc.scheme}://{loc.netloc}" == ONYX
+    assert loc.path == "/connect/agent-wiki"
+    q = parse_qs(loc.query)
+    assert q["redirect_uri"] == ["http://testserver/api/craft/connect/callback"]
+    assert q["code_challenge_method"] == ["S256"]
+    assert q["state"][0].startswith("cs_")
+    assert len(q["code_challenge"][0]) == 43  # b64url(sha256) without padding
+
+
+# --------------------------------------------------------------------------- #
+# Callback                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def _start_and_get_state(client) -> str:
+    res = client.get("/api/craft/connect/start", follow_redirects=False)
+    q = parse_qs(urlparse(res.headers["location"]).query)
+    return q["state"][0]
+
+
+def test_connect_callback_stores_connection(client, monkeypatch):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    state = _start_and_get_state(client)
+
+    seen: dict[str, Any] = {}
+
+    def fake_exchange(base: str, *, code: str, code_verifier: str) -> dict[str, Any]:
+        seen.update(base=base, code=code, code_verifier=code_verifier)
+        return {"pat": "onyx_pat_" + "a" * 40, "onyx_user_email": "nik@onyx.app"}
+
+    monkeypatch.setattr("app.api.craft.exchange_connect_code", fake_exchange)
+    res = client.get(
+        "/api/craft/connect/callback",
+        params={"code": "c_1", "state": state},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "onyx_connect=ok" in res.headers["location"]
+    assert seen["base"] == ONYX
+    assert seen["code"] == "c_1"
+    assert len(seen["code_verifier"]) >= 43
+
+    status = connections.status(uid)
+    assert status is not None
+    assert status["onyx_user_email"] == "nik@onyx.app"
+    assert "…" in status["token_display"]
+    assert "a" * 40 not in status["token_display"]
+
+    via_api = client.get("/api/craft/connect").json()
+    assert via_api["connected"] is True
+    assert via_api["onyx_user_email"] == "nik@onyx.app"
+
+
+def test_connect_callback_rejects_unknown_state(client, monkeypatch):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    monkeypatch.setattr(
+        "app.api.craft.exchange_connect_code",
+        lambda *a, **k: pytest.fail("exchange must not be called on bad state"),
+    )
+    res = client.get(
+        "/api/craft/connect/callback",
+        params={"code": "c", "state": "cs_bogus"},
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "onyx_connect=error" in res.headers["location"]
+    assert connections.status(uid) is None
+
+
+def test_connect_state_is_single_use(client, monkeypatch):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    state = _start_and_get_state(client)
+    monkeypatch.setattr(
+        "app.api.craft.exchange_connect_code",
+        lambda *a, **k: {"pat": "onyx_pat_" + "b" * 40},
+    )
+    first = client.get(
+        "/api/craft/connect/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert "onyx_connect=ok" in first.headers["location"]
+    replay = client.get(
+        "/api/craft/connect/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert "onyx_connect=error" in replay.headers["location"]
+
+
+def test_connect_state_bound_to_user(client, monkeypatch):
+    _configure_onyx()
+    alice = seed_user(uid="alice", email="a@x.com")
+    bob = seed_user(uid="bob", email="b@x.com")
+    login_fastapi(client, alice)
+    state = _start_and_get_state(client)
+
+    login_fastapi(client, bob)
+    monkeypatch.setattr(
+        "app.api.craft.exchange_connect_code",
+        lambda *a, **k: pytest.fail("exchange must not run for a foreign state"),
+    )
+    res = client.get(
+        "/api/craft/connect/callback",
+        params={"code": "c", "state": state},
+        follow_redirects=False,
+    )
+    assert "onyx_connect=error" in res.headers["location"]
+    assert connections.status(bob) is None
+
+
+# --------------------------------------------------------------------------- #
+# Disconnect                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def _connect(uid: str) -> None:
+    connections.upsert(
+        user_id=uid,
+        onyx_pat="onyx_pat_" + "c" * 40,
+        onyx_user_email="nik@onyx.app",
+        expires_at=None,
+        onyx_base_url=ONYX,
+    )
+
+
+def test_disconnect_removes_row_even_when_revoke_fails(client, monkeypatch):
+    _configure_onyx()
+    uid = seed_user()
+    login_fastapi(client, uid)
+    _connect(uid)
+
+    class ExplodingClient:
+        def __init__(self, base_url: str, pat: str):
+            pass
+
+        def revoke_pat(self) -> None:
+            raise OnyxError("boom")
+
+    monkeypatch.setattr("app.api.craft.OnyxClient", ExplodingClient)
+    res = client.delete("/api/craft/connect")
+    assert res.status_code == 200
+    assert res.json()["disconnected"] is True
+    assert connections.status(uid) is None
+
+
+# --------------------------------------------------------------------------- #
+# Admin "Onyx Connection" config + URL validation                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_admin_put_validates_onyx_base_url(client):
+    admin = seed_user(uid="adm", email="adm@x.com", is_admin=True)
+    login_fastapi(client, admin)
+    bad = client.put(
+        "/api/admin/ingest",
+        json={"max_doc_chars": 100_000, "onyx_base_url": "http://internal.corp"},
+    )
+    assert bad.status_code == 400
+    ok = client.put(
+        "/api/admin/ingest",
+        json={"max_doc_chars": 100_000, "onyx_base_url": ONYX},
+    )
+    assert ok.status_code == 200
+    assert ok.json()["onyx_base_url"] == ONYX
+    assert ingest_settings.get_onyx_base_url() == ONYX
+
+
+def test_validate_onyx_base_url_rules():
+    assert validate_onyx_base_url(ONYX) == ONYX
+    assert validate_onyx_base_url("http://localhost:3000") == "http://localhost:3000"
+    with pytest.raises(ValueError):
+        validate_onyx_base_url("http://internal.host")
+    with pytest.raises(ValueError):
+        validate_onyx_base_url("https://onyx.example.com/")
+    with pytest.raises(ValueError):
+        validate_onyx_base_url("ftp://onyx.example.com")
+    with pytest.raises(ValueError):
+        validate_onyx_base_url("not-a-url")

--- a/backend/tests/test_craft_launch.py
+++ b/backend/tests/test_craft_launch.py
@@ -1,0 +1,237 @@
+"""POST /api/craft/launch + the craft_launch worker task."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import agent_sessions as sessions_repo
+from app.db import notifications as notifications_repo
+from app.ingest import settings as ingest_settings
+from app.main import create_app
+from app.onyx import connections
+from app.onyx.client import (
+    OnyxAuthError,
+    OnyxCapacityError,
+    OnyxError,
+    OnyxUnreachableError,
+)
+from app.tasks.craft import attachment_filename
+from app.tasks.queues import craft_queue
+from app.wiki import acl as wiki_acl
+from app.wiki import git as wiki_git
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+ONYX = "https://onyx.example.com"
+PAGE = "Projects/Page One.md"
+
+
+@pytest.fixture
+def client(tmp_repo):
+    # tmp_repo (not tmp_config): these tests commit wiki pages, so wiki_git
+    # must point at the tmp repo — otherwise it writes to the real WIKI_DIR.
+    return TestClient(create_app())
+
+
+@pytest.fixture
+def connected_user(client) -> str:
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url=ONYX)
+    uid = seed_user()
+    login_fastapi(client, uid)
+    connections.upsert(
+        user_id=uid,
+        onyx_pat="onyx_pat_" + "p" * 40,
+        onyx_user_email="nik@onyx.app",
+        expires_at=None,
+        onyx_base_url=ONYX,
+    )
+    return uid
+
+
+def _fake_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    message_count: int = 0,
+    create_error: OnyxError | None = None,
+) -> list[tuple[str, Any]]:
+    """Patch the worker's OnyxClient seam; returns the recorded call list."""
+    calls: list[tuple[str, Any]] = []
+
+    class Fake:
+        def __init__(self, base_url: str, pat: str):
+            calls.append(("init", base_url))
+
+        def create_build_session(self) -> str:
+            if create_error is not None:
+                raise create_error
+            calls.append(("create", None))
+            return "bs_123"
+
+        def set_session_name(self, session_id: str, *, name: str) -> None:
+            calls.append(("name", (session_id, name)))
+
+        def upload_attachment(self, session_id: str, *, filename: str, content: bytes) -> None:
+            calls.append(("upload", (session_id, filename)))
+
+        def session_message_count(self, session_id: str) -> int:
+            calls.append(("count", session_id))
+            return message_count
+
+        def send_seed_message(self, session_id: str, *, content: str) -> None:
+            calls.append(("send", (session_id, content)))
+
+    monkeypatch.setattr("app.tasks.craft.OnyxClient", Fake)
+    return calls
+
+
+def _launch(client, *, wiki_path: str | None = PAGE, message: str = "build a dashboard"):
+    return client.post("/api/craft/launch", json={"wiki_path": wiki_path, "message": message})
+
+
+# --------------------------------------------------------------------------- #
+# Gates                                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_launch_requires_connection(client):
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url=ONYX)
+    uid = seed_user()
+    login_fastapi(client, uid)
+    res = _launch(client, wiki_path=None)
+    assert res.status_code == 409
+    assert res.json()["error"] == "needs_onyx_connect"
+
+
+def test_launch_acl_denied(client, connected_user):
+    wiki_git.commit_file("secret/plan.md", "# secret\n", "seed", author=None)
+    other = seed_user(uid="other", email="o@x.com")
+    wiki_acl.set_owner("secret/plan.md", other)
+    res = _launch(client, wiki_path="secret/plan.md")
+    assert res.status_code == 403
+    assert sessions_repo.list_for_user(connected_user) == []
+
+
+def test_launch_rate_limited_per_user(client, connected_user):
+    for i in range(3):
+        sessions_repo.create(
+            user_id=connected_user,
+            tool_id="onyx-craft",
+            first_turn_prompt="x",
+            wiki_path=f"p{i}.md",
+            working_dir=None,
+            status="provisioning",
+        )
+    res = _launch(client, wiki_path=None)
+    assert res.status_code == 429
+
+
+# --------------------------------------------------------------------------- #
+# Happy path + idempotency                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_launch_happy_path(client, connected_user, monkeypatch):
+    wiki_git.commit_file(PAGE, "# Page One\nbody\n", "seed", author=None)
+    calls = _fake_client(monkeypatch)
+    with craft_queue.immediate_mode():
+        res = _launch(client)
+    assert res.status_code == 200
+    sid = res.json()["agent_session_id"]
+
+    row = sessions_repo.get(sid)
+    assert row is not None
+    assert row["status"] == "ready"
+    assert row["external_session_id"] == "bs_123"
+    assert row["external_url"] == f"{ONYX}/craft/v1?sessionId=bs_123"
+
+    ops = [c[0] for c in calls]
+    assert ops == ["init", "create", "name", "upload", "count", "send"]
+    assert calls[2][1] == ("bs_123", "Page One")
+    upload_args = calls[3][1]
+    assert upload_args == ("bs_123", "Page_One.md")
+    seed_content = calls[5][1][1]
+    assert "PAGE_ATTACHMENT: attachments/Page_One.md" in seed_content
+    assert "build a dashboard" in seed_content
+
+    page = notifications_repo.list_for_user(connected_user)
+    assert page["undismissed_count"] == 1
+    notif = page["notifications"][0]
+    assert notif["notif_type"] == "craft_ready"
+    assert notif["data"]["link"] == f"{ONYX}/craft/v1?sessionId=bs_123"
+    assert notif["data"]["agent_session_id"] == sid
+
+
+def test_launch_idempotent_for_same_page(client, connected_user, monkeypatch):
+    wiki_git.commit_file(PAGE, "# Page One\n", "seed", author=None)
+    calls = _fake_client(monkeypatch)
+    with craft_queue.immediate_mode():
+        first = _launch(client)
+        second = _launch(client)
+    assert first.json()["agent_session_id"] == second.json()["agent_session_id"]
+    assert [c[0] for c in calls].count("create") == 1
+
+
+def test_seed_send_skipped_when_session_has_messages(client, connected_user, monkeypatch):
+    wiki_git.commit_file(PAGE, "# Page One\n", "seed", author=None)
+    calls = _fake_client(monkeypatch, message_count=1)
+    with craft_queue.immediate_mode():
+        res = _launch(client)
+    assert res.status_code == 200
+    assert "send" not in [c[0] for c in calls]
+    row = sessions_repo.get(res.json()["agent_session_id"])
+    assert row is not None
+    assert row["status"] == "ready"
+
+
+# --------------------------------------------------------------------------- #
+# Failure taxonomy                                                            #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("error", "reason", "connection_survives"),
+    [
+        (OnyxAuthError("401"), "auth_expired", False),
+        (OnyxCapacityError("429"), "org_at_capacity", True),
+        (OnyxUnreachableError("down"), "onyx_unreachable", True),
+        (OnyxError("weird"), "provisioning_failed", True),
+    ],
+)
+def test_launch_failure_taxonomy(
+    client, connected_user, monkeypatch, error, reason, connection_survives
+):
+    wiki_git.commit_file(PAGE, "# Page One\n", "seed", author=None)
+    _fake_client(monkeypatch, create_error=error)
+    with craft_queue.immediate_mode():
+        res = _launch(client)
+    assert res.status_code == 200  # the launch itself succeeded; the task failed
+
+    row = sessions_repo.get(res.json()["agent_session_id"])
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["failure_reason"] == reason
+    assert (connections.status(connected_user) is not None) == connection_survives
+
+    page = notifications_repo.list_for_user(connected_user)
+    notif = page["notifications"][0]
+    assert notif["notif_type"] == "craft_failed"
+    assert notif["data"]["failure_reason"] == reason
+
+
+# --------------------------------------------------------------------------- #
+# attachment_filename                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def test_attachment_filename_sanitizes():
+    assert attachment_filename("Engineering Projects/Craft Integration.md") == (
+        "Craft_Integration.md"
+    )
+    assert attachment_filename("a/b/c.md") == "c.md"
+    assert attachment_filename("weird*page?.md").endswith(".md")
+    assert "/" not in attachment_filename("x/../../etc/passwd.md")
+    assert attachment_filename("....md") == "page.md"

--- a/backend/tests/test_launch_api.py
+++ b/backend/tests/test_launch_api.py
@@ -66,13 +66,42 @@ def test_setup_status_token_true_after_mint(client):
 
 
 def test_catalog_available_for_launch_flag(client):
-    """— only local_cli tools are available_for_launch in v1."""
+    """local_cli tools always launchable; onyx-craft dark without a base URL."""
     uid = seed_user()
     login_fastapi(client, uid)
     res = client.get("/api/launchers")
     by_id = {x["id"]: x for x in res.json()["launchers"]}
     assert by_id["claude-code"]["available_for_launch"] is True
     assert by_id["codex"]["available_for_launch"] is True
+    # craft_enabled is True in tmp_config, but no onyx_base_url is set yet.
+    assert by_id["onyx-craft"]["available_for_launch"] is False
+
+
+def test_catalog_craft_launchable_when_configured(client):
+    """onyx-craft flips launchable once Craft is enabled AND a base URL is set."""
+    from app.ingest import settings as ingest_settings
+
+    uid = seed_user()
+    login_fastapi(client, uid)
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url="https://onyx.example.com")
+    res = client.get("/api/launchers")
+    by_id = {x["id"]: x for x in res.json()["launchers"]}
+    assert by_id["onyx-craft"]["available_for_launch"] is True
+
+
+def test_catalog_craft_dark_when_disabled(client, monkeypatch, tmp_config):
+    """With a base URL set but CRAFT_ENABLED off, onyx-craft stays dark."""
+    from app.ingest import settings as ingest_settings
+
+    uid = seed_user()
+    login_fastapi(client, uid)
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url="https://onyx.example.com")
+    monkeypatch.setattr(
+        "app.api.launchers.CONFIG",
+        tmp_config.model_copy(update={"craft_enabled": False}),
+    )
+    res = client.get("/api/launchers")
+    by_id = {x["id"]: x for x in res.json()["launchers"]}
     assert by_id["onyx-craft"]["available_for_launch"] is False
 
 

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,105 @@
+"""Notification center — repo dedup semantics + the /api/notifications surface."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import notifications as repo
+from app.db.session import init_db
+from app.main import create_app
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_config):
+    init_db()
+    return TestClient(create_app())
+
+
+# --------------------------------------------------------------------------- #
+# Repo dedup semantics                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_create_dedups_and_bumps_last_shown(client):
+    uid = seed_user()
+    key = {"agent_session_id": "as_1"}
+    repo.create(user_id=uid, notif_type="craft_ready", title="t1", data=key)
+    first = repo.list_for_user(uid)["notifications"][0]
+
+    repo.create(user_id=uid, notif_type="craft_ready", title="t1", data=key)
+    page = repo.list_for_user(uid)
+    assert page["total_items"] == 1
+    assert page["notifications"][0]["last_shown"] >= first["last_shown"]
+
+    # Different dedup key → second row.
+    repo.create(
+        user_id=uid, notif_type="craft_ready", title="t2", data={"agent_session_id": "as_2"}
+    )
+    assert repo.list_for_user(uid)["total_items"] == 2
+
+
+def test_create_does_not_resurrect_dismissed(client):
+    uid = seed_user()
+    key = {"agent_session_id": "as_1"}
+    repo.create(user_id=uid, notif_type="craft_ready", title="t", data=key)
+    nid = repo.list_for_user(uid)["notifications"][0]["id"]
+    assert repo.dismiss(nid, user_id=uid)
+
+    repo.create(user_id=uid, notif_type="craft_ready", title="t", data=key)
+    page = repo.list_for_user(uid)
+    assert page["total_items"] == 1
+    assert page["undismissed_count"] == 0
+    assert page["notifications"][0]["dismissed"] is True
+
+
+# --------------------------------------------------------------------------- #
+# API surface                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def test_list_and_counts(client):
+    uid = seed_user()
+    login_fastapi(client, uid)
+    for i in range(3):
+        repo.create(user_id=uid, notif_type="craft_ready", title=f"t{i}", data={"k": i})
+
+    res = client.get("/api/notifications")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["total_items"] == 3
+    assert body["undismissed_count"] == 3
+    assert body["has_more"] is False
+    assert len(body["notifications"]) == 3
+
+    paged = client.get("/api/notifications", params={"limit": 2}).json()
+    assert len(paged["notifications"]) == 2
+    assert paged["has_more"] is True
+
+
+def test_dismiss_scoped_to_owner(client):
+    alice = seed_user(uid="alice", email="a@x.com")
+    bob = seed_user(uid="bob", email="b@x.com")
+    repo.create(user_id=alice, notif_type="craft_ready", title="t", data={})
+    nid = repo.list_for_user(alice)["notifications"][0]["id"]
+
+    login_fastapi(client, bob)
+    assert client.post(f"/api/notifications/{nid}/dismiss").status_code == 404
+
+    login_fastapi(client, alice)
+    assert client.post(f"/api/notifications/{nid}/dismiss").status_code == 200
+    assert repo.list_for_user(alice)["undismissed_count"] == 0
+
+
+def test_dismiss_all(client):
+    uid = seed_user()
+    login_fastapi(client, uid)
+    for i in range(4):
+        repo.create(user_id=uid, notif_type="craft_failed", title=f"t{i}", data={"k": i})
+    res = client.post("/api/notifications/dismiss-all")
+    assert res.status_code == 200
+    assert res.json()["dismissed"] == 4
+    assert repo.list_for_user(uid)["undismissed_count"] == 0


### PR DESCRIPTION
## Description

**Stacked PR 3/7 — backend api** (targets `nikg/craft-2-backend-logic`). The HTTP surface over the logic layer.

- `api/craft.py` — POST connect (manual PAT), GET status, POST launch (idempotent, ACL-gated, rate-limited)
- notifications API; launcher **availability gate** (`CRAFT_ENABLED` + admin `onyx_base_url`); admin `onyx_base_url` write; agent-session craft fields in the list response
- config `CRAFT_ENABLED`, ingest `upsert(onyx_base_url)` (write side), pydantic request/response models, router registration, full craft test suite

Stack: 1 schema → 2 backend-logic → **3 backend-api** → 4 fe-api → 5 settings → 6 notifications → 7 side-panel.

## How Has This Been Tested?

<!--- filled in on the top branch -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check