### PR TITLE
fix(wiki): seed template policy on create (new-doc flow never inherited it)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -118,18 +118,26 @@ def _git_author(user: User | None) -> str | None:
     return f"{user.name or user.email} <{user.email}>"
 
 
-def _seed_template_policy(rel: str, actor_user_id: str) -> None:
+def _seed_template_policy(
+    rel: str, actor_user_id: str, template_id: str | None = None
+) -> None:
     """Seed a new page's update policy from the template it was created from.
 
-    The new-doc draft records which template a page is being written from; if
-    that template carries a default policy (auto-update off, scope/update
+    If that template carries a default policy (auto-update off, scope/update
     instruction), apply it to the page's ``update_policies`` row. Only fields
     the template actually sets are written — the rest stay inherited.
+
+    ``template_id`` comes from the create request (the reliable source — the
+    new-doc UI records its draft *after* the create commits). Falls back to the
+    page's new-doc draft when not supplied.
     """
-    draft = wiki_drafts.get(rel)
-    if not draft or not draft.get("template_id"):
+    tid = template_id
+    if tid is None:
+        draft = wiki_drafts.get(rel)
+        tid = draft.get("template_id") if draft else None
+    if not tid:
         return
-    tmpl = templates_repo.get(draft["template_id"])
+    tmpl = templates_repo.get(tid)
     if tmpl is None:
         return
     patch: dict[str, Any] = {}
@@ -270,7 +278,7 @@ def put_document_by_path(
     # On first create, seed the page's update policy from its template (before
     # the draft row may be cleared below).
     if not existed:
-        _seed_template_policy(rel, user.id)
+        _seed_template_policy(rel, user.id, req.template_id)
     # Drafting state: if the saved body diverges from the template
     # snapshot, the user has made it their own — clear the row so the
     # chat banner drops and the template's system prompt stops applying.

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -248,6 +248,12 @@ def put_document_by_path(
         # a new page is always allowed for an authenticated user; the
         # creator becomes the owner and gets full rights.
         require_can("write", rel, user)
+    # Validate an explicit create-from-template id up front — before any
+    # commit — so a stale/deleted template_id fails the request instead of
+    # silently creating a page with no policy applied.
+    if not existed and req.template_id is not None:
+        if templates_repo.get(req.template_id) is None:
+            raise HTTPException(status_code=404, detail="template not found")
     author = _git_author(user)
     change_kind = ChangeKind.EDIT if existed else ChangeKind.CREATE
     msg = f"{change_kind} {rel}"

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -33,6 +33,10 @@ class PutDocumentRequest(BaseModel):
     path: str = Field(min_length=1)
     body: str = ""
     base_sha: str | None = None
+    # On create, the template the page was started from — seeds the page's
+    # update policy from that template (auto-update default + update
+    # instruction). Ignored when editing an existing page.
+    template_id: str | None = None
 
 
 class CreateFolderRequest(BaseModel):

--- a/backend/tests/test_template_update_policy.py
+++ b/backend/tests/test_template_update_policy.py
@@ -72,6 +72,30 @@ def test_page_created_from_template_inherits_policy(client: TestClient) -> None:
     assert eff.update_instruction == "Only meeting facts."
 
 
+def test_create_with_template_id_seeds_policy(client: TestClient) -> None:
+    # The real new-doc flow records its draft *after* the create commits, so the
+    # create request carries template_id directly — no prior draft.
+    uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    login_fastapi(client, uid)
+    t = _make_template(
+        uid,
+        ingestion_auto_update_disabled=True,
+        update_instruction="Only meeting facts.",
+    )
+    path = "team/from-create.md"
+    assert (
+        client.put(
+            "/api/wiki/file",
+            json={"path": path, "body": "# Notes\n\nx\n", "template_id": t["id"]},
+        ).status_code
+        == 200
+    )
+
+    eff = update_policy.resolve_for_path(path)
+    assert eff.ingestion_auto_update_disabled is True
+    assert eff.update_instruction == "Only meeting facts."
+
+
 def test_update_omitting_policy_fields_preserves_them(client: TestClient) -> None:
     # The current frontend PUTs name/body/etc. without the policy fields; that
     # must not wipe a template's stored policy.

--- a/backend/tests/test_template_update_policy.py
+++ b/backend/tests/test_template_update_policy.py
@@ -96,6 +96,18 @@ def test_create_with_template_id_seeds_policy(client: TestClient) -> None:
     assert eff.update_instruction == "Only meeting facts."
 
 
+def test_create_with_unknown_template_id_404s(client: TestClient) -> None:
+    # A stale/deleted template_id must fail the request, not silently create a
+    # page with no policy.
+    uid = users_repo.create(email="o@x.com", password="hunter2-x", name="O")
+    login_fastapi(client, uid)
+    resp = client.put(
+        "/api/wiki/file",
+        json={"path": "team/x.md", "body": "# x\n", "template_id": "nope"},
+    )
+    assert resp.status_code == 404
+
+
 def test_update_omitting_policy_fields_preserves_them(client: TestClient) -> None:
     # The current frontend PUTs name/body/etc. without the policy fields; that
     # must not wipe a template's stored policy.

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -735,7 +735,13 @@ function NewDocView({ dir }: { dir: string }) {
       const fullPath = (destDir ? destDir + "/" : "") + name;
       await apiFetch("/wiki/file", {
         method: "PUT",
-        body: JSON.stringify({ path: fullPath, body: draft }),
+        body: JSON.stringify({
+          path: fullPath,
+          body: draft,
+          // Seeds the new page's update policy from the template; the draft
+          // recorded below lands after the commit, too late for that.
+          ...(appliedTemplateId ? { template_id: appliedTemplateId } : {}),
+        }),
       });
       // If a template was applied, record the draft row so the chat
       // banner + template system prompt persist on the saved doc.

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -680,16 +680,20 @@ function NewDocView({ dir }: { dir: string }) {
   const trimmedFilename = filename.trim().replace(/^\/+|\/+$/g, "");
   const filenameNoExt = trimmedFilename.replace(/\.md$/i, "");
   const filenameValid = !!filenameNoExt && !filenameNoExt.includes("/");
-  const canCreate = filenameValid && !saving;
+  // Block Create while a template's body is still loading, so it can't be
+  // saved before the template (and its policy) is applied.
+  const canCreate = filenameValid && !saving && applyingTemplateId === null;
 
   async function onPickTemplate(template: DocumentTemplateSummary) {
     setApplyingTemplateId(template.id);
+    // Set the applied id synchronously — the create request seeds the page's
+    // policy from it, so it must be set before the (async) body load, not after.
+    setAppliedTemplateId(template.id);
     setError(null);
     try {
       const full = await getTemplate(template.id);
       setDraft(full.body);
       setAppliedTemplateBody(full.body);
-      setAppliedTemplateId(template.id);
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to apply template");
     } finally {


### PR DESCRIPTION
## Bug
A page created from a template **never inherited the template's update policy** (auto-update default *or* update instruction). Reported: pages made from the **Blank** template weren't auto-update-off; another template's `update_instruction` didn't carry over either.

## Cause
`put_document_by_path` seeds the new page's policy *during* the create by reading the page's new-doc **draft** — but `NewDocView.onCreate` records that draft **after** the create PUT commits (`setDraftTemplate` runs post-PUT). So at seed time there's no draft → no policy. (The backend test passed only because it recorded the draft *before* the PUT, unlike the real UI.)

## Fix
Carry the template id **in the create request** and seed from it directly:
- `PutDocumentRequest.template_id` (ignored when editing an existing page).
- `_seed_template_policy(rel, user, template_id)` prefers the request id; falls back to the draft (covers the edit-time empty-page template-apply flow, which records its draft before saving).
- `NewDocView.onCreate` passes `template_id` in the PUT.

## Test
New `test_create_with_template_id_seeds_policy` (create with `template_id`, no prior draft → policy applied). Existing draft-path test still passes via the fallback. ruff, basedpyright, frontend `tsc`/prettier green.

## After merge
Re-deploy; existing pages are unaffected (create-time only). New pages from Blank/policy templates will inherit correctly.