### PR TITLE
feat(wiki): actionable frequent-update guidance + hide Blank from templates admin

### DIFF
--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -48,13 +48,25 @@ function TemplatesList() {
   if (error)
     return <div className="text-(--status-text-error-05)">{error.message}</div>;
 
+  // Blank is the system default new pages fall back to — pinned first and
+  // undeletable, so there's nothing to manage here. Hide it from the list, but
+  // keep it in the reorder payload (reorder requires every current id).
+  const blankTemplates = templates.filter(
+    (t) => t.name === BLANK_TEMPLATE_NAME,
+  );
+  const visibleTemplates = templates.filter(
+    (t) => t.name !== BLANK_TEMPLATE_NAME,
+  );
+
   async function move(index: number, direction: -1 | 1) {
     const target = index + direction;
-    if (target < 0 || target >= templates.length) return;
-    const next = [...templates];
-    const [moved] = next.splice(index, 1);
-    next.splice(target, 0, moved);
-    const ids = next.map((t) => t.id);
+    if (target < 0 || target >= visibleTemplates.length) return;
+    const nextVisible = [...visibleTemplates];
+    const [moved] = nextVisible.splice(index, 1);
+    nextVisible.splice(target, 0, moved);
+    // Keep Blank pinned at the front; only the visible templates reorder.
+    const nextOrder = [...blankTemplates, ...nextVisible];
+    const ids = nextOrder.map((t) => t.id);
     // Optimistic update so the row jumps immediately; SWR returns the
     // authoritative list on success.
     setReordering(moved.id);
@@ -71,7 +83,7 @@ function TemplatesList() {
         }
       },
       {
-        optimisticData: { templates: next },
+        optimisticData: { templates: nextOrder },
         rollbackOnError: true,
         revalidate: false,
       },
@@ -90,13 +102,13 @@ function TemplatesList() {
           {reorderError}
         </div>
       )}
-      {templates.length === 0 ? (
+      {visibleTemplates.length === 0 ? (
         <div className="rounded-(--border-radius-08) border border-dashed border-(--border-01) p-6 text-center text-(--text-03)">
           No templates yet. Click "New template" to define the first one.
         </div>
       ) : (
         <ul className="m-0 flex list-none flex-col gap-2 p-0">
-          {templates.map((t, i) => (
+          {visibleTemplates.map((t, i) => (
             <li
               key={t.id}
               className="flex items-center gap-3 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-3"
@@ -104,7 +116,7 @@ function TemplatesList() {
               <ReorderHandle
                 disabled={reordering !== null}
                 canUp={i > 0}
-                canDown={i < templates.length - 1}
+                canDown={i < visibleTemplates.length - 1}
                 onUp={() => void move(i, -1)}
                 onDown={() => void move(i, 1)}
               />
@@ -130,12 +142,6 @@ function TemplatesList() {
               <Button
                 size="sm"
                 variant="danger"
-                disabled={t.name === "Blank"}
-                tooltip={
-                  t.name === "Blank"
-                    ? "The Blank template is the default for new pages and can't be deleted."
-                    : undefined
-                }
                 onClick={async () => {
                   if (
                     !(await confirmDialog({
@@ -376,6 +382,11 @@ function TemplateModal({
     </div>
   );
 }
+
+// The Blank template is a system default (empty body, auto-update off). It's
+// hidden from this management list — there's nothing to edit and it can't be
+// deleted — but still backs the new-doc picker's "Blank" card.
+const BLANK_TEMPLATE_NAME = "Blank";
 
 const inputClass =
   "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";

--- a/frontend/src/components/wiki/UpdateHealthBanner.tsx
+++ b/frontend/src/components/wiki/UpdateHealthBanner.tsx
@@ -52,13 +52,16 @@ export function UpdateHealthBanner({ path, onOpenPolicy }: Props) {
   }
 
   // Advisory frequency warning (threshold 0 = every update). The owner can act
-  // on it — raise the threshold or turn off auto-update — so it keeps the CTA.
+  // on it, so it keeps the CTA + a short decision-tree of remedies: is the
+  // churn expected (raise the threshold) or not (narrow what auto-update does,
+  // or the page's scope)?
   if (health.count_24h > 0 && health.count_24h >= health.threshold_24h) {
     const description =
       `Auto-updated ${health.count_24h} times in the past 24 hours` +
       (health.threshold_24h > 0
-        ? `, above the warning threshold of ${health.threshold_24h}.`
-        : ".");
+        ? `, above the warning threshold of ${health.threshold_24h}. `
+        : ". ") +
+      "Check whether this is expected, then:";
     return (
       <div className="mb-3">
         <MessageCard
@@ -69,6 +72,22 @@ export function UpdateHealthBanner({ path, onOpenPolicy }: Props) {
             <Button size="sm" onClick={onOpenPolicy}>
               Review settings
             </Button>
+          }
+          bottomChildren={
+            <ul className="m-0 flex list-disc flex-col gap-1 pl-4 text-[13px] text-(--text-03)">
+              <li>
+                If this rate is expected, raise the warning threshold so it
+                stops flagging.
+              </li>
+              <li>
+                If auto-update is changing the wrong things, add update
+                instructions telling it what to keep or ignore.
+              </li>
+              <li>
+                If the page simply covers too much, narrow its scope — tighten
+                what it&apos;s about, or split it into focused pages.
+              </li>
+            </ul>
           }
         />
       </div>


### PR DESCRIPTION
Two small frontend refinements to the templates / update-policy surface.

## 1. Actionable guidance on the frequent-update warning banner

The too-frequent-update banner showed only a count + a bare **Review settings** button — it didn't tell the owner *what to do*. Now it's a short decision-tree of the three real remedies:

- **If the rate is expected** → raise the warning threshold so it stops flagging.
- **If auto-update is changing the wrong things** → add update instructions telling it what to keep or ignore.
- **If the page covers too much** → narrow its scope, or split it into focused pages.

Rendered in the Opal `MessageCard`'s `bottomChildren` (below a divider); the count stays in `description`, and **Review settings** remains the single CTA into the Update Policy panel where the threshold slider + Update Instructions field live.

## 2. Hide the Blank template from the admin templates list

Blank is the system default new pages fall back to — pinned first, undeletable, and with nothing meaningful to edit (empty body, auto-update off). It's now filtered out of the admin templates management list. It stays in the reorder payload (reorder requires every current id) pinned at the front, and the new-doc picker's Blank card + the agent's `list_templates` are unaffected.

## Notes

- Frontend-only; no API/contract change.
- "Narrow scope / split into focused pages" is guidance only for now — the actual split flow is **Step 3** (refactor-when-too-long) of the Taming Bad-Behaved Wikis arc.
- Verified locally: `bun run typecheck` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<img width="999" height="402" alt="Screenshot 2026-06-26 at 3 25 09 PM" src="https://github.com/user-attachments/assets/ea402844-b472-48e5-8dfe-99062cc67ba9" />
<img width="841" height="214" alt="Screenshot 2026-06-26 at 3 24 57 PM" src="https://github.com/user-attachments/assets/b68c4dd8-ea45-47f3-94b3-ad50eb29d2f1" />

