### PR TITLE
feat(coedit): Postgres editing-buffer store (co-editing, step 1)

### DIFF
--- a/backend/app/db/migrations/versions/0038_coedit_sessions.py
+++ b/backend/app/db/migrations/versions/0038_coedit_sessions.py
@@ -1,0 +1,112 @@
+"""coedit_sessions + coedit_participants: the Postgres editing buffer
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-06-30 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0038"
+down_revision: str | None = "0037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    # Fresh installs get these tables from 0001's create_all — guard so this
+    # migration is a no-op there and only does real work on databases created
+    # before co-editing landed.
+    if "coedit_sessions" not in existing:
+        op.create_table(
+            "coedit_sessions",
+            sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+            sa.Column("path", sa.Text(), nullable=False),
+            sa.Column(
+                "buffer_text", sa.Text(), server_default=sa.text("''"), nullable=False
+            ),
+            sa.Column(
+                "version", sa.BigInteger(), server_default=sa.text("0"), nullable=False
+            ),
+            sa.Column("base_sha", sa.Text(), nullable=True),
+            sa.Column(
+                "status", sa.Text(), server_default=sa.text("'active'"), nullable=False
+            ),
+            sa.Column(
+                "created_at",
+                sa.Text(),
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.Text(),
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+                nullable=False,
+            ),
+            sa.Column("last_checkpoint_at", sa.Text(), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('active', 'closed')", name="coedit_sessions_status_check"
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        # At most one active session per page; closed sessions accumulate as
+        # history without blocking a fresh one.
+        op.create_index(
+            "idx_coedit_sessions_active_path",
+            "coedit_sessions",
+            ["path"],
+            unique=True,
+            postgresql_where=sa.text("status = 'active'"),
+        )
+
+    if "coedit_participants" not in existing:
+        op.create_table(
+            "coedit_participants",
+            sa.Column("session_id", sa.BigInteger(), nullable=False),
+            sa.Column("user_id", sa.Text(), nullable=False),
+            sa.Column(
+                "joined_at",
+                sa.Text(),
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+                nullable=False,
+            ),
+            sa.Column(
+                "last_seen_at",
+                sa.Text(),
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["session_id"], ["coedit_sessions.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("session_id", "user_id"),
+        )
+        op.create_index(
+            "idx_coedit_participants_user", "coedit_participants", ["user_id"]
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_coedit_participants_user", table_name="coedit_participants")
+    op.drop_table("coedit_participants")
+    op.drop_index("idx_coedit_sessions_active_path", table_name="coedit_sessions")
+    op.drop_table("coedit_sessions")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -846,6 +846,80 @@ class AgentActivity(Base):
 
 
 # --------------------------------------------------------------------------- #
+# Co-editing — live shared editing sessions (the Postgres editing buffer)     #
+# --------------------------------------------------------------------------- #
+#
+# One live session per page (path-keyed): multiple humans join the same
+# session and converge on a single server-authoritative buffer. A single-user
+# edit is just a 1-participant session, which is how the per-user draft will
+# eventually fold into this model. The session periodically checkpoints to git
+# through ``commit_and_fan_out`` — ``base_sha`` is the HEAD it last merged
+# against, the merge base for the checkpoint 3-way merge. This store is the
+# editing *buffer* only; git stays the source of truth for committed pages.
+
+
+class CoeditSession(Base):
+    __tablename__ = "coedit_sessions"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    # Canonical wiki-relative path (no leading slash), per
+    # ``app.wiki.filesystem.safe_rel_path``. At most one *active* session per
+    # path (enforced by the partial unique index below).
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    # Server-authoritative buffer text — the live document everyone is editing.
+    buffer_text: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    # Monotonic version, bumped on every applied edit. Clients tag each patch
+    # with the version it was based on; the server rebases a stale patch onto
+    # the current buffer before applying.
+    version: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default=text("0"))
+    # Git HEAD the buffer was last checkpointed against — the merge base for the
+    # checkpoint 3-way merge. Null until the session is seeded from a page's
+    # HEAD (or, for a brand-new page, until the first checkpoint).
+    base_sha: Mapped[str | None] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'active'"))
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    last_checkpoint_at: Mapped[str | None] = mapped_column(Text)
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active', 'closed')", name="coedit_sessions_status_check"
+        ),
+        # At most one active session per page. A partial unique index lets
+        # closed sessions accumulate as history without blocking a fresh one.
+        Index(
+            "idx_coedit_sessions_active_path",
+            "path",
+            unique=True,
+            postgresql_where=text("status = 'active'"),
+        ),
+    )
+
+
+class CoeditParticipant(Base):
+    __tablename__ = "coedit_participants"
+
+    session_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("coedit_sessions.id", ondelete="CASCADE"), primary_key=True
+    )
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    joined_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    last_seen_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (Index("idx_coedit_participants_user", "user_id"),)
+
+
+# --------------------------------------------------------------------------- #
 # Cron state — per-(queue, task) last-fired timestamp so the periodic         #
 # scheduler can survive restarts without silently dropping or stampeding      #
 # missed fires. See app/tasks/queue.py:_run_periodic_scheduler.               #

--- a/backend/app/tracing/braintrust.py
+++ b/backend/app/tracing/braintrust.py
@@ -163,7 +163,9 @@ def start_llm_span(
         import braintrust
         from braintrust.span_types import SpanTypeAttribute
 
-        span_cm: Any = braintrust.start_span(
+        # braintrust's start_span member typing varies across SDK versions; the
+        # ignore keeps the check stable whatever version CI resolves.
+        span_cm: Any = braintrust.start_span(  # pyright: ignore[reportUnknownMemberType]
             name=f"llm:{provider}",
             type=SpanTypeAttribute.LLM,
             input=to_openai_message_shape(messages),
@@ -197,7 +199,9 @@ def start_tool_span(
         import braintrust
         from braintrust.span_types import SpanTypeAttribute
 
-        span_cm: Any = braintrust.start_span(
+        # braintrust's start_span member typing varies across SDK versions; the
+        # ignore keeps the check stable whatever version CI resolves.
+        span_cm: Any = braintrust.start_span(  # pyright: ignore[reportUnknownMemberType]
             name=f"tool:{name}",
             type=SpanTypeAttribute.TOOL,
             input=arguments,

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -23,7 +23,7 @@ import logging
 from datetime import datetime, timezone
 
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import CoeditParticipant, CoeditSession, User
@@ -162,15 +162,26 @@ def set_buffer(session_id: int, *, base_version: int, buffer_text: str) -> Sessi
     Returns the updated row, or ``None`` if the session is gone/closed or the
     version moved underneath the caller (stale — the caller must rebase its
     patch onto the current buffer and retry).
+
+    The compare and the swap are a single conditional ``UPDATE`` so they are
+    atomic: two concurrent callers based on the same version can't both win
+    (the version predicate is re-checked inside the write, not in Python), so
+    there is no lost-update window.
     """
+    now = _iso(_now())
     with session() as s:
-        sess = s.get(CoeditSession, session_id)
-        if sess is None or sess.status != "active" or sess.version != base_version:
-            return None
-        sess.buffer_text = buffer_text
-        sess.version = base_version + 1
-        sess.updated_at = _iso(_now())
-        return _session_row(sess)
+        sess = s.scalars(
+            update(CoeditSession)
+            .where(
+                CoeditSession.id == session_id,
+                CoeditSession.version == base_version,
+                CoeditSession.status == "active",
+            )
+            .values(buffer_text=buffer_text, version=base_version + 1, updated_at=now)
+            .returning(CoeditSession)
+            .execution_options(synchronize_session=False)
+        ).one_or_none()
+        return _session_row(sess) if sess is not None else None
 
 
 def mark_checkpointed(session_id: int, *, base_sha: str) -> None:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -1,0 +1,264 @@
+"""Co-editing session store — the Postgres editing buffer.
+
+The DB is the source of truth for an in-progress *live* edit. There is **one
+active session per page** (path-keyed); multiple humans join it and converge on
+a single server-authoritative ``buffer_text`` + monotonic ``version``. A
+single-user edit is just a 1-participant session — the model the per-user draft
+will eventually fold into.
+
+This module is the *storage* seam only: get-or-create a session, join/leave/
+touch participants, and compare-and-swap the buffer. The op/patch channel and
+the checkpoint-to-git path (3-way merge through ``commit_and_fan_out``) build on
+top of these primitives and live elsewhere. ``base_sha`` is the HEAD the buffer
+was last checkpointed against — the merge base for that future checkpoint.
+
+Git stays the source of truth for *committed* pages; this store only holds the
+unsaved buffer. See
+``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import CoeditParticipant, CoeditSession, User
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Time helpers (match agent_activity: ISO-8601 UTC text, second precision)    #
+# --------------------------------------------------------------------------- #
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _iso(ts: datetime) -> str:
+    return ts.isoformat()
+
+
+# --------------------------------------------------------------------------- #
+# Row shapes                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class SessionRow(BaseModel):
+    """A row from `coedit_sessions`."""
+
+    id: int
+    path: str
+    buffer_text: str
+    version: int
+    base_sha: str | None
+    status: str
+    created_at: str
+    updated_at: str
+    last_checkpoint_at: str | None
+
+
+class ParticipantRow(BaseModel):
+    """A `coedit_participants` row joined with the user's display name."""
+
+    session_id: int
+    user_id: str
+    user_display: str
+    joined_at: str
+    last_seen_at: str
+
+
+def _session_row(s: CoeditSession) -> SessionRow:
+    return SessionRow(
+        id=s.id,
+        path=s.path,
+        buffer_text=s.buffer_text,
+        version=s.version,
+        base_sha=s.base_sha,
+        status=s.status,
+        created_at=s.created_at,
+        updated_at=s.updated_at,
+        last_checkpoint_at=s.last_checkpoint_at,
+    )
+
+
+def _participant_row(p: CoeditParticipant, user_display: str) -> ParticipantRow:
+    return ParticipantRow(
+        session_id=p.session_id,
+        user_id=p.user_id,
+        user_display=user_display,
+        joined_at=p.joined_at,
+        last_seen_at=p.last_seen_at,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Sessions                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def get_active_session(path: str) -> SessionRow | None:
+    """The active session for ``path``, or None if nobody is co-editing it."""
+    with session() as s:
+        row = s.scalar(
+            select(CoeditSession).where(
+                CoeditSession.path == path, CoeditSession.status == "active"
+            )
+        )
+        return _session_row(row) if row is not None else None
+
+
+def open_session(path: str, *, base_sha: str | None, initial_buffer: str = "") -> SessionRow:
+    """Get-or-create the active session for ``path``.
+
+    Returns the existing active session if one is open (``base_sha`` /
+    ``initial_buffer`` are ignored then — the live buffer wins). Otherwise
+    creates a fresh session seeded from the page's HEAD. Concurrent opens race
+    on the partial unique index; the loser re-reads the winner's row.
+    """
+    with session() as s:
+        existing = s.scalar(
+            select(CoeditSession).where(
+                CoeditSession.path == path, CoeditSession.status == "active"
+            )
+        )
+        if existing is not None:
+            return _session_row(existing)
+        fresh = CoeditSession(
+            path=path,
+            buffer_text=initial_buffer,
+            version=0,
+            base_sha=base_sha,
+            status="active",
+        )
+        s.add(fresh)
+        try:
+            s.flush()
+        except IntegrityError:
+            # Another opener won the unique-index race — adopt their session.
+            s.rollback()
+            winner = s.scalar(
+                select(CoeditSession).where(
+                    CoeditSession.path == path, CoeditSession.status == "active"
+                )
+            )
+            if winner is None:  # pragma: no cover - winner closed in the gap
+                raise
+            return _session_row(winner)
+        return _session_row(fresh)
+
+
+def set_buffer(session_id: int, *, base_version: int, buffer_text: str) -> SessionRow | None:
+    """Compare-and-swap the buffer.
+
+    Bumps ``version`` and replaces ``buffer_text`` only if ``base_version``
+    still matches the session's current version (and the session is active).
+    Returns the updated row, or ``None`` if the session is gone/closed or the
+    version moved underneath the caller (stale — the caller must rebase its
+    patch onto the current buffer and retry).
+    """
+    with session() as s:
+        sess = s.get(CoeditSession, session_id)
+        if sess is None or sess.status != "active" or sess.version != base_version:
+            return None
+        sess.buffer_text = buffer_text
+        sess.version = base_version + 1
+        sess.updated_at = _iso(_now())
+        return _session_row(sess)
+
+
+def mark_checkpointed(session_id: int, *, base_sha: str) -> None:
+    """Record that the buffer was committed to git at ``base_sha``."""
+    with session() as s:
+        sess = s.get(CoeditSession, session_id)
+        if sess is not None:
+            sess.base_sha = base_sha
+            sess.last_checkpoint_at = _iso(_now())
+
+
+def close_session(session_id: int) -> None:
+    """Mark a session closed, freeing the path for a new active session."""
+    with session() as s:
+        sess = s.get(CoeditSession, session_id)
+        if sess is not None and sess.status != "closed":
+            sess.status = "closed"
+            sess.updated_at = _iso(_now())
+
+
+def rename_path(old_path: str, new_path: str) -> None:
+    """Re-point sessions when a page moves (called from the move lifecycle)."""
+    with session() as s:
+        for sess in s.scalars(
+            select(CoeditSession).where(CoeditSession.path == old_path)
+        ).all():
+            sess.path = new_path
+
+
+def delete_for_path(path: str) -> None:
+    """Drop all sessions for a page (called when the page is deleted).
+
+    Participants cascade via the FK.
+    """
+    with session() as s:
+        for sess in s.scalars(
+            select(CoeditSession).where(CoeditSession.path == path)
+        ).all():
+            s.delete(sess)
+
+
+# --------------------------------------------------------------------------- #
+# Participants                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def join(session_id: int, user_id: str) -> None:
+    """Add ``user_id`` to a session, or refresh their ``last_seen_at``."""
+    now = _iso(_now())
+    with session() as s:
+        existing = s.get(CoeditParticipant, (session_id, user_id))
+        if existing is not None:
+            existing.last_seen_at = now
+        else:
+            s.add(
+                CoeditParticipant(
+                    session_id=session_id,
+                    user_id=user_id,
+                    joined_at=now,
+                    last_seen_at=now,
+                )
+            )
+
+
+def touch(session_id: int, user_id: str) -> None:
+    """Refresh a participant's ``last_seen_at`` (presence heartbeat)."""
+    with session() as s:
+        existing = s.get(CoeditParticipant, (session_id, user_id))
+        if existing is not None:
+            existing.last_seen_at = _iso(_now())
+
+
+def leave(session_id: int, user_id: str) -> None:
+    """Remove ``user_id`` from a session."""
+    with session() as s:
+        existing = s.get(CoeditParticipant, (session_id, user_id))
+        if existing is not None:
+            s.delete(existing)
+
+
+def list_participants(session_id: int) -> list[ParticipantRow]:
+    """All participants of a session, with display names, oldest join first."""
+    user_display = func.coalesce(User.name, User.email).label("user_display")
+    with session() as s:
+        rows = s.execute(
+            select(CoeditParticipant, user_display)
+            .join(User, User.id == CoeditParticipant.user_id)
+            .where(CoeditParticipant.session_id == session_id)
+            .order_by(CoeditParticipant.joined_at.asc())
+        ).all()
+        return [_participant_row(p, disp) for p, disp in rows]

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -73,6 +73,23 @@ def test_set_buffer_cas_stale_is_rejected(users):
     assert current.buffer_text == "v1"
 
 
+def test_set_buffer_concurrent_writers_one_wins(users):
+    # Two writers both read version 0 and race to apply a patch. The atomic
+    # conditional UPDATE means exactly one swap lands; the loser is rejected
+    # (None) and must rebase. No lost update — the winner's text survives.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
+    first = coedit.set_buffer(s.id, base_version=0, buffer_text="from-A")
+    second = coedit.set_buffer(s.id, base_version=0, buffer_text="from-B")
+
+    winners = [r for r in (first, second) if r is not None]
+    assert len(winners) == 1
+    assert winners[0].version == 1
+    current = coedit.get_active_session(_PATH)
+    assert current is not None
+    assert current.version == 1
+    assert current.buffer_text == winners[0].buffer_text
+
+
 def test_set_buffer_on_closed_session_returns_none(users):
     s = coedit.open_session(_PATH, base_sha=None)
     coedit.close_session(s.id)
@@ -88,8 +105,10 @@ def test_participants_join_touch_leave(users):
     assert [r.user_id for r in rows] == ["usr_a", "usr_b"]
     assert {r.user_display for r in rows} == {"Ada", "Bo"}
 
-    # join is idempotent — refreshes last_seen, no duplicate row.
+    # join on an existing participant is idempotent (refreshes last_seen, no
+    # duplicate row); touch does the same without re-adding.
     before = next(r for r in coedit.list_participants(s.id) if r.user_id == "usr_a")
+    coedit.join(s.id, "usr_a")
     coedit.touch(s.id, "usr_a")
     after = next(r for r in coedit.list_participants(s.id) if r.user_id == "usr_a")
     assert after.last_seen_at >= before.last_seen_at

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -1,0 +1,141 @@
+"""Co-editing session store (app/wiki/coedit.py) — get-or-create sessions,
+CAS on the buffer, participant presence, checkpoint + lifecycle helpers.
+
+DB-backed (uses the per-test schema from the ``tmp_db`` fixture), mirroring
+``test_comments_repo.py``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.db.models import CoeditSession
+from app.wiki import coedit
+from tests._seed import count_rows, seed_user
+
+_PATH = "guides/setup.md"
+
+
+@pytest.fixture
+def users(tmp_db):
+    seed_user("usr_a", "a@x.com", name="Ada")
+    seed_user("usr_b", "b@x.com", name="Bo")
+    return tmp_db
+
+
+def test_open_session_get_or_create(users):
+    first = coedit.open_session(_PATH, base_sha="sha1", initial_buffer="hello")
+    assert first.path == _PATH
+    assert first.buffer_text == "hello"
+    assert first.version == 0
+    assert first.base_sha == "sha1"
+    assert first.status == "active"
+
+    # Second open on the same path adopts the existing session — the live
+    # buffer wins, the new base_sha/initial_buffer are ignored.
+    again = coedit.open_session(_PATH, base_sha="sha2", initial_buffer="ignored")
+    assert again.id == first.id
+    assert again.buffer_text == "hello"
+    assert again.base_sha == "sha1"
+    assert count_rows(CoeditSession) == 1
+
+
+def test_get_active_session(users):
+    assert coedit.get_active_session(_PATH) is None
+    opened = coedit.open_session(_PATH, base_sha=None)
+    fetched = coedit.get_active_session(_PATH)
+    assert fetched is not None
+    assert fetched.id == opened.id
+
+
+def test_set_buffer_cas_success(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
+    updated = coedit.set_buffer(s.id, base_version=0, buffer_text="v1")
+    assert updated is not None
+    assert updated.version == 1
+    assert updated.buffer_text == "v1"
+
+    again = coedit.set_buffer(s.id, base_version=1, buffer_text="v2")
+    assert again is not None
+    assert again.version == 2
+    assert again.buffer_text == "v2"
+
+
+def test_set_buffer_cas_stale_is_rejected(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
+    assert coedit.set_buffer(s.id, base_version=0, buffer_text="v1") is not None
+
+    # Caller still thinks it's on version 0 — reject, leave the buffer alone.
+    stale = coedit.set_buffer(s.id, base_version=0, buffer_text="clobber")
+    assert stale is None
+    current = coedit.get_active_session(_PATH)
+    assert current is not None
+    assert current.version == 1
+    assert current.buffer_text == "v1"
+
+
+def test_set_buffer_on_closed_session_returns_none(users):
+    s = coedit.open_session(_PATH, base_sha=None)
+    coedit.close_session(s.id)
+    assert coedit.set_buffer(s.id, base_version=0, buffer_text="x") is None
+
+
+def test_participants_join_touch_leave(users):
+    s = coedit.open_session(_PATH, base_sha=None)
+    coedit.join(s.id, "usr_a")
+    coedit.join(s.id, "usr_b")
+
+    rows = coedit.list_participants(s.id)
+    assert [r.user_id for r in rows] == ["usr_a", "usr_b"]
+    assert {r.user_display for r in rows} == {"Ada", "Bo"}
+
+    # join is idempotent — refreshes last_seen, no duplicate row.
+    before = next(r for r in coedit.list_participants(s.id) if r.user_id == "usr_a")
+    coedit.touch(s.id, "usr_a")
+    after = next(r for r in coedit.list_participants(s.id) if r.user_id == "usr_a")
+    assert after.last_seen_at >= before.last_seen_at
+    assert len(coedit.list_participants(s.id)) == 2
+
+    coedit.leave(s.id, "usr_a")
+    assert [r.user_id for r in coedit.list_participants(s.id)] == ["usr_b"]
+
+
+def test_mark_checkpointed(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.mark_checkpointed(s.id, base_sha="sha2")
+    fetched = coedit.get_active_session(_PATH)
+    assert fetched is not None
+    assert fetched.base_sha == "sha2"
+    assert fetched.last_checkpoint_at is not None
+
+
+def test_close_frees_path_for_new_session(users):
+    first = coedit.open_session(_PATH, base_sha=None)
+    coedit.close_session(first.id)
+    # Closing frees the path: a new active session can open (partial unique
+    # index only constrains active rows), and the closed one is retained.
+    second = coedit.open_session(_PATH, base_sha=None)
+    assert second.id != first.id
+    assert count_rows(CoeditSession) == 2
+    active = coedit.get_active_session(_PATH)
+    assert active is not None
+    assert active.id == second.id
+
+
+def test_close_session_with_participants_cascades(users):
+    s = coedit.open_session(_PATH, base_sha=None)
+    coedit.join(s.id, "usr_a")
+    coedit.delete_for_path(_PATH)
+    assert coedit.get_active_session(_PATH) is None
+    assert count_rows(CoeditSession) == 0
+    # Participant rows cascade with the session.
+    fresh = coedit.open_session(_PATH, base_sha=None)
+    assert coedit.list_participants(fresh.id) == []
+
+
+def test_rename_path(users):
+    s = coedit.open_session(_PATH, base_sha=None)
+    coedit.rename_path(_PATH, "guides/renamed.md")
+    assert coedit.get_active_session(_PATH) is None
+    moved = coedit.get_active_session("guides/renamed.md")
+    assert moved is not None
+    assert moved.id == s.id


### PR DESCRIPTION
## What

First backend step toward **real-time co-editing**: the Postgres store that holds a live, shared editing session per page. Storage layer only — no op channel, no checkpoint-to-git, no presence yet (those build on these primitives in follow-up PRs).

**Design doc:** `Engineering Projects/Agent Wiki Project/design/Co-Editing.md` — two-layer convergence (live human↔human buffer + checkpoint 3-way merge through the existing `commit_and_fan_out`), with the engine decision and build order recorded there.

## Decided direction (context for review)

- **Convergence: OT-lite now (snapshot + version CAS).** Full OT/CRDT is a deliberately deferred, *forward-compatible* upgrade — it only improves the rare same-word/same-instant collision and offline durability, and does nothing for the human↔agent merge that dominates this system. The `version` column here is the CAS token and graduates directly into the OT revision number if we ever upgrade.
- **One shared session per page** (path-keyed). A single-user edit is a 1-participant session — the model the per-user draft branches will later fold into. Git stays the source of truth for committed pages; this is the unsaved buffer only.
- **Presence** (later PR) stays a *thin* row here + ephemeral cursor/typing over the bus. **Op log** (`coedit_ops`, later PR) is recorded from v1 as a passive history substrate.

## Changes in this PR

- `app/db/models.py` — `coedit_sessions` (path, buffer_text, version, base_sha, status, timestamps) + `coedit_participants` (membership + heartbeat). Partial unique index = one *active* session per path; closed sessions retained.
- `app/db/migrations/versions/0038_coedit_sessions.py` — guarded create/drop, idempotent (no-op on fresh DBs where `0001`'s `create_all` already builds the tables). Up/down verified on a real chain.
- `app/wiki/coedit.py` — repo: get-or-create session, **`set_buffer` atomic version CAS** (conditional `UPDATE ... RETURNING`, no lost-update window), join/touch/leave/`list_participants`, `mark_checkpointed`, `close_session`, `rename_path`/`delete_for_path`. Returns narrow pydantic rows (mirrors `agent_activity`).
- `tests/test_coedit_repo.py` — 11 tests: CAS success + stale-rejection + concurrent-writers-one-wins, closed-session rejection, presence join/touch/leave, checkpoint, close frees the path, cascade on delete, rename.

## Verification

- `pytest tests/test_coedit_repo.py` — 11 passed.
- Migration `0037→0038→0037` applied + rolled back cleanly; guard no-ops on fresh schema.
- `ruff` + `basedpyright` (whole project) clean.

## Build order (see design doc)

1. ✅ **Buffer store** — this PR.
2. **Live bidirectional channel** (SSE+POST vs. WebSocket — decided there).
3. **Edit-op apply loop + `coedit_ops` op log.**
4. **Presence** (`status` column + ephemeral cursor/typing/follow over the bus).
5. **Checkpoint worker** (`merge_content` → `commit_and_fan_out`; co-author attribution).
6. **Fold per-user draft branches in**, then **frontend editor** (separate FE PRs).