### PR TITLE
feat(history): jump to changes + inline single-line diff highlighting

### DIFF
--- a/frontend/src/components/wiki/DiffHunk.module.css
+++ b/frontend/src/components/wiki/DiffHunk.module.css
@@ -76,9 +76,22 @@
   color: currentColor;
 }
 
-/* Inline word edits — render the swap inside an `.add` block (green
-   container with the same quote indent + radius + padding). The
-   <del> is red strikethrough, the <ins> is green text. */
+/* Single-line edits render as a plain line (matching .context inset) with
+   only the changed words highlighted — no full-line band — so it's clear
+   exactly where the change is. */
+.wordLine {
+  padding: 0 12px;
+  color: var(--text-05);
+}
+
+/* Inline anchor wrapping the changed words; the navigator scrolls here so a
+   jump lands on the change itself, even mid-paragraph. scroll-margin keeps it
+   off the floating navigator when centered. */
+.wordChange {
+  scroll-margin: 24px 0;
+}
+
+/* The <del> is red strikethrough, the <ins> is green underline. */
 .wordRemoved {
   color: var(--status-text-error-05);
   text-decoration: line-through;
@@ -86,4 +99,5 @@
 
 .wordAdded {
   color: var(--status-text-success-05);
+  text-decoration: underline;
 }

--- a/frontend/src/components/wiki/DiffHunk.module.css
+++ b/frontend/src/components/wiki/DiffHunk.module.css
@@ -91,13 +91,22 @@
   scroll-margin: 24px 0;
 }
 
-/* The <del> is red strikethrough, the <ins> is green underline. */
+/* Highlight scoped to just the changed words, reusing the block-band status
+   tokens. clone keeps the background intact where the span wraps lines. */
 .wordRemoved {
+  background: var(--status-error-01);
   color: var(--status-text-error-05);
   text-decoration: line-through;
+  border-radius: 3px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }
 
 .wordAdded {
+  background: var(--status-success-01);
   color: var(--status-text-success-05);
   text-decoration: underline;
+  border-radius: 3px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
 }

--- a/frontend/src/components/wiki/DiffHunk.tsx
+++ b/frontend/src/components/wiki/DiffHunk.tsx
@@ -4,67 +4,29 @@ import remarkGfm from "remark-gfm";
 
 import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
 
-import type { DiffHunk as DiffHunkData, DiffLine, WordDiff } from "@/lib/wiki";
+import type { WordDiff } from "@/lib/wiki";
 
+import type { AnnotatedEntry } from "./diffEntries";
 import styles from "./DiffHunk.module.css";
-
-type BlockKind = "context" | "add" | "remove";
-
-interface BlockEntry {
-  kind: BlockKind;
-  text: string;
-}
-
-interface WordEntry {
-  kind: "word";
-  line: DiffLine;
-}
-
-type Entry = BlockEntry | WordEntry;
-
-function groupEntries(lines: DiffLine[]): Entry[] {
-  const out: Entry[] = [];
-  let current: BlockEntry | null = null;
-  const flush = () => {
-    if (current) {
-      out.push(current);
-      current = null;
-    }
-  };
-  for (const line of lines) {
-    if (line.kind === "word") {
-      flush();
-      out.push({ kind: "word", line });
-      continue;
-    }
-    const text = line.text ?? "";
-    if (current && current.kind === line.kind) {
-      current.text += "\n" + text;
-    } else {
-      flush();
-      current = { kind: line.kind, text };
-    }
-  }
-  flush();
-  return out;
-}
 
 const HEADING_RE = /^(#{1,6})\s+(.*)$/;
 const LIST_RE = /^(\s*)([-*+])\s+(.*)$/;
 const ORDERED_LIST_RE = /^(\s*)(\d+\.)\s+(.*)$/;
 const BLOCKQUOTE_RE = /^(>+)\s*(.*)$/;
 
-function WordChips({ w }: { w: WordDiff | null }) {
+/** Wraps the changed run inside a line. Carries the navigator scroll anchor
+    so jumping lands on the changed words, not the top of a wrapped line. */
+function WordChips({ w, anchor }: { w: WordDiff | null; anchor?: number }) {
   if (!w) return null;
   return (
-    <>
+    <span className={styles.wordChange} data-change-index={anchor}>
       {w.removed ? <del className={styles.wordRemoved}>{w.removed}</del> : null}
       {w.added ? <ins className={styles.wordAdded}>{w.added}</ins> : null}
-    </>
+    </span>
   );
 }
 
-function WordLine({ w }: { w: WordDiff | null }) {
+function WordLine({ w, anchor }: { w: WordDiff | null; anchor?: number }) {
   if (!w) return null;
 
   const headingMatch = HEADING_RE.exec(w.prefix);
@@ -75,7 +37,7 @@ function WordLine({ w }: { w: WordDiff | null }) {
     return (
       <Tag>
         {headingPrefixText}
-        <WordChips w={w} />
+        <WordChips w={w} anchor={anchor} />
         {w.suffix}
       </Tag>
     );
@@ -90,7 +52,7 @@ function WordLine({ w }: { w: WordDiff | null }) {
         <li>
           {indent}
           {listPrefixText}
-          <WordChips w={w} />
+          <WordChips w={w} anchor={anchor} />
           {w.suffix}
         </li>
       </ul>
@@ -106,7 +68,7 @@ function WordLine({ w }: { w: WordDiff | null }) {
         <li>
           {indent}
           {listPrefixText}
-          <WordChips w={w} />
+          <WordChips w={w} anchor={anchor} />
           {w.suffix}
         </li>
       </ol>
@@ -120,7 +82,7 @@ function WordLine({ w }: { w: WordDiff | null }) {
       <blockquote>
         <p>
           {quotePrefixText}
-          <WordChips w={w} />
+          <WordChips w={w} anchor={anchor} />
           {w.suffix}
         </p>
       </blockquote>
@@ -130,23 +92,23 @@ function WordLine({ w }: { w: WordDiff | null }) {
   return (
     <p>
       {w.prefix}
-      <WordChips w={w} />
+      <WordChips w={w} anchor={anchor} />
       {w.suffix}
     </p>
   );
 }
 
-export function DiffHunk({ hunk }: { hunk: DiffHunkData }) {
-  const entries = groupEntries(hunk.lines);
+export function DiffHunk({ entries }: { entries: AnnotatedEntry[] }) {
   return (
     <section className={styles.hunk}>
-      {entries.map((entry, idx) => {
+      {entries.map(({ entry, changeIndex }, idx) => {
+        const anchor = changeIndex ?? undefined;
         if (entry.kind === "word") {
+          // Single-line edits render inline (no full-line band) so only the
+          // changed words are highlighted, not the whole line.
           return (
-            <div key={idx} className={styles.add}>
-              <div className={`${styles.blockContent} markdown`}>
-                <WordLine w={entry.line.word_diff} />
-              </div>
+            <div key={idx} className={`${styles.wordLine} markdown`}>
+              <WordLine w={entry.line.word_diff} anchor={anchor} />
             </div>
           );
         }
@@ -161,7 +123,7 @@ export function DiffHunk({ hunk }: { hunk: DiffHunkData }) {
         }
         const cls = entry.kind === "add" ? styles.add : styles.remove;
         return (
-          <div key={idx} className={cls}>
+          <div key={idx} className={cls} data-change-index={anchor}>
             <div className={`${styles.blockContent} markdown`}>
               <ReactMarkdown remarkPlugins={[remarkGfm, remarkBareSpaceLinks]}>
                 {entry.text}

--- a/frontend/src/components/wiki/DiffView.module.css
+++ b/frontend/src/components/wiki/DiffView.module.css
@@ -104,12 +104,19 @@
   color: var(--text-03);
 }
 
+/* Right gutter keeps the diff content clear of the floating navigator so the
+   selector sits in whitespace, never over the text. */
+.diffContent {
+  padding-right: 150px;
+}
+
 /* Floating change navigator (Figma 283:22157) — pinned to the diff viewport
    (not the scrolling body) so it stays put while you step through changes. */
 .navigator {
   position: absolute;
   right: 16px;
-  bottom: 16px;
+  top: 50%;
+  transform: translateY(-50%);
   z-index: 2;
   display: flex;
   align-items: center;

--- a/frontend/src/components/wiki/DiffView.module.css
+++ b/frontend/src/components/wiki/DiffView.module.css
@@ -109,7 +109,8 @@
 .navigator {
   position: absolute;
   right: 16px;
-  bottom: 16px;
+  top: 50%;
+  transform: translateY(-50%);
   z-index: 2;
   display: flex;
   align-items: center;
@@ -139,11 +140,6 @@
   cursor: pointer;
 }
 
-.navBtn:hover:not(:disabled) {
+.navBtn:hover {
   background: var(--background-tint-03);
-}
-
-.navBtn:disabled {
-  opacity: 0.35;
-  cursor: default;
 }

--- a/frontend/src/components/wiki/DiffView.module.css
+++ b/frontend/src/components/wiki/DiffView.module.css
@@ -1,4 +1,5 @@
 .view {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -101,4 +102,48 @@
   padding: 24px;
   text-align: center;
   color: var(--text-03);
+}
+
+/* Floating change navigator (Figma 283:22157) — pinned to the diff viewport
+   (not the scrolling body) so it stays put while you step through changes. */
+.navigator {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 6px 6px 10px;
+  background: var(--background-tint-00);
+  border-radius: var(--border-radius-12);
+  box-shadow: var(--shadow-sm);
+}
+
+.navArrows {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.navBtn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--text-04);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border-radius: var(--border-radius-08);
+  cursor: pointer;
+}
+
+.navBtn:hover:not(:disabled) {
+  background: var(--background-tint-03);
+}
+
+.navBtn:disabled {
+  opacity: 0.35;
+  cursor: default;
 }

--- a/frontend/src/components/wiki/DiffView.module.css
+++ b/frontend/src/components/wiki/DiffView.module.css
@@ -3,6 +3,10 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Let the flex item shrink to its container; otherwise wide, non-wrapping
+     content (code blocks, tables) expands the view past the pane and the
+     floating navigator gets clipped. The body scrolls the overflow instead. */
+  min-width: 0;
 }
 
 .header {
@@ -107,7 +111,7 @@
 /* Right gutter keeps the diff content clear of the floating navigator so the
    selector sits in whitespace, never over the text. */
 .diffContent {
-  padding-right: 150px;
+  padding-right: 128px;
 }
 
 /* Floating change navigator (Figma 283:22157) — pinned to the diff viewport
@@ -123,7 +127,7 @@
   gap: 8px;
   padding: 6px 6px 6px 10px;
   background: var(--background-tint-00);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   box-shadow: var(--shadow-sm);
 }
 
@@ -142,7 +146,7 @@
   align-items: center;
   justify-content: center;
   padding: 4px;
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   cursor: pointer;
 }
 

--- a/frontend/src/components/wiki/DiffView.module.css
+++ b/frontend/src/components/wiki/DiffView.module.css
@@ -109,8 +109,7 @@
 .navigator {
   position: absolute;
   right: 16px;
-  top: 50%;
-  transform: translateY(-50%);
+  bottom: 16px;
   z-index: 2;
   display: flex;
   align-items: center;

--- a/frontend/src/components/wiki/DiffView.tsx
+++ b/frontend/src/components/wiki/DiffView.tsx
@@ -97,11 +97,21 @@ export function DiffView({
   const metaLine = metaPieces.join(" · ");
   const metaTitle = commit?.ts ? absoluteTime(commit.ts) : undefined;
 
-  const scrollToChange = useCallback((i: number, behavior: ScrollBehavior) => {
-    const el = bodyRef.current?.querySelector<HTMLElement>(
+  // Center change `i` in the scroll body. We set scrollTop directly rather
+  // than scrollIntoView: smooth scrolling no-ops inside this nested overflow
+  // container, and scrollIntoView there is unreliable.
+  const scrollToChange = useCallback((i: number) => {
+    const container = bodyRef.current;
+    const el = container?.querySelector<HTMLElement>(
       `[data-change-index="${i}"]`,
     );
-    el?.scrollIntoView({ block: "center", behavior });
+    if (!container || !el) return;
+    const cRect = container.getBoundingClientRect();
+    const eRect = el.getBoundingClientRect();
+    const elTop = eRect.top - cRect.top + container.scrollTop;
+    const target = elTop - (container.clientHeight - eRect.height) / 2;
+    const max = container.scrollHeight - container.clientHeight;
+    container.scrollTop = Math.max(0, Math.min(max, target));
   }, []);
 
   const goToChange = useCallback(
@@ -109,7 +119,7 @@ export function DiffView({
       if (total === 0) return;
       const clamped = Math.max(0, Math.min(total - 1, i));
       setCurrent(clamped);
-      scrollToChange(clamped, "smooth");
+      scrollToChange(clamped);
     },
     [total, scrollToChange],
   );
@@ -124,8 +134,18 @@ export function DiffView({
   // commit click lands you on the change, not the top of the file.
   useLayoutEffect(() => {
     if (mode !== "diff") return;
-    const raf = requestAnimationFrame(() => scrollToChange(0, "auto"));
-    return () => cancelAnimationFrame(raf);
+    let cancelled = false;
+    const jump = () => {
+      if (!cancelled) scrollToChange(0);
+    };
+    const raf = requestAnimationFrame(jump);
+    // Re-run once web fonts settle — their metrics shift line positions, so a
+    // first-frame jump can land short on a freshly loaded, content-heavy diff.
+    void document.fonts?.ready.then(() => requestAnimationFrame(jump));
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+    };
   }, [data, mode, scrollToChange]);
 
   async function pickMode(next: Mode) {

--- a/frontend/src/components/wiki/DiffView.tsx
+++ b/frontend/src/components/wiki/DiffView.tsx
@@ -1,5 +1,13 @@
 import { SelectButton, Text } from "@onyx-ai/opal/components";
-import { useState } from "react";
+import { SvgChevronDown, SvgChevronUp } from "@onyx-ai/opal/icons";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -10,6 +18,7 @@ import { absoluteTime, relativeTime } from "@/lib/time";
 import type { FileDiffResponse } from "@/lib/wiki";
 
 import { DiffHunk } from "./DiffHunk";
+import { annotateHunks } from "./diffEntries";
 import styles from "./DiffView.module.css";
 
 interface CommitMeta {
@@ -20,6 +29,47 @@ interface CommitMeta {
 }
 
 type Mode = "diff" | "doc";
+
+/** Floating pill (Figma 283:22157): change position + prev/next steppers. */
+function ChangeNavigator({
+  current,
+  total,
+  onPrev,
+  onNext,
+}: {
+  current: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className={styles.navigator}>
+      <Text font="secondary-mono" color="text-03" nowrap>
+        {`${current + 1} / ${total}`}
+      </Text>
+      <div className={styles.navArrows}>
+        <button
+          type="button"
+          className={styles.navBtn}
+          onClick={onPrev}
+          disabled={current <= 0}
+          aria-label="Previous change"
+        >
+          <SvgChevronUp size={16} />
+        </button>
+        <button
+          type="button"
+          className={styles.navBtn}
+          onClick={onNext}
+          disabled={current >= total - 1}
+          aria-label="Next change"
+        >
+          <SvgChevronDown size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}
 
 export function DiffView({
   data,
@@ -34,6 +84,10 @@ export function DiffView({
   const [body, setBody] = useState<string | null>(null);
   const [bodyError, setBodyError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [current, setCurrent] = useState(0);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const { perHunk, total } = useMemo(() => annotateHunks(data.hunks), [data]);
 
   const shaShort = data.sha.slice(0, 7);
   const authorLabel = commit?.author ?? "?";
@@ -42,6 +96,37 @@ export function DiffView({
   if (timeLabel) metaPieces.push(timeLabel);
   const metaLine = metaPieces.join(" · ");
   const metaTitle = commit?.ts ? absoluteTime(commit.ts) : undefined;
+
+  const scrollToChange = useCallback((i: number, behavior: ScrollBehavior) => {
+    const el = bodyRef.current?.querySelector<HTMLElement>(
+      `[data-change-index="${i}"]`,
+    );
+    el?.scrollIntoView({ block: "center", behavior });
+  }, []);
+
+  const goToChange = useCallback(
+    (i: number) => {
+      if (total === 0) return;
+      const clamped = Math.max(0, Math.min(total - 1, i));
+      setCurrent(clamped);
+      scrollToChange(clamped, "smooth");
+    },
+    [total, scrollToChange],
+  );
+
+  // New commit selected → back to diff mode at the first change.
+  useEffect(() => {
+    setMode("diff");
+    setCurrent(0);
+  }, [data]);
+
+  // Once the diff for a new commit has painted, jump to the first change so a
+  // commit click lands you on the change, not the top of the file.
+  useLayoutEffect(() => {
+    if (mode !== "diff") return;
+    const raf = requestAnimationFrame(() => scrollToChange(0, "auto"));
+    return () => cancelAnimationFrame(raf);
+  }, [data, mode, scrollToChange]);
 
   async function pickMode(next: Mode) {
     if (next === mode) return;
@@ -101,7 +186,7 @@ export function DiffView({
           </SelectButton>
         </div>
       </div>
-      <div className={styles.body}>
+      <div className={styles.body} ref={bodyRef}>
         {mode === "diff" ? (
           data.hunks.length === 0 ? (
             <div className={styles.empty}>
@@ -110,7 +195,9 @@ export function DiffView({
               </Text>
             </div>
           ) : (
-            data.hunks.map((hunk, idx) => <DiffHunk key={idx} hunk={hunk} />)
+            perHunk.map((entries, idx) => (
+              <DiffHunk key={idx} entries={entries} />
+            ))
           )
         ) : loading ? (
           <div className={styles.empty}>
@@ -130,6 +217,14 @@ export function DiffView({
           </article>
         )}
       </div>
+      {mode === "diff" && total > 0 ? (
+        <ChangeNavigator
+          current={current}
+          total={total}
+          onPrev={() => goToChange(current - 1)}
+          onNext={() => goToChange(current + 1)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/wiki/DiffView.tsx
+++ b/frontend/src/components/wiki/DiffView.tsx
@@ -34,16 +34,21 @@ type Mode = "diff" | "doc";
 function ChangeNavigator({
   current,
   total,
+  top,
   onPrev,
   onNext,
 }: {
   current: number;
   total: number;
+  top: number | null;
   onPrev: () => void;
   onNext: () => void;
 }) {
   return (
-    <div className={styles.navigator}>
+    <div
+      className={styles.navigator}
+      style={top !== null ? { top: `${top}px` } : undefined}
+    >
       <Text font="secondary-mono" color="text-03" nowrap>
         {`${current + 1} / ${total}`}
       </Text>
@@ -83,7 +88,10 @@ export function DiffView({
   const [bodyError, setBodyError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [current, setCurrent] = useState(0);
+  const [navTop, setNavTop] = useState<number | null>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<HTMLDivElement>(null);
+  const currentRef = useRef(0);
 
   const { perHunk, total } = useMemo(() => annotateHunks(data.hunks), [data]);
 
@@ -112,21 +120,39 @@ export function DiffView({
     container.scrollTop = Math.max(0, Math.min(max, target));
   }, []);
 
+  // Park the navigator vertically beside the current change, clamped inside
+  // the view so it stays visible when the change scrolls toward an edge.
+  const updateNavPosition = useCallback(() => {
+    const view = viewRef.current;
+    const el = bodyRef.current?.querySelector<HTMLElement>(
+      `[data-change-index="${currentRef.current}"]`,
+    );
+    if (!view || !el) return;
+    const vRect = view.getBoundingClientRect();
+    const eRect = el.getBoundingClientRect();
+    const center = eRect.top + eRect.height / 2 - vRect.top;
+    const margin = 28;
+    setNavTop(Math.max(margin, Math.min(vRect.height - margin, center)));
+  }, []);
+
   const goToChange = useCallback(
     (i: number) => {
       if (total === 0) return;
       // Wrap around so next past the last change returns to the first.
       const wrapped = ((i % total) + total) % total;
+      currentRef.current = wrapped;
       setCurrent(wrapped);
       scrollToChange(wrapped);
+      updateNavPosition();
     },
-    [total, scrollToChange],
+    [total, scrollToChange, updateNavPosition],
   );
 
   // New commit selected → back to diff mode at the first change.
   useEffect(() => {
     setMode("diff");
     setCurrent(0);
+    currentRef.current = 0;
   }, [data]);
 
   // Once the diff for a new commit has painted, jump to the first change so a
@@ -135,7 +161,9 @@ export function DiffView({
     if (mode !== "diff") return;
     let cancelled = false;
     const jump = () => {
-      if (!cancelled) scrollToChange(0);
+      if (cancelled) return;
+      scrollToChange(0);
+      updateNavPosition();
     };
     const raf = requestAnimationFrame(jump);
     // Re-run once web fonts settle — their metrics shift line positions, so a
@@ -145,7 +173,23 @@ export function DiffView({
       cancelled = true;
       cancelAnimationFrame(raf);
     };
-  }, [data, mode, scrollToChange]);
+  }, [data, mode, scrollToChange, updateNavPosition]);
+
+  // Keep the navigator beside the active change while the diff is scrolled.
+  useEffect(() => {
+    const container = bodyRef.current;
+    if (mode !== "diff" || !container) return;
+    let raf = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(updateNavPosition);
+    };
+    container.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(raf);
+    };
+  }, [data, mode, total, updateNavPosition]);
 
   async function pickMode(next: Mode) {
     if (next === mode) return;
@@ -165,7 +209,7 @@ export function DiffView({
   }
 
   return (
-    <div className={styles.view}>
+    <div className={styles.view} ref={viewRef}>
       <div className={styles.header}>
         <div className={styles.headerInfo}>
           <Text
@@ -214,9 +258,11 @@ export function DiffView({
               </Text>
             </div>
           ) : (
-            perHunk.map((entries, idx) => (
-              <DiffHunk key={idx} entries={entries} />
-            ))
+            <div className={styles.diffContent}>
+              {perHunk.map((entries, idx) => (
+                <DiffHunk key={idx} entries={entries} />
+              ))}
+            </div>
           )
         ) : loading ? (
           <div className={styles.empty}>
@@ -240,6 +286,7 @@ export function DiffView({
         <ChangeNavigator
           current={current}
           total={total}
+          top={navTop}
           onPrev={() => goToChange(current - 1)}
           onNext={() => goToChange(current + 1)}
         />

--- a/frontend/src/components/wiki/DiffView.tsx
+++ b/frontend/src/components/wiki/DiffView.tsx
@@ -52,7 +52,6 @@ function ChangeNavigator({
           type="button"
           className={styles.navBtn}
           onClick={onPrev}
-          disabled={current <= 0}
           aria-label="Previous change"
         >
           <SvgChevronUp size={16} />
@@ -61,7 +60,6 @@ function ChangeNavigator({
           type="button"
           className={styles.navBtn}
           onClick={onNext}
-          disabled={current >= total - 1}
           aria-label="Next change"
         >
           <SvgChevronDown size={16} />
@@ -117,9 +115,10 @@ export function DiffView({
   const goToChange = useCallback(
     (i: number) => {
       if (total === 0) return;
-      const clamped = Math.max(0, Math.min(total - 1, i));
-      setCurrent(clamped);
-      scrollToChange(clamped);
+      // Wrap around so next past the last change returns to the first.
+      const wrapped = ((i % total) + total) % total;
+      setCurrent(wrapped);
+      scrollToChange(wrapped);
     },
     [total, scrollToChange],
   );

--- a/frontend/src/components/wiki/diffEntries.ts
+++ b/frontend/src/components/wiki/diffEntries.ts
@@ -1,0 +1,76 @@
+import type { DiffHunk, DiffLine } from "@/lib/wiki";
+
+/* Grouping + change-indexing for the diff viewer. Coalesces consecutive
+   same-kind lines into render blocks, then tags the first entry of each
+   contiguous run of changes with a sequential index the navigator steps
+   through. Kept pure (no React) so it's trivially testable. */
+
+/** Every diff-line kind except the synthetic single-line "word" edit, derived
+    from the source type so it can't drift from DiffLine. */
+export type BlockKind = Exclude<DiffLine["kind"], "word">;
+
+export interface BlockEntry {
+  kind: BlockKind;
+  text: string;
+}
+
+export interface WordEntry {
+  kind: "word";
+  line: DiffLine;
+}
+
+export type Entry = BlockEntry | WordEntry;
+
+export interface AnnotatedEntry {
+  entry: Entry;
+  /** Set when this entry begins a contiguous change run; null otherwise.
+      It's the navigator's scroll target index for that change. */
+  changeIndex: number | null;
+}
+
+export function groupEntries(lines: DiffLine[]): Entry[] {
+  const out: Entry[] = [];
+  let current: BlockEntry | null = null;
+  const flush = () => {
+    if (current) {
+      out.push(current);
+      current = null;
+    }
+  };
+  for (const line of lines) {
+    if (line.kind === "word") {
+      flush();
+      out.push({ kind: "word", line });
+      continue;
+    }
+    const text = line.text ?? "";
+    if (current && current.kind === line.kind) {
+      current.text += "\n" + text;
+    } else {
+      flush();
+      current = { kind: line.kind, text };
+    }
+  }
+  flush();
+  return out;
+}
+
+/** Group every hunk and number each contiguous run of changes. A run is a
+    maximal stretch of non-context entries — e.g. a remove block followed by
+    an add block (a replacement) is one change, as is a lone word-diff line. */
+export function annotateHunks(hunks: DiffHunk[]): {
+  perHunk: AnnotatedEntry[][];
+  total: number;
+} {
+  let changeIndex = 0;
+  const perHunk = hunks.map((hunk) => {
+    let prevWasChange = false;
+    return groupEntries(hunk.lines).map((entry) => {
+      const isChange = entry.kind !== "context";
+      const startsRun = isChange && !prevWasChange;
+      prevWasChange = isChange;
+      return { entry, changeIndex: startsRun ? changeIndex++ : null };
+    });
+  });
+  return { perHunk, total: changeIndex };
+}


### PR DESCRIPTION
## Description

History page diff viewer: change navigation + clearer inline highlighting.

- **Jump to change:** opening a commit scrolls to its first change (centered), not the top of the file.
- **Change selector:** a rounded pill (count + up/down chevrons) that sits beside the current change in the right gutter, tracks it while scrolling, steps next/prev, and wraps around at the ends.
- **Inline single-line edits:** only the changed words are highlighted — red strikethrough for removals, green underline for additions — instead of banding the whole line. Multi-line add/remove blocks keep their bands.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check