### PR TITLE
feat(agent-wiki): add AWS Bedrock provider

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -229,6 +229,8 @@ def _llm_view(s: LLMSettings) -> LLMView:
         bedrock_aws_secret_access_key_set=bool(s.bedrock_aws_secret_access_key),
         bedrock_aws_secret_access_key_hint=_redact(s.bedrock_aws_secret_access_key),
         bedrock_aws_session_token_set=bool(s.bedrock_aws_session_token),
+        bedrock_aws_bearer_token_set=bool(s.bedrock_aws_bearer_token),
+        bedrock_aws_bearer_token_hint=_redact(s.bedrock_aws_bearer_token),
         provider_models=s.provider_models,
         ingest_selector_model=s.ingest_selector_model,
     )
@@ -341,6 +343,11 @@ def put_llm(
         req.bedrock_aws_session_token,
         current.bedrock_aws_session_token,
     )
+    bedrock_bearer_token = _resolve_secret(
+        "bedrock_aws_bearer_token",
+        req.bedrock_aws_bearer_token,
+        current.bedrock_aws_bearer_token,
+    )
 
     new_provider_models = req.provider_models if "provider_models" in sent_fields else None
 
@@ -364,6 +371,7 @@ def put_llm(
         bedrock_aws_access_key_id=bedrock_access_key_id,
         bedrock_aws_secret_access_key=bedrock_secret_access_key,
         bedrock_aws_session_token=bedrock_session_token,
+        bedrock_aws_bearer_token=bedrock_bearer_token,
         provider_models=new_provider_models,
         ingest_selector_model=ingest_selector_model,
     )

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -222,6 +222,13 @@ def _llm_view(s: LLMSettings) -> LLMView:
         custom_api_key_hint=_redact(s.custom_api_key),
         custom_base_url=s.custom_base_url,
         custom_display_name=s.custom_display_name,
+        bedrock_aws_region=s.bedrock_aws_region,
+        bedrock_endpoint_url=s.bedrock_endpoint_url,
+        bedrock_aws_access_key_id_set=bool(s.bedrock_aws_access_key_id),
+        bedrock_aws_access_key_id_hint=_redact(s.bedrock_aws_access_key_id),
+        bedrock_aws_secret_access_key_set=bool(s.bedrock_aws_secret_access_key),
+        bedrock_aws_secret_access_key_hint=_redact(s.bedrock_aws_secret_access_key),
+        bedrock_aws_session_token_set=bool(s.bedrock_aws_session_token),
         provider_models=s.provider_models,
         ingest_selector_model=s.ingest_selector_model,
     )
@@ -240,6 +247,16 @@ def _normalize_custom_base_url(raw: str) -> str:
                 status_code=400,
                 detail="custom_base_url should be the API base (e.g. https://host/v1) — requests append /chat/completions automatically",
             )
+    return url
+
+
+def _normalize_bedrock_endpoint(raw: str) -> str:
+    url = raw.strip().rstrip("/")
+    if url and not url.startswith(("http://", "https://")):
+        raise HTTPException(
+            status_code=400,
+            detail="bedrock_endpoint_url must start with http:// or https://",
+        )
     return url
 
 
@@ -299,6 +316,32 @@ def put_llm(
     else:
         custom_display_name = current.custom_display_name
 
+    # Region + endpoint aren't secrets, but they follow the same blank=keep /
+    # null=clear convention as the other URL fields (ollama/custom_base_url).
+    bedrock_aws_region = _resolve_secret(
+        "bedrock_aws_region", req.bedrock_aws_region, current.bedrock_aws_region
+    ).strip()
+    bedrock_endpoint_url = _normalize_bedrock_endpoint(
+        _resolve_secret(
+            "bedrock_endpoint_url", req.bedrock_endpoint_url, current.bedrock_endpoint_url
+        )
+    )
+    bedrock_access_key_id = _resolve_secret(
+        "bedrock_aws_access_key_id",
+        req.bedrock_aws_access_key_id,
+        current.bedrock_aws_access_key_id,
+    )
+    bedrock_secret_access_key = _resolve_secret(
+        "bedrock_aws_secret_access_key",
+        req.bedrock_aws_secret_access_key,
+        current.bedrock_aws_secret_access_key,
+    )
+    bedrock_session_token = _resolve_secret(
+        "bedrock_aws_session_token",
+        req.bedrock_aws_session_token,
+        current.bedrock_aws_session_token,
+    )
+
     new_provider_models = req.provider_models if "provider_models" in sent_fields else None
 
     if "ingest_selector_model" in sent_fields:
@@ -316,6 +359,11 @@ def put_llm(
         custom_api_key=custom_api_key,
         custom_base_url=custom_base_url,
         custom_display_name=custom_display_name,
+        bedrock_aws_region=bedrock_aws_region,
+        bedrock_endpoint_url=bedrock_endpoint_url,
+        bedrock_aws_access_key_id=bedrock_access_key_id,
+        bedrock_aws_secret_access_key=bedrock_secret_access_key,
+        bedrock_aws_session_token=bedrock_session_token,
         provider_models=new_provider_models,
         ingest_selector_model=ingest_selector_model,
     )

--- a/backend/app/api/llm.py
+++ b/backend/app/api/llm.py
@@ -32,6 +32,7 @@ _PROVIDER_LABELS = {
     "openai": ("OpenAI", "gpt-5.5"),
     "gemini": ("Gemini", "gemini-3.1-pro-preview"),
     "ollama": ("Ollama", "llama3.1"),
+    "bedrock": ("Amazon Bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"),
 }
 
 _PROVIDER_DEFAULT_MODELS: dict[str, list[str]] = {
@@ -39,6 +40,13 @@ _PROVIDER_DEFAULT_MODELS: dict[str, list[str]] = {
     "openai": ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.2"],
     "gemini": ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
     "ollama": ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
+    # Starting points only — admins set their account's exact model IDs (incl.
+    # GovCloud `us-gov.` inference profiles) via the editable per-provider list.
+    "bedrock": [
+        "anthropic.claude-3-5-sonnet-20241022-v2:0",
+        "anthropic.claude-3-5-haiku-20241022-v1:0",
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    ],
 }
 
 
@@ -53,6 +61,7 @@ def available(_user: User = Depends(require_user)) -> AvailableProvidersResponse
         ("gemini", bool(s.gemini_api_key)),
         ("ollama", bool(s.ollama_base_url)),
         ("custom", bool(s.custom_base_url)),
+        ("bedrock", bool(s.bedrock_aws_region)),
     ]
     for name, has_creds in checks:
         if not has_creds:

--- a/backend/app/api/llm.py
+++ b/backend/app/api/llm.py
@@ -32,7 +32,7 @@ _PROVIDER_LABELS = {
     "openai": ("OpenAI", "gpt-5.5"),
     "gemini": ("Gemini", "gemini-3.1-pro-preview"),
     "ollama": ("Ollama", "llama3.1"),
-    "bedrock": ("Amazon Bedrock", "anthropic.claude-3-5-sonnet-20241022-v2:0"),
+    "bedrock": ("Amazon Bedrock", "us.anthropic.claude-sonnet-4-6"),
 }
 
 _PROVIDER_DEFAULT_MODELS: dict[str, list[str]] = {
@@ -43,9 +43,9 @@ _PROVIDER_DEFAULT_MODELS: dict[str, list[str]] = {
     # Starting points only — admins set their account's exact model IDs (incl.
     # GovCloud `us-gov.` inference profiles) via the editable per-provider list.
     "bedrock": [
-        "anthropic.claude-3-5-sonnet-20241022-v2:0",
-        "anthropic.claude-3-5-haiku-20241022-v1:0",
-        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        "us.anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "us.anthropic.claude-opus-4-8",
     ],
 }
 

--- a/backend/app/db/migrations/versions/0036_bedrock_provider.py
+++ b/backend/app/db/migrations/versions/0036_bedrock_provider.py
@@ -1,0 +1,74 @@
+"""bedrock-provider
+
+Adds AWS Bedrock (Converse API) provider config to ``llm_settings``:
+
+- ``bedrock_aws_region``, ``bedrock_endpoint_url`` (Text config)
+- ``bedrock_aws_access_key_id``, ``bedrock_aws_secret_access_key``,
+  ``bedrock_aws_session_token`` (EncryptedString / ``bytea`` secrets)
+
+Guarded adds — ``0001``'s ``create_all`` already builds these on fresh installs,
+so each column is skipped when present. On an existing install the secret
+columns are added nullable, the singleton row is backfilled with an encrypted
+empty string (a literal ``b''`` would crash on decrypt), then tightened to NOT
+NULL — the same storage contract as the other EncryptedString secret columns.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-06-24 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.crypto import encrypt_string
+
+revision: str = "0036"
+down_revision: str | None = "0035"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_TEXT_COLUMNS = ("bedrock_aws_region", "bedrock_endpoint_url")
+_SECRET_COLUMNS = (
+    "bedrock_aws_access_key_id",
+    "bedrock_aws_secret_access_key",
+    "bedrock_aws_session_token",
+)
+
+
+def _existing_columns(bind: sa.engine.Connection) -> set[str]:
+    return {col["name"] for col in sa.inspect(bind).get_columns("llm_settings")}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    cols = _existing_columns(bind)
+
+    for name in _TEXT_COLUMNS:
+        if name not in cols:
+            op.add_column(
+                "llm_settings",
+                sa.Column(name, sa.Text, nullable=False, server_default=sa.text("''")),
+            )
+
+    to_add = [name for name in _SECRET_COLUMNS if name not in cols]
+    for name in to_add:
+        op.add_column("llm_settings", sa.Column(name, sa.LargeBinary, nullable=True))
+    if to_add:
+        empty = encrypt_string("")
+        set_clause = ", ".join(f'"{name}" = :{name}' for name in to_add)
+        bind.execute(
+            sa.text(f"UPDATE llm_settings SET {set_clause} WHERE id = 1"),
+            {name: empty for name in to_add},
+        )
+        for name in to_add:
+            op.alter_column("llm_settings", name, nullable=False)
+
+
+def downgrade() -> None:
+    for name in (*_SECRET_COLUMNS, *_TEXT_COLUMNS):
+        op.drop_column("llm_settings", name)

--- a/backend/app/db/migrations/versions/0037_bedrock_bearer_token.py
+++ b/backend/app/db/migrations/versions/0037_bedrock_bearer_token.py
@@ -1,0 +1,44 @@
+"""bedrock-bearer-token
+
+Adds the AWS Bedrock API key (bearer token) credential to ``llm_settings``:
+``bedrock_aws_bearer_token`` (EncryptedString / ``bytea`` secret). Same guarded
+add-nullable / backfill-encrypted-empty / set-NOT-NULL shape as the other
+EncryptedString secret columns (a literal ``b''`` would crash on decrypt).
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-06-29 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from app.db.crypto import encrypt_string
+
+revision: str = "0037"
+down_revision: str | None = "0036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_COLUMN = "bedrock_aws_bearer_token"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    cols = {col["name"] for col in sa.inspect(bind).get_columns("llm_settings")}
+    if _COLUMN in cols:
+        return  # fresh install already has it from 0001's create_all
+    op.add_column("llm_settings", sa.Column(_COLUMN, sa.LargeBinary, nullable=True))
+    bind.execute(
+        sa.text(f'UPDATE llm_settings SET "{_COLUMN}" = :v WHERE id = 1'),
+        {"v": encrypt_string("")},
+    )
+    op.alter_column("llm_settings", _COLUMN, nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column("llm_settings", _COLUMN)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -713,6 +713,7 @@ class LLMSettings(Base):
     bedrock_aws_access_key_id: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     bedrock_aws_secret_access_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     bedrock_aws_session_token: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    bedrock_aws_bearer_token: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     provider_models: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -702,6 +702,17 @@ class LLMSettings(Base):
     custom_display_name: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("''")
     )
+    # AWS Bedrock (Converse API). Region + optional endpoint are config (Text);
+    # the AWS credentials are AES-GCM encrypted at rest like the other secrets.
+    bedrock_aws_region: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    bedrock_endpoint_url: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    bedrock_aws_access_key_id: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    bedrock_aws_secret_access_key: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    bedrock_aws_session_token: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
     provider_models: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )

--- a/backend/app/llm/providers/__init__.py
+++ b/backend/app/llm/providers/__init__.py
@@ -101,6 +101,7 @@ def names() -> list[str]:
 # actually compiled in. Keep imports at the bottom — each module references
 # `register` from this module.
 from app.llm.providers import anthropic as _anthropic  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
+from app.llm.providers import bedrock as _bedrock  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
 from app.llm.providers import custom as _custom  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
 from app.llm.providers import gemini as _gemini  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]
 from app.llm.providers import ollama as _ollama  # noqa: E402,F401  # pyright: ignore[reportUnusedImport]

--- a/backend/app/llm/providers/_converse.py
+++ b/backend/app/llm/providers/_converse.py
@@ -1,0 +1,145 @@
+"""Translation glue for the AWS Bedrock Converse API.
+
+Pure dict<->dict translation between the normalized provider shape (see
+``app.llm.client``) and Bedrock's Converse wire format — no ``boto3`` import,
+so the request builder and the stream decoder are unit-testable without AWS.
+``bedrock.py`` owns the SDK client and feeds ``iter_stream_events`` the raw
+``converse_stream`` event iterator.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator
+
+from app.llm.providers._common import safe_json_loads, split_system, stringify_tool_result
+
+StreamEvent = dict[str, Any]
+
+
+def build_converse_request(
+    messages: list[dict[str, Any]],
+    *,
+    model: str,
+    tools: list[dict[str, Any]] | None,
+    max_tokens: int,
+) -> dict[str, Any]:
+    """Normalized messages/tools -> kwargs for ``client.converse_stream``.
+
+    Converse takes system text as a top-level ``system`` list (split out here)
+    and every message ``content`` as a list of typed blocks, so a plain string
+    turn becomes a single ``{"text": ...}`` block."""
+    system_text, convo = split_system(messages)
+    request: dict[str, Any] = {
+        "modelId": model,
+        "messages": [_converse_message(m) for m in convo],
+        "inferenceConfig": {"maxTokens": max_tokens},
+    }
+    if system_text is not None:
+        request["system"] = [{"text": system_text}]
+    if tools:
+        request["toolConfig"] = {"tools": [_tool_spec(t) for t in tools]}
+    return request
+
+
+def iter_stream_events(stream: Iterable[dict[str, Any]]) -> Iterator[StreamEvent]:
+    """Decode a Converse ``converse_stream`` event iterator into our StreamEvents.
+
+    Each event is a dict keyed by one wrapper name. Tool-use arguments arrive as
+    ordered partial-JSON string fragments under ``contentBlockDelta`` and are
+    concatenated per content-block index, then parsed once the block stops.
+    Exactly one terminal ``done`` carries the stop reason + usage."""
+    tool_blocks: dict[int, dict[str, Any]] = {}
+    stop_reason = ""
+    usage: dict[str, Any] = {}
+
+    for event in stream:
+        if "contentBlockStart" in event:
+            block = event["contentBlockStart"]
+            start: Any = block.get("start")
+            tool_use: Any = start.get("toolUse") if start else None
+            if tool_use is not None:
+                tool_blocks[block["contentBlockIndex"]] = {
+                    "id": tool_use["toolUseId"],
+                    "name": tool_use["name"],
+                    "buf": "",
+                }
+        elif "contentBlockDelta" in event:
+            block = event["contentBlockDelta"]
+            delta = block["delta"]
+            if "text" in delta:
+                yield {"type": "text_delta", "text": delta["text"]}
+            elif "toolUse" in delta:
+                rec = tool_blocks.get(block["contentBlockIndex"])
+                if rec is not None:
+                    rec["buf"] += delta["toolUse"].get("input", "")
+        elif "contentBlockStop" in event:
+            rec = tool_blocks.pop(event["contentBlockStop"]["contentBlockIndex"], None)
+            if rec is not None:
+                yield {
+                    "type": "tool_call",
+                    "id": rec["id"],
+                    "name": rec["name"],
+                    "arguments": safe_json_loads(rec["buf"]),
+                }
+        elif "messageStop" in event:
+            stop_reason = event["messageStop"].get("stopReason", "") or ""
+        elif "metadata" in event:
+            usage = event["metadata"].get("usage") or {}
+
+    in_tok = int(usage.get("inputTokens", 0) or 0)
+    out_tok = int(usage.get("outputTokens", 0) or 0)
+    # Converse reports inputTokens EXCLUDING cache read/write (like Anthropic),
+    # so uncached = fresh input + cache writes, cached = cache reads.
+    cache_read = int(usage.get("cacheReadInputTokens", 0) or 0)
+    cache_write = int(usage.get("cacheWriteInputTokens", 0) or 0)
+    yield {
+        "type": "done",
+        "stop_reason": stop_reason,
+        "usage": {
+            "input_tokens": in_tok,
+            "output_tokens": out_tok,
+            "reasoning_tokens": 0,
+            "cached_input_tokens": cache_read,
+            "uncached_input_tokens": in_tok + cache_write,
+        },
+    }
+
+
+def _converse_message(m: dict[str, Any]) -> dict[str, Any]:
+    """One normalized message -> a Converse ``{role, content: [...]}`` turn."""
+    role = m["role"]
+    if role == "tool":
+        # Normalized tool result -> toolResult block carried on a user turn.
+        return {
+            "role": "user",
+            "content": [
+                {
+                    "toolResult": {
+                        "toolUseId": m["tool_call_id"],
+                        "content": [{"text": stringify_tool_result(m["content"])}],
+                    }
+                }
+            ],
+        }
+    if role == "assistant" and m.get("tool_calls"):
+        blocks: list[dict[str, Any]] = []
+        if m.get("content"):
+            blocks.append({"text": m["content"]})
+        for tc in m["tool_calls"]:
+            blocks.append(
+                {"toolUse": {"toolUseId": tc["id"], "name": tc["name"], "input": tc["arguments"]}}
+            )
+        return {"role": "assistant", "content": blocks}
+
+    return {"role": role, "content": [{"text": m["content"]}]}
+
+
+def _tool_spec(tool: dict[str, Any]) -> dict[str, Any]:
+    """Normalized tool spec -> Converse ``toolSpec`` (JSON Schema under inputSchema.json)."""
+    spec: dict[str, Any] = {
+        "name": tool["name"],
+        "inputSchema": {"json": tool["input_schema"]},
+    }
+    if tool.get("description"):
+        spec["description"] = tool["description"]
+    return {"toolSpec": spec}

--- a/backend/app/llm/providers/bedrock.py
+++ b/backend/app/llm/providers/bedrock.py
@@ -4,14 +4,16 @@ One provider for every Bedrock model family (Claude, Nova, Llama, …) via the
 unified Converse API. GovCloud is the same provider with a ``us-gov-*`` region:
 boto3 derives the GovCloud partition endpoint from the region name; an optional
 endpoint override covers FIPS / PrivateLink. Auth is boto3-native — static
-access keys (+ optional session token) or, with no keys, the default credential
-chain (instance/IAM role). Message/tool/stream translation lives in
+access keys (+ optional session token), a Bedrock API key (bearer token), or —
+with no creds — the default chain (instance/IAM role). Message/tool/stream
+translation lives in
 ``_converse.py``; this module owns the SDK client and error mapping.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from functools import lru_cache
 from typing import Any, Iterator
 
@@ -35,6 +37,17 @@ def _make_client(service: str, **kwargs: Any) -> Any:
     """``boto3.client`` behind an ``Any`` boundary — botocore is untyped, so the
     unavoidable Unknown is confined to this one seam."""
     return boto3.client(service, **kwargs)  # pyright: ignore
+
+
+def _apply_bedrock_auth_env(bearer_token: str) -> None:
+    """A Bedrock API key (bearer token) reaches botocore only through the
+    AWS_BEARER_TOKEN_BEDROCK env var. Settings are a singleton, so the value is
+    stable; set it when configured and clear it otherwise, so a later switch to
+    access-key / IAM auth is not shadowed by a stale token."""
+    if bearer_token:
+        os.environ["AWS_BEARER_TOKEN_BEDROCK"] = bearer_token
+    else:
+        os.environ.pop("AWS_BEARER_TOKEN_BEDROCK", None)
 
 
 @lru_cache(maxsize=4)
@@ -71,6 +84,7 @@ class BedrockProvider:
     def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
         """Preflight the saved config: a non-fatal model-listing probe (control
         plane) plus a decisive 1-token ``converse`` against ``model``."""
+        _apply_bedrock_auth_env(settings.bedrock_aws_bearer_token)
         region = settings.bedrock_aws_region
         cfg: Any = BotoConfig(
             connect_timeout=PREFLIGHT_TIMEOUT_SECONDS,
@@ -94,7 +108,9 @@ class BedrockProvider:
         )
         return run_preflight(
             base_url=display_endpoint,
-            auth_present=bool(settings.bedrock_aws_access_key_id),
+            auth_present=bool(
+                settings.bedrock_aws_access_key_id or settings.bedrock_aws_bearer_token
+            ),
             model=model,
             listing=lambda: control.list_foundation_models(),
             completion=lambda: runtime.converse(
@@ -122,6 +138,7 @@ class BedrockProvider:
             max_tokens,
             len(request["messages"]),
         )
+        _apply_bedrock_auth_env(settings.bedrock_aws_bearer_token)
         client = _client(
             settings.bedrock_aws_access_key_id,
             settings.bedrock_aws_secret_access_key,

--- a/backend/app/llm/providers/bedrock.py
+++ b/backend/app/llm/providers/bedrock.py
@@ -1,0 +1,210 @@
+"""AWS Bedrock provider — Converse API.
+
+One provider for every Bedrock model family (Claude, Nova, Llama, …) via the
+unified Converse API. GovCloud is the same provider with a ``us-gov-*`` region:
+boto3 derives the GovCloud partition endpoint from the region name; an optional
+endpoint override covers FIPS / PrivateLink. Auth is boto3-native — static
+access keys (+ optional session token) or, with no keys, the default credential
+chain (instance/IAM role). Message/tool/stream translation lives in
+``_converse.py``; this module owns the SDK client and error mapping.
+"""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import Any, Iterator
+
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import BotoCoreError, ClientError
+
+from app.llm.errors import LLMError
+from app.llm.providers._common import PREFLIGHT_TIMEOUT_SECONDS, run_preflight
+from app.llm.providers._converse import build_converse_request, iter_stream_events
+from app.llm.settings import LLMSettings
+
+log = logging.getLogger(__name__)
+
+StreamEvent = dict[str, Any]
+
+_PROVIDER_LABEL = "Amazon Bedrock"
+
+
+def _make_client(service: str, **kwargs: Any) -> Any:
+    """``boto3.client`` behind an ``Any`` boundary — botocore is untyped, so the
+    unavoidable Unknown is confined to this one seam."""
+    return boto3.client(service, **kwargs)  # pyright: ignore
+
+
+@lru_cache(maxsize=4)
+def _client(
+    access_key: str,
+    secret_key: str,
+    session_token: str,
+    region: str,
+    endpoint_url: str,
+) -> Any:
+    """Cached ``bedrock-runtime`` client. Empty credentials fall through to the
+    boto3 default chain (instance/IAM role); an empty region/endpoint lets boto3
+    derive the partition endpoint from the region name."""
+    return _make_client(
+        "bedrock-runtime",
+        region_name=region or None,
+        aws_access_key_id=access_key or None,
+        aws_secret_access_key=secret_key or None,
+        aws_session_token=session_token or None,
+        endpoint_url=endpoint_url or None,
+    )
+
+
+class BedrockProvider:
+    name = "bedrock"
+
+    def check_configured(self, settings: LLMSettings) -> None:
+        if not settings.bedrock_aws_region:
+            raise LLMError(
+                "not_configured",
+                "AWS Bedrock region is not set. An admin needs to add it on the admin page.",
+            )
+
+    def test_connection(self, settings: LLMSettings, *, model: str) -> dict[str, Any]:
+        """Preflight the saved config: a non-fatal model-listing probe (control
+        plane) plus a decisive 1-token ``converse`` against ``model``."""
+        region = settings.bedrock_aws_region
+        cfg: Any = BotoConfig(
+            connect_timeout=PREFLIGHT_TIMEOUT_SECONDS,
+            read_timeout=PREFLIGHT_TIMEOUT_SECONDS,
+            retries={"max_attempts": 0},
+        )
+        creds: dict[str, Any] = {
+            "region_name": region or None,
+            "aws_access_key_id": settings.bedrock_aws_access_key_id or None,
+            "aws_secret_access_key": settings.bedrock_aws_secret_access_key or None,
+            "aws_session_token": settings.bedrock_aws_session_token or None,
+            "config": cfg,
+        }
+        runtime: Any = _make_client(
+            "bedrock-runtime", endpoint_url=settings.bedrock_endpoint_url or None, **creds
+        )
+        # Control plane has its own endpoint — don't borrow the runtime override.
+        control: Any = _make_client("bedrock", **creds)
+        display_endpoint = settings.bedrock_endpoint_url or (
+            f"https://bedrock-runtime.{region}.amazonaws.com" if region else ""
+        )
+        return run_preflight(
+            base_url=display_endpoint,
+            auth_present=bool(settings.bedrock_aws_access_key_id),
+            model=model,
+            listing=lambda: control.list_foundation_models(),
+            completion=lambda: runtime.converse(
+                modelId=model,
+                messages=[{"role": "user", "content": [{"text": "ping"}]}],
+                inferenceConfig={"maxTokens": 1},
+            ),
+            translate=_translate_bedrock_error,
+        )
+
+    def stream(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+        settings: LLMSettings,
+    ) -> Iterator[StreamEvent]:
+        request = build_converse_request(messages, model=model, tools=tools, max_tokens=max_tokens)
+        log.info(
+            "llm request provider=bedrock model=%s tools=%d max_tokens=%d msgs=%d",
+            model,
+            len(tools or []),
+            max_tokens,
+            len(request["messages"]),
+        )
+        client = _client(
+            settings.bedrock_aws_access_key_id,
+            settings.bedrock_aws_secret_access_key,
+            settings.bedrock_aws_session_token,
+            settings.bedrock_aws_region,
+            settings.bedrock_endpoint_url,
+        )
+        try:
+            response = client.converse_stream(**request)
+            # Mid-stream service faults surface as botocore exceptions while
+            # iterating response["stream"], so the loop is inside the try.
+            for event in iter_stream_events(response["stream"]):
+                if event["type"] == "done":
+                    usage = event["usage"]
+                    log.info(
+                        "llm done provider=bedrock model=%s stop=%s tokens=%d/%d cached=%d",
+                        model,
+                        event["stop_reason"],
+                        usage["input_tokens"],
+                        usage["output_tokens"],
+                        usage["cached_input_tokens"],
+                    )
+                yield event
+        except LLMError:
+            raise
+        except Exception as exc:
+            log.exception("llm provider error provider=bedrock model=%s", model)
+            raise _translate_bedrock_error(exc) from exc
+
+
+# botocore error code -> normalized LLMError code. Codes are shared by converse
+# and converse_stream (the latter wraps mid-stream faults in EventStreamError,
+# a ClientError subclass, so this handles both).
+_ERROR_CODES: dict[str, tuple[str, str]] = {
+    "AccessDeniedException": ("auth", "AWS denied access — check the IAM permissions / keys."),
+    "UnrecognizedClientException": (
+        "auth",
+        "AWS rejected the credentials. An admin needs to update them.",
+    ),
+    "ThrottlingException": ("rate_limit", "Bedrock rate limit hit. Please retry in a moment."),
+    "ResourceNotFoundException": (
+        "config",
+        "Bedrock could not find that model — check the model ID and region.",
+    ),
+    "ModelNotReadyException": (
+        "config",
+        "The Bedrock model is not ready yet. Please retry shortly.",
+    ),
+    "ValidationException": ("bad_request", "Bedrock rejected the request."),
+    "ModelTimeoutException": ("provider", "The Bedrock model timed out. Please retry."),
+    "ServiceUnavailableException": (
+        "provider",
+        "Bedrock is temporarily unavailable. Please retry.",
+    ),
+    "InternalServerException": ("provider", "Bedrock returned an internal error. Please retry."),
+}
+
+
+def _translate_bedrock_error(exc: Exception) -> LLMError:
+    """Map a botocore exception to an LLMError. Detail-light — never echoes
+    credentials, which can ride in the request that failed."""
+    if isinstance(exc, ClientError):
+        response: Any = getattr(exc, "response", None)
+        error: Any = response.get("Error") if response else None
+        raw_code: Any = error.get("Code") if error else None
+        code = str(raw_code) if raw_code else ""
+        mapped = _ERROR_CODES.get(code)
+        if mapped is not None:
+            return LLMError(mapped[0], mapped[1])
+        return LLMError("provider", f"Bedrock error ({code or 'unknown'}).")
+    if isinstance(exc, BotoCoreError):
+        # Endpoint/region/connection problems before a response — e.g. a bad
+        # region or unreachable (FIPS) endpoint.
+        return LLMError(
+            "network",
+            "Could not reach Bedrock — check the region, endpoint, and network access.",
+        )
+    return LLMError("unknown", "Unexpected error talking to Bedrock.")
+
+
+PROVIDER = BedrockProvider()
+
+
+from app.llm.providers import register  # noqa: E402
+
+register(PROVIDER)  # pyright: ignore[reportUnknownMemberType]

--- a/backend/app/llm/settings.py
+++ b/backend/app/llm/settings.py
@@ -34,6 +34,7 @@ class LLMSettings(BaseModel):
     bedrock_aws_access_key_id: str = ""
     bedrock_aws_secret_access_key: str = ""
     bedrock_aws_session_token: str = ""
+    bedrock_aws_bearer_token: str = ""
     provider_models: dict[str, list[str]] = Field(default_factory=dict)
     ingest_selector_model: str = ""  # empty or same as model → stage 3 skipped
 
@@ -65,6 +66,7 @@ def upsert(
     bedrock_aws_access_key_id: str,
     bedrock_aws_secret_access_key: str,
     bedrock_aws_session_token: str,
+    bedrock_aws_bearer_token: str,
     provider_models: dict[str, list[str]] | None = None,
     ingest_selector_model: str | None = None,
 ) -> None:
@@ -88,6 +90,7 @@ def upsert(
         row.bedrock_aws_access_key_id = bedrock_aws_access_key_id
         row.bedrock_aws_secret_access_key = bedrock_aws_secret_access_key
         row.bedrock_aws_session_token = bedrock_aws_session_token
+        row.bedrock_aws_bearer_token = bedrock_aws_bearer_token
         if provider_models is not None:
             row.provider_models = provider_models
         if ingest_selector_model is not None:

--- a/backend/app/llm/settings.py
+++ b/backend/app/llm/settings.py
@@ -29,6 +29,11 @@ class LLMSettings(BaseModel):
     custom_api_key: str = ""
     custom_base_url: str = ""
     custom_display_name: str = ""
+    bedrock_aws_region: str = ""
+    bedrock_endpoint_url: str = ""
+    bedrock_aws_access_key_id: str = ""
+    bedrock_aws_secret_access_key: str = ""
+    bedrock_aws_session_token: str = ""
     provider_models: dict[str, list[str]] = Field(default_factory=dict)
     ingest_selector_model: str = ""  # empty or same as model → stage 3 skipped
 
@@ -55,6 +60,11 @@ def upsert(
     custom_api_key: str,
     custom_base_url: str,
     custom_display_name: str,
+    bedrock_aws_region: str,
+    bedrock_endpoint_url: str,
+    bedrock_aws_access_key_id: str,
+    bedrock_aws_secret_access_key: str,
+    bedrock_aws_session_token: str,
     provider_models: dict[str, list[str]] | None = None,
     ingest_selector_model: str | None = None,
 ) -> None:
@@ -73,6 +83,11 @@ def upsert(
         row.custom_api_key = custom_api_key
         row.custom_base_url = custom_base_url
         row.custom_display_name = custom_display_name
+        row.bedrock_aws_region = bedrock_aws_region
+        row.bedrock_endpoint_url = bedrock_endpoint_url
+        row.bedrock_aws_access_key_id = bedrock_aws_access_key_id
+        row.bedrock_aws_secret_access_key = bedrock_aws_secret_access_key
+        row.bedrock_aws_session_token = bedrock_aws_session_token
         if provider_models is not None:
             row.provider_models = provider_models
         if ingest_selector_model is not None:

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -43,6 +43,7 @@ class LLMConfigRequest(BaseModel):
     bedrock_aws_access_key_id: str | None = None
     bedrock_aws_secret_access_key: str | None = None
     bedrock_aws_session_token: str | None = None
+    bedrock_aws_bearer_token: str | None = None
     provider_models: dict[str, list[str]] | None = None
     ingest_selector_model: str | None = None
 
@@ -152,6 +153,8 @@ class LLMView(BaseModel):
     bedrock_aws_secret_access_key_set: bool
     bedrock_aws_secret_access_key_hint: str
     bedrock_aws_session_token_set: bool
+    bedrock_aws_bearer_token_set: bool
+    bedrock_aws_bearer_token_hint: str
     provider_models: dict[str, list[str]]
     ingest_selector_model: str
 

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -38,6 +38,11 @@ class LLMConfigRequest(BaseModel):
     custom_base_url: str | None = None
     # Plain set-on-sent (not a secret) — "" clears, unlike the key fields.
     custom_display_name: str | None = None
+    bedrock_aws_region: str | None = None
+    bedrock_endpoint_url: str | None = None
+    bedrock_aws_access_key_id: str | None = None
+    bedrock_aws_secret_access_key: str | None = None
+    bedrock_aws_session_token: str | None = None
     provider_models: dict[str, list[str]] | None = None
     ingest_selector_model: str | None = None
 
@@ -139,6 +144,14 @@ class LLMView(BaseModel):
     custom_api_key_hint: str
     custom_base_url: str
     custom_display_name: str
+    # AWS Bedrock — region + endpoint shown in the clear; AWS keys redacted.
+    bedrock_aws_region: str
+    bedrock_endpoint_url: str
+    bedrock_aws_access_key_id_set: bool
+    bedrock_aws_access_key_id_hint: str
+    bedrock_aws_secret_access_key_set: bool
+    bedrock_aws_secret_access_key_hint: str
+    bedrock_aws_session_token_set: bool
     provider_models: dict[str, list[str]]
     ingest_selector_model: str
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "authlib>=1.3",      # OIDC via authlib.integrations.starlette_client
     "bcrypt>=4.1",       # basic auth password hashing
     "anthropic>=0.40",
+    "boto3>=1.43.36", # AWS Bedrock (Converse API) provider
     "openai>=1.50",      # Responses API + streaming events
     "google-genai>=1.0", # Gemini provider
     "ollama>=0.4",       # Local-model provider (uses Ollama HTTP API)

--- a/backend/tests/test_admin_llm_custom.py
+++ b/backend/tests/test_admin_llm_custom.py
@@ -71,6 +71,7 @@ def test_allowlist_matches_registry() -> None:
         "gemini",
         "ollama",
         "custom",
+        "bedrock",
     }
 
 

--- a/backend/tests/test_bedrock_converse.py
+++ b/backend/tests/test_bedrock_converse.py
@@ -1,0 +1,191 @@
+"""Bedrock Converse provider — request translation + stream decoding at the seam.
+
+Pure-translation coverage (no AWS) plus provider-level stream tests that patch
+the boto3 client factory, asserting the normalized text/tool_call/done events
+and botocore-error -> LLMError mapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.llm.errors import LLMError
+from app.llm.providers import bedrock
+from app.llm.providers._converse import build_converse_request, iter_stream_events
+from app.llm.settings import LLMSettings
+
+
+def test_build_request_splits_system_and_wraps_text() -> None:
+    req = build_converse_request(
+        [
+            {"role": "system", "content": "be terse"},
+            {"role": "user", "content": "hi"},
+        ],
+        model="m",
+        tools=None,
+        max_tokens=7,
+    )
+    assert req["modelId"] == "m"
+    assert req["system"] == [{"text": "be terse"}]
+    assert req["inferenceConfig"] == {"maxTokens": 7}
+    assert req["messages"] == [{"role": "user", "content": [{"text": "hi"}]}]
+    assert "toolConfig" not in req
+
+
+def test_build_request_tools_and_tool_roundtrip() -> None:
+    req = build_converse_request(
+        [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{"id": "t1", "name": "search", "arguments": {"q": "x"}}],
+            },
+            {"role": "tool", "tool_call_id": "t1", "content": "result text"},
+        ],
+        model="m",
+        tools=[{"name": "search", "description": "find", "input_schema": {"type": "object"}}],
+        max_tokens=10,
+    )
+    assert req["toolConfig"]["tools"] == [
+        {
+            "toolSpec": {
+                "name": "search",
+                "inputSchema": {"json": {"type": "object"}},
+                "description": "find",
+            }
+        }
+    ]
+    assert req["messages"][1] == {
+        "role": "assistant",
+        "content": [{"toolUse": {"toolUseId": "t1", "name": "search", "input": {"q": "x"}}}],
+    }
+    assert req["messages"][2] == {
+        "role": "user",
+        "content": [{"toolResult": {"toolUseId": "t1", "content": [{"text": "result text"}]}}],
+    }
+
+
+def test_iter_stream_events_text_and_done() -> None:
+    events = [
+        {"messageStart": {"role": "assistant"}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "Hel"}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "lo"}}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 5, "outputTokens": 2, "totalTokens": 7}}},
+    ]
+    out = list(iter_stream_events(events))
+    assert out[0] == {"type": "text_delta", "text": "Hel"}
+    assert out[1] == {"type": "text_delta", "text": "lo"}
+    done = out[-1]
+    assert done["type"] == "done"
+    assert done["stop_reason"] == "end_turn"
+    assert done["usage"]["input_tokens"] == 5
+    assert done["usage"]["output_tokens"] == 2
+    assert done["usage"]["uncached_input_tokens"] == 5
+
+
+def test_iter_stream_events_tool_call_accumulates_input() -> None:
+    events = [
+        {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {"toolUse": {"toolUseId": "t9", "name": "lookup"}},
+            }
+        },
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"toolUse": {"input": '{"q":'}}}},
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"toolUse": {"input": '"hi"}'}}}},
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {"messageStop": {"stopReason": "tool_use"}},
+        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}}},
+    ]
+    out = list(iter_stream_events(events))
+    tool_calls = [e for e in out if e["type"] == "tool_call"]
+    assert tool_calls == [
+        {"type": "tool_call", "id": "t9", "name": "lookup", "arguments": {"q": "hi"}}
+    ]
+    assert out[-1]["stop_reason"] == "tool_use"
+
+
+def test_iter_stream_events_cache_tokens() -> None:
+    events = [
+        {"messageStop": {"stopReason": "end_turn"}},
+        {
+            "metadata": {
+                "usage": {
+                    "inputTokens": 10,
+                    "outputTokens": 3,
+                    "totalTokens": 13,
+                    "cacheReadInputTokens": 100,
+                    "cacheWriteInputTokens": 20,
+                }
+            }
+        },
+    ]
+    done = list(iter_stream_events(events))[-1]
+    assert done["usage"]["cached_input_tokens"] == 100
+    assert done["usage"]["uncached_input_tokens"] == 30  # inputTokens + cacheWrite
+
+
+class _FakeClient:
+    def __init__(
+        self, events: list[dict[str, Any]] | None = None, error: Exception | None = None
+    ) -> None:
+        self._events = events or []
+        self._error = error
+
+    def converse_stream(self, **kwargs: Any) -> dict[str, Any]:
+        if self._error is not None:
+            raise self._error
+        return {"stream": iter(self._events)}
+
+
+def _settings() -> LLMSettings:
+    return LLMSettings(provider="bedrock", model="m", bedrock_aws_region="us-gov-west-1")
+
+
+def test_provider_stream_yields_normalized_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    events = [
+        {"contentBlockDelta": {"contentBlockIndex": 0, "delta": {"text": "ok"}}},
+        {"messageStop": {"stopReason": "end_turn"}},
+        {"metadata": {"usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}}},
+    ]
+    monkeypatch.setattr(bedrock, "_client", lambda *a, **k: _FakeClient(events))
+    out = list(
+        bedrock.PROVIDER.stream(
+            [{"role": "user", "content": "hi"}],
+            model="m",
+            tools=None,
+            max_tokens=4,
+            settings=_settings(),
+        )
+    )
+    assert {"type": "text_delta", "text": "ok"} in out
+    assert out[-1]["type"] == "done"
+
+
+def test_provider_stream_translates_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from botocore.exceptions import ClientError
+
+    err = ClientError({"Error": {"Code": "ThrottlingException", "Message": "slow"}}, "Converse")
+    monkeypatch.setattr(bedrock, "_client", lambda *a, **k: _FakeClient(error=err))
+    with pytest.raises(LLMError) as excinfo:
+        list(
+            bedrock.PROVIDER.stream(
+                [{"role": "user", "content": "hi"}],
+                model="m",
+                tools=None,
+                max_tokens=4,
+                settings=_settings(),
+            )
+        )
+    assert excinfo.value.code == "rate_limit"
+
+
+def test_check_configured_requires_region() -> None:
+    with pytest.raises(LLMError) as excinfo:
+        bedrock.PROVIDER.check_configured(LLMSettings(provider="bedrock", model="m"))
+    assert excinfo.value.code == "not_configured"

--- a/backend/tests/test_encrypt_secret_columns_migration.py
+++ b/backend/tests/test_encrypt_secret_columns_migration.py
@@ -54,6 +54,11 @@ def test_existing_plaintext_is_encrypted_in_place(tmp_db: object) -> None:
         custom_api_key="",
         custom_base_url="",
         custom_display_name="",
+        bedrock_aws_region="",
+        bedrock_endpoint_url="",
+        bedrock_aws_access_key_id="",
+        bedrock_aws_secret_access_key="",
+        bedrock_aws_session_token="",
     )
     _rewind_to_text_with_plaintext()
 

--- a/backend/tests/test_encrypt_secret_columns_migration.py
+++ b/backend/tests/test_encrypt_secret_columns_migration.py
@@ -59,6 +59,7 @@ def test_existing_plaintext_is_encrypted_in_place(tmp_db: object) -> None:
         bedrock_aws_access_key_id="",
         bedrock_aws_secret_access_key="",
         bedrock_aws_session_token="",
+        bedrock_aws_bearer_token="",
     )
     _rewind_to_text_with_plaintext()
 

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -47,6 +47,11 @@ def _upsert(**overrides: Any) -> None:
         "custom_api_key": "",
         "custom_base_url": "",
         "custom_display_name": "",
+        "bedrock_aws_region": "",
+        "bedrock_endpoint_url": "",
+        "bedrock_aws_access_key_id": "",
+        "bedrock_aws_secret_access_key": "",
+        "bedrock_aws_session_token": "",
     }
     base.update(overrides)
     llm_settings.upsert(**base)

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -52,6 +52,7 @@ def _upsert(**overrides: Any) -> None:
         "bedrock_aws_access_key_id": "",
         "bedrock_aws_secret_access_key": "",
         "bedrock_aws_session_token": "",
+        "bedrock_aws_bearer_token": "",
     }
     base.update(overrides)
     llm_settings.upsert(**base)

--- a/backend/tests/test_llm_settings.py
+++ b/backend/tests/test_llm_settings.py
@@ -31,6 +31,7 @@ def _upsert(**overrides: Any) -> None:
         "bedrock_aws_access_key_id": "",
         "bedrock_aws_secret_access_key": "",
         "bedrock_aws_session_token": "",
+        "bedrock_aws_bearer_token": "",
     }
     base.update(overrides)
     llm_settings.upsert(**base)

--- a/backend/tests/test_llm_settings.py
+++ b/backend/tests/test_llm_settings.py
@@ -26,6 +26,11 @@ def _upsert(**overrides: Any) -> None:
         "custom_api_key": "",
         "custom_base_url": "",
         "custom_display_name": "",
+        "bedrock_aws_region": "",
+        "bedrock_endpoint_url": "",
+        "bedrock_aws_access_key_id": "",
+        "bedrock_aws_secret_access_key": "",
+        "bedrock_aws_session_token": "",
     }
     base.update(overrides)
     llm_settings.upsert(**base)

--- a/backend/tests/test_rotate_encryption_key.py
+++ b/backend/tests/test_rotate_encryption_key.py
@@ -40,6 +40,7 @@ def test_rotate_reencrypts_under_new_key(tmp_db: object, monkeypatch: pytest.Mon
         bedrock_aws_access_key_id="",
         bedrock_aws_secret_access_key="",
         bedrock_aws_session_token="",
+        bedrock_aws_bearer_token="",
     )
 
     old_secret = crypto.active_key_secret()

--- a/backend/tests/test_rotate_encryption_key.py
+++ b/backend/tests/test_rotate_encryption_key.py
@@ -1,4 +1,5 @@
 """rotate_encryption_key: re-encrypt secret columns from an old key to the new one."""
+
 from __future__ import annotations
 
 import pytest
@@ -34,6 +35,11 @@ def test_rotate_reencrypts_under_new_key(tmp_db: object, monkeypatch: pytest.Mon
         custom_api_key="",
         custom_base_url="",
         custom_display_name="",
+        bedrock_aws_region="",
+        bedrock_endpoint_url="",
+        bedrock_aws_access_key_id="",
+        bedrock_aws_secret_access_key="",
+        bedrock_aws_session_token="",
     )
 
     old_secret = crypto.active_key_secret()

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -3,8 +3,10 @@
 import {
   useEffect,
   useState,
+  type Dispatch,
   type FormEvent,
   type InputHTMLAttributes,
+  type SetStateAction,
 } from "react";
 import { mutate as globalMutate } from "swr";
 
@@ -62,6 +64,12 @@ const PROVIDER_META: Record<Provider, ProviderMeta> = {
     keyPlaceholder: "sk-…",
     initial: "C",
   },
+  bedrock: {
+    defaultModel: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    keyLabel: "Access key ID",
+    keyPlaceholder: "AKIA…",
+    initial: "B",
+  },
 };
 
 const PROVIDER_MODELS: Record<Provider, string[]> = {
@@ -75,6 +83,11 @@ const PROVIDER_MODELS: Record<Provider, string[]> = {
   gemini: ["gemini-3.1-pro-preview", "gemini-3-flash-preview"],
   ollama: ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
   custom: [],
+  bedrock: [
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  ],
 };
 
 function keyHint(p: Provider, s: LLMSettings): string {
@@ -83,6 +96,7 @@ function keyHint(p: Provider, s: LLMSettings): string {
   if (p === "gemini") return s.gemini_api_key_hint;
   if (p === "ollama") return s.ollama_base_url || "http://localhost:11434";
   if (p === "custom") return s.custom_base_url;
+  if (p === "bedrock") return s.bedrock_aws_region;
   return "";
 }
 
@@ -419,6 +433,12 @@ function ProviderCard({
               configured={configured}
               onSaved={onSaved}
             />
+          ) : provider === "bedrock" ? (
+            <BedrockProviderForm
+              settings={settings}
+              configured={configured}
+              onSaved={onSaved}
+            />
           ) : (
             <ProviderForm
               provider={provider}
@@ -439,8 +459,8 @@ function ProviderForm({
   configured,
   onSaved,
 }: {
-  // Custom routes to CustomProviderForm — encode that in the type.
-  provider: Exclude<Provider, "custom">;
+  // Custom + bedrock route to their own multi-field forms — encode that here.
+  provider: Exclude<Provider, "custom" | "bedrock">;
   settings: LLMSettings;
   configured: boolean;
   onSaved: () => void;
@@ -686,6 +706,74 @@ function TestConnection({
   );
 }
 
+// Free-add list of model IDs, shared by the providers without a fixed catalog
+// (custom OpenAI-compatible gateways and Bedrock).
+function ModelListEditor({
+  models,
+  setModels,
+  placeholder,
+  hint,
+}: {
+  models: string[];
+  setModels: Dispatch<SetStateAction<string[]>>;
+  placeholder: string;
+  hint: string;
+}) {
+  const [newModel, setNewModel] = useState("");
+
+  function addModel() {
+    const m = newModel.trim();
+    if (!m || models.includes(m)) return;
+    setModels((prev) => [...prev, m]);
+    setNewModel("");
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-baseline justify-between">
+        <div className={lblClass}>Models</div>
+        <div className="text-xs text-(--text-03)">{hint}</div>
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {models.map((id) => (
+          <div
+            key={id}
+            className="flex items-center justify-between rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) py-[6px] pr-2 pl-3"
+          >
+            <span className="font-mono text-[13px] text-(--text-05)">{id}</span>
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              onClick={() => setModels((prev) => prev.filter((m) => m !== id))}
+            >
+              Remove
+            </Button>
+          </div>
+        ))}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newModel}
+            onChange={(e) => setNewModel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addModel();
+              }
+            }}
+            placeholder={placeholder}
+            className={inputClass}
+          />
+          <Button type="button" variant="default" size="sm" onClick={addModel}>
+            Add
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function CustomProviderForm({
   settings,
   configured,
@@ -701,18 +789,10 @@ function CustomProviderForm({
   const [models, setModels] = useState<string[]>(
     () => settings.provider_models["custom"] ?? [],
   );
-  const [newModel, setNewModel] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const confirmDialog = useConfirm();
-
-  function addModel() {
-    const m = newModel.trim();
-    if (!m || models.includes(m)) return;
-    setModels((prev) => [...prev, m]);
-    setNewModel("");
-  }
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
@@ -799,62 +879,178 @@ function CustomProviderForm({
         placeholder="Custom"
       />
 
-      <div>
-        <div className="mb-2 flex items-baseline justify-between">
-          <div className={lblClass}>Models</div>
-          <div className="text-xs text-(--text-03)">
-            Add at least one model name
-          </div>
-        </div>
-        <div className="flex flex-col gap-1.5">
-          {models.map((id) => (
-            <div
-              key={id}
-              className="flex items-center justify-between rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) py-[6px] pr-2 pl-3"
-            >
-              <span className="font-mono text-[13px] text-(--text-05)">
-                {id}
-              </span>
-              <Button
-                type="button"
-                variant="default"
-                size="sm"
-                onClick={() =>
-                  setModels((prev) => prev.filter((m) => m !== id))
-                }
-              >
-                Remove
-              </Button>
-            </div>
-          ))}
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newModel}
-              onChange={(e) => setNewModel(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  addModel();
-                }
-              }}
-              placeholder="deepseek-chat"
-              className={inputClass}
-            />
-            <Button
-              type="button"
-              variant="default"
-              size="sm"
-              onClick={addModel}
-            >
-              Add
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ModelListEditor
+        models={models}
+        setModels={setModels}
+        placeholder="deepseek-chat"
+        hint="Add at least one model name"
+      />
 
       <TestConnection
         provider="custom"
+        model={models[0] ?? null}
+        configured={configured}
+      />
+
+      <FormMessages error={error} saved={saved} />
+      <FormActions saving={saving} configured={configured} onClear={onClear} />
+    </form>
+  );
+}
+
+function BedrockProviderForm({
+  settings,
+  configured,
+  onSaved,
+}: {
+  settings: LLMSettings;
+  configured: boolean;
+  onSaved: () => void;
+}) {
+  const [region, setRegion] = useState(settings.bedrock_aws_region);
+  const [endpoint, setEndpoint] = useState(settings.bedrock_endpoint_url);
+  const [accessKeyId, setAccessKeyId] = useState("");
+  const [secretAccessKey, setSecretAccessKey] = useState("");
+  const [sessionToken, setSessionToken] = useState("");
+  const [models, setModels] = useState<string[]>(
+    () => settings.provider_models["bedrock"] ?? PROVIDER_MODELS.bedrock,
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+  const confirmDialog = useConfirm();
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!region.trim() && !configured) {
+      setError("AWS region is required (e.g. us-gov-west-1).");
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    setSaved(false);
+    try {
+      const body: Record<string, unknown> = {
+        provider_models: { ...settings.provider_models, bedrock: models },
+      };
+      // Blank means "keep current" server-side; only send real values.
+      if (region.trim()) body.bedrock_aws_region = region.trim();
+      if (endpoint.trim()) body.bedrock_endpoint_url = endpoint.trim();
+      if (accessKeyId) body.bedrock_aws_access_key_id = accessKeyId;
+      if (secretAccessKey) body.bedrock_aws_secret_access_key = secretAccessKey;
+      if (sessionToken) body.bedrock_aws_session_token = sessionToken;
+      await apiFetch("/admin/llm", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+      setAccessKeyId("");
+      setSecretAccessKey("");
+      setSessionToken("");
+      setSaved(true);
+      onSaved();
+      void globalMutate("/llm/status");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onClear() {
+    if (
+      !(await confirmDialog({
+        title: "Remove Amazon Bedrock credentials?",
+        confirmLabel: "Remove",
+      }))
+    )
+      return;
+    setSaving(true);
+    setError(null);
+    try {
+      await apiFetch("/admin/llm", {
+        method: "PUT",
+        body: JSON.stringify({
+          bedrock_aws_region: null,
+          bedrock_endpoint_url: null,
+          bedrock_aws_access_key_id: null,
+          bedrock_aws_secret_access_key: null,
+          bedrock_aws_session_token: null,
+          provider_models: { ...settings.provider_models, bedrock: [] },
+        }),
+      });
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to remove");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <Field
+        label="AWS region"
+        type="text"
+        value={region}
+        onChange={(e) => setRegion(e.target.value)}
+        placeholder="us-gov-west-1"
+        hint="GovCloud regions (us-gov-west-1 / us-gov-east-1) route to the GovCloud partition automatically."
+      />
+
+      <Field
+        label="Access key ID (optional)"
+        type="password"
+        value={accessKeyId}
+        onChange={(e) => setAccessKeyId(e.target.value)}
+        placeholder={
+          settings.bedrock_aws_access_key_id_set
+            ? "leave blank to keep current"
+            : "AKIA…  (blank = use the instance/IAM role)"
+        }
+      />
+
+      <Field
+        label="Secret access key (optional)"
+        type="password"
+        value={secretAccessKey}
+        onChange={(e) => setSecretAccessKey(e.target.value)}
+        placeholder={
+          settings.bedrock_aws_secret_access_key_set
+            ? "leave blank to keep current"
+            : "…"
+        }
+      />
+
+      <Field
+        label="Session token (optional)"
+        type="password"
+        value={sessionToken}
+        onChange={(e) => setSessionToken(e.target.value)}
+        placeholder={
+          settings.bedrock_aws_session_token_set
+            ? "leave blank to keep current"
+            : "for temporary credentials"
+        }
+      />
+
+      <Field
+        label="Endpoint URL (optional)"
+        type="text"
+        value={endpoint}
+        onChange={(e) => setEndpoint(e.target.value)}
+        placeholder="https://bedrock-runtime-fips.us-gov-west-1.amazonaws.com"
+        hint="Only for a FIPS or private (PrivateLink) endpoint; blank derives it from the region."
+      />
+
+      <ModelListEditor
+        models={models}
+        setModels={setModels}
+        placeholder="us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        hint="Bedrock model IDs enabled in your account"
+      />
+
+      <TestConnection
+        provider="bedrock"
         model={models[0] ?? null}
         configured={configured}
       />

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -65,7 +65,7 @@ const PROVIDER_META: Record<Provider, ProviderMeta> = {
     initial: "C",
   },
   bedrock: {
-    defaultModel: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+    defaultModel: "us.anthropic.claude-sonnet-4-6",
     keyLabel: "Access key ID",
     keyPlaceholder: "AKIA…",
     initial: "B",
@@ -84,9 +84,9 @@ const PROVIDER_MODELS: Record<Provider, string[]> = {
   ollama: ["llama3.1", "llama3.2", "mistral", "phi3", "qwen2.5", "deepseek-r1"],
   custom: [],
   bedrock: [
-    "anthropic.claude-3-5-sonnet-20241022-v2:0",
-    "anthropic.claude-3-5-haiku-20241022-v1:0",
-    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "us.anthropic.claude-sonnet-4-6",
+    "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "us.anthropic.claude-opus-4-8",
   ],
 };
 
@@ -912,6 +912,7 @@ function BedrockProviderForm({
   const [accessKeyId, setAccessKeyId] = useState("");
   const [secretAccessKey, setSecretAccessKey] = useState("");
   const [sessionToken, setSessionToken] = useState("");
+  const [bearerToken, setBearerToken] = useState("");
   const [models, setModels] = useState<string[]>(
     () => settings.provider_models["bedrock"] ?? PROVIDER_MODELS.bedrock,
   );
@@ -939,6 +940,7 @@ function BedrockProviderForm({
       if (accessKeyId) body.bedrock_aws_access_key_id = accessKeyId;
       if (secretAccessKey) body.bedrock_aws_secret_access_key = secretAccessKey;
       if (sessionToken) body.bedrock_aws_session_token = sessionToken;
+      if (bearerToken) body.bedrock_aws_bearer_token = bearerToken;
       await apiFetch("/admin/llm", {
         method: "PUT",
         body: JSON.stringify(body),
@@ -946,6 +948,7 @@ function BedrockProviderForm({
       setAccessKeyId("");
       setSecretAccessKey("");
       setSessionToken("");
+      setBearerToken("");
       setSaved(true);
       onSaved();
       void globalMutate("/llm/status");
@@ -975,6 +978,7 @@ function BedrockProviderForm({
           bedrock_aws_access_key_id: null,
           bedrock_aws_secret_access_key: null,
           bedrock_aws_session_token: null,
+          bedrock_aws_bearer_token: null,
           provider_models: { ...settings.provider_models, bedrock: [] },
         }),
       });
@@ -995,6 +999,19 @@ function BedrockProviderForm({
         onChange={(e) => setRegion(e.target.value)}
         placeholder="us-gov-west-1"
         hint="GovCloud regions (us-gov-west-1 / us-gov-east-1) route to the GovCloud partition automatically."
+      />
+
+      <Field
+        label="Bedrock API key (optional)"
+        type="password"
+        value={bearerToken}
+        onChange={(e) => setBearerToken(e.target.value)}
+        placeholder={
+          settings.bedrock_aws_bearer_token_set
+            ? "leave blank to keep current"
+            : "a Bedrock API key (alternative to AWS access keys)"
+        }
+        hint="Use this OR the AWS access key + secret below — not both."
       />
 
       <Field
@@ -1045,7 +1062,7 @@ function BedrockProviderForm({
       <ModelListEditor
         models={models}
         setModels={setModels}
-        placeholder="us-gov.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        placeholder="us.anthropic.claude-sonnet-4-6"
         hint="Bedrock model IDs enabled in your account"
       />
 

--- a/frontend/src/lib/llm.ts
+++ b/frontend/src/lib/llm.ts
@@ -65,6 +65,8 @@ export interface LLMSettings {
   bedrock_aws_secret_access_key_set: boolean;
   bedrock_aws_secret_access_key_hint: string;
   bedrock_aws_session_token_set: boolean;
+  bedrock_aws_bearer_token_set: boolean;
+  bedrock_aws_bearer_token_hint: string;
   provider_models: Record<string, string[]>;
   ingest_selector_model: string;
 }

--- a/frontend/src/lib/llm.ts
+++ b/frontend/src/lib/llm.ts
@@ -17,7 +17,13 @@ export function useLLMStatus(opts: { skip?: boolean } = {}) {
   };
 }
 
-export type Provider = "anthropic" | "openai" | "gemini" | "ollama" | "custom";
+export type Provider =
+  | "anthropic"
+  | "openai"
+  | "gemini"
+  | "ollama"
+  | "custom"
+  | "bedrock";
 
 export const ALL_PROVIDERS: Provider[] = [
   "anthropic",
@@ -25,6 +31,7 @@ export const ALL_PROVIDERS: Provider[] = [
   "gemini",
   "ollama",
   "custom",
+  "bedrock",
 ];
 
 export const PROVIDER_LABELS: Record<Provider, string> = {
@@ -33,6 +40,7 @@ export const PROVIDER_LABELS: Record<Provider, string> = {
   gemini: "Gemini",
   ollama: "Ollama",
   custom: "Custom",
+  bedrock: "Amazon Bedrock",
 };
 
 // Shape of GET /admin/llm (LLMView) — shared by the admin pages that render it.
@@ -50,6 +58,13 @@ export interface LLMSettings {
   custom_api_key_hint: string;
   custom_base_url: string;
   custom_display_name: string;
+  bedrock_aws_region: string;
+  bedrock_endpoint_url: string;
+  bedrock_aws_access_key_id_set: boolean;
+  bedrock_aws_access_key_id_hint: string;
+  bedrock_aws_secret_access_key_set: boolean;
+  bedrock_aws_secret_access_key_hint: string;
+  bedrock_aws_session_token_set: boolean;
   provider_models: Record<string, string[]>;
   ingest_selector_model: string;
 }
@@ -60,6 +75,7 @@ export function isConfigured(p: Provider, s: LLMSettings): boolean {
   if (p === "gemini") return s.gemini_api_key_set;
   if (p === "ollama") return !!s.ollama_base_url;
   if (p === "custom") return !!s.custom_base_url;
+  if (p === "bedrock") return !!s.bedrock_aws_region;
   return false;
 }
 


### PR DESCRIPTION
## Description

Adds a `bedrock` LLM provider serving any Bedrock model family (Claude, Nova, Llama, …) via AWS's unified **Converse API**, configured from the admin Language Models page like the other providers. **GovCloud works by region alone** — a `us-gov-*` region routes to the GovCloud partition automatically; an optional endpoint override covers FIPS / PrivateLink. Driven by a customer needing Claude on GovCloud Bedrock.

- `providers/bedrock.py` — boto3 `bedrock-runtime` client + auth (a Bedrock API key / bearer token, static access key + secret / session token, or the default chain for an IAM role), botocore→`LLMError` mapping, and a `converse` preflight for Test connection.
- `providers/_converse.py` — pure normalized↔Converse translation + stream decoder (tool-arg fragment accumulation, cache-aware usage), unit-tested without AWS.
- Schema — 6 credential/config columns (region/endpoint `Text`; AWS creds + bearer token `EncryptedString`), migrations `0036`/`0037`, admin get/put with redaction + write-only-on-PUT, `/available` wiring.
- Frontend — a Bedrock provider card; extracted a shared `ModelListEditor`.

Design doc: wiki `Engineering Projects/Agent Wiki Project/design/AWS Bedrock Provider.md`. Converse request/stream shapes verified against the botocore service model.

## How Has This Been Tested?

- **Unit (no AWS)** — `tests/test_bedrock_converse.py` (8 tests): Converse request translation, the `converse_stream` decoder (text + streamed tool-arg accumulation + cache-aware usage), the provider `stream()` via a patched boto3 client, and botocore-error→`LLMError` mapping.
- **DB-backed (real Postgres)** — migrations `0036`/`0037` apply cleanly via `alembic upgrade head` (after main's `0034`/`0035`); the `EncryptedString` credential columns encrypt/round-trip at rest; admin save → redacted-read round-trip. Full backend suite, ruff, basedpyright (strict), and frontend `tsc` all green.
- **Live, end-to-end against real AWS Bedrock (`us-west-2`) with a real Bedrock API key:**
  - Provider `stream()` → real `converse_stream` → decoded `text_delta` + terminal `done` correctly (model replied; usage `input/output/cached` decoded; `stop_reason=end_turn`).
  - Through the running app/admin API: `PUT /admin/llm` stored the bearer token (returned only as a redacted hint, never raw), then `POST /admin/llm/bedrock/test` → a live `converse` returned `ok` against `us.anthropic.claude-sonnet-4-6` (the new default).
  - This also surfaced + fixed two real issues: the bearer-token auth method (a Bedrock API key isn't usable via access-key fields) and EOL 2024 model IDs (replaced with current inference profiles).
- **Not yet exercised:** a GovCloud (`us-gov-*`) account — it's the identical code path, differing only by region.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
