### PR TITLE
feat(ingest): 6-month retention sweep for ingest_eval_samples

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -177,7 +177,7 @@ def load_config() -> Config:
         oidc_redirect_uri=os.environ.get("OIDC_REDIRECT_URI", ""),
         ingest_eval_logging=os.environ.get("INGEST_EVAL_LOGGING", "false").lower()
         in {"1", "true", "yes"},
-        ingest_eval_retention_days=_nonneg_int("INGEST_EVAL_RETENTION_DAYS", 90),
+        ingest_eval_retention_days=_nonneg_int("INGEST_EVAL_RETENTION_DAYS", 180),
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         dev_mode=os.environ.get("DEV_MODE", "false").lower() in {"1", "true", "yes"},
         encryption_key_secret=os.environ.get("ENCRYPTION_KEY_SECRET", ""),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -66,6 +66,9 @@ class Config(BaseModel):
 
     # Opt-in eval logging — captures reconciler inputs/outputs to ingest_eval_samples
     ingest_eval_logging: bool
+    # Retention for ingest_eval_samples, in days; rows older than this are pruned
+    # by the daily retention sweep. 0 disables pruning (keep forever).
+    ingest_eval_retention_days: int
     # Public-facing wiki origin (e.g. "https://dev-wiki.onyx.app" or
     # "http://localhost:3088"). REQUIRED — set via the PUBLIC_BASE_URL
     # env var. Single source of truth for the browser-facing URL the
@@ -127,6 +130,19 @@ def _positive_int(name: str, default: int) -> int:
     return value
 
 
+def _nonneg_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError as e:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from e
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0, got {value}")
+    return value
+
+
 def _resolve_wiki_dir() -> str:
     # Anchor relative paths against the repo root so the resolved location
     # doesn't depend on which directory the process was launched from
@@ -161,6 +177,7 @@ def load_config() -> Config:
         oidc_redirect_uri=os.environ.get("OIDC_REDIRECT_URI", ""),
         ingest_eval_logging=os.environ.get("INGEST_EVAL_LOGGING", "false").lower()
         in {"1", "true", "yes"},
+        ingest_eval_retention_days=_nonneg_int("INGEST_EVAL_RETENTION_DAYS", 90),
         secure_cookies=os.environ.get("SECURE_COOKIES", "false").lower() in {"1", "true", "yes"},
         dev_mode=os.environ.get("DEV_MODE", "false").lower() in {"1", "true", "yes"},
         encryption_key_secret=os.environ.get("ENCRYPTION_KEY_SECRET", ""),

--- a/backend/app/db/migrations/versions/0033_ingest_eval_created_at_index.py
+++ b/backend/app/db/migrations/versions/0033_ingest_eval_created_at_index.py
@@ -1,0 +1,36 @@
+"""ensure ix_ingest_eval_samples_created_at exists
+
+The retention sweep filters on created_at; the index must exist for it to be a
+range scan rather than a seq scan. Fresh installs materialize the table via
+0001's create_all and 0021 then early-returns, so the index could be missing
+depending on install path. Create it idempotently to cover every DB.
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-06-24 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision: str = "0033"
+down_revision: str = "0032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_ingest_eval_samples_created_at",
+        "ingest_eval_samples",
+        ["created_at"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_ingest_eval_samples_created_at",
+        table_name="ingest_eval_samples",
+        if_exists=True,
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1146,7 +1146,7 @@ class IngestEvalSample(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     created_at: Mapped[str] = mapped_column(
-        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT, index=True
     )
     source_document_id: Mapped[str | None] = mapped_column(Text)
     source_type: Mapped[str | None] = mapped_column(Text)

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 # Max rows a single retention sweep deletes — keeps the lightweight-maintenance
 # DELETE bounded and quick. The daily schedule drains any larger backlog over
 # successive runs.
-RETENTION_BATCH = 50_000
+RETENTION_BATCH = 100_000
 
 
 def log_sample(

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -13,6 +13,7 @@ search fetch). Intended for human review and building a regression test suite.
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Literal
 
 from sqlalchemy import delete, select
@@ -66,19 +67,21 @@ def log_sample(
         ))
 
 
-def delete_older_than(cutoff: str, *, limit: int = RETENTION_BATCH) -> int:
+def delete_older_than(cutoff: datetime, *, limit: int = RETENTION_BATCH) -> int:
     """Delete up to ``limit`` rows whose ``created_at`` is before ``cutoff``.
 
-    ``cutoff`` is a ``YYYY-MM-DD HH:MM:SS`` UTC string — the same fixed-width
-    format the column stores — so the lexicographic ``<`` comparison is also
-    chronological and rides the ``created_at`` index. Bounded by ``limit`` so a
-    single sweep stays quick even against a backlog; callers run it on a
-    schedule that drains the rest. Returns the number of rows deleted.
+    ``cutoff`` is a UTC ``datetime``; it is formatted to the fixed-width
+    ``YYYY-MM-DD HH:MM:SS`` string the column stores so the lexicographic
+    ``<`` comparison is also chronological and rides the ``created_at`` index.
+    Bounded by ``limit`` so a single sweep stays quick even against a backlog;
+    callers run it on a schedule that drains the rest. Returns the number of
+    rows deleted.
     """
+    cutoff_str = cutoff.strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
         ids = s.scalars(
             select(IngestEvalSample.id)
-            .where(IngestEvalSample.created_at < cutoff)
+            .where(IngestEvalSample.created_at < cutoff_str)
             .order_by(IngestEvalSample.created_at)
             .limit(limit)
         ).all()

--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -15,11 +15,18 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
+from sqlalchemy import delete, select
+
 from app.db.models import IngestEvalSample
 from app.db.session import session
 from app.wiki import git as wiki_git
 
 log = logging.getLogger(__name__)
+
+# Max rows a single retention sweep deletes — keeps the lightweight-maintenance
+# DELETE bounded and quick. The daily schedule drains any larger backlog over
+# successive runs.
+RETENTION_BATCH = 50_000
 
 
 def log_sample(
@@ -57,3 +64,25 @@ def log_sample(
             bm25_score=bm25_score,
             commit_sha=commit_sha,
         ))
+
+
+def delete_older_than(cutoff: str, *, limit: int = RETENTION_BATCH) -> int:
+    """Delete up to ``limit`` rows whose ``created_at`` is before ``cutoff``.
+
+    ``cutoff`` is a ``YYYY-MM-DD HH:MM:SS`` UTC string — the same fixed-width
+    format the column stores — so the lexicographic ``<`` comparison is also
+    chronological and rides the ``created_at`` index. Bounded by ``limit`` so a
+    single sweep stays quick even against a backlog; callers run it on a
+    schedule that drains the rest. Returns the number of rows deleted.
+    """
+    with session() as s:
+        ids = s.scalars(
+            select(IngestEvalSample.id)
+            .where(IngestEvalSample.created_at < cutoff)
+            .order_by(IngestEvalSample.created_at)
+            .limit(limit)
+        ).all()
+        if not ids:
+            return 0
+        s.execute(delete(IngestEvalSample).where(IngestEvalSample.id.in_(ids)))
+        return len(ids)

--- a/backend/app/tasks/ingest_eval_retention.py
+++ b/backend/app/tasks/ingest_eval_retention.py
@@ -24,7 +24,9 @@ from app.tasks.queues import lightweight_maintenance_queue
 log = logging.getLogger(__name__)
 
 
-@lightweight_maintenance_queue.periodic_task(crontab(hour="3", minute="0"))
+# 11:00 UTC == 03:00 PST (UTC-8). The scheduler evaluates cron in UTC and does
+# not follow DST, so this lands at 03:00 Pacific in winter and 04:00 in summer.
+@lightweight_maintenance_queue.periodic_task(crontab(hour="11", minute="0"))
 def prune_ingest_eval_samples() -> None:
     days = CONFIG.ingest_eval_retention_days
     if days <= 0:

--- a/backend/app/tasks/ingest_eval_retention.py
+++ b/backend/app/tasks/ingest_eval_retention.py
@@ -1,0 +1,44 @@
+"""Daily retention sweep for the ``ingest_eval_samples`` table.
+
+Opt-in eval logging (``INGEST_EVAL_LOGGING``) is the dominant writer to the
+database — the table is the vast majority of it and only grows. This periodic
+task prunes rows older than ``INGEST_EVAL_RETENTION_DAYS`` (default 90) so the
+table stays bounded.
+
+Runs on ``lightweight_maintenance_queue``: each sweep is a single bounded,
+indexed ``DELETE`` (no LLM, no external HTTP, no wiki commits), and the daily
+cadence keeps steady-state deletes small. A retention of 0 disables the sweep.
+
+See ``app/tasks/queues.py`` for the queue rationale.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.config import CONFIG
+from app.ingest import eval_sample
+from app.tasks.queue import crontab
+from app.tasks.queues import lightweight_maintenance_queue
+
+log = logging.getLogger(__name__)
+
+
+@lightweight_maintenance_queue.periodic_task(crontab(hour="3", minute="0"))
+def prune_ingest_eval_samples() -> None:
+    days = CONFIG.ingest_eval_retention_days
+    if days <= 0:
+        return
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    deleted = eval_sample.delete_older_than(cutoff)
+    if deleted:
+        log.info(
+            "ingest_eval retention: deleted %d rows older than %s (%dd)",
+            deleted, cutoff, days,
+        )
+    if deleted >= eval_sample.RETENTION_BATCH:
+        # Hit the per-sweep cap — a backlog remains; the next daily run continues.
+        log.warning(
+            "ingest_eval retention: hit per-sweep cap (%d), backlog remains",
+            eval_sample.RETENTION_BATCH,
+        )

--- a/backend/app/tasks/ingest_eval_retention.py
+++ b/backend/app/tasks/ingest_eval_retention.py
@@ -31,12 +31,12 @@ def prune_ingest_eval_samples() -> None:
     days = CONFIG.ingest_eval_retention_days
     if days <= 0:
         return
-    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d %H:%M:%S")
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     deleted = eval_sample.delete_older_than(cutoff)
     if deleted:
         log.info(
             "ingest_eval retention: deleted %d rows older than %s (%dd)",
-            deleted, cutoff, days,
+            deleted, cutoff.isoformat(timespec="seconds"), days,
         )
     if deleted >= eval_sample.RETENTION_BATCH:
         # Hit the per-sweep cap — a backlog remains; the next daily run continues.

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -45,6 +45,9 @@ Queues:
     - Agent-activity expiration cleanup
       (``cleanup_expired_activity``) — a single ``DELETE`` enqueued
       with a delay equal to the row's ``expires_at``.
+    - ingest_eval_samples retention
+      (``prune_ingest_eval_samples``) — a daily, per-run-bounded indexed
+      ``DELETE`` of rows past ``INGEST_EVAL_RETENTION_DAYS``.
 
 Each consumer runs as a separate worker container — see
 ``docker-compose.yml`` (``worker-documents``, ``worker-triggers``,

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -33,6 +33,7 @@ _TASK_MODULES = (
     "app.tasks.craft",
     "app.tasks.wiki_update",
     "app.tasks.expire_launch_artifacts",
+    "app.tasks.ingest_eval_retention",
     "app.tasks.mcp_session_cleanup",
     "app.tasks.periodic",
     "app.tasks.reindex",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,6 +119,7 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
         ingest_eval_logging=False,
+        ingest_eval_retention_days=90,
         launchers_enabled=True,
         launch_code_ttl_seconds=60,
         agent_session_idle_seconds=300,

--- a/backend/tests/test_ingest_eval_retention.py
+++ b/backend/tests/test_ingest_eval_retention.py
@@ -31,7 +31,7 @@ def test_delete_older_than_removes_old_keeps_recent(tmp_db):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     _seed("old.md", "2020-01-01 00:00:00")
     _seed("new.md", now)
-    deleted = eval_sample.delete_older_than("2021-01-01 00:00:00")
+    deleted = eval_sample.delete_older_than(datetime(2021, 1, 1, tzinfo=timezone.utc))
     assert deleted == 1
     assert _paths() == {"new.md"}
 
@@ -39,7 +39,7 @@ def test_delete_older_than_removes_old_keeps_recent(tmp_db):
 def test_delete_older_than_respects_limit(tmp_db):
     for i in range(5):
         _seed(f"{i}.md", "2020-01-01 00:00:00")
-    deleted = eval_sample.delete_older_than("2021-01-01 00:00:00", limit=2)
+    deleted = eval_sample.delete_older_than(datetime(2021, 1, 1, tzinfo=timezone.utc), limit=2)
     assert deleted == 2
     assert len(_paths()) == 3
 

--- a/backend/tests/test_ingest_eval_retention.py
+++ b/backend/tests/test_ingest_eval_retention.py
@@ -1,0 +1,73 @@
+"""Retention sweep for ingest_eval_samples — delete_older_than + the periodic task."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+
+from app.config import CONFIG
+from app.db.models import IngestEvalSample
+from app.db.session import session
+from app.ingest import eval_sample
+
+
+def _seed(wiki_path: str, created_at: str) -> None:
+    with session() as s:
+        s.add(IngestEvalSample(
+            source_content="c",
+            wiki_path=wiki_path,
+            wiki_body_before="b",
+            outcome="irrelevant",
+            created_at=created_at,
+        ))
+
+
+def _paths() -> set[str]:
+    with session() as s:
+        return {r.wiki_path for r in s.scalars(select(IngestEvalSample)).all()}
+
+
+def test_delete_older_than_removes_old_keeps_recent(tmp_db):
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    _seed("old.md", "2020-01-01 00:00:00")
+    _seed("new.md", now)
+    deleted = eval_sample.delete_older_than("2021-01-01 00:00:00")
+    assert deleted == 1
+    assert _paths() == {"new.md"}
+
+
+def test_delete_older_than_respects_limit(tmp_db):
+    for i in range(5):
+        _seed(f"{i}.md", "2020-01-01 00:00:00")
+    deleted = eval_sample.delete_older_than("2021-01-01 00:00:00", limit=2)
+    assert deleted == 2
+    assert len(_paths()) == 3
+
+
+def test_prune_task_deletes_beyond_retention(tmp_db, monkeypatch):
+    monkeypatch.setattr(
+        "app.tasks.ingest_eval_retention.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_retention_days": 90}),
+    )
+    old = (datetime.now(timezone.utc) - timedelta(days=120)).strftime("%Y-%m-%d %H:%M:%S")
+    recent = (datetime.now(timezone.utc) - timedelta(days=10)).strftime("%Y-%m-%d %H:%M:%S")
+    _seed("stale.md", old)
+    _seed("fresh.md", recent)
+    from app.tasks.ingest_eval_retention import prune_ingest_eval_samples
+    from app.tasks.queues import lightweight_maintenance_queue
+    with lightweight_maintenance_queue.immediate_mode():
+        prune_ingest_eval_samples()
+    assert _paths() == {"fresh.md"}
+
+
+def test_prune_task_disabled_when_zero(tmp_db, monkeypatch):
+    monkeypatch.setattr(
+        "app.tasks.ingest_eval_retention.CONFIG",
+        CONFIG.model_copy(update={"ingest_eval_retention_days": 0}),
+    )
+    _seed("ancient.md", "2020-01-01 00:00:00")
+    from app.tasks.ingest_eval_retention import prune_ingest_eval_samples
+    from app.tasks.queues import lightweight_maintenance_queue
+    with lightweight_maintenance_queue.immediate_mode():
+        prune_ingest_eval_samples()
+    assert _paths() == {"ancient.md"}


### PR DESCRIPTION
## What
Adds a daily retention sweep that prunes `ingest_eval_samples` rows older than **`INGEST_EVAL_RETENTION_DAYS` (default 180 / 6 months)**. `0` disables pruning.

## Why
`ingest_eval_samples` is the dominant writer to the database — on the prod RDS it's ~99% of the DB and only grows. The merged `filtered_by_search_rank` logging (#281) raised the per-document row rate further (now ~15–20k rows/day), so the table needs a backstop. RDS storage autoscaling is off (200 GB hard cap), so an unbounded table is a real risk over time.

## How
- New periodic task `prune_ingest_eval_samples` on `lightweight_maintenance_queue`, scheduled daily at **03:00 PST (11:00 UTC)**. The scheduler is fixed-UTC/no-DST, so it lands at 03:00 Pacific in winter, 04:00 in summer.
- Each sweep is a **single bounded, indexed `DELETE`** capped at `RETENTION_BATCH = 100k` rows — no LLM, no HTTP, no commits, honoring the queue's fast-handler contract. Steady-state daily volume is well under the cap; a larger backlog drains over successive daily runs (logs a warning when it hits the cap).
- `eval_sample.delete_older_than(cutoff: datetime, limit)` does the work — takes a UTC `datetime` and formats it to the column's fixed-width string internally, so callers don't reconstruct the storage format.
- `INGEST_EVAL_RETENTION_DAYS` config (+ `_nonneg_int` helper allowing `0`).
- **Index:** `created_at` filtering must be a range scan, not a seq scan. Added `index=True` on the model and migration **0033** (`create_index … if_not_exists`) so `ix_ingest_eval_samples_created_at` exists on every install path (fresh `create_all` + the 0021 early-return gap, and any existing DB missing it).

## Testing
- `tests/test_ingest_eval_retention.py`: old-vs-recent deletion, per-run `limit` cap, the task end-to-end past retention, and the `0`-disables case. Migration 0033 is exercised by the per-test `alembic upgrade head`. Full suite + `ruff` + `basedpyright` green.

No production behavior change until rows age past 180 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)