### PR TITLE
feat(coedit): live channel (SSE + POST) with presence — step 2

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -1,18 +1,19 @@
 """Co-editing live channel — SSE down, HTTP POST up (cookie-authed humans).
 
 Thin HTTP layer: gate by page permission, drive the ``app/wiki/coedit.py`` store
-and the ``app/wiki/coedit_channel.py`` broadcast layer. Edit ops land in a
-follow-up (build-order step 3); this PR establishes the channel + presence.
+and the ``app/wiki/coedit_channel.py`` broadcast layer. Synchronous throughout
+(no asyncio) — the SSE stream is a plain sync generator, one threadpool thread
+per open connection. Edit ops land in a follow-up (build-order step 3); this PR
+establishes the channel + presence.
 """
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import Iterator
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 
 from app.auth import User, require_can
@@ -23,8 +24,7 @@ from app.models.coedit import (
     LeaveRequest,
     ParticipantOut,
 )
-from app.wiki import coedit, coedit_channel
-from app.wiki import git
+from app.wiki import coedit, coedit_channel, git
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -46,7 +46,7 @@ def _participants_out(session_id: int) -> list[ParticipantOut]:
 
 
 @router.post("/join")
-async def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
+def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
     """Open (or join) the live session for a page and return its buffer.
 
     Joining is editing, so it requires write. A fresh session is seeded from the
@@ -69,7 +69,7 @@ async def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResp
 
 
 @router.post("/leave")
-async def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bool]:
+def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bool]:
     """Explicitly leave a session (e.g. closing the editor)."""
     coedit.leave(req.session_id, user.id)
     coedit_channel.broadcast_presence(req.session_id)
@@ -77,16 +77,15 @@ async def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[s
 
 
 @router.get("/stream")
-async def stream(
-    session_id: int,
-    request: Request,
-    user: User = Depends(require_user),
-) -> StreamingResponse:
+def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResponse:
     """Long-lived SSE stream of session frames (presence now, ops later).
 
-    The connection is the presence heartbeat: each keepalive tick refreshes the
-    participant's ``last_seen_at``, and on disconnect we fire ``leave`` once the
-    user's last connection for the session closes.
+    A plain sync generator: it blocks on the connection's queue, emitting a
+    keepalive every ``_SSE_HEARTBEAT_SECONDS`` of silence. The connection is the
+    presence heartbeat — each keepalive refreshes ``last_seen_at``. When the
+    client disconnects, Starlette closes the generator (``GeneratorExit`` at the
+    next yield, at most one heartbeat later), and the ``finally`` block fires
+    ``leave`` once the user's last connection for the session closes.
     """
     sess = coedit.get_session(session_id)
     if sess is None or sess.status != "active":
@@ -95,26 +94,29 @@ async def stream(
     require_can("read", sess.path, user)
 
     coedit.join(session_id, user.id)
-    conn_id, queue = coedit_channel.connect(session_id, user.id)
+    conn_id, q = coedit_channel.connect(session_id, user.id)
     coedit_channel.broadcast_presence(session_id)
 
-    async def gen() -> AsyncIterator[bytes]:
+    def gen() -> Iterator[bytes]:
         try:
             # Prime the stream with the current roster so a joiner doesn't wait
             # for the next change to render presence.
-            yield _sse({"type": "presence", "session_id": session_id,
-                        "participants": [p.model_dump() for p in coedit.list_participants(session_id)]})
+            yield _sse(
+                {
+                    "type": "presence",
+                    "session_id": session_id,
+                    "participants": [
+                        p.model_dump() for p in coedit.list_participants(session_id)
+                    ],
+                }
+            )
             while True:
-                if await request.is_disconnected():
-                    break
-                frame = await coedit_channel.drain(queue, _SSE_HEARTBEAT_SECONDS)
+                frame = coedit_channel.drain(q, _SSE_HEARTBEAT_SECONDS)
                 if frame is None:
                     coedit.touch(session_id, user.id)
                     yield b": keepalive\n\n"
                     continue
                 yield _sse(frame)
-        except asyncio.CancelledError:
-            raise
         finally:
             coedit_channel.disconnect(conn_id)
             # Only mark the user gone when their last connection closes, so a

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -1,0 +1,135 @@
+"""Co-editing live channel — SSE down, HTTP POST up (cookie-authed humans).
+
+Thin HTTP layer: gate by page permission, drive the ``app/wiki/coedit.py`` store
+and the ``app/wiki/coedit_channel.py`` broadcast layer. Edit ops land in a
+follow-up (build-order step 3); this PR establishes the channel + presence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
+
+from app.auth import User, require_can
+from app.auth.deps import require_user
+from app.models.coedit import (
+    JoinRequest,
+    JoinResponse,
+    LeaveRequest,
+    ParticipantOut,
+)
+from app.wiki import coedit, coedit_channel
+from app.wiki import git
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+# Matches the MCP SSE cadence so proxies see the same idle behavior.
+_SSE_HEARTBEAT_SECONDS = 15.0
+
+
+def _participants_out(session_id: int) -> list[ParticipantOut]:
+    return [
+        ParticipantOut(
+            user_id=p.user_id,
+            user_display=p.user_display,
+            joined_at=p.joined_at,
+            last_seen_at=p.last_seen_at,
+        )
+        for p in coedit.list_participants(session_id)
+    ]
+
+
+@router.post("/join")
+async def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
+    """Open (or join) the live session for a page and return its buffer.
+
+    Joining is editing, so it requires write. A fresh session is seeded from the
+    page's current HEAD; an already-open session is adopted as-is (its live
+    buffer wins).
+    """
+    require_can("write", req.path, user)
+    head = git.head_sha_for_path(req.path)
+    initial = git.read_file_opt(req.path) or ""
+    sess = coedit.open_session(req.path, base_sha=head, initial_buffer=initial)
+    coedit.join(sess.id, user.id)
+    coedit_channel.broadcast_presence(sess.id)
+    return JoinResponse(
+        session_id=sess.id,
+        buffer=sess.buffer_text,
+        version=sess.version,
+        base_sha=sess.base_sha,
+        participants=_participants_out(sess.id),
+    )
+
+
+@router.post("/leave")
+async def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bool]:
+    """Explicitly leave a session (e.g. closing the editor)."""
+    coedit.leave(req.session_id, user.id)
+    coedit_channel.broadcast_presence(req.session_id)
+    return {"ok": True}
+
+
+@router.get("/stream")
+async def stream(
+    session_id: int,
+    request: Request,
+    user: User = Depends(require_user),
+) -> StreamingResponse:
+    """Long-lived SSE stream of session frames (presence now, ops later).
+
+    The connection is the presence heartbeat: each keepalive tick refreshes the
+    participant's ``last_seen_at``, and on disconnect we fire ``leave`` once the
+    user's last connection for the session closes.
+    """
+    sess = coedit.get_session(session_id)
+    if sess is None or sess.status != "active":
+        raise HTTPException(status_code=404, detail="no active session")
+    # Still need read access to the underlying page to watch it being edited.
+    require_can("read", sess.path, user)
+
+    coedit.join(session_id, user.id)
+    conn_id, queue = coedit_channel.connect(session_id, user.id)
+    coedit_channel.broadcast_presence(session_id)
+
+    async def gen() -> AsyncIterator[bytes]:
+        try:
+            # Prime the stream with the current roster so a joiner doesn't wait
+            # for the next change to render presence.
+            yield _sse({"type": "presence", "session_id": session_id,
+                        "participants": [p.model_dump() for p in coedit.list_participants(session_id)]})
+            while True:
+                if await request.is_disconnected():
+                    break
+                frame = await coedit_channel.drain(queue, _SSE_HEARTBEAT_SECONDS)
+                if frame is None:
+                    coedit.touch(session_id, user.id)
+                    yield b": keepalive\n\n"
+                    continue
+                yield _sse(frame)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            coedit_channel.disconnect(conn_id)
+            # Only mark the user gone when their last connection closes, so a
+            # second tab doesn't evict them.
+            if not coedit_channel.user_still_connected(session_id, user.id):
+                coedit.leave(session_id, user.id)
+                coedit_channel.broadcast_presence(session_id)
+            log.info("coedit sse closed session=%s user=%s", session_id, user.id)
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no"},
+    )
+
+
+def _sse(frame: dict[str, object]) -> bytes:
+    return f"data: {json.dumps(frame)}\n\n".encode("utf-8")

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -1,10 +1,8 @@
 """Co-editing live channel — SSE down, HTTP POST up (cookie-authed humans).
 
 Thin HTTP layer: gate by page permission, drive the ``app/wiki/coedit.py`` store
-and the ``app/wiki/coedit_channel.py`` broadcast layer. Synchronous throughout
-(no asyncio) — the SSE stream is a plain sync generator, one threadpool thread
-per open connection. Edit ops land in a follow-up (build-order step 3); this PR
-establishes the channel + presence.
+and the ``app/wiki/coedit_channel.py`` broadcast layer. The SSE stream is a
+plain sync generator, one threadpool thread per open connection.
 """
 
 from __future__ import annotations
@@ -78,7 +76,7 @@ def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bo
 
 @router.get("/stream")
 def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResponse:
-    """Long-lived SSE stream of session frames (presence now, ops later).
+    """Long-lived SSE stream of session frames (presence).
 
     A plain sync generator: it blocks on the connection's queue, emitting a
     keepalive every ``_SSE_HEARTBEAT_SECONDS`` of silence. The connection is the

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -98,7 +98,7 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
     # this one — otherwise the broadcast lands in our own queue and gen() would
     # emit it on top of the inline initial roster below (a duplicate frame).
     coedit_channel.broadcast_presence(session_id)
-    conn_id, q = coedit_channel.connect(session_id, user.id)
+    conn = coedit_channel.connect(session_id, user.id)
 
     def gen() -> Iterator[bytes]:
         try:
@@ -114,14 +114,14 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
                 }
             )
             while True:
-                frame = coedit_channel.drain(q, _SSE_HEARTBEAT_SECONDS)
+                frame = coedit_channel.drain(conn.queue, _SSE_HEARTBEAT_SECONDS)
                 if frame is None:
                     coedit.touch(session_id, user.id)
                     yield b": keepalive\n\n"
                     continue
                 yield _sse(frame)
         finally:
-            coedit_channel.disconnect(conn_id)
+            coedit_channel.disconnect(conn.id)
             # Only mark the user gone when their last connection closes, so a
             # second tab doesn't evict them.
             if not coedit_channel.user_still_connected(session_id, user.id):

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -94,8 +94,11 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
     require_can("write", sess.path, user)
 
     coedit.join(session_id, user.id)
-    conn_id, q = coedit_channel.connect(session_id, user.id)
+    # Announce the new participant to existing connections *before* registering
+    # this one — otherwise the broadcast lands in our own queue and gen() would
+    # emit it on top of the inline initial roster below (a duplicate frame).
     coedit_channel.broadcast_presence(session_id)
+    conn_id, q = coedit_channel.connect(session_id, user.id)
 
     def gen() -> Iterator[bytes]:
         try:

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -88,8 +88,10 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
     sess = coedit.get_session(session_id)
     if sess is None or sess.status != "active":
         raise HTTPException(status_code=404, detail="no active session")
-    # Still need read access to the underlying page to watch it being edited.
-    require_can("read", sess.path, user)
+    # Opening the stream makes the user a session participant (roster +
+    # heartbeat + commit attribution), so it requires write — symmetric with
+    # POST /join. Read-only observation would be a separate non-participant path.
+    require_can("write", sess.path, user)
 
     coedit.join(session_id, user.id)
     conn_id, q = coedit_channel.connect(session_id, user.id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ import app.config as _app_config
 from app.db import comment_fts
 from app.wiki import comments as _comments_repo
 from app.metrics import setup_prometheus
-from app.mcp_server import pubsub as mcp_pubsub
+from app.realtime import bus
 from app.llm.errors import LLMError
 from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestError
 from app.db.session import init_db
@@ -173,14 +173,14 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_repo.rebuild_from_filesystem()
     schedule_all_pending_cleanups()
-    # Cross-process MCP pub-sub bridge: the worker process commits docs,
-    # the web process owns the SSE stream — Postgres LISTEN/NOTIFY
-    # ferries update events between them.
-    mcp_pubsub.start_listener()
+    # Cross-process realtime bus: the worker process commits docs, the web
+    # process owns the SSE stream — Postgres LISTEN/NOTIFY ferries events
+    # (MCP doc/job updates, co-edit frames) between them.
+    bus.start_listener()
 
     yield
 
-    mcp_pubsub.stop_listener()
+    bus.stop_listener()
 
 
 def create_app() -> FastAPI:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,7 @@ from app.api import (
     agent_sessions,
     auth,
     chat,
+    coedit,
     comments,
     craft,
     documents,
@@ -231,6 +232,7 @@ def create_app() -> FastAPI:
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")
     app.include_router(triggers.router, prefix="/api/triggers")
     app.include_router(wiki.router, prefix="/api/wiki")
+    app.include_router(coedit.router, prefix="/api/coedit")
     app.include_router(comments.router, prefix="/api/comments")
     app.include_router(documents.router, prefix="/api/documents")
     app.include_router(chat.router, prefix="/api/chat")

--- a/backend/app/mcp_server/pubsub.py
+++ b/backend/app/mcp_server/pubsub.py
@@ -1,4 +1,4 @@
-"""Persistent subscription registry + in-memory delivery + Postgres LISTEN/NOTIFY bridge.
+"""Persistent subscription registry + in-memory delivery + cross-process bus handlers.
 
 Three concerns, separated:
 
@@ -17,11 +17,12 @@ Three concerns, separated:
    bounded sync queue, drained at stream open (and peeked by the
    ``stale_paths`` tool for poll-based clients).
 
-3. **Cross-process delivery via Postgres LISTEN/NOTIFY**
-   (``NOTIFY wiki_commit``). The worker process commits, a web
-   process owns the SSE stream; the same notification is emitted on
-   the channel and the listener thread on each replica re-publishes
-   locally (self-originated payloads are skipped via an origin tag).
+3. **Cross-process delivery via the shared realtime bus**
+   (``app/realtime/bus.py``, Postgres LISTEN/NOTIFY). The worker
+   process commits, a web process owns the SSE stream; ``publish_*``
+   emits on the bus, and the handlers registered here (``_on_update``
+   etc.) re-publish locally on every other replica. Self-originated
+   payloads are skipped by the bus via an origin tag.
 
 Fan-out on every publish (originating or relayed) targets
 ``db_subscribers(rel) ∩ (live ∪ parked)`` — the subscription tables
@@ -45,9 +46,7 @@ auto-subscribe.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import secrets
 import threading
 from queue import Empty, Full, Queue
 from typing import Any
@@ -58,16 +57,9 @@ from sqlalchemy import delete, select
 from app.db import models as orm
 from app.db.session import execute_dml, session as db_session
 from app.models.wiki import ChangeKind
+from app.realtime import bus
 
 log = logging.getLogger(__name__)
-
-NOTIFY_CHANNEL = "wiki_commit"
-
-# Per-process tag stamped into every NOTIFY payload. The LISTEN bridge
-# drops payloads carrying our own tag — local delivery already happened
-# in-process at publish time, so re-publishing the echo would hand every
-# subscriber on the originating replica a duplicate SSE frame.
-_PROCESS_ORIGIN = secrets.token_hex(8)
 
 
 class Notification(BaseModel):
@@ -397,14 +389,14 @@ def publish_doc_update(rel: str, sha: str, change_kind: ChangeKind) -> None:
     have lost read access to ``rel`` since their last successful read.
     """
     _publish_local(rel, _build_update(rel, sha, change_kind))
-    _emit_pg_notify({"kind": "update", "rel": rel, "sha": sha, "change_kind": change_kind})
+    bus.emit({"kind": "update", "rel": rel, "sha": sha, "change_kind": change_kind})
 
 
 def publish_doc_delete(rel: str, sha: str) -> None:
     """Same shape as ``publish_doc_update`` but with ``changeKind="delete"``;
     subscribers can re-issue ``read_doc`` to confirm and unsubscribe."""
     _publish_local(rel, _build_update(rel, sha, ChangeKind.DELETE))
-    _emit_pg_notify({"kind": "delete", "rel": rel, "sha": sha})
+    bus.emit({"kind": "delete", "rel": rel, "sha": sha})
 
 
 def publish_job_update(job_id: str, status: str) -> None:
@@ -413,7 +405,7 @@ def publish_job_update(job_id: str, status: str) -> None:
     ``running`` / ``succeeded`` / ``failed``.
     """
     _publish_local_job(job_id, _build_job_update(job_id, status))
-    _emit_pg_notify({"kind": "job_update", "job_id": job_id, "status": status})
+    bus.emit({"kind": "job_update", "job_id": job_id, "status": status})
 
 
 def publish_list_changed() -> None:
@@ -432,7 +424,7 @@ def publish_list_changed() -> None:
 
     for session_id in mcp_session.all_session_ids():
         _deliver(session_id, notif)
-    _emit_pg_notify({"kind": "list_changed"})
+    bus.emit({"kind": "list_changed"})
 
 
 # --------------------------------------------------------------------------- #
@@ -543,149 +535,48 @@ def _publish_local_job(job_id: str, notif: Notification) -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Postgres LISTEN/NOTIFY bridge — opt-in (only the web process arms it)       #
+# Cross-process delivery — handlers on the shared realtime bus                #
 # --------------------------------------------------------------------------- #
+#
+# The bus (app/realtime/bus.py) owns the single LISTEN/NOTIFY connection and
+# routes each incoming payload to the handler registered for its ``kind``.
+# Handlers see cross-process payloads only — a process never dispatches its own
+# echo — and re-publish them to this replica's local subscribers.
 
 
-_listener_thread: threading.Thread | None = None
-_listener_stop = threading.Event()
-
-
-def _emit_pg_notify(payload: dict[str, Any]) -> None:
-    """``NOTIFY wiki_commit, '<json>'`` so other replicas / the worker
-    fan out to their local subscribers too. Best-effort; transient
-    connection errors are swallowed and logged.
-
-    Postgres' ``NOTIFY`` syntax doesn't accept parameter bindings — the
-    payload literal has to be inlined into the SQL. We single-quote-
-    escape it (doubling apostrophes) since the JSON itself is the only
-    thing that could contain a quote.
-    """
-    try:
-        from sqlalchemy import text
-
-        literal = json.dumps({**payload, "origin": _PROCESS_ORIGIN}).replace("'", "''")
-        with db_session() as s:
-            s.execute(text(f"NOTIFY {NOTIFY_CHANNEL}, '{literal}'"))
-    except Exception:
-        # Don't let a NOTIFY hiccup take down the originating commit —
-        # local delivery already happened, and the cross-process pipe
-        # is not load-bearing for correctness.
-        log.exception("mcp pubsub: NOTIFY %s failed (local delivery still occurred)", NOTIFY_CHANNEL)
-
-
-def emit_external(payload: dict[str, Any]) -> None:
-    """Public entry for non-MCP publishers (co-editing) to ride the same
-    cross-process NOTIFY bus. ``payload["kind"]`` is routed by
-    ``_dispatch_notify_payload`` on the receiving side."""
-    _emit_pg_notify(payload)
-
-
-def start_listener() -> None:
-    """Start the LISTEN thread — call once from the web process at
-    startup (``app/main.py:create_app``).
-
-    The thread holds a single dedicated psycopg connection running
-    ``LISTEN wiki_commit;`` and re-publishes incoming notifications
-    locally. Self-emitted notifications (recognized via the
-    ``_PROCESS_ORIGIN`` tag in the payload) are skipped — the local
-    publish already happened in-process at emit time, so re-publishing
-    the echo would deliver duplicates.
-    """
-    global _listener_thread
-    if _listener_thread is not None and _listener_thread.is_alive():
-        return
-
-    _listener_stop.clear()
-    _listener_thread = threading.Thread(
-        target=_listener_loop,
-        name="mcp-pubsub-listener",
-        daemon=True,
+def _on_update(payload: dict[str, Any]) -> None:
+    _publish_local(
+        payload["rel"],
+        _build_update(payload["rel"], payload["sha"], payload["change_kind"]),
     )
-    _listener_thread.start()
 
 
-def stop_listener() -> None:
-    """Signal the listener to exit. Mostly for tests + clean shutdown."""
-    _listener_stop.set()
+def _on_delete(payload: dict[str, Any]) -> None:
+    _publish_local(
+        payload["rel"],
+        _build_update(payload["rel"], payload["sha"], ChangeKind.DELETE),
+    )
 
 
-def _listener_loop() -> None:
-    """Block on the LISTEN connection, dispatch notifications back
-    through ``_publish_local`` / ``publish_list_changed``.
+def _on_list_changed(payload: dict[str, Any]) -> None:
+    notif = Notification(method="notifications/resources/list_changed", params={})
+    from app.mcp_server import session as mcp_session
 
-    Uses raw psycopg (not SQLAlchemy) because LISTEN/NOTIFY needs a
-    dedicated connection in autocommit mode held open across many
-    notifications — outside the ORM session scope.
-    """
-    import psycopg
-
-    from app.config import CONFIG
-
-    while not _listener_stop.is_set():
-        try:
-            with psycopg.connect(CONFIG.database_url, autocommit=True) as conn:
-                conn.execute(f"LISTEN {NOTIFY_CHANNEL}")
-                # ``notifies(timeout=...)`` is a generator that STOPS
-                # once the timeout elapses (it is not a per-item poll
-                # interval). Re-enter it on the same connection — tearing
-                # the connection down between timeouts would open a
-                # re-LISTEN gap where NOTIFYs are silently lost, and
-                # would churn one Postgres connection per second while
-                # idle.
-                while not _listener_stop.is_set():
-                    for notify in conn.notifies(timeout=1.0):
-                        if _listener_stop.is_set():
-                            break
-                        _dispatch_notify_payload(notify.payload)
-        except Exception:
-            log.exception("mcp pubsub: LISTEN loop crashed; restarting in 5s")
-            _listener_stop.wait(5.0)
+    for session_id in mcp_session.all_session_ids():
+        _deliver(session_id, notif)
 
 
-def _dispatch_notify_payload(raw: str) -> None:
-    """Translate a NOTIFY payload back into a local publish. Same shape
-    we emit in ``_emit_pg_notify``."""
-    try:
-        payload = json.loads(raw)
-    except (ValueError, TypeError):
-        log.warning("mcp pubsub: malformed NOTIFY payload %r", raw)
-        return
-    if payload.get("origin") == _PROCESS_ORIGIN:
-        # Our own echo — local delivery already happened at publish time.
-        return
-    kind = payload.get("kind")
-    if kind == "update":
-        _publish_local(
-            payload["rel"],
-            _build_update(payload["rel"], payload["sha"], payload["change_kind"]),
-        )
-    elif kind == "delete":
-        _publish_local(
-            payload["rel"],
-            _build_update(payload["rel"], payload["sha"], ChangeKind.DELETE),
-        )
-    elif kind == "list_changed":
-        # Same as ``publish_list_changed`` but skip the re-NOTIFY (we
-        # got here from one).
-        notif = Notification(
-            method="notifications/resources/list_changed", params={}
-        )
-        from app.mcp_server import session as mcp_session
+def _on_job_update(payload: dict[str, Any]) -> None:
+    _publish_local_job(
+        payload["job_id"],
+        _build_job_update(payload["job_id"], payload["status"]),
+    )
 
-        for session_id in mcp_session.all_session_ids():
-            _deliver(session_id, notif)
-    elif kind == "job_update":
-        _publish_local_job(
-            payload["job_id"],
-            _build_job_update(payload["job_id"], payload["status"]),
-        )
-    elif kind == "coedit":
-        # Co-editing rides the same bus; deliver to local co-edit connections.
-        # Lazy import keeps the MCP module free of a co-edit dependency.
-        from app.wiki import coedit_channel
 
-        coedit_channel.handle_remote(payload)
+bus.register("update", _on_update)
+bus.register("delete", _on_delete)
+bus.register("list_changed", _on_list_changed)
+bus.register("job_update", _on_job_update)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/mcp_server/pubsub.py
+++ b/backend/app/mcp_server/pubsub.py
@@ -574,6 +574,13 @@ def _emit_pg_notify(payload: dict[str, Any]) -> None:
         log.exception("mcp pubsub: NOTIFY %s failed (local delivery still occurred)", NOTIFY_CHANNEL)
 
 
+def emit_external(payload: dict[str, Any]) -> None:
+    """Public entry for non-MCP publishers (co-editing) to ride the same
+    cross-process NOTIFY bus. ``payload["kind"]`` is routed by
+    ``_dispatch_notify_payload`` on the receiving side."""
+    _emit_pg_notify(payload)
+
+
 def start_listener() -> None:
     """Start the LISTEN thread — call once from the web process at
     startup (``app/main.py:create_app``).
@@ -673,6 +680,12 @@ def _dispatch_notify_payload(raw: str) -> None:
             payload["job_id"],
             _build_job_update(payload["job_id"], payload["status"]),
         )
+    elif kind == "coedit":
+        # Co-editing rides the same bus; deliver to local co-edit connections.
+        # Lazy import keeps the MCP module free of a co-edit dependency.
+        from app.wiki import coedit_channel
+
+        coedit_channel.handle_remote(payload)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -1,0 +1,32 @@
+"""HTTP request/response shapes for the co-editing live channel.
+
+Kept separate from the ORM rows in ``app/wiki/coedit.py`` (the DB shape) and the
+in-memory frames in ``app/wiki/coedit_channel.py`` (the wire shape).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class JoinRequest(BaseModel):
+    path: str
+
+
+class LeaveRequest(BaseModel):
+    session_id: int
+
+
+class ParticipantOut(BaseModel):
+    user_id: str
+    user_display: str
+    joined_at: str
+    last_seen_at: str
+
+
+class JoinResponse(BaseModel):
+    session_id: int
+    buffer: str
+    version: int
+    base_sha: str | None
+    participants: list[ParticipantOut]

--- a/backend/app/realtime/bus.py
+++ b/backend/app/realtime/bus.py
@@ -28,9 +28,9 @@ from app.db.session import session as db_session
 
 log = logging.getLogger(__name__)
 
-# Channel name is kept as ``wiki_commit`` so the bus interoperates with NOTIFYs
-# emitted before the bus was extracted out of the MCP pubsub module.
-CHANNEL = "wiki_commit"
+# Single Postgres LISTEN/NOTIFY channel shared by every consumer; the bus
+# routes each payload to a handler by its ``kind``.
+CHANNEL = "realtime_bus"
 
 # Per-process tag stamped into every payload. The listener drops payloads
 # carrying our own tag — the originating process already delivered locally.
@@ -98,7 +98,7 @@ def start_listener() -> None:
     (``app/main.py``'s lifespan).
 
     The thread holds a single dedicated psycopg connection running
-    ``LISTEN wiki_commit;`` and routes incoming notifications to registered
+    ``LISTEN realtime_bus;`` and routes incoming notifications to registered
     handlers. Self-emitted notifications are skipped via the origin tag.
     """
     global _listener_thread

--- a/backend/app/realtime/bus.py
+++ b/backend/app/realtime/bus.py
@@ -24,6 +24,10 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
+import psycopg
+from sqlalchemy import text
+
+from app.config import CONFIG
 from app.db.session import session as db_session
 
 log = logging.getLogger(__name__)
@@ -64,8 +68,6 @@ def emit(payload: dict[str, Any]) -> None:
     inlined and single-quote-escaped (only the JSON could contain a quote).
     """
     try:
-        from sqlalchemy import text
-
         literal = json.dumps({**payload, "origin": _PROCESS_ORIGIN}).replace("'", "''")
         with db_session() as s:
             s.execute(text(f"NOTIFY {CHANNEL}, '{literal}'"))
@@ -125,10 +127,6 @@ def _listener_loop() -> None:
     connection in autocommit mode held open across many notifications — outside
     the ORM session scope.
     """
-    import psycopg
-
-    from app.config import CONFIG
-
     while not _listener_stop.is_set():
         try:
             with psycopg.connect(CONFIG.database_url, autocommit=True) as conn:

--- a/backend/app/realtime/bus.py
+++ b/backend/app/realtime/bus.py
@@ -1,0 +1,147 @@
+"""Cross-process realtime message bus over Postgres LISTEN/NOTIFY.
+
+A single dedicated connection ``LISTEN``s on one channel; publishers ``NOTIFY``
+a JSON payload carrying a ``kind``. Each process stamps an origin tag and the
+listener drops payloads carrying its own tag — local delivery already happened
+in-process at publish time, so re-publishing the echo would duplicate it.
+
+Consumers register one handler per ``kind`` (``register``); the listener routes
+each incoming payload to the matching handler. This keeps the bus
+transport-agnostic — it knows nothing about its consumers. Today those are the
+MCP pubsub (``app/mcp_server/pubsub.py``) and the co-edit channel
+(``app/wiki/coedit_channel.py``).
+
+Raw ``LISTEN``/``NOTIFY`` is one of the few sanctioned raw-SQL sites (the ORM
+can't express it), alongside ``app/db/fts.py`` and ``app/tasks/queue.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from app.db.session import session as db_session
+
+log = logging.getLogger(__name__)
+
+# Channel name is kept as ``wiki_commit`` so the bus interoperates with NOTIFYs
+# emitted before the bus was extracted out of the MCP pubsub module.
+CHANNEL = "wiki_commit"
+
+# Per-process tag stamped into every payload. The listener drops payloads
+# carrying our own tag — the originating process already delivered locally.
+_PROCESS_ORIGIN = secrets.token_hex(8)
+
+Handler = Callable[[dict[str, Any]], None]
+_handlers: dict[str, Handler] = {}
+_handlers_lock = threading.Lock()
+
+_listener_thread: threading.Thread | None = None
+_listener_stop = threading.Event()
+
+
+def register(kind: str, handler: Handler) -> None:
+    """Route incoming payloads whose ``kind`` equals ``kind`` to ``handler``.
+
+    Handlers run on the listener thread and receive cross-process payloads only
+    (a process never dispatches its own echo). Registering the same ``kind``
+    twice replaces the prior handler.
+    """
+    with _handlers_lock:
+        _handlers[kind] = handler
+
+
+def emit(payload: dict[str, Any]) -> None:
+    """``NOTIFY`` all replicas / the worker. Stamps the process origin so the
+    sender skips its own echo. Best-effort: a transient connection error is
+    logged and swallowed (local delivery already happened at the call site).
+
+    Postgres' ``NOTIFY`` takes no bind parameters, so the JSON literal is
+    inlined and single-quote-escaped (only the JSON could contain a quote).
+    """
+    try:
+        from sqlalchemy import text
+
+        literal = json.dumps({**payload, "origin": _PROCESS_ORIGIN}).replace("'", "''")
+        with db_session() as s:
+            s.execute(text(f"NOTIFY {CHANNEL}, '{literal}'"))
+    except Exception:
+        log.exception("realtime bus: NOTIFY %s failed (local delivery still occurred)", CHANNEL)
+
+
+def _dispatch(raw: str) -> None:
+    """Route one received NOTIFY payload to its registered handler."""
+    try:
+        payload = json.loads(raw)
+    except (ValueError, TypeError):
+        log.warning("realtime bus: malformed payload %r", raw)
+        return
+    if payload.get("origin") == _PROCESS_ORIGIN:
+        # Our own echo — local delivery already happened at emit time.
+        return
+    kind = payload.get("kind")
+    if not isinstance(kind, str):
+        return
+    with _handlers_lock:
+        handler = _handlers.get(kind)
+    if handler is None:
+        return
+    handler(payload)
+
+
+def start_listener() -> None:
+    """Start the LISTEN thread — call once from the web process at startup
+    (``app/main.py``'s lifespan).
+
+    The thread holds a single dedicated psycopg connection running
+    ``LISTEN wiki_commit;`` and routes incoming notifications to registered
+    handlers. Self-emitted notifications are skipped via the origin tag.
+    """
+    global _listener_thread
+    if _listener_thread is not None and _listener_thread.is_alive():
+        return
+    _listener_stop.clear()
+    _listener_thread = threading.Thread(
+        target=_listener_loop,
+        name="realtime-bus-listener",
+        daemon=True,
+    )
+    _listener_thread.start()
+
+
+def stop_listener() -> None:
+    """Signal the listener to exit. Mostly for tests + clean shutdown."""
+    _listener_stop.set()
+
+
+def _listener_loop() -> None:
+    """Block on the LISTEN connection and dispatch notifications.
+
+    Uses raw psycopg (not SQLAlchemy) because LISTEN/NOTIFY needs a dedicated
+    connection in autocommit mode held open across many notifications — outside
+    the ORM session scope.
+    """
+    import psycopg
+
+    from app.config import CONFIG
+
+    while not _listener_stop.is_set():
+        try:
+            with psycopg.connect(CONFIG.database_url, autocommit=True) as conn:
+                conn.execute(f"LISTEN {CHANNEL}")
+                # ``notifies(timeout=...)`` STOPS once the timeout elapses (it
+                # is not a per-item poll interval). Re-enter it on the same
+                # connection — tearing the connection down between timeouts
+                # would open a re-LISTEN gap where NOTIFYs are silently lost.
+                while not _listener_stop.is_set():
+                    for notify in conn.notifies(timeout=1.0):
+                        if _listener_stop.is_set():
+                            break
+                        _dispatch(notify.payload)
+        except Exception:
+            log.exception("realtime bus: LISTEN loop crashed; restarting in 5s")
+            _listener_stop.wait(5.0)

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -114,6 +114,13 @@ def get_active_session(path: str) -> SessionRow | None:
         return _session_row(row) if row is not None else None
 
 
+def get_session(session_id: int) -> SessionRow | None:
+    """Look up a session by id, regardless of status (active or closed)."""
+    with session() as s:
+        row = s.get(CoeditSession, session_id)
+        return _session_row(row) if row is not None else None
+
+
 def open_session(path: str, *, base_sha: str | None, initial_buffer: str = "") -> SessionRow:
     """Get-or-create the active session for ``path``.
 

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -1,14 +1,14 @@
 """Live channel for co-editing — the SSE-down + POST-up transport.
 
 Browser clients open one SSE connection per co-edit session (cookie-authed) and
-the server pushes frames — presence now, edit ops later — to every connection in
-the session. Cross-process delivery rides the existing ``wiki_commit``
+the server pushes session frames (e.g. presence) to every connection in the
+session. Cross-process delivery rides the existing ``wiki_commit``
 LISTEN/NOTIFY bus in ``app/mcp_server/pubsub.py`` (a ``coedit`` payload kind), so
 participants connected to different app servers still see each other.
 
-Synchronous by design (no asyncio): one thread-per-connection, a thread-safe
-``queue.Queue`` per connection, mirroring ``pubsub``'s sync ``_queues`` /
-``drain_blocking`` path. Connection state is in-process and ephemeral — nothing
+One thread per connection with a thread-safe ``queue.Queue``, mirroring
+``pubsub``'s sync ``_queues`` / ``drain_blocking`` path. Connection state is
+in-process and ephemeral — nothing
 here is persisted; durable session/participant state lives in
 ``app/wiki/coedit.py``. Frames are plain JSON-serializable dicts.
 

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -2,15 +2,15 @@
 
 Browser clients open one SSE connection per co-edit session (cookie-authed) and
 the server pushes session frames (e.g. presence) to every connection in the
-session. Cross-process delivery rides the existing ``wiki_commit``
-LISTEN/NOTIFY bus in ``app/mcp_server/pubsub.py`` (a ``coedit`` payload kind), so
-participants connected to different app servers still see each other.
+session. Cross-process delivery rides the shared realtime bus
+(``app/realtime/bus.py``, Postgres LISTEN/NOTIFY) under a ``coedit`` payload
+kind, so participants connected to different app servers still see each other.
 
-One thread per connection with a thread-safe ``queue.Queue``, mirroring
-``pubsub``'s sync ``_queues`` / ``drain_blocking`` path. Connection state is
-in-process and ephemeral — nothing
-here is persisted; durable session/participant state lives in
-``app/wiki/coedit.py``. Frames are plain JSON-serializable dicts.
+One thread per connection with a thread-safe ``queue.Queue``, mirroring the MCP
+pubsub's sync ``_queues`` / ``drain_blocking`` path. Connection state is
+in-process and ephemeral — nothing here is persisted; durable
+session/participant state lives in ``app/wiki/coedit.py``. Frames are plain
+JSON-serializable dicts.
 
 See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
 """

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -23,12 +23,24 @@ import threading
 import uuid
 from typing import Any
 
+from pydantic import BaseModel, ConfigDict
+
 from app.realtime import bus
 from app.wiki import coedit
 
 log = logging.getLogger(__name__)
 
 Frame = dict[str, Any]
+
+
+class Connection(BaseModel):
+    """Handle for one live SSE connection: its opaque id (for ``disconnect``)
+    and the queue the stream generator drains."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    id: str
+    queue: queue.Queue[Frame]
 
 # Per-connection registry, keyed by an opaque connection id (one per open SSE
 # stream). Parallel dicts rather than a class, mirroring ``pubsub``'s sync
@@ -40,8 +52,8 @@ _conns_by_session: dict[int, set[str]] = {}  # coedit_session_id -> {conn_id}
 _lock = threading.Lock()
 
 
-def connect(coedit_session_id: int, user_id: str) -> tuple[str, queue.Queue[Frame]]:
-    """Register a live connection for a session. Returns its id + queue."""
+def connect(coedit_session_id: int, user_id: str) -> Connection:
+    """Register a live connection for a session. Returns its handle."""
     conn_id = uuid.uuid4().hex
     q: queue.Queue[Frame] = queue.Queue()
     with _lock:
@@ -49,7 +61,7 @@ def connect(coedit_session_id: int, user_id: str) -> tuple[str, queue.Queue[Fram
         _session_of[conn_id] = coedit_session_id
         _user_of[conn_id] = user_id
         _conns_by_session.setdefault(coedit_session_id, set()).add(conn_id)
-    return conn_id, q
+    return Connection(id=conn_id, queue=q)
 
 
 def disconnect(conn_id: str) -> None:

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -23,7 +23,7 @@ import threading
 import uuid
 from typing import Any
 
-from app.mcp_server import pubsub
+from app.realtime import bus
 
 log = logging.getLogger(__name__)
 
@@ -91,15 +91,16 @@ def publish(coedit_session_id: int, frame: Frame) -> None:
     """Deliver ``frame`` to every connection in the session, on this process and
     (via NOTIFY) on every other."""
     _deliver_local(coedit_session_id, frame)
-    pubsub.emit_external(
-        {"kind": "coedit", "coedit_session_id": coedit_session_id, "frame": frame}
-    )
+    bus.emit({"kind": "coedit", "coedit_session_id": coedit_session_id, "frame": frame})
 
 
 def handle_remote(payload: dict[str, Any]) -> None:
-    """Called by the pubsub LISTEN listener for a ``coedit`` NOTIFY from another
-    process — local delivery only (no re-emit)."""
+    """Bus handler for a ``coedit`` NOTIFY from another process — local delivery
+    only (no re-emit)."""
     _deliver_local(int(payload["coedit_session_id"]), payload["frame"])
+
+
+bus.register("coedit", handle_remote)
 
 
 def broadcast_presence(coedit_session_id: int) -> None:

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -6,17 +6,19 @@ the session. Cross-process delivery rides the existing ``wiki_commit``
 LISTEN/NOTIFY bus in ``app/mcp_server/pubsub.py`` (a ``coedit`` payload kind), so
 participants connected to different app servers still see each other.
 
-This module is ephemeral by design: connection state (queues, loops) lives in
-process memory and nothing here is persisted. Durable session/participant state
-lives in ``app/wiki/coedit.py``. Frames are plain JSON-serializable dicts.
+Synchronous by design (no asyncio): one thread-per-connection, a thread-safe
+``queue.Queue`` per connection, mirroring ``pubsub``'s sync ``_queues`` /
+``drain_blocking`` path. Connection state is in-process and ephemeral — nothing
+here is persisted; durable session/participant state lives in
+``app/wiki/coedit.py``. Frames are plain JSON-serializable dicts.
 
 See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
+import queue
 import threading
 import uuid
 from typing import Any
@@ -28,33 +30,25 @@ log = logging.getLogger(__name__)
 Frame = dict[str, Any]
 
 # Per-connection registry, keyed by an opaque connection id (one per open SSE
-# stream). Parallel dicts rather than a class, mirroring ``pubsub``'s
-# ``_async_queues`` / ``_async_loops`` style for the same runtime state.
-_queues: dict[str, asyncio.Queue[Frame]] = {}
-_loops: dict[str, asyncio.AbstractEventLoop] = {}
+# stream). Parallel dicts rather than a class, mirroring ``pubsub``'s sync
+# ``_queues`` style for the same runtime state.
+_queues: dict[str, queue.Queue[Frame]] = {}
 _session_of: dict[str, int] = {}  # conn_id -> coedit_session_id
 _user_of: dict[str, str] = {}  # conn_id -> user_id
 _conns_by_session: dict[int, set[str]] = {}  # coedit_session_id -> {conn_id}
 _lock = threading.Lock()
 
 
-def connect(coedit_session_id: int, user_id: str) -> tuple[str, asyncio.Queue[Frame]]:
-    """Register a live connection for a session. Returns its id + queue.
-
-    Must be called from inside the running event loop of the SSE handler — the
-    loop is captured so cross-thread publishers (the LISTEN listener, sync
-    request handlers) can hand frames in via ``call_soon_threadsafe``.
-    """
+def connect(coedit_session_id: int, user_id: str) -> tuple[str, queue.Queue[Frame]]:
+    """Register a live connection for a session. Returns its id + queue."""
     conn_id = uuid.uuid4().hex
-    loop = asyncio.get_running_loop()
-    queue: asyncio.Queue[Frame] = asyncio.Queue()
+    q: queue.Queue[Frame] = queue.Queue()
     with _lock:
-        _queues[conn_id] = queue
-        _loops[conn_id] = loop
+        _queues[conn_id] = q
         _session_of[conn_id] = coedit_session_id
         _user_of[conn_id] = user_id
         _conns_by_session.setdefault(coedit_session_id, set()).add(conn_id)
-    return conn_id, queue
+    return conn_id, q
 
 
 def disconnect(conn_id: str) -> None:
@@ -62,7 +56,6 @@ def disconnect(conn_id: str) -> None:
     with _lock:
         sid = _session_of.pop(conn_id, None)
         _queues.pop(conn_id, None)
-        _loops.pop(conn_id, None)
         _user_of.pop(conn_id, None)
         if sid is not None:
             conns = _conns_by_session.get(sid)
@@ -85,18 +78,18 @@ def user_still_connected(coedit_session_id: int, user_id: str) -> bool:
         )
 
 
-async def drain(queue: asyncio.Queue[Frame], timeout: float) -> Frame | None:
-    """Await the next frame up to ``timeout`` seconds; ``None`` on timeout so
+def drain(q: queue.Queue[Frame], timeout: float) -> Frame | None:
+    """Block up to ``timeout`` seconds for the next frame; ``None`` on timeout so
     the SSE writer can emit a heartbeat."""
     try:
-        return await asyncio.wait_for(queue.get(), timeout)
-    except asyncio.TimeoutError:
+        return q.get(timeout=timeout)
+    except queue.Empty:
         return None
 
 
 def publish(coedit_session_id: int, frame: Frame) -> None:
-    """Deliver ``frame`` to every connection in the session, on this process
-    and (via NOTIFY) on every other."""
+    """Deliver ``frame`` to every connection in the session, on this process and
+    (via NOTIFY) on every other."""
     _deliver_local(coedit_session_id, frame)
     pubsub.emit_external(
         {"kind": "coedit", "coedit_session_id": coedit_session_id, "frame": frame}
@@ -125,23 +118,21 @@ def broadcast_presence(coedit_session_id: int) -> None:
 
 
 def _deliver_local(coedit_session_id: int, frame: Frame) -> None:
+    # ``queue.Queue`` is thread-safe, so a plain ``put_nowait`` works from any
+    # thread (the LISTEN listener, a request handler) — no event loop, no
+    # cross-thread scheduling dance.
     with _lock:
-        conn_ids = list(_conns_by_session.get(coedit_session_id, ()))
-        targets = [(cid, _queues.get(cid), _loops.get(cid)) for cid in conn_ids]
-    for cid, queue, loop in targets:
-        if queue is None or loop is None:
-            continue
-        try:
-            loop.call_soon_threadsafe(queue.put_nowait, frame)
-        except RuntimeError:
-            # Loop already closed (connection tearing down) — drop the frame.
-            log.debug("coedit: dropping frame for dead connection %s", cid)
+        targets = [
+            _queues.get(cid) for cid in _conns_by_session.get(coedit_session_id, ())
+        ]
+    for q in targets:
+        if q is not None:
+            q.put_nowait(frame)
 
 
 def reset_for_tests() -> None:
     with _lock:
         _queues.clear()
-        _loops.clear()
         _session_of.clear()
         _user_of.clear()
         _conns_by_session.clear()

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -24,6 +24,7 @@ import uuid
 from typing import Any
 
 from app.realtime import bus
+from app.wiki import coedit
 
 log = logging.getLogger(__name__)
 
@@ -105,8 +106,6 @@ bus.register("coedit", handle_remote)
 
 def broadcast_presence(coedit_session_id: int) -> None:
     """Push the current participant roster to the session."""
-    from app.wiki import coedit
-
     participants = coedit.list_participants(coedit_session_id)
     publish(
         coedit_session_id,

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -1,0 +1,147 @@
+"""Live channel for co-editing — the SSE-down + POST-up transport.
+
+Browser clients open one SSE connection per co-edit session (cookie-authed) and
+the server pushes frames — presence now, edit ops later — to every connection in
+the session. Cross-process delivery rides the existing ``wiki_commit``
+LISTEN/NOTIFY bus in ``app/mcp_server/pubsub.py`` (a ``coedit`` payload kind), so
+participants connected to different app servers still see each other.
+
+This module is ephemeral by design: connection state (queues, loops) lives in
+process memory and nothing here is persisted. Durable session/participant state
+lives in ``app/wiki/coedit.py``. Frames are plain JSON-serializable dicts.
+
+See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+import uuid
+from typing import Any
+
+from app.mcp_server import pubsub
+
+log = logging.getLogger(__name__)
+
+Frame = dict[str, Any]
+
+# Per-connection registry, keyed by an opaque connection id (one per open SSE
+# stream). Parallel dicts rather than a class, mirroring ``pubsub``'s
+# ``_async_queues`` / ``_async_loops`` style for the same runtime state.
+_queues: dict[str, asyncio.Queue[Frame]] = {}
+_loops: dict[str, asyncio.AbstractEventLoop] = {}
+_session_of: dict[str, int] = {}  # conn_id -> coedit_session_id
+_user_of: dict[str, str] = {}  # conn_id -> user_id
+_conns_by_session: dict[int, set[str]] = {}  # coedit_session_id -> {conn_id}
+_lock = threading.Lock()
+
+
+def connect(coedit_session_id: int, user_id: str) -> tuple[str, asyncio.Queue[Frame]]:
+    """Register a live connection for a session. Returns its id + queue.
+
+    Must be called from inside the running event loop of the SSE handler — the
+    loop is captured so cross-thread publishers (the LISTEN listener, sync
+    request handlers) can hand frames in via ``call_soon_threadsafe``.
+    """
+    conn_id = uuid.uuid4().hex
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue[Frame] = asyncio.Queue()
+    with _lock:
+        _queues[conn_id] = queue
+        _loops[conn_id] = loop
+        _session_of[conn_id] = coedit_session_id
+        _user_of[conn_id] = user_id
+        _conns_by_session.setdefault(coedit_session_id, set()).add(conn_id)
+    return conn_id, queue
+
+
+def disconnect(conn_id: str) -> None:
+    """Tear down a connection's in-memory state."""
+    with _lock:
+        sid = _session_of.pop(conn_id, None)
+        _queues.pop(conn_id, None)
+        _loops.pop(conn_id, None)
+        _user_of.pop(conn_id, None)
+        if sid is not None:
+            conns = _conns_by_session.get(sid)
+            if conns is not None:
+                conns.discard(conn_id)
+                if not conns:
+                    _conns_by_session.pop(sid, None)
+
+
+def user_still_connected(coedit_session_id: int, user_id: str) -> bool:
+    """True if ``user_id`` still has any open connection to the session.
+
+    Lets the SSE handler avoid firing ``leave`` when one of a user's several
+    tabs closes while another stays open.
+    """
+    with _lock:
+        return any(
+            _user_of.get(cid) == user_id
+            for cid in _conns_by_session.get(coedit_session_id, ())
+        )
+
+
+async def drain(queue: asyncio.Queue[Frame], timeout: float) -> Frame | None:
+    """Await the next frame up to ``timeout`` seconds; ``None`` on timeout so
+    the SSE writer can emit a heartbeat."""
+    try:
+        return await asyncio.wait_for(queue.get(), timeout)
+    except asyncio.TimeoutError:
+        return None
+
+
+def publish(coedit_session_id: int, frame: Frame) -> None:
+    """Deliver ``frame`` to every connection in the session, on this process
+    and (via NOTIFY) on every other."""
+    _deliver_local(coedit_session_id, frame)
+    pubsub.emit_external(
+        {"kind": "coedit", "coedit_session_id": coedit_session_id, "frame": frame}
+    )
+
+
+def handle_remote(payload: dict[str, Any]) -> None:
+    """Called by the pubsub LISTEN listener for a ``coedit`` NOTIFY from another
+    process — local delivery only (no re-emit)."""
+    _deliver_local(int(payload["coedit_session_id"]), payload["frame"])
+
+
+def broadcast_presence(coedit_session_id: int) -> None:
+    """Push the current participant roster to the session."""
+    from app.wiki import coedit
+
+    participants = coedit.list_participants(coedit_session_id)
+    publish(
+        coedit_session_id,
+        {
+            "type": "presence",
+            "session_id": coedit_session_id,
+            "participants": [p.model_dump() for p in participants],
+        },
+    )
+
+
+def _deliver_local(coedit_session_id: int, frame: Frame) -> None:
+    with _lock:
+        conn_ids = list(_conns_by_session.get(coedit_session_id, ()))
+        targets = [(cid, _queues.get(cid), _loops.get(cid)) for cid in conn_ids]
+    for cid, queue, loop in targets:
+        if queue is None or loop is None:
+            continue
+        try:
+            loop.call_soon_threadsafe(queue.put_nowait, frame)
+        except RuntimeError:
+            # Loop already closed (connection tearing down) — drop the frame.
+            log.debug("coedit: dropping frame for dead connection %s", cid)
+
+
+def reset_for_tests() -> None:
+    with _lock:
+        _queues.clear()
+        _loops.clear()
+        _session_of.clear()
+        _user_of.clear()
+        _conns_by_session.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,7 +35,7 @@ import pytest
 from psycopg import sql
 
 from app.config import Config
-from app.mcp_server import pubsub as _mcp_pubsub
+from app.realtime import bus as _bus
 from app.mcp_server import session as _mcp_session
 
 # --------------------------------------------------------------------------- #
@@ -61,11 +61,11 @@ needs_opensearch = pytest.mark.skipif(
 )
 
 # Suppress the cross-process Postgres LISTEN bridge in tests. ``create_app``'s
-# lifespan calls ``mcp_pubsub.start_listener`` (app/main.py), which would
-# open a connection on the shared test DB and receive every NOTIFY emitted
-# by every other xdist worker. Tests exercise in-process delivery directly,
-# so the listener has no value and only adds cross-worker noise.
-_mcp_pubsub.start_listener = lambda: None  # type: ignore[assignment]
+# lifespan calls ``bus.start_listener`` (app/main.py), which would open a
+# connection on the shared test DB and receive every NOTIFY emitted by every
+# other xdist worker. Tests exercise in-process delivery directly, so the
+# listener has no value and only adds cross-worker noise.
+_bus.start_listener = lambda: None  # type: ignore[assignment]
 
 _BASE_URL = os.environ.get(
     "TEST_DATABASE_URL",

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -1,0 +1,83 @@
+"""Co-edit HTTP surface (app/api/coedit.py) — join / leave and their
+permission gating. The SSE stream's live delivery is covered at the channel
+level in test_coedit_channel.py; here we exercise the request layer.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.main import create_app
+from app.wiki import acl, coedit, git
+
+from tests._auth import login_fastapi
+
+_PATH = "guides/setup.md"
+
+
+@pytest.fixture
+def client(tmp_db, tmp_repo):
+    return TestClient(create_app())
+
+
+def _seed_page(body: str = "# Setup\n\nhello\n") -> str:
+    return git.commit_file(_PATH, body, message="seed", author="t <t@x.com>")
+
+
+def test_join_requires_auth(client):
+    assert client.post("/api/coedit/join", json={"path": _PATH}).status_code == 401
+
+
+def test_join_creates_session_seeded_from_head(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    sha = _seed_page()
+
+    resp = client.post("/api/coedit/join", json={"path": _PATH})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == 0
+    assert body["buffer"] == "# Setup\n\nhello\n"
+    assert body["base_sha"] == sha
+    assert [p["user_id"] for p in body["participants"]] == [uid]
+
+
+def test_join_is_idempotent_and_shared(client):
+    a = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    b = users_repo.create(email="bo@x.com", password="hunter2-x", name="Bo")
+    _seed_page()
+
+    login_fastapi(client, a)
+    first = client.post("/api/coedit/join", json={"path": _PATH}).json()
+    login_fastapi(client, b)
+    second = client.post("/api/coedit/join", json={"path": _PATH}).json()
+
+    # Same shared session; both users are participants.
+    assert first["session_id"] == second["session_id"]
+    assert {p["user_id"] for p in second["participants"]} == {a, b}
+
+
+def test_join_without_write_is_forbidden(client):
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
+    _seed_page()
+    # Committing via git directly bypasses the lifecycle hook, so the page has
+    # no ACL rows — setting an owner makes it owner-only (no public grant).
+    acl.set_owner(_PATH, owner)
+
+    login_fastapi(client, other)
+    assert client.post("/api/coedit/join", json={"path": _PATH}).status_code == 403
+
+
+def test_leave_removes_participant(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page()
+
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    assert len(coedit.list_participants(sid)) == 1
+
+    resp = client.post("/api/coedit/leave", json={"session_id": sid})
+    assert resp.status_code == 200
+    assert coedit.list_participants(sid) == []

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -70,6 +70,22 @@ def test_join_without_write_is_forbidden(client):
     assert client.post("/api/coedit/join", json={"path": _PATH}).status_code == 403
 
 
+def test_stream_requires_write(client):
+    # Opening the stream is editing (it joins the roster), so a non-writer is
+    # rejected — symmetric with /join. require_can raises before the response
+    # starts streaming, so this returns 403 without hanging.
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
+    _seed_page()
+    acl.set_owner(_PATH, owner)  # owner-only page
+
+    login_fastapi(client, owner)
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+
+    login_fastapi(client, other)
+    assert client.get(f"/api/coedit/stream?session_id={sid}").status_code == 403
+
+
 def test_leave_removes_participant(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -1,93 +1,61 @@
 """Co-edit live channel (app/wiki/coedit_channel.py) — the in-memory
 connection registry, fan-out, and the cross-process ``handle_remote`` path.
 
-Async bits are driven through ``asyncio.run`` since the suite has no
-pytest-asyncio; ``connect`` needs a running loop.
+Synchronous (thread-per-connection + ``queue.Queue``), so the tests are plain
+puts and gets — no event loop.
 """
 from __future__ import annotations
-
-import asyncio
 
 from app.wiki import coedit_channel
 
 
-def _drain_now(queue) -> dict | None:
-    # Frames are scheduled via call_soon_threadsafe; a zero-ish timeout still
-    # lets the scheduled callback run before we read.
-    return asyncio.run(coedit_channel.drain(queue, 0.5))
-
-
 def test_connect_publish_delivers_to_connection():
-    async def scenario():
-        coedit_channel.reset_for_tests()
-        _conn, queue = coedit_channel.connect(1, "usr_a")
-        coedit_channel._deliver_local(1, {"type": "presence", "n": 1})
-        return await coedit_channel.drain(queue, 0.5)
-
-    frame = asyncio.run(scenario())
-    assert frame == {"type": "presence", "n": 1}
+    coedit_channel.reset_for_tests()
+    _conn, q = coedit_channel.connect(1, "usr_a")
+    coedit_channel._deliver_local(1, {"type": "presence", "n": 1})
+    assert coedit_channel.drain(q, 0.5) == {"type": "presence", "n": 1}
 
 
 def test_fan_out_to_all_connections_in_session():
-    async def scenario():
-        coedit_channel.reset_for_tests()
-        _a, qa = coedit_channel.connect(7, "usr_a")
-        _b, qb = coedit_channel.connect(7, "usr_b")
-        coedit_channel._deliver_local(7, {"hello": "world"})
-        return (await coedit_channel.drain(qa, 0.5), await coedit_channel.drain(qb, 0.5))
-
-    fa, fb = asyncio.run(scenario())
-    assert fa == {"hello": "world"}
-    assert fb == {"hello": "world"}
+    coedit_channel.reset_for_tests()
+    _a, qa = coedit_channel.connect(7, "usr_a")
+    _b, qb = coedit_channel.connect(7, "usr_b")
+    coedit_channel._deliver_local(7, {"hello": "world"})
+    assert coedit_channel.drain(qa, 0.5) == {"hello": "world"}
+    assert coedit_channel.drain(qb, 0.5) == {"hello": "world"}
 
 
 def test_other_session_does_not_receive():
-    async def scenario():
-        coedit_channel.reset_for_tests()
-        _a, qa = coedit_channel.connect(1, "usr_a")
-        coedit_channel._deliver_local(2, {"to": "other"})
-        return await coedit_channel.drain(qa, 0.2)
-
-    assert asyncio.run(scenario()) is None  # timed out — nothing delivered
+    coedit_channel.reset_for_tests()
+    _a, qa = coedit_channel.connect(1, "usr_a")
+    coedit_channel._deliver_local(2, {"to": "other"})
+    assert coedit_channel.drain(qa, 0.1) is None  # timed out — nothing delivered
 
 
 def test_disconnect_stops_delivery_and_clears_state():
-    async def scenario():
-        coedit_channel.reset_for_tests()
-        conn, queue = coedit_channel.connect(3, "usr_a")
-        coedit_channel.disconnect(conn)
-        coedit_channel._deliver_local(3, {"x": 1})
-        return await coedit_channel.drain(queue, 0.2)
-
-    assert asyncio.run(scenario()) is None
+    coedit_channel.reset_for_tests()
+    conn, q = coedit_channel.connect(3, "usr_a")
+    coedit_channel.disconnect(conn)
+    coedit_channel._deliver_local(3, {"x": 1})
+    assert coedit_channel.drain(q, 0.1) is None
 
 
 def test_user_still_connected_tracks_multiple_tabs():
-    async def scenario():
-        coedit_channel.reset_for_tests()
-        c1, _ = coedit_channel.connect(5, "usr_a")
-        c2, _ = coedit_channel.connect(5, "usr_a")
-        first = coedit_channel.user_still_connected(5, "usr_a")
-        coedit_channel.disconnect(c1)
-        # One tab closed, the other still open → user is still present.
-        mid = coedit_channel.user_still_connected(5, "usr_a")
-        coedit_channel.disconnect(c2)
-        last = coedit_channel.user_still_connected(5, "usr_a")
-        return first, mid, last
-
-    first, mid, last = asyncio.run(scenario())
-    assert first is True
-    assert mid is True
-    assert last is False
+    coedit_channel.reset_for_tests()
+    c1, _ = coedit_channel.connect(5, "usr_a")
+    c2, _ = coedit_channel.connect(5, "usr_a")
+    assert coedit_channel.user_still_connected(5, "usr_a") is True
+    coedit_channel.disconnect(c1)
+    # One tab closed, the other still open → user is still present.
+    assert coedit_channel.user_still_connected(5, "usr_a") is True
+    coedit_channel.disconnect(c2)
+    assert coedit_channel.user_still_connected(5, "usr_a") is False
 
 
 def test_handle_remote_delivers_locally():
-    async def scenario():
-        coedit_channel.reset_for_tests()
-        _c, queue = coedit_channel.connect(9, "usr_a")
-        coedit_channel.handle_remote(
-            {"coedit_session_id": 9, "frame": {"type": "presence", "via": "notify"}}
-        )
-        return await coedit_channel.drain(queue, 0.5)
-
-    assert asyncio.run(scenario()) == {"type": "presence", "via": "notify"}
+    coedit_channel.reset_for_tests()
+    _c, q = coedit_channel.connect(9, "usr_a")
+    coedit_channel.handle_remote(
+        {"coedit_session_id": 9, "frame": {"type": "presence", "via": "notify"}}
+    )
+    assert coedit_channel.drain(q, 0.5) == {"type": "presence", "via": "notify"}

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -11,51 +11,51 @@ from app.wiki import coedit_channel
 
 def test_connect_publish_delivers_to_connection():
     coedit_channel.reset_for_tests()
-    _conn, q = coedit_channel.connect(1, "usr_a")
+    conn = coedit_channel.connect(1, "usr_a")
     coedit_channel._deliver_local(1, {"type": "presence", "n": 1})
-    assert coedit_channel.drain(q, 0.5) == {"type": "presence", "n": 1}
+    assert coedit_channel.drain(conn.queue, 0.5) == {"type": "presence", "n": 1}
 
 
 def test_fan_out_to_all_connections_in_session():
     coedit_channel.reset_for_tests()
-    _a, qa = coedit_channel.connect(7, "usr_a")
-    _b, qb = coedit_channel.connect(7, "usr_b")
+    a = coedit_channel.connect(7, "usr_a")
+    b = coedit_channel.connect(7, "usr_b")
     coedit_channel._deliver_local(7, {"hello": "world"})
-    assert coedit_channel.drain(qa, 0.5) == {"hello": "world"}
-    assert coedit_channel.drain(qb, 0.5) == {"hello": "world"}
+    assert coedit_channel.drain(a.queue, 0.5) == {"hello": "world"}
+    assert coedit_channel.drain(b.queue, 0.5) == {"hello": "world"}
 
 
 def test_other_session_does_not_receive():
     coedit_channel.reset_for_tests()
-    _a, qa = coedit_channel.connect(1, "usr_a")
+    a = coedit_channel.connect(1, "usr_a")
     coedit_channel._deliver_local(2, {"to": "other"})
-    assert coedit_channel.drain(qa, 0.1) is None  # timed out — nothing delivered
+    assert coedit_channel.drain(a.queue, 0.1) is None  # timed out — nothing delivered
 
 
 def test_disconnect_stops_delivery_and_clears_state():
     coedit_channel.reset_for_tests()
-    conn, q = coedit_channel.connect(3, "usr_a")
-    coedit_channel.disconnect(conn)
+    conn = coedit_channel.connect(3, "usr_a")
+    coedit_channel.disconnect(conn.id)
     coedit_channel._deliver_local(3, {"x": 1})
-    assert coedit_channel.drain(q, 0.1) is None
+    assert coedit_channel.drain(conn.queue, 0.1) is None
 
 
 def test_user_still_connected_tracks_multiple_tabs():
     coedit_channel.reset_for_tests()
-    c1, _ = coedit_channel.connect(5, "usr_a")
-    c2, _ = coedit_channel.connect(5, "usr_a")
+    c1 = coedit_channel.connect(5, "usr_a")
+    c2 = coedit_channel.connect(5, "usr_a")
     assert coedit_channel.user_still_connected(5, "usr_a") is True
-    coedit_channel.disconnect(c1)
+    coedit_channel.disconnect(c1.id)
     # One tab closed, the other still open → user is still present.
     assert coedit_channel.user_still_connected(5, "usr_a") is True
-    coedit_channel.disconnect(c2)
+    coedit_channel.disconnect(c2.id)
     assert coedit_channel.user_still_connected(5, "usr_a") is False
 
 
 def test_handle_remote_delivers_locally():
     coedit_channel.reset_for_tests()
-    _c, q = coedit_channel.connect(9, "usr_a")
+    conn = coedit_channel.connect(9, "usr_a")
     coedit_channel.handle_remote(
         {"coedit_session_id": 9, "frame": {"type": "presence", "via": "notify"}}
     )
-    assert coedit_channel.drain(q, 0.5) == {"type": "presence", "via": "notify"}
+    assert coedit_channel.drain(conn.queue, 0.5) == {"type": "presence", "via": "notify"}

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -1,0 +1,93 @@
+"""Co-edit live channel (app/wiki/coedit_channel.py) — the in-memory
+connection registry, fan-out, and the cross-process ``handle_remote`` path.
+
+Async bits are driven through ``asyncio.run`` since the suite has no
+pytest-asyncio; ``connect`` needs a running loop.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from app.wiki import coedit_channel
+
+
+def _drain_now(queue) -> dict | None:
+    # Frames are scheduled via call_soon_threadsafe; a zero-ish timeout still
+    # lets the scheduled callback run before we read.
+    return asyncio.run(coedit_channel.drain(queue, 0.5))
+
+
+def test_connect_publish_delivers_to_connection():
+    async def scenario():
+        coedit_channel.reset_for_tests()
+        _conn, queue = coedit_channel.connect(1, "usr_a")
+        coedit_channel._deliver_local(1, {"type": "presence", "n": 1})
+        return await coedit_channel.drain(queue, 0.5)
+
+    frame = asyncio.run(scenario())
+    assert frame == {"type": "presence", "n": 1}
+
+
+def test_fan_out_to_all_connections_in_session():
+    async def scenario():
+        coedit_channel.reset_for_tests()
+        _a, qa = coedit_channel.connect(7, "usr_a")
+        _b, qb = coedit_channel.connect(7, "usr_b")
+        coedit_channel._deliver_local(7, {"hello": "world"})
+        return (await coedit_channel.drain(qa, 0.5), await coedit_channel.drain(qb, 0.5))
+
+    fa, fb = asyncio.run(scenario())
+    assert fa == {"hello": "world"}
+    assert fb == {"hello": "world"}
+
+
+def test_other_session_does_not_receive():
+    async def scenario():
+        coedit_channel.reset_for_tests()
+        _a, qa = coedit_channel.connect(1, "usr_a")
+        coedit_channel._deliver_local(2, {"to": "other"})
+        return await coedit_channel.drain(qa, 0.2)
+
+    assert asyncio.run(scenario()) is None  # timed out — nothing delivered
+
+
+def test_disconnect_stops_delivery_and_clears_state():
+    async def scenario():
+        coedit_channel.reset_for_tests()
+        conn, queue = coedit_channel.connect(3, "usr_a")
+        coedit_channel.disconnect(conn)
+        coedit_channel._deliver_local(3, {"x": 1})
+        return await coedit_channel.drain(queue, 0.2)
+
+    assert asyncio.run(scenario()) is None
+
+
+def test_user_still_connected_tracks_multiple_tabs():
+    async def scenario():
+        coedit_channel.reset_for_tests()
+        c1, _ = coedit_channel.connect(5, "usr_a")
+        c2, _ = coedit_channel.connect(5, "usr_a")
+        first = coedit_channel.user_still_connected(5, "usr_a")
+        coedit_channel.disconnect(c1)
+        # One tab closed, the other still open → user is still present.
+        mid = coedit_channel.user_still_connected(5, "usr_a")
+        coedit_channel.disconnect(c2)
+        last = coedit_channel.user_still_connected(5, "usr_a")
+        return first, mid, last
+
+    first, mid, last = asyncio.run(scenario())
+    assert first is True
+    assert mid is True
+    assert last is False
+
+
+def test_handle_remote_delivers_locally():
+    async def scenario():
+        coedit_channel.reset_for_tests()
+        _c, queue = coedit_channel.connect(9, "usr_a")
+        coedit_channel.handle_remote(
+            {"coedit_session_id": 9, "frame": {"type": "presence", "via": "notify"}}
+        )
+        return await coedit_channel.drain(queue, 0.5)
+
+    assert asyncio.run(scenario()) == {"type": "presence", "via": "notify"}

--- a/backend/tests/test_mcp_pubsub.py
+++ b/backend/tests/test_mcp_pubsub.py
@@ -29,6 +29,7 @@ from fastapi.responses import StreamingResponse
 from app.auth import User
 from app.mcp_server import pubsub as mcp_pubsub
 from app.mcp_server import session as mcp_session
+from app.realtime import bus
 from app.models.wiki import ChangeKind
 
 # Per-test pubsub/session reset is handled by the autouse ``_reset_mcp_state``
@@ -205,15 +206,11 @@ def test_dispatch_skips_self_originated_notify(tmp_repo):
     payload = {"kind": "update", "rel": "page.md", "sha": "sha1", "change_kind": "edit"}
 
     # Self-originated → dropped, nothing delivered.
-    mcp_pubsub._dispatch_notify_payload(
-        json.dumps({**payload, "origin": mcp_pubsub._PROCESS_ORIGIN})
-    )
+    bus._dispatch(json.dumps({**payload, "origin": bus._PROCESS_ORIGIN}))
     assert mcp_pubsub.drain_blocking(sess_id, timeout=0.05) is None
 
     # Foreign origin (another replica / the worker) → delivered.
-    mcp_pubsub._dispatch_notify_payload(
-        json.dumps({**payload, "origin": "some-other-process"})
-    )
+    bus._dispatch(json.dumps({**payload, "origin": "some-other-process"}))
     notif = mcp_pubsub.drain_blocking(sess_id, timeout=1.0)
     assert notif is not None
     assert notif.params["uri"] == "wiki:///page.md"


### PR DESCRIPTION
## What

Build-order **step 2** of [real-time co-editing](Engineering Projects/Agent Wiki Project/design/Co-Editing.md): the live channel humans connect to. Backend only — the editor frontend and the edit-op apply loop are later steps. Builds on the buffer store from #305.

## Design choices (per the design doc)

- **Parallel module, reuse the bus.** A new `app/wiki/coedit_channel.py` with its own cookie-authed connection registry, reusing the existing `wiki_commit` `LISTEN/NOTIFY` listener for cross-process fan-out (a new `coedit` payload kind). Kept separate from the MCP pubsub's bearer/`mcp_sessions` coupling; the only edits to `pubsub.py` are a public `emit_external()` and one dispatch branch (lazy import → no MCP→coedit dependency).
- **SSE down + POST up** (not WebSocket) — reuses proven infra and cookie auth; cursors/ops will throttle (later step).
- **Ephemeral channel state.** Connection queues live in memory; nothing here is persisted. Durable session/participant state stays in `coedit` (#305).

## Changes

- `app/wiki/coedit_channel.py` — per-connection registry (queues/loops keyed by connection id), local fan-out by session, cross-process `handle_remote`, `broadcast_presence`, `user_still_connected` (multi-tab aware).
- `app/api/coedit.py` — cookie-authed router:
  - `POST /join` — `require_can("write")`, seed session from page HEAD, `join`, broadcast roster, return buffer + version + participants.
  - `POST /leave` — leave + broadcast.
  - `GET /stream` — SSE; the connection is the presence heartbeat (`touch` per keepalive); fires `leave` only when the user's **last** connection closes.
- `app/mcp_server/pubsub.py` — `emit_external()` + `coedit` dispatch branch.
- `app/wiki/coedit.py` — `get_session(id)` for the stream's ACL recheck.
- `app/models/coedit.py` — request/response shapes.

## Verification

- `pytest tests/test_coedit_channel.py tests/test_coedit_api.py` — **22 coedit tests pass** (incl. fan-out, session isolation, disconnect cleanup, multi-tab, cross-process `handle_remote`; join idempotency + shared session + write-gating + leave).
- `ruff` + `basedpyright` (whole project) clean.

## Next (step 3)

Edit-op apply loop: server applies ops via the `set_buffer` CAS, broadcasts on the same channel, and writes the passive `coedit_ops` op log. Then presence cursors/typing (step 4), checkpoint worker (step 5).