### PR TITLE
feat(wiki): warn when a page auto-updates too frequently

### DIFF
--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -6,11 +6,11 @@ import logging
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import or_, select
 
 from app.auth import User
 from app.auth.deps import require_user
-from app.db.models import Event as EventRow, Trigger
+from app.db.models import Event as EventRow, Trigger, WikiOwner
 from app.db.session import session
 from app.models.event import Event, EventListResponse
 
@@ -44,10 +44,21 @@ def list_events(
     limit: int = Query(100, ge=1, le=500),
     kind: str | None = None,
 ) -> EventListResponse:
+    # The activity feed shows two families of events keyed on ``target``:
+    # trigger fires (target = a trigger the user owns) and page-scoped events
+    # like ``wiki.frequent_updates`` (target = a page the user owns).
     owned_trigger_ids = select(Trigger.id).where(Trigger.owner_user_id == user.id)
+    owned_page_paths = select(WikiOwner.path).where(
+        WikiOwner.owner_user_id == user.id
+    )
     stmt = (
         select(EventRow)
-        .where(EventRow.target.in_(owned_trigger_ids))
+        .where(
+            or_(
+                EventRow.target.in_(owned_trigger_ids),
+                EventRow.target.in_(owned_page_paths),
+            )
+        )
         .order_by(EventRow.id.desc())
         .limit(limit)
     )

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -57,7 +57,9 @@ from app.models.file_system import (
 from app.tasks.reindex import index_path
 from app.triggers import repo as triggers_repo
 from app.wiki import (
+    acl,
     agent_activity,
+    constants as wiki_constants,
     diff as wiki_diff,
     drafts as wiki_drafts,
     filesystem,
@@ -599,7 +601,7 @@ def update_health(
 
     since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
     count = wiki_git.count_commits_since(
-        rel, author=wiki_utils.INGEST_AUTHOR_EMAIL, since_iso=since
+        rel, author=wiki_constants.INGEST_AUTHOR_EMAIL, since_iso=since
     )
     return UpdateHealthResponse(
         path=rel,
@@ -609,6 +611,7 @@ def update_health(
         auto_update_disabled=update_policy_repo.resolve_for_path(
             rel
         ).ingestion_auto_update_disabled,
+        can_manage=acl.can(user.id, user.is_admin, "write", rel),
     )
 
 

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -41,6 +41,7 @@ class UpdateHealthResponse(BaseModel):
     threshold_24h: int  # per-page warning threshold, updates/24h (0 = every update)
     cap_24h: int  # admin global cap, updates/24h (slider max; 0 = no cap)
     auto_update_disabled: bool  # effective: ingestion auto-update is off here
+    can_manage: bool  # viewer has write access — may act on the warning
 
 
 class PatchUpdatePolicyRequest(BaseModel):

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -38,6 +38,7 @@ _TASK_MODULES = (
     "app.tasks.periodic",
     "app.tasks.reindex",
     "app.tasks.triggers",
+    "app.tasks.update_frequency",
 )
 for _mod in _TASK_MODULES:
     importlib.import_module(_mod)

--- a/backend/app/tasks/update_frequency.py
+++ b/backend/app/tasks/update_frequency.py
@@ -1,0 +1,71 @@
+"""Too-frequent-update guardrail — surface churn in the activity feed.
+
+Part of "Taming Bad-Behaved Wikis" (see the wiki design page). After an
+ingestion auto-update commits a page, ``after_doc_write`` enqueues
+``check_update_frequency`` here. It counts the page's ingestion updates in a
+**sliding 24h window** (``git log --since=now-24h`` by the ``Onyx Ingest``
+author) and, on the commit that crosses the page's warning threshold, records a
+``wiki.frequent_updates`` event so it shows in the owner's Activities panel.
+
+Advisory only — it does not block or disable anything. (Enforcing the admin cap
+by pausing over-cap ingestion is a follow-up PR.) The event is recorded once
+per crossing (when ``count == threshold``) so a hot page doesn't spam the feed.
+All work here is a git read + one Postgres insert — no LLM, no wiki commit.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.db.models import Event
+from app.db.session import session
+from app.tasks.queues import lightweight_maintenance_queue
+from app.wiki import constants as wiki_constants
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
+
+log = logging.getLogger(__name__)
+
+_WINDOW_HOURS = 24
+
+EVENT_FREQUENT_UPDATES = "wiki.frequent_updates"
+
+
+@lightweight_maintenance_queue.task()
+def check_update_frequency(path: str) -> None:
+    _check_update_frequency_inline(path)
+
+
+def _check_update_frequency_inline(path: str) -> None:
+    if not path.endswith(".md"):
+        return
+    since = (datetime.now(timezone.utc) - timedelta(hours=_WINDOW_HOURS)).isoformat()
+    count = wiki_git.count_commits_since(
+        path, author=wiki_constants.INGEST_AUTHOR_EMAIL, since_iso=since
+    )
+    if count == 0:
+        return
+    # Warnings are moot when the page's auto-update is off (no ingestion to
+    # warn about); ingestion shouldn't even reach here, but guard anyway.
+    if update_policy.resolve_for_path(path).ingestion_auto_update_disabled:
+        return
+    threshold = update_policy.resolve_warn_threshold(path)
+    if count < threshold:
+        return
+    # threshold 0 → warn on every auto-update; threshold > 0 → warn once, on the
+    # crossing commit (count == threshold), so a ramp-up doesn't flood the feed.
+    if threshold > 0 and count != threshold:
+        return
+    log.info("frequent-updates: %s at %d updates/24h (threshold %d)", path, count, threshold)
+    with session() as s:
+        s.add(
+            Event(
+                kind=EVENT_FREQUENT_UPDATES,
+                actor=wiki_constants.INGEST_AUTHOR,
+                target=path,
+                payload_json=json.dumps(
+                    {"doc_path": path, "count": count, "threshold": threshold}
+                ),
+            )
+        )

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -52,7 +52,7 @@ from app.mcp_server import jobs as mcp_jobs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.auth import UserMissingError, load_user, set_current_user
 from app.tasks.queues import documents_queue
-from app.wiki import agent_activity, git as wiki_git, update_policy
+from app.wiki import agent_activity, constants as wiki_constants, git as wiki_git, update_policy
 from app.models.wiki import ChangeKind, CommitMaxRetriesError
 
 
@@ -258,7 +258,7 @@ def process_pushed_document(push: dict[str, Any]) -> None:
     ``Onyx Ingest`` author for the run so its commits surface under that name in
     history instead of the generic fallback, then delegate to the reconciler.
     """
-    with wiki_utils.system_author(wiki_utils.INGEST_AUTHOR):
+    with wiki_utils.system_author(wiki_constants.INGEST_AUTHOR):
         _reconcile_pushed_document(push)
 
 

--- a/backend/app/wiki/constants.py
+++ b/backend/app/wiki/constants.py
@@ -1,0 +1,17 @@
+"""Leaf constants for the wiki package — no imports, so any module can read
+these without pulling in a heavy dependency chain.
+
+The ingest git-identity below is needed by both ``app/wiki/utils.py`` (which
+binds it on the ingest path via ``system_author``) and leaf consumers like
+``app/tasks/update_frequency.py`` and ``app/wiki/notify.py``. Keeping it here
+rather than in ``utils.py`` avoids a cycle: ``utils`` imports
+``llm.agents.tools`` → ``notify``, so a constant living in ``utils`` couldn't be
+read by ``notify`` / ``update_frequency`` without an import loop.
+"""
+from __future__ import annotations
+
+# Git identity for connector-pushed ingestion commits. Bound on the ingest path
+# via ``utils.system_author(INGEST_AUTHOR)``; the email is what callers filter on
+# when counting ingestion commits (``count_commits_since``).
+INGEST_AUTHOR_EMAIL = "onyx-ingest@local"
+INGEST_AUTHOR = f"Onyx Ingest <{INGEST_AUTHOR_EMAIL}>"

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -35,8 +35,9 @@ from app.db import fts, page_dirs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
+from app.tasks.update_frequency import check_update_frequency
 from app.triggers import repo as triggers_repo
-from app.wiki import acl, agent_activity, comments, drafts, update_policy
+from app.wiki import acl, agent_activity, comments, constants as wiki_constants, drafts, update_policy
 from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind
 
@@ -87,6 +88,10 @@ def after_doc_write(
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
     index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
+    # Ingestion churn → check the page's 24h update frequency against the
+    # owner's threshold + the admin cap (enqueues a lightweight task).
+    if actor == wiki_constants.INGEST_AUTHOR:
+        check_update_frequency(rel_path)
     # Drift any comments anchored to this page onto the new body. A no-op on
     # CREATE (no comments yet); the real work is on EDIT.
     _remap_comments_safe(rel_path)

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -99,13 +99,6 @@ def assert_base_sha(path: str, base_sha: str | None) -> dict[str, str] | None:
 
 _FALLBACK_AUTHOR = "AI Wiki Helper <ai-wiki-helper@local>"
 
-# Git identity for connector-pushed ingestion commits — these have no human
-# user, so without this they'd fall back to ``_FALLBACK_AUTHOR``. Bound via
-# ``system_author(INGEST_AUTHOR)`` on the ingest path; the email is what
-# callers filter on when counting ingestion commits (see git.count_commits_since).
-INGEST_AUTHOR_EMAIL = "onyx-ingest@local"
-INGEST_AUTHOR = f"Onyx Ingest <{INGEST_AUTHOR_EMAIL}>"
-
 # Explicit git author for system-initiated commits that legitimately have no
 # user in context (document ingestion from a connector, etc.). Bound by the
 # ``system_author`` context manager; consulted by ``author_string`` before it

--- a/backend/tests/test_count_commits_since.py
+++ b/backend/tests/test_count_commits_since.py
@@ -7,11 +7,11 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from app.wiki import constants as wiki_constants
 from app.wiki import git as wiki_git
-from app.wiki import utils as wiki_utils
 
-INGEST = wiki_utils.INGEST_AUTHOR
-EMAIL = wiki_utils.INGEST_AUTHOR_EMAIL
+INGEST = wiki_constants.INGEST_AUTHOR
+EMAIL = wiki_constants.INGEST_AUTHOR_EMAIL
 HUMAN_AUTHOR = "Nik <nik@x.com>"
 
 

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -23,6 +23,7 @@ from app.ingest import search as ingest_search
 from app.ingest.source_tiers import is_filtered
 from app.llm.agents.common import IRRELEVANT_SENTINEL
 from app.llm.settings import _EMPTY as _EMPTY_LLM_SETTINGS, LLMSettings
+from app.wiki import constants as wiki_constants
 from app.wiki import git as wiki_git
 from app.wiki.utils import author_string
 
@@ -295,7 +296,7 @@ def test_commit_attributed_to_onyx_ingest(
     mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     mock_reconcile.return_value = (["new body"], 1)
     _run(_make_push())
-    assert mock_commit.call_args.kwargs["author"] == "Onyx Ingest <onyx-ingest@local>"
+    assert mock_commit.call_args.kwargs["author"] == wiki_constants.INGEST_AUTHOR
     # And the binding is unwound after the run — no leak into later tasks.
     assert author_string() == "AI Wiki Helper <ai-wiki-helper@local>"
 

--- a/backend/tests/test_update_frequency.py
+++ b/backend/tests/test_update_frequency.py
@@ -1,0 +1,71 @@
+"""Tests for the too-frequent-update guardrail (app/tasks/update_frequency.py).
+
+The guardrail records a ``wiki.frequent_updates`` activity event on the commit
+that crosses a page's warning threshold — once per crossing, not per commit.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.tasks.update_frequency import (
+    EVENT_FREQUENT_UPDATES,
+    _check_update_frequency_inline,
+)
+from app.wiki import constants as wiki_constants
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
+from tests._seed import list_events
+
+PATH = "team/page.md"
+
+
+@pytest.fixture(autouse=True)
+def _db(tmp_db: None, tmp_repo: None) -> None:
+    return None
+
+
+def _ingest_commit_and_check(n: int) -> None:
+    """One ingestion commit, then the post-commit frequency check — mirrors the
+    real per-commit flow (after_doc_write enqueues a check per commit)."""
+    wiki_git.commit_file(PATH, f"body {n}\n", "ingest", author=wiki_constants.INGEST_AUTHOR)
+    _check_update_frequency_inline(PATH)
+
+
+def _events() -> list[dict]:
+    return [e for e in list_events(EVENT_FREQUENT_UPDATES) if e["target"] == PATH]
+
+
+def test_below_threshold_records_nothing() -> None:
+    update_policy.set_policy(PATH, warn_update_threshold=5)
+    for n in range(3):
+        _ingest_commit_and_check(n)
+    assert _events() == []
+
+
+def test_records_event_on_crossing() -> None:
+    update_policy.set_policy(PATH, warn_update_threshold=3)
+    for n in range(3):
+        _ingest_commit_and_check(n)
+    evs = _events()
+    assert len(evs) == 1
+    assert evs[0]["payload"]["count"] == 3
+    assert evs[0]["payload"]["threshold"] == 3
+
+
+def test_no_duplicate_while_over_threshold() -> None:
+    update_policy.set_policy(PATH, warn_update_threshold=3)
+    # Four commits, each followed by its check: the event fires only on the
+    # crossing commit (count == 3), not again at 4.
+    for n in range(4):
+        _ingest_commit_and_check(n)
+    assert len(_events()) == 1
+
+
+def test_threshold_zero_warns_every_update() -> None:
+    # Threshold 0 means "warn on every auto-update" (not off) — one event per
+    # ingestion commit.
+    update_policy.set_policy(PATH, warn_update_threshold=0)
+    for n in range(3):
+        _ingest_commit_and_check(n)
+    assert len(_events()) == 3

--- a/backend/tests/test_update_health_api.py
+++ b/backend/tests/test_update_health_api.py
@@ -10,9 +10,10 @@ from fastapi.testclient import TestClient
 from app.auth import users as users_repo
 from app.ingest import settings as ingest_settings
 from app.main import create_app
+from app.wiki import acl
+from app.wiki import constants as wiki_constants
 from app.wiki import git as wiki_git
 from app.wiki import update_policy
-from app.wiki import utils as wiki_utils
 from tests._auth import login_fastapi
 
 PATH = "team/page.md"
@@ -31,13 +32,48 @@ def test_returns_count_threshold_and_cap(client: TestClient) -> None:
     uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
     login_fastapi(client, uid)
     for i in range(3):
-        wiki_git.commit_file(PATH, f"b{i}\n", "ingest", author=wiki_utils.INGEST_AUTHOR)
+        wiki_git.commit_file(PATH, f"b{i}\n", "ingest", author=wiki_constants.INGEST_AUTHOR)
     update_policy.set_policy(PATH, warn_update_threshold=2)
 
     body = client.get(f"/api/wiki/update-health?path={PATH}").json()
     assert body["count_24h"] == 3
     assert body["threshold_24h"] == 2  # explicit per-page value
     assert "cap_24h" in body  # admin cap, for the slider max
+    assert body["can_manage"] is True  # first user is admin → can act on the warning
+
+
+def test_can_manage_true_for_non_admin_owner(client: TestClient) -> None:
+    # The page owner (not just admins) can act on the warning, so the banner
+    # shows for them too.
+    users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")  # first = admin
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    wiki_git.commit_file(PATH, "b\n", "ingest", author=wiki_constants.INGEST_AUTHOR)
+    acl.set_owner(PATH, owner)
+    login_fastapi(client, owner)
+
+    body = client.get(f"/api/wiki/update-health?path={PATH}").json()
+    assert body["can_manage"] is True
+
+
+def test_can_manage_false_for_non_owner_reader(client: TestClient) -> None:
+    # The banner + its "Review settings" CTA only render when can_manage is true,
+    # so a reader who can't change the policy never sees them.
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    reader = users_repo.create(email="reader@x.com", password="hunter2-x", name="Read")
+    wiki_git.commit_file(PATH, "b\n", "ingest", author=wiki_constants.INGEST_AUTHOR)
+    acl.set_owner(PATH, owner)
+    acl.grant(
+        resource_kind="page",
+        resource_path=PATH,
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
+        granted_by_user_id=owner,
+    )
+    login_fastapi(client, reader)
+
+    body = client.get(f"/api/wiki/update-health?path={PATH}").json()
+    assert body["can_manage"] is False
 
 
 def test_threshold_falls_back_to_workspace_default(client: TestClient) -> None:

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -54,6 +54,7 @@ import {
 } from "@/lib/launchers";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
+import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { apiFetch, ApiError } from "@/lib/api";
 import { listComments } from "@/lib/comments";
@@ -2468,6 +2469,12 @@ function FileViewer({ path }: { path: string }) {
             <div
               className={`min-h-0 flex-1 overflow-y-auto ${isMobile ? "-mx-3 px-3" : "-mx-8 px-8"}`}
             >
+              <div className="mx-auto w-full max-w-[768px]">
+                <UpdateHealthBanner
+                  path={path}
+                  onOpenPolicy={() => setPolicyOpen(true)}
+                />
+              </div>
               <article
                 ref={articleRef}
                 className="markdown mx-auto w-full max-w-[768px]"

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -22,14 +22,60 @@ interface TriggerFirePayload {
   reason?: string;
 }
 
+interface FrequentUpdatesPayload {
+  doc_path?: string;
+  count?: number;
+  threshold?: number;
+}
+
+// Searchable text for an event regardless of kind.
+function eventHaystack(event: AppEvent): string {
+  const p = event.payload as TriggerFirePayload & FrequentUpdatesPayload;
+  return [p.doc_path, p.change_kind, p.reason, event.target, event.kind]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
 interface ActivityCardProps {
   event: AppEvent;
 }
 
+const cardClass =
+  "mx-3 my-1.5 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-3 py-2.5";
+
+function FrequentUpdatesCard({ event }: ActivityCardProps) {
+  const p = event.payload as FrequentUpdatesPayload;
+  return (
+    <div className={cardClass}>
+      <div className="mb-1 flex items-start justify-between gap-2">
+        <span className="truncate font-mono text-xs text-(--text-04)">
+          {p.doc_path ? formatScopePath(p.doc_path) : "(no path)"}
+        </span>
+        <span className="shrink-0 rounded-(--border-radius-04) bg-(--status-warning-01) px-1.5 py-[2px] text-[10px] font-semibold tracking-[0.3px] text-(--status-text-warning-05) uppercase">
+          Frequent
+        </span>
+      </div>
+      <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
+        Auto-updated {p.count ?? "?"} times in the past 24 hours
+        {p.threshold ? ` (warns at ${p.threshold}).` : "."}
+      </p>
+      <div className="flex items-center justify-end">
+        <span className="text-[11px] text-(--text-02)">
+          {timeAgo(toEventIso(event.ts))}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function ActivityCard({ event }: ActivityCardProps) {
+  if (event.kind === "wiki.frequent_updates") {
+    return <FrequentUpdatesCard event={event} />;
+  }
   const p = event.payload as TriggerFirePayload;
   return (
-    <div className="mx-3 my-1.5 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-3 py-2.5">
+    <div className={cardClass}>
       <div className="mb-1 flex items-start justify-between gap-2">
         {p.doc_path ? (
           <span className="truncate font-mono text-xs text-(--text-04)">
@@ -65,21 +111,14 @@ export default function ActivitiesPanel() {
   const { toggleActivities } = useLeftPanel();
   const [query, setQuery] = useState("");
   const { events, isLoading } = useEvents(
-    { kind: "trigger.fire", limit: 100 },
+    { limit: 100 },
     { refreshInterval: 30_000 },
   );
 
   const unreadCount = events.filter((ev) => isNewActivity(ev.ts)).length;
 
   const filtered = query
-    ? events.filter((ev) => {
-        const p = ev.payload as TriggerFirePayload;
-        const haystack = [p.doc_path, p.change_kind, p.reason, ev.target]
-          .filter(Boolean)
-          .join(" ")
-          .toLowerCase();
-        return haystack.includes(query.toLowerCase());
-      })
+    ? events.filter((ev) => eventHaystack(ev).includes(query.toLowerCase()))
     : events;
 
   const newEvents = filtered.filter((ev) => isNewActivity(ev.ts));

--- a/frontend/src/components/wiki/UpdateHealthBanner.tsx
+++ b/frontend/src/components/wiki/UpdateHealthBanner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { Button, MessageCard } from "@onyx-ai/opal/components";
+
+import { useUpdateHealth } from "@/lib/wiki";
+
+interface Props {
+  path: string;
+  // Opens the Update Policy panel so the owner can adjust the threshold or
+  // re-enable auto-update.
+  onOpenPolicy: () => void;
+}
+
+/**
+ * Banner shown when a page is auto-updating too frequently. Pull-based: polls
+ * the raw `update-health` facts (via the shared SWR hook, so it appears and
+ * clears without a manual reload) and decides here whether to show — count
+ * at/over the page's warning threshold. Mirrors the inline warning-banner
+ * pattern used elsewhere in the wiki page view.
+ */
+export function UpdateHealthBanner({ path, onOpenPolicy }: Props) {
+  const { health } = useUpdateHealth(path);
+
+  // Client-side decision from the raw facts: warn when the page has had updates
+  // at/over its threshold (threshold 0 = every update). Suppressed when
+  // auto-update is off (nothing to warn about), and shown only to viewers who
+  // can manage the page — the warning + its "Review settings" CTA are only
+  // actionable for writers, and the threshold isn't a non-owner's concern.
+  const shouldWarn =
+    !!health &&
+    health.can_manage &&
+    !health.auto_update_disabled &&
+    health.count_24h > 0 &&
+    health.count_24h >= health.threshold_24h;
+  if (!shouldWarn) return null;
+
+  // Advisory frequency warning. The owner can act on it (raise the threshold
+  // or turn off auto-update), so it keeps the "Review settings" CTA.
+  const description =
+    `Auto-updated ${health.count_24h} times in the past 24 hours` +
+    (health.threshold_24h > 0
+      ? `, above the warning threshold of ${health.threshold_24h}.`
+      : ".");
+
+  return (
+    <div className="mb-3">
+      <MessageCard
+        variant="warning"
+        title="This page is updating frequently"
+        description={description}
+        rightChildren={
+          <Button size="sm" onClick={onOpenPolicy}>
+            Review settings
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -54,9 +54,12 @@ export function UpdatePolicyPanel({
   // failure here never blocks the policy card — null hides the activity row +
   // slider.
   const { health, refresh: refreshHealth } = useUpdateHealth(path);
-  // Seed the slider from the effective threshold once per page. Tracking the
-  // health's own path (not a poll tick) keeps a 15s revalidation from yanking
-  // the thumb mid-drag while still re-seeding when the panel switches pages.
+  // Seed the slider from the effective threshold once per page, keyed on the
+  // health's own path. This (rather than nulling on a path change) is what
+  // re-seeds when the panel switches pages, and it survives the shared SWR
+  // cache being already warm from the page-view banner — nulling sliderVal here
+  // would race this effect and leave the slider permanently hidden. A 15s
+  // revalidation for the same path is a no-op, so it never yanks the thumb.
   const seededFor = useRef<string | null>(null);
   useEffect(() => {
     if (health && seededFor.current !== health.path) {
@@ -71,7 +74,6 @@ export function UpdatePolicyPanel({
     setLoaded(false);
     setError(null);
     setEditing(false);
-    setSliderVal(null);
     getUpdatePolicy(path)
       .then((r) => {
         if (alive) {

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -162,6 +162,7 @@ export interface UpdateHealth {
   threshold_24h: number;
   cap_24h: number;
   auto_update_disabled: boolean;
+  can_manage: boolean;
 }
 
 /** Auto-update health as a live SWR subscription. Polls so the 24h count and


### PR DESCRIPTION
Completes **Taming Bad-Behaved Wikis – step 2**. #288 added the threshold + ingest-health knobs; #289 added the slider UI + `update-health` endpoint; #291 made the count refresh live. This PR is the part that **acts on the threshold**: detect too-frequent ingestion updates and surface them to the page owner.

> **Stacked on #291** (the banner uses the `useUpdateHealth` hook). Review/merge #291 first; GitHub will retarget this to `main`.

## Backend
- **`tasks/update_frequency.py`** — new `check_update_frequency` (lightweight queue): after an ingestion write, count the page's `Onyx Ingest` commits in a sliding 24h window and, on the commit that **crosses** the page's warn threshold, record a `wiki.frequent_updates` activity event. Advisory only — no blocking, no wiki commit, no LLM (honors the `lightweight_maintenance_queue` contract). Threshold `0` = warn on every auto-update; `>0` = warn once per crossing (so a hot page doesn't spam the feed).
- **`notify.py`** — hook the check into `after_doc_write` for ingest-authored writes.
- **`api/events.py`** — `GET /api/events` now also returns events whose `target` is a **page the caller owns** (previously trigger-owned only), so frequent-update events reach page owners.
- **INGEST_AUTHOR move** — the `Onyx Ingest` author constants move from `wiki/utils.py` to `wiki/git.py`. Git-commit identity belongs with the git wrapper, and `utils.py` imports `llm.agents.tools`, which cycles back through `notify` — keeping the constant there would force a lazy import. Blast radius was 5 refs.

## Frontend
- **`UpdateHealthBanner`** on the page view, driven by the `useUpdateHealth` poll so it appears/clears **live**. Shows when `count_24h >= threshold_24h` and auto-update is on; suppressed when off. "Review settings" opens the policy panel.
- **`ActivitiesPanel`** renders a "Frequent" card for `wiki.frequent_updates` and drops the `trigger.fire`-only filter so all event kinds show.

## Test
- `test_update_frequency.py` — below-threshold records nothing; records once on crossing; no duplicate while over; **threshold 0 warns on every update** (fixed from a stale "0 = off" assertion that predated the final semantics).
- Updated `test_count_commits_since` / `test_update_health_api` for the constant move.
- ruff, basedpyright, `bun run typecheck`, prettier all green. Verified end-to-end on the local stack: a page warned-after-2 with 4 ingest updates shows the banner and records one crossing event that surfaces to its owner (and is hidden from non-owners).
<img width="1456" height="579" alt="Screenshot 2026-06-25 at 1 41 05 PM" src="https://github.com/user-attachments/assets/5fc6535d-3623-4589-8781-e659e8307819" />
<img width="1428" height="580" alt="Screenshot 2026-06-25 at 1 41 01 PM" src="https://github.com/user-attachments/assets/99ea66db-f4ec-4934-a75e-aa5fbd91043a" />


## Not in scope (follow-ups)
- Enforcing the admin **cap** (pausing over-cap ingestion) — warn-only this round.
- **Email** delivery — the event is the seam it'll reuse.
- Default warn threshold value (separate small PR).