### PR TITLE
feat(craft): notifications — bell + ready/failed toasts (stack 6/7)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -36,6 +36,39 @@ body {
   --shadow-fab: 0 6px 20px var(--shadow-03);
   --shadow-modal: 0 24px 60px var(--shadow-03);
   --shadow-panel: -4px 0 24px var(--shadow-02);
+  --toast-width: 24rem;
+}
+
+/* ── Toast animations ─────────────────────────────────────────────────────
+   Defined globally (not in a CSS Module) so the animation names survive —
+   CSS Modules scope @keyframes, leaving a module-scoped `animation:` ref
+   pointing at a name that doesn't exist. Used by ToastContainer.
+   ───────────────────────────────────────────────────────────────────── */
+@keyframes fade-in-scale {
+  from {
+    opacity: 0;
+    transform: scale(0.96) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+@keyframes fade-out-scale {
+  from {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: scale(0.96) translateY(8px);
+  }
+}
+.animate-fade-in-scale {
+  animation: fade-in-scale 0.2s ease-out;
+}
+.animate-fade-out-scale {
+  animation: fade-out-scale 0.2s ease-in forwards;
 }
 
 /* ── Primary (action) buttons ─────────────────────────────────────────────

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { AuthProvider } from "@/lib/auth";
 import { DraftingProvider } from "@/lib/drafting";
 import { SWRProvider } from "@/lib/swr";
 import { ThemeProvider } from "@/lib/theme-provider";
+import { ToastContainer } from "@/providers/ToastProvider";
 
 const hankenGrotesk = Hanken_Grotesk({
   subsets: ["latin"],
@@ -76,6 +77,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                   <ConfirmProvider>
                     {children}
                     <ChatWidget />
+                    <ToastContainer />
                   </ConfirmProvider>
                 </Tooltip.Provider>
               </DraftingProvider>

--- a/frontend/src/components/common/NotificationBell.tsx
+++ b/frontend/src/components/common/NotificationBell.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+
+import {
+  Button,
+  LineItemButton,
+  Popover,
+  PopoverMenu,
+  Text,
+} from "@onyx-ai/opal/components";
+import { SvgBell } from "@onyx-ai/opal/icons";
+
+import { toast } from "@/hooks/useToast";
+import {
+  dismissAllNotifications,
+  dismissNotification,
+  notifLink,
+  useNotifications,
+  type NotificationView,
+} from "@/lib/notifications";
+
+export function NotificationBell() {
+  const { notifications, undismissedCount, error, refresh } =
+    useNotifications();
+  const [open, setOpen] = useState(false);
+
+  // Notifications are a general feature; if the endpoint ever 404s, fail
+  // closed and render nothing rather than a broken bell.
+  if (error) return null;
+
+  function openLink(link: string) {
+    if (/^https?:\/\//.test(link)) {
+      window.open(link, "_blank", "noopener,noreferrer");
+    } else if (link.startsWith("/") && !link.startsWith("//")) {
+      // Same-tab nav for internal absolute paths only. Reject schemes
+      // (javascript:/data:) and protocol-relative (//host) links — a
+      // malformed notification record must not run script or escape origin.
+      window.location.href = link;
+    }
+  }
+
+  function onItemClick(n: NotificationView) {
+    if (!n.dismissed) {
+      void dismissNotification(n.id)
+        .then(() => refresh())
+        .catch(() => toast.error("Couldn't dismiss the notification."));
+    }
+    const link = notifLink(n);
+    if (link) openLink(link);
+    setOpen(false);
+  }
+
+  function row(n: NotificationView) {
+    return (
+      <LineItemButton
+        key={n.id}
+        title={n.title}
+        description={n.description ?? undefined}
+        sizePreset="main-ui"
+        variant="section"
+        rounding="sm"
+        onClick={() => onItemClick(n)}
+      />
+    );
+  }
+
+  const unread = notifications.filter((n) => !n.dismissed);
+  const read = notifications.filter((n) => n.dismissed);
+
+  // PopoverMenu takes an array of nodes; a `null` entry renders a divider.
+  const items: ReactNode[] = [
+    <div key="hdr" className="flex items-center justify-between px-2 pt-1">
+      <Text font="secondary-body" color="text-04">
+        Notifications
+      </Text>
+      {undismissedCount > 0 && (
+        <Button
+          size="sm"
+          prominence="tertiary"
+          onClick={() =>
+            void dismissAllNotifications()
+              .then(() => refresh())
+              .catch(() => toast.error("Couldn't mark notifications read."))
+          }
+        >
+          Mark all read
+        </Button>
+      )}
+    </div>,
+    null,
+  ];
+  if (notifications.length === 0) {
+    items.push(
+      <div key="empty" className="p-2">
+        <Text font="secondary-body" color="text-03">
+          No notifications yet.
+        </Text>
+      </div>,
+    );
+  } else {
+    unread.forEach((n) => items.push(row(n)));
+    if (unread.length && read.length) items.push(null);
+    read.forEach((n) => items.push(row(n)));
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Anchor asChild>
+        <div className="relative">
+          <Button
+            icon={SvgBell}
+            prominence="tertiary"
+            tooltip="Notifications"
+            aria-label={`Notifications${
+              undismissedCount ? ` (${undismissedCount} unread)` : ""
+            }`}
+            onClick={() => setOpen((o) => !o)}
+          />
+          {undismissedCount > 0 && (
+            <span className="pointer-events-none absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-(--status-error-05) px-1 text-[10px] leading-none font-semibold text-(--text-inverted-05)">
+              {undismissedCount > 9 ? "9+" : undismissedCount}
+            </span>
+          )}
+        </div>
+      </Popover.Anchor>
+      <Popover.Content
+        width="lg"
+        align="end"
+        sideOffset={6}
+        container={typeof document !== "undefined" ? document.body : undefined}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
+        <PopoverMenu>{items}</PopoverMenu>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/frontend/src/components/wiki/CraftNotifier.tsx
+++ b/frontend/src/components/wiki/CraftNotifier.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { mutate as globalMutate } from "swr";
+
+import { toast } from "@/hooks/useToast";
+import { craftFailureMessage } from "@/lib/craft";
+import { useAgentSessions } from "@/lib/launchers";
+
+/**
+ * Render-null. Watches the user's Craft sessions (the agent-sessions poll)
+ * and fires a transient toast the moment one flips `provisioning → ready`
+ * or `→ failed`. The durable, clickable "Open Craft" lives in the
+ * notification bell + the page's active-agents bar; this is just the nudge.
+ */
+export function CraftNotifier() {
+  const { sessions, isLoading } = useAgentSessions();
+  const lastStatus = useRef<Map<string, string>>(new Map());
+  const primed = useRef(false);
+
+  useEffect(() => {
+    // Wait for SWR's first loaded frame before arming the priming guard:
+    // priming on the pre-fetch empty list would leave every already-terminal
+    // session with prev === undefined and re-announce it once data lands.
+    if (isLoading) return;
+    const craft = sessions.filter((s) => s.tool_id === "onyx-craft");
+
+    // First loaded frame: record current statuses without toasting, so a
+    // session that was already ready before we mounted doesn't re-announce.
+    if (!primed.current) {
+      craft.forEach((s) => lastStatus.current.set(s.id, s.status));
+      primed.current = true;
+      return;
+    }
+
+    let resolved = false;
+    for (const s of craft) {
+      const prev = lastStatus.current.get(s.id);
+      lastStatus.current.set(s.id, s.status);
+      // Fire on any un-announced arrival at a terminal state. We don't require
+      // prev==="provisioning": if the tab was backgrounded during provisioning
+      // (SWR pauses polling while hidden) the session first surfaces as ready,
+      // and the user still needs the toast. The `prev === s.status` skip + the
+      // priming pass keep this from re-announcing a state we've already shown.
+      if (prev === s.status) continue;
+      if (s.status === "ready") {
+        const url = s.external_url;
+        toast.success("Craft is ready", {
+          description: "Your build is ready to open.",
+          duration: 15000,
+          action: url
+            ? {
+                label: "Open Craft",
+                onClick: () =>
+                  window.open(url, "_blank", "noopener,noreferrer"),
+              }
+            : undefined,
+        });
+        resolved = true;
+      } else if (s.status === "failed") {
+        toast.error("Craft launch failed", {
+          description: craftFailureMessage(s.failure_reason),
+        });
+        resolved = true;
+      }
+    }
+    // A terminal transition means the worker wrote a notification — refresh
+    // the bell so its badge updates without waiting for a focus revalidate.
+    if (resolved) void globalMutate("/notifications");
+  }, [sessions, isLoading]);
+
+  return null;
+}

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { Button } from "@onyx-ai/opal/components";
 import { SvgFolder } from "@onyx-ai/opal/icons";
+import { NotificationBell } from "@/components/common/NotificationBell";
+import { CraftNotifier } from "@/components/wiki/CraftNotifier";
 import { useAppFocus } from "@/hooks/useAppFocus";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 import { useHeaderActionsHost } from "@/providers/WikiHeaderActionsProvider";
@@ -60,6 +62,8 @@ export function WikiHeader() {
           WikiHeaderActionsProvider). Pushed right by the flex spacer. */}
       <div className="flex-1" />
       <div ref={host?.setEl} className="flex items-center gap-1" />
+      <NotificationBell />
+      <CraftNotifier />
     </div>
   );
 }

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,262 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ToastLevel = "success" | "error" | "warning" | "info" | "default";
+
+/** Optional call-to-action rendered as a button inside the toast. */
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface ToastOptions {
+  message: string;
+  level?: ToastLevel;
+  description?: string;
+  duration?: number; // ms – default 4000, Infinity = persistent
+  dismissible?: boolean; // default true (shows close button)
+  action?: ToastAction;
+}
+
+export interface Toast extends ToastOptions {
+  id: string;
+  createdAt: number;
+  leaving?: boolean; // true while exit‑animation plays
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const MAX_VISIBLE_TOASTS = 3;
+const DEFAULT_DURATION = 4000;
+// Exit-animation (fade-out-scale) duration. Auto-dismiss and manual close both
+// mark the toast leaving, then remove after this delay; must match globals.css.
+export const TOAST_ANIMATION_MS = 200;
+const TOAST_CONSOLE_METHOD: Record<
+  ToastLevel,
+  "log" | "warn" | "error" | "info"
+> = {
+  error: "error",
+  warning: "warn",
+  info: "info",
+  success: "log",
+  default: "log",
+};
+
+// ---------------------------------------------------------------------------
+// Module‑level store (external to React)
+// ---------------------------------------------------------------------------
+
+let toasts: Toast[] = [];
+const subscribers = new Set<() => void>();
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+let nextId = 0;
+
+function notify() {
+  subscribers.forEach((cb) => cb());
+}
+
+function addToast(options: ToastOptions): string {
+  const id = `toast-${++nextId}-${Date.now()}`;
+  const duration = options.duration ?? DEFAULT_DURATION;
+
+  const level = options.level ?? "info";
+
+  const entry: Toast = {
+    ...options,
+    id,
+    level,
+    dismissible: options.dismissible ?? true,
+    createdAt: Date.now(),
+  };
+
+  if (process.env.NODE_ENV === "development") {
+    const method = TOAST_CONSOLE_METHOD[level];
+    if (entry.description) {
+      console[method](`[Toast] ${entry.message}`, entry.description);
+    } else {
+      console[method](`[Toast] ${entry.message}`);
+    }
+  }
+
+  toasts = [...toasts, entry];
+  notify();
+
+  if (duration !== Infinity) {
+    const timer = setTimeout(() => expire(id), duration);
+    timers.set(id, timer);
+  }
+
+  return id;
+}
+
+function removeToast(id: string): void {
+  const timer = timers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    timers.delete(id);
+  }
+  toasts = toasts.filter((t) => t.id !== id);
+  notify();
+}
+
+function setAutoDismiss(id: string, duration: number): void {
+  const existing = timers.get(id);
+  if (existing) {
+    clearTimeout(existing);
+    timers.delete(id);
+  }
+  if (duration === Infinity) {
+    return;
+  }
+  const timer = setTimeout(() => expire(id), duration);
+  timers.set(id, timer);
+}
+
+function markLeaving(id: string): void {
+  toasts = toasts.map((t) => (t.id === id ? { ...t, leaving: true } : t));
+  notify();
+}
+
+// Auto-dismiss the way a manual close does: play the exit animation, then
+// remove. Calling removeToast directly hard-cuts the toast mid-screen.
+function expire(id: string): void {
+  markLeaving(id);
+  const timer = setTimeout(() => removeToast(id), TOAST_ANIMATION_MS);
+  timers.set(id, timer);
+}
+
+function clearAll(): void {
+  timers.forEach((timer) => clearTimeout(timer));
+  timers.clear();
+  toasts = [];
+  notify();
+}
+
+function subscribe(cb: () => void): () => void {
+  subscribers.add(cb);
+  return () => {
+    subscribers.delete(cb);
+  };
+}
+
+function getSnapshot(): Toast[] {
+  return toasts;
+}
+
+// ---------------------------------------------------------------------------
+// Imperative API (works anywhere – components, hooks, plain .ts files)
+// ---------------------------------------------------------------------------
+
+interface ToastFn {
+  (options: ToastOptions): string;
+  success: (
+    message: string,
+    opts?: Omit<ToastOptions, "message" | "level">,
+  ) => string;
+  error: (
+    message: string,
+    opts?: Omit<ToastOptions, "message" | "level">,
+  ) => string;
+  warning: (
+    message: string,
+    opts?: Omit<ToastOptions, "message" | "level">,
+  ) => string;
+  info: (
+    message: string,
+    opts?: Omit<ToastOptions, "message" | "level">,
+  ) => string;
+  dismiss: (id: string) => void;
+  clearAll: () => void;
+  /**
+   * Reset (or cancel) a toast's auto-dismiss timer. Pass `Infinity` to make the
+   * toast persistent. Used by ToastContainer when the user expands a truncated
+   * toast and needs more time to read it.
+   */
+  setAutoDismiss: (id: string, duration: number) => void;
+  /** @internal – used by ToastContainer for exit animation */
+  _markLeaving: (id: string) => void;
+}
+
+function toastBase(options: ToastOptions): string {
+  return addToast(options);
+}
+
+export const toast: ToastFn = Object.assign(toastBase, {
+  success: (message: string, opts?: Omit<ToastOptions, "message" | "level">) =>
+    addToast({ ...opts, message, level: "success" }),
+  error: (message: string, opts?: Omit<ToastOptions, "message" | "level">) =>
+    addToast({ ...opts, message, level: "error" }),
+  warning: (message: string, opts?: Omit<ToastOptions, "message" | "level">) =>
+    addToast({ ...opts, message, level: "warning" }),
+  info: (message: string, opts?: Omit<ToastOptions, "message" | "level">) =>
+    addToast({ ...opts, message, level: "info" }),
+  dismiss: removeToast,
+  clearAll,
+  setAutoDismiss,
+  _markLeaving: markLeaving,
+});
+
+// ---------------------------------------------------------------------------
+// React hook (convenience wrapper)
+// ---------------------------------------------------------------------------
+
+export function useToast() {
+  useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return { toast, dismiss: toast.dismiss, clearAll: toast.clearAll };
+}
+
+// ---------------------------------------------------------------------------
+// Query-param toast hook
+// ---------------------------------------------------------------------------
+
+interface ToastFromQueryMessages {
+  [key: string]: {
+    message: string;
+    type?: ToastLevel | null;
+  };
+}
+
+/**
+ * Reads a `?message=<key>` query param on mount, fires the matching toast,
+ * and strips the param from the URL.
+ */
+export function useToastFromQuery(messages: ToastFromQueryMessages) {
+  useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const messageValue = searchParams?.get("message");
+
+    if (messageValue && messageValue in messages) {
+      searchParams.delete("message");
+      const newSearch = searchParams.toString()
+        ? "?" + searchParams.toString()
+        : "";
+      window.history.replaceState(
+        null,
+        "",
+        window.location.pathname + newSearch,
+      );
+      const spec = messages[messageValue];
+      if (spec !== undefined) {
+        toast({
+          message: spec.message,
+          level: spec.type ?? "info",
+        });
+      }
+    }
+  }, [messages]);
+}
+
+// ---------------------------------------------------------------------------
+// Store accessors (used by ToastContainer)
+// ---------------------------------------------------------------------------
+
+export const toastStore = {
+  subscribe,
+  getSnapshot,
+};

--- a/frontend/src/providers/ToastProvider.tsx
+++ b/frontend/src/providers/ToastProvider.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useState, useSyncExternalStore } from "react";
+import { Button, MessageCard, Text } from "@onyx-ai/opal/components";
+import { cn } from "@onyx-ai/opal/utils";
+
+import {
+  toast,
+  toastStore,
+  MAX_VISIBLE_TOASTS,
+  TOAST_ANIMATION_MS,
+} from "@/hooks/useToast";
+import type { Toast, ToastLevel } from "@/hooks/useToast";
+const MAX_TOAST_MESSAGE_LENGTH = 150;
+// How long a toast lingers after the user clicks to expand it. Long enough to
+// read a multi-line stack trace / API error without forcing a manual dismiss.
+const EXPANDED_DURATION_MS = 30000;
+
+type MessageCardVariant = React.ComponentProps<typeof MessageCard>["variant"];
+
+const LEVEL_TO_VARIANT: Record<ToastLevel, MessageCardVariant> = {
+  success: "success",
+  error: "error",
+  warning: "warning",
+  info: "info",
+  default: "default",
+};
+
+function buildDescription(t: Toast): string | undefined {
+  return t.description ? t.description : undefined;
+}
+
+interface ExpandedDetailsProps {
+  message: string;
+}
+
+function ExpandedDetails({ message }: ExpandedDetailsProps) {
+  return (
+    <div className="max-h-72 overflow-y-auto px-3 py-2 wrap-break-word whitespace-pre-wrap">
+      <Text font="secondary-body" color="text-03" as="p">
+        {message}
+      </Text>
+    </div>
+  );
+}
+
+function ToastAction({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <div className="px-3 pb-2">
+      <Button type="button" size="sm" variant="action" onClick={onClick}>
+        {label}
+      </Button>
+    </div>
+  );
+}
+
+function ToastContainer() {
+  const allToasts = useSyncExternalStore(
+    toastStore.subscribe,
+    toastStore.getSnapshot,
+    toastStore.getSnapshot,
+  );
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const visible = allToasts.slice(-MAX_VISIBLE_TOASTS);
+
+  const handleClose = useCallback((id: string) => {
+    toast._markLeaving(id);
+    setTimeout(() => {
+      toast.dismiss(id);
+      setExpandedIds((prev) => {
+        if (!prev.has(id)) return prev;
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+    }, TOAST_ANIMATION_MS);
+  }, []);
+
+  const handleExpand = useCallback((id: string) => {
+    setExpandedIds((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    // Reset the auto-dismiss timer so the user has time to read the full
+    // message before it fades.
+    toast.setAutoDismiss(id, EXPANDED_DURATION_MS);
+  }, []);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div
+      data-testid="toast-container"
+      role="status"
+      aria-live="polite"
+      aria-atomic="false"
+      className="fixed right-4 bottom-4 z-(--z-toast) flex w-full max-w-(--toast-width) flex-col items-end gap-2"
+    >
+      {visible.map((t) => {
+        const isTruncatable = t.message.length > MAX_TOAST_MESSAGE_LENGTH;
+        const isExpanded = expandedIds.has(t.id);
+        const truncatedTitle = isTruncatable
+          ? t.message.slice(0, MAX_TOAST_MESSAGE_LENGTH) + "…"
+          : t.message;
+        const expandable = isTruncatable && !isExpanded;
+        return (
+          <div
+            key={t.id}
+            className={cn(
+              "w-full",
+              t.leaving ? "animate-fade-out-scale" : "animate-fade-in-scale",
+              expandable && "cursor-pointer",
+            )}
+            onClick={
+              expandable
+                ? (e) => {
+                    // Don't intercept clicks on the inner close button.
+                    if (
+                      (e.target as HTMLElement).closest(
+                        'button[aria-label="Close"]',
+                      )
+                    ) {
+                      return;
+                    }
+                    handleExpand(t.id);
+                  }
+                : undefined
+            }
+          >
+            <MessageCard
+              variant={LEVEL_TO_VARIANT[t.level ?? "info"]}
+              title={truncatedTitle}
+              description={buildDescription(t)}
+              padding="xs"
+              onClose={t.dismissible ? () => handleClose(t.id) : undefined}
+              bottomChildren={
+                isExpanded ? (
+                  <ExpandedDetails message={t.message} />
+                ) : t.action ? (
+                  <ToastAction
+                    label={t.action.label}
+                    onClick={() => {
+                      t.action?.onClick();
+                      handleClose(t.id);
+                    }}
+                  />
+                ) : undefined
+              }
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export { ToastContainer };


### PR DESCRIPTION
## Description

**Stacked PR 6/7 — notifications** (targets `nikg/craft-5-settings`). The recoverable + real-time notice surface, plus the generic toast infra it relies on.

- **toast subsystem** — `useToast` store (success/error/info + optional action button), `ToastProvider`/`ToastContainer`, keyframes in `globals.css`, mounted in the root layout
- `NotificationBell` — per-user notification center (Opal `Popover` + unread badge)
- `CraftNotifier` — render-null; toasts on `provisioning → ready/failed` with an **Open Craft** action; refreshes the bell
- `WikiHeader` mounts the bell + notifier

(The toast infra ships here because the notification center is its first consumer; the side-panel in 7/7 reuses it.)

Stack: … → 5 settings → **6 notifications** → 7 side-panel.

## How Has This Been Tested?

<!--- filled in on the top branch -->

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check