### PR TITLE
feat(ingest): log search hits beyond the top-N cap + record BM25 score

### DIFF
--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -262,7 +262,11 @@ def search(
     if client is None:
         return []
 
-    fetch_size = min(limit * 5, 200)
+    # Over-fetch 5x (capped) when visibility filtering may drop hits, so we
+    # still have ``limit`` survivors. With no visibility filter (e.g. ingest),
+    # fetch exactly ``limit`` — this lets ingest request a wide candidate set
+    # without the 200-doc cap silently truncating it.
+    fetch_size = limit if not apply_visibility else min(limit * 5, 200)
     body = {
         "query": {
             "multi_match": {

--- a/backend/app/db/migrations/versions/0032_ingest_eval_bm25_score.py
+++ b/backend/app/db/migrations/versions/0032_ingest_eval_bm25_score.py
@@ -1,0 +1,30 @@
+"""add bm25_score to ingest_eval_samples
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-06-23 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "0032"
+down_revision: str = "0031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # create_all in 0001 already materializes the current schema on fresh
+    # installs; skip if the column is already present so upgrading existing DBs
+    # and fresh installs both work.
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("ingest_eval_samples")}
+    if "bm25_score" in cols:
+        return
+    op.add_column("ingest_eval_samples", sa.Column("bm25_score", sa.Float, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ingest_eval_samples", "bm25_score")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    Float,
     ForeignKey,
     Index,
     Integer,
@@ -1156,6 +1157,9 @@ class IngestEvalSample(Base):
     wiki_body_before: Mapped[str] = mapped_column(Text, nullable=False)
     diff: Mapped[str | None] = mapped_column(Text)
     outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    # Title-boosted BM25 score of the candidate page against the source document.
+    # Nullable: rows written before this column existed have no score.
+    bm25_score: Mapped[float | None] = mapped_column(Float)
     commit_sha: Mapped[str | None] = mapped_column(Text)
 
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1158,7 +1158,7 @@ class IngestEvalSample(Base):
     diff: Mapped[str | None] = mapped_column(Text)
     outcome: Mapped[str] = mapped_column(Text, nullable=False)
     # Title-boosted BM25 score of the candidate page against the source document.
-    # Nullable: rows written before this column existed have no score.
+    # None when no score was recorded for the row.
     bm25_score: Mapped[float | None] = mapped_column(Float)
     commit_sha: Mapped[str | None] = mapped_column(Text)
 

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -1,12 +1,14 @@
 """Opt-in logging of ingest candidate decisions to the ingest_eval_samples table.
 
 Enabled via INGEST_EVAL_LOGGING=true. Each row captures the source document, a
-candidate wiki page, the unified diff of any edit, and the outcome — one row per
-(document, candidate page) pair. Besides the reconciler verdicts
-(committed/no_change/irrelevant) it also records pre-reconciler drops:
-``filtered_by_selector`` (weak-model selector) and ``filtered_by_bm25_score``
-(below the BM25 score threshold). Intended for human review and building a
-regression test suite.
+candidate wiki page, its title-boosted BM25 score, the unified diff of any edit,
+and the outcome — one row per (document, candidate page) pair. Besides the
+reconciler verdicts (committed/no_change/irrelevant) it also records
+pre-reconciler drops: ``filtered_by_selector`` (weak-model selector),
+``filtered_by_bm25_score`` (below the BM25 score threshold), and
+``filtered_by_search_rank`` (a real search hit that fell outside the top-N
+candidate cap — only captured when eval logging is on, since it widens the
+search fetch). Intended for human review and building a regression test suite.
 """
 from __future__ import annotations
 
@@ -35,7 +37,9 @@ def log_sample(
         "irrelevant",
         "filtered_by_selector",
         "filtered_by_bm25_score",
+        "filtered_by_search_rank",
     ],
+    bm25_score: float | None,
     commit_sha: str | None,
 ) -> None:
     diff = wiki_git.diff_for_commit(commit_sha, wiki_path) if commit_sha is not None else None
@@ -50,5 +54,6 @@ def log_sample(
             wiki_body_before=wiki_body_before,
             diff=diff,
             outcome=outcome,
+            bm25_score=bm25_score,
             commit_sha=commit_sha,
         ))

--- a/backend/app/ingest/search.py
+++ b/backend/app/ingest/search.py
@@ -8,7 +8,7 @@ Wraps ``app.db.fts.search`` with:
 Parameters are read from env vars so they can be tuned without a deploy:
   INGEST_BM25_MIN_SCORE    float, default 5.0
   INGEST_BM25_TITLE_BOOST  float, default 2.0
-  INGEST_BM25_LIMIT        int,   default 20  (candidates fetched from OS)
+  INGEST_BM25_LIMIT        int,   default 20  (top-N candidates kept for the pipeline)
 """
 from __future__ import annotations
 
@@ -26,6 +26,12 @@ from app.metrics import ingest_bm25_hits, ingest_bm25_passed, ingest_bm25_score
 log = logging.getLogger(__name__)
 
 _TOKEN_RE = re.compile(r"\w+")
+
+# Wide candidate fetch used only when eval logging is on: pull far more than the
+# top-N kept for the pipeline so we can record real search hits that fell outside
+# the cap (``filtered_by_search_rank``). A page ranked below this is noise. Not a
+# tuned knob — INGEST_BM25_LIMIT stays the production selection size.
+EVAL_WIDE_FETCH_LIMIT = 500
 
 
 class IngestSearchError(Exception):
@@ -56,29 +62,46 @@ def _jaccard(a: set[str], b: set[str]) -> float:
 
 
 class CandidateSearch(BaseModel):
-    """Result of a BM25 candidate search: pages above the score threshold
-    (`passed`, most relevant first) and those below it (`dropped`), both with
-    title-boosted scores. Pure data — the caller decides what to do with the
-    drops (outcome metric, eval logging) via a post-process step, so this
-    module stays free of git/DB/metadata concerns."""
+    """Result of a BM25 candidate search, all with title-boosted scores:
+
+      - ``passed``       — within the top-N cap and above the score threshold
+                           (most relevant first); the set the pipeline acts on.
+      - ``dropped``      — within the top-N cap but below the score threshold.
+      - ``rank_dropped`` — real search hits that fell *outside* the top-N cap.
+                           Only populated when ``fetch_limit`` widens the fetch
+                           (eval logging); empty otherwise.
+
+    Pure data — the caller decides what to do with the drops (outcome metric,
+    eval logging) via a post-process step, so this module stays free of
+    git/DB/metadata concerns."""
 
     passed: list[SearchHit]
     dropped: list[SearchHit]
+    rank_dropped: list[SearchHit] = []
 
 
-def candidates(content: str, title: str | None) -> CandidateSearch:
-    """Return the BM25 candidates split into `passed`/`dropped` by the score
-    threshold, most relevant first.
+def candidates(
+    content: str, title: str | None, *, fetch_limit: int | None = None
+) -> CandidateSearch:
+    """Return the BM25 candidates split by the top-N cap and score threshold.
 
-    Title similarity boosts the raw BM25 score before thresholding so pages
-    whose titles closely match the incoming document rank higher. Emits only
-    search telemetry (hits/passed/raw-score); per-drop outcome accounting is the
-    caller's post-process (see ``wiki_update``).
+    The top ``INGEST_BM25_LIMIT`` hits by raw BM25 are kept for the pipeline and
+    split into `passed`/`dropped` by the score threshold — production behavior is
+    independent of ``fetch_limit``. When ``fetch_limit`` exceeds that cap, the
+    extra hits beyond it are returned as `rank_dropped` so the caller can record
+    search hits the cap would otherwise hide (``filtered_by_search_rank``).
+
+    Title similarity boosts the raw BM25 score before thresholding so pages whose
+    titles closely match the incoming document rank higher. Emits only search
+    telemetry (hits/passed/raw-score) for the kept set; per-drop outcome
+    accounting is the caller's post-process (see ``wiki_update``).
     """
+    top_n = CONFIG.ingest_bm25_limit
+    fetch = max(fetch_limit or top_n, top_n)
     try:
         hits = fts_search(
             content,
-            limit=CONFIG.ingest_bm25_limit,
+            limit=fetch,
             apply_visibility=False,
             raise_on_error=True,
         )
@@ -93,30 +116,42 @@ def candidates(content: str, title: str | None) -> CandidateSearch:
 
     query_title_tokens: set[str] = _tokens(title) if title else set()
 
-    boosted: list[SearchHit] = []
-    dropped: list[SearchHit] = []
-    for hit in hits:
-        raw_score = hit.score
-        score = raw_score
+    def _boost(hit: SearchHit) -> SearchHit:
+        score = hit.score
         if query_title_tokens and hit.title:
             sim = _jaccard(query_title_tokens, _tokens(hit.title))
             score += sim * CONFIG.ingest_bm25_title_boost
-        ingest_bm25_score.observe(raw_score)
+        return hit.model_copy(update={"score": score})
+
+    # Top-N by raw BM25 (OpenSearch order) is the pipeline set; the rest is the
+    # rank-dropped tail. Slicing before boosting keeps the kept set identical to
+    # the non-widened fetch.
+    in_scope = hits[:top_n]
+    tail = hits[top_n:]
+
+    boosted: list[SearchHit] = []
+    dropped: list[SearchHit] = []
+    for hit in in_scope:
+        scored = _boost(hit)
+        ingest_bm25_score.observe(hit.score)
         log.debug(
             "ingest candidate: path=%r raw_bm25=%.3f boosted=%.3f threshold=%.3f pass=%s",
-            hit.path, raw_score, score, CONFIG.ingest_bm25_min_score, score >= CONFIG.ingest_bm25_min_score,
+            hit.path, hit.score, scored.score, CONFIG.ingest_bm25_min_score,
+            scored.score >= CONFIG.ingest_bm25_min_score,
         )
-        scored = hit.model_copy(update={"score": score})
-        if score >= CONFIG.ingest_bm25_min_score:
+        if scored.score >= CONFIG.ingest_bm25_min_score:
             boosted.append(scored)
         else:
             dropped.append(scored)
 
-    ingest_bm25_hits.observe(len(hits))
+    rank_dropped = [_boost(hit) for hit in tail]
+
+    ingest_bm25_hits.observe(len(in_scope))
     ingest_bm25_passed.observe(len(boosted))
     log.info(
-        "ingest candidates: title=%r hits=%d passed=%d threshold=%.3f",
-        title, len(hits), len(boosted), CONFIG.ingest_bm25_min_score,
+        "ingest candidates: title=%r hits=%d passed=%d rank_dropped=%d threshold=%.3f",
+        title, len(in_scope), len(boosted), len(rank_dropped), CONFIG.ingest_bm25_min_score,
     )
     boosted.sort(key=lambda h: h.score, reverse=True)
-    return CandidateSearch(passed=boosted, dropped=dropped)
+    rank_dropped.sort(key=lambda h: h.score, reverse=True)
+    return CandidateSearch(passed=boosted, dropped=dropped, rank_dropped=rank_dropped)

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any
+from typing import Any, Literal
 
 from app.config import CONFIG
 from app.ingest import eval_sample as ingest_eval_sample
@@ -309,25 +309,26 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     _meta: dict[str, Any] = push.get("metadata") or {}
     url: str = str(push.get("url") or _meta.get("url") or "")
 
-    def _record_bm25_drops(dropped: list[ingest_search.SearchHit]) -> None:
-        # Post-process the candidates the BM25 score threshold dropped: the
-        # per-pair outcome metric, and (when eval logging is on) an eval row —
-        # reading the page body here since this path never reads it otherwise.
+    def _record_search_drops(
+        dropped: list[ingest_search.SearchHit],
+        outcome: Literal["filtered_by_bm25_score", "filtered_by_search_rank"],
+    ) -> None:
+        # Post-process candidates dropped before the reconciler — by the BM25
+        # score threshold (``filtered_by_bm25_score``) or by the top-N candidate
+        # cap (``filtered_by_search_rank``): the per-pair outcome metric, and
+        # (when eval logging is on) an eval row — reading the page body here
+        # since this path never reads it otherwise.
         for hit in dropped:
-            ingest_outcomes_total.labels(
-                outcome="filtered_by_bm25_score", wiki_path=hit.path
-            ).inc()
-            ingest_bm25_score_by_outcome.labels(
-                outcome="filtered_by_bm25_score"
-            ).observe(hit.score)
+            ingest_outcomes_total.labels(outcome=outcome, wiki_path=hit.path).inc()
+            ingest_bm25_score_by_outcome.labels(outcome=outcome).observe(hit.score)
             if not CONFIG.ingest_eval_logging:
                 continue
             try:
                 body = wiki_git.read_file(hit.path)
             except Exception:
                 log.warning(
-                    "ingest_eval_sample: failed to read %s for filtered_by_bm25_score sample",
-                    hit.path,
+                    "ingest_eval_sample: failed to read %s for %s sample",
+                    hit.path, outcome,
                     exc_info=True,
                 )
                 continue
@@ -340,19 +341,24 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                     source_content=content,
                     wiki_path=hit.path,
                     wiki_body_before=body,
-                    outcome="filtered_by_bm25_score",
+                    outcome=outcome,
+                    bm25_score=hit.score,
                     commit_sha=None,
                 )
             except Exception:
                 log.warning(
-                    "ingest_eval_sample: failed to log filtered_by_bm25_score sample",
+                    "ingest_eval_sample: failed to log %s sample", outcome,
                     exc_info=True,
                 )
 
     t_start = time.monotonic()
     used_fallback = False
+    # Widen the candidate fetch only when eval logging is on, so we can record
+    # real search hits beyond the top-N cap (filtered_by_search_rank). The kept
+    # set the pipeline acts on is unchanged either way.
+    fetch_limit = ingest_search.EVAL_WIDE_FETCH_LIMIT if CONFIG.ingest_eval_logging else None
     try:
-        search_result = ingest_search.candidates(content, title)
+        search_result = ingest_search.candidates(content, title, fetch_limit=fetch_limit)
     except ingest_search.IngestSearchError:
         used_fallback = True
         # The candidate search failed — almost always because the full document
@@ -384,11 +390,14 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             )
             return
 
-    # Only record BM25 drops from the primary, full-content search. The fallback
-    # scores against a lossy summary query, so its below-threshold pages aren't
-    # comparable to the document and would mislabel the eval rows.
+    # Only record search drops from the primary, full-content search. The
+    # fallback scores against a lossy summary query, so its below-threshold /
+    # below-rank pages aren't comparable to the document and would mislabel the
+    # eval rows. rank_dropped is non-empty only when eval logging widened the
+    # fetch, so it's a no-op otherwise.
     if not used_fallback:
-        _record_bm25_drops(search_result.dropped)
+        _record_search_drops(search_result.dropped, "filtered_by_bm25_score")
+        _record_search_drops(search_result.rank_dropped, "filtered_by_search_rank")
     hits = search_result.passed
     if not hits:
         log.info("process_pushed_document: no BM25 candidates above threshold, doc_id=%s", doc_id)
@@ -470,6 +479,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                             wiki_path=c.hit.path,
                             wiki_body_before=c.body,
                             outcome="filtered_by_selector",
+                            bm25_score=c.hit.score,
                             commit_sha=None,
                         )
                     except Exception:
@@ -523,6 +533,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,
                         outcome="irrelevant",
+                        bm25_score=c.hit.score,
                         commit_sha=None,
                     )
                 except Exception:
@@ -579,6 +590,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,
                         outcome="committed",
+                        bm25_score=c.hit.score,
                         commit_sha=sha,
                     )
                 except Exception:
@@ -599,6 +611,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                         wiki_path=c.hit.path,
                         wiki_body_before=c.body,
                         outcome="no_change",
+                        bm25_score=c.hit.score,
                         commit_sha=None,
                     )
                 except Exception:

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -86,10 +86,14 @@ def _hit(path: str, title: str | None, score: float) -> SearchHit:
 
 
 def _cs(
-    passed: list[SearchHit], dropped: list[SearchHit] | None = None
+    passed: list[SearchHit],
+    dropped: list[SearchHit] | None = None,
+    rank_dropped: list[SearchHit] | None = None,
 ) -> ingest_search.CandidateSearch:
     """Build a CandidateSearch for mocking ingest_search.candidates()."""
-    return ingest_search.CandidateSearch(passed=passed, dropped=dropped or [])
+    return ingest_search.CandidateSearch(
+        passed=passed, dropped=dropped or [], rank_dropped=rank_dropped or []
+    )
 
 
 def test_candidates_empty_when_no_fts_results():
@@ -152,6 +156,30 @@ def test_title_boost_threshold_interaction(monkeypatch):
     assert len(result.passed) == 1
 
 
+def test_candidates_no_rank_dropped_without_fetch_limit(monkeypatch):
+    # Default fetch: fts_search is asked for exactly the top-N cap, so there's
+    # no tail beyond it — rank_dropped is empty (production behavior unchanged).
+    monkeypatch.setattr(ingest_search, "CONFIG", CONFIG.model_copy(update={"ingest_bm25_min_score": 0.0, "ingest_bm25_limit": 2}))
+    hits = [_hit("a.md", None, 9.0), _hit("b.md", None, 8.0)]
+    with patch("app.ingest.search.fts_search", return_value=hits) as m:
+        result = ingest_search.candidates("content", None)
+    assert m.call_args.kwargs["limit"] == 2
+    assert result.rank_dropped == []
+
+
+def test_candidates_rank_dropped_beyond_cap(monkeypatch):
+    # A wider fetch_limit pulls hits beyond the top-N cap; the top-N still go to
+    # the pipeline, the rest land in rank_dropped (most relevant first).
+    monkeypatch.setattr(ingest_search, "CONFIG", CONFIG.model_copy(update={"ingest_bm25_min_score": 0.0, "ingest_bm25_limit": 2}))
+    hits = [_hit("a.md", None, 9.0), _hit("b.md", None, 8.0), _hit("c.md", None, 7.0), _hit("d.md", None, 6.0)]
+    with patch("app.ingest.search.fts_search", return_value=hits) as m:
+        result = ingest_search.candidates("content", None, fetch_limit=10)
+    # fetch_limit is passed through to the search backend.
+    assert m.call_args.kwargs["limit"] == 10
+    assert [h.path for h in result.passed] == ["a.md", "b.md"]
+    assert [h.path for h in result.rank_dropped] == ["c.md", "d.md"]
+
+
 # --------------------------------------------------------------------------- #
 # process_pushed_document                                                      #
 # --------------------------------------------------------------------------- #
@@ -192,12 +220,18 @@ def _doc_result_count(result: str) -> float:
 
 
 @patch("app.tasks.wiki_update.ingest_search.candidates", return_value=_cs([]))
-def test_no_candidates_returns_early(mock_search):
+def test_no_candidates_returns_early(mock_search, monkeypatch):
     # No BM25 hit -> the doc still gets a per-document terminal result so the
     # "search filtered out" tile accounts for it (panel reconciles to ingested).
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_logging": False}),
+    )
     before = _doc_result_count("no_candidates")
     _run(_make_push())
     mock_search.assert_called_once()
+    # Eval logging off: the candidate fetch is not widened.
+    assert mock_search.call_args.kwargs["fetch_limit"] is None
     assert _doc_result_count("no_candidates") - before == 1.0
 
 
@@ -446,7 +480,11 @@ def _eval_rows(outcome: str) -> list[dict[str, Any]]:
 
     with session() as s:
         return [
-            {"wiki_path": r.wiki_path, "source_document_id": r.source_document_id}
+            {
+                "wiki_path": r.wiki_path,
+                "source_document_id": r.source_document_id,
+                "bm25_score": r.bm25_score,
+            }
             for r in s.execute(
                 sa_select(IngestEvalSample).where(IngestEvalSample.outcome == outcome)
             ).scalars().all()
@@ -470,6 +508,28 @@ def test_bm25_drop_recorded_and_eval_logged(mock_search, tmp_repo, monkeypatch):
     assert len(rows) == 1
     assert rows[0]["wiki_path"] == "low.md"
     assert rows[0]["source_document_id"] == "doc-abc"
+    assert rows[0]["bm25_score"] == 2.0
+
+
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_rank_drop_recorded_and_eval_logged(mock_search, tmp_repo, monkeypatch):
+    # A real search hit beyond the top-N cap is recorded as
+    # filtered_by_search_rank, with its BM25 score, when eval logging widens the
+    # fetch. The fetch is widened via fetch_limit=EVAL_WIDE_FETCH_LIMIT.
+    wiki_git.commit_file("tail.md", "# Tail\nbody\n", "seed", author=None)
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_logging": True}),
+    )
+    mock_search.return_value = _cs([], rank_dropped=[_hit("tail.md", "Tail", 1.5)])
+    before = _outcome_count("filtered_by_search_rank", "tail.md")
+    _run(_make_push())
+    assert mock_search.call_args.kwargs["fetch_limit"] == ingest_search.EVAL_WIDE_FETCH_LIMIT
+    assert _outcome_count("filtered_by_search_rank", "tail.md") - before == 1.0
+    rows = _eval_rows("filtered_by_search_rank")
+    assert len(rows) == 1
+    assert rows[0]["wiki_path"] == "tail.md"
+    assert rows[0]["bm25_score"] == 1.5
 
 
 @patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile", return_value=([], 0))

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.26
+version: 0.3.27
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
+++ b/deploy/helm/agent-workspace/files/wiki-ingest-dashboard.json
@@ -1014,7 +1014,23 @@
           },
           "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "filtered_by_search_rank"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
## What

Extends ingest eval logging to capture the **search long tail** and the **BM25 score** that drove each decision.

### Problem
Eval logging only ever saw candidates *within* the top-N BM25 cap (`INGEST_BM25_LIMIT`, default 20). A page that genuinely matched in search but ranked #21+ was never fetched, so it was invisible — `filtered_by_bm25_score` could only show pages the *threshold* dropped, never ones the *cap* dropped. And no row recorded the BM25 score at all, even though it was available at every call site.

### Change
- **Wide fetch (eval-only).** When `INGEST_EVAL_LOGGING=true`, the candidate fetch is widened to `EVAL_WIDE_FETCH_LIMIT` (500). The top-N selected for the pipeline is **byte-identical to before** — production candidate selection is unchanged. Hits beyond the cap return in a new `CandidateSearch.rank_dropped` bucket and are recorded as a new outcome, **`filtered_by_search_rank`**, with their score. When eval logging is off, the fetch and behavior are exactly as today (zero added cost).
- **`bm25_score` column** on `ingest_eval_samples` (nullable; migration `0032`), populated on **every** outcome — `committed` / `no_change` / `irrelevant` / `filtered_by_selector` / `filtered_by_bm25_score` / `filtered_by_search_rank`.
- **`fts.search`** now honors a large `limit` when visibility filtering is off (the ingest path) instead of capping the internal fetch at 200.
- **Grafana**: `filtered_by_search_rank` gets an explicit, distinct color on the "Ingest Outcomes (total breakdown)" panel (it otherwise auto-appears by label). Chart `0.3.26 → 0.3.27`.

The fallback (oversized-query) path is deliberately excluded from rank-drop logging, same as the existing bm25-drop logging — its lossy summary query isn't score-comparable.

## Testing
- Unit: new `candidates()` tests for the `rank_dropped` split + `fetch_limit` passthrough; pipeline test for `filtered_by_search_rank` + `bm25_score`; `bm25_score` asserted on the existing bm25-drop test. Full ingest suite green.
- `ruff` + `basedpyright` clean.
- **Deployed locally** and verified end-to-end against the live stack:
  - migration applied via the `add_column` path (`alembic 0032`, `bm25_score double precision`)
  - wide fetch + `rank_dropped` split runs against real OpenSearch (forced small cap → 3 in-scope, 4 in tail)
  - `filtered_by_search_rank` + `bm25_score` round-trip through the migrated DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)