### PR TITLE
feat(wiki): template update-policy controls + picker surface [frontend]

### DIFF
--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -26,7 +26,7 @@ export default function AdminTemplatesPage() {
         <BackLink />
         <PageHeader
           title="Document templates"
-          description="Define named starting points users can pick when creating a new wiki page. Each template can supply an optional chat system prompt that guides the in-app assistant while the user is still drafting the initial version."
+          description="Define named starting points users can pick when creating a new wiki page. Each template can set a default update policy (auto-update on/off and update instructions) applied to pages created from it."
         />
         <TemplatesList />
       </main>
@@ -121,8 +121,7 @@ function TemplatesList() {
                     : t.ingestion_auto_update_disabled
                       ? "Auto-update: off"
                       : "Auto-update: on"}{" "}
-                  • {t.system_prompt ? "Has chat prompt" : "No chat prompt"} •
-                  Updated {t.updated_at}
+                  • Updated {t.updated_at}
                 </div>
               </div>
               <Button size="sm" onClick={() => setEditing(t)}>
@@ -238,9 +237,6 @@ function TemplateModal({
   const [name, setName] = useState(initial?.name ?? "");
   const [body, setBody] = useState(initial?.body ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
-  const [systemPrompt, setSystemPrompt] = useState(
-    initial?.system_prompt ?? "",
-  );
   // Default auto-update for pages created from this template: "default" leaves
   // it to the workspace default; "on"/"off" set it explicitly.
   const [autoUpdate, setAutoUpdate] = useState<"default" | "on" | "off">(
@@ -273,7 +269,9 @@ function TemplateModal({
         name: name.trim(),
         body,
         description: description.trim() || null,
-        system_prompt: systemPrompt.trim() || null,
+        // System prompt is no longer editable here; preserve any stored value
+        // (e.g. from a seed template) rather than clearing it on edit.
+        system_prompt: initial?.system_prompt ?? null,
         ingestion_auto_update_disabled:
           autoUpdate === "default" ? null : autoUpdate === "off",
         update_instruction: updateInstruction.trim() || null,
@@ -336,17 +334,6 @@ function TemplateModal({
         </label>
 
         <label>
-          <div className={lblClass}>Chat system prompt</div>
-          <textarea
-            value={systemPrompt}
-            onChange={(e) => setSystemPrompt(e.target.value)}
-            placeholder="Optional. Appended to the chat agent's default prompt while the user is drafting from this template."
-            rows={5}
-            className={`${inputClass} resize-y font-mono`}
-          />
-        </label>
-
-        <label>
           <div className={lblClass}>Auto-update default</div>
           <select
             value={autoUpdate}
@@ -355,7 +342,10 @@ function TemplateModal({
             }
             className={inputClass}
           >
-            <option value="default">Use workspace default</option>
+            <option value="default">
+              Don't set — pages inherit the default (auto-update on unless a
+              parent folder disables it)
+            </option>
             <option value="on">On — keep pages current from ingestion</option>
             <option value="off">
               Off — pages start with auto-update disabled

--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 
-import { Button } from "@onyx-ai/opal/components";
+import { Button, InputTypeIn } from "@onyx-ai/opal/components";
 import { SvgChevronDown, SvgChevronUp } from "@onyx-ai/opal/icons";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
@@ -307,22 +307,19 @@ function TemplateModal({
 
         <label>
           <div className={lblClass}>Name *</div>
-          <input
+          <InputTypeIn
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g. Project brief, RFC, Meeting notes"
-            required
-            className={inputClass}
           />
         </label>
 
         <label>
           <div className={lblClass}>Description</div>
-          <input
+          <InputTypeIn
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Optional. Shown in the picker."
-            className={inputClass}
           />
         </label>
 

--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -116,7 +116,12 @@ function TemplatesList() {
                   </div>
                 )}
                 <div className="mt-1 text-xs text-(--text-02)">
-                  {t.system_prompt ? "Has chat prompt" : "No chat prompt"} •
+                  {t.ingestion_auto_update_disabled == null
+                    ? "Auto-update: default"
+                    : t.ingestion_auto_update_disabled
+                      ? "Auto-update: off"
+                      : "Auto-update: on"}{" "}
+                  • {t.system_prompt ? "Has chat prompt" : "No chat prompt"} •
                   Updated {t.updated_at}
                 </div>
               </div>
@@ -236,6 +241,18 @@ function TemplateModal({
   const [systemPrompt, setSystemPrompt] = useState(
     initial?.system_prompt ?? "",
   );
+  // Default auto-update for pages created from this template: "default" leaves
+  // it to the workspace default; "on"/"off" set it explicitly.
+  const [autoUpdate, setAutoUpdate] = useState<"default" | "on" | "off">(
+    initial == null || initial.ingestion_auto_update_disabled == null
+      ? "default"
+      : initial.ingestion_auto_update_disabled
+        ? "off"
+        : "on",
+  );
+  const [updateInstruction, setUpdateInstruction] = useState(
+    initial?.update_instruction ?? "",
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -257,6 +274,9 @@ function TemplateModal({
         body,
         description: description.trim() || null,
         system_prompt: systemPrompt.trim() || null,
+        ingestion_auto_update_disabled:
+          autoUpdate === "default" ? null : autoUpdate === "off",
+        update_instruction: updateInstruction.trim() || null,
       };
       if (initial) {
         await updateTemplate(initial.id, payload);
@@ -326,6 +346,38 @@ function TemplateModal({
             placeholder="Optional. Appended to the chat agent's default prompt while the user is drafting from this template."
             rows={5}
             className={`${inputClass} resize-y font-mono`}
+          />
+        </label>
+
+        <label>
+          <div className={lblClass}>Auto-update default</div>
+          <select
+            value={autoUpdate}
+            onChange={(e) =>
+              setAutoUpdate(e.target.value as "default" | "on" | "off")
+            }
+            className={inputClass}
+          >
+            <option value="default">Use workspace default</option>
+            <option value="on">On — keep pages current from ingestion</option>
+            <option value="off">
+              Off — pages start with auto-update disabled
+            </option>
+          </select>
+          <div className="mt-1 text-xs text-(--text-02)">
+            Applied to a page when it's created from this template. e.g. set
+            "off" for meeting notes that shouldn't be rewritten by ingestion.
+          </div>
+        </label>
+
+        <label>
+          <div className={lblClass}>Update instructions</div>
+          <textarea
+            value={updateInstruction}
+            onChange={(e) => setUpdateInstruction(e.target.value)}
+            placeholder="Optional. Scope/how-to guidance for the updater, seeded onto pages made from this template (e.g. 'Only track decisions and owners; ignore status chatter')."
+            rows={4}
+            className={`${inputClass} resize-y`}
           />
         </label>
 

--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 
-import { Button, InputTypeIn } from "@onyx-ai/opal/components";
+import { Button, InputTypeIn, Switch } from "@onyx-ai/opal/components";
 import { SvgChevronDown, SvgChevronUp } from "@onyx-ai/opal/icons";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
@@ -237,14 +237,11 @@ function TemplateModal({
   const [name, setName] = useState(initial?.name ?? "");
   const [body, setBody] = useState(initial?.body ?? "");
   const [description, setDescription] = useState(initial?.description ?? "");
-  // Default auto-update for pages created from this template: "default" leaves
-  // it to the workspace default; "on"/"off" set it explicitly.
-  const [autoUpdate, setAutoUpdate] = useState<"default" | "on" | "off">(
-    initial == null || initial.ingestion_auto_update_disabled == null
-      ? "default"
-      : initial.ingestion_auto_update_disabled
-        ? "off"
-        : "on",
+  // Whether pages created from this template start with ingestion auto-update
+  // on. New templates default to off (disabled) — a template author opts a page
+  // into auto-update deliberately.
+  const [autoUpdateOn, setAutoUpdateOn] = useState<boolean>(
+    initial == null ? false : initial.ingestion_auto_update_disabled !== true,
   );
   const [updateInstruction, setUpdateInstruction] = useState(
     initial?.update_instruction ?? "",
@@ -272,8 +269,7 @@ function TemplateModal({
         // System prompt is no longer editable here; preserve any stored value
         // (e.g. from a seed template) rather than clearing it on edit.
         system_prompt: initial?.system_prompt ?? null,
-        ingestion_auto_update_disabled:
-          autoUpdate === "default" ? null : autoUpdate === "off",
+        ingestion_auto_update_disabled: !autoUpdateOn,
         update_instruction: updateInstruction.trim() || null,
       };
       if (initial) {
@@ -333,29 +329,17 @@ function TemplateModal({
           />
         </label>
 
-        <label>
-          <div className={lblClass}>Auto-update default</div>
-          <select
-            value={autoUpdate}
-            onChange={(e) =>
-              setAutoUpdate(e.target.value as "default" | "on" | "off")
-            }
-            className={inputClass}
-          >
-            <option value="default">
-              Don't set — pages inherit the default (auto-update on unless a
-              parent folder disables it)
-            </option>
-            <option value="on">On — keep pages current from ingestion</option>
-            <option value="off">
-              Off — pages start with auto-update disabled
-            </option>
-          </select>
-          <div className="mt-1 text-xs text-(--text-02)">
-            Applied to a page when it's created from this template. e.g. set
-            "off" for meeting notes that shouldn't be rewritten by ingestion.
+        <div>
+          <div className="flex items-center justify-between gap-3">
+            <div className={lblClass}>Auto-update</div>
+            <Switch checked={autoUpdateOn} onCheckedChange={setAutoUpdateOn} />
           </div>
-        </label>
+          <div className="mt-1 text-xs text-(--text-02)">
+            Pages created from this template start with ingestion auto-update{" "}
+            {autoUpdateOn ? "on" : "off"}. Leave it off for pages that shouldn't
+            be rewritten by ingestion (e.g. meeting notes).
+          </div>
+        </div>
 
         <label>
           <div className={lblClass}>Update instructions</div>

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -949,6 +949,9 @@ function TemplateStrip({
             <TemplateCard
               title={t.name}
               description={t.description}
+              note={
+                t.ingestion_auto_update_disabled ? "Auto-update off" : undefined
+              }
               active={activeId === t.id}
               busy={applyingId === t.id}
               onClick={() => onPick(t)}
@@ -992,12 +995,14 @@ function StripArrow({
 function TemplateCard({
   title,
   description,
+  note,
   active,
   busy,
   onClick,
 }: {
   title: string;
   description: string | null;
+  note?: string;
   active: boolean;
   busy: boolean;
   onClick: () => void;
@@ -1027,6 +1032,7 @@ function TemplateCard({
           {description}
         </div>
       )}
+      {note && <div className="text-[11px] text-(--text-02)">{note}</div>}
     </button>
   );
 }

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -119,6 +119,11 @@ export function WikiHome() {
               <TemplateCard
                 title={t.name}
                 description={t.description ?? ""}
+                note={
+                  t.ingestion_auto_update_disabled
+                    ? "Auto-update off"
+                    : undefined
+                }
                 onClick={() => startNewPage(t.id)}
               />
             </div>
@@ -195,11 +200,13 @@ export function WikiHome() {
 function TemplateCard({
   title,
   description,
+  note,
   glyph,
   onClick,
 }: {
   title: string;
   description?: string;
+  note?: string;
   glyph?: React.ReactNode;
   onClick: () => void;
 }) {
@@ -224,11 +231,20 @@ function TemplateCard({
         </Text>
         {glyph ? (
           glyph
-        ) : description ? (
-          <Text font="secondary-body" color="text-03">
-            {description}
-          </Text>
-        ) : null}
+        ) : (
+          <>
+            {description ? (
+              <Text font="secondary-body" color="text-03">
+                {description}
+              </Text>
+            ) : null}
+            {note ? (
+              <Text font="secondary-body" color="text-02">
+                {note}
+              </Text>
+            ) : null}
+          </>
+        )}
       </Section>
     </SelectCard>
   );

--- a/frontend/src/lib/templates.ts
+++ b/frontend/src/lib/templates.ts
@@ -8,6 +8,9 @@ export interface DocumentTemplate {
   body: string;
   description: string | null;
   system_prompt: string | null;
+  // Default update policy applied to a page created from this template.
+  ingestion_auto_update_disabled: boolean | null;
+  update_instruction: string | null;
   sort_order: number;
   created_at: string;
   updated_at: string;
@@ -17,6 +20,7 @@ export interface DocumentTemplateSummary {
   id: string;
   name: string;
   description: string | null;
+  ingestion_auto_update_disabled: boolean | null;
 }
 
 export interface CreateTemplateInput {
@@ -24,6 +28,8 @@ export interface CreateTemplateInput {
   body: string;
   description?: string | null;
   system_prompt?: string | null;
+  ingestion_auto_update_disabled?: boolean | null;
+  update_instruction?: string | null;
 }
 
 export type UpdateTemplateInput = CreateTemplateInput;


### PR DESCRIPTION
Frontend for **Step 1 — templates carry a default update policy** (backend #298, merged). Makes the policy fields operable in the UI.

## What
- **Admin template editor** (`/admin/templates`): adds an **"Auto-update default"** select — *Use workspace default* / *On* / *Off* — and an **"Update instructions"** field. The template list row shows each template's auto-update default ("Auto-update: off/on/default").
- **New-doc picker** (home grid + wiki composer): flags **"Auto-update off"** on templates that disable it, so the author knows before selecting (`DocumentTemplateSummary.ingestion_auto_update_disabled`).
- **`lib/templates`**: types carry `ingestion_auto_update_disabled` + `update_instruction`; the editor always sends both (explicit `null` = use workspace default, which the backend's `model_fields_set` handling treats as a real clear).

## Result
An admin can define e.g. a "Meeting notes" template that starts pages with auto-update **off**, and the picker shows it. Pages created from that template inherit the policy (backend #298).

## Notes / follow-ups (unchanged from #298)
- **Empty template** + **agent create-from-template** still deferred.

## Test
`bun run typecheck` + prettier clean. UI-only; reuses the existing admin template + picker flows.