### PR TITLE
feat(wiki): per-page warn threshold + ingest health knobs (DB + read/write) [1/3]

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -423,6 +423,8 @@ def _ingest_view(s: IngestSettings) -> IngestView:
         api_key_set=bool(s.api_key),
         api_key_hint=_redact(s.api_key or ""),
         onyx_base_url=s.onyx_base_url,
+        warn_update_threshold_default=s.warn_update_threshold_default,
+        auto_update_cap=s.auto_update_cap,
     )
 
 
@@ -452,12 +454,20 @@ def put_ingest(
                 validate_onyx_base_url(onyx_base_url)
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
-    ingest_settings.upsert(max_doc_chars=req.max_doc_chars, onyx_base_url=onyx_base_url)
+    ingest_settings.upsert(
+        max_doc_chars=req.max_doc_chars,
+        onyx_base_url=onyx_base_url,
+        warn_update_threshold_default=req.warn_update_threshold_default,
+        auto_update_cap=req.auto_update_cap,
+    )
     log.info(
-        "admin: %s updated ingest settings max_doc_chars=%d onyx_base_url_set=%s",
+        "admin: %s updated ingest settings max_doc_chars=%d onyx_base_url_set=%s "
+        "warn_default=%s auto_update_cap=%s",
         actor.id,
         req.max_doc_chars,
         bool(onyx_base_url),
+        req.warn_update_threshold_default,
+        req.auto_update_cap,
     )
     return _ingest_view(ingest_settings.get())
 

--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -68,6 +68,8 @@ def patch_update_policy(
         patch["ingestion_auto_update_disabled"] = req.ingestion_auto_update_disabled
     if "update_instruction" in req.model_fields_set:
         patch["update_instruction"] = req.update_instruction
+    if "warn_update_threshold" in req.model_fields_set:
+        patch["warn_update_threshold"] = req.warn_update_threshold
     # Nothing to change — don't touch the row (would falsify updated_by/_at).
     if not patch:
         return _build_response(norm)

--- a/backend/app/db/migrations/versions/0034_ingest_health_warn_threshold.py
+++ b/backend/app/db/migrations/versions/0034_ingest_health_warn_threshold.py
@@ -1,0 +1,59 @@
+"""ingest auto-update health knobs + per-page warn_update_threshold
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-06-24 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0034"
+down_revision: str | None = "0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Fresh installs get these from 0001's create_all — guard so this is a no-op.
+    policy_cols = {c["name"] for c in inspector.get_columns("update_policies")}
+    if "warn_update_threshold" not in policy_cols:
+        op.add_column(
+            "update_policies",
+            sa.Column("warn_update_threshold", sa.Integer(), nullable=True),
+        )
+
+    ingest_cols = {c["name"] for c in inspector.get_columns("ingest_settings")}
+    if "warn_update_threshold_default" not in ingest_cols:
+        op.add_column(
+            "ingest_settings",
+            sa.Column(
+                "warn_update_threshold_default",
+                sa.Integer(),
+                server_default=sa.text("10"),
+                nullable=False,
+            ),
+        )
+    if "auto_update_cap" not in ingest_cols:
+        op.add_column(
+            "ingest_settings",
+            sa.Column(
+                "auto_update_cap",
+                sa.Integer(),
+                server_default=sa.text("200"),
+                nullable=False,
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("ingest_settings", "auto_update_cap")
+    op.drop_column("ingest_settings", "warn_update_threshold_default")
+    op.drop_column("update_policies", "warn_update_threshold")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -736,6 +736,15 @@ class IngestSettings(Base):
     # origin used for Craft build-API calls, connect redirects, and
     # "Open Craft" deep links. Null = Craft launches unavailable.
     onyx_base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
+    # per-page warning threshold owners override via update_policies, and a hard
+    # cap above which a page's ingestion auto-update is turned off. 0 = off.
+    warn_update_threshold_default: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("10")
+    )
+    auto_update_cap: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("200")
+    )
     updated_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
@@ -1006,6 +1015,11 @@ class UpdatePolicy(Base):
     kind: Mapped[str] = mapped_column(Text, nullable=False)  # "page" | "folder"
     ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
     update_instruction: Mapped[str | None] = mapped_column(Text)
+    # Owner-set per-page warning threshold: notify the owner once a page is
+    # auto-updated more than this many times in 24h. ``NULL`` inherits the
+    # global default (``ingest_settings.warn_update_threshold_default``). Per-page
+    # only — not part of the most-granular-wins cascade above.
+    warn_update_threshold: Mapped[int | None] = mapped_column(Integer)
     updated_by_user_id: Mapped[str | None] = mapped_column(
         Text, ForeignKey("users.id", ondelete="SET NULL")
     )

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -15,6 +15,10 @@ log = logging.getLogger(__name__)
 DEFAULT_MAX_DOC_CHARS = 100_000
 
 
+DEFAULT_WARN_UPDATE_THRESHOLD = 10
+DEFAULT_AUTO_UPDATE_CAP = 200
+
+
 class IngestSettings(BaseModel):
     model_config = ConfigDict(frozen=True)
 
@@ -23,14 +27,31 @@ class IngestSettings(BaseModel):
     # Outbound half of the "Onyx Connection" admin page — the public Onyx
     # origin for Craft launches. None = Craft unavailable.
     onyx_base_url: str | None
+    # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
+    # per-page warning threshold owners can override, and a hard cap above which
+    # a page's ingestion auto-update is turned off. 0 = off.
+    warn_update_threshold_default: int
+    auto_update_cap: int
 
 
 def get() -> IngestSettings:
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            return IngestSettings(max_doc_chars=DEFAULT_MAX_DOC_CHARS, api_key=None, onyx_base_url=None)
-        return IngestSettings(max_doc_chars=row.max_doc_chars, api_key=row.api_key, onyx_base_url=row.onyx_base_url)
+            return IngestSettings(
+                max_doc_chars=DEFAULT_MAX_DOC_CHARS,
+                api_key=None,
+                onyx_base_url=None,
+                warn_update_threshold_default=DEFAULT_WARN_UPDATE_THRESHOLD,
+                auto_update_cap=DEFAULT_AUTO_UPDATE_CAP,
+            )
+        return IngestSettings(
+            max_doc_chars=row.max_doc_chars,
+            api_key=row.api_key,
+            onyx_base_url=row.onyx_base_url,
+            warn_update_threshold_default=row.warn_update_threshold_default,
+            auto_update_cap=row.auto_update_cap,
+        )
 
 
 def get_onyx_base_url() -> str | None:
@@ -38,17 +59,35 @@ def get_onyx_base_url() -> str | None:
     return get().onyx_base_url
 
 
-def upsert(*, max_doc_chars: int, onyx_base_url: str | None) -> None:
+def upsert(
+    *,
+    max_doc_chars: int,
+    onyx_base_url: str | None,
+    warn_update_threshold_default: int | None = None,
+    auto_update_cap: int | None = None,
+) -> None:
+    """Upsert the connection fields, and the auto-update health knobs when
+    provided. The two health knobs are ``None`` => leave unchanged (a new row
+    falls back to the column defaults), so connection-only callers don't reset
+    them."""
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            s.add(IngestSettingsRow(id=1, max_doc_chars=max_doc_chars, onyx_base_url=onyx_base_url, updated_at=now))
-        else:
-            row.max_doc_chars = max_doc_chars
-            row.onyx_base_url = onyx_base_url
-            row.updated_at = now
-    log.info("ingest_settings upserted max_doc_chars=%d onyx_base_url_set=%s", max_doc_chars, bool(onyx_base_url))
+            row = IngestSettingsRow(id=1)
+            s.add(row)
+        row.max_doc_chars = max_doc_chars
+        row.onyx_base_url = onyx_base_url
+        if warn_update_threshold_default is not None:
+            row.warn_update_threshold_default = warn_update_threshold_default
+        if auto_update_cap is not None:
+            row.auto_update_cap = auto_update_cap
+        row.updated_at = now
+    log.info(
+        "ingest_settings upserted max_doc_chars=%d onyx_base_url_set=%s",
+        max_doc_chars,
+        bool(onyx_base_url),
+    )
 
 
 def regenerate_key() -> str:

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -62,6 +62,10 @@ class IngestConfigRequest(BaseModel):
     # Outbound Onyx origin for Craft launches. Omit to preserve the stored
     # value; an explicit empty string clears it.
     onyx_base_url: str | None = None
+    # Auto-update health knobs. Omit to preserve the stored value (like
+    # onyx_base_url); 0 disables either.
+    warn_update_threshold_default: int | None = Field(default=None, ge=0)
+    auto_update_cap: int | None = Field(default=None, ge=0)
 
 
 class BraintrustConfigRequest(BaseModel):
@@ -172,6 +176,8 @@ class IngestView(BaseModel):
     api_key_set: bool
     api_key_hint: str
     onyx_base_url: str | None
+    warn_update_threshold_default: int
+    auto_update_cap: int
 
 
 class RegenerateKeyResponse(BaseModel):

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class EffectivePolicy(BaseModel):
@@ -20,6 +20,7 @@ class ExplicitPolicy(BaseModel):
     kind: Literal["page", "folder"]
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    warn_update_threshold: int | None = None
     updated_by_user_id: str | None = None
     created_at: str | None = None
     updated_at: str | None = None
@@ -43,3 +44,4 @@ class PatchUpdatePolicyRequest(BaseModel):
     path: str
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    warn_update_threshold: int | None = Field(default=None, ge=0)

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -69,6 +69,7 @@ def _to_dict(row: UpdatePolicy) -> dict[str, Any]:
         "kind": row.kind,
         "ingestion_auto_update_disabled": row.ingestion_auto_update_disabled,
         "update_instruction": row.update_instruction,
+        "warn_update_threshold": row.warn_update_threshold,
         "updated_by_user_id": row.updated_by_user_id,
         "created_at": row.created_at,
         "updated_at": row.updated_at,
@@ -87,13 +88,14 @@ def set_policy(
     *,
     ingestion_auto_update_disabled: bool | None | _UnsetType = _UNSET,
     update_instruction: str | None | _UnsetType = _UNSET,
+    warn_update_threshold: int | None | _UnsetType = _UNSET,
     actor_user_id: str | None = None,
 ) -> dict[str, Any] | None:
     """Upsert the policy for ``path`` with patch semantics.
 
     Only fields passed (not ``_UNSET``) are changed. An empty-string
     ``update_instruction`` clears it. When the row ends up carrying no setting
-    (both fields NULL/empty) it is deleted and ``None`` is returned.
+    (every field NULL/empty) it is deleted and ``None`` is returned.
     """
     norm = normalize_path(path)
     with session() as s:
@@ -106,8 +108,14 @@ def set_policy(
             row.ingestion_auto_update_disabled = ingestion_auto_update_disabled
         if not isinstance(update_instruction, _UnsetType):
             row.update_instruction = update_instruction or None
+        if not isinstance(warn_update_threshold, _UnsetType):
+            row.warn_update_threshold = warn_update_threshold
 
-        if row.ingestion_auto_update_disabled is None and not row.update_instruction:
+        if (
+            row.ingestion_auto_update_disabled is None
+            and not row.update_instruction
+            and row.warn_update_threshold is None
+        ):
             if existed:
                 s.delete(row)
             return None

--- a/backend/tests/integration/test_update_policy_api.py
+++ b/backend/tests/integration/test_update_policy_api.py
@@ -43,6 +43,25 @@ def test_patch_get_delete_roundtrip(integration):
     assert body["effective"]["ingestion_auto_update_disabled"] is False
 
 
+def test_patch_warn_threshold_set_and_rejects_negative(integration):
+    integration.signup(email="admin@x.com")
+    integration.put_doc("guide.md", "# Guide")
+
+    ok = integration.client.patch(
+        "/api/update-policy",
+        json={"path": "guide.md", "warn_update_threshold": 25},
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["explicit"]["warn_update_threshold"] == 25
+
+    # Negative threshold is rejected by the ge=0 constraint.
+    bad = integration.client.patch(
+        "/api/update-policy",
+        json={"path": "guide.md", "warn_update_threshold": -1},
+    )
+    assert bad.status_code in (400, 422), bad.text
+
+
 def test_patch_one_field_preserves_the_other(integration):
     integration.signup(email="admin@x.com")
     integration.put_doc("guide.md", "# Guide")

--- a/backend/tests/test_ingest_health_settings.py
+++ b/backend/tests/test_ingest_health_settings.py
@@ -1,0 +1,50 @@
+"""Tests for the auto-update health knobs on the admin ingest settings endpoint
+(GET/PUT /api/admin/ingest)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.ingest import settings as ingest_settings
+from app.main import create_app
+from tests._auth import login_fastapi
+
+
+@pytest.fixture
+def client(tmp_db: None, tmp_repo: None) -> TestClient:
+    return TestClient(create_app())
+
+
+def test_defaults_exposed(client: TestClient) -> None:
+    admin = users_repo.create(email="admin@x.com", password="hunter2-x", name="A")
+    login_fastapi(client, admin)  # first user is auto-admin
+    got = client.get("/api/admin/ingest").json()
+    assert got["warn_update_threshold_default"] == 10
+    assert got["auto_update_cap"] == 200
+
+
+def test_put_round_trips_health_knobs(client: TestClient) -> None:
+    admin = users_repo.create(email="admin@x.com", password="hunter2-x", name="A")
+    login_fastapi(client, admin)
+    put = client.put(
+        "/api/admin/ingest",
+        json={
+            "max_doc_chars": 100000,
+            "warn_update_threshold_default": 5,
+            "auto_update_cap": 25,
+        },
+    )
+    assert put.status_code == 200
+    assert put.json()["warn_update_threshold_default"] == 5
+    assert put.json()["auto_update_cap"] == 25
+    # Persisted.
+    assert ingest_settings.get().auto_update_cap == 25
+
+
+def test_requires_admin(client: TestClient) -> None:
+    users_repo.create(email="admin@x.com", password="hunter2-x", name="A")  # admin #1
+    member = users_repo.create(email="m@x.com", password="hunter2-x", name="M")
+    login_fastapi(client, member)
+    assert client.get("/api/admin/ingest").status_code == 403

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -55,6 +55,25 @@ def test_instruction_closest_scope_wins(tmp_db):
     assert update_policy.resolve_for_path("a/other.md").update_instruction == "folder rule"
 
 
+def test_warn_update_threshold_round_trips(tmp_db):
+    update_policy.set_policy("a/page.md", warn_update_threshold=25)
+    row = update_policy.get("a/page.md")
+    assert row is not None and row["warn_update_threshold"] == 25
+    # Independent of the other fields — setting the disable later keeps it.
+    update_policy.set_policy("a/page.md", ingestion_auto_update_disabled=True)
+    row = update_policy.get("a/page.md")
+    assert row is not None
+    assert row["warn_update_threshold"] == 25
+    assert row["ingestion_auto_update_disabled"] is True
+
+
+def test_warn_update_threshold_clearing_can_delete_row(tmp_db):
+    update_policy.set_policy("a/page.md", warn_update_threshold=5)
+    # Clearing the only field set on the row deletes it entirely.
+    assert update_policy.set_policy("a/page.md", warn_update_threshold=None) is None
+    assert update_policy.get("a/page.md") is None
+
+
 def test_disabled_paths_batch(tmp_db):
     update_policy.set_policy("a", ingestion_auto_update_disabled=True)  # folder off
     update_policy.set_policy("a/on.md", ingestion_auto_update_disabled=False)  # re-enabled


### PR DESCRIPTION
**PR 1 of 3** — too-frequent-update guardrails ("Taming Bad-Behaved Wikis", step 2). This is the **schema + field read/write only**; no detection, endpoint, or UI (those follow in PR 2 = UI, PR 3 = the warning logic). Replaces the combined #287.

## What

- `update_policies.warn_update_threshold` — owner-set per-page warning threshold; threaded through `update_policy.set_policy`/`_to_dict`, the PATCH model, and `PATCH /api/update-policy`. `NULL` = inherit the global default; `0` = warnings off for the page.
- `IngestSettings.warn_update_threshold_default` (default **10**) + `auto_update_cap` (default **200**) — admin-managed global knobs, read/written via `GET/PUT /admin/ingest` (consolidated onto the existing ingest settings, not a new table).
- Migration `0034` — column adds, guarded so fresh installs (which get them from `create_all`) are a no-op.

## Not in this PR (follow-ups)
- **PR 2 (UI):** per-page threshold editor + admin inputs.
- **PR 3 (the rest):** detection task, `after_doc_write` hook, `resolve_warn_threshold`, `GET /api/wiki/update-health`, owner notification + in-page banner.

## Testing
- `warn_update_threshold` round-trips and clearing it deletes an otherwise-empty row.
- Admin ingest health-knob GET/PUT + admin-only gating.
- ruff, basedpyright, tests green.

Design: `Taming Bad-Behaved Wikis` wiki page.