### PR TITLE
feat(wiki): poll update-health so the 24h count refreshes live

### DIFF
--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Switch, Text } from "@onyx-ai/opal/components";
 import { SvgEdit, SvgHistory, SvgX } from "@onyx-ai/opal/icons";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { ApiError } from "@/lib/api";
 import {
@@ -10,7 +10,7 @@ import {
   patchUpdatePolicy,
   type UpdatePolicyResponse,
 } from "@/lib/updatePolicy";
-import { fetchUpdateHealth, type UpdateHealth } from "@/lib/wiki";
+import { useUpdateHealth } from "@/lib/wiki";
 
 import styles from "./UpdatePolicyPanel.module.css";
 
@@ -49,23 +49,21 @@ export function UpdatePolicyPanel({
   const [sliderVal, setSliderVal] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // Auto-update health (24h count, effective threshold, cap). Loaded separately
-  // so a failure here never blocks the policy card — null hides the activity row
-  // + slider.
-  const [health, setHealth] = useState<UpdateHealth | null>(null);
-
-  function loadHealth(p: string, alive: () => boolean) {
-    fetchUpdateHealth(p)
-      .then((r) => {
-        if (alive()) {
-          setHealth(r);
-          setSliderVal(r.threshold_24h);
-        }
-      })
-      .catch(() => {
-        // Non-fatal: leave the activity row + slider hidden.
-      });
-  }
+  // Auto-update health (24h count, effective threshold, cap) as a live poll, so
+  // the count + slider reflect ingestion writes without reopening the panel. A
+  // failure here never blocks the policy card — null hides the activity row +
+  // slider.
+  const { health, refresh: refreshHealth } = useUpdateHealth(path);
+  // Seed the slider from the effective threshold once per page. Tracking the
+  // health's own path (not a poll tick) keeps a 15s revalidation from yanking
+  // the thumb mid-drag while still re-seeding when the panel switches pages.
+  const seededFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (health && seededFor.current !== health.path) {
+      seededFor.current = health.path;
+      setSliderVal(health.threshold_24h);
+    }
+  }, [health]);
 
   useEffect(() => {
     let alive = true;
@@ -73,7 +71,6 @@ export function UpdatePolicyPanel({
     setLoaded(false);
     setError(null);
     setEditing(false);
-    setHealth(null);
     setSliderVal(null);
     getUpdatePolicy(path)
       .then((r) => {
@@ -88,7 +85,6 @@ export function UpdatePolicyPanel({
       .finally(() => {
         if (alive) setLoading(false);
       });
-    loadHealth(path, () => alive);
     return () => {
       alive = false;
     };
@@ -126,12 +122,13 @@ export function UpdatePolicyPanel({
   }
 
   // Persist the slider's value as the page's explicit threshold (or clear it
-  // back to the default), then refresh health so the effective value shown is
-  // accurate.
+  // back to the default), then revalidate health and re-seed the slider so the
+  // effective value shown is accurate (notably when clearing to the default).
   function saveThreshold(value: number | null) {
-    void save({ warn_update_threshold: value }, () =>
-      loadHealth(path, () => true),
-    );
+    void save({ warn_update_threshold: value }, async () => {
+      const fresh = await refreshHealth();
+      if (fresh) setSliderVal(fresh.threshold_24h);
+    });
   }
 
   // "Auto-Update Wiki" ON = ingestion auto-update enabled (NOT disabled).

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -1,3 +1,5 @@
+import useSWR from "swr";
+
 import { apiFetch } from "@/lib/api";
 
 /** Last path segment as a display name — drops a trailing `.md`. Shared by the
@@ -162,11 +164,23 @@ export interface UpdateHealth {
   auto_update_disabled: boolean;
 }
 
-/** Auto-update health for a page — drives the too-frequent-update banner. */
-export async function fetchUpdateHealth(path: string): Promise<UpdateHealth> {
-  return apiFetch<UpdateHealth>(
-    `/wiki/update-health?path=${encodeURIComponent(path)}`,
-  );
+/** Auto-update health as a live SWR subscription. Polls so the 24h count and
+ * the too-frequent-update banner reflect ingestion writes without a manual
+ * reload — the count moves slowly, so a coarser interval than the doc body's
+ * is plenty. Pass `null` to disable (no path selected). */
+export function useUpdateHealth(path: string | null) {
+  const key = path
+    ? `/wiki/update-health?path=${encodeURIComponent(path)}`
+    : null;
+  const { data, error, isLoading, mutate } = useSWR<UpdateHealth>(key, {
+    refreshInterval: 15_000,
+  });
+  return {
+    health: data ?? null,
+    error: error as Error | undefined,
+    isLoading,
+    refresh: mutate,
+  };
 }
 
 /**


### PR DESCRIPTION
## What

The Update Policy panel fetched `update-health` **once** on open (a one-shot `useEffect`), so the **"N Auto Updates in the past 24 hours"** count and the slider seed froze until the panel was reopened or the page hard-reloaded — even though the doc body already revalidates via SWR (`liveDoc`, 1.5s).

This adds a `useUpdateHealth(path)` SWR hook and has the panel consume it, mirroring the `liveDoc` poll on the page view. After an ingestion write the count now ticks up on its own.

## How

- `lib/wiki.ts`: new `useUpdateHealth(path)` — `useSWR` keyed on `/wiki/update-health?path=…`, `refreshInterval: 15_000` (coarser than the doc poll since the 24h count moves slowly).
- `UpdatePolicyPanel.tsx`: drop the one-shot `loadHealth` + `health` state for the hook. The slider is seeded from the **health's own path** (via a ref), so a 15s revalidation tick can't yank the thumb mid-drag, but it still re-seeds when the panel switches pages or the threshold is cleared to the workspace default.

## Context

Part of **Taming Bad-Behaved Wikis – step 2**. The too-frequent-update **banner** (PR 3) will consume the same hook so it appears/clears live.

## Test

- `bun run typecheck`, prettier clean.