### PR TITLE
feat(wiki): templates carry a default update policy [backend]

### DIFF
--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -132,14 +132,22 @@ def update_template(
     if not req.body:
         raise HTTPException(status_code=400, detail="body is required")
     try:
+        # Patch only the policy fields actually present in the body; omitted
+        # fields keep their stored value (``model_fields_set`` distinguishes
+        # "omitted" from an explicit ``null`` clear), so a client that doesn't
+        # send them can't silently wipe a template's policy.
+        policy: dict[str, Any] = {}
+        if "ingestion_auto_update_disabled" in req.model_fields_set:
+            policy["ingestion_auto_update_disabled"] = req.ingestion_auto_update_disabled
+        if "update_instruction" in req.model_fields_set:
+            policy["update_instruction"] = req.update_instruction or None
         row = templates_repo.update(
             template_id,
             name=name,
             body=req.body,
             description=(req.description or None),
             system_prompt=(req.system_prompt or None),
-            ingestion_auto_update_disabled=req.ingestion_auto_update_disabled,
-            update_instruction=(req.update_instruction or None),
+            **policy,
         )
     except templates_repo.TemplateNameTaken as exc:
         raise HTTPException(

--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -35,6 +35,8 @@ def _view(row: dict[str, Any]) -> DocumentTemplateView:
         body=row["body"],
         description=row["description"],
         system_prompt=row["system_prompt"],
+        ingestion_auto_update_disabled=row["ingestion_auto_update_disabled"],
+        update_instruction=row["update_instruction"],
         sort_order=row["sort_order"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -46,6 +48,7 @@ def _summary(row: dict[str, Any]) -> DocumentTemplateSummary:
         id=row["id"],
         name=row["name"],
         description=row["description"],
+        ingestion_auto_update_disabled=row["ingestion_auto_update_disabled"],
     )
 
 
@@ -105,6 +108,8 @@ def create_template(
             body=req.body,
             description=(req.description or None),
             system_prompt=(req.system_prompt or None),
+            ingestion_auto_update_disabled=req.ingestion_auto_update_disabled,
+            update_instruction=(req.update_instruction or None),
             created_by_user_id=actor.id,
         )
     except templates_repo.TemplateNameTaken as exc:
@@ -133,6 +138,8 @@ def update_template(
             body=req.body,
             description=(req.description or None),
             system_prompt=(req.system_prompt or None),
+            ingestion_auto_update_disabled=req.ingestion_auto_update_disabled,
+            update_instruction=(req.update_instruction or None),
         )
     except templates_repo.TemplateNameTaken as exc:
         raise HTTPException(

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+from typing import Any
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -115,6 +116,29 @@ def _git_author(user: User | None) -> str | None:
     if user is None:
         return None
     return f"{user.name or user.email} <{user.email}>"
+
+
+def _seed_template_policy(rel: str, actor_user_id: str) -> None:
+    """Seed a new page's update policy from the template it was created from.
+
+    The new-doc draft records which template a page is being written from; if
+    that template carries a default policy (auto-update off, scope/update
+    instruction), apply it to the page's ``update_policies`` row. Only fields
+    the template actually sets are written — the rest stay inherited.
+    """
+    draft = wiki_drafts.get(rel)
+    if not draft or not draft.get("template_id"):
+        return
+    tmpl = templates_repo.get(draft["template_id"])
+    if tmpl is None:
+        return
+    patch: dict[str, Any] = {}
+    if tmpl.get("ingestion_auto_update_disabled") is not None:
+        patch["ingestion_auto_update_disabled"] = tmpl["ingestion_auto_update_disabled"]
+    if tmpl.get("update_instruction"):
+        patch["update_instruction"] = tmpl["update_instruction"]
+    if patch:
+        update_policy_repo.set_policy(rel, actor_user_id=actor_user_id, **patch)
 
 
 @router.get("", response_model=ListDocumentsResponse)
@@ -243,6 +267,10 @@ def put_document_by_path(
     else:
         sha = result.sha
         body_to_commit = result.new_body
+    # On first create, seed the page's update policy from its template (before
+    # the draft row may be cleared below).
+    if not existed:
+        _seed_template_policy(rel, user.id)
     # Drafting state: if the saved body diverges from the template
     # snapshot, the user has made it their own — clear the row so the
     # chat banner drops and the template's system prompt stops applying.

--- a/backend/app/db/migrations/versions/0035_template_update_policy.py
+++ b/backend/app/db/migrations/versions/0035_template_update_policy.py
@@ -1,0 +1,41 @@
+"""document_templates: default update policy (auto-update + update instruction)
+
+Revision ID: 0035
+Revises: 0034
+Create Date: 2026-06-25 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0035"
+down_revision: str | None = "0034"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Fresh installs get these from 0001's create_all — guard so this is a no-op.
+    cols = {c["name"] for c in inspector.get_columns("document_templates")}
+    if "ingestion_auto_update_disabled" not in cols:
+        op.add_column(
+            "document_templates",
+            sa.Column("ingestion_auto_update_disabled", sa.Boolean(), nullable=True),
+        )
+    if "update_instruction" not in cols:
+        op.add_column(
+            "document_templates",
+            sa.Column("update_instruction", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("document_templates", "update_instruction")
+    op.drop_column("document_templates", "ingestion_auto_update_disabled")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -601,6 +601,12 @@ class DocumentTemplate(Base):
     body: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text)
     system_prompt: Mapped[str | None] = mapped_column(Text)
+    # Default update policy seeded onto a page created from this template
+    # (applied to its update_policies row). NULL = leave to the inherited
+    # default. Lets a template (e.g. "Meeting notes") start with auto-update
+    # off, or carry scope guidance for the updater.
+    ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
+    update_instruction: Mapped[str | None] = mapped_column(Text)
     # Admin-controlled ordering for the picker. Lower values render
     # first; ties fall back to ``name`` alphabetical. New rows land at
     # the end (max(sort_order) + 1) so admins decide where they live.

--- a/backend/app/models/template.py
+++ b/backend/app/models/template.py
@@ -12,6 +12,9 @@ class DocumentTemplateView(BaseModel):
     body: str
     description: str | None
     system_prompt: str | None
+    # Default update policy applied to a page created from this template.
+    ingestion_auto_update_disabled: bool | None = None
+    update_instruction: str | None = None
     sort_order: int
     created_at: str
     updated_at: str
@@ -25,6 +28,8 @@ class DocumentTemplateSummary(BaseModel):
     id: str
     name: str
     description: str | None
+    # Surfaced so the picker can flag e.g. "auto-update off" before selection.
+    ingestion_auto_update_disabled: bool | None = None
 
 
 class DocumentTemplateListResponse(BaseModel):
@@ -40,6 +45,8 @@ class CreateDocumentTemplateRequest(BaseModel):
     body: str = Field(min_length=1)
     description: str | None = None
     system_prompt: str | None = None
+    ingestion_auto_update_disabled: bool | None = None
+    update_instruction: str | None = None
 
 
 class UpdateDocumentTemplateRequest(BaseModel):
@@ -47,6 +54,8 @@ class UpdateDocumentTemplateRequest(BaseModel):
     body: str = Field(min_length=1)
     description: str | None = None
     system_prompt: str | None = None
+    ingestion_auto_update_disabled: bool | None = None
+    update_instruction: str | None = None
 
 
 class ReorderDocumentTemplatesRequest(BaseModel):

--- a/backend/app/wiki/templates.py
+++ b/backend/app/wiki/templates.py
@@ -51,6 +51,8 @@ def _to_dict(t: DocumentTemplate) -> dict[str, Any]:
         "body": t.body,
         "description": t.description,
         "system_prompt": t.system_prompt,
+        "ingestion_auto_update_disabled": t.ingestion_auto_update_disabled,
+        "update_instruction": t.update_instruction,
         "sort_order": t.sort_order,
         "created_by_user_id": t.created_by_user_id,
         "created_at": t.created_at,
@@ -81,6 +83,8 @@ def create(
     body: str,
     description: str | None,
     system_prompt: str | None,
+    ingestion_auto_update_disabled: bool | None = None,
+    update_instruction: str | None = None,
     created_by_user_id: str | None,
 ) -> dict[str, Any]:
     template_id = str(uuid.uuid4())
@@ -98,6 +102,8 @@ def create(
                 body=body,
                 description=description,
                 system_prompt=system_prompt,
+                ingestion_auto_update_disabled=ingestion_auto_update_disabled,
+                update_instruction=update_instruction,
                 sort_order=next_order,
                 created_by_user_id=created_by_user_id,
             )
@@ -119,6 +125,8 @@ def update(
     body: str,
     description: str | None,
     system_prompt: str | None,
+    ingestion_auto_update_disabled: bool | None = None,
+    update_instruction: str | None = None,
 ) -> dict[str, Any] | None:
     with session() as s:
         t = s.get(DocumentTemplate, template_id)
@@ -128,6 +136,8 @@ def update(
         t.body = body
         t.description = description
         t.system_prompt = system_prompt
+        t.ingestion_auto_update_disabled = ingestion_auto_update_disabled
+        t.update_instruction = update_instruction
         t.updated_at = _now_text(s)
         try:
             s.flush()

--- a/backend/app/wiki/templates.py
+++ b/backend/app/wiki/templates.py
@@ -40,6 +40,13 @@ STARTER_TEMPLATES_DIR = (
 )
 
 
+class _UnsetType:
+    """Sentinel: a field omitted from ``update`` keeps its stored value."""
+
+
+_UNSET = _UnsetType()
+
+
 class TemplateNameTaken(Exception):
     """Raised when a template name conflicts with an existing row."""
 
@@ -125,8 +132,8 @@ def update(
     body: str,
     description: str | None,
     system_prompt: str | None,
-    ingestion_auto_update_disabled: bool | None = None,
-    update_instruction: str | None = None,
+    ingestion_auto_update_disabled: bool | None | _UnsetType = _UNSET,
+    update_instruction: str | None | _UnsetType = _UNSET,
 ) -> dict[str, Any] | None:
     with session() as s:
         t = s.get(DocumentTemplate, template_id)
@@ -136,8 +143,12 @@ def update(
         t.body = body
         t.description = description
         t.system_prompt = system_prompt
-        t.ingestion_auto_update_disabled = ingestion_auto_update_disabled
-        t.update_instruction = update_instruction
+        # Omitted (``_UNSET``) policy fields keep their stored value, so a
+        # client that doesn't send them can't silently clear a template's policy.
+        if not isinstance(ingestion_auto_update_disabled, _UnsetType):
+            t.ingestion_auto_update_disabled = ingestion_auto_update_disabled
+        if not isinstance(update_instruction, _UnsetType):
+            t.update_instruction = update_instruction
         t.updated_at = _now_text(s)
         try:
             s.flush()

--- a/backend/tests/test_template_update_policy.py
+++ b/backend/tests/test_template_update_policy.py
@@ -1,0 +1,85 @@
+"""A template can carry a default update policy that is applied to a page
+created from it (app/wiki/templates.py + put_document_by_path seeding)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.main import create_app
+from app.wiki import templates as templates_repo
+from app.wiki import update_policy
+from tests._auth import login_fastapi
+
+
+@pytest.fixture
+def client(tmp_db: None, tmp_repo: None) -> TestClient:
+    return TestClient(create_app())
+
+
+def _make_template(uid: str, **policy: object) -> dict:
+    return templates_repo.create(
+        name="Meeting notes",
+        body="# Notes\n",
+        description=None,
+        system_prompt=None,
+        created_by_user_id=uid,
+        **policy,
+    )
+
+
+def test_template_round_trips_policy_fields(tmp_db: None) -> None:
+    t = _make_template(
+        None,
+        ingestion_auto_update_disabled=True,
+        update_instruction="Only meeting facts.",
+    )
+    got = templates_repo.get(t["id"])
+    assert got is not None
+    assert got["ingestion_auto_update_disabled"] is True
+    assert got["update_instruction"] == "Only meeting facts."
+
+
+def test_page_created_from_template_inherits_policy(client: TestClient) -> None:
+    uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    login_fastapi(client, uid)
+    t = _make_template(
+        uid,
+        ingestion_auto_update_disabled=True,
+        update_instruction="Only meeting facts.",
+    )
+    path = "team/notes.md"
+    # The editor records the page is being written from this template...
+    assert (
+        client.post(
+            "/api/wiki/file/draft", json={"path": path, "template_id": t["id"]}
+        ).status_code
+        == 200
+    )
+    # ...then the first save creates the page.
+    assert (
+        client.put(
+            "/api/wiki/file", json={"path": path, "body": "# Notes\n\nfacts\n"}
+        ).status_code
+        == 200
+    )
+
+    eff = update_policy.resolve_for_path(path)
+    assert eff.ingestion_auto_update_disabled is True
+    assert eff.update_instruction == "Only meeting facts."
+
+
+def test_template_without_policy_seeds_nothing(client: TestClient) -> None:
+    uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    login_fastapi(client, uid)
+    t = _make_template(uid)  # no policy fields
+    path = "team/plain.md"
+    client.post("/api/wiki/file/draft", json={"path": path, "template_id": t["id"]})
+    client.put("/api/wiki/file", json={"path": path, "body": "# Plain\n\nx\n"})
+
+    # No explicit policy row → inherited defaults (auto-update on, no instruction).
+    assert update_policy.get(path) is None
+    eff = update_policy.resolve_for_path(path)
+    assert eff.ingestion_auto_update_disabled is False
+    assert eff.update_instruction is None

--- a/backend/tests/test_template_update_policy.py
+++ b/backend/tests/test_template_update_policy.py
@@ -3,6 +3,8 @@ created from it (app/wiki/templates.py + put_document_by_path seeding)."""
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -18,7 +20,7 @@ def client(tmp_db: None, tmp_repo: None) -> TestClient:
     return TestClient(create_app())
 
 
-def _make_template(uid: str, **policy: object) -> dict:
+def _make_template(uid: str | None, **policy: Any) -> dict[str, Any]:
     return templates_repo.create(
         name="Meeting notes",
         body="# Notes\n",
@@ -68,6 +70,28 @@ def test_page_created_from_template_inherits_policy(client: TestClient) -> None:
     eff = update_policy.resolve_for_path(path)
     assert eff.ingestion_auto_update_disabled is True
     assert eff.update_instruction == "Only meeting facts."
+
+
+def test_update_omitting_policy_fields_preserves_them(client: TestClient) -> None:
+    # The current frontend PUTs name/body/etc. without the policy fields; that
+    # must not wipe a template's stored policy.
+    admin = users_repo.create(email="a@x.com", password="hunter2-x", name="A")
+    login_fastapi(client, admin)  # first user is auto-admin
+    t = _make_template(
+        admin,
+        ingestion_auto_update_disabled=True,
+        update_instruction="Only facts.",
+    )
+    resp = client.put(
+        f"/api/admin/templates/{t['id']}",
+        json={"name": "Meeting notes", "body": "# Notes\n", "system_prompt": None},
+    )
+    assert resp.status_code == 200
+
+    got = templates_repo.get(t["id"])
+    assert got is not None
+    assert got["ingestion_auto_update_disabled"] is True  # preserved
+    assert got["update_instruction"] == "Only facts."  # preserved
 
 
 def test_template_without_policy_seeds_nothing(client: TestClient) -> None:


### PR DESCRIPTION
**Step 1 of Taming Bad-Behaved Wikis** — *scope guidance at setup*, realized as **templates carrying a default update policy**. Instead of letting a page misbehave and then tuning it, a page starts from a template that already sets the right policy.

> Backend half; the admin-editor controls + picker surface are a stacked frontend follow-up.

## What
- **`DocumentTemplate`** gains `ingestion_auto_update_disabled` + `update_instruction` (migration `0035`, guarded like `0034`). So a "Meeting notes" template can default **auto-update off**, and any template can seed scope/update guidance for the updater.
- **Repo + admin API** thread both fields through create/update. The picker **summary** also exposes `ingestion_auto_update_disabled` so the UI can flag "auto-update off" before the author picks it.
- **Apply on create**: `put_document_by_path` seeds the new page's `update_policies` row from the template behind its new-doc draft (`_seed_template_policy`), writing **only the fields the template sets** — the rest stay inherited. Works for the human new-doc flow today.

## Notes / follow-ups
- **Empty template** (`body=""`) and **agent create-from-template** (a `template_id` on `write_doc`/MCP) are deferred — this PR establishes the template→policy mechanism first.
- The `update_instruction` here is the same field the ingest reconciler already consumes, so template scope guidance flows straight into matching.

## Test
`test_template_update_policy.py`: repo round-trips the fields; a page created from a policy-bearing template inherits it; a no-policy template seeds nothing. Full backend suite green; ruff + basedpyright clean.