### PR TITLE
feat(craft): side panel — Run Agent → Onyx Craft (stack 7/7)

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -28,6 +28,7 @@ import {
   SvgChevronRight,
   SvgDocFile,
   SvgEdit,
+  SvgExternalLink,
   SvgFolder,
   SvgFolderPlus,
   SvgHistory,
@@ -45,6 +46,7 @@ import { DiffView } from "@/components/wiki/DiffView";
 import { HistoryPanel } from "@/components/wiki/HistoryPanel";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { WikiHome } from "@/components/wiki/WikiHome";
+import { craftFailureMessage } from "@/lib/craft";
 import {
   closeSession,
   useAgentSessions,
@@ -1598,7 +1600,14 @@ function FileViewer({ path }: { path: string }) {
   const { sessions: agentSessions, refresh: refreshSessions } =
     useAgentSessions(path);
   const activeSessions = agentSessions.filter(
-    (s) => s.status === "active" || s.status === "idle",
+    (s) =>
+      s.status === "active" ||
+      s.status === "idle" ||
+      // Onyx Craft (in_app) lifecycle states worth surfacing on the page.
+      (s.tool_id === "onyx-craft" &&
+        (s.status === "provisioning" ||
+          s.status === "ready" ||
+          s.status === "failed")),
   );
 
   const handleCloseSession = useCallback(
@@ -2770,14 +2779,42 @@ function ActiveSessionRow({
 
       <span className="shrink-0 font-medium text-(--text-05)">{s.tool_id}</span>
 
-      <span className="flex-1" />
+      {s.tool_id === "onyx-craft" && s.status === "failed" ? (
+        <span
+          className="min-w-0 grow overflow-hidden text-ellipsis text-(--status-text-error-05)"
+          title={craftFailureMessage(s.failure_reason)}
+        >
+          {craftFailureMessage(s.failure_reason)}
+        </span>
+      ) : (
+        <>
+          <span className="flex-1" />
+          <span
+            className="shrink-0 text-[11px] text-(--text-02)"
+            title={`Started ${absoluteTime(s.started_at)}`}
+          >
+            started {relativeTime(s.started_at, "short")}
+          </span>
+        </>
+      )}
 
-      <span
-        className="shrink-0 text-[11px] text-(--text-02)"
-        title={`Started ${absoluteTime(s.started_at)}`}
-      >
-        started {relativeTime(s.started_at, "short")}
-      </span>
+      {s.tool_id === "onyx-craft" && s.status === "ready" && s.external_url && (
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          icon={SvgExternalLink}
+          onClick={() =>
+            window.open(
+              s.external_url as string,
+              "_blank",
+              "noopener,noreferrer",
+            )
+          }
+        >
+          Open Craft
+        </Button>
+      )}
 
       <Button type="button" variant="default" size="sm" onClick={onClose}>
         Close

--- a/frontend/src/components/wiki/RunAgentPanel.tsx
+++ b/frontend/src/components/wiki/RunAgentPanel.tsx
@@ -8,7 +8,10 @@ import { WorkingDirInput } from "@/components/agents/WorkingDirInput";
 import { Button, MessageCard, Text } from "@onyx-ai/opal/components";
 import { SvgChevronDown, SvgFileText, SvgX } from "@onyx-ai/opal/icons";
 import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
+import { ConnectOnyxCraft } from "@/components/agents/ConnectOnyxCraft";
 import { ApiError } from "@/lib/api";
+import { craftLaunch, useCraftConnect } from "@/lib/craft";
+import { toast } from "@/hooks/useToast";
 import {
   launch,
   probeHelper,
@@ -50,6 +53,7 @@ export function RunAgentPanel({ open, onClose, wikiPath }: Props) {
     wikiPath,
   });
   const { refresh: refreshSessions } = useAgentSessions(wikiPath ?? undefined);
+  const { status: craftStatus, refresh: refreshCraft } = useCraftConnect();
   const launchable = useMemo(
     () => launchers.filter((c) => c.available_for_launch),
     [launchers],
@@ -163,16 +167,53 @@ export function RunAgentPanel({ open, onClose, wikiPath }: Props) {
   const selected = launchers.find((c) => c.id === selectedId);
   const selectedName = selected?.name ?? "your agent";
   const selectedKind = selected?.kind;
+  const isCraft = selectedKind === "in_app";
+  const craftConnected = craftStatus?.connected ?? false;
   const docLabel = docName(wikiPath);
   const SelectedIcon = agentIcon(selectedId);
 
   async function onRun(e: FormEvent) {
     e.preventDefault();
     if (!selectedId) return;
-    // Only local_cli tools require the localhost helper. in_app
-    // (e.g. onyx-craft) and web_handoff tools launch through the
-    // backend directly — gating them on the probe result would trap
-    // the user in a wizard loop they can never escape.
+
+    // Onyx Craft (in_app): launch server-side as the connected user — no
+    // localhost helper, no agentwiki:// dispatch. Surfaces in the bar + bell.
+    if (isCraft) {
+      if (!craftConnected) return; // Start stays disabled until connected
+      setBusy(true);
+      setError(null);
+      try {
+        await craftLaunch({
+          wiki_path: docContextOn ? wikiPath : null,
+          message,
+        });
+      } catch (err) {
+        setError(
+          err instanceof ApiError ? err.message : "Failed to launch Craft",
+        );
+        setBusy(false);
+        return;
+      }
+      // Launch succeeded. Confirm via toast (the panel closes; CraftNotifier
+      // fires the "ready" toast with the Open Craft link). The revalidations
+      // are best-effort — a background failure must not surface a false
+      // "launch failed" the next time the panel opens.
+      toast.success("Craft build started", {
+        description:
+          "Provisioning a sandbox — you'll get a link when it's ready.",
+      });
+      onClose();
+      try {
+        await refreshSessions();
+        await refreshCatalog();
+      } catch {
+        // ignore — the launch already happened and was confirmed.
+      }
+      return;
+    }
+
+    // Only local_cli tools require the localhost helper. Gating them on the
+    // probe result would trap the user in a wizard loop they can never escape.
     const selectedTool = launchable.find((c) => c.id === selectedId);
     if (selectedTool?.kind === "local_cli" && probe?.acked === false) {
       setWizardOpen(true);
@@ -217,7 +258,8 @@ export function RunAgentPanel({ open, onClose, wikiPath }: Props) {
   const canRun =
     message.trim().length > 0 &&
     selectedId !== null &&
-    launchable.some((c) => c.id === selectedId);
+    launchable.some((c) => c.id === selectedId) &&
+    (!isCraft || craftConnected);
 
   return (
     <form
@@ -334,6 +376,19 @@ export function RunAgentPanel({ open, onClose, wikiPath }: Props) {
               </>
             )}
 
+            {isCraft && !craftConnected && (
+              <div className={styles.section}>
+                <Text font="main-ui-action" color="text-04">
+                  Connect Onyx
+                </Text>
+                <Text font="secondary-body" color="text-03">
+                  Craft runs as you, with your Onyx knowledge and model access.
+                  Connect your account to launch.
+                </Text>
+                <ConnectOnyxCraft onConnected={() => void refreshCraft()} />
+              </div>
+            )}
+
             <div className={styles.divider} />
 
             <div className={styles.section}>
@@ -374,8 +429,14 @@ export function RunAgentPanel({ open, onClose, wikiPath }: Props) {
 
           <div className={styles.footerBand}>
             <span className={styles.helper}>
-              This will launch a session in <strong>{selectedName}</strong> with
-              your message.
+              {isCraft ? (
+                <>This will start an Onyx Craft build with your message.</>
+              ) : (
+                <>
+                  This will launch a session in <strong>{selectedName}</strong>{" "}
+                  with your message.
+                </>
+              )}
             </span>
             <Button type="submit" variant="action" disabled={!canRun || busy}>
               {busy ? "Launching..." : "Start"}


### PR DESCRIPTION
## Description

**Stacked PR 7/7 — side panel** (targets `nikg/craft-6-notifications`). The launch surface on a wiki page — the top of the stack.

- `RunAgentPanel` — `onyx-craft` branch: inline **Connect** when unlinked, else server-side `craftLaunch` + an immediate "build started" toast
- active-agents panel: `provisioning`/`ready`/`failed` Craft rows with an **Open Craft** deep link + failure reason

The full 7-PR stack reconstructs the original #259 exactly (verified: empty diff vs the combined branch).

Stack: 1 schema → 2 backend-logic → 3 backend-api → 4 fe-api → 5 settings → 6 notifications → **7 side-panel**.

## How Has This Been Tested?

Manual QA on this (top) branch: connect a PAT, launch Craft from a wiki page, watch provisioning → ready, open the build. Backend: 87 tests green across the stack.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check