### PR TITLE
refactor(craft): run launches on the triggers queue, drop dedicated worker

### DIFF
--- a/backend/app/tasks/craft.py
+++ b/backend/app/tasks/craft.py
@@ -37,7 +37,7 @@ from app.onyx.client import (
     OnyxError,
     OnyxUnreachableError,
 )
-from app.tasks.queues import craft_queue
+from app.tasks.queues import triggers_queue
 from app.wiki import git as wiki_git
 
 log = logging.getLogger(__name__)
@@ -76,7 +76,8 @@ def _fail(sid: str, *, user_id: str, wiki_path: str | None, reason: str) -> None
     )
 
 
-@craft_queue.task()
+# Long-running (~10-60s on Onyx sandbox provisioning).
+@triggers_queue.task()
 def craft_launch(agent_session_id: str) -> None:
     row = sessions_repo.get(agent_session_id)
     if row is None:

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -30,6 +30,8 @@ Queues:
   code paths, different ignition. Kept separate from ``documents_queue``
   because trigger eval is read-only (no commits) and we want one queue's
   backlog to be the only thing that delays an event-log entry.
+  Onyx Craft launches also ride this queue (each blocks ~10-60s on Onyx
+  sandbox provisioning).
 
 * ``lightweight_maintenance_queue`` — **fast upkeep tasks.** Sub-second,
   no LLM, no external HTTP, no wiki commits. Anything that fits that
@@ -56,7 +58,6 @@ from app.tasks.queue import QueueFullError, TaskQueue
 __all__ = [
     "QueueFullError",
     "QUEUES",
-    "craft_queue",
     "documents_queue",
     "lightweight_maintenance_queue",
     "triggers_queue",
@@ -70,11 +71,6 @@ def _make(name: str) -> TaskQueue:
 documents_queue = _make("documents")
 triggers_queue = _make("triggers")
 lightweight_maintenance_queue = _make("lightweight_maintenance")
-# craft_queue — outbound Onyx Craft launches. Each task BLOCKS on Onyx
-# sandbox provisioning (~10-60s of external HTTP), which violates the
-# lightweight queue's sub-second/no-HTTP contract and would starve
-# documents_queue's LLM work — hence its own queue + worker.
-craft_queue = _make("craft")
 
 # Map queue-name → instance, used by run_worker.py to launch the right
 # consumer per worker container.
@@ -82,5 +78,4 @@ QUEUES = {
     "documents": documents_queue,
     "triggers": triggers_queue,
     "lightweight_maintenance": lightweight_maintenance_queue,
-    "craft": craft_queue,
 }

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -1,7 +1,7 @@
 """Entry point for a worker container.
 
 Run with: ``python -m app.tasks.run_worker <queue>`` where ``<queue>`` is
-one of ``documents``, ``triggers``, ``lightweight_maintenance``, ``craft``.
+one of ``documents``, ``triggers``, or ``lightweight_maintenance``.
 Each queue gets its own worker process — see ``app/tasks/queues.py`` for the
 queue rationale.
 
@@ -80,9 +80,6 @@ _CONCURRENCY = {
     "documents": 1,
     "triggers": 4,
     "lightweight_maintenance": 4,
-    # Craft launches are network-bound (provisioning blocks on Onyx); a few
-    # in parallel is fine, no shared provider lock to serialize on.
-    "craft": 4,
 }
 
 # Per-queue Prometheus port. Distinct ports so all three workers can run on
@@ -93,7 +90,6 @@ _METRICS_PORT = {
     "documents": 9091,
     "triggers": 9092,
     "lightweight_maintenance": 9093,
-    "craft": 9094,
 }
 
 

--- a/backend/tests/test_craft_launch.py
+++ b/backend/tests/test_craft_launch.py
@@ -19,7 +19,7 @@ from app.onyx.client import (
     OnyxUnreachableError,
 )
 from app.tasks.craft import attachment_filename
-from app.tasks.queues import craft_queue
+from app.tasks.queues import triggers_queue
 from app.wiki import acl as wiki_acl
 from app.wiki import git as wiki_git
 
@@ -137,7 +137,7 @@ def test_launch_rate_limited_per_user(client, connected_user):
 def test_launch_happy_path(client, connected_user, monkeypatch):
     wiki_git.commit_file(PAGE, "# Page One\nbody\n", "seed", author=None)
     calls = _fake_client(monkeypatch)
-    with craft_queue.immediate_mode():
+    with triggers_queue.immediate_mode():
         res = _launch(client)
     assert res.status_code == 200
     sid = res.json()["agent_session_id"]
@@ -168,7 +168,7 @@ def test_launch_happy_path(client, connected_user, monkeypatch):
 def test_launch_idempotent_for_same_page(client, connected_user, monkeypatch):
     wiki_git.commit_file(PAGE, "# Page One\n", "seed", author=None)
     calls = _fake_client(monkeypatch)
-    with craft_queue.immediate_mode():
+    with triggers_queue.immediate_mode():
         first = _launch(client)
         second = _launch(client)
     assert first.json()["agent_session_id"] == second.json()["agent_session_id"]
@@ -178,7 +178,7 @@ def test_launch_idempotent_for_same_page(client, connected_user, monkeypatch):
 def test_seed_send_skipped_when_session_has_messages(client, connected_user, monkeypatch):
     wiki_git.commit_file(PAGE, "# Page One\n", "seed", author=None)
     calls = _fake_client(monkeypatch, message_count=1)
-    with craft_queue.immediate_mode():
+    with triggers_queue.immediate_mode():
         res = _launch(client)
     assert res.status_code == 200
     assert "send" not in [c[0] for c in calls]
@@ -206,7 +206,7 @@ def test_launch_failure_taxonomy(
 ):
     wiki_git.commit_file(PAGE, "# Page One\n", "seed", author=None)
     _fake_client(monkeypatch, create_error=error)
-    with craft_queue.immediate_mode():
+    with triggers_queue.immediate_mode():
         res = _launch(client)
     assert res.status_code == 200  # the launch itself succeeded; the task failed
 

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.25
+version: 0.3.26
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,12 +1,12 @@
 {{- /*
 One Deployment per queue. The backend's `app.tasks.run_worker`
-requires a queue argument (`documents`, `triggers`,
-`lightweight_maintenance`, or `craft`), and each queue gets its own
-consumer process to keep slow LLM doc work from backpressuring fast paths
-like the BM25 reindex or agent-activity expiration cleanup.
+requires a queue argument (`documents`, `triggers`, or
+`lightweight_maintenance`), and each queue gets its own consumer
+process to keep slow LLM doc work from backpressuring fast paths like
+the BM25 reindex or agent-activity expiration cleanup.
 */ -}}
 {{- /* Per-queue Prometheus port — must match _METRICS_PORT in app/tasks/run_worker.py. */ -}}
-{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "craft" 9094 -}}
+{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 -}}
 {{- range $queue := .Values.worker.queues }}
 ---
 apiVersion: apps/v1

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -112,15 +112,13 @@ worker:
   # co-schedule, AND the per-queue periodic-task scheduler runs in-process
   # (running multiple replicas would double-fire the cron tasks).
   replicaCount: 1
-  # Redis Stream queues, one consumer process each. Match
-  # `backend/app/tasks/queues.py:QUEUES`. To add one, register the queue in
-  # code AND add its metrics port to worker-deployment.yaml's $metricsPorts.
-  # The craft worker idles until an admin configures the Onyx base URL.
+  # Three Redis Stream queues, one consumer process each. Match
+  # `backend/app/tasks/queues.py:QUEUES`. Don't add a fourth without
+  # corresponding code.
   queues:
     - documents
     - triggers
     - lightweight_maintenance
-    - craft
   resources:
     requests:
       cpu: 100m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,26 +138,6 @@ services:
       opensearch:
         condition: service_healthy
 
-  worker-craft:
-    profiles: ["app"]
-    build: ./backend
-    command: ["python", "-m", "app.tasks.run_worker", "craft"]
-    env_file: .env
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
-      - REDIS_URL=redis://redis:6379/0
-      - OPENSEARCH_URL=http://opensearch:9200
-      - WIKI_DIR=/data/wiki
-    volumes:
-      - ./local_data:/data
-    depends_on:
-      backend:
-        condition: service_started
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-
   worker-lightweight-maintenance:
     profiles: ["app"]
     build: ./backend


### PR DESCRIPTION
## Description

Craft launches ran on a dedicated `craft` queue with its own worker **pod**. This folds them onto the existing **triggers** queue and deletes the dedicated queue/worker/pod — a whole idle pod for a low-volume, manual feature isn't worth it.

`triggers` (concurrency 4) is the only viable home: `documents` is concurrency 1 (a 10–60s launch would stall doc reconciliation) and `lightweight_maintenance` forbids slow HTTP. The async work itself stays — provisioning can't run in the web request.

- `craft_launch` → `@triggers_queue.task()`; removed the `craft` queue from `queues.py` + `run_worker.py`
- Helm chart back to three workers (chart `0.3.26`); removed `worker-craft` from `docker-compose.yml`
- Supersedes the craft-worker half of #272

## How Has This Been Tested?

ruff + basedpyright clean; `helm lint`/`template` verified (renders 3 workers, no craft); `test_craft_launch` updated to use `triggers_queue` and runs in CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check