### PR TITLE
perf(ingest): cache the incoming document across reconciler/selector batches

### DIFF
--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -121,6 +121,8 @@ def batch_reconcile(
     candidate_budget = max(_RECONCILER_BUDGET_CHARS - len(content), 0)
     batches = batch_by_chars(candidates, candidate_budget)
 
+    # Worth caching the incoming doc only when sibling batches will reread it.
+    cache_doc = len(batches) > 1
     results: list[str | None] = []
     for batch in batches:
         results.extend(
@@ -131,6 +133,7 @@ def batch_reconcile(
                 source=source,
                 batch=batch,
                 model=model,
+                cache_doc=cache_doc,
             )
         )
 
@@ -154,6 +157,7 @@ def _reconcile_batch(
     source: str,
     batch: list[WikiUpdateCandidate],
     model: str,
+    cache_doc: bool,
 ) -> list[str | None]:
     def _format_candidate(index: int, c: WikiUpdateCandidate) -> str:
         header = f"[{index + 1}] {c.hit.path}"
@@ -168,22 +172,35 @@ def _reconcile_batch(
     )
 
     system = load_prompt("ingest_batch_reconciler.system")
-    user = load_prompt("ingest_batch_reconciler.input").format(
+    doc = load_prompt("ingest_batch_reconciler.doc").format(
         title=title or "(no title)",
         url=url or "",
         source=source,
         content=content,
+    )
+    candidates = load_prompt("ingest_batch_reconciler.candidates").format(
         candidates=candidate_text,
         n=len(batch),
     )
 
+    if cache_doc:
+        # The incoming doc is identical across this document's batches; mark it
+        # as a cache breakpoint so the sibling batches read it back instead of
+        # reprocessing it. The per-batch candidates stay after the breakpoint,
+        # uncached (they vary, so caching them would only cost write premium).
+        convo: list[dict[str, Any]] = [
+            {"role": "user", "content": doc, "cache": True},
+            {"role": "user", "content": candidates},
+        ]
+    else:
+        # Single batch: nothing rereads the doc, so a breakpoint would just pay
+        # the ~1.25x write premium for a cache that's never read. One message.
+        convo = [{"role": "user", "content": f"{doc.rstrip()}\n\n{candidates}"}]
+
     try:
         with trace_flow("agent.ingest_batch_reconciler"):
             result = client.complete(
-                messages=[
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": user},
-                ],
+                messages=[{"role": "system", "content": system}, *convo],
                 model=model,
                 tools=[_SUBMIT_TOOL],
                 max_tokens=_RECONCILER_MAX_TOKENS,

--- a/backend/app/llm/agents/ingest_selector.py
+++ b/backend/app/llm/agents/ingest_selector.py
@@ -56,9 +56,15 @@ def select_candidates(
     candidate_budget = max(_SELECTOR_BUDGET_CHARS - min(len(content), _SELECTOR_CONTENT_CHARS), 0)
     batches = batch_by_chars(candidates, candidate_budget)
 
+    # Worth caching the incoming doc only when sibling batches will reread it.
+    cache_doc = len(batches) > 1
     selected: list[WikiUpdateCandidate] = []
     for batch in batches:
-        selected.extend(_select_batch(title=title, content=content, batch=batch, model=model))
+        selected.extend(
+            _select_batch(
+                title=title, content=content, batch=batch, model=model, cache_doc=cache_doc
+            )
+        )
 
     ingest_selector_calls_per_doc.observe(len(batches))
     log.info(
@@ -78,25 +84,36 @@ def _select_batch(
     content: str,
     batch: list[WikiUpdateCandidate],
     model: str,
+    cache_doc: bool,
 ) -> list[WikiUpdateCandidate]:
     candidate_text = "\n\n".join(
         f"[{i + 1}] {c.hit.path}\n{c.body}" for i, c in enumerate(batch)
     )
 
     system = load_prompt("ingest_selector.system")
-    user = load_prompt("ingest_selector.input").format(
+    doc = load_prompt("ingest_selector.doc").format(
         title=title or "(no title)",
         content=content[:_SELECTOR_CONTENT_CHARS],
-        candidates=candidate_text,
     )
+    candidates = load_prompt("ingest_selector.candidates").format(candidates=candidate_text)
+
+    if cache_doc:
+        # Same incoming doc across this document's batches; cache it so the
+        # sibling batches read it back. The per-batch candidates (which vary)
+        # stay after the breakpoint, uncached.
+        convo: list[dict[str, Any]] = [
+            {"role": "user", "content": doc, "cache": True},
+            {"role": "user", "content": candidates},
+        ]
+    else:
+        # Single batch: no reread, so a breakpoint would only cost the write
+        # premium. Send one message.
+        convo = [{"role": "user", "content": f"{doc.rstrip()}\n\n{candidates}"}]
 
     try:
         with trace_flow("agent.ingest_selector"):
             result = client.complete(
-                messages=[
-                    {"role": "system", "content": system},
-                    {"role": "user", "content": user},
-                ],
+                messages=[{"role": "system", "content": system}, *convo],
                 model=model,
             )
         text = result.text.strip()

--- a/backend/app/llm/prompts/ingest_batch_reconciler.candidates.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.candidates.md
@@ -1,0 +1,3 @@
+--- Candidate wiki pages ({n} total) ---
+{candidates}
+--- End ---

--- a/backend/app/llm/prompts/ingest_batch_reconciler.doc.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.doc.md
@@ -5,7 +5,3 @@ Document URL: {url}
 --- Incoming document ---
 {content}
 --- End ---
-
---- Candidate wiki pages ({n} total) ---
-{candidates}
---- End ---

--- a/backend/app/llm/prompts/ingest_selector.candidates.md
+++ b/backend/app/llm/prompts/ingest_selector.candidates.md
@@ -1,8 +1,3 @@
-Incoming document:
-Title: {title}
-
-{content}
-
 ---
 
 Candidate wiki pages:

--- a/backend/app/llm/prompts/ingest_selector.doc.md
+++ b/backend/app/llm/prompts/ingest_selector.doc.md
@@ -1,0 +1,4 @@
+Incoming document:
+Title: {title}
+
+{content}

--- a/backend/app/llm/providers/anthropic.py
+++ b/backend/app/llm/providers/anthropic.py
@@ -70,10 +70,20 @@ class AnthropicProvider:
         settings: LLMSettings,
     ) -> Iterator[StreamEvent]:
         system, convo = split_system(messages)
+        anthropic_messages = [_message(m) for m in convo]
+        # Explicit per-message cache breakpoints (the system breakpoint below
+        # caches tools+system). A caller marks a message with ``cache: True``
+        # when it knows a prefix will be reread — e.g. the ingest stages tag
+        # the incoming-document message so the candidate batches that follow
+        # read it from cache instead of reprocessing it every batch. Content
+        # after the marked block (the per-batch candidates) stays uncached.
+        for i, m in enumerate(convo):
+            if m.get("cache"):
+                _mark_block_ephemeral(anthropic_messages[i])
         kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
-            "messages": [_message(m) for m in convo],
+            "messages": anthropic_messages,
         }
         if system is not None:
             # Cache the (usually large, stable) system prompt so multi-turn
@@ -166,6 +176,24 @@ class AnthropicProvider:
         except Exception as exc:
             log.exception("llm provider error provider=anthropic model=%s", model)
             raise _translate_error(exc) from exc
+
+
+def _mark_block_ephemeral(message: dict[str, Any]) -> None:
+    """Add a cache breakpoint to the final content block of ``message``.
+
+    Everything rendered up to and including this block becomes a cacheable
+    prefix, so a later call sharing that prefix reads it back instead of
+    reprocessing it. A string ``content`` is promoted to a single text block
+    so the marker has somewhere to live."""
+    content = message["content"]
+    if isinstance(content, str):
+        if not content:
+            return  # don't emit an empty text block
+        message["content"] = [
+            {"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}
+        ]
+    elif content:
+        content[-1] = {**content[-1], "cache_control": {"type": "ephemeral"}}
 
 
 def _message(m: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -443,6 +443,37 @@ def test_anthropic_translates_tools_argument(configure_anthropic, fake_anthropic
     ]
 
 
+def test_anthropic_explicit_cache_marker_breakpoints_that_block(
+    configure_anthropic, fake_anthropic
+):
+    """A message tagged ``cache: True`` gets the breakpoint; the trailing
+    (volatile) message does not — explicit marks suppress the auto-tail so the
+    ingest stages cache the doc, not the per-batch candidates."""
+    fake = fake_anthropic(_a_text_block_events(["ok"]), _a_final())
+
+    llm_client.complete(
+        [
+            {"role": "system", "content": "instructions"},
+            {"role": "user", "content": "the incoming document", "cache": True},
+            {"role": "user", "content": "the candidates"},
+        ]
+    )
+
+    msgs = fake.calls[0]["messages"]
+    assert msgs[0] == {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "the incoming document",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    }
+    # Trailing message is untouched — no stray breakpoint on volatile content.
+    assert msgs[1] == {"role": "user", "content": "the candidates"}
+
+
 def test_anthropic_passes_max_tokens(configure_anthropic, fake_anthropic):
     fake = fake_anthropic(_a_text_block_events(["ok"]), _a_final())
     llm_client.complete([{"role": "user", "content": "hi"}], max_tokens=512)


### PR DESCRIPTION
## Problem

The ingest **selector** and **batch reconciler** fan a single document out into several char-budget batches (`batch_by_chars`), each a separate *synchronous* LLM call that re-sends the **same incoming document**. Only the system prompt carried a `cache_control` breakpoint, so the doc — the largest repeated chunk — was reprocessed at full price on every batch.

Observed prompt-cache rates were near zero:

| stage | cached / total input | rate |
|---|---|---|
| Selector | 150K / 66.4M | ~0.2% |
| Reconciler | 1.82M / 44.8M | ~4% |

(The selector's ~275-token system prompt is below the model's minimum cacheable prefix, so it never cached at all; the reconciler's ~1678-token system prompt is the only thing that did.)

## Change

- **Provider-agnostic cache marker.** Normalized messages accept an optional `cache: True` flag; the Anthropic provider places a `cache_control` breakpoint on that message's last block. Other providers ignore the flag.
- **Ingest stages** split their prompt into a `doc` part and a `candidates` part. When a document produces more than one batch, the doc goes in its own cache-marked `user` message ahead of the candidates, so batches 2..N read `tools + system + doc` from cache. The candidates stay after the breakpoint (they vary per batch — caching them would only cost write premium).
- **Gated on `len(batches) > 1`.** A single-batch doc has no sibling to reread it, so it stays one uncached message and avoids the ~1.25× cache-write premium — byte-identical to the previous prompt.
- The doc **stays in the `user` role** (not hoisted into the system prompt), so untrusted ingested content keeps its lower trust level and model behavior is unchanged (Anthropic merges the two consecutive `user` messages into one turn).

Because the batches run **sequentially**, batch 1 warms the cache and the rest read it — no concurrent-write race.

> The chat-loop conversation caching (auto-tail breakpoint) was split into a separate stacked PR: #276.

## Testing

- `test_anthropic_explicit_cache_marker_breakpoints_that_block` — marks the doc, leaves the trailing candidates message untouched.
- All LLM-client + ingest/selector/reconciler tests pass; `ruff` and `basedpyright --strict` clean.

## Verify after merge

Watch `ingest_reconciler_cached_input_tokens` vs `…_uncached_input_tokens` (and the selector pair) on the next multi-batch ingest — the cached series should climb on batches 2..N; single-batch docs stay flat (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)