### PR TITLE
feat(wiki): revalidate update-health on policy change (no stale banner)

### DIFF
--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -114,6 +114,11 @@ export function UpdatePolicyPanel({
     setError(null);
     try {
       setPolicy(await patchUpdatePolicy(path, patch));
+      // Any policy change can move the health facts (auto-update on/off, the
+      // threshold), so revalidate the shared update-health cache now instead of
+      // waiting for the poll — the page-view banner reuses the same key and
+      // updates in lockstep.
+      void refreshHealth();
       after?.();
     } catch (e) {
       setError(errorMessage(e));


### PR DESCRIPTION
## What
Toggling **Auto-Update Wiki** (enable/disable) — and "reset to inherited" — changed the policy but left the `update-health` facts stale until the next 15s SWR poll, so the page-view cap/warning banner lagged the toggle.

This forces an **SWR revalidation** (stale-while-revalidate) of the shared `update-health` key inside `save()`, so any policy change reloads the stale facts immediately. The page-view `UpdateHealthBanner` reuses the same key, so it updates in lockstep with the panel.

## Why in `save()`
Every policy change can move the health facts (auto-update on/off, the threshold), so revalidating once in the common save path covers the toggle, the reset, and threshold edits without per-call wiring.

## Test
<img width="690" height="223" alt="Screenshot 2026-06-25 at 2 28 01 PM" src="https://github.com/user-attachments/assets/bfe17088-c719-450c-a84d-52b9cad163c4" />
<img width="708" height="287" alt="Screenshot 2026-06-25 at 2 27 58 PM" src="https://github.com/user-attachments/assets/6adae38c-5fad-4ec8-b354-a847a2546804" />

Frontend-only. `bun run typecheck` + prettier clean.
