### PR TITLE
feat(ingest): reconciler prompt — stop run-on bullet accretion

### DIFF
--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -63,7 +63,8 @@ Match the granularity already on the page. If the page covers a topic in a
 single line or brief phrase, keep the update at that same grain — do not
 expand it to a full sentence or paragraph just because the source provides
 more context. If the edit cannot be expressed at the existing grain, use
-`no_change`.
+`no_change`. But if an existing entry is already an overly long run-on line,
+do not match it — keep your addition short and on its own new line.
 
 ## Per-page update instructions
 
@@ -83,7 +84,12 @@ still return `no_change` or `irrelevant` even when an instruction is present.
   new task. A call summary where a person already tracked on the page
   attended and concrete next steps are stated does qualify.
 - Never remove information the page has that the external doc omits.
-- Don't duplicate. If a section already covers the point, refine it in place.
+- Don't duplicate. If a section already states the point, only edit the
+  existing text when the source shows it is now wrong — otherwise use
+  `no_change`. Never append a clause that restates or extends what's there.
+- Add a genuinely new fact as its own new bullet on its own line — never by
+  extending an existing bullet or sentence. Keep each bullet to one short item
+  (one or two sentences); never grow a bullet into a long run-on line.
 - Do not copy the external document wholesale — integrate only what is
   genuinely new or corrects something wrong.
 - Prefer one focused addition over several marginal ones.
@@ -102,7 +108,8 @@ still return `no_change` or `irrelevant` even when an instruction is present.
 - New sections go at the correct heading level — never add a bare `###` under
   a `#` with no `##` in between.
 - Every bullet list must sit under a heading or an introductory sentence.
-- Prefer short paragraphs (2–4 sentences).
+- Keep bullets and paragraphs short (one or two sentences); split anything
+  longer into separate bullets rather than growing one line.
 - No HTML. No fenced code blocks unless the content is literally a command or
   code snippet.
 - Do not add a trailing newline block or sign-off like "Updated by …".


### PR DESCRIPTION
## Problem

Some wiki pages grew single bullets to **13k+ tokens on one line**. e.g. `Things Yuhong cares about.md` has a bullet that climbed from ~48,900 chars (06-21) to ~55,200 chars (12,223 → 13,803 tokens) — monotonically, a few hundred chars per ingest commit.

This isn't one bad generation. The reconciler with an 8192 output cap can't emit a 13k-token line in one call. It **accretes**: each commit splices a short clause (~50–430 chars, well under the cap) onto the *end of an existing run-on bullet* via a tail-anchored find/replace. No newline is ever inserted, so it's one ever-growing "line." Past ~8192 tokens the line can no longer be rewritten by ingest at all — append-only ratchet.

The prompt was steering this:
- *"Don't duplicate. If a section already covers the point, refine it in place."* → on a run-on bullet, "refine in place" = append another clause.
- *"Match the granularity already on the page"* → on a bloated page the grain *is* a 13k-token line, so it keeps making them.

## Change (prompt only)

`ingest_batch_reconciler.system.md`:
1. **Reframe "refine in place"** — only edit existing text when the source shows it's now wrong; otherwise `no_change`. Never append a clause that restates/extends what's there.
2. **New fact → new line** — add new facts as their own short bullet on their own line, never by extending an existing bullet; keep bullets to one or two sentences.
3. **Granularity caveat** — don't match an existing overlong run-on line; keep additions short and on a new line.
4. **Markdown structure** — prefer short split bullets over growing one line.

## Scope

- Stops **new** accretion. Cheap, no code, takes effect on deploy.
- Does **not** repair the existing overlong lines (can't be done under the output cap) — those need a one-off restructure pass, tracked separately.
- Does **not** add a hard length signal/budget to the model — that's the code-side follow-up.

Background: `Engineering Projects/Agent Wiki Project/design/Bloat and Drift Handling.md`.

## Testing

- `tests/test_ingest_batch_reconciler.py`: 24 passed; prompt loads clean.
- Independent of #279 (different sections of the same prompt; no conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)