### PR TITLE
feat(craft): settings — Connect Onyx (PAT) + admin Onyx URL (stack 5/7)

### DIFF
--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -21,6 +21,7 @@ interface IngestSettings {
   max_doc_chars: number;
   api_key_set: boolean;
   api_key_hint: string;
+  onyx_base_url: string | null;
 }
 
 export default function AdminIngestPage() {
@@ -50,6 +51,7 @@ function IngestForm() {
   const [saved, setSaved] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [baseUrl, setBaseUrl] = useState("");
+  const [onyxBaseUrl, setOnyxBaseUrl] = useState("");
   const confirmDialog = useConfirm();
 
   useEffect(() => {
@@ -64,6 +66,7 @@ function IngestForm() {
       ]);
       setSettings(ingest);
       setMaxDocChars(String(ingest.max_doc_chars));
+      setOnyxBaseUrl(ingest.onyx_base_url ?? "");
       setLlmSettings(llm);
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to load");
@@ -83,9 +86,13 @@ function IngestForm() {
     try {
       const r = await apiFetch<IngestSettings>("/admin/ingest", {
         method: "PUT",
-        body: JSON.stringify({ max_doc_chars: Number(maxDocChars) }),
+        body: JSON.stringify({
+          max_doc_chars: Number(maxDocChars),
+          onyx_base_url: onyxBaseUrl.trim() || null,
+        }),
       });
       setSettings(r);
+      setOnyxBaseUrl(r.onyx_base_url ?? "");
       setSaved("Saved.");
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to save");
@@ -137,7 +144,9 @@ function IngestForm() {
 
   if (!settings || !llmSettings) return <LoadingSpinner />;
 
-  const dirty = maxDocChars !== String(settings.max_doc_chars);
+  const dirty =
+    maxDocChars !== String(settings.max_doc_chars) ||
+    (onyxBaseUrl.trim() || "") !== (settings.onyx_base_url ?? "");
 
   return (
     <div className="flex flex-col gap-6">
@@ -208,9 +217,31 @@ function IngestForm() {
         </div>
       </section>
 
-      {/* Max doc size */}
+      {/* Outbound: the Onyx instance this wiki calls (Craft launches). */}
       <form onSubmit={onSubmit} className="flex flex-col gap-3">
-        <h3 className="m-0 text-sm font-semibold">Ingest settings</h3>
+        <h3 className="m-0 text-sm font-semibold">Onyx instance</h3>
+        <label>
+          <div className="mb-1 text-[13px] font-medium">
+            Onyx instance URL{" "}
+            <span className="font-normal text-(--text-03)">
+              — enables launching Onyx Craft from wiki pages
+            </span>
+          </div>
+          <input
+            type="url"
+            inputMode="url"
+            value={onyxBaseUrl}
+            onChange={(e) => setOnyxBaseUrl(e.target.value)}
+            placeholder="https://your-onyx.example.com"
+            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 font-mono text-sm"
+          />
+          <div className="mt-1.5 text-xs text-(--text-03)">
+            The public origin of your Onyx deployment (no trailing slash). Users
+            then connect their own Onyx token under Agents → Onyx Craft.
+          </div>
+        </label>
+
+        <h3 className="m-0 mt-2 text-sm font-semibold">Ingest settings</h3>
         <label>
           <div className="mb-1 text-[13px] font-medium">
             Max document size (characters)

--- a/frontend/src/components/agents/ConnectOnyxCraft.tsx
+++ b/frontend/src/components/agents/ConnectOnyxCraft.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@onyx-ai/opal/components";
+import { ApiError } from "@/lib/api";
+import { connectCraft, disconnectCraft, useCraftConnect } from "@/lib/craft";
+
+interface Props {
+  /** Fires after a successful connect — e.g. to dismiss a launch-panel modal. */
+  onConnected?: () => void;
+}
+
+function connectErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.status === 401) {
+      return "Onyx rejected that token. Double-check you copied the whole PAT.";
+    }
+    if (err.status === 502) {
+      return "Couldn't reach Onyx. Try again in a moment.";
+    }
+    return err.message;
+  }
+  return "Failed to connect.";
+}
+
+/**
+ * Connect / disconnect the current user's Onyx account via a pasted PAT.
+ * Renders nothing while the feature is dark (the status endpoint 404s),
+ * so it can be dropped into any surface unconditionally.
+ */
+export function ConnectOnyxCraft({ onConnected }: Props) {
+  const { status, error, isUnavailable, isLoading, refresh } =
+    useCraftConnect();
+  const [pat, setPat] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // 404 (Craft not configured by an admin) → feature dark; show nothing.
+  if (isUnavailable) return null;
+  if (isLoading) return null;
+  // A non-dark error (500/timeout) surfaces rather than silently hiding.
+  if (error || !status) {
+    return (
+      <div className="rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+        Couldn&apos;t load your Onyx connection. Try again in a moment.
+      </div>
+    );
+  }
+
+  async function onConnect() {
+    const trimmed = pat.trim();
+    if (!trimmed || busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await connectCraft(trimmed);
+      setPat("");
+      await refresh();
+      onConnected?.();
+    } catch (caught) {
+      setErr(connectErrorMessage(caught));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onDisconnect() {
+    setBusy(true);
+    setErr(null);
+    try {
+      await disconnectCraft();
+      await refresh();
+    } catch (caught) {
+      setErr(
+        caught instanceof ApiError ? caught.message : "Failed to disconnect.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (status.connected) {
+    return (
+      <div className="flex items-center gap-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-(--status-text-success-05)">
+            ✓ Connected to Onyx
+          </div>
+          <div className="mt-0.5 truncate text-xs text-(--text-03)">
+            {status.onyx_user_email ?? "your account"}
+            {status.token_hint ? ` · ${status.token_hint}` : ""}
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="danger"
+          onClick={onDisconnect}
+          disabled={busy}
+        >
+          {busy ? "…" : "Disconnect"}
+        </Button>
+      </div>
+    );
+  }
+
+  // Scheme-guard the admin-set URL before it becomes an href — a javascript:
+  // value would otherwise execute on click (stored XSS).
+  const patHref =
+    status.onyx_base_url && /^https?:\/\//i.test(status.onyx_base_url)
+      ? `${status.onyx_base_url}/settings`
+      : undefined;
+
+  return (
+    // Not a <form>: this drops into surfaces that are already inside a form
+    // (the Run Agent panel), and a nested form submits the outer one — which
+    // reloads the page and drops the connect. Submit via button + Enter key.
+    <div className="rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-01) p-3">
+      <label className="text-[13px] text-(--text-04)">
+        Onyx Personal Access Token
+        <input
+          type="password"
+          autoComplete="off"
+          value={pat}
+          onChange={(e) => setPat(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void onConnect();
+            }
+          }}
+          placeholder="onyx_pat_…"
+          className="mt-1 box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 font-mono text-sm"
+          maxLength={1024}
+        />
+      </label>
+      <div className="mt-1.5 text-xs text-(--text-03)">
+        Craft runs as you, so it uses your Onyx knowledge and model access. Mint
+        a token in{" "}
+        {patHref ? (
+          <a
+            href={patHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-(--action-link-05) underline"
+          >
+            Onyx → Settings → Accounts &amp; Access
+          </a>
+        ) : (
+          "Onyx → Settings → Accounts & Access"
+        )}
+        , then paste it here.
+      </div>
+      {err && (
+        <div className="mt-[10px] mb-1 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+          {err}
+        </div>
+      )}
+      <div className="mt-3">
+        <Button
+          type="button"
+          variant="action"
+          onClick={() => void onConnect()}
+          disabled={busy || !pat.trim()}
+        >
+          {busy ? "Connecting…" : "Connect Onyx"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/agents-and-actions/AgentsAndActionsPage.tsx
+++ b/frontend/src/views/agents-and-actions/AgentsAndActionsPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 
+import { ConnectOnyxCraft } from "@/components/agents/ConnectOnyxCraft";
 import { SetupWizard } from "@/components/agents/SetupWizard";
 import { ToolCard } from "@/components/agents/ToolCard";
 import { Button } from "@onyx-ai/opal/components";
@@ -21,6 +22,7 @@ import {
 } from "@/lib/agents";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
+import { useCraftConnect } from "@/lib/craft";
 import { type ProbeResult } from "@/lib/launchers";
 
 export default function AgentsAndActionsPage() {
@@ -41,10 +43,38 @@ export default function AgentsAndActionsPage() {
         <TokenManager />
         <ClientConfigHelp />
         <CodingToolsSection />
+        <OnyxCraftSection />
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );
 }
+
+// --------------------------------------------------------------------------- //
+// Onyx Craft connection                                                       //
+// --------------------------------------------------------------------------- //
+
+function OnyxCraftSection() {
+  // Hidden while loading and when the feature is dark (status endpoint 404s).
+  // A non-dark error (500/timeout) still renders so the feature doesn't
+  // silently vanish — ConnectOnyxCraft surfaces the error instead.
+  const { isUnavailable, isLoading } = useCraftConnect();
+  if (isLoading || isUnavailable) return null;
+
+  return (
+    <section className="mb-4 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+      <h2 className="m-0 mb-1 text-base">Onyx Craft</h2>
+      <p className="m-0 mb-3 text-[13px] text-(--text-03)">
+        Connect your Onyx account to launch Craft builds from any wiki page with
+        Run Agent. The build runs as you, with your knowledge and model access.
+      </p>
+      <ConnectOnyxCraft />
+    </section>
+  );
+}
+
+// --------------------------------------------------------------------------- //
+// Endpoint                                                                    //
+// --------------------------------------------------------------------------- //
 
 function EndpointBlock() {
   const [endpoint, setEndpoint] = useState("");


### PR DESCRIPTION
## Description

**Stacked PR 5/7 — settings / PAT** (targets `nikg/craft-4-fe-api`). Where a user links their Onyx account.

- `ConnectOnyxCraft` — paste-PAT connect form / connected view (masked token, disconnect)
- Agents & Actions page — the Onyx Craft connect section
- Admin → Ingest — the Onyx instance URL field that arms Craft

`tsc` clean.

Stack: … → 4 fe-api → **5 settings** → 6 notifications → 7 side-panel.

## How Has This Been Tested?

<!--- filled in on the top branch -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check