### PR TITLE
feat(wiki): cap-reached banner on the page view

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -59,7 +59,6 @@ from app.triggers import repo as triggers_repo
 from app.wiki import (
     acl,
     agent_activity,
-    constants as wiki_constants,
     diff as wiki_diff,
     drafts as wiki_drafts,
     filesystem,
@@ -599,19 +598,29 @@ def update_health(
         raise HTTPException(status_code=400, detail=str(e)) from e
     require_can("read", rel, user)
 
-    since = (datetime.now(timezone.utc) - timedelta(hours=24)).isoformat()
-    count = wiki_git.count_commits_since(
-        rel, author=wiki_constants.INGEST_AUTHOR_EMAIL, since_iso=since
-    )
+    times = wiki_git.ingest_update_times_24h(rel)
+    count = len(times)
+    cap = ingest_settings.get().auto_update_cap
+    # When over the cap, the page resumes once enough of the oldest in-window
+    # updates age out for the count to drop back under the cap: the
+    # (count - cap + 1)-th oldest update (index count - cap) leaves the window
+    # 24h after it landed.
+    cap_resets_at: str | None = None
+    if cap > 0 and count >= cap:
+        reset = datetime.fromtimestamp(times[count - cap], tz=timezone.utc) + timedelta(
+            hours=24
+        )
+        cap_resets_at = reset.isoformat()
     return UpdateHealthResponse(
         path=rel,
         count_24h=count,
         threshold_24h=update_policy_repo.resolve_warn_threshold(rel),
-        cap_24h=ingest_settings.get().auto_update_cap,
+        cap_24h=cap,
         auto_update_disabled=update_policy_repo.resolve_for_path(
             rel
         ).ingestion_auto_update_disabled,
         can_manage=acl.can(user.id, user.is_admin, "write", rel),
+        cap_resets_at=cap_resets_at,
     )
 
 

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -42,6 +42,9 @@ class UpdateHealthResponse(BaseModel):
     cap_24h: int  # admin global cap, updates/24h (slider max; 0 = no cap)
     auto_update_disabled: bool  # effective: ingestion auto-update is off here
     can_manage: bool  # viewer has write access — may act on the warning
+    # When over the cap, ISO-8601/UTC time the page drops back under it and
+    # auto-update resumes; None when not over the cap.
+    cap_resets_at: str | None = None
 
 
 class PatchUpdatePolicyRequest(BaseModel):

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -16,12 +16,14 @@ import tempfile
 import time
 from contextlib import contextmanager
 from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from urllib.parse import quote, unquote
 
 from pydantic import BaseModel
 
 from app.config import CONFIG
+from app.wiki import constants
 
 log = logging.getLogger(__name__)
 
@@ -439,6 +441,33 @@ def count_commits_since(rel_path: str, *, author: str, since_iso: str) -> int:
         check=False,
     ).stdout
     return sum(1 for line in out.splitlines() if line.strip())
+
+
+_INGEST_WINDOW_HOURS = 24
+
+
+def ingest_update_times_24h(rel_path: str) -> list[int]:
+    """Committer unix timestamps of ``Onyx Ingest`` auto-update commits to
+    ``rel_path`` in the trailing 24h, oldest first.
+
+    ``len(...)`` is the rolling update count; the timestamps let callers work
+    out when an over-cap page drops back under the cap (the oldest updates age
+    out of the 24h window)."""
+    since = (
+        datetime.now(timezone.utc) - timedelta(hours=_INGEST_WINDOW_HOURS)
+    ).isoformat()
+    out = _run(
+        [
+            "log",
+            f"--since={since}",
+            f"--author=<{constants.INGEST_AUTHOR_EMAIL}>$",
+            "--pretty=format:%ct",
+            "--",
+            rel_path or ".",
+        ],
+        check=False,
+    ).stdout
+    return sorted(int(line) for line in out.splitlines() if line.strip())
 
 
 def list_paths(prefix: str = "") -> list[str]:

--- a/backend/tests/test_update_health_api.py
+++ b/backend/tests/test_update_health_api.py
@@ -4,6 +4,8 @@ client-side too-frequent-update banner."""
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -40,6 +42,22 @@ def test_returns_count_threshold_and_cap(client: TestClient) -> None:
     assert body["threshold_24h"] == 2  # explicit per-page value
     assert "cap_24h" in body  # admin cap, for the slider max
     assert body["can_manage"] is True  # first user is admin → can act on the warning
+    assert body["cap_resets_at"] is None  # not over the cap
+
+
+def test_cap_resets_at_set_when_over_cap(client: TestClient) -> None:
+    uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    login_fastapi(client, uid)
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url=None, auto_update_cap=2)
+    for i in range(3):
+        wiki_git.commit_file(PATH, f"b{i}\n", "ingest", author=wiki_constants.INGEST_AUTHOR)
+
+    body = client.get(f"/api/wiki/update-health?path={PATH}").json()
+    assert body["count_24h"] == 3
+    assert body["cap_24h"] == 2
+    # Over the cap → a resume time is returned (ISO-8601, ~24h out).
+    assert body["cap_resets_at"] is not None
+    datetime.fromisoformat(body["cap_resets_at"])
 
 
 def test_can_manage_true_for_non_admin_owner(client: TestClient) -> None:

--- a/frontend/src/components/wiki/UpdateHealthBanner.tsx
+++ b/frontend/src/components/wiki/UpdateHealthBanner.tsx
@@ -28,12 +28,24 @@ export function UpdateHealthBanner({ path, onOpenPolicy }: Props) {
   // back under the cap. The cap is admin-controlled, so there's no owner action
   // and no "Review settings" CTA — this banner is purely informational.
   if (health.cap_24h > 0 && health.count_24h >= health.cap_24h) {
+    const resumes = health.cap_resets_at
+      ? new Date(health.cap_resets_at).toLocaleString(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        })
+      : null;
+    const description =
+      `This page hit the workspace limit of ${health.cap_24h} auto-updates in 24 hours, ` +
+      (resumes
+        ? `so it won't auto-update until around ${resumes}. `
+        : "so automatic updates are paused until the rate drops. ") +
+      "The limit is set by an admin.";
     return (
       <div className="mb-3">
         <MessageCard
           variant="error"
           title="Auto-update paused — update limit reached"
-          description={`This page hit the workspace limit of ${health.cap_24h} auto-updates in 24 hours, so automatic updates are paused until the rate drops. The limit is set by an admin.`}
+          description={description}
         />
       </div>
     );

--- a/frontend/src/components/wiki/UpdateHealthBanner.tsx
+++ b/frontend/src/components/wiki/UpdateHealthBanner.tsx
@@ -7,53 +7,61 @@ import { useUpdateHealth } from "@/lib/wiki";
 interface Props {
   path: string;
   // Opens the Update Policy panel so the owner can adjust the threshold or
-  // re-enable auto-update.
+  // re-enable auto-update. Used by the frequency warning only.
   onOpenPolicy: () => void;
 }
 
 /**
- * Banner shown when a page is auto-updating too frequently. Pull-based: polls
- * the raw `update-health` facts (via the shared SWR hook, so it appears and
- * clears without a manual reload) and decides here whether to show — count
- * at/over the page's warning threshold. Mirrors the inline warning-banner
- * pattern used elsewhere in the wiki page view.
+ * Pull-based banner for a page's auto-update health. Polls the raw
+ * `update-health` facts (via the shared SWR hook, so it appears and clears
+ * without a manual reload) and decides client-side which state to show. Only
+ * surfaced to viewers who can manage the page, and never when auto-update is
+ * off — there's nothing to act on.
  */
 export function UpdateHealthBanner({ path, onOpenPolicy }: Props) {
   const { health } = useUpdateHealth(path);
 
-  // Client-side decision from the raw facts: warn when the page has had updates
-  // at/over its threshold (threshold 0 = every update). Suppressed when
-  // auto-update is off (nothing to warn about), and shown only to viewers who
-  // can manage the page — the warning + its "Review settings" CTA are only
-  // actionable for writers, and the threshold isn't a non-owner's concern.
-  const shouldWarn =
-    !!health &&
-    health.can_manage &&
-    !health.auto_update_disabled &&
-    health.count_24h > 0 &&
-    health.count_24h >= health.threshold_24h;
-  if (!shouldWarn) return null;
+  if (!health || !health.can_manage || health.auto_update_disabled) return null;
 
-  // Advisory frequency warning. The owner can act on it (raise the threshold
-  // or turn off auto-update), so it keeps the "Review settings" CTA.
-  const description =
-    `Auto-updated ${health.count_24h} times in the past 24 hours` +
-    (health.threshold_24h > 0
-      ? `, above the warning threshold of ${health.threshold_24h}.`
-      : ".");
+  // Cap takes precedence over the warning: once a page hits the admin cap, the
+  // ingest pipeline pauses its auto-updates until the trailing-24h count rolls
+  // back under the cap. The cap is admin-controlled, so there's no owner action
+  // and no "Review settings" CTA — this banner is purely informational.
+  if (health.cap_24h > 0 && health.count_24h >= health.cap_24h) {
+    return (
+      <div className="mb-3">
+        <MessageCard
+          variant="error"
+          title="Auto-update paused — update limit reached"
+          description={`This page hit the workspace limit of ${health.cap_24h} auto-updates in 24 hours, so automatic updates are paused until the rate drops. The limit is set by an admin.`}
+        />
+      </div>
+    );
+  }
 
-  return (
-    <div className="mb-3">
-      <MessageCard
-        variant="warning"
-        title="This page is updating frequently"
-        description={description}
-        rightChildren={
-          <Button size="sm" onClick={onOpenPolicy}>
-            Review settings
-          </Button>
-        }
-      />
-    </div>
-  );
+  // Advisory frequency warning (threshold 0 = every update). The owner can act
+  // on it — raise the threshold or turn off auto-update — so it keeps the CTA.
+  if (health.count_24h > 0 && health.count_24h >= health.threshold_24h) {
+    const description =
+      `Auto-updated ${health.count_24h} times in the past 24 hours` +
+      (health.threshold_24h > 0
+        ? `, above the warning threshold of ${health.threshold_24h}.`
+        : ".");
+    return (
+      <div className="mb-3">
+        <MessageCard
+          variant="warning"
+          title="This page is updating frequently"
+          description={description}
+          rightChildren={
+            <Button size="sm" onClick={onOpenPolicy}>
+              Review settings
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
+
+  return null;
 }

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -163,6 +163,8 @@ export interface UpdateHealth {
   cap_24h: number;
   auto_update_disabled: boolean;
   can_manage: boolean;
+  // When over the cap, ISO-8601/UTC time auto-update resumes; null otherwise.
+  cap_resets_at: string | null;
 }
 
 /** Auto-update health as a live SWR subscription. Polls so the 24h count and


### PR DESCRIPTION
**PR 1 of 3** in the cap-enforcement split for *Taming Bad-Behaved Wikis*. (2 = `wiki.auto_update_capped` activity event + card; 3 = the ingest-pipeline sliding-window restriction that does the actual pausing.)

## What
When a page's ingestion auto-updates reach the admin cap (`count_24h >= cap_24h > 0`), the page view shows a **distinct** banner from the too-frequent-update warning:

> ⛔ **Auto-update paused — update limit reached.** This page hit the workspace limit of N auto-updates in 24 hours…

- **No "Review settings" CTA** — the cap is admin-controlled, so the owner can't act on it (unlike the warning, which keeps its CTA).
- **Takes precedence** over the frequency warning when both would apply.
- **No backend change** — reuses the existing `update-health` facts (`count_24h`, `cap_24h`, `can_manage`). Gated to managers, hidden when auto-update is off.

## Note on merge order
The banner says "paused," but the actual pause lands in **PR 3** (the ingest-pipeline restriction). Recommend merging PR 3 before/with this one so the banner isn't aspirational. The copy is otherwise harmless if it merges first (a page at the cap is about to stop updating regardless).

## Test
`bun run typecheck`, prettier clean. Frontend-only.
<img width="871" height="281" alt="Screenshot 2026-06-25 at 2 16 30 PM" src="https://github.com/user-attachments/assets/1ea109bc-c701-4aa7-a6c1-ab9e18a12db6" />

