### PR TITLE
feat(triggers): destination_configs registry (typed destination foundation)

### DIFF
--- a/backend/app/db/migrations/versions/0039_destination_configs.py
+++ b/backend/app/db/migrations/versions/0039_destination_configs.py
@@ -1,0 +1,71 @@
+"""destination configs registry
+
+Adds the per-user ``destination_configs`` table — a typed, named delivery
+target a trigger can fire to, generalizing ``slack_webhooks`` to any
+destination type. ``type`` is a ``trigger_destinations`` catalog slug,
+``config_json`` holds the non-secret per-type settings, and ``secret`` is the
+optional AES-GCM-encrypted credential (``app/db/crypto.py:EncryptedString``).
+
+The table create is guarded on the live inspector because ``0001_initial``
+runs ``Base.metadata.create_all`` against the current model registry, so a
+fresh database already has the table (same pattern as ``0023_slack_destination``).
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-06-24 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "0039"
+down_revision: str | None = "0038"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if "destination_configs" not in inspector.get_table_names():
+        op.create_table(
+            "destination_configs",
+            sa.Column("id", sa.Text, primary_key=True),
+            sa.Column(
+                "owner_user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("type", sa.Text, nullable=False),
+            sa.Column("name", sa.Text, nullable=False),
+            sa.Column(
+                "config_json",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+            sa.Column("secret", sa.LargeBinary, nullable=True),
+            sa.Column(
+                "created_at",
+                sa.Text,
+                nullable=False,
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+            ),
+        )
+        op.create_index("idx_destination_configs_owner", "destination_configs", ["owner_user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_destination_configs_owner", table_name="destination_configs")
+    op.drop_table("destination_configs")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -511,6 +511,35 @@ class SlackWebhook(Base):
     __table_args__ = (Index("idx_slack_webhooks_owner", "owner_user_id"),)
 
 
+class DestinationConfig(Base):
+    """A user-owned, named, typed delivery target a trigger can fire to.
+
+    Generalizes ``slack_webhooks`` beyond Slack: ``type`` is a
+    ``trigger_destinations`` catalog slug (``slack``, ``webhook``, …),
+    ``config_json`` holds the non-secret per-type settings, and ``secret`` is
+    the optional encrypted credential (an incoming-webhook URL, a signing
+    secret, …). Private to ``owner_user_id`` — only the owner's triggers may
+    reference one, and the secret never reaches the wiki git repo.
+    """
+
+    __tablename__ = "destination_configs"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    owner_user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    type: Mapped[str] = mapped_column(Text, nullable=False)  # trigger_destinations slug
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    config_json: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    # Optional secret — AES-GCM encrypted at rest (bytea). See app/db/crypto.py.
+    secret: Mapped[str | None] = mapped_column(EncryptedString())
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+
+    __table_args__ = (Index("idx_destination_configs_owner", "owner_user_id"),)
+
+
 # --------------------------------------------------------------------------- #
 # Chat sessions — persisted conversations with the in-app ChatUI              #
 # --------------------------------------------------------------------------- #

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -1,0 +1,140 @@
+"""Per-user trigger destination-config registry.
+
+A *destination config* is a user-owned, named, typed delivery target a trigger
+can fire to — a Slack channel, an outbound webhook, an email address, … This
+generalizes ``app/slack/webhooks.py`` (Slack-only) into a typed registry:
+``type`` is a ``trigger_destinations`` catalog slug, ``config`` holds the
+non-secret per-type settings, and ``secret`` is the optional encrypted
+credential.
+
+Configs are private to ``owner_user_id`` — list/get/delete are owner-scoped and
+``get_secret`` enforces ownership before returning the decrypted secret. The
+secret is never written to the wiki git repo. Repos return dicts, not ORM rows.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+
+from app.db.models import DestinationConfig
+from app.db.session import session
+from app.triggers import destinations
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _to_dict(d: DestinationConfig) -> dict[str, Any]:
+    # Secret is deliberately omitted — callers that need it go through
+    # ``get_secret``, which enforces ownership.
+    return {
+        "id": d.id,
+        "owner_user_id": d.owner_user_id,
+        "type": d.type,
+        "name": d.name,
+        "config": d.config_json,
+        "has_secret": d.secret is not None,
+        "created_at": d.created_at,
+    }
+
+
+def list_for_user(user_id: str) -> list[dict[str, Any]]:
+    """A user's destination configs, newest first. Secrets omitted."""
+    with session() as s:
+        rows = s.scalars(
+            select(DestinationConfig)
+            .where(DestinationConfig.owner_user_id == user_id)
+            .order_by(DestinationConfig.created_at.desc())
+        ).all()
+        return [_to_dict(d) for d in rows]
+
+
+def create(
+    user_id: str,
+    *,
+    type: str,
+    name: str,
+    config: dict[str, Any] | None = None,
+    secret: str | None = None,
+) -> dict[str, Any]:
+    """Register a destination config for a user. Validates the type slug
+    against the ``trigger_destinations`` catalog."""
+    name = name.strip()
+    if not name:
+        raise ValueError("name is required")
+    if not destinations.exists(type):
+        raise ValueError(f"unknown destination type: {type}")
+
+    config_id = "dst_" + uuid.uuid4().hex[:12]
+    created_at = _now_iso()
+    with session() as s:
+        s.add(
+            DestinationConfig(
+                id=config_id,
+                owner_user_id=user_id,
+                type=type,
+                name=name,
+                config_json=config or {},
+                secret=secret,
+                created_at=created_at,
+            )
+        )
+    log.info("destination config created id=%s user_id=%s type=%s", config_id, user_id, type)
+    return {
+        "id": config_id,
+        "owner_user_id": user_id,
+        "type": type,
+        "name": name,
+        "config": config or {},
+        "has_secret": secret is not None,
+        "created_at": created_at,
+    }
+
+
+def get(config_id: str, user_id: str) -> dict[str, Any] | None:
+    """Owner-scoped fetch (secret omitted). None if missing or not owned."""
+    with session() as s:
+        d = s.get(DestinationConfig, config_id)
+        if d is None or d.owner_user_id != user_id:
+            return None
+        return _to_dict(d)
+
+
+def delete(config_id: str, user_id: str) -> bool:
+    """Delete a config. Returns False if it doesn't exist or isn't owned by
+    ``user_id`` (so the API can 404 vs 204 cleanly)."""
+    with session() as s:
+        d = s.get(DestinationConfig, config_id)
+        if d is None or d.owner_user_id != user_id:
+            return False
+        s.delete(d)
+    log.info("destination config deleted id=%s user_id=%s", config_id, user_id)
+    return True
+
+
+def owned_by(config_id: str, user_id: str) -> bool:
+    """True iff ``config_id`` exists and belongs to ``user_id``."""
+    with session() as s:
+        d = s.get(DestinationConfig, config_id)
+        return d is not None and d.owner_user_id == user_id
+
+
+def get_secret(config_id: str, *, owner_user_id: str) -> str | None:
+    """Resolve a config id to its decrypted secret, enforcing ownership.
+
+    Returns None if the config is missing, owned by someone else, or has no
+    secret — the dispatcher treats that as "skip outbound" (the fire is still
+    recorded)."""
+    with session() as s:
+        d = s.get(DestinationConfig, config_id)
+        if d is None or d.owner_user_id != owner_user_id:
+            return None
+        return d.secret

--- a/backend/tests/test_destination_configs.py
+++ b/backend/tests/test_destination_configs.py
@@ -1,0 +1,103 @@
+"""Tests for app/triggers/destination_configs.py — the per-user destination
+config registry (the typed generalization of the Slack webhook registry).
+
+Guards the owner-scoping and at-rest secret encryption that the trigger
+dispatch path will rely on once destinations route through this table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.triggers import destination_configs as configs
+
+from tests._seed import seed_user
+
+_SECRET = "https://hooks.slack.com/services/EXAMPLE"
+
+
+def test_create_then_list(tmp_db):
+    seed_user("usr_1")
+    c = configs.create("usr_1", type="slack", name="PM Standup", secret=_SECRET)
+    assert c["id"].startswith("dst_")
+    assert c["type"] == "slack"
+    assert c["has_secret"] is True
+
+    rows = configs.list_for_user("usr_1")
+    assert [r["name"] for r in rows] == ["PM Standup"]
+    assert "secret" not in rows[0]  # secrets never appear in listings
+    assert rows[0]["has_secret"] is True
+
+
+def test_create_validates_type(tmp_db):
+    seed_user("usr_1")
+    with pytest.raises(ValueError):
+        configs.create("usr_1", type="not_a_real_type", name="X")
+
+
+def test_create_rejects_empty_name(tmp_db):
+    seed_user("usr_1")
+    with pytest.raises(ValueError):
+        configs.create("usr_1", type="slack", name="   ")
+
+
+def test_create_without_secret(tmp_db):
+    seed_user("usr_1")
+    c = configs.create("usr_1", type="slack", name="No secret")
+    assert c["has_secret"] is False
+    assert configs.get_secret(c["id"], owner_user_id="usr_1") is None
+
+
+def test_config_json_roundtrip(tmp_db):
+    seed_user("usr_1")
+    c = configs.create("usr_1", type="slack", name="Tagged", config={"routing_tag": "jira"})
+    got = configs.get(c["id"], "usr_1")
+    assert got is not None
+    assert got["config"] == {"routing_tag": "jira"}
+
+
+def test_list_is_owner_scoped(tmp_db):
+    seed_user("usr_1")
+    seed_user("usr_2", email="two@x.com")
+    configs.create("usr_1", type="slack", name="Mine")
+    assert configs.list_for_user("usr_2") == []
+
+
+def test_delete_is_owner_scoped(tmp_db):
+    seed_user("usr_1")
+    seed_user("usr_2", email="two@x.com")
+    c = configs.create("usr_1", type="slack", name="Mine")
+
+    assert configs.delete(c["id"], "usr_2") is False  # not the owner
+    assert configs.delete(c["id"], "usr_1") is True
+    assert configs.list_for_user("usr_1") == []
+
+
+def test_owned_by_and_get_secret(tmp_db):
+    seed_user("usr_1")
+    seed_user("usr_2", email="two@x.com")
+    c = configs.create("usr_1", type="slack", name="Mine", secret=_SECRET)
+
+    assert configs.owned_by(c["id"], "usr_1") is True
+    assert configs.owned_by(c["id"], "usr_2") is False
+    assert configs.owned_by("dst_missing", "usr_1") is False
+
+    assert configs.get_secret(c["id"], owner_user_id="usr_1") == _SECRET
+    # ownership enforced — wrong owner gets nothing
+    assert configs.get_secret(c["id"], owner_user_id="usr_2") is None
+
+
+def test_secret_encrypted_at_rest(tmp_db):
+    """The raw column holds ciphertext, not the plaintext secret — but the
+    repo decrypts transparently on read."""
+    from sqlalchemy import text
+
+    from app.db.session import session
+
+    seed_user("usr_1")
+    c = configs.create("usr_1", type="slack", name="Mine", secret=_SECRET)
+
+    with session() as s:
+        raw = s.execute(text("SELECT secret FROM destination_configs LIMIT 1")).scalar_one()
+    assert _SECRET.encode() not in bytes(raw)  # not stored in the clear
+    assert configs.get_secret(c["id"], owner_user_id="usr_1") == _SECRET


### PR DESCRIPTION
Adds a per-user `destination_configs` table — a typed, named delivery target a trigger can fire to — generalizing the Slack-only `slack_webhooks` registry so a new destination type (webhook, email, Craft) is just a row, not another column bolted onto `triggers`.

**What's here**
- `DestinationConfig` model + `0033_destination_configs` migration (guarded create, mirrors the `0023` slack style). `type` = a `trigger_destinations` catalog slug; `config_json` (JSONB) = non-secret settings; `secret` = optional AES-GCM `EncryptedString`.
- `app/triggers/destination_configs.py` — owner-scoped CRUD mirroring `app/slack/webhooks.py`. Secrets omitted from list/get; only the owner-checked `get_secret` returns the value, and nothing logs it.
- `tests/test_destination_configs.py` — 9 tests (CRUD, type validation, owner-scoping, at-rest secret encryption).

**Scope**
Purely additive — nothing reads the table yet, so the existing Event Log + Slack-webhook path is untouched. Follow-ups: backfill `slack_webhooks` + repoint the trigger reference; generalize the `_record_fire` dispatch switch; add the webhook type + dispatcher (SSRF guard, routing tag, send-test).

Design: `Engineering Projects/Agent Wiki Project/design/Triggers Destinations Plan.md` (wiki). `type` is validated against the `trigger_destinations` catalog (no duplicated type list); the generic table removes the per-type `*_id` column pattern.

**Checks:** ruff check + basedpyright (whole-project, strict) + `pytest` (9 passed).
