### PR TITLE
feat(coedit): checkpoint engine — commit live buffer to git (step 5a)

### DIFF
--- a/backend/app/db/migrations/versions/0041_coedit_checkpointed_version.py
+++ b/backend/app/db/migrations/versions/0041_coedit_checkpointed_version.py
@@ -1,0 +1,41 @@
+"""coedit_sessions.checkpointed_version: track the last-committed version
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-07-01 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    # Fresh installs get the column from 0001's create_all — guard so this is a
+    # no-op there and only adds it on databases created before co-editing.
+    cols = {c["name"] for c in inspector.get_columns("coedit_sessions")}
+    if "checkpointed_version" not in cols:
+        op.add_column(
+            "coedit_sessions",
+            sa.Column(
+                "checkpointed_version",
+                sa.BigInteger(),
+                server_default=sa.text("0"),
+                nullable=False,
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("coedit_sessions", "checkpointed_version")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -901,6 +901,12 @@ class CoeditSession(Base):
     # with the version it was based on; the server rebases a stale patch onto
     # the current buffer before applying.
     version: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default=text("0"))
+    # The ``version`` at the last checkpoint — the buffer is "dirty" (has
+    # uncommitted edits) when ``version > checkpointed_version``. Lets the
+    # checkpoint worker skip clean sessions instead of re-committing them.
+    checkpointed_version: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
     # Git HEAD the buffer was last checkpointed against — the merge base for the
     # checkpoint 3-way merge. Null until the session is seeded from a page's
     # HEAD (or, for a brand-new page, until the first checkpoint).

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -339,13 +339,23 @@ def mark_checkpointed(session_id: int, *, base_sha: str, version: int) -> None:
 
     Advancing ``checkpointed_version`` to ``version`` is what marks the session
     clean — a later edit bumps ``version`` past it, making it dirty again.
+    Conditional UPDATE (only advances) so a slow in-flight checkpoint can't
+    regress the watermark past what a faster concurrent one already recorded.
     """
     with session() as s:
-        sess = s.get(CoeditSession, session_id)
-        if sess is not None:
-            sess.base_sha = base_sha
-            sess.checkpointed_version = version
-            sess.last_checkpoint_at = _iso(_now())
+        s.execute(
+            update(CoeditSession)
+            .where(
+                CoeditSession.id == session_id,
+                CoeditSession.checkpointed_version < version,
+            )
+            .values(
+                base_sha=base_sha,
+                checkpointed_version=version,
+                last_checkpoint_at=_iso(_now()),
+            )
+            .execution_options(synchronize_session=False)
+        )
 
 
 def last_op_author(session_id: int) -> str | None:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -58,6 +58,7 @@ class SessionRow(BaseModel):
     path: str
     buffer_text: str
     version: int
+    checkpointed_version: int
     base_sha: str | None
     status: str
     created_at: str
@@ -81,6 +82,7 @@ def _session_row(s: CoeditSession) -> SessionRow:
         path=s.path,
         buffer_text=s.buffer_text,
         version=s.version,
+        checkpointed_version=s.checkpointed_version,
         base_sha=s.base_sha,
         status=s.status,
         created_at=s.created_at,
@@ -332,13 +334,30 @@ def ops_since(session_id: int, after_version: int) -> list[OpRow]:
         ]
 
 
-def mark_checkpointed(session_id: int, *, base_sha: str) -> None:
-    """Record that the buffer was committed to git at ``base_sha``."""
+def mark_checkpointed(session_id: int, *, base_sha: str, version: int) -> None:
+    """Record that the buffer at ``version`` was committed to git at ``base_sha``.
+
+    Advancing ``checkpointed_version`` to ``version`` is what marks the session
+    clean — a later edit bumps ``version`` past it, making it dirty again.
+    """
     with session() as s:
         sess = s.get(CoeditSession, session_id)
         if sess is not None:
             sess.base_sha = base_sha
+            sess.checkpointed_version = version
             sess.last_checkpoint_at = _iso(_now())
+
+
+def last_op_author(session_id: int) -> str | None:
+    """The user who applied the most recent op (highest seq), or None if the
+    session has no logged ops yet. Used to attribute a checkpoint commit."""
+    with session() as s:
+        return s.scalars(
+            select(CoeditOp.author_user_id)
+            .where(CoeditOp.session_id == session_id)
+            .order_by(CoeditOp.seq.desc())
+            .limit(1)
+        ).first()
 
 
 def close_session(session_id: int) -> None:

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -102,4 +102,13 @@ def checkpoint_session(session_id: int) -> str | None:
     head = wiki_git.head_sha_for_path(path)
     if head is not None:
         coedit.mark_checkpointed(session_id, base_sha=head, version=sess.version)
+    else:
+        # Shouldn't happen — a no-op merge implies HEAD exists. Surface it rather
+        # than silently leaving the session dirty and re-entering this path on
+        # every future trigger.
+        log.warning(
+            "coedit checkpoint: no-op merge but no HEAD for %s (session %s); left dirty",
+            path,
+            session_id,
+        )
     return None

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -1,0 +1,105 @@
+"""Checkpoint a co-edit session's live buffer back into git.
+
+The live buffer lives in Postgres (``coedit_sessions.buffer_text``); a checkpoint
+is the Layer-2 boundary that commits it to git through the *existing* write
+gateway, reconciling any agent/ingest commit that landed meanwhile via the same
+3-way + AI merge. Durability is Postgres, so a checkpoint is about visibility
+(making the committed page fresh for readers/search/agents) and bounding merge
+size — not data safety.
+
+Attribution: the commit author is the last editor (so git blame credits whoever
+last touched the buffer); the other session participants are added as
+``Co-authored-by:`` trailers. See
+``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
+
+This module is the engine (``checkpoint_session``). What *triggers* it — a
+periodic scan, last-participant-leave, an explicit save — is wired separately.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.auth import User, set_current_user
+from app.auth import users as users_repo
+from app.models.wiki import ChangeKind
+from app.wiki import coedit
+from app.wiki import git as wiki_git
+from app.wiki.utils import commit_and_fan_out
+
+log = logging.getLogger(__name__)
+
+
+def _user(user_id: str) -> User | None:
+    row = users_repo.get_by_id(user_id)
+    if row is None:
+        return None
+    return User(
+        id=row["id"], email=row["email"], name=row["name"], is_admin=bool(row["is_admin"])
+    )
+
+
+def _commit_message(session_id: int, *, primary_author_id: str | None) -> str:
+    """`Co-authored-by:` trailers for every participant except the primary
+    author (git credits the primary author separately via the commit author)."""
+    lines = ["Co-editing checkpoint"]
+    trailers: list[str] = []
+    for p in coedit.list_participants(session_id):
+        if p.user_id == primary_author_id:
+            continue
+        u = users_repo.get_by_id(p.user_id)
+        if u is not None:
+            trailers.append(f"Co-authored-by: {u['name'] or u['email']} <{u['email']}>")
+    if trailers:
+        lines.append("")
+        lines.extend(trailers)
+    return "\n".join(lines)
+
+
+def checkpoint_session(session_id: int) -> str | None:
+    """Commit a dirty session's buffer to git; return the new sha (or None).
+
+    No-op (returns None) when the session is gone, clean
+    (``version == checkpointed_version``), or the merge collapses to the current
+    HEAD. Reconciles concurrent agent/ingest commits via the gateway's 3-way +
+    AI merge. Idempotent: after a successful commit the session is marked clean.
+    """
+    sess = coedit.get_session(session_id)
+    if sess is None or sess.version == sess.checkpointed_version:
+        return None  # gone or nothing new to commit
+
+    path = sess.path
+    # Merge base = the page content at the last checkpoint. None when the
+    # session was opened on a not-yet-existing page (→ create).
+    base_body = wiki_git.read_file_opt(path, ref=sess.base_sha) if sess.base_sha else None
+    change_kind = ChangeKind.EDIT if sess.base_sha else ChangeKind.CREATE
+
+    primary_id = coedit.last_op_author(session_id)
+    author = _user(primary_id) if primary_id else None
+    message = _commit_message(session_id, primary_author_id=primary_id)
+
+    # System-initiated write: the editors' write permission was already enforced
+    # when they joined/POSTed ops, so skip the ACL gate; not "agent activity".
+    with set_current_user(author):
+        result = commit_and_fan_out(
+            path,
+            sess.buffer_text,
+            message,
+            change_kind=change_kind,
+            base_body=base_body,
+            ai_merge=True,
+            skip_acl=True,
+            record_activity=False,
+        )
+
+    if result is not None:
+        coedit.mark_checkpointed(session_id, base_sha=result.sha, version=sess.version)
+        return result.sha
+
+    # None = the merge produced exactly the current HEAD (buffer already matches
+    # committed content). Still mark clean against current HEAD so we don't
+    # re-attempt this version forever.
+    head = wiki_git.head_sha_for_path(path)
+    if head is not None:
+        coedit.mark_checkpointed(session_id, base_sha=head, version=sess.version)
+    return None

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -1,0 +1,89 @@
+"""Checkpoint engine (app/wiki/coedit_checkpoint.py) — commits a session's live
+buffer to git via the merge gateway, with last-editor author + co-author
+trailers. DB + real git (the ``tmp_repo`` fixture).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.auth import users as users_repo
+from app.wiki import coedit, coedit_checkpoint
+from app.wiki import git as wiki_git
+
+_PATH = "guides/setup.md"
+
+
+def _seed_page(body: str) -> str:
+    return wiki_git.commit_file(_PATH, body, "seed", author="Seed <seed@x.com>")
+
+
+def _ch(frm: int, to: int, insert: str) -> coedit.Change:
+    return coedit.Change.model_validate({"from": frm, "to": to, "insert": insert})
+
+
+@pytest.fixture
+def repo(tmp_repo):
+    return tmp_repo
+
+
+def test_checkpoint_commits_buffer_and_attributes_last_editor(repo):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+
+    new_sha = coedit_checkpoint.checkpoint_session(sess.id)
+
+    assert new_sha is not None
+    assert wiki_git.read_file(_PATH) == "hi world"
+    st = coedit.get_active_session(_PATH)
+    assert st is not None
+    assert st.checkpointed_version == 1
+    assert st.base_sha == new_sha
+    # git author is the last editor.
+    assert wiki_git.history(_PATH)[0].author == "Ada"
+
+
+def test_checkpoint_is_noop_when_clean(repo):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+    assert coedit_checkpoint.checkpoint_session(sess.id) is not None
+    # Nothing new since the last checkpoint → no second commit.
+    assert coedit_checkpoint.checkpoint_session(sess.id) is None
+
+
+def test_checkpoint_merges_concurrent_agent_commit(repo):
+    # Distant, non-overlapping edits so git merge-file resolves cleanly (no LLM):
+    # the buffer edits the first line, the agent edits the last, lines apart.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    doc = "one\ntwo\nthree\nfour\nfive\n"
+    sha = _seed_page(doc)
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer=doc)
+    coedit.join(sess.id, uid)
+    # Human edits the first line in the buffer ("one" → "ONE")...
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 3, "ONE")], author_user_id=uid)
+    # ...while an agent commits a change to the last line out of band.
+    wiki_git.commit_file(
+        _PATH, "one\ntwo\nthree\nfour\nFIVE\n", "agent edit", author="Agent <a@x.com>"
+    )
+
+    coedit_checkpoint.checkpoint_session(sess.id)
+
+    # 3-way merge keeps both non-overlapping edits.
+    assert wiki_git.read_file(_PATH) == "ONE\ntwo\nthree\nfour\nFIVE\n"
+
+
+def test_commit_message_credits_other_participants_as_coauthors(repo):
+    a = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    b = users_repo.create(email="bo@x.com", password="hunter2-x", name="Bo")
+    sess = coedit.open_session(_PATH, base_sha=None)
+    coedit.join(sess.id, a)
+    coedit.join(sess.id, b)
+    # Bo is the primary author (git author); Ada is credited as a co-author.
+    msg = coedit_checkpoint._commit_message(sess.id, primary_author_id=b)
+    assert "Co-authored-by: Ada <ada@x.com>" in msg
+    assert "bo@x.com" not in msg

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -135,6 +135,17 @@ def test_mark_checkpointed(users):
     assert fetched.last_checkpoint_at is not None
 
 
+def test_mark_checkpointed_never_regresses(users):
+    s = coedit.open_session(_PATH, base_sha=None)
+    coedit.mark_checkpointed(s.id, base_sha="sha6", version=6)
+    # A slower concurrent checkpoint at a lower version must not roll it back.
+    coedit.mark_checkpointed(s.id, base_sha="sha5", version=5)
+    fetched = coedit.get_active_session(_PATH)
+    assert fetched is not None
+    assert fetched.checkpointed_version == 6
+    assert fetched.base_sha == "sha6"
+
+
 def test_close_frees_path_for_new_session(users):
     first = coedit.open_session(_PATH, base_sha=None)
     coedit.close_session(first.id)

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -127,10 +127,11 @@ def test_participants_join_touch_leave(users):
 
 def test_mark_checkpointed(users):
     s = coedit.open_session(_PATH, base_sha="sha1")
-    coedit.mark_checkpointed(s.id, base_sha="sha2")
+    coedit.mark_checkpointed(s.id, base_sha="sha2", version=3)
     fetched = coedit.get_active_session(_PATH)
     assert fetched is not None
     assert fetched.base_sha == "sha2"
+    assert fetched.checkpointed_version == 3
     assert fetched.last_checkpoint_at is not None
 
 


### PR DESCRIPTION
## What

**Step 5a** of [co-editing](Engineering Projects/Agent Wiki Project/design/Co-Editing.md) — the Layer-2 boundary that commits a session's live buffer back into git. This is the **engine**; the triggers (periodic scan, on-last-leave, explicit save) are **step 5b**.

Until now, co-edited text lived only in Postgres (`coedit_sessions.buffer_text`). This is what actually lands it in git.

## How it works

```
base_body = page content @ session.base_sha   (the last checkpoint)
incoming  = session.buffer_text
→ commit_and_fan_out(base_body=base_body, ai_merge=True, skip_acl, record_activity=False)
→ mark_checkpointed(base_sha=new_sha, version=session.version)
```
It reuses the existing write gateway, so a concurrent agent/ingest commit that landed since `base_sha` is reconciled by the same **3-way + AI merge**. Durability is Postgres, so a checkpoint is about *visibility* (fresh committed page for readers/search/agents) and bounding merge size — not data safety.

## Changes

- **`coedit_sessions.checkpointed_version`** (migration `0041`, guarded): the version at the last checkpoint. `version > checkpointed_version` ⇒ dirty. Lets the worker skip clean sessions.
- **`coedit.mark_checkpointed(base_sha, version)`** + **`last_op_author()`**.
- **`coedit_checkpoint.checkpoint_session(id)`** — the engine. Skips clean/gone sessions, handles the no-op-merge case, idempotent.
- **Attribution**: last editor is the git author (via `set_current_user`); other participants get `Co-authored-by:` trailers (human co-authors — distinct from the no-Claude-coauthor rule).

## Verification

- `pytest` — **25 tests**: commit + last-editor attribution, no-op when clean, **clean 3-way merge of a concurrent agent commit**, co-author trailers.
- `ruff` + `basedpyright` clean; migration `0040→0041→0040` verified up/down.

## Next (5b)

Triggers: periodic scan (idle-debounce + max-interval) + checkpoint-on-last-leave + explicit `POST /checkpoint`.