### PR TITLE
feat(coedit): live cursor/selection presence — step 4 (backend)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -120,7 +120,9 @@ def cursor(req: CursorRequest, user: User = Depends(require_user)) -> dict[str, 
     coedit_channel.broadcast_cursor(
         req.session_id,
         user_id=user.id,
-        user_display=user.name or user.email,
+        # Match list_participants' SQL COALESCE(name, email) exactly — substitute
+        # only on NULL, not on "" — so a peer's caret label and roster name agree.
+        user_display=user.name if user.name is not None else user.email,
         anchor=req.anchor,
         head=req.head,
         typing=req.typing,

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -17,6 +17,7 @@ from fastapi.responses import StreamingResponse
 from app.auth import User, require_can
 from app.auth.deps import require_user
 from app.models.coedit import (
+    CursorRequest,
     JoinRequest,
     JoinResponse,
     LeaveRequest,
@@ -106,6 +107,25 @@ def op(req: OpRequest, user: User = Depends(require_user)) -> OpResponse:
     coedit.touch(req.session_id, user.id)
     coedit_channel.broadcast_op(req.session_id, out.version, req.changes, user.id)
     return OpResponse(version=out.version)
+
+
+@router.post("/cursor")
+def cursor(req: CursorRequest, user: User = Depends(require_user)) -> dict[str, bool]:
+    """Broadcast the caller's live cursor/selection to the session (ephemeral).
+
+    High-frequency + throttled client-side; deliberately does not touch the DB
+    (no last_seen write) — the SSE heartbeat covers liveness.
+    """
+    _require_active(req.session_id, user, "write")
+    coedit_channel.broadcast_cursor(
+        req.session_id,
+        user_id=user.id,
+        user_display=user.name or user.email,
+        anchor=req.anchor,
+        head=req.head,
+        typing=req.typing,
+    )
+    return {"ok": True}
 
 
 @router.get("/session")

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -6,7 +6,7 @@ in-memory frames in ``app/wiki/coedit_channel.py`` (the wire shape).
 
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.wiki.coedit import Change
 
@@ -30,6 +30,17 @@ class OpRequest(BaseModel):
 
 class OpResponse(BaseModel):
     version: int  # the session version this op produced
+
+
+class CursorRequest(BaseModel):
+    """A participant's live cursor/selection. ``anchor``/``head`` are UTF-16
+    offsets (like Change); a collapsed selection (anchor == head) is a caret,
+    otherwise it's a highlighted range. Ephemeral — never persisted."""
+
+    session_id: int
+    anchor: int = Field(ge=0)
+    head: int = Field(ge=0)
+    typing: bool = False
 
 
 class ParticipantOut(BaseModel):

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -134,6 +134,32 @@ def broadcast_presence(coedit_session_id: int) -> None:
     )
 
 
+def broadcast_cursor(
+    coedit_session_id: int,
+    *,
+    user_id: str,
+    user_display: str,
+    anchor: int,
+    head: int,
+    typing: bool,
+) -> None:
+    """Broadcast a participant's live cursor/selection — an ephemeral frame,
+    never persisted. A collapsed selection (anchor == head) is a caret; a range
+    is a selection highlight. Peers shift these offsets client-side as ops land."""
+    publish(
+        coedit_session_id,
+        {
+            "type": "cursor",
+            "session_id": coedit_session_id,
+            "user_id": user_id,
+            "user_display": user_display,
+            "anchor": anchor,
+            "head": head,
+            "typing": typing,
+        },
+    )
+
+
 def broadcast_op(
     coedit_session_id: int,
     version: int,

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -150,6 +150,31 @@ def test_op_malformed_change_is_rejected(client):
     assert resp.status_code == 400
 
 
+def test_cursor_broadcasts_and_returns_ok(client):
+    sid = _login_and_join(client)
+    resp = client.post(
+        "/api/coedit/cursor",
+        json={"session_id": sid, "anchor": 0, "head": 5, "typing": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_cursor_requires_write(client):
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
+    _seed_page()
+    acl.set_owner(_PATH, owner)  # owner-only
+    login_fastapi(client, owner)
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+
+    login_fastapi(client, other)
+    resp = client.post(
+        "/api/coedit/cursor", json={"session_id": sid, "anchor": 0, "head": 0, "typing": False}
+    )
+    assert resp.status_code == 403
+
+
 def test_op_requires_write(client):
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -79,6 +79,23 @@ def test_broadcast_op_oversized_falls_back_to_resync():
     assert frame == {"type": "resync", "session_id": 4, "version": 5}
 
 
+def test_broadcast_cursor_delivers_selection_frame():
+    coedit_channel.reset_for_tests()
+    conn = coedit_channel.connect(6, "usr_a")
+    coedit_channel.broadcast_cursor(
+        6, user_id="usr_a", user_display="Ada", anchor=3, head=10, typing=True
+    )
+    assert coedit_channel.drain(conn.queue, 0.5) == {
+        "type": "cursor",
+        "session_id": 6,
+        "user_id": "usr_a",
+        "user_display": "Ada",
+        "anchor": 3,
+        "head": 10,
+        "typing": True,
+    }
+
+
 def test_handle_remote_delivers_locally():
     coedit_channel.reset_for_tests()
     conn = coedit_channel.connect(9, "usr_a")

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -79,13 +79,14 @@ def test_broadcast_op_oversized_falls_back_to_resync():
     assert frame == {"type": "resync", "session_id": 4, "version": 5}
 
 
-def test_broadcast_cursor_delivers_selection_frame():
+def test_broadcast_cursor_delivers_selection_frame_to_peers():
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(6, "usr_a")
+    a = coedit_channel.connect(6, "usr_a")
+    b = coedit_channel.connect(6, "usr_b")  # a peer in the same session
     coedit_channel.broadcast_cursor(
         6, user_id="usr_a", user_display="Ada", anchor=3, head=10, typing=True
     )
-    assert coedit_channel.drain(conn.queue, 0.5) == {
+    expected = {
         "type": "cursor",
         "session_id": 6,
         "user_id": "usr_a",
@@ -94,6 +95,9 @@ def test_broadcast_cursor_delivers_selection_frame():
         "head": 10,
         "typing": True,
     }
+    # The peer receives it — not just the sender's own connection.
+    assert coedit_channel.drain(b.queue, 0.5) == expected
+    assert coedit_channel.drain(a.queue, 0.5) == expected
 
 
 def test_handle_remote_delivers_locally():


### PR DESCRIPTION
## What

**Step 4 (backend only)** of [co-editing](Engineering Projects/Agent Wiki Project/design/Co-Editing.md) — live cursors, **selection highlights**, and typing indicators. The editor-side rendering (remote carets, selection painting, follow-a-user) is a **separate frontend PR**, per the backend-first split.

## Changes

- **`POST /api/coedit/cursor`** `{session_id, anchor, head, typing}` (write-gated) → broadcasts an ephemeral `cursor` frame to the session.
  - `anchor`/`head` are UTF-16 offsets (matching `Change`). Collapsed (`anchor == head`) = a caret; a range = a **selection highlight** ("someone selected a sentence, you see it").
  - Server stamps `user_id` / `user_display` from the cookie — never trusts the client for identity.
- **`coedit_channel.broadcast_cursor`** — publishes the frame over the same bus as ops/presence. **Ephemeral, never persisted** — vanishes on disconnect. Peers shift these offsets **client-side** as ops land (server stays stateless for cursors).

## Deliberate v1 choices (noted for review)

- **No DB write on cursor moves.** They're high-frequency (throttled client-side, ~75ms); the SSE heartbeat already refreshes `last_seen`, so cursor moves don't hammer Postgres.
- **No stored "current cursor."** A late joiner sees a peer's caret on its *next* move — no snapshot-on-join. Simple; can add later.
- ACL is still re-checked per cursor move; if that costs too much at density, cache it per session (a later optimization, not now).

## Verification

- `pytest` — **22 coedit tests** (channel + API): cursor-frame delivery, endpoint broadcast, write-gating.
- `ruff` + `basedpyright` (whole project) clean.

## Next

The frontend editor PR (render remote carets + selection highlights + follow), and step 5 — the checkpoint worker (`merge_content` → `commit_and_fan_out`).