### PR TITLE
feat(wiki): too-frequent-update guardrails — backend

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -423,6 +423,8 @@ def _ingest_view(s: IngestSettings) -> IngestView:
         api_key_set=bool(s.api_key),
         api_key_hint=_redact(s.api_key or ""),
         onyx_base_url=s.onyx_base_url,
+        warn_update_threshold_default=s.warn_update_threshold_default,
+        auto_update_cap=s.auto_update_cap,
     )
 
 
@@ -452,12 +454,20 @@ def put_ingest(
                 validate_onyx_base_url(onyx_base_url)
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
-    ingest_settings.upsert(max_doc_chars=req.max_doc_chars, onyx_base_url=onyx_base_url)
+    ingest_settings.upsert(
+        max_doc_chars=req.max_doc_chars,
+        onyx_base_url=onyx_base_url,
+        warn_update_threshold_default=req.warn_update_threshold_default,
+        auto_update_cap=req.auto_update_cap,
+    )
     log.info(
-        "admin: %s updated ingest settings max_doc_chars=%d onyx_base_url_set=%s",
+        "admin: %s updated ingest settings max_doc_chars=%d onyx_base_url_set=%s "
+        "warn_default=%d auto_update_cap=%d",
         actor.id,
         req.max_doc_chars,
         bool(onyx_base_url),
+        req.warn_update_threshold_default,
+        req.auto_update_cap,
     )
     return _ingest_view(ingest_settings.get())
 

--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -68,6 +68,8 @@ def patch_update_policy(
         patch["ingestion_auto_update_disabled"] = req.ingestion_auto_update_disabled
     if "update_instruction" in req.model_fields_set:
         patch["update_instruction"] = req.update_instruction
+    if "warn_update_threshold" in req.model_fields_set:
+        patch["warn_update_threshold"] = req.warn_update_threshold
     # Nothing to change — don't touch the row (would falsify updated_by/_at).
     if not patch:
         return _build_response(norm)

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.auth import User, require_can
 from app.auth.deps import require_user
+from app.ingest import settings as ingest_settings
 from app.llm.agents import merge_conflict_update
 from app.models.file_system import (
     ActivityRowView,
@@ -58,6 +59,7 @@ from app.models.file_system import (
 from app.tasks.reindex import index_path
 from app.triggers import repo as triggers_repo
 from app.wiki import (
+    acl as _acl,
     agent_activity,
     diff as wiki_diff,
     drafts as wiki_drafts,
@@ -71,6 +73,7 @@ from app.wiki import (
     update_policy as update_policy_repo,
     utils as wiki_utils,
 )
+from app.models.update_policy import UpdateHealthResponse
 from app.models.wiki import ChangeKind, CommitMaxRetriesError
 
 router = APIRouter()
@@ -122,8 +125,6 @@ def list_documents(
 ) -> ListDocumentsResponse:
     raw = wiki_git.list_paths_with_mtime(prefix)
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
         md_paths = [p for p, _ in raw if p.endswith(".md")]
         visible = set(_acl.filter_paths_in_python(user.id, False, md_paths))
         # Keep non-md paths (folders, .gitkeep) so the explorer can render
@@ -147,8 +148,6 @@ def list_recent_pages(
     raw = wiki_git.paths_authored_by(user.email)
     md = [(p, ts) for p, ts in raw if p.endswith(".md")]
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
         visible = set(_acl.filter_paths_in_python(user.id, False, [p for p, _ in md]))
         md = [(p, ts) for p, ts in md if p in visible]
     # Newest first; empty timestamps sink to the bottom.
@@ -472,8 +471,6 @@ def list_recent_docs(user: User = Depends(require_user)) -> RecentDocsResponse:
     # revoke access after the fact, so re-filter on every read.
     paths = [p for p in paths if filesystem.absolute(p).is_file()]
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
         paths = _acl.filter_paths_in_python(user.id, False, paths)
     return RecentDocsResponse(paths=paths)
 
@@ -498,8 +495,6 @@ def list_starred_docs(user: User = Depends(require_user)) -> StarredDocsResponse
     # after the star must hide the entry.
     paths = [p for p in paths if filesystem.absolute(p).is_file()]
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
         paths = _acl.filter_paths_in_python(user.id, False, paths)
     return StarredDocsResponse(paths=paths)
 
@@ -600,9 +595,47 @@ def auto_update_count(
     require_can("read", rel, user)
     since = (datetime.now(timezone.utc) - timedelta(hours=hours)).isoformat()
     count = wiki_git.count_commits_since(
-        rel, author=wiki_utils.INGEST_AUTHOR_EMAIL, since_iso=since
+        rel, author=wiki_git.INGEST_AUTHOR_EMAIL, since_iso=since
     )
     return AutoUpdateCountResponse(path=rel, hours=hours, count=count)
+
+
+@router.get("/update-health", response_model=UpdateHealthResponse)
+def update_health(
+    user: User = Depends(require_user),
+    path: str = "",
+) -> UpdateHealthResponse:
+    """Auto-update health for a page: 24h ingestion-update count vs the page's
+    warning threshold and the admin cap, plus whether the viewer (owner/admin)
+    should see the too-frequent-update banner."""
+    try:
+        rel = update_policy_repo.normalize_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    require_can("read", rel, user)
+
+    since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
+    count = wiki_git.count_commits_since(
+        rel, author=wiki_git.INGEST_AUTHOR_EMAIL, since_iso=since
+    )
+    threshold = update_policy_repo.resolve_warn_threshold(rel)
+    cap = ingest_settings.get().auto_update_cap
+    auto_disabled = update_policy_repo.resolve_for_path(rel).ingestion_auto_update_disabled
+    over_threshold = threshold > 0 and count >= threshold
+
+    is_owner_or_admin = user.is_admin or _acl.get_owner(rel) == user.id
+    show_banner = (over_threshold or auto_disabled) and is_owner_or_admin
+
+    return UpdateHealthResponse(
+        path=rel,
+        hours=24,
+        count=count,
+        threshold=threshold,
+        cap=cap,
+        over_threshold=over_threshold,
+        auto_disabled=auto_disabled,
+        show_banner=show_banner,
+    )
 
 
 @router.get("/file/diff", response_model=FileDiffResponse)

--- a/backend/app/db/migrations/versions/0034_ingest_health_warn_threshold.py
+++ b/backend/app/db/migrations/versions/0034_ingest_health_warn_threshold.py
@@ -1,0 +1,59 @@
+"""ingest auto-update health knobs + per-page warn_update_threshold
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-06-24 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0034"
+down_revision: str | None = "0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Fresh installs get these from 0001's create_all — guard so this is a no-op.
+    policy_cols = {c["name"] for c in inspector.get_columns("update_policies")}
+    if "warn_update_threshold" not in policy_cols:
+        op.add_column(
+            "update_policies",
+            sa.Column("warn_update_threshold", sa.Integer(), nullable=True),
+        )
+
+    ingest_cols = {c["name"] for c in inspector.get_columns("ingest_settings")}
+    if "warn_update_threshold_default" not in ingest_cols:
+        op.add_column(
+            "ingest_settings",
+            sa.Column(
+                "warn_update_threshold_default",
+                sa.Integer(),
+                server_default=sa.text("10"),
+                nullable=False,
+            ),
+        )
+    if "auto_update_cap" not in ingest_cols:
+        op.add_column(
+            "ingest_settings",
+            sa.Column(
+                "auto_update_cap",
+                sa.Integer(),
+                server_default=sa.text("200"),
+                nullable=False,
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("ingest_settings", "auto_update_cap")
+    op.drop_column("ingest_settings", "warn_update_threshold_default")
+    op.drop_column("update_policies", "warn_update_threshold")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -736,6 +736,15 @@ class IngestSettings(Base):
     # origin used for Craft build-API calls, connect redirects, and
     # "Open Craft" deep links. Null = Craft launches unavailable.
     onyx_base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
+    # per-page warning threshold owners override via update_policies, and a hard
+    # cap above which a page's ingestion auto-update is turned off. 0 = off.
+    warn_update_threshold_default: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("10")
+    )
+    auto_update_cap: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("200")
+    )
     updated_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
@@ -1006,6 +1015,11 @@ class UpdatePolicy(Base):
     kind: Mapped[str] = mapped_column(Text, nullable=False)  # "page" | "folder"
     ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
     update_instruction: Mapped[str | None] = mapped_column(Text)
+    # Owner-set per-page warning threshold: notify the owner once a page is
+    # auto-updated more than this many times in 24h. ``NULL`` inherits the
+    # global default (``ingest_settings.warn_update_threshold_default``). Per-page
+    # only — not part of the most-granular-wins cascade above.
+    warn_update_threshold: Mapped[int | None] = mapped_column(Integer)
     updated_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -15,6 +15,10 @@ log = logging.getLogger(__name__)
 DEFAULT_MAX_DOC_CHARS = 100_000
 
 
+DEFAULT_WARN_UPDATE_THRESHOLD = 10
+DEFAULT_AUTO_UPDATE_CAP = 200
+
+
 class IngestSettings(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -23,14 +27,31 @@ class IngestSettings(BaseModel):
     # Outbound half of the "Onyx Connection" admin page — the public Onyx
     # origin for Craft launches. None = Craft unavailable.
     onyx_base_url: str | None
+    # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
+    # per-page warning threshold owners can override, and a hard cap above which
+    # a page's ingestion auto-update is turned off. 0 = off.
+    warn_update_threshold_default: int
+    auto_update_cap: int
 
 
 def get() -> IngestSettings:
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            return IngestSettings(max_doc_chars=DEFAULT_MAX_DOC_CHARS, api_key=None, onyx_base_url=None)
-        return IngestSettings(max_doc_chars=row.max_doc_chars, api_key=row.api_key, onyx_base_url=row.onyx_base_url)
+            return IngestSettings(
+                max_doc_chars=DEFAULT_MAX_DOC_CHARS,
+                api_key=None,
+                onyx_base_url=None,
+                warn_update_threshold_default=DEFAULT_WARN_UPDATE_THRESHOLD,
+                auto_update_cap=DEFAULT_AUTO_UPDATE_CAP,
+            )
+        return IngestSettings(
+            max_doc_chars=row.max_doc_chars,
+            api_key=row.api_key,
+            onyx_base_url=row.onyx_base_url,
+            warn_update_threshold_default=row.warn_update_threshold_default,
+            auto_update_cap=row.auto_update_cap,
+        )
 
 
 def get_onyx_base_url() -> str | None:
@@ -38,17 +59,35 @@ def get_onyx_base_url() -> str | None:
     return get().onyx_base_url
 
 
-def upsert(*, max_doc_chars: int, onyx_base_url: str | None) -> None:
+def upsert(
+    *,
+    max_doc_chars: int,
+    onyx_base_url: str | None,
+    warn_update_threshold_default: int | None = None,
+    auto_update_cap: int | None = None,
+) -> None:
+    """Upsert the connection fields, and the auto-update health knobs when
+    provided. The two health knobs are ``None`` => leave unchanged (a new row
+    falls back to the column defaults), so connection-only callers don't reset
+    them."""
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            s.add(IngestSettingsRow(id=1, max_doc_chars=max_doc_chars, onyx_base_url=onyx_base_url, updated_at=now))
-        else:
-            row.max_doc_chars = max_doc_chars
-            row.onyx_base_url = onyx_base_url
-            row.updated_at = now
-    log.info("ingest_settings upserted max_doc_chars=%d onyx_base_url_set=%s", max_doc_chars, bool(onyx_base_url))
+            row = IngestSettingsRow(id=1)
+            s.add(row)
+        row.max_doc_chars = max_doc_chars
+        row.onyx_base_url = onyx_base_url
+        if warn_update_threshold_default is not None:
+            row.warn_update_threshold_default = warn_update_threshold_default
+        if auto_update_cap is not None:
+            row.auto_update_cap = auto_update_cap
+        row.updated_at = now
+    log.info(
+        "ingest_settings upserted max_doc_chars=%d onyx_base_url_set=%s",
+        max_doc_chars,
+        bool(onyx_base_url),
+    )
 
 
 def regenerate_key() -> str:

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -62,6 +62,9 @@ class IngestConfigRequest(BaseModel):
     # Outbound Onyx origin for Craft launches. Omit to preserve the stored
     # value; an explicit empty string clears it.
     onyx_base_url: str | None = None
+    # Auto-update health knobs. 0 disables either.
+    warn_update_threshold_default: int = Field(ge=0)
+    auto_update_cap: int = Field(ge=0)
 
 
 class BraintrustConfigRequest(BaseModel):
@@ -172,6 +175,8 @@ class IngestView(BaseModel):
     api_key_set: bool
     api_key_hint: str
     onyx_base_url: str | None
+    warn_update_threshold_default: int
+    auto_update_cap: int
 
 
 class RegenerateKeyResponse(BaseModel):

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -20,6 +20,7 @@ class ExplicitPolicy(BaseModel):
     kind: Literal["page", "folder"]
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    warn_update_threshold: int | None = None
     updated_by_user_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
@@ -28,6 +29,20 @@ class ExplicitPolicy(BaseModel):
 class UpdatePolicyResponse(BaseModel):
     explicit: ExplicitPolicy | None = None
     effective: EffectivePolicy
+
+
+class UpdateHealthResponse(BaseModel):
+    """Auto-update health for a page — drives the in-page too-frequent-update
+    banner and surfaces the resolved threshold/cap to the owner."""
+
+    path: str
+    hours: int
+    count: int
+    threshold: int  # effective per-page warning threshold (0 = off)
+    cap: int  # admin global hard cap (0 = off)
+    over_threshold: bool
+    auto_disabled: bool  # ingestion auto-update currently off for this page
+    show_banner: bool  # the viewer (owner/admin) should see the banner
 
 
 class PatchUpdatePolicyRequest(BaseModel):
@@ -43,3 +58,4 @@ class PatchUpdatePolicyRequest(BaseModel):
     path: str
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    warn_update_threshold: int | None = None

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -38,6 +38,7 @@ _TASK_MODULES = (
     "app.tasks.periodic",
     "app.tasks.reindex",
     "app.tasks.triggers",
+    "app.tasks.update_frequency",
 )
 for _mod in _TASK_MODULES:
     importlib.import_module(_mod)

--- a/backend/app/tasks/update_frequency.py
+++ b/backend/app/tasks/update_frequency.py
@@ -1,0 +1,96 @@
+"""Too-frequent-update guardrails — warn owners (and cap) on ingestion churn.
+
+Part of "Taming Bad-Behaved Wikis" (see the wiki design page). After an
+ingestion auto-update commits a page, ``after_doc_write`` enqueues
+``check_update_frequency`` here. It counts the page's ingestion updates in the
+last 24h and, comparing against the page's warning threshold and the admin
+global cap:
+
+  - **>= cap (>0)** → turn off the page's ingestion auto-update (persisted in
+    ``update_policies``) and notify the owner it was auto-disabled.
+  - **>= threshold (>0)** → notify the owner the page is updating frequently.
+
+Owner-facing notifications dedup per page (one row until dismissed). Runs on
+``lightweight_maintenance_queue``: a git read + Postgres writes, no LLM and no
+wiki commit.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.db import notifications as notifications_repo
+from app.ingest import settings as ingest_settings
+from app.tasks.queues import lightweight_maintenance_queue
+from app.wiki import acl
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
+
+log = logging.getLogger(__name__)
+
+_WINDOW_HOURS = 24
+
+NOTIF_FREQUENT_UPDATES = "wiki.frequent_updates"
+NOTIF_AUTO_UPDATE_DISABLED = "wiki.auto_update_disabled"
+
+
+@lightweight_maintenance_queue.task()
+def check_update_frequency(path: str) -> None:
+    _check_update_frequency_inline(path)
+
+
+def _page_name(path: str) -> str:
+    base = path.rsplit("/", 1)[-1]
+    return base[:-3] if base.endswith(".md") else base
+
+
+def _check_update_frequency_inline(path: str) -> None:
+    if not path.endswith(".md"):
+        return
+
+    since = (datetime.now(timezone.utc) - timedelta(hours=_WINDOW_HOURS)).isoformat()
+    count = wiki_git.count_commits_since(
+        path, author=wiki_git.INGEST_AUTHOR_EMAIL, since_iso=since
+    )
+    if count == 0:
+        return
+
+    cap = ingest_settings.get().auto_update_cap
+    owner_id = acl.get_owner(path)
+    link = f"/app/wiki/{path}"
+    name = _page_name(path)
+
+    # Admin hard cap applies regardless of ownership — disable, then notify the
+    # owner if there is one.
+    if cap > 0 and count >= cap:
+        update_policy.set_policy(
+            path, ingestion_auto_update_disabled=True, actor_user_id=None
+        )
+        log.info("auto-update cap hit for %s (count=%d cap=%d) — disabled", path, count, cap)
+        if owner_id is not None:
+            notifications_repo.create(
+                user_id=owner_id,
+                notif_type=NOTIF_AUTO_UPDATE_DISABLED,
+                title="Auto-update turned off",
+                description=(
+                    f"“{name}” exceeded the org limit of {cap} "
+                    "auto-updates per day, so auto-update was turned off. "
+                    "You can turn it back on in the page's update policy."
+                ),
+                data={"path": path, "link": link},
+            )
+        return
+
+    threshold = update_policy.resolve_warn_threshold(path)
+    if owner_id is not None and threshold > 0 and count >= threshold:
+        notifications_repo.create(
+            user_id=owner_id,
+            notif_type=NOTIF_FREQUENT_UPDATES,
+            title="Page updating frequently",
+            description=(
+                f"“{name}” was auto-updated {count} times in the past "
+                "24 hours. You can adjust the threshold or turn off auto-update "
+                "in the page's update policy."
+            ),
+            data={"path": path, "link": link},
+        )

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -258,7 +258,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
     ``Onyx Ingest`` author for the run so its commits surface under that name in
     history instead of the generic fallback, then delegate to the reconciler.
     """
-    with wiki_utils.system_author(wiki_utils.INGEST_AUTHOR):
+    with wiki_utils.system_author(wiki_git.INGEST_AUTHOR):
         _reconcile_pushed_document(push)
 
 

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -27,6 +27,14 @@ log = logging.getLogger(__name__)
 
 _SHA_LINE_RE = re.compile(r"^[0-9a-f]{40}$")
 
+# Git identity for connector-pushed ingestion commits. Lives here (a leaf
+# module) rather than in ``app/wiki/utils.py`` so the ingest task can read it
+# without dragging in utils' heavy import chain. Bound on the ingest path via
+# ``utils.system_author(INGEST_AUTHOR)``; the email is what callers filter on
+# when counting ingestion commits (``count_commits_since``).
+INGEST_AUTHOR_EMAIL = "onyx-ingest@local"
+INGEST_AUTHOR = f"Onyx Ingest <{INGEST_AUTHOR_EMAIL}>"
+
 
 class CommitInfo(BaseModel):
     """One commit in a path's history (newest first)."""

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -35,8 +35,9 @@ from app.db import fts, page_dirs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
+from app.tasks.update_frequency import check_update_frequency
 from app.triggers import repo as triggers_repo
-from app.wiki import acl, agent_activity, comments, drafts, update_policy
+from app.wiki import acl, agent_activity, comments, drafts, git as wiki_git, update_policy
 from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind
 
@@ -87,6 +88,10 @@ def after_doc_write(
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
     index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
+    # Ingestion churn → check the page's 24h update frequency against the
+    # owner's threshold + the admin cap (enqueues a lightweight task).
+    if actor == wiki_git.INGEST_AUTHOR:
+        check_update_frequency(rel_path)
     # Drift any comments anchored to this page onto the new body. A no-op on
     # CREATE (no comments yet); the real work is on EDIT.
     _remap_comments_safe(rel_path)

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -22,6 +22,7 @@ from sqlalchemy import func, select, update
 
 from app.db.models import UpdatePolicy
 from app.db.session import session
+from app.ingest import settings as ingest_settings
 from app.wiki import filesystem
 
 log = logging.getLogger(__name__)
@@ -69,6 +70,7 @@ def _to_dict(row: UpdatePolicy) -> dict[str, Any]:
         "kind": row.kind,
         "ingestion_auto_update_disabled": row.ingestion_auto_update_disabled,
         "update_instruction": row.update_instruction,
+        "warn_update_threshold": row.warn_update_threshold,
         "updated_by_user_id": row.updated_by_user_id,
         "created_at": row.created_at,
         "updated_at": row.updated_at,
@@ -82,18 +84,34 @@ def get(path: str) -> dict[str, Any] | None:
         return _to_dict(row) if row is not None else None
 
 
+def resolve_warn_threshold(path: str) -> int:
+    """Effective too-frequent-update warning threshold for ``path``.
+
+    The page's own ``warn_update_threshold`` if set, else the wiki-wide default
+    (``ingest_settings.warn_update_threshold_default``). Per-page only — unlike
+    the two cascaded fields, this does not walk ancestor folders. ``0`` means
+    warnings are off for the page.
+    """
+    with session() as s:
+        row = s.get(UpdatePolicy, normalize_path(path))
+        if row is not None and row.warn_update_threshold is not None:
+            return row.warn_update_threshold
+    return ingest_settings.get().warn_update_threshold_default
+
+
 def set_policy(
     path: str,
     *,
     ingestion_auto_update_disabled: bool | None | _UnsetType = _UNSET,
     update_instruction: str | None | _UnsetType = _UNSET,
+    warn_update_threshold: int | None | _UnsetType = _UNSET,
     actor_user_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Upsert the policy for ``path`` with patch semantics.
 
     Only fields passed (not ``_UNSET``) are changed. An empty-string
     ``update_instruction`` clears it. When the row ends up carrying no setting
-    (both fields NULL/empty) it is deleted and ``None`` is returned.
+    (every field NULL/empty) it is deleted and ``None`` is returned.
     """
     norm = normalize_path(path)
     with session() as s:
@@ -106,8 +124,14 @@ def set_policy(
             row.ingestion_auto_update_disabled = ingestion_auto_update_disabled
         if not isinstance(update_instruction, _UnsetType):
             row.update_instruction = update_instruction or None
+        if not isinstance(warn_update_threshold, _UnsetType):
+            row.warn_update_threshold = warn_update_threshold
 
-        if row.ingestion_auto_update_disabled is None and not row.update_instruction:
+        if (
+            row.ingestion_auto_update_disabled is None
+            and not row.update_instruction
+            and row.warn_update_threshold is None
+        ):
             if existed:
                 s.delete(row)
             return None

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -99,13 +99,6 @@ def assert_base_sha(path: str, base_sha: str | None) -> dict[str, str] | None:
 
 _FALLBACK_AUTHOR = "AI Wiki Helper <ai-wiki-helper@local>"
 
-# Git identity for connector-pushed ingestion commits — these have no human
-# user, so without this they'd fall back to ``_FALLBACK_AUTHOR``. Bound via
-# ``system_author(INGEST_AUTHOR)`` on the ingest path; the email is what
-# callers filter on when counting ingestion commits (see git.count_commits_since).
-INGEST_AUTHOR_EMAIL = "onyx-ingest@local"
-INGEST_AUTHOR = f"Onyx Ingest <{INGEST_AUTHOR_EMAIL}>"
-
 # Explicit git author for system-initiated commits that legitimately have no
 # user in context (document ingestion from a connector, etc.). Bound by the
 # ``system_author`` context manager; consulted by ``author_string`` before it

--- a/backend/tests/test_auto_update_count_api.py
+++ b/backend/tests/test_auto_update_count_api.py
@@ -11,7 +11,6 @@ from fastapi.testclient import TestClient
 from app.auth import users as users_repo
 from app.main import create_app
 from app.wiki import git as wiki_git
-from app.wiki import utils as wiki_utils
 from tests._auth import login_fastapi
 
 HUMAN_AUTHOR = "Nik <nik@x.com>"
@@ -25,7 +24,7 @@ def client(tmp_db: None, tmp_repo: None) -> TestClient:
 def _seed(client: TestClient) -> None:
     uid = users_repo.create(email="nik@x.com", password="hunter2-x", name="Nik")
     login_fastapi(client, uid)
-    ingest = wiki_utils.INGEST_AUTHOR
+    ingest = wiki_git.INGEST_AUTHOR
     # team/a.md: two ingest updates + one human edit (human must not count).
     wiki_git.commit_file("team/a.md", "a1\n", "ingest", author=ingest)
     wiki_git.commit_file("team/a.md", "a2\n", "ingest", author=ingest)
@@ -68,7 +67,7 @@ def test_author_match_is_anchored_not_substring(client: TestClient) -> None:
     wiki_git.commit_file(
         "team/a.md", "x\n", "edit", author="Imposter <onyx-ingest@localhost>"
     )
-    wiki_git.commit_file("team/a.md", "y\n", "ingest", author=wiki_utils.INGEST_AUTHOR)
+    wiki_git.commit_file("team/a.md", "y\n", "ingest", author=wiki_git.INGEST_AUTHOR)
     body = client.get("/api/wiki/auto-update-count?path=team/a.md").json()
     assert body["count"] == 1
 
@@ -79,7 +78,7 @@ def test_window_excludes_commits_before_since(client: TestClient) -> None:
     future = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
     assert (
         wiki_git.count_commits_since(
-            "team/a.md", author=wiki_utils.INGEST_AUTHOR_EMAIL, since_iso=future
+            "team/a.md", author=wiki_git.INGEST_AUTHOR_EMAIL, since_iso=future
         )
         == 0
     )

--- a/backend/tests/test_update_frequency.py
+++ b/backend/tests/test_update_frequency.py
@@ -1,0 +1,84 @@
+"""Tests for the too-frequent-update guardrails (app/tasks/update_frequency.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.auth import users as users_repo
+from app.db import notifications as notifications_repo
+from app.ingest import settings as ingest_settings
+from app.tasks.update_frequency import (
+    NOTIF_AUTO_UPDATE_DISABLED,
+    NOTIF_FREQUENT_UPDATES,
+    _check_update_frequency_inline,
+)
+from app.wiki import acl
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
+
+PATH = "team/page.md"
+
+
+@pytest.fixture(autouse=True)
+def _db(tmp_db: None, tmp_repo: None) -> None:
+    return None
+
+
+def _owned_page(*, commits: int) -> str:
+    uid = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    acl.set_owner(PATH, uid)
+    for i in range(commits):
+        wiki_git.commit_file(PATH, f"body {i}\n", "ingest", author=wiki_git.INGEST_AUTHOR)
+    return uid
+
+
+def _counts(uid: str, notif_type: str) -> int:
+    rows = notifications_repo.list_for_user(uid)["notifications"]
+    return sum(1 for r in rows if r["notif_type"] == notif_type)
+
+
+def test_below_threshold_no_notification() -> None:
+    uid = _owned_page(commits=2)
+    update_policy.set_policy(PATH, warn_update_threshold=5)
+    _check_update_frequency_inline(PATH)
+    assert _counts(uid, NOTIF_FREQUENT_UPDATES) == 0
+
+
+def test_warns_owner_over_threshold() -> None:
+    uid = _owned_page(commits=3)
+    update_policy.set_policy(PATH, warn_update_threshold=2)
+    _check_update_frequency_inline(PATH)
+    assert _counts(uid, NOTIF_FREQUENT_UPDATES) == 1
+
+
+def test_unowned_page_no_notification_no_error() -> None:
+    # No owner stamped — must not raise and must not notify anyone.
+    for i in range(3):
+        wiki_git.commit_file(PATH, f"b{i}\n", "ingest", author=wiki_git.INGEST_AUTHOR)
+    update_policy.set_policy(PATH, warn_update_threshold=1)
+    _check_update_frequency_inline(PATH)  # no exception
+    assert acl.get_owner(PATH) is None
+
+
+def test_cap_disables_and_notifies() -> None:
+    uid = _owned_page(commits=2)
+    ingest_settings.upsert(
+        max_doc_chars=ingest_settings.DEFAULT_MAX_DOC_CHARS,
+        onyx_base_url=None,
+        warn_update_threshold_default=10,
+        auto_update_cap=2,
+    )
+    _check_update_frequency_inline(PATH)
+    assert update_policy.resolve_for_path(PATH).ingestion_auto_update_disabled is True
+    assert _counts(uid, NOTIF_AUTO_UPDATE_DISABLED) == 1
+    # The warning notification is not also sent when the cap fires.
+    assert _counts(uid, NOTIF_FREQUENT_UPDATES) == 0
+
+
+def test_warning_dedups_until_dismissed() -> None:
+    uid = _owned_page(commits=3)
+    update_policy.set_policy(PATH, warn_update_threshold=2)
+    _check_update_frequency_inline(PATH)
+    _check_update_frequency_inline(PATH)
+    listing = notifications_repo.list_for_user(uid)
+    assert listing["undismissed_count"] == 1

--- a/backend/tests/test_update_health_api.py
+++ b/backend/tests/test_update_health_api.py
@@ -1,0 +1,86 @@
+"""Tests for GET /api/wiki/update-health and the auto-update health knobs on
+the admin ingest settings endpoint."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.ingest import settings as ingest_settings
+from app.main import create_app
+from app.wiki import acl
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
+from tests._auth import login_fastapi
+
+PATH = "team/page.md"
+
+
+@pytest.fixture
+def client(tmp_db: None, tmp_repo: None) -> TestClient:
+    return TestClient(create_app())
+
+
+def test_update_health_unauthenticated_is_401(client: TestClient) -> None:
+    assert client.get(f"/api/wiki/update-health?path={PATH}").status_code == 401
+
+
+def test_update_health_flags_owner_banner_over_threshold(client: TestClient) -> None:
+    uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    login_fastapi(client, uid)
+    acl.set_owner(PATH, uid)
+    for i in range(3):
+        wiki_git.commit_file(PATH, f"b{i}\n", "ingest", author=wiki_git.INGEST_AUTHOR)
+    update_policy.set_policy(PATH, warn_update_threshold=2)
+
+    body = client.get(f"/api/wiki/update-health?path={PATH}").json()
+    assert body["count"] == 3
+    assert body["threshold"] == 2
+    assert body["over_threshold"] is True
+    assert body["show_banner"] is True
+
+
+def test_update_health_non_owner_no_banner(client: TestClient) -> None:
+    owner = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    viewer = users_repo.create(email="v@x.com", password="hunter2-x", name="V")
+    acl.set_owner(PATH, owner)
+    # Owner-stamped pages are private; let everyone read so a non-owner viewer
+    # can load the page (and confirm they still get no banner).
+    acl.grant(
+        resource_kind="page",
+        resource_path=PATH,
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
+        granted_by_user_id=owner,
+    )
+    for i in range(3):
+        wiki_git.commit_file(PATH, f"b{i}\n", "ingest", author=wiki_git.INGEST_AUTHOR)
+    update_policy.set_policy(PATH, warn_update_threshold=2)
+
+    login_fastapi(client, viewer)
+    body = client.get(f"/api/wiki/update-health?path={PATH}").json()
+    assert body["over_threshold"] is True
+    assert body["show_banner"] is False  # not the owner / admin
+
+
+def test_admin_ingest_health_knobs_get_put(client: TestClient) -> None:
+    admin = users_repo.create(email="admin@x.com", password="hunter2-x", name="A")
+    login_fastapi(client, admin)  # first user is auto-admin
+
+    got = client.get("/api/admin/ingest").json()
+    assert got["warn_update_threshold_default"] == 10
+    assert got["auto_update_cap"] == 200
+
+    put = client.put(
+        "/api/admin/ingest",
+        json={
+            "max_doc_chars": 100000,
+            "warn_update_threshold_default": 5,
+            "auto_update_cap": 25,
+        },
+    )
+    assert put.status_code == 200
+    assert put.json()["auto_update_cap"] == 25
+    assert ingest_settings.get().warn_update_threshold_default == 5


### PR DESCRIPTION
**Step 2 (phase 1) of Taming Bad-Behaved Wikis — backend half.** (Frontend lands in a stacked follow-up PR.) Replaces the combined #286.

## What

When ingestion churns a page, warn the **owner** and let admins cap it:
- **≥ per-page threshold** → activity notification (bell).
- **≥ admin global cap** → turn the page's ingestion auto-update **off** (persisted) and notify the owner.

Owners set their **own per-page threshold**; admins set the **default + cap** on the existing **Onyx Integration** settings (consolidated onto `IngestSettings` rather than a new table). **Email is deferred**; the detection event is the seam it'll reuse.

## How

- Detection off `after_doc_write` (gated on the `Onyx Ingest` author) → `check_update_frequency` on `lightweight_maintenance_queue` (git read + Postgres writes, no LLM/commit). Reuses `count_commits_since` and the existing `notifications` repo (dedup ⇒ one warning per page until dismissed). Owner via `acl.get_owner`; unowned pages skip the notification but the cap still disables.

## Changes

- `update_policies.warn_update_threshold` (per-page, owner-set) threaded through repo/model/PATCH; `resolve_warn_threshold` falls back to the global default.
- `IngestSettings.warn_update_threshold_default` + `auto_update_cap`, surfaced on `GET/PUT /admin/ingest`.
- `app/tasks/update_frequency.py`; `GET /api/wiki/update-health` (drives the banner in the frontend PR).
- Migration `0034` (column adds, fresh-install guarded).

## Testing

- New: detection task (threshold / cap / unowned / dedup), `update-health` + ingest health-knob endpoints.
- Full backend suite green; `ruff`, `basedpyright` clean.

Design: `Taming Bad-Behaved Wikis` wiki page.