### PR TITLE
perf(chat): cache the conversation tail in the agent tool loop

### DIFF
--- a/backend/app/llm/providers/anthropic.py
+++ b/backend/app/llm/providers/anthropic.py
@@ -71,15 +71,27 @@ class AnthropicProvider:
     ) -> Iterator[StreamEvent]:
         system, convo = split_system(messages)
         anthropic_messages = [_message(m) for m in convo]
-        # Explicit per-message cache breakpoints (the system breakpoint below
-        # caches tools+system). A caller marks a message with ``cache: True``
-        # when it knows a prefix will be reread — e.g. the ingest stages tag
-        # the incoming-document message so the candidate batches that follow
-        # read it from cache instead of reprocessing it every batch. Content
-        # after the marked block (the per-batch candidates) stays uncached.
-        for i, m in enumerate(convo):
-            if m.get("cache"):
+        # Second-tier cache breakpoints on the conversation (the system
+        # breakpoint below caches tools+system). Two ways to place them:
+        #
+        #  * Explicit: a caller marks specific messages with ``cache: True``
+        #    when it knows a prefix will be reread (e.g. the ingest stages tag
+        #    the incoming-document message so the candidate batches that follow
+        #    read it from cache instead of reprocessing it every batch).
+        #  * Automatic: with no explicit marks, a multi-iteration agent loop
+        #    re-sends the whole growing history each call, so we breakpoint the
+        #    tail and iteration N+1 reads everything through iteration N.
+        #
+        # Explicit marks win — a caller that placed them doesn't want a stray
+        # tail breakpoint on volatile trailing content (e.g. per-batch
+        # candidates). Single-message calls with no mark get nothing: no prior
+        # turn to reread, so the write would just be wasted.
+        explicit = [i for i, m in enumerate(convo) if m.get("cache")]
+        if explicit:
+            for i in explicit:
                 _mark_block_ephemeral(anthropic_messages[i])
+        elif len(anthropic_messages) > 1:
+            _mark_block_ephemeral(anthropic_messages[-1])
         kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -396,10 +396,17 @@ def test_anthropic_translates_tool_result_message(configure_anthropic, fake_anth
             },
         ],
     }
+    # The final block of a multi-message conversation carries the auto-tail
+    # cache breakpoint (see test_anthropic_caches_conversation_tail).
     assert msgs[2] == {
         "role": "user",
         "content": [
-            {"type": "tool_result", "tool_use_id": "tu_1", "content": "result text"}
+            {
+                "type": "tool_result",
+                "tool_use_id": "tu_1",
+                "content": "result text",
+                "cache_control": {"type": "ephemeral"},
+            }
         ],
     }
 
@@ -478,6 +485,47 @@ def test_anthropic_passes_max_tokens(configure_anthropic, fake_anthropic):
     fake = fake_anthropic(_a_text_block_events(["ok"]), _a_final())
     llm_client.complete([{"role": "user", "content": "hi"}], max_tokens=512)
     assert fake.calls[0]["max_tokens"] == 512
+
+
+def test_anthropic_single_message_has_no_tail_breakpoint(
+    configure_anthropic, fake_anthropic
+):
+    """A single-shot call only caches the system prompt — there's no prior
+    turn to reread, so the auto-tail breakpoint would be a wasted cache write."""
+    fake = fake_anthropic(_a_text_block_events(["ok"]), _a_final())
+    llm_client.complete([{"role": "user", "content": "hi"}])
+    assert fake.calls[0]["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_anthropic_caches_conversation_tail(configure_anthropic, fake_anthropic):
+    """Multi-turn conversations with no explicit marks get an auto-tail cache
+    breakpoint on the last block, so the growing history is read back instead
+    of reprocessed. A string-content tail is promoted to a text block to carry
+    the marker."""
+    fake = fake_anthropic(_a_text_block_events(["ok"]), _a_final())
+
+    llm_client.complete(
+        [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "reply"},
+            {"role": "user", "content": "second"},
+        ]
+    )
+
+    msgs = fake.calls[0]["messages"]
+    # Earlier turns are untouched; only the final block carries the breakpoint.
+    assert msgs[0] == {"role": "user", "content": "first"}
+    assert msgs[1] == {"role": "assistant", "content": "reply"}
+    assert msgs[-1] == {
+        "role": "user",
+        "content": [
+            {
+                "type": "text",
+                "text": "second",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    }
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Problem

The streaming chat agent loop (`_drive_loop`) re-sends the full, growing message history on every iteration of a tool-use turn. Only the system prompt was cached, so all prior turns (assistant text + often-large tool results) were reprocessed at full price on each iteration.

## Change

When a request carries **no explicit cache marks**, place a `cache_control` breakpoint on the last conversation block, so iteration N+1 reads everything through iteration N from cache. Builds on the explicit `cache: True` marker mechanism added in #275 (now merged):

- **Explicit marks win** — a caller that placed them (the ingest stages) doesn't get a stray auto-tail breakpoint on volatile trailing content.
- **Single-message calls get nothing** — no prior turn to reread, so the write would just cost the ~1.25× premium for no read.

Because the chat loop's iterations are sequential turns, iteration 1 warms the cache and the rest read it.

## Testing

- `test_anthropic_caches_conversation_tail` — multi-turn conversation gets the tail breakpoint.
- `test_anthropic_single_message_has_no_tail_breakpoint` — single-shot does not.
- `test_anthropic_translates_tool_result_message` — updated to reflect the tail breakpoint.
- All `test_llm_client.py` pass (34); `ruff` + `basedpyright --strict` clean. Verified live against Sonnet 4.6 in local docker (cache hit on the second identical multi-turn call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)