### PR TITLE
feat(wiki): starter-template default policies + a Blank template

### DIFF
--- a/backend/app/wiki/templates.py
+++ b/backend/app/wiki/templates.py
@@ -292,6 +292,10 @@ def iter_starter_templates() -> list[dict[str, Any]]:
                 "name": meta["name"].strip(),
                 "description": meta.get("description"),
                 "system_prompt": meta.get("system_prompt"),
+                "ingestion_auto_update_disabled": meta.get(
+                    "ingestion_auto_update_disabled"
+                ),
+                "update_instruction": meta.get("update_instruction"),
                 "body": body,
             }
         )
@@ -333,6 +337,8 @@ def write_starter_templates(*, skip_existing: bool) -> int:
                 body=row["body"],
                 description=row["description"],
                 system_prompt=row["system_prompt"],
+                ingestion_auto_update_disabled=row["ingestion_auto_update_disabled"],
+                update_instruction=row["update_instruction"],
                 created_by_user_id=None,
             )
         except TemplateNameTaken:

--- a/backend/app/wiki/templates.py
+++ b/backend/app/wiki/templates.py
@@ -220,6 +220,7 @@ def _now_text(s: Any) -> str:
 # from the templates admin page after seeding — this only sets the
 # initial position on a brand-new database.
 _STARTER_TEMPLATE_DEFAULT_ORDER: tuple[str, ...] = (
+    "Blank",
     "Weekly notes",
     "Project tracker",
     "Product Requirements Doc",

--- a/backend/starter_templates/architecture-decision-record.md
+++ b/backend/starter_templates/architecture-decision-record.md
@@ -1,6 +1,7 @@
 ---
 name: Architecture Decision Record
 description: Architecture Decision Record — short, immutable record of one decision.
+ingestion_auto_update_disabled: true
 ---
 # ADR <NNNN>: <short, decisive title>
 

--- a/backend/starter_templates/blank.md
+++ b/backend/starter_templates/blank.md
@@ -1,0 +1,5 @@
+---
+name: Blank
+description: Start from an empty page.
+ingestion_auto_update_disabled: true
+---

--- a/backend/starter_templates/incident-report.md
+++ b/backend/starter_templates/incident-report.md
@@ -1,6 +1,7 @@
 ---
 name: Incident report
 description: Postmortem template — timeline, impact, root cause, and action items.
+ingestion_auto_update_disabled: true
 ---
 # Incident <YYYY-MM-DD>: <short summary>
 

--- a/backend/starter_templates/meeting-notes.md
+++ b/backend/starter_templates/meeting-notes.md
@@ -1,13 +1,16 @@
 ---
 name: Meeting notes
 description: A self-populating overview of a meeting — attendees, decisions, and action items.
+update_instruction: >-
+  Fill in the sections from the meeting's discussion or transcript and keep
+  attribution where it matters. Keep the action items current — mark them
+  complete as they get done rather than deleting them — and move any open
+  question to Decisions once it is resolved.
 ---
 
 # <Meeting title> — <YYYY-MM-DD>
 
 This doc captures the discussion, decisions, and follow-ups for a single meeting.
-
-Note: If you are an AI agent updating this document, fill in the sections from the meeting's discussion or transcript and keep attribution where it matters. After the meeting, keep the action items current — mark them complete as they get done rather than deleting them — and move any open question to Decisions once it is resolved.
 
 **Attendees:**
 **Recording:** <link if available>

--- a/backend/starter_templates/product-requirements-doc.md
+++ b/backend/starter_templates/product-requirements-doc.md
@@ -1,6 +1,9 @@
 ---
 name: Product Requirements Doc
 description: Engineering proposal (PRD) — context, problem, proposal, alternatives, rollout, and risks.
+update_instruction: >-
+  Record each change as a dated entry in the Change log section; don't rewrite
+  prior entries.
 ---
 # PRD: <title>
 
@@ -102,7 +105,5 @@ Rough milestones and owners. Not a Gantt chart — a sketch of sequencing.
 Reference links, supporting analysis, prototype notes, raw benchmark numbers.
 
 ## Change log
-
-If you are an Agent updating this document, please track your changes along with the date below
 
 - <YYYY-MM-DD> — <update summary>

--- a/backend/starter_templates/weekly-notes.md
+++ b/backend/starter_templates/weekly-notes.md
@@ -1,13 +1,15 @@
 ---
 name: Weekly notes
 description: A self maintaining weekly log with progress, blockers, and what is next.
+update_instruction: >-
+  Date all changes and place them under the correct Week section. If a section
+  for the current week does not exist yet, create it. Keep the most recent week
+  on top.
 ---
 
 # Weekly Notes for [team/user]
 
 This doc maintains the progress, blockers, upcoming items, and other items of note for the user.
-
-Note: If you are an AI agent updating this document, make sure to date all of the changes and ensure it's under the right Week section. If a section for the current week does not exist yet, feel free to create it. Keep the most recent week on top.
 
 ## Week of <YYYY-MM-DD>
 

--- a/backend/tests/test_starter_templates_seed.py
+++ b/backend/tests/test_starter_templates_seed.py
@@ -28,6 +28,26 @@ def test_iter_starter_templates_parses_every_bundled_file():
         assert row["body"].strip(), f"empty body for {row['name']!r}"
 
 
+def test_starter_template_policies_parse_and_seed(tmp_db):
+    """The bundled point-in-time records seed with ingestion auto-update off,
+    and the self-maintaining ones carry an update instruction."""
+    from app.wiki.templates import list_all, seed_starter_templates_if_empty
+
+    if not seed_starter_templates_if_empty():
+        pytest.skip("no bundled starter templates available in this environment")
+    by_name = {r["name"]: r for r in list_all()}
+
+    for name in ("Architecture Decision Record", "Incident report"):
+        if name in by_name:
+            assert by_name[name]["ingestion_auto_update_disabled"] is True
+
+    for name in ("Weekly notes", "Meeting notes", "Product Requirements Doc"):
+        if name in by_name:
+            assert by_name[name]["update_instruction"], (
+                f"{name} should carry an update instruction"
+            )
+
+
 def test_seed_starter_templates_if_empty_inserts_all(tmp_db):
     from app.wiki.templates import (
         count,

--- a/backend/tests/test_starter_templates_seed.py
+++ b/backend/tests/test_starter_templates_seed.py
@@ -25,7 +25,9 @@ def test_iter_starter_templates_parses_every_bundled_file():
     assert len(names) == len(set(names)), f"duplicate template names: {names}"
     for row in rows:
         assert row["name"], f"empty name in row: {row}"
-        assert row["body"].strip(), f"empty body for {row['name']!r}"
+        # The Blank template is intentionally empty; every other body is content.
+        if row["name"] != "Blank":
+            assert row["body"].strip(), f"empty body for {row['name']!r}"
 
 
 def test_starter_template_policies_parse_and_seed(tmp_db):
@@ -38,14 +40,14 @@ def test_starter_template_policies_parse_and_seed(tmp_db):
     by_name = {r["name"]: r for r in list_all()}
 
     for name in ("Architecture Decision Record", "Incident report"):
-        if name in by_name:
-            assert by_name[name]["ingestion_auto_update_disabled"] is True
+        assert name in by_name
+        assert by_name[name]["ingestion_auto_update_disabled"] is True
 
     for name in ("Weekly notes", "Meeting notes", "Product Requirements Doc"):
-        if name in by_name:
-            assert by_name[name]["update_instruction"], (
-                f"{name} should carry an update instruction"
-            )
+        assert name in by_name
+        assert by_name[name]["update_instruction"], (
+            f"{name} should carry an update instruction"
+        )
 
 
 def test_seed_starter_templates_if_empty_inserts_all(tmp_db):

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -928,6 +928,15 @@ function TemplateStrip({
   const CARD_WIDTH = 200;
   const STEP = CARD_WIDTH + 8; // card width + gap
 
+  // The "Blank" template is the empty-start entry point — route the blank card
+  // through it (so its auto-update policy applies) when present, and drop it
+  // from the list so it isn't shown twice. Falls back to a plain blank page
+  // when no Blank template is seeded.
+  const blankTemplate = templates.find((t) => t.name === "Blank");
+  const rest = templates.filter((t) => t.name !== "Blank");
+  const blankCardActive =
+    blankActive || (blankTemplate != null && activeId === blankTemplate.id);
+
   return (
     <div className="relative">
       <div
@@ -939,12 +948,12 @@ function TemplateStrip({
           <TemplateCard
             title="Blank document"
             description="Empty file — just start typing."
-            active={blankActive}
+            active={blankCardActive}
             busy={false}
-            onClick={onBlank}
+            onClick={() => (blankTemplate ? onPick(blankTemplate) : onBlank())}
           />
         </div>
-        {templates.map((t) => (
+        {rest.map((t) => (
           <div key={t.id} className="w-[200px] shrink-0 snap-start">
             <TemplateCard
               title={t.name}

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -46,7 +46,13 @@ export function WikiHome() {
     "templates:summaries",
     listTemplateSummaries,
   );
-  const featured = (templates ?? []).slice(0, 2);
+  // The "Blank" template is the empty-start entry point (carries an auto-update
+  // policy); route the blank card through it when present, and keep it out of
+  // the featured row so it isn't shown twice.
+  const blankTemplate = (templates ?? []).find((t) => t.name === "Blank");
+  const featured = (templates ?? [])
+    .filter((t) => t.name !== "Blank")
+    .slice(0, 2);
 
   function startNewPage(templateId?: string) {
     const qs = templateId
@@ -111,7 +117,7 @@ export function WikiHome() {
                   <SvgPlusCircle size={22} />
                 </span>
               }
-              onClick={() => startNewPage()}
+              onClick={() => startNewPage(blankTemplate?.id)}
             />
           </div>
           {featured.map((t) => (


### PR DESCRIPTION
Builds on the template update-policy work (#298/#299): the **bundled starter templates** ship with sensible default policies, and a new **Blank** template becomes the empty-start entry point (carrying a policy), instead of seeding with no policy (effectively auto-update on for everything).

## Backend
- Starter-template **frontmatter** now supports `ingestion_auto_update_disabled` + `update_instruction`; the seed parser threads them through `write_starter_templates → create`.
- **Disabled** ingestion auto-update on point-in-time records: **Architecture Decision Record**, **Incident report**.
- **Moved** the inline "if you are an AI agent updating this document…" notes out of **Weekly notes / Meeting notes / PRD** bodies into their `update_instruction` field (they stay auto-update on).
- New **Blank** starter template (empty body, auto-update **off**), sorted first.

## Frontend
- The picker's blank card (home grid + new-doc composer) routes through the **Blank** template when present — so the empty start carries its policy — and Blank is filtered out of the list so it isn't shown twice. Falls back to a plain blank page when no Blank template is seeded.

## Scope
Affects **fresh installs** (seed runs only when the table is empty) + the CLI `write_starter_templates` path. Existing installs keep their templates; the picker falls back gracefully when no Blank template exists.

## Test
`test_starter_templates_seed.py` asserts the policy-bearing templates seed with the right policy (presence asserted, not skipped). ruff, basedpyright, frontend `tsc` green.
<img width="1073" height="931" alt="Screenshot 2026-06-25 at 6 00 33 PM" src="https://github.com/user-attachments/assets/0f4abede-73e4-497b-b74d-66be3f8ca2eb" />
<img width="1114" height="384" alt="Screenshot 2026-06-25 at 6 00 27 PM" src="https://github.com/user-attachments/assets/c30e4517-951e-4554-8acb-856cb58d3fec" />


