### PR TITLE
feat(update-policy): show 24h auto-update count in the policy panel

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -13,6 +14,7 @@ from app.auth.deps import require_user
 from app.llm.agents import merge_conflict_update
 from app.models.file_system import (
     ActivityRowView,
+    AutoUpdateCountResponse,
     CommitView,
     CreateFolderRequest,
     CreateFolderResponse,
@@ -66,6 +68,7 @@ from app.wiki import (
     search as wiki_search,
     starred as wiki_starred,
     templates as templates_repo,
+    update_policy as update_policy_repo,
     utils as wiki_utils,
 )
 from app.models.wiki import ChangeKind, CommitMaxRetriesError
@@ -577,6 +580,29 @@ def file_history(
         if r.sha not in deprecated
     ]
     return FileHistoryResponse(path=rel, head_sha=head_sha, commits=visible)
+
+
+@router.get("/auto-update-count", response_model=AutoUpdateCountResponse)
+def auto_update_count(
+    user: User = Depends(require_user),
+    path: str = "",
+    hours: int = Query(24, ge=1, le=8760),
+) -> AutoUpdateCountResponse:
+    """How many ingestion auto-updates touched a page/folder in the last
+    ``hours``. Counts only commits authored by ``Onyx Ingest`` — human and
+    other-agent edits are excluded."""
+    try:
+        # Same normalization as /update-policy (the panel passes the same
+        # path): "" / "/" mean the wiki root, which scopes the whole repo.
+        rel = update_policy_repo.normalize_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    require_can("read", rel, user)
+    since = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
+    count = wiki_git.count_commits_since(
+        rel, author=wiki_utils.INGEST_AUTHOR_EMAIL, since_iso=since
+    )
+    return AutoUpdateCountResponse(path=rel, hours=hours, count=count)
 
 
 @router.get("/file/diff", response_model=FileDiffResponse)

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -217,6 +217,15 @@ class FileHistoryResponse(BaseModel):
     commits: list[CommitView]
 
 
+class AutoUpdateCountResponse(BaseModel):
+    """Count of ingestion auto-update commits for a page or folder within a
+    recent window — drives the Update Policy panel's activity line."""
+
+    path: str
+    hours: int
+    count: int
+
+
 class WordDiff(BaseModel):
     """A 1-remove/1-add line collapsed into one rendered row.
 

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -68,11 +68,6 @@ _DEBOUNCE_SECONDS = int(os.environ.get("MCP_NL_DEBOUNCE_SECONDS", "30"))
 # instruction may be long, but we only want a quick handle.
 _COMMIT_MESSAGE_MAX = 80
 
-# Git author for connector-pushed ingestion commits — these have no human
-# user, so without this they'd fall back to the generic "AI Wiki Helper".
-# The originating connector + URL still ride in the commit message.
-_INGEST_AUTHOR = "Onyx Ingest <onyx-ingest@local>"
-
 
 @documents_queue.task()
 def update_document_from_payload(doc_id: str, source: str, payload: dict[str, Any]) -> None:
@@ -263,7 +258,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
     ``Onyx Ingest`` author for the run so its commits surface under that name in
     history instead of the generic fallback, then delegate to the reconciler.
     """
-    with wiki_utils.system_author(_INGEST_AUTHOR):
+    with wiki_utils.system_author(wiki_utils.INGEST_AUTHOR):
         _reconcile_pushed_document(push)
 
 

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -422,14 +422,16 @@ def count_commits_since(rel_path: str, *, author: str, since_iso: str) -> int:
     ``rel_path`` may be a single ``.md`` file or a folder — git's pathspec
     counts every commit touching anything beneath a folder, so a folder count
     aggregates its pages. Empty path scopes the whole repo. ``author`` is a
-    git ``--author`` regex matched against the commit's author name+email;
-    pass an email for a precise match. ``since_iso`` is any timestamp git
-    ``--since`` accepts (filters by commit date)."""
+    bare email; we anchor it as ``<email>$`` so git's ``--author`` regex matches
+    that exact identity rather than substring-matching it (e.g. so
+    ``onyx-ingest@local`` can't match ``onyx-ingest@localhost``). ``since_iso``
+    is any timestamp git ``--since`` accepts (filters by commit date)."""
+    author_pattern = f"<{author}>$"
     out = _run(
         [
             "log",
             f"--since={since_iso}",
-            f"--author={author}",
+            f"--author={author_pattern}",
             "--pretty=format:%H",
             "--",
             rel_path or ".",

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -415,6 +415,30 @@ def commits_between(base_sha: str, head_sha: str, rel_path: str) -> list[str]:
     return [s for s in out.splitlines() if s]
 
 
+def count_commits_since(rel_path: str, *, author: str, since_iso: str) -> int:
+    """Number of commits since ``since_iso`` by ``author`` that touched
+    ``rel_path``.
+
+    ``rel_path`` may be a single ``.md`` file or a folder — git's pathspec
+    counts every commit touching anything beneath a folder, so a folder count
+    aggregates its pages. Empty path scopes the whole repo. ``author`` is a
+    git ``--author`` regex matched against the commit's author name+email;
+    pass an email for a precise match. ``since_iso`` is any timestamp git
+    ``--since`` accepts (filters by commit date)."""
+    out = _run(
+        [
+            "log",
+            f"--since={since_iso}",
+            f"--author={author}",
+            "--pretty=format:%H",
+            "--",
+            rel_path or ".",
+        ],
+        check=False,
+    ).stdout
+    return sum(1 for line in out.splitlines() if line.strip())
+
+
 def list_paths(prefix: str = "") -> list[str]:
     """List tracked files under a path prefix."""
     out = _run(["ls-files", "-z", prefix or "."]).stdout

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -99,6 +99,13 @@ def assert_base_sha(path: str, base_sha: str | None) -> dict[str, str] | None:
 
 _FALLBACK_AUTHOR = "AI Wiki Helper <ai-wiki-helper@local>"
 
+# Git identity for connector-pushed ingestion commits — these have no human
+# user, so without this they'd fall back to ``_FALLBACK_AUTHOR``. Bound via
+# ``system_author(INGEST_AUTHOR)`` on the ingest path; the email is what
+# callers filter on when counting ingestion commits (see git.count_commits_since).
+INGEST_AUTHOR_EMAIL = "onyx-ingest@local"
+INGEST_AUTHOR = f"Onyx Ingest <{INGEST_AUTHOR_EMAIL}>"
+
 # Explicit git author for system-initiated commits that legitimately have no
 # user in context (document ingestion from a connector, etc.). Bound by the
 # ``system_author`` context manager; consulted by ``author_string`` before it

--- a/backend/tests/test_auto_update_count_api.py
+++ b/backend/tests/test_auto_update_count_api.py
@@ -60,6 +60,19 @@ def test_root_path_counts_whole_repo(client: TestClient) -> None:
     assert body["count"] == 4  # all four ingest commits, no human edit
 
 
+def test_author_match_is_anchored_not_substring(client: TestClient) -> None:
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+    # A lookalike whose email merely contains the ingest email as a prefix must
+    # not be counted — the match is anchored to the exact <email>.
+    wiki_git.commit_file(
+        "team/a.md", "x\n", "edit", author="Imposter <onyx-ingest@localhost>"
+    )
+    wiki_git.commit_file("team/a.md", "y\n", "ingest", author=wiki_utils.INGEST_AUTHOR)
+    body = client.get("/api/wiki/auto-update-count?path=team/a.md").json()
+    assert body["count"] == 1
+
+
 def test_window_excludes_commits_before_since(client: TestClient) -> None:
     _seed(client)
     # The window is committer-date based; a since in the future matches nothing.

--- a/backend/tests/test_auto_update_count_api.py
+++ b/backend/tests/test_auto_update_count_api.py
@@ -1,0 +1,72 @@
+"""Tests for GET /api/wiki/auto-update-count — the 24h ingestion-update count
+surfaced in the Update Policy panel."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.main import create_app
+from app.wiki import git as wiki_git
+from app.wiki import utils as wiki_utils
+from tests._auth import login_fastapi
+
+HUMAN_AUTHOR = "Nik <nik@x.com>"
+
+
+@pytest.fixture
+def client(tmp_db: None, tmp_repo: None) -> TestClient:
+    return TestClient(create_app())
+
+
+def _seed(client: TestClient) -> None:
+    uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
+    login_fastapi(client, uid)
+    ingest = wiki_utils.INGEST_AUTHOR
+    # team/a.md: two ingest updates + one human edit (human must not count).
+    wiki_git.commit_file("team/a.md", "a1\n", "ingest", author=ingest)
+    wiki_git.commit_file("team/a.md", "a2\n", "ingest", author=ingest)
+    wiki_git.commit_file("team/a.md", "a3 human\n", "edit", author=HUMAN_AUTHOR)
+    # team/b.md: one ingest update (folder count should aggregate it with a.md).
+    wiki_git.commit_file("team/b.md", "b1\n", "ingest", author=ingest)
+    # other/c.md: one ingest update outside the team/ folder.
+    wiki_git.commit_file("other/c.md", "c1\n", "ingest", author=ingest)
+
+
+def test_unauthenticated_is_401(client: TestClient) -> None:
+    assert client.get("/api/wiki/auto-update-count?path=team/a.md").status_code == 401
+
+
+def test_counts_ingest_commits_for_a_page(client: TestClient) -> None:
+    _seed(client)
+    body = client.get("/api/wiki/auto-update-count?path=team/a.md").json()
+    assert body == {"path": "team/a.md", "hours": 24, "count": 2}
+
+
+def test_folder_path_aggregates_pages_beneath_it(client: TestClient) -> None:
+    _seed(client)
+    # team/ holds a.md (2 ingest) + b.md (1 ingest); other/c.md is excluded.
+    body = client.get("/api/wiki/auto-update-count?path=team").json()
+    assert body["count"] == 3
+
+
+def test_root_path_counts_whole_repo(client: TestClient) -> None:
+    _seed(client)
+    body = client.get("/api/wiki/auto-update-count").json()
+    assert body["path"] == ""
+    assert body["count"] == 4  # all four ingest commits, no human edit
+
+
+def test_window_excludes_commits_before_since(client: TestClient) -> None:
+    _seed(client)
+    # The window is committer-date based; a since in the future matches nothing.
+    future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    assert (
+        wiki_git.count_commits_since(
+            "team/a.md", author=wiki_utils.INGEST_AUTHOR_EMAIL, since_iso=future
+        )
+        == 0
+    )

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -2529,6 +2529,7 @@ function FileViewer({ path }: { path: string }) {
                 <UpdatePolicyPanel
                   path={path}
                   onClose={() => setPolicyOpen(false)}
+                  onShowHistory={toggleHistory}
                   fullHeight
                 />
               </div>,
@@ -2602,6 +2603,7 @@ function FileViewer({ path }: { path: string }) {
             <UpdatePolicyPanel
               path={path}
               onClose={() => setPolicyOpen(false)}
+              onShowHistory={toggleHistory}
               fullHeight
             />
           </div>

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -72,6 +72,14 @@
   color: var(--text-03);
 }
 
+/* The 24h auto-update count sits at the foot of the card, fenced off from the
+   settings above by a hairline and centered against its "Update History" link. */
+.activityRow {
+  align-items: center;
+  padding-top: 14px;
+  border-top: 1px solid var(--border-01);
+}
+
 .instruction {
   font-size: 13px;
   color: var(--text-05);

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -46,9 +46,12 @@ export function UpdatePolicyPanel({
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // 24h ingestion auto-update count. Loaded separately so a failure here never
-  // blocks the policy card — null just hides the activity row.
-  const [autoUpdateCount, setAutoUpdateCount] = useState<number | null>(null);
+  // Ingestion auto-update count + the window it covers. Loaded separately so a
+  // failure here never blocks the policy card — null just hides the activity row.
+  const [autoUpdate, setAutoUpdate] = useState<{
+    count: number;
+    hours: number;
+  } | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -56,7 +59,7 @@ export function UpdatePolicyPanel({
     setLoaded(false);
     setError(null);
     setEditing(false);
-    setAutoUpdateCount(null);
+    setAutoUpdate(null);
     getUpdatePolicy(path)
       .then((r) => {
         if (alive) {
@@ -72,7 +75,7 @@ export function UpdatePolicyPanel({
       });
     fetchAutoUpdateCount(path)
       .then((r) => {
-        if (alive) setAutoUpdateCount(r.count);
+        if (alive) setAutoUpdate({ count: r.count, hours: r.hours });
       })
       .catch(() => {
         // Non-fatal: leave the activity row hidden.
@@ -254,13 +257,15 @@ export function UpdatePolicyPanel({
               </div>
             )}
 
-            {autoUpdateCount !== null && (
+            {autoUpdate !== null && (
               <div className={`${styles.row} ${styles.activityRow}`}>
                 <div className={styles.rowText}>
                   <Text font="main-content-emphasis" color="text-04">
-                    {`${autoUpdateCount} Auto Update${autoUpdateCount === 1 ? "" : "s"}`}
+                    {`${autoUpdate.count} Auto Update${autoUpdate.count === 1 ? "" : "s"}`}
                   </Text>
-                  <span className={styles.desc}>in the past 24 hours</span>
+                  <span className={styles.desc}>
+                    {`in the past ${autoUpdate.hours} hour${autoUpdate.hours === 1 ? "" : "s"}`}
+                  </span>
                 </div>
                 {onShowHistory && (
                   <Button

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Switch, Text } from "@onyx-ai/opal/components";
-import { SvgEdit, SvgX } from "@onyx-ai/opal/icons";
+import { SvgEdit, SvgHistory, SvgX } from "@onyx-ai/opal/icons";
 import { useEffect, useState } from "react";
 
 import { ApiError } from "@/lib/api";
@@ -10,6 +10,7 @@ import {
   patchUpdatePolicy,
   type UpdatePolicyResponse,
 } from "@/lib/updatePolicy";
+import { fetchAutoUpdateCount } from "@/lib/wiki";
 
 import styles from "./UpdatePolicyPanel.module.css";
 
@@ -17,6 +18,9 @@ interface Props {
   path: string;
   onClose: () => void;
   fullHeight?: boolean;
+  // When set, the activity row shows an "Update History" link that calls this.
+  // Omit on surfaces with no history view (e.g. the folder explorer drawer).
+  onShowHistory?: () => void;
 }
 
 function errorMessage(e: unknown): string {
@@ -26,7 +30,12 @@ function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : "Something went wrong.";
 }
 
-export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
+export function UpdatePolicyPanel({
+  path,
+  onClose,
+  fullHeight,
+  onShowHistory,
+}: Props) {
   const kind = path.endsWith(".md") ? "page" : "folder";
 
   const [loading, setLoading] = useState(true);
@@ -37,6 +46,9 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
   const [draft, setDraft] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 24h ingestion auto-update count. Loaded separately so a failure here never
+  // blocks the policy card — null just hides the activity row.
+  const [autoUpdateCount, setAutoUpdateCount] = useState<number | null>(null);
 
   useEffect(() => {
     let alive = true;
@@ -44,6 +56,7 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
     setLoaded(false);
     setError(null);
     setEditing(false);
+    setAutoUpdateCount(null);
     getUpdatePolicy(path)
       .then((r) => {
         if (alive) {
@@ -56,6 +69,13 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
       })
       .finally(() => {
         if (alive) setLoading(false);
+      });
+    fetchAutoUpdateCount(path)
+      .then((r) => {
+        if (alive) setAutoUpdateCount(r.count);
+      })
+      .catch(() => {
+        // Non-fatal: leave the activity row hidden.
       });
     return () => {
       alive = false;
@@ -231,6 +251,27 @@ export function UpdatePolicyPanel({ path, onClose, fullHeight }: Props) {
                     {saving ? "Saving…" : "Save"}
                   </Button>
                 </div>
+              </div>
+            )}
+
+            {autoUpdateCount !== null && (
+              <div className={`${styles.row} ${styles.activityRow}`}>
+                <div className={styles.rowText}>
+                  <Text font="main-content-emphasis" color="text-04">
+                    {`${autoUpdateCount} Auto Update${autoUpdateCount === 1 ? "" : "s"}`}
+                  </Text>
+                  <span className={styles.desc}>in the past 24 hours</span>
+                </div>
+                {onShowHistory && (
+                  <Button
+                    icon={SvgHistory}
+                    prominence="tertiary"
+                    size="sm"
+                    onClick={onShowHistory}
+                  >
+                    Update History
+                  </Button>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -154,6 +154,21 @@ export async function fetchFileHistory(
   );
 }
 
+export interface AutoUpdateCount {
+  path: string;
+  hours: number;
+  count: number;
+}
+
+/** Count of ingestion auto-updates to a page/folder in the last 24h. */
+export async function fetchAutoUpdateCount(
+  path: string,
+): Promise<AutoUpdateCount> {
+  return apiFetch<AutoUpdateCount>(
+    `/wiki/auto-update-count?path=${encodeURIComponent(path)}`,
+  );
+}
+
 /**
  * Pull the originating source URL + title out of a commit body.
  *


### PR DESCRIPTION
## What

Adds a **24h auto-update count** to the Update Policy panel — *"N Auto Updates in the past 24 hours"* — for both pages and folders, plus an **Update History** link on the page view.

## How it's counted

Derived from **git history** — commits authored by `Onyx Ingest <onyx-ingest@local>` touching the path within the window. So it reflects only **ingestion** auto-updates (human edits, chat edits, and NL-trigger edits are excluded), and a folder path aggregates the pages beneath it via git's pathspec. No new table.

> Note: `git log --since` filters by commit date, which coincides with author date for our commits.

## Changes

**Backend**
- `app/wiki/utils.py` — promote the ingest identity to public `INGEST_AUTHOR` / `INGEST_AUTHOR_EMAIL` (was a private constant in `tasks/wiki_update.py`).
- `app/wiki/git.py` — `count_commits_since(rel_path, *, author, since_iso)`.
- `app/api/wiki.py` — `GET /api/wiki/auto-update-count?path=…&hours=24`, gated by `require_can("read", …)`; reuses `update_policy.normalize_path` so root/`""` behaves like the policy fetch.
- `app/models/file_system.py` — `AutoUpdateCountResponse`.

**Frontend (Opal)**
- `lib/wiki.ts` — `fetchAutoUpdateCount`.
- `components/wiki/UpdatePolicyPanel.tsx` — activity row (count fetched in parallel; failure is non-fatal and just hides the row) + optional `onShowHistory` link.
- `app/app/wiki/[[...slug]]/page.tsx` — page view (desktop + mobile) wires `onShowHistory` to the existing history panel; the folder explorer drawer shows the count without a link.

**Docs**
- Updated `design/Update Policy.md` (Observability / Interfaces / Code map).

## Testing

- New `backend/tests/test_auto_update_count_api.py`: page count, folder aggregation, root, human-edit exclusion, and the time-window cutoff — all green.
- `ruff`, `basedpyright`, and frontend `tsc` clean.
- Not yet exercised against the live app with real ingestion data.
<img width="419" height="373" alt="Screenshot 2026-06-24 at 11 55 00 AM" src="https://github.com/user-attachments/assets/1734466e-605a-4c28-88bd-5c370074b52a" />
