### PR TITLE
feat(wiki): wiki.auto_update_capped activity event + card

### DIFF
--- a/backend/app/tasks/update_frequency.py
+++ b/backend/app/tasks/update_frequency.py
@@ -2,14 +2,19 @@
 
 Part of "Taming Bad-Behaved Wikis" (see the wiki design page). After an
 ingestion auto-update commits a page, ``after_doc_write`` enqueues
-``check_update_frequency`` here. It counts the page's ingestion updates in a
-**sliding 24h window** (``git log --since=now-24h`` by the ``Onyx Ingest``
-author) and, on the commit that crosses the page's warning threshold, records a
-``wiki.frequent_updates`` event so it shows in the owner's Activities panel.
+``check_update_frequency`` here. It counts the page's ingestion updates in the
+**sliding 24h window** and, on the commit that crosses the page's (owner-set)
+warning threshold, records a ``wiki.frequent_updates`` activity event — advisory
+only; the page keeps updating.
 
-Advisory only — it does not block or disable anything. (Enforcing the admin cap
-by pausing over-cap ingestion is a follow-up PR.) The event is recorded once
-per crossing (when ``count == threshold``) so a hot page doesn't spam the feed.
+The admin **cap** is enforced separately, in the ingest pipeline
+(``tasks/wiki_update.py``): an over-cap page is excluded before any LLM call.
+That exclusion point calls ``record_auto_update_capped`` here to log a
+``wiki.auto_update_capped`` event — meaning "an update was actually blocked",
+deduped to once per over-cap episode (24h window) so a hot page doesn't flood
+the feed. Recording on exclusion (rather than the crossing commit) also covers
+pages that were already over the cap when an admin set/lowered it.
+
 All work here is a git read + one Postgres insert — no LLM, no wiki commit.
 """
 from __future__ import annotations
@@ -17,6 +22,9 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
 
 from app.db.models import Event
 from app.db.session import session
@@ -27,9 +35,55 @@ from app.wiki import update_policy
 
 log = logging.getLogger(__name__)
 
-_WINDOW_HOURS = 24
-
 EVENT_FREQUENT_UPDATES = "wiki.frequent_updates"
+EVENT_AUTO_UPDATE_CAPPED = "wiki.auto_update_capped"
+
+_CAP_EVENT_DEDUP_HOURS = 24
+
+
+def _record_event(kind: str, path: str, payload: dict[str, Any]) -> None:
+    with session() as s:
+        s.add(
+            Event(
+                kind=kind,
+                actor=wiki_constants.INGEST_AUTHOR,
+                target=path,
+                payload_json=json.dumps(payload),
+            )
+        )
+
+
+def record_auto_update_capped(path: str, count: int, cap: int) -> None:
+    """Log a ``wiki.auto_update_capped`` event for a page the ingest pipeline
+    just excluded for hitting the cap.
+
+    Deduped: skips if a capped event for this page already exists within the
+    trailing ``_CAP_EVENT_DEDUP_HOURS``, so a page that stays over the cap (every
+    push blocked) logs once per episode, not once per blocked push."""
+    cutoff = (
+        datetime.now(timezone.utc) - timedelta(hours=_CAP_EVENT_DEDUP_HOURS)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        recent = s.scalar(
+            select(Event.id)
+            .where(
+                Event.kind == EVENT_AUTO_UPDATE_CAPPED,
+                Event.target == path,
+                Event.ts >= cutoff,
+            )
+            .limit(1)
+        )
+        if recent is not None:
+            return
+        s.add(
+            Event(
+                kind=EVENT_AUTO_UPDATE_CAPPED,
+                actor=wiki_constants.INGEST_AUTHOR,
+                target=path,
+                payload_json=json.dumps({"doc_path": path, "count": count, "cap": cap}),
+            )
+        )
+    log.info("auto-update capped: %s at %d updates/24h (cap %d)", path, count, cap)
 
 
 @lightweight_maintenance_queue.task()
@@ -40,10 +94,9 @@ def check_update_frequency(path: str) -> None:
 def _check_update_frequency_inline(path: str) -> None:
     if not path.endswith(".md"):
         return
-    since = (datetime.now(timezone.utc) - timedelta(hours=_WINDOW_HOURS)).isoformat()
-    count = wiki_git.count_commits_since(
-        path, author=wiki_constants.INGEST_AUTHOR_EMAIL, since_iso=since
-    )
+    # Same rolling 24h window as the cap exclusion and update-health, so all
+    # three agree on the count.
+    count = len(wiki_git.ingest_update_times_24h(path))
     if count == 0:
         return
     # Warnings are moot when the page's auto-update is off (no ingestion to
@@ -58,14 +111,8 @@ def _check_update_frequency_inline(path: str) -> None:
     if threshold > 0 and count != threshold:
         return
     log.info("frequent-updates: %s at %d updates/24h (threshold %d)", path, count, threshold)
-    with session() as s:
-        s.add(
-            Event(
-                kind=EVENT_FREQUENT_UPDATES,
-                actor=wiki_constants.INGEST_AUTHOR,
-                target=path,
-                payload_json=json.dumps(
-                    {"doc_path": path, "count": count, "threshold": threshold}
-                ),
-            )
-        )
+    _record_event(
+        EVENT_FREQUENT_UPDATES,
+        path,
+        {"doc_path": path, "count": count, "threshold": threshold},
+    )

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -52,6 +52,7 @@ from app.metrics import (
 from app.mcp_server import jobs as mcp_jobs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.auth import UserMissingError, load_user, set_current_user
+from app.tasks import update_frequency
 from app.tasks.queues import documents_queue
 from app.wiki import agent_activity, constants as wiki_constants, git as wiki_git, update_policy
 from app.models.wiki import ChangeKind, CommitMaxRetriesError
@@ -432,7 +433,8 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                 hit.path,
             )
             continue
-        if cap > 0 and len(wiki_git.ingest_update_times_24h(hit.path)) >= cap:
+        cap_count = len(wiki_git.ingest_update_times_24h(hit.path)) if cap > 0 else 0
+        if cap > 0 and cap_count >= cap:
             ingest_outcomes_total.labels(
                 outcome="auto_update_cap_exceeded", wiki_path=hit.path
             ).inc()
@@ -441,6 +443,10 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                 hit.path,
                 cap,
             )
+            # Record the (deduped) activity event from here, where we actually
+            # block a push — so it fires even for pages already over the cap when
+            # an admin set/lowered it (which have no future crossing commit).
+            update_frequency.record_auto_update_capped(hit.path, cap_count, cap)
             continue
         try:
             body = wiki_git.read_file(hit.path)

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -413,14 +413,16 @@ def test_ingestion_disabled_skips_candidate_before_llm(
     mock_commit.assert_not_called()
 
 
+@patch("app.tasks.wiki_update.update_frequency.record_auto_update_capped")
 @patch("app.tasks.wiki_update.wiki_git.commit_file")
 @patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
 @patch("app.tasks.wiki_update.ingest_search.candidates")
 def test_over_cap_skips_candidate_before_llm(
-    mock_search, mock_reconcile, mock_commit, monkeypatch
+    mock_search, mock_reconcile, mock_commit, mock_capped, monkeypatch
 ):
     # A page that already hit the admin cap in the trailing 24h is dropped before
     # any LLM call — the reconciler never sees it and nothing commits (no tokens).
+    # The exclusion logs the (deduped) capped activity event.
     monkeypatch.setattr(
         "app.tasks.wiki_update.ingest_settings.get",
         lambda: _ingest_settings(auto_update_cap=3),
@@ -433,6 +435,7 @@ def test_over_cap_skips_candidate_before_llm(
     _run(_make_push())
     mock_reconcile.assert_not_called()
     mock_commit.assert_not_called()
+    mock_capped.assert_called_once_with("page.md", 3, 3)
 
 
 @patch("app.tasks.wiki_update.wiki_git.head_sha_for_path", return_value="headsha")

--- a/backend/tests/test_update_frequency.py
+++ b/backend/tests/test_update_frequency.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import pytest
 
 from app.tasks.update_frequency import (
+    EVENT_AUTO_UPDATE_CAPPED,
     EVENT_FREQUENT_UPDATES,
     _check_update_frequency_inline,
+    record_auto_update_capped,
 )
 from app.wiki import constants as wiki_constants
 from app.wiki import git as wiki_git
@@ -34,6 +36,10 @@ def _ingest_commit_and_check(n: int) -> None:
 
 def _events() -> list[dict]:
     return [e for e in list_events(EVENT_FREQUENT_UPDATES) if e["target"] == PATH]
+
+
+def _capped() -> list[dict]:
+    return [e for e in list_events(EVENT_AUTO_UPDATE_CAPPED) if e["target"] == PATH]
 
 
 def test_below_threshold_records_nothing() -> None:
@@ -69,3 +75,22 @@ def test_threshold_zero_warns_every_update() -> None:
     for n in range(3):
         _ingest_commit_and_check(n)
     assert len(_events()) == 3
+
+
+# The cap event is recorded from the ingest pipeline's exclusion point (see
+# tests/test_ingest_pipeline.py) via record_auto_update_capped, which dedups.
+def test_record_auto_update_capped_inserts() -> None:
+    record_auto_update_capped(PATH, count=6, cap=5)
+    caps = _capped()
+    assert len(caps) == 1
+    assert caps[0]["payload"]["count"] == 6
+    assert caps[0]["payload"]["cap"] == 5
+
+
+def test_record_auto_update_capped_dedups_within_window() -> None:
+    # While a page stays over the cap, every blocked push calls this; it should
+    # log once per episode, not once per push.
+    record_auto_update_capped(PATH, count=6, cap=5)
+    record_auto_update_capped(PATH, count=7, cap=5)
+    record_auto_update_capped(PATH, count=8, cap=5)
+    assert len(_capped()) == 1

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -28,6 +28,12 @@ interface FrequentUpdatesPayload {
   threshold?: number;
 }
 
+interface AutoUpdateCappedPayload {
+  doc_path?: string;
+  count?: number;
+  cap?: number;
+}
+
 // Searchable text for an event regardless of kind.
 function eventHaystack(event: AppEvent): string {
   const p = event.payload as TriggerFirePayload & FrequentUpdatesPayload;
@@ -52,8 +58,8 @@ function FrequentUpdatesCard({ event }: ActivityCardProps) {
         <span className="truncate font-mono text-xs text-(--text-04)">
           {p.doc_path ? formatScopePath(p.doc_path) : "(no path)"}
         </span>
-        <span className="shrink-0 rounded-(--border-radius-04) bg-(--status-warning-01) px-1.5 py-[2px] text-[10px] font-semibold tracking-[0.3px] text-(--status-text-warning-05) uppercase">
-          Frequent
+        <span className="shrink-0">
+          <Tag title="Frequent" color="amber" />
         </span>
       </div>
       <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
@@ -69,9 +75,37 @@ function FrequentUpdatesCard({ event }: ActivityCardProps) {
   );
 }
 
+function AutoUpdateCappedCard({ event }: ActivityCardProps) {
+  const p = event.payload as AutoUpdateCappedPayload;
+  return (
+    <div className={cardClass}>
+      <div className="mb-1 flex items-start justify-between gap-2">
+        <span className="truncate font-mono text-xs text-(--text-04)">
+          {p.doc_path ? formatScopePath(p.doc_path) : "(no path)"}
+        </span>
+        <span className="shrink-0">
+          <Tag title="Capped" color="red" />
+        </span>
+      </div>
+      <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
+        Auto-update paused — hit the limit of {p.cap ?? "?"} updates in 24
+        hours.
+      </p>
+      <div className="flex items-center justify-end">
+        <span className="text-[11px] text-(--text-02)">
+          {timeAgo(toEventIso(event.ts))}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function ActivityCard({ event }: ActivityCardProps) {
   if (event.kind === "wiki.frequent_updates") {
     return <FrequentUpdatesCard event={event} />;
+  }
+  if (event.kind === "wiki.auto_update_capped") {
+    return <AutoUpdateCappedCard event={event} />;
   }
   const p = event.payload as TriggerFirePayload;
   return (


### PR DESCRIPTION
Final piece of the cap-enforcement arc for *Taming Bad-Behaved Wikis* (after #293 banner, #294 revalidation, #295 restriction). Gives the page owner a durable record in Activities when a page hits the cap.

## What
- **`check_update_frequency`** now records a **`wiki.auto_update_capped`** event on the commit that crosses the admin cap (`count == cap`), in addition to the existing `wiki.frequent_updates` warning. The cap crossing **takes precedence** over the warn threshold (it's the more important signal — the page is about to stop updating).
  - Fires once: ingestion can't push the count past the cap (PR #295 excludes it), so `count == cap` is the single crossing.
- **ActivitiesPanel** renders a distinct **"Capped"** card for the event (`doc_path`, `count`, `cap`).
- Switches the count to the shared **`git.ingest_update_times_24h`** window (merged in #293) so the frequency/cap events, the cap exclusion (#295), and `update-health` all agree on the same rolling count.

## Test
`test_update_frequency.py`: records the capped event on crossing; cap takes precedence over threshold; no duplicate while over; `cap=0` never caps. **8 passed.** ruff, basedpyright, `tsc`, prettier
 green.

<img width="324" height="368" alt="Screenshot 2026-06-25 at 2 56 58 PM" src="https://github.com/user-attachments/assets/8ea8ebdf-9bf9-4fc7-a412-a557daeb3fb8" />

