### PR TITLE
feat(craft): frontend api layer — typed Craft + notifications clients (stack 4/7)

### DIFF
--- a/frontend/src/lib/craft.ts
+++ b/frontend/src/lib/craft.ts
@@ -1,0 +1,78 @@
+"use client";
+
+import useSWR from "swr";
+
+import { apiFetch, ApiError } from "@/lib/api";
+
+// Mirrors app/models/craft.py:CraftConnectStatus.
+export interface CraftConnectStatus {
+  connected: boolean;
+  onyx_user_email: string | null;
+  // Redacted display hint only — never the raw PAT.
+  token_hint: string | null;
+  expires_at: string | null;
+  onyx_base_url: string | null;
+  connect_url: string | null;
+}
+
+export interface CraftLaunchResponse {
+  agent_session_id: string;
+  status: string;
+}
+
+/** Connection status for the current user. `data` is undefined while the
+ * feature is dark (the endpoint 404s) — callers treat that as "unavailable". */
+export function useCraftConnect() {
+  const { data, error, isLoading, mutate } =
+    useSWR<CraftConnectStatus>("/craft/connect");
+  // The endpoint 404s when Craft is dark; expose that as a typed flag so
+  // callers don't have to cast `error` and check the status themselves.
+  const isUnavailable = error instanceof ApiError && error.status === 404;
+  return {
+    status: data ?? null,
+    error,
+    isUnavailable,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+/** Manual-PAT connect (v0): validate + store the user's pasted Onyx PAT. */
+export function connectCraft(pat: string): Promise<CraftConnectStatus> {
+  return apiFetch<CraftConnectStatus>("/craft/connect", {
+    method: "POST",
+    body: JSON.stringify({ pat }),
+  });
+}
+
+export function disconnectCraft(): Promise<{ disconnected: boolean }> {
+  return apiFetch<{ disconnected: boolean }>("/craft/connect", {
+    method: "DELETE",
+  });
+}
+
+export function craftLaunch(req: {
+  wiki_path: string | null;
+  message: string;
+}): Promise<CraftLaunchResponse> {
+  return apiFetch<CraftLaunchResponse>("/craft/launch", {
+    method: "POST",
+    body: JSON.stringify(req),
+  });
+}
+
+/** Map a craft session's `failure_reason` to a user-facing message. */
+export function craftFailureMessage(reason: string | null): string {
+  switch (reason) {
+    case "auth_expired":
+      return "Your Onyx connection expired — reconnect under Agents → Onyx Craft.";
+    case "org_at_capacity":
+      return "Onyx is at capacity — try again shortly.";
+    case "rate_limited":
+      return "Too many Craft launches — wait a moment.";
+    case "onyx_unreachable":
+      return "Couldn't reach Onyx — try again.";
+    default:
+      return "Couldn't start the Craft build.";
+  }
+}

--- a/frontend/src/lib/launchers.ts
+++ b/frontend/src/lib/launchers.ts
@@ -48,7 +48,10 @@ export type AgentSessionStatus =
   | "active"
   | "idle"
   | "closed"
-  | "failed";
+  | "failed"
+  // Onyx Craft (in_app) lifecycle.
+  | "provisioning"
+  | "ready";
 
 export interface AgentSessionSummary {
   id: string;
@@ -60,6 +63,9 @@ export interface AgentSessionSummary {
   last_activity_at: string;
   closed_at: string | null;
   cli_session_id: string | null;
+  // onyx-craft only: the "Open Craft" deep link + the failure-taxonomy reason.
+  external_url: string | null;
+  failure_reason: string | null;
 }
 
 export interface AgentSessionList {

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+
+// Mirrors app/models/notifications.py.
+export interface NotificationView {
+  id: number;
+  notif_type: string;
+  title: string;
+  description: string | null;
+  dismissed: boolean;
+  first_shown: string;
+  last_shown: string;
+  data: Record<string, unknown>;
+}
+
+export interface NotificationList {
+  notifications: NotificationView[];
+  total_items: number;
+  undismissed_count: number;
+  has_more: boolean;
+}
+
+/**
+ * The per-user notification center feed.
+ *
+ * Polls every 5s only while `activePoll` is true (i.e. a Craft launch is in
+ * flight on the page) so the "Craft is ready" notification surfaces promptly;
+ * otherwise it refreshes on focus/navigation only — no idle polling.
+ */
+export function useNotifications(opts: { activePoll?: boolean } = {}) {
+  const { data, error, isLoading, mutate } = useSWR<NotificationList>(
+    "/notifications",
+    { refreshInterval: opts.activePoll ? 5000 : 0 },
+  );
+  return {
+    notifications: data?.notifications ?? [],
+    undismissedCount: data?.undismissed_count ?? 0,
+    isLoading,
+    error: error as Error | undefined,
+    refresh: mutate,
+  };
+}
+
+export function dismissNotification(id: number): Promise<{ ok: boolean }> {
+  return apiFetch<{ ok: boolean }>(`/notifications/${id}/dismiss`, {
+    method: "POST",
+  });
+}
+
+export function dismissAllNotifications(): Promise<{ dismissed: number }> {
+  return apiFetch<{ dismissed: number }>("/notifications/dismiss-all", {
+    method: "POST",
+  });
+}
+
+/** Read a string field from a notification's free-form `data` payload. */
+export function notifLink(n: NotificationView): string | null {
+  const link = n.data?.link;
+  return typeof link === "string" ? link : null;
+}


### PR DESCRIPTION
## Description

**Stacked PR 4/7 — frontend api layer** (targets `nikg/craft-3-backend-api`). The browser-side API seam, no UI yet.

- `lib/craft.ts` — `useCraftConnect`, connect/disconnect, `craftLaunch`
- `lib/notifications.ts` — `useNotifications`, dismiss, `notifLink`
- `lib/launchers.ts` — `AgentSessionStatus` gains `provisioning`/`ready`; `AgentSessionSummary` gains `external_url`/`failure_reason`

All via the shared `apiFetch` seam. Frontend-only (no Python) — `tsc` clean.

Stack: … → 3 backend-api → **4 fe-api** → 5 settings → 6 notifications → 7 side-panel.

## How Has This Been Tested?

<!--- filled in on the top branch -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check