### PR TITLE
feat(ingest): leaner reconciler output — minimal anchors, omit irrelevant candidates

### DIFF
--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -44,7 +44,11 @@ _SUBMIT_TOOL: dict[str, Any] = {
         "properties": {
             "results": {
                 "type": "array",
-                "description": "One entry per candidate wiki page, in order.",
+                "description": (
+                    "One entry only for candidates you are editing or marking "
+                    "no_change, ordered by candidate number. Omit irrelevant "
+                    "candidates — a candidate with no entry is treated as irrelevant."
+                ),
                 "items": {
                     "type": "object",
                     "properties": {

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -109,17 +109,27 @@ still return `no_change` or `irrelevant` even when an instruction is present.
 
 ## Output
 
-Call `submit_results` with your decisions for all N candidates.
+Call `submit_results` with an entry only for candidates you are editing or
+explicitly marking `no_change`. **Omit `irrelevant` candidates entirely** — a
+candidate with no entry is treated as irrelevant. Most candidates in a batch
+are irrelevant, so most batches return only a few entries.
 
 Rules for `find`/`replace` edit pairs:
 - `find` must be copied verbatim from the page — whitespace and punctuation
   must match exactly.
-- `find` must be long enough to uniquely identify the location. If the text
-  appears more than once, extend it to include surrounding context.
-- To add content after an existing line, include that line in `find` and
-  repeat it at the start of `replace` followed by the new content.
-- To add a new section at the end, anchor `find` on the last existing heading
-  or paragraph.
+- Make `find` the shortest snippet that uniquely locates the change — usually
+  just a few words on either side of the edit. If that snippet appears more
+  than once, extend it just enough to disambiguate. Never quote an entire long
+  line or paragraph: a single wiki bullet can run to thousands of characters on
+  one line, and quoting the whole line wastes output and can exceed the response
+  limit, which makes the edit fail.
+- `replace` repeats only that short snippet with your change applied — not the
+  surrounding line.
+- To add content after an existing point, anchor `find` on the last few words
+  of that point and repeat just those words at the start of `replace`, followed
+  by the new content. Do not quote the whole preceding line.
+- To add a new section at the end, anchor `find` on a short unique tail of the
+  last existing heading or paragraph.
 - `replace` should be as short as the corrected or new fact allows. Never
   remove information the external doc does not address.
 - Use multiple edit objects for non-adjacent changes, ordered top-to-bottom.

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -13,7 +13,7 @@ Covers:
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -288,6 +288,51 @@ def test_irrelevant_does_not_commit(mock_search, mock_reconcile, mock_read, mock
     mock_reconcile.return_value = ([IRRELEVANT_SENTINEL], 1)
     _run(_make_push())
     mock_commit.assert_not_called()
+
+
+@patch("app.tasks.wiki_update.ingest_eval_sample.log_sample")
+@patch("app.llm.client.complete")
+@patch("app.tasks.wiki_update.wiki_git.read_file", return_value="body")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_omitted_candidate_recorded_as_irrelevant(
+    mock_search, mock_read, mock_complete, mock_log, monkeypatch
+):
+    # The reconciler now omits irrelevant candidates from its tool call (only
+    # edit/no_change are emitted). This drives the real _parse_tool_results +
+    # post-process: an omitted candidate must still land as an `irrelevant`
+    # outcome — same metric + eval row as an explicit irrelevant — so DB logging
+    # and accounting stay correct.
+    monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_logging": True}),
+    )
+    from app.llm.client import ToolCall
+
+    mock_search.return_value = _cs([_hit("kept.md", "Kept", 6.0), _hit("omitted.md", "Omitted", 5.0)])
+    # Model reports only candidate 1 (no_change); candidate 2 is omitted entirely.
+    resp = MagicMock()
+    resp.text = ""
+    resp.tool_calls = [
+        ToolCall(
+            id="c1",
+            name="submit_results",
+            arguments={"results": [{"candidate_index": 1, "action": "no_change"}]},
+        )
+    ]
+    resp.usage.input_tokens = 100
+    resp.usage.output_tokens = 10
+    resp.usage.cached_input_tokens = 0
+    resp.usage.uncached_input_tokens = 100
+    mock_complete.return_value = resp
+
+    before = _outcome_count("irrelevant", "omitted.md")
+    _run(_make_push())
+
+    assert _outcome_count("irrelevant", "omitted.md") - before == 1.0
+    logged = {(c.kwargs["wiki_path"], c.kwargs["outcome"]) for c in mock_log.call_args_list}
+    assert ("omitted.md", "irrelevant") in logged
+    assert ("kept.md", "no_change") in logged
 
 
 @patch("app.tasks.wiki_update.wiki_git.commit_file")


### PR DESCRIPTION
## What

Two prompt-only changes to the ingest **batch reconciler** to cut its LLM **output** tokens. No parser or logic change.

1. **Shortest-anchor find/replace.** The output rules now tell the model to make `find` the shortest *unique* snippet (a few words around the change) and never quote a whole line/paragraph. `apply_edits` already matches on substrings (`result.replace(find, replace, 1)`), so the whole line was never needed.
2. **Omit no-op candidates.** The model now emits an entry only for `edit`/`no_change` and **omits `irrelevant`** candidates. `_parse_tool_results` already treats a missing index as `IRRELEVANT_SENTINEL` (covered by `test_parse_tool_results_missing_index_defaults_to_irrelevant`), so this is behavior-preserving.

The `_SUBMIT_TOOL` `results` schema description was updated to match (it previously said "one entry per candidate page, in order").

## Why

Investigating a spike in reconciler output tokens (~1M/day) showed two sources of waste, neither of which is durable content:

- **Per-candidate bookkeeping.** On a typical batch ~70% of candidates resolve to irrelevant/no_change, yet the model emitted a full `{candidate_index, action}` object for every one.
- **Whole-line quoting on long-line pages.** Some wiki pages have run-on bullets thousands of chars long on a single line. Editing inside one could push the `find`/`replace` past the 8192-token (`_RECONCILER_MAX_TOKENS`) response cap → truncated tool call → silently dropped edit → page stays stale → the same doc re-triggers the reconcile on the next push. So this is an efficiency *and* a correctness fix.

## Safety / testing

- No parser change; the omission path is already exercised by existing tests.
- `tests/test_ingest_batch_reconciler.py`: 24 passed.
- ruff clean.
- Prompt-only behavior change — takes effect on deploy, no migration. Old prompt preserved in git history per the repo convention.

Worth watching `ingest_reconciler_output_tokens_sum` / `_count` after rollout to quantify the reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)