### PR TITLE
feat(wiki): exclude over-cap pages from ingestion before the LLM

### DIFF
--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -28,6 +28,7 @@ from app.config import CONFIG
 from app.ingest import eval_sample as ingest_eval_sample
 from app.ingest import intent as ingest_intent
 from app.ingest import search as ingest_search
+from app.ingest import settings as ingest_settings
 from app.ingest.source_tiers import is_filtered
 from app.ingest.models import WikiUpdateCandidate
 from app.llm.agents import ingest_batch_reconciler, ingest_selector, nl_updater
@@ -409,6 +410,16 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     # auto-update *before* any LLM call, and carry each kept page's resolved
     # update instruction onto its candidate for the reconciler prompt.
     policies = update_policy.resolve_for_paths([hit.path for hit in hits])
+    # Admin hard cap: pages that already hit the cap in the trailing 24h are
+    # dropped here, before any LLM call, so a runaway page stops burning tokens.
+    # Dynamic — no persisted disable; a page resumes on its own once its rolling
+    # window falls back under the cap. 0 disables the cap.
+    #
+    # The count is a per-hit git read, only when cap > 0 — in line with the
+    # per-hit read_file below and fine for today's small candidate sets. If
+    # candidate sets grow, give ingest_update_times_24h a multi-path sibling and
+    # batch the cap reads like resolve_for_paths above.
+    cap = ingest_settings.get().auto_update_cap
     readable: list[WikiUpdateCandidate] = []
     for hit in hits:
         policy = policies.get(hit.path)
@@ -419,6 +430,16 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             log.debug(
                 "process_pushed_document: ingestion auto-update disabled for %s, skipping",
                 hit.path,
+            )
+            continue
+        if cap > 0 and len(wiki_git.ingest_update_times_24h(hit.path)) >= cap:
+            ingest_outcomes_total.labels(
+                outcome="auto_update_cap_exceeded", wiki_path=hit.path
+            ).inc()
+            log.info(
+                "process_pushed_document: %s hit the %d/24h auto-update cap, skipping",
+                hit.path,
+                cap,
             )
             continue
         try:

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -20,6 +20,7 @@ import pytest
 from app.config import CONFIG
 from app.db.fts import SearchHit
 from app.ingest import search as ingest_search
+from app.ingest.settings import IngestSettings
 from app.ingest.source_tiers import is_filtered
 from app.llm.agents.common import IRRELEVANT_SENTINEL
 from app.llm.settings import _EMPTY as _EMPTY_LLM_SETTINGS, LLMSettings
@@ -47,6 +48,27 @@ def _stub_resolve_policies(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "app.tasks.wiki_update.update_policy.resolve_for_paths",
         lambda paths: {},
+    )
+
+
+def _ingest_settings(*, auto_update_cap: int) -> IngestSettings:
+    return IngestSettings(
+        max_doc_chars=100_000,
+        api_key=None,
+        onyx_base_url=None,
+        warn_update_threshold_default=10,
+        auto_update_cap=auto_update_cap,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_ingest_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The candidate loop reads the admin cap via ingest_settings.get() (a DB
+    read). Default to cap=0 (no cap) so the no-DB unit tests are unaffected;
+    cap-specific tests override."""
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.ingest_settings.get",
+        lambda: _ingest_settings(auto_update_cap=0),
     )
 
 
@@ -384,6 +406,28 @@ def test_ingestion_disabled_skips_candidate_before_llm(
     monkeypatch.setattr(
         "app.tasks.wiki_update.update_policy.resolve_for_paths",
         lambda paths: {"page.md": ResolvedPolicy(ingestion_auto_update_disabled=True)},
+    )
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
+    _run(_make_push())
+    mock_reconcile.assert_not_called()
+    mock_commit.assert_not_called()
+
+
+@patch("app.tasks.wiki_update.wiki_git.commit_file")
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_over_cap_skips_candidate_before_llm(
+    mock_search, mock_reconcile, mock_commit, monkeypatch
+):
+    # A page that already hit the admin cap in the trailing 24h is dropped before
+    # any LLM call — the reconciler never sees it and nothing commits (no tokens).
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.ingest_settings.get",
+        lambda: _ingest_settings(auto_update_cap=3),
+    )
+    monkeypatch.setattr(
+        "app.tasks.wiki_update.wiki_git.ingest_update_times_24h",
+        lambda _: [1, 2, 3],  # 3 updates in window >= cap 3
     )
     mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
     _run(_make_push())


### PR DESCRIPTION
**PR 3 of 3** in the cap-enforcement split for *Taming Bad-Behaved Wikis*. This is the piece that actually **stops** runaway auto-updates — and makes the already-merged cap banner (#293) truthful.

## What
In the ingest candidate loop (right beside the existing "ingestion auto-update disabled" skip, **before any LLM call**), drop any page whose rolling 24h ingest-update count has reached the admin cap:

```python
if cap > 0 and len(wiki_git.ingest_update_times_24h(hit.path)) >= cap:
    # outcome="auto_update_cap_exceeded"; skip
```

- **Token-saving:** excluded before the selector/reconciler, so a runaway page burns nothing.
- **Dynamic, no persisted disable:** the page resumes on its own once its sliding window falls back under the cap (matches what the banner's resume-time reports). `cap = 0` disables the cap.
- Reuses `git.ingest_update_times_24h` (added in #293) for the count — no new helper.

## Test fix + coverage
The pipeline unit tests run without a DB, so the new `ingest_settings.get()` read needed a stub — added an autouse `_stub_ingest_settings` fixture (cap=0) mirroring the existing `_stub_llm_settings` / `_stub_resolve_policies` fixtures. New test asserts an over-cap page is skipped before reconcile/commit. Full suite: **40 passed**.

## Unblocks
With this merged, the cap banner (#293) is accurate — mark it / it is already merged, so this closes the loop. ruff, basedpyright, tests all green.