### PR TITLE
fix(history): group a remove+add replacement into one block

### DIFF
--- a/frontend/src/components/wiki/DiffHunk.module.css
+++ b/frontend/src/components/wiki/DiffHunk.module.css
@@ -38,14 +38,19 @@
   padding: 2px 8px;
 }
 
+/* Connect runs of the same kind, and connect a remove block directly above
+   the add block that replaces it, so a replacement reads as one unit (old
+   over new) rather than two unrelated cards. */
 .add + .add,
-.remove + .remove {
+.remove + .remove,
+.remove + .add {
   margin-top: 0;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
 .add:has(+ .add),
-.remove:has(+ .remove) {
+.remove:has(+ .remove),
+.remove:has(+ .add) {
   margin-bottom: 0;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;

--- a/frontend/src/components/wiki/diffEntries.ts
+++ b/frontend/src/components/wiki/diffEntries.ts
@@ -55,21 +55,24 @@ export function groupEntries(lines: DiffLine[]): Entry[] {
   return out;
 }
 
-/** Group every hunk and number each contiguous run of changes. A run is a
-    maximal stretch of non-context entries — e.g. a remove block followed by
-    an add block (a replacement) is one change, as is a lone word-diff line. */
+/** Group every hunk and number the changes. Each change entry is its own
+    change, EXCEPT an add block directly after a remove block — that's the
+    "new" half of a replacement, so it stays part of the remove's change.
+    The change index marks the entry the navigator scrolls to. */
 export function annotateHunks(hunks: DiffHunk[]): {
   perHunk: AnnotatedEntry[][];
   total: number;
 } {
   let changeIndex = 0;
   const perHunk = hunks.map((hunk) => {
-    let prevWasChange = false;
+    let prevKind: Entry["kind"] = "context";
     return groupEntries(hunk.lines).map((entry) => {
       const isChange = entry.kind !== "context";
-      const startsRun = isChange && !prevWasChange;
-      prevWasChange = isChange;
-      return { entry, changeIndex: startsRun ? changeIndex++ : null };
+      const continuesReplacement =
+        entry.kind === "add" && prevKind === "remove";
+      const startsChange = isChange && !continuesReplacement;
+      prevKind = entry.kind;
+      return { entry, changeIndex: startsChange ? changeIndex++ : null };
     });
   });
   return { perHunk, total: changeIndex };


### PR DESCRIPTION
## Description

In the history diff viewer, a removed block and the block that replaces it were two separate cards, and the change navigator's counting was too coarse.

**Fix:**
- **Visual:** an adjacent remove→add (a replacement) connects into one unit — old directly above new, one rounded outline, flat where they meet.
- **Counting:** each change is its own navigator stop, *except* an add block directly after a remove block (the "new" half of a replacement), which stays grouped with it. Previously any contiguous run merged, so an inline edit next to a brand-new block collapsed into one stop.

Counting now matches the visual grouping.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check