### PR TITLE
feat(mcp): sharpen server instructions + conditional result guidance

### DIFF
--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -151,6 +151,9 @@ def call_for_mcp(
     )
     _maybe_auto_subscribe(sess, name, arguments, payload, is_error)
     payload.setdefault("stale_paths", _compute_stale_paths(sess))
+    guidance = _guidance_for(payload)
+    if guidance is not None:
+        payload["guidance"] = guidance
     return payload, is_error
 
 
@@ -323,6 +326,34 @@ def _compute_stale_paths(sess: McpSession) -> list[str]:
             except Exception:
                 break
     return paths
+
+
+def _guidance_for(payload: dict[str, Any]) -> str | None:
+    """Short, actionable next-step hint for a tool result — only when there's
+    something concrete to act on.
+
+    Returns ``None`` when nothing needs saying, so results don't carry a nudge
+    on every call (a constant nudge just trains clients to ignore the field).
+    The hint rides a tool call the agent already made — the one place an MCP
+    server can steer the next action without a dedicated trigger.
+    """
+    hints: list[str] = []
+
+    stale = payload.get("stale_paths")
+    if isinstance(stale, list) and stale:
+        joined = ", ".join(str(p) for p in cast("list[object]", stale))
+        hints.append(
+            f"Pages you relied on changed since you last read them ({joined}); "
+            "re-read them before continuing."
+        )
+
+    broken = payload.get("broken_links")
+    if isinstance(broken, list) and broken:
+        hints.append("This edit left broken markdown links — fix or remove them.")
+
+    if not hints:
+        return None
+    return " ".join(hints)
 
 
 def to_mcp_content(payload: dict[str, Any]) -> list[dict[str, Any]]:

--- a/backend/app/mcp_server/transport.py
+++ b/backend/app/mcp_server/transport.py
@@ -37,13 +37,13 @@ SERVER_VERSION = "0.1.0"
 SERVER_INSTRUCTIONS = """\
 Agent Wiki is a shared collaboration space for humans and agents, and the source of truth for status and progress on all ongoing projects. Documents are markdown organized as a file hierarchy — paths convey scope (e.g. `projects/<name>/`, `runbooks/`, `decisions/`).
 
-CRITICAL: Before beginning any work, search the wiki for relevant context. Use `search_wiki` to look up topics, `read_doc` to fetch full pages, and `ask_nl_question` for fuzzy questions across the corpus. Reference the paths you used in your response so humans and other agents can verify and follow up.
+Loading context. Before you start a task — and again whenever you turn to a new file, topic, or sub-problem — search the wiki for relevant context; don't wait to be asked. Use `search_wiki` for keywords, `read_doc` for full pages, and `ask_nl_question` for fuzzy questions across the corpus. If a tool result tells you that pages you relied on have changed, re-read them before continuing rather than pressing on with stale context. When nothing relevant exists, that's fine — don't force a search.
 
-As you progress, keep relevant pages up to date. Update at major checkpoints rather than on every step. Scratchpads and in-progress notes are welcome — communicating non-final progress is valuable when it might affect another agent's work. Add cross-links between related pages so the graph stays navigable. If your work produces a significant deliverable, ask the user whether they'd like a dedicated page for it — never create one proactively.
+Keeping it current. When your work produces something durable — a decision and its rationale, a non-obvious gotcha, a status change, or a change to how something the wiki documents actually works — record it on the right page. Do this at meaningful checkpoints, not on every step. Refine existing pages instead of appending; keep them free of bloat and changelog noise, and add cross-links between related pages so the graph stays navigable. If your work produces a significant new deliverable, ask the user whether they'd like a dedicated page — never create one proactively.
 
-Documents change while you work. Other agents and humans may edit pages you depend on. If new information lands that affects your task, incorporate it rather than pressing on with stale context.
+Showing your work. Name the pages you read and the pages you changed (by path) in your reply, so humans and other agents can see what informed your work and follow up.
 
-The wiki holds the team's critical knowledge — keep it current proactively so nothing important is lost, and prune or correct anything that's been invalidated. Remember that this wiki is intended for use by both humans and AI agents — keep it organized and free from bloat."""
+Staying proportionate. All of this serves the user's task — keep wiki actions timely and in proportion. Don't over-search or over-update, and surface what matters rather than narrating every step. This wiki is for both humans and AI agents: keep it organized, current, and free from bloat."""
 
 # JSON-RPC 2.0 standard error codes
 PARSE_ERROR = -32700


### PR DESCRIPTION
## What

Sharpens the agent-wiki MCP server so an external coding agent (Claude Code first) loads and updates the wiki more reliably — using only MCP levers, so it's portable across clients and needs no hooks.

## Changes

**`SERVER_INSTRUCTIONS`** restructured into four labeled moves:
- **Loading context** — search before a task *and on pivot* to a new file/topic; re-read when results report a page changed; don't force a search when nothing's relevant.
- **Keeping it current** — explicit capture triggers (decision + rationale, gotcha, status change, documented-behavior change) at checkpoints.
- **Showing your work** — name the pages read and changed, by path.
- **Staying proportionate** — don't over-search or over-update.

**Conditional `guidance` field on tool results** — `_guidance_for(payload)` adds a hint only when actionable: re-read on non-empty `stale_paths`, fix on `broken_links`. Returns `None` otherwise, so results don't carry a nudge on every call. This is the one place MCP can steer the next action without a dedicated trigger — it rides a tool call the agent already made.

## Why

Maps to the Agent Experience rubric: context timing/loading (1a), capture (2a), transparency (3a), smoothness/restraint (3b), plus a broken-links assist (2b).

## Testing

- `ruff` + `basedpyright` (strict): pass.
- MCP test suite not run in this environment (test Postgres/OpenSearch unavailable). No existing test asserts on the instructions text or rejects an extra result key (`guidance` is additive), so the change is non-breaking by analysis. Run `uv run pytest tests/test_mcp_server*.py` against the test DB before merge.

## Deferred follow-ups

- MCP `resources` + citation-ready fields for navigable references (3a).
- Backend per-user preference store for presentation tuning (3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)