### PR TITLE
feat(craft): enable via admin Onyx URL, drop CRAFT_ENABLED flag

### DIFF
--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -16,9 +16,9 @@ knowledge ACLs + LLM access are respected. The redirect-mint flow
 (``connect/start`` + ``connect/callback``) is the future no-copy-paste UX and
 stays dormant until the Onyx ``/connect/agent-wiki`` endpoints ship.
 
-All gated on ``CONFIG.craft_enabled`` AND an admin-configured Onyx base URL
-(``ingest_settings.onyx_base_url``) — availability is computed, not a toggle,
-so the feature merges dark. See "Engineering Projects/Craft Integration".
+Gated on an admin-configured Onyx base URL (``ingest_settings.onyx_base_url``,
+the "Onyx Connection" admin page) — availability is computed from config, not a
+deploy flag, so the feature merges dark. See "Engineering Projects/Craft Integration".
 """
 
 from __future__ import annotations
@@ -62,8 +62,6 @@ _MAX_PROVISIONING_PER_USER = 3
 
 def _require_available() -> str:
     """404 when the feature is dark; otherwise the Onyx origin."""
-    if not CONFIG.craft_enabled:
-        raise HTTPException(status_code=404, detail="craft launches disabled")
     base = ingest_settings.get_onyx_base_url()
     if not base:
         raise HTTPException(status_code=404, detail="onyx connection not configured")

--- a/backend/app/api/launchers.py
+++ b/backend/app/api/launchers.py
@@ -60,13 +60,13 @@ def _check_flag() -> None:
 
 def _entry_available(m: Manifest) -> bool:
     """Frontend filters the Run-Agent picker by this flag. local_cli tools
-    are always launchable; onyx-craft (in_app) is launchable only when Craft
-    is enabled AND an admin has configured the Onyx instance URL — otherwise
-    the launch endpoint would 404."""
+    are always launchable; onyx-craft (in_app) is launchable only once an
+    admin has configured the Onyx instance URL — otherwise the launch
+    endpoint would 404."""
     if m.kind == "local_cli":
         return True
     if m.id == "onyx-craft":
-        return CONFIG.craft_enabled and bool(ingest_settings.get_onyx_base_url())
+        return bool(ingest_settings.get_onyx_base_url())
     return False
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,12 +76,6 @@ class Config(BaseModel):
     # external_url, Sentry system.url-prefix, Mattermost SiteURL).
     public_base_url: str
 
-    # Onyx Craft launches (Run Agent → Onyx Craft). Kill-switch only —
-    # the Onyx base URL itself is admin-configured in the DB
-    # (ingest_settings.onyx_base_url, the "Onyx Connection" admin page).
-    # The feature is live only when BOTH this flag and that URL are set.
-    craft_enabled: bool
-
     # Coding-tool launchers (Run Agent button) — see
     # local_data/wiki/Wiki Project/Specific Features/coding_tool_launchers/.
     launchers_enabled: bool
@@ -170,7 +164,6 @@ def load_config() -> Config:
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         dev_mode=os.environ.get("DEV_MODE", "false").lower() in {"1", "true", "yes"},
         encryption_key_secret=os.environ.get("ENCRYPTION_KEY_SECRET", ""),
-        craft_enabled=os.environ.get("CRAFT_ENABLED", "false").lower() in {"1", "true", "yes"},
         launchers_enabled=os.environ.get("LAUNCHERS_ENABLED", "false").lower()
         in {"1", "true", "yes"},
         launch_code_ttl_seconds=_positive_int("LAUNCH_CODE_TTL_SECONDS", 60),

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,7 +119,6 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
         ingest_eval_logging=False,
-        craft_enabled=True,
         launchers_enabled=True,
         launch_code_ttl_seconds=60,
         agent_session_idle_seconds=300,

--- a/backend/tests/test_craft_connect.py
+++ b/backend/tests/test_craft_connect.py
@@ -42,17 +42,6 @@ def test_craft_routes_dark_without_base_url(client):
     assert res.status_code == 404
 
 
-def test_craft_routes_dark_when_disabled(client, tmp_config, monkeypatch):
-    _configure_onyx()
-    monkeypatch.setattr(
-        "app.api.craft.CONFIG", tmp_config.model_copy(update={"craft_enabled": False})
-    )
-    uid = seed_user()
-    login_fastapi(client, uid)
-    assert client.get("/api/craft/connect").status_code == 404
-    assert client.post("/api/craft/launch", json={"message": "x"}).status_code == 404
-
-
 # --------------------------------------------------------------------------- #
 # Manual-PAT connect (v0)                                                     #
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_launch_api.py
+++ b/backend/tests/test_launch_api.py
@@ -73,12 +73,12 @@ def test_catalog_available_for_launch_flag(client):
     by_id = {x["id"]: x for x in res.json()["launchers"]}
     assert by_id["claude-code"]["available_for_launch"] is True
     assert by_id["codex"]["available_for_launch"] is True
-    # craft_enabled is True in tmp_config, but no onyx_base_url is set yet.
+    # onyx-craft has no onyx_base_url configured yet.
     assert by_id["onyx-craft"]["available_for_launch"] is False
 
 
 def test_catalog_craft_launchable_when_configured(client):
-    """onyx-craft flips launchable once Craft is enabled AND a base URL is set."""
+    """onyx-craft flips launchable once an admin configures a base URL."""
     from app.ingest import settings as ingest_settings
 
     uid = seed_user()
@@ -87,22 +87,6 @@ def test_catalog_craft_launchable_when_configured(client):
     res = client.get("/api/launchers")
     by_id = {x["id"]: x for x in res.json()["launchers"]}
     assert by_id["onyx-craft"]["available_for_launch"] is True
-
-
-def test_catalog_craft_dark_when_disabled(client, monkeypatch, tmp_config):
-    """With a base URL set but CRAFT_ENABLED off, onyx-craft stays dark."""
-    from app.ingest import settings as ingest_settings
-
-    uid = seed_user()
-    login_fastapi(client, uid)
-    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url="https://onyx.example.com")
-    monkeypatch.setattr(
-        "app.api.launchers.CONFIG",
-        tmp_config.model_copy(update={"craft_enabled": False}),
-    )
-    res = client.get("/api/launchers")
-    by_id = {x["id"]: x for x in res.json()["launchers"]}
-    assert by_id["onyx-craft"]["available_for_launch"] is False
 
 
 def test_catalog_with_machine_id_includes_default_workdir(client):

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.24
+version: 0.3.25
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,12 +1,12 @@
 {{- /*
 One Deployment per queue. The backend's `app.tasks.run_worker`
-requires a queue argument (`documents`, `triggers`, or
-`lightweight_maintenance`), and each queue gets its own consumer
-process to keep slow LLM doc work from backpressuring fast paths like
-the BM25 reindex or agent-activity expiration cleanup.
+requires a queue argument (`documents`, `triggers`,
+`lightweight_maintenance`, or `craft`), and each queue gets its own
+consumer process to keep slow LLM doc work from backpressuring fast paths
+like the BM25 reindex or agent-activity expiration cleanup.
 */ -}}
 {{- /* Per-queue Prometheus port — must match _METRICS_PORT in app/tasks/run_worker.py. */ -}}
-{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 -}}
+{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "craft" 9094 -}}
 {{- range $queue := .Values.worker.queues }}
 ---
 apiVersion: apps/v1

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -112,13 +112,15 @@ worker:
   # co-schedule, AND the per-queue periodic-task scheduler runs in-process
   # (running multiple replicas would double-fire the cron tasks).
   replicaCount: 1
-  # Three Redis Stream queues, one consumer process each. Match
-  # `backend/app/tasks/queues.py:QUEUES`. Don't add a fourth without
-  # corresponding code.
+  # Redis Stream queues, one consumer process each. Match
+  # `backend/app/tasks/queues.py:QUEUES`. To add one, register the queue in
+  # code AND add its metrics port to worker-deployment.yaml's $metricsPorts.
+  # The craft worker idles until an admin configures the Onyx base URL.
   queues:
     - documents
     - triggers
     - lightweight_maintenance
+    - craft
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## What
Craft launches were gated on a `CRAFT_ENABLED` env var **and** an admin-configured Onyx base URL. This removes the env var and gates on the URL alone.

## Why
The flag was redundant — Craft can't function without the admin-set `onyx_base_url`, so that DB config is already the real "on" signal. This matches the **ingest pipeline**, which has no enable flag (its admin API key is the gate), and removes a deploy-time setup step. Craft still sits behind `LAUNCHERS_ENABLED` at the Run Agent surface.

## Also in here
Deploys the **craft worker** — adds the `craft` queue (metrics port 9094) to the Helm chart so launches are actually consumed. It idles until an admin configures the Onyx URL. This was missing from the chart entirely, so launches would otherwise sit in `provisioning` forever.

## Enabling after this ships
Admin sets the Onyx base URL on the "Onyx Connection" page → Craft goes live. No env flag, no values-file change.

## Testing
ruff + basedpyright clean; `helm lint` + `helm template` verified (craft worker renders, port 9094). The two affected DB-backed test files run in CI (no local Postgres available).