### PR TITLE
feat(coedit): op-apply engine + coedit_ops log (step 3a)

### DIFF
--- a/backend/app/db/migrations/versions/0040_coedit_ops.py
+++ b/backend/app/db/migrations/versions/0040_coedit_ops.py
@@ -1,0 +1,55 @@
+"""coedit_ops: append-only edit-operation log for co-edit sessions
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-06-30 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "0040"
+down_revision: str | None = "0039"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Fresh installs get this table from 0001's create_all — guard so this is a
+    # no-op there and only does real work on databases created before it.
+    if "coedit_ops" not in set(inspector.get_table_names()):
+        op.create_table(
+            "coedit_ops",
+            sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+            sa.Column("session_id", sa.BigInteger(), nullable=False),
+            sa.Column("seq", sa.BigInteger(), nullable=False),
+            sa.Column("author_user_id", sa.Text(), nullable=False),
+            sa.Column("base_version", sa.BigInteger(), nullable=False),
+            sa.Column("op_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.Text(),
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(
+                ["session_id"], ["coedit_sessions.id"], ondelete="CASCADE"
+            ),
+            sa.ForeignKeyConstraint(["author_user_id"], ["users.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("session_id", "seq", name="idx_coedit_ops_session_seq"),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("coedit_ops")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -948,6 +948,42 @@ class CoeditParticipant(Base):
     __table_args__ = (Index("idx_coedit_participants_user", "user_id"),)
 
 
+class CoeditOp(Base):
+    """Append-only log of edit operations applied to a co-edit session.
+
+    Passive record — convergence is snapshot + CAS on ``coedit_sessions``, so
+    this log is written alongside each applied op but nothing reads it on the
+    hot path. It enables late-joiner catch-up ("ops since version N"),
+    per-author within-session history, and is the substrate a future OT/CRDT
+    upgrade would build on. ``seq`` is the session ``version`` the op produced
+    (unique per session); ``base_version`` is the version it was applied onto.
+    ``op_payload`` is the wire op — a list of ``{from, to, insert}`` range
+    changes — kept as a generic envelope so it survives an engine change.
+    """
+
+    __tablename__ = "coedit_ops"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    session_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("coedit_sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    seq: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    author_user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    base_version: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    op_payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (
+        # One op per produced version, in order — also the lookup for
+        # "ops since version N" catch-up.
+        UniqueConstraint("session_id", "seq", name="idx_coedit_ops_session_seq"),
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Cron state — per-(queue, task) last-fired timestamp so the periodic         #
 # scheduler can survive restarts without silently dropping or stampeding      #

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -208,18 +208,28 @@ def _apply_changes(text: str, changes: list[dict[str, Any]]) -> str:
     Each change is ``{"from": int, "to": int, "insert": str}`` — replace the
     half-open range ``[from, to)`` with ``insert``. Offsets are relative to the
     *original* ``text`` (as the client saw it), and changes are expected
-    non-overlapping. We apply them right-to-left (highest ``from`` first) so an
+    non-overlapping; we apply them right-to-left (highest ``from`` first) so an
     earlier change's length delta never shifts a later change's offsets.
-    Raises ``ValueError`` on an out-of-bounds range.
+
+    **Offsets are UTF-16 code-unit indices**, matching JS / CodeMirror string
+    positions (where an astral char like an emoji counts as 2). We therefore
+    slice in UTF-16 space, *not* Python code points — otherwise any document
+    containing an emoji or other non-BMP character would slice at the wrong
+    place. Raises ``ValueError`` on an out-of-bounds range or a range that
+    splits a surrogate pair.
     """
-    result = text
+    # 2 bytes per UTF-16 code unit → unit offset N is byte offset 2N.
+    buf = bytearray(text.encode("utf-16-le"))
+    n_units = len(buf) // 2
     for ch in sorted(changes, key=lambda c: int(c["from"]), reverse=True):
         frm, to = int(ch["from"]), int(ch["to"])
-        insert = str(ch.get("insert", ""))
-        if not (0 <= frm <= to <= len(result)):
-            raise ValueError(f"change range [{frm},{to}) out of bounds for length {len(result)}")
-        result = result[:frm] + insert + result[to:]
-    return result
+        if not (0 <= frm <= to <= n_units):
+            raise ValueError(f"change range [{frm},{to}) out of bounds for length {n_units}")
+        buf[2 * frm : 2 * to] = str(ch.get("insert", "")).encode("utf-16-le")
+    try:
+        return bytes(buf).decode("utf-16-le")
+    except UnicodeDecodeError as e:
+        raise ValueError("change split a UTF-16 surrogate pair") from e
 
 
 def apply_op(

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -23,7 +23,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 
@@ -192,6 +192,20 @@ def set_buffer(session_id: int, *, base_version: int, buffer_text: str) -> Sessi
         return _session_row(sess) if sess is not None else None
 
 
+class Change(BaseModel):
+    """One range-replacement edit: replace the half-open range ``[from, to)``
+    with ``insert``. Offsets are **UTF-16 code units** (JS / CodeMirror string
+    positions). ``from`` is a Python keyword, so the field is ``from_`` aliased
+    to ``from`` on the wire. This is the shared op shape — the HTTP request
+    model (`app/models/coedit.py`) reuses it so FastAPI validates the body."""
+
+    model_config = ConfigDict(populate_by_name=True, frozen=True)
+
+    from_: int = Field(alias="from", ge=0)
+    to: int = Field(ge=0)
+    insert: str = ""
+
+
 class OpRow(BaseModel):
     """One logged edit op from `coedit_ops`."""
 
@@ -202,54 +216,38 @@ class OpRow(BaseModel):
     created_at: str
 
 
-def _apply_changes(text: str, changes: list[dict[str, Any]]) -> str:
+def _apply_changes(text: str, changes: list[Change]) -> str:
     """Apply range-replacement ``changes`` to ``text``.
 
-    Each change is ``{"from": int, "to": int, "insert": str}`` — replace the
-    half-open range ``[from, to)`` with ``insert``. Offsets are relative to the
-    *original* ``text`` (as the client saw it), and changes are expected
-    non-overlapping; we apply them right-to-left (highest ``from`` first) so an
-    earlier change's length delta never shifts a later change's offsets.
+    Structural validity (fields present, ``from``/``to`` are ints ``≥ 0``) is
+    guaranteed by the ``Change`` type; this enforces the *semantic* rules that
+    need the buffer: each range in-bounds, ranges non-overlapping, and no
+    surrogate-pair split. Changes apply right-to-left (highest ``from`` first)
+    so an earlier change's length delta never shifts a later change's offsets.
 
-    **Offsets are UTF-16 code-unit indices**, matching JS / CodeMirror string
-    positions (where an astral char like an emoji counts as 2). We therefore
-    slice in UTF-16 space, *not* Python code points — otherwise any document
-    containing an emoji or other non-BMP character would slice at the wrong
-    place. Raises ``ValueError`` on an out-of-bounds range, overlapping ranges,
-    or a range that splits a surrogate pair.
+    **Offsets are UTF-16 code units** (JS / CodeMirror positions; an astral char
+    like an emoji counts as 2), so we slice in UTF-16 space, not Python code
+    points — otherwise a document with an emoji would slice at the wrong place.
+    Raises ``ValueError`` on an out-of-bounds range, overlapping ranges, or a
+    range that splits a surrogate pair.
     """
     # 2 bytes per UTF-16 code unit → unit offset N is byte offset 2N.
     buf = bytearray(text.encode("utf-16-le"))
     n_units = len(buf) // 2
 
-    # Parse first, so a malformed change surfaces as ValueError (not KeyError /
-    # TypeError) — the whole function's error contract is ValueError.
-    parsed: list[tuple[int, int, str]] = []
-    for ch in changes:
-        if "from" not in ch or "to" not in ch:
-            raise ValueError(f"change missing 'from'/'to': {ch!r}")
-        try:
-            frm, to = int(ch["from"]), int(ch["to"])
-        except (TypeError, ValueError) as e:
-            raise ValueError(f"change has non-integer 'from'/'to': {ch!r}") from e
-        parsed.append((frm, to, str(ch.get("insert", ""))))
-
-    # Validate up front — bounds + non-overlap — rather than trust the caller's
-    # unenforced "non-overlapping" contract. Overlapping ranges would apply onto
-    # an already-mutated buffer and silently corrupt it.
-    parsed.sort(key=lambda t: (t[0], t[1]))
+    # Validate bounds + non-overlap up front — overlapping ranges would apply
+    # onto an already-mutated buffer and silently corrupt it.
+    ordered = sorted(changes, key=lambda c: (c.from_, c.to))
     prev_to = 0
-    for frm, to, _ in parsed:
-        if not (0 <= frm <= to <= n_units):
-            raise ValueError(f"change range [{frm},{to}) out of bounds for length {n_units}")
-        if frm < prev_to:
-            raise ValueError(f"overlapping change: [{frm},{to}) intrudes on a prior range ending at {prev_to}")
-        prev_to = to
+    for c in ordered:
+        if not (0 <= c.from_ <= c.to <= n_units):
+            raise ValueError(f"change range [{c.from_},{c.to}) out of bounds for length {n_units}")
+        if c.from_ < prev_to:
+            raise ValueError(f"overlapping change: [{c.from_},{c.to}) intrudes on a prior range ending at {prev_to}")
+        prev_to = c.to
 
-    # Apply right-to-left so an earlier change's length delta never shifts a
-    # later change's (original-text) offsets.
-    for frm, to, insert in reversed(parsed):
-        buf[2 * frm : 2 * to] = insert.encode("utf-16-le")
+    for c in reversed(ordered):
+        buf[2 * c.from_ : 2 * c.to] = c.insert.encode("utf-16-le")
     try:
         return bytes(buf).decode("utf-16-le")
     except UnicodeDecodeError as e:
@@ -260,7 +258,7 @@ def apply_op(
     session_id: int,
     *,
     base_version: int,
-    changes: list[dict[str, Any]],
+    changes: list[Change],
     author_user_id: str,
 ) -> SessionRow | None:
     """Apply an edit op to the buffer and log it, atomically.
@@ -307,7 +305,7 @@ def apply_op(
                 seq=new_version,
                 author_user_id=author_user_id,
                 base_version=base_version,
-                op_payload={"changes": changes},
+                op_payload={"changes": [c.model_dump(by_alias=True) for c in changes]},
             )
         )
         return _session_row(row)

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -215,17 +215,41 @@ def _apply_changes(text: str, changes: list[dict[str, Any]]) -> str:
     positions (where an astral char like an emoji counts as 2). We therefore
     slice in UTF-16 space, *not* Python code points — otherwise any document
     containing an emoji or other non-BMP character would slice at the wrong
-    place. Raises ``ValueError`` on an out-of-bounds range or a range that
-    splits a surrogate pair.
+    place. Raises ``ValueError`` on an out-of-bounds range, overlapping ranges,
+    or a range that splits a surrogate pair.
     """
     # 2 bytes per UTF-16 code unit → unit offset N is byte offset 2N.
     buf = bytearray(text.encode("utf-16-le"))
     n_units = len(buf) // 2
-    for ch in sorted(changes, key=lambda c: int(c["from"]), reverse=True):
-        frm, to = int(ch["from"]), int(ch["to"])
+
+    # Parse first, so a malformed change surfaces as ValueError (not KeyError /
+    # TypeError) — the whole function's error contract is ValueError.
+    parsed: list[tuple[int, int, str]] = []
+    for ch in changes:
+        if "from" not in ch or "to" not in ch:
+            raise ValueError(f"change missing 'from'/'to': {ch!r}")
+        try:
+            frm, to = int(ch["from"]), int(ch["to"])
+        except (TypeError, ValueError) as e:
+            raise ValueError(f"change has non-integer 'from'/'to': {ch!r}") from e
+        parsed.append((frm, to, str(ch.get("insert", ""))))
+
+    # Validate up front — bounds + non-overlap — rather than trust the caller's
+    # unenforced "non-overlapping" contract. Overlapping ranges would apply onto
+    # an already-mutated buffer and silently corrupt it.
+    parsed.sort(key=lambda t: (t[0], t[1]))
+    prev_to = 0
+    for frm, to, _ in parsed:
         if not (0 <= frm <= to <= n_units):
             raise ValueError(f"change range [{frm},{to}) out of bounds for length {n_units}")
-        buf[2 * frm : 2 * to] = str(ch.get("insert", "")).encode("utf-16-le")
+        if frm < prev_to:
+            raise ValueError(f"overlapping change: [{frm},{to}) intrudes on a prior range ending at {prev_to}")
+        prev_to = to
+
+    # Apply right-to-left so an earlier change's length delta never shifts a
+    # later change's (original-text) offsets.
+    for frm, to, insert in reversed(parsed):
+        buf[2 * frm : 2 * to] = insert.encode("utf-16-le")
     try:
         return bytes(buf).decode("utf-16-le")
     except UnicodeDecodeError as e:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -21,12 +21,13 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import Any
 
 from pydantic import BaseModel
 from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
 
-from app.db.models import CoeditParticipant, CoeditSession, User
+from app.db.models import CoeditOp, CoeditParticipant, CoeditSession, User
 from app.db.session import session
 
 log = logging.getLogger(__name__)
@@ -189,6 +190,114 @@ def set_buffer(session_id: int, *, base_version: int, buffer_text: str) -> Sessi
             .execution_options(synchronize_session=False)
         ).one_or_none()
         return _session_row(sess) if sess is not None else None
+
+
+class OpRow(BaseModel):
+    """One logged edit op from `coedit_ops`."""
+
+    seq: int  # the session version this op produced
+    author_user_id: str
+    base_version: int
+    changes: list[dict[str, Any]]
+    created_at: str
+
+
+def _apply_changes(text: str, changes: list[dict[str, Any]]) -> str:
+    """Apply range-replacement ``changes`` to ``text``.
+
+    Each change is ``{"from": int, "to": int, "insert": str}`` — replace the
+    half-open range ``[from, to)`` with ``insert``. Offsets are relative to the
+    *original* ``text`` (as the client saw it), and changes are expected
+    non-overlapping. We apply them right-to-left (highest ``from`` first) so an
+    earlier change's length delta never shifts a later change's offsets.
+    Raises ``ValueError`` on an out-of-bounds range.
+    """
+    result = text
+    for ch in sorted(changes, key=lambda c: int(c["from"]), reverse=True):
+        frm, to = int(ch["from"]), int(ch["to"])
+        insert = str(ch.get("insert", ""))
+        if not (0 <= frm <= to <= len(result)):
+            raise ValueError(f"change range [{frm},{to}) out of bounds for length {len(result)}")
+        result = result[:frm] + insert + result[to:]
+    return result
+
+
+def apply_op(
+    session_id: int,
+    *,
+    base_version: int,
+    changes: list[dict[str, Any]],
+    author_user_id: str,
+) -> SessionRow | None:
+    """Apply an edit op to the buffer and log it, atomically.
+
+    Applies ``changes`` to the buffer as of ``base_version`` and compare-and-
+    swaps the version to ``base_version + 1`` — so if another op landed first
+    this returns ``None`` (stale; the caller must re-sync and re-apply). On
+    success, appends a `coedit_ops` row in the same transaction. Raises
+    ``ValueError`` if a change is out of bounds for the current buffer.
+    """
+    now = _iso(_now())
+    with session() as s:
+        # Read the buffer at exactly base_version (also confirms active). If the
+        # version has moved, the caller is stale — nothing to apply onto.
+        current = s.execute(
+            select(CoeditSession.buffer_text).where(
+                CoeditSession.id == session_id,
+                CoeditSession.status == "active",
+                CoeditSession.version == base_version,
+            )
+        ).scalar_one_or_none()
+        if current is None:
+            return None
+        new_buffer = _apply_changes(current, changes)
+        new_version = base_version + 1
+        # Re-check the version inside the write (CAS) to close the gap between
+        # the read above and this update.
+        row = s.scalars(
+            update(CoeditSession)
+            .where(
+                CoeditSession.id == session_id,
+                CoeditSession.version == base_version,
+                CoeditSession.status == "active",
+            )
+            .values(buffer_text=new_buffer, version=new_version, updated_at=now)
+            .returning(CoeditSession)
+            .execution_options(synchronize_session=False)
+        ).one_or_none()
+        if row is None:
+            return None
+        s.add(
+            CoeditOp(
+                session_id=session_id,
+                seq=new_version,
+                author_user_id=author_user_id,
+                base_version=base_version,
+                op_payload={"changes": changes},
+            )
+        )
+        return _session_row(row)
+
+
+def ops_since(session_id: int, after_version: int) -> list[OpRow]:
+    """Logged ops with ``seq > after_version``, oldest first — for a late
+    joiner (or a reconnecting client) to catch up incrementally."""
+    with session() as s:
+        rows = s.scalars(
+            select(CoeditOp)
+            .where(CoeditOp.session_id == session_id, CoeditOp.seq > after_version)
+            .order_by(CoeditOp.seq.asc())
+        ).all()
+        return [
+            OpRow(
+                seq=o.seq,
+                author_user_id=o.author_user_id,
+                base_version=o.base_version,
+                changes=list(o.op_payload.get("changes", [])),
+                created_at=o.created_at,
+            )
+            for o in rows
+        ]
 
 
 def mark_checkpointed(session_id: int, *, base_sha: str) -> None:

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -15,6 +15,10 @@ from tests._seed import count_rows, seed_user
 _PATH = "guides/setup.md"
 
 
+def _ch(frm: int, to: int, insert: str = "") -> coedit.Change:
+    return coedit.Change(from_=frm, to=to, insert=insert)
+
+
 @pytest.fixture
 def users(tmp_db):
     seed_user("usr_a", "a@x.com", name="Ada")
@@ -167,12 +171,7 @@ def test_rename_path(users):
 
 def test_apply_op_applies_change_bumps_version_and_logs(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hello world")
-    out = coedit.apply_op(
-        s.id,
-        base_version=0,
-        changes=[{"from": 0, "to": 5, "insert": "hi"}],
-        author_user_id="usr_a",
-    )
+    out = coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id="usr_a")
     assert out is not None
     assert out.version == 1
     assert out.buffer_text == "hi world"
@@ -186,13 +185,7 @@ def test_apply_op_applies_change_bumps_version_and_logs(users):
 def test_apply_op_multiple_changes_apply_right_to_left(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="abcdef")
     out = coedit.apply_op(
-        s.id,
-        base_version=0,
-        changes=[
-            {"from": 0, "to": 1, "insert": "X"},
-            {"from": 4, "to": 6, "insert": "Y"},
-        ],
-        author_user_id="usr_a",
+        s.id, base_version=0, changes=[_ch(0, 1, "X"), _ch(4, 6, "Y")], author_user_id="usr_a"
     )
     assert out is not None
     assert out.buffer_text == "XbcdY"
@@ -200,13 +193,9 @@ def test_apply_op_multiple_changes_apply_right_to_left(users):
 
 def test_apply_op_stale_base_version_rejected(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
-    assert coedit.apply_op(
-        s.id, base_version=0, changes=[{"from": 2, "to": 2, "insert": "!"}], author_user_id="usr_a"
-    ) is not None
+    assert coedit.apply_op(s.id, base_version=0, changes=[_ch(2, 2, "!")], author_user_id="usr_a") is not None
     # Caller still on version 0 — rejected, buffer untouched.
-    stale = coedit.apply_op(
-        s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "X"}], author_user_id="usr_a"
-    )
+    stale = coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 0, "X")], author_user_id="usr_a")
     assert stale is None
     current = coedit.get_active_session(_PATH)
     assert current is not None
@@ -217,15 +206,13 @@ def test_apply_op_stale_base_version_rejected(users):
 def test_apply_op_out_of_bounds_raises(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="short")
     with pytest.raises(ValueError):
-        coedit.apply_op(
-            s.id, base_version=0, changes=[{"from": 0, "to": 999, "insert": "x"}], author_user_id="usr_a"
-        )
+        coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 999, "x")], author_user_id="usr_a")
 
 
 def test_apply_op_concurrent_one_wins(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
-    a = coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "A"}], author_user_id="usr_a")
-    b = coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "B"}], author_user_id="usr_b")
+    a = coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 0, "A")], author_user_id="usr_a")
+    b = coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 0, "B")], author_user_id="usr_b")
     winners = [r for r in (a, b) if r is not None]
     assert len(winners) == 1
     assert winners[0].version == 1
@@ -235,19 +222,17 @@ def test_apply_op_rejects_overlapping_changes(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="abcdef")
     with pytest.raises(ValueError):
         coedit.apply_op(
-            s.id,
-            base_version=0,
-            changes=[{"from": 0, "to": 3, "insert": "X"}, {"from": 2, "to": 4, "insert": "Y"}],
-            author_user_id="usr_a",
+            s.id, base_version=0, changes=[_ch(0, 3, "X"), _ch(2, 4, "Y")], author_user_id="usr_a"
         )
 
 
-def test_apply_op_rejects_malformed_change(users):
-    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="abc")
+def test_change_rejects_malformed_input():
+    # Missing 'to' / negative offset are rejected at the type boundary
+    # (pydantic ValidationError is a ValueError subclass).
     with pytest.raises(ValueError):
-        coedit.apply_op(
-            s.id, base_version=0, changes=[{"from": 0, "insert": "x"}], author_user_id="usr_a"
-        )
+        coedit.Change.model_validate({"from": 0, "insert": "x"})
+    with pytest.raises(ValueError):
+        coedit.Change.model_validate({"from": -1, "to": 0})
 
 
 def test_apply_op_uses_utf16_offsets_with_emoji(users):
@@ -255,26 +240,22 @@ def test_apply_op_uses_utf16_offsets_with_emoji(users):
     # Replacing [3,4) must hit 'b' → "a😀!". Code-point slicing (len 3) would
     # instead append, giving "a😀b!", so this pins the UTF-16 contract.
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="a😀b")
-    out = coedit.apply_op(
-        s.id, base_version=0, changes=[{"from": 3, "to": 4, "insert": "!"}], author_user_id="usr_a"
-    )
+    out = coedit.apply_op(s.id, base_version=0, changes=[_ch(3, 4, "!")], author_user_id="usr_a")
     assert out is not None
     assert out.buffer_text == "a😀!"
 
 
 def test_apply_op_can_insert_astral_char(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="ab")
-    out = coedit.apply_op(
-        s.id, base_version=0, changes=[{"from": 1, "to": 1, "insert": "🎉"}], author_user_id="usr_a"
-    )
+    out = coedit.apply_op(s.id, base_version=0, changes=[_ch(1, 1, "🎉")], author_user_id="usr_a")
     assert out is not None
     assert out.buffer_text == "a🎉b"
 
 
 def test_ops_since_returns_ops_after_version(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="")
-    coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "a"}], author_user_id="usr_a")
-    coedit.apply_op(s.id, base_version=1, changes=[{"from": 1, "to": 1, "insert": "b"}], author_user_id="usr_a")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 0, "a")], author_user_id="usr_a")
+    coedit.apply_op(s.id, base_version=1, changes=[_ch(1, 1, "b")], author_user_id="usr_a")
     assert [o.seq for o in coedit.ops_since(s.id, 0)] == [1, 2]
     assert [o.seq for o in coedit.ops_since(s.id, 1)] == [2]
     assert coedit.ops_since(s.id, 2) == []

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -231,6 +231,27 @@ def test_apply_op_concurrent_one_wins(users):
     assert winners[0].version == 1
 
 
+def test_apply_op_uses_utf16_offsets_with_emoji(users):
+    # 'a'=unit 0, 😀=units 1-2 (astral → 2 UTF-16 units), 'b'=unit 3.
+    # Replacing [3,4) must hit 'b' → "a😀!". Code-point slicing (len 3) would
+    # instead append, giving "a😀b!", so this pins the UTF-16 contract.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="a😀b")
+    out = coedit.apply_op(
+        s.id, base_version=0, changes=[{"from": 3, "to": 4, "insert": "!"}], author_user_id="usr_a"
+    )
+    assert out is not None
+    assert out.buffer_text == "a😀!"
+
+
+def test_apply_op_can_insert_astral_char(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="ab")
+    out = coedit.apply_op(
+        s.id, base_version=0, changes=[{"from": 1, "to": 1, "insert": "🎉"}], author_user_id="usr_a"
+    )
+    assert out is not None
+    assert out.buffer_text == "a🎉b"
+
+
 def test_ops_since_returns_ops_after_version(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="")
     coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "a"}], author_user_id="usr_a")

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -231,6 +231,25 @@ def test_apply_op_concurrent_one_wins(users):
     assert winners[0].version == 1
 
 
+def test_apply_op_rejects_overlapping_changes(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="abcdef")
+    with pytest.raises(ValueError):
+        coedit.apply_op(
+            s.id,
+            base_version=0,
+            changes=[{"from": 0, "to": 3, "insert": "X"}, {"from": 2, "to": 4, "insert": "Y"}],
+            author_user_id="usr_a",
+        )
+
+
+def test_apply_op_rejects_malformed_change(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="abc")
+    with pytest.raises(ValueError):
+        coedit.apply_op(
+            s.id, base_version=0, changes=[{"from": 0, "insert": "x"}], author_user_id="usr_a"
+        )
+
+
 def test_apply_op_uses_utf16_offsets_with_emoji(users):
     # 'a'=unit 0, 😀=units 1-2 (astral → 2 UTF-16 units), 'b'=unit 3.
     # Replacing [3,4) must hit 'b' → "a😀!". Code-point slicing (len 3) would

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -16,7 +16,10 @@ _PATH = "guides/setup.md"
 
 
 def _ch(frm: int, to: int, insert: str = "") -> coedit.Change:
-    return coedit.Change(from_=frm, to=to, insert=insert)
+    # Build via model_validate so the aliased "from" field is set by its wire
+    # name — Change(from_=...) isn't expressible (the constructor param is the
+    # alias "from", a keyword).
+    return coedit.Change.model_validate({"from": frm, "to": to, "insert": insert})
 
 
 @pytest.fixture

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -158,3 +158,83 @@ def test_rename_path(users):
     moved = coedit.get_active_session("guides/renamed.md")
     assert moved is not None
     assert moved.id == s.id
+
+
+# --------------------------------------------------------------------------- #
+# apply_op — range-change application + version CAS + op log                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_op_applies_change_bumps_version_and_logs(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hello world")
+    out = coedit.apply_op(
+        s.id,
+        base_version=0,
+        changes=[{"from": 0, "to": 5, "insert": "hi"}],
+        author_user_id="usr_a",
+    )
+    assert out is not None
+    assert out.version == 1
+    assert out.buffer_text == "hi world"
+    logged = coedit.ops_since(s.id, 0)
+    assert [o.seq for o in logged] == [1]
+    assert logged[0].base_version == 0
+    assert logged[0].author_user_id == "usr_a"
+    assert logged[0].changes == [{"from": 0, "to": 5, "insert": "hi"}]
+
+
+def test_apply_op_multiple_changes_apply_right_to_left(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="abcdef")
+    out = coedit.apply_op(
+        s.id,
+        base_version=0,
+        changes=[
+            {"from": 0, "to": 1, "insert": "X"},
+            {"from": 4, "to": 6, "insert": "Y"},
+        ],
+        author_user_id="usr_a",
+    )
+    assert out is not None
+    assert out.buffer_text == "XbcdY"
+
+
+def test_apply_op_stale_base_version_rejected(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
+    assert coedit.apply_op(
+        s.id, base_version=0, changes=[{"from": 2, "to": 2, "insert": "!"}], author_user_id="usr_a"
+    ) is not None
+    # Caller still on version 0 — rejected, buffer untouched.
+    stale = coedit.apply_op(
+        s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "X"}], author_user_id="usr_a"
+    )
+    assert stale is None
+    current = coedit.get_active_session(_PATH)
+    assert current is not None
+    assert current.version == 1
+    assert current.buffer_text == "v0!"
+
+
+def test_apply_op_out_of_bounds_raises(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="short")
+    with pytest.raises(ValueError):
+        coedit.apply_op(
+            s.id, base_version=0, changes=[{"from": 0, "to": 999, "insert": "x"}], author_user_id="usr_a"
+        )
+
+
+def test_apply_op_concurrent_one_wins(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="v0")
+    a = coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "A"}], author_user_id="usr_a")
+    b = coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "B"}], author_user_id="usr_b")
+    winners = [r for r in (a, b) if r is not None]
+    assert len(winners) == 1
+    assert winners[0].version == 1
+
+
+def test_ops_since_returns_ops_after_version(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="")
+    coedit.apply_op(s.id, base_version=0, changes=[{"from": 0, "to": 0, "insert": "a"}], author_user_id="usr_a")
+    coedit.apply_op(s.id, base_version=1, changes=[{"from": 1, "to": 1, "insert": "b"}], author_user_id="usr_a")
+    assert [o.seq for o in coedit.ops_since(s.id, 0)] == [1, 2]
+    assert [o.seq for o in coedit.ops_since(s.id, 1)] == [2]
+    assert coedit.ops_since(s.id, 2) == []


### PR DESCRIPTION
## What

**Step 3a** of [co-editing](Engineering Projects/Agent Wiki Project/design/Co-Editing.md) — the engine that turns an edit into a buffer mutation + a logged op. Backend logic only; the `POST /op` endpoint + broadcast are **step 3b** (stacked next). Builds on the buffer store (#305) and live channel (#306).

Step 3 was split into 3a (engine/log, this PR — mirrors #305) and 3b (endpoint/broadcast — mirrors #306) to keep each small and independently reviewable.

## Changes

- **`coedit_ops` table** (`models.py` + migration `0040`, guarded/idempotent): `session_id, seq, author_user_id, base_version, op_payload (JSONB), created_at`; unique `(session_id, seq)`. `seq` is the version the op produced; `op_payload` is the generic wire op (a list of `{from,to,insert}` range changes).
- **`coedit.apply_op(session_id, base_version, changes, author)`** — applies the range changes to the buffer as of `base_version` and **CASes** the version to `base_version+1` (stale → `None`, caller re-syncs), appending the op-log row **in the same transaction**. Changes apply right-to-left so earlier deltas don't shift later offsets; out-of-bounds → `ValueError`.
- **`coedit.ops_since(session_id, after_version)`** — incremental catch-up for a late/reconnecting client.

The op log is **passive** — convergence stays snapshot + CAS; nothing reads it on the hot path yet (it exists for catch-up, history, and the future OT/CRDT substrate).

## Verification

- `pytest tests/test_coedit_repo.py` — **17 pass** (apply + log, multi-change ordering, stale rejection, out-of-bounds, concurrent-one-wins, `ops_since`).
- Migration `0039→0040→0039` applies + rolls back cleanly; guard no-ops on fresh DBs.
- `ruff` + `basedpyright` clean.

## Next (3b)

`POST /api/coedit/op` (gate write → `apply_op` → `broadcast_op`), the op frame over the channel with the 8 KB notify-then-fetch guard, and a resync endpoint — with live tests.