### PR TITLE
feat(wiki): route the blank picker card through the Blank template

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -928,6 +928,15 @@ function TemplateStrip({
   const CARD_WIDTH = 200;
   const STEP = CARD_WIDTH + 8; // card width + gap
 
+  // The "Blank" template is the empty-start entry point — route the blank card
+  // through it (so its auto-update policy applies) when present, and drop it
+  // from the list so it isn't shown twice. Falls back to a plain blank page
+  // when no Blank template is seeded.
+  const blankTemplate = templates.find((t) => t.name === "Blank");
+  const rest = templates.filter((t) => t.name !== "Blank");
+  const blankCardActive =
+    blankActive || (blankTemplate != null && activeId === blankTemplate.id);
+
   return (
     <div className="relative">
       <div
@@ -939,12 +948,12 @@ function TemplateStrip({
           <TemplateCard
             title="Blank document"
             description="Empty file — just start typing."
-            active={blankActive}
+            active={blankCardActive}
             busy={false}
-            onClick={onBlank}
+            onClick={() => (blankTemplate ? onPick(blankTemplate) : onBlank())}
           />
         </div>
-        {templates.map((t) => (
+        {rest.map((t) => (
           <div key={t.id} className="w-[200px] shrink-0 snap-start">
             <TemplateCard
               title={t.name}

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -46,7 +46,13 @@ export function WikiHome() {
     "templates:summaries",
     listTemplateSummaries,
   );
-  const featured = (templates ?? []).slice(0, 2);
+  // The "Blank" template is the empty-start entry point (carries an auto-update
+  // policy); route the blank card through it when present, and keep it out of
+  // the featured row so it isn't shown twice.
+  const blankTemplate = (templates ?? []).find((t) => t.name === "Blank");
+  const featured = (templates ?? [])
+    .filter((t) => t.name !== "Blank")
+    .slice(0, 2);
 
   function startNewPage(templateId?: string) {
     const qs = templateId
@@ -111,7 +117,7 @@ export function WikiHome() {
                   <SvgPlusCircle size={22} />
                 </span>
               }
-              onClick={() => startNewPage()}
+              onClick={() => startNewPage(blankTemplate?.id)}
             />
           </div>
           {featured.map((t) => (


### PR DESCRIPTION
Frontend half of the **Blank template** (backend seed in #300): makes the picker's blank entry start from the seeded **Blank** template, so the empty start carries an update policy (auto-update **off**) like the original Step-1 vision ("empty template, auto-update disabled as default").

## What
- The blank card (home grid + new-doc composer's `TemplateStrip`) routes through the **"Blank"** template when one exists — so picking blank applies that template's policy. Falls back to a plain blank page when no Blank template is seeded (existing installs).
- Filters the Blank template out of the featured row / template strip so it isn't shown twice.
- Keeps the blank card's active-highlight correct when it maps to the Blank template.

## Depends on
#300 (seeds the `Blank` starter template). Without it, the blank card behaves exactly as before (plain blank) — safe to merge in either order.

## Test
`bun run typecheck` + prettier clean. UI-only.