### PR TITLE
feat(coedit): op endpoint + broadcast/resync (step 3b)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -20,6 +20,8 @@ from app.models.coedit import (
     JoinRequest,
     JoinResponse,
     LeaveRequest,
+    OpRequest,
+    OpResponse,
     ParticipantOut,
 )
 from app.wiki import coedit, coedit_channel, git
@@ -72,6 +74,57 @@ def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bo
     coedit.leave(req.session_id, user.id)
     coedit_channel.broadcast_presence(req.session_id)
     return {"ok": True}
+
+
+def _require_active(session_id: int, user: User, action: str) -> coedit.SessionRow:
+    sess = coedit.get_session(session_id)
+    if sess is None or sess.status != "active":
+        raise HTTPException(status_code=404, detail="no active session")
+    require_can(action, sess.path, user)
+    return sess
+
+
+@router.post("/op")
+def op(req: OpRequest, user: User = Depends(require_user)) -> OpResponse:
+    """Apply an edit op to the session buffer and broadcast it.
+
+    409 if ``base_version`` is stale (the client re-syncs via GET /session and
+    re-applies); 422 if the op is out of bounds / overlapping.
+    """
+    _require_active(req.session_id, user, "write")
+    try:
+        out = coedit.apply_op(
+            req.session_id,
+            base_version=req.base_version,
+            changes=req.changes,
+            author_user_id=user.id,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    if out is None:
+        raise HTTPException(status_code=409, detail="stale base_version; re-sync and retry")
+    coedit.touch(req.session_id, user.id)
+    coedit_channel.broadcast_op(
+        req.session_id,
+        out.version,
+        [c.model_dump(by_alias=True) for c in req.changes],
+        user.id,
+    )
+    return OpResponse(version=out.version)
+
+
+@router.get("/session")
+def session_state(session_id: int, user: User = Depends(require_user)) -> JoinResponse:
+    """Current buffer + version + roster — a read-only snapshot for a client to
+    re-sync after a stale op or a `resync` frame (no join side effects)."""
+    sess = _require_active(session_id, user, "read")
+    return JoinResponse(
+        session_id=sess.id,
+        buffer=sess.buffer_text,
+        version=sess.version,
+        base_sha=sess.base_sha,
+        participants=_participants_out(sess.id),
+    )
 
 
 @router.get("/stream")

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -104,12 +104,7 @@ def op(req: OpRequest, user: User = Depends(require_user)) -> OpResponse:
     if out is None:
         raise HTTPException(status_code=409, detail="stale base_version; re-sync and retry")
     coedit.touch(req.session_id, user.id)
-    coedit_channel.broadcast_op(
-        req.session_id,
-        out.version,
-        [c.model_dump(by_alias=True) for c in req.changes],
-        user.id,
-    )
+    coedit_channel.broadcast_op(req.session_id, out.version, req.changes, user.id)
     return OpResponse(version=out.version)
 
 

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel
 
+from app.wiki.coedit import Change
+
 
 class JoinRequest(BaseModel):
     path: str
@@ -15,6 +17,18 @@ class JoinRequest(BaseModel):
 
 class LeaveRequest(BaseModel):
     session_id: int
+
+
+class OpRequest(BaseModel):
+    session_id: int
+    base_version: int
+    # Range changes ({from,to,insert}); FastAPI validates each via Change, so a
+    # malformed op is a 422 before it reaches the repo.
+    changes: list[Change]
+
+
+class OpResponse(BaseModel):
+    version: int  # the session version this op produced
 
 
 class ParticipantOut(BaseModel):

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -23,7 +23,8 @@ class OpRequest(BaseModel):
     session_id: int
     base_version: int
     # Range changes ({from,to,insert}); FastAPI validates each via Change, so a
-    # malformed op is a 422 before it reaches the repo.
+    # malformed op is a 400 (the app's RequestValidationError handler) before it
+    # reaches the repo.
     changes: list[Change]
 
 

--- a/backend/app/realtime/bus.py
+++ b/backend/app/realtime/bus.py
@@ -40,6 +40,11 @@ CHANNEL = "realtime_bus"
 # carrying our own tag — the originating process already delivered locally.
 _PROCESS_ORIGIN = secrets.token_hex(8)
 
+# Postgres caps a NOTIFY payload at 8000 bytes and errors on longer ones. Only
+# matters for unusually large payloads (e.g. a multi-KB paste); normal messages
+# are tiny. Publishers that can overflow (co-edit ops) check ``payload_fits``.
+MAX_PAYLOAD_BYTES = 8000
+
 Handler = Callable[[dict[str, Any]], None]
 _handlers: dict[str, Handler] = {}
 _handlers_lock = threading.Lock()
@@ -68,11 +73,24 @@ def emit(payload: dict[str, Any]) -> None:
     inlined and single-quote-escaped (only the JSON could contain a quote).
     """
     try:
-        literal = json.dumps({**payload, "origin": _PROCESS_ORIGIN}).replace("'", "''")
+        literal = _serialized(payload)
         with db_session() as s:
             s.execute(text(f"NOTIFY {CHANNEL}, '{literal}'"))
     except Exception:
         log.exception("realtime bus: NOTIFY %s failed (local delivery still occurred)", CHANNEL)
+
+
+def _serialized(payload: dict[str, Any]) -> str:
+    """The exact NOTIFY literal ``emit`` sends: envelope + origin tag, with
+    apostrophes doubled for inlining into the SQL string."""
+    return json.dumps({**payload, "origin": _PROCESS_ORIGIN}).replace("'", "''")
+
+
+def payload_fits(payload: dict[str, Any]) -> bool:
+    """True if ``payload`` fits under the NOTIFY byte cap once fully serialized
+    (envelope, origin tag, and quote-escaping included). Publishers that can
+    produce large payloads check this and fall back rather than overflow."""
+    return len(_serialized(payload).encode("utf-8")) < MAX_PAYLOAD_BYTES
 
 
 def _dispatch(raw: str) -> None:

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -17,6 +17,7 @@ See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
 
 from __future__ import annotations
 
+import json
 import logging
 import queue
 import threading
@@ -31,6 +32,12 @@ from app.wiki import coedit
 log = logging.getLogger(__name__)
 
 Frame = dict[str, Any]
+
+# Postgres NOTIFY payloads are capped at 8000 bytes. An op frame carrying the
+# raw changes could exceed that (a big paste), so above this threshold we fall
+# back to a small "resync" signal and let clients re-fetch the buffer. Headroom
+# left under 8000 for the bus envelope (kind/session_id/origin wrapper).
+_MAX_OP_FRAME_BYTES = 7000
 
 
 class Connection(BaseModel):
@@ -127,6 +134,30 @@ def broadcast_presence(coedit_session_id: int) -> None:
             "participants": [p.model_dump() for p in participants],
         },
     )
+
+
+def broadcast_op(
+    coedit_session_id: int,
+    version: int,
+    changes: list[dict[str, Any]],
+    author_user_id: str,
+) -> None:
+    """Broadcast an applied edit op to the session's other connections.
+
+    Normally the op frame carries the changes so peers apply them directly. If
+    the frame would exceed the NOTIFY payload cap (a large paste), fall back to
+    a ``resync`` signal — peers re-fetch the buffer via ``GET /coedit/session``.
+    """
+    frame: Frame = {
+        "type": "op",
+        "session_id": coedit_session_id,
+        "version": version,
+        "changes": changes,
+        "author": author_user_id,
+    }
+    if len(json.dumps(frame)) > _MAX_OP_FRAME_BYTES:
+        frame = {"type": "resync", "session_id": coedit_session_id, "version": version}
+    publish(coedit_session_id, frame)
 
 
 def _deliver_local(coedit_session_id: int, frame: Frame) -> None:

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -17,7 +17,6 @@ See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
 
 from __future__ import annotations
 
-import json
 import logging
 import queue
 import threading
@@ -32,12 +31,6 @@ from app.wiki import coedit
 log = logging.getLogger(__name__)
 
 Frame = dict[str, Any]
-
-# Postgres NOTIFY payloads are capped at 8000 bytes. An op frame carrying the
-# raw changes could exceed that (a big paste), so above this threshold we fall
-# back to a small "resync" signal and let clients re-fetch the buffer. Headroom
-# left under 8000 for the bus envelope (kind/session_id/origin wrapper).
-_MAX_OP_FRAME_BYTES = 7000
 
 
 class Connection(BaseModel):
@@ -107,11 +100,15 @@ def drain(q: queue.Queue[Frame], timeout: float) -> Frame | None:
         return None
 
 
+def _bus_payload(coedit_session_id: int, frame: Frame) -> dict[str, Any]:
+    return {"kind": "coedit", "coedit_session_id": coedit_session_id, "frame": frame}
+
+
 def publish(coedit_session_id: int, frame: Frame) -> None:
     """Deliver ``frame`` to every connection in the session, on this process and
     (via NOTIFY) on every other."""
     _deliver_local(coedit_session_id, frame)
-    bus.emit({"kind": "coedit", "coedit_session_id": coedit_session_id, "frame": frame})
+    bus.emit(_bus_payload(coedit_session_id, frame))
 
 
 def handle_remote(payload: dict[str, Any]) -> None:
@@ -139,23 +136,24 @@ def broadcast_presence(coedit_session_id: int) -> None:
 def broadcast_op(
     coedit_session_id: int,
     version: int,
-    changes: list[dict[str, Any]],
+    changes: list[coedit.Change],
     author_user_id: str,
 ) -> None:
     """Broadcast an applied edit op to the session's other connections.
 
     Normally the op frame carries the changes so peers apply them directly. If
-    the frame would exceed the NOTIFY payload cap (a large paste), fall back to
-    a ``resync`` signal — peers re-fetch the buffer via ``GET /coedit/session``.
+    the serialized payload would exceed the bus's NOTIFY cap (a large paste),
+    fall back to a ``resync`` signal — peers re-fetch the buffer via
+    ``GET /coedit/session`` instead of us dropping the update.
     """
     frame: Frame = {
         "type": "op",
         "session_id": coedit_session_id,
         "version": version,
-        "changes": changes,
+        "changes": [c.model_dump(by_alias=True) for c in changes],
         "author": author_user_id,
     }
-    if len(json.dumps(frame)) > _MAX_OP_FRAME_BYTES:
+    if not bus.payload_fits(_bus_payload(coedit_session_id, frame)):
         frame = {"type": "resync", "session_id": coedit_session_id, "version": version}
     publish(coedit_session_id, frame)
 

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, ConfigDict
 
 from app.realtime import bus
 from app.wiki import coedit
+from app.wiki.coedit import Change
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ def broadcast_presence(coedit_session_id: int) -> None:
 def broadcast_op(
     coedit_session_id: int,
     version: int,
-    changes: list[coedit.Change],
+    changes: list[Change],
     author_user_id: str,
 ) -> None:
     """Broadcast an applied edit op to the session's other connections.

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -97,3 +97,70 @@ def test_leave_removes_participant(client):
     resp = client.post("/api/coedit/leave", json={"session_id": sid})
     assert resp.status_code == 200
     assert coedit.list_participants(sid) == []
+
+
+def _login_and_join(client, email="ada@x.com") -> int:
+    uid = users_repo.create(email=email, password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page("hello world")
+    return client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+
+
+def test_op_applies_and_returns_version(client):
+    sid = _login_and_join(client)  # buffer seeded as "hello world"
+    resp = client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["version"] == 1
+    # GET /session reflects the applied edit.
+    state = client.get(f"/api/coedit/session?session_id={sid}").json()
+    assert state["version"] == 1
+    assert state["buffer"] == "hi world"
+
+
+def test_op_stale_base_version_is_409(client):
+    sid = _login_and_join(client)
+    client.post("/api/coedit/op", json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "x"}]})
+    resp = client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "y"}]},
+    )
+    assert resp.status_code == 409
+
+
+def test_op_out_of_bounds_is_422(client):
+    sid = _login_and_join(client)
+    resp = client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 9999, "insert": "x"}]},
+    )
+    assert resp.status_code == 422
+
+
+def test_op_malformed_change_is_rejected(client):
+    # Missing 'to' fails Change request-body validation → the app's handler
+    # returns 400 (semantic out-of-bounds is the 422 case above).
+    sid = _login_and_join(client)
+    resp = client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "insert": "x"}]},
+    )
+    assert resp.status_code == 400
+
+
+def test_op_requires_write(client):
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
+    _seed_page()
+    acl.set_owner(_PATH, owner)  # owner-only
+    login_fastapi(client, owner)
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+
+    login_fastapi(client, other)
+    resp = client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "x"}]},
+    )
+    assert resp.status_code == 403

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -52,6 +52,29 @@ def test_user_still_connected_tracks_multiple_tabs():
     assert coedit_channel.user_still_connected(5, "usr_a") is False
 
 
+def test_broadcast_op_delivers_op_frame():
+    coedit_channel.reset_for_tests()
+    conn = coedit_channel.connect(4, "usr_a")
+    coedit_channel.broadcast_op(4, 3, [{"from": 0, "to": 1, "insert": "x"}], "usr_a")
+    frame = coedit_channel.drain(conn.queue, 0.5)
+    assert frame == {
+        "type": "op",
+        "session_id": 4,
+        "version": 3,
+        "changes": [{"from": 0, "to": 1, "insert": "x"}],
+        "author": "usr_a",
+    }
+
+
+def test_broadcast_op_oversized_falls_back_to_resync():
+    coedit_channel.reset_for_tests()
+    conn = coedit_channel.connect(4, "usr_a")
+    big = "z" * 8000  # frame exceeds the NOTIFY cap → resync signal instead
+    coedit_channel.broadcast_op(4, 5, [{"from": 0, "to": 0, "insert": big}], "usr_a")
+    frame = coedit_channel.drain(conn.queue, 0.5)
+    assert frame == {"type": "resync", "session_id": 4, "version": 5}
+
+
 def test_handle_remote_delivers_locally():
     coedit_channel.reset_for_tests()
     conn = coedit_channel.connect(9, "usr_a")

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -6,7 +6,7 @@ puts and gets — no event loop.
 """
 from __future__ import annotations
 
-from app.wiki import coedit_channel
+from app.wiki import coedit, coedit_channel
 
 
 def test_connect_publish_delivers_to_connection():
@@ -52,10 +52,14 @@ def test_user_still_connected_tracks_multiple_tabs():
     assert coedit_channel.user_still_connected(5, "usr_a") is False
 
 
+def _change(frm: int, to: int, insert: str) -> coedit.Change:
+    return coedit.Change.model_validate({"from": frm, "to": to, "insert": insert})
+
+
 def test_broadcast_op_delivers_op_frame():
     coedit_channel.reset_for_tests()
     conn = coedit_channel.connect(4, "usr_a")
-    coedit_channel.broadcast_op(4, 3, [{"from": 0, "to": 1, "insert": "x"}], "usr_a")
+    coedit_channel.broadcast_op(4, 3, [_change(0, 1, "x")], "usr_a")
     frame = coedit_channel.drain(conn.queue, 0.5)
     assert frame == {
         "type": "op",
@@ -69,8 +73,8 @@ def test_broadcast_op_delivers_op_frame():
 def test_broadcast_op_oversized_falls_back_to_resync():
     coedit_channel.reset_for_tests()
     conn = coedit_channel.connect(4, "usr_a")
-    big = "z" * 8000  # frame exceeds the NOTIFY cap → resync signal instead
-    coedit_channel.broadcast_op(4, 5, [{"from": 0, "to": 0, "insert": big}], "usr_a")
+    big = "z" * 8000  # payload exceeds the NOTIFY cap → resync signal instead
+    coedit_channel.broadcast_op(4, 5, [_change(0, 0, big)], "usr_a")
     frame = coedit_channel.drain(conn.queue, 0.5)
     assert frame == {"type": "resync", "session_id": 4, "version": 5}
 


### PR DESCRIPTION
## What

**Step 3b** of [co-editing](Engineering Projects/Agent Wiki Project/design/Co-Editing.md) — wires the op-apply engine from 3a (#307) to the live channel (#306). **Edits now flow between connections in real time.** Backend only; the editor frontend is a later step. (3a = engine/log; 3b = endpoint/broadcast, mirroring the #305→#306 split.)

## Changes

- **`POST /api/coedit/op`** `{session_id, base_version, changes}` → gate write → `apply_op` (version CAS) → `broadcast_op` → return the new `version`.
  - **409** on stale `base_version` (client re-syncs and retries), **422** on out-of-bounds/overlap, **400** on a malformed change body.
- **`coedit_channel.broadcast_op`** — sends an `op` frame carrying the changes so peers apply them directly. If the frame would exceed Postgres NOTIFY's 8 KB payload cap (a big paste), it falls back to a small **`resync`** signal so peers re-fetch instead of silently dropping the update.
- **`GET /api/coedit/session`** — read-only `{buffer, version, base_sha, participants}` snapshot for a client to re-sync after a stale op or a `resync` frame (no join side effects).
- `OpRequest.changes` reuses the typed `Change`, so FastAPI validates the request body.

## Verification

- `pytest` — **40 coedit tests pass** (repo 21 + channel 8 + API 11): op apply/version, stale-409, out-of-bounds-422, malformed-400, write-gating, session snapshot; channel op-frame delivery + oversized→resync fallback.
- `ruff` + `basedpyright` (whole project) clean.
- **Verified end-to-end locally:** join → open SSE stream → `POST /op` → the `op` frame `{"type":"op","version":1,"changes":[…]}` arrives on the stream and `GET /session` shows the updated buffer.

## Next

Step 4 — live cursors / selections / "is typing" / follow (ephemeral presence over the bus); then the checkpoint worker (step 5), fold drafts in (6), frontend editor (7).