### PR TITLE
feat(triggers): multi-action trigger shape and dispatch

### DIFF
--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 
 from app.auth import User, require_can
 from app.auth.deps import require_user
-from app.models.slack import (
-    CreateSlackWebhookRequest,
-    SlackWebhookListResponse,
-    SlackWebhookView,
+from app.models.destination_config import (
+    CreateDestinationConfigRequest,
+    DestinationConfigListResponse,
+    DestinationConfigView,
 )
 from app.models.trigger import (
     CreateTriggerRequest,
@@ -25,7 +25,7 @@ from app.models.trigger import (
     TriggerView,
     UpdateTriggerRequest,
 )
-from app.slack import webhooks as slack_webhooks
+from app.triggers import destination_configs as dest_configs
 from app.triggers import destinations as destinations_repo
 from app.triggers import repo as triggers_repo
 from app.triggers import storage as triggers_storage
@@ -41,19 +41,12 @@ def _git_author(user: User) -> str:
     return f"{user.name or user.email} <{user.email}>"
 
 
-def _mask_url(url: str) -> str:
-    """Show only enough of a webhook URL to recognize it (last path segment)."""
-    tail = url.rstrip("/").rsplit("/", 1)[-1]
-    if len(tail) <= 4:
-        return "…" + tail
-    return "…/" + tail[:4] + "…" + tail[-4:]
-
-
-def _webhook_view(row: dict[str, Any]) -> SlackWebhookView:
-    return SlackWebhookView(
+def _config_view(row: dict[str, Any]) -> DestinationConfigView:
+    return DestinationConfigView(
         id=row["id"],
+        type=row["type"],
         name=row["name"],
-        webhook_url_hint=_mask_url(row["webhook_url"]),
+        has_secret=bool(row.get("has_secret")),
         created_at=row.get("created_at"),
     )
 
@@ -91,31 +84,39 @@ def list_destinations(
     )
 
 
-@router.get("/slack-webhooks", response_model=SlackWebhookListResponse)
-def list_slack_webhooks(user: User = Depends(require_user)) -> SlackWebhookListResponse:
-    """The caller's own Slack channels (named webhooks). URLs are masked."""
-    rows = slack_webhooks.list_for_user(user.id)
-    return SlackWebhookListResponse(webhooks=[_webhook_view(r) for r in rows])
+@router.get("/destination-configs", response_model=DestinationConfigListResponse)
+def list_destination_configs(
+    user: User = Depends(require_user),
+) -> DestinationConfigListResponse:
+    """The caller's own destination configs. Secrets are never returned."""
+    rows = dest_configs.list_for_user(user.id)
+    return DestinationConfigListResponse(configs=[_config_view(r) for r in rows])
 
 
 @router.post(
-    "/slack-webhooks",
-    response_model=SlackWebhookView,
+    "/destination-configs",
+    response_model=DestinationConfigView,
     status_code=status.HTTP_201_CREATED,
 )
-def create_slack_webhook(
-    req: CreateSlackWebhookRequest, user: User = Depends(require_user)
-) -> SlackWebhookView:
+def create_destination_config(
+    req: CreateDestinationConfigRequest, user: User = Depends(require_user)
+) -> DestinationConfigView:
     try:
-        row = slack_webhooks.create(user.id, req.name, req.webhook_url)
+        row = dest_configs.create(
+            user.id, type=req.type, name=req.name, config=req.config, secret=req.secret
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return _webhook_view(row)
+    return _config_view(row)
 
 
-@router.delete("/slack-webhooks/{webhook_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_slack_webhook(webhook_id: str, user: User = Depends(require_user)) -> Response:
-    if not slack_webhooks.delete(webhook_id, user.id):
+@router.delete(
+    "/destination-configs/{config_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+def delete_destination_config(
+    config_id: str, user: User = Depends(require_user)
+) -> Response:
+    if not dest_configs.delete(config_id, user.id):
         raise HTTPException(status_code=404, detail="not found")
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -144,8 +145,7 @@ def create_trigger(
             scope_path=scope_path,
             nl_description=req.nl_description.strip(),
             message=req.message.strip(),
-            destination=req.destination,
-            slack_webhook_id=req.slack_webhook_id,
+            destination_config_id=req.destination_config_id,
             kind=req.kind,
             enabled=req.enabled,
             actor=_git_author(user),
@@ -204,11 +204,8 @@ def update_trigger(
             raise HTTPException(status_code=400, detail="message cannot be empty")
         kwargs["message"] = msg
 
-    if "destination" in sent_fields:
-        kwargs["destination"] = req.destination
-
-    if "slack_webhook_id" in sent_fields:
-        kwargs["slack_webhook_id"] = req.slack_webhook_id
+    if "destination_config_id" in sent_fields:
+        kwargs["destination_config_id"] = req.destination_config_id
 
     if "enabled" in sent_fields:
         kwargs["enabled"] = req.enabled
@@ -294,11 +291,12 @@ def trigger_version(
         log.exception("failed to read trigger %s at %s", trigger_id, sha)
         raise HTTPException(status_code=500, detail="failed to read version") from exc
 
+    first_action = cast(dict[str, Any], (data.get("actions") or [{}])[0])
     return TriggerVersionResponse(
         scope_path=data.get("scope_path"),
         nl_description=data.get("nl_description"),
-        message=data.get("message"),
-        destination=data.get("destination"),
+        message=first_action.get("message"),
+        destination_config_id=first_action.get("destination_config_id"),
         enabled=bool(data.get("enabled", True)),
         sha=sha,
         path=path,

--- a/backend/app/db/migrations/versions/0041_trigger_multi_action.py
+++ b/backend/app/db/migrations/versions/0041_trigger_multi_action.py
@@ -1,0 +1,98 @@
+"""trigger action list + drop slack_webhook_id column
+
+Folds each trigger's single ``{message, destination}`` blob plus its
+``slack_webhook_id`` column into the ``action_json`` actions list
+(``{"actions": [{type, message, slack_webhook_id}]}``), then drops the
+now-redundant column. The channel id lives inside the action.
+
+Guarded on whether the column exists: a schema built fresh from the current
+models never has it, an upgraded database does.
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-07-01 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_triggers = sa.table(
+    "triggers",
+    sa.column("id", sa.Text),
+    sa.column("action_json", sa.Text),
+    sa.column("slack_webhook_id", sa.Text),
+)
+
+
+def _load(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, str) or not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    columns = {c["name"] for c in sa.inspect(bind).get_columns("triggers")}
+    if "slack_webhook_id" not in columns:
+        return
+
+    rows = bind.execute(
+        sa.select(_triggers.c.id, _triggers.c.action_json, _triggers.c.slack_webhook_id)
+    ).all()
+    for row in rows:
+        data = _load(row.action_json)
+        if "actions" in data:
+            continue
+        new_json = json.dumps(
+            {
+                "actions": [
+                    {
+                        "type": data.get("destination"),
+                        "message": data.get("message"),
+                        "slack_webhook_id": row.slack_webhook_id,
+                    }
+                ]
+            }
+        )
+        bind.execute(
+            sa.update(_triggers).where(_triggers.c.id == row.id).values(action_json=new_json)
+        )
+
+    op.drop_column("triggers", "slack_webhook_id")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    columns = {c["name"] for c in sa.inspect(bind).get_columns("triggers")}
+    if "slack_webhook_id" not in columns:
+        op.add_column("triggers", sa.Column("slack_webhook_id", sa.Text, nullable=True))
+
+    rows = bind.execute(sa.select(_triggers.c.id, _triggers.c.action_json)).all()
+    for row in rows:
+        data = _load(row.action_json)
+        actions = data.get("actions")
+        first = actions[0] if isinstance(actions, list) and actions else {}
+        old_json = json.dumps(
+            {"message": first.get("message"), "destination": first.get("type")}
+        )
+        bind.execute(
+            sa.update(_triggers)
+            .where(_triggers.c.id == row.id)
+            .values(action_json=old_json, slack_webhook_id=first.get("slack_webhook_id"))
+        )

--- a/backend/app/db/migrations/versions/0041_trigger_multi_action.py
+++ b/backend/app/db/migrations/versions/0041_trigger_multi_action.py
@@ -1,12 +1,14 @@
-"""trigger action list + drop slack_webhook_id column
+"""drop the trigger slack_webhook_id column
 
-Folds each trigger's single ``{message, destination}`` blob plus its
-``slack_webhook_id`` column into the ``action_json`` actions list
-(``{"actions": [{type, message, slack_webhook_id}]}``), then drops the
-now-redundant column. The channel id lives inside the action.
+The Slack channel a trigger posts to now lives in the ``destination_configs``
+registry, referenced from ``action_json`` by ``destination_config_id``. Folding
+existing Slack channels into that registry and rewriting the trigger YAML is
+done in application code (``app/triggers/reconcile.py``), because it touches the
+wiki git repo and encrypted secrets. This migration only drops the column.
 
-Guarded on whether the column exists: a schema built fresh from the current
-models never has it, an upgraded database does.
+Guarded on the column existing: ``0001_initial`` builds a fresh schema from the
+current models (which no longer declare it) while ``0023`` adds it on the
+upgrade path, mirroring ``0023``'s own guard.
 
 Revision ID: 0041
 Revises: 0040
@@ -15,8 +17,7 @@ Create Date: 2026-07-01 00:00:00.000000+00:00
 
 from __future__ import annotations
 
-import json
-from typing import Any, Sequence
+from typing import Sequence
 
 import sqlalchemy as sa
 from alembic import op
@@ -28,71 +29,16 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
-_triggers = sa.table(
-    "triggers",
-    sa.column("id", sa.Text),
-    sa.column("action_json", sa.Text),
-    sa.column("slack_webhook_id", sa.Text),
-)
-
-
-def _load(raw: object) -> dict[str, Any]:
-    if not isinstance(raw, str) or not raw:
-        return {}
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError:
-        return {}
-    return data if isinstance(data, dict) else {}
+def _has_slack_webhook_id() -> bool:
+    cols = {c["name"] for c in sa.inspect(op.get_bind()).get_columns("triggers")}
+    return "slack_webhook_id" in cols
 
 
 def upgrade() -> None:
-    bind = op.get_bind()
-    columns = {c["name"] for c in sa.inspect(bind).get_columns("triggers")}
-    if "slack_webhook_id" not in columns:
-        return
-
-    rows = bind.execute(
-        sa.select(_triggers.c.id, _triggers.c.action_json, _triggers.c.slack_webhook_id)
-    ).all()
-    for row in rows:
-        data = _load(row.action_json)
-        if "actions" in data:
-            continue
-        new_json = json.dumps(
-            {
-                "actions": [
-                    {
-                        "type": data.get("destination"),
-                        "message": data.get("message"),
-                        "slack_webhook_id": row.slack_webhook_id,
-                    }
-                ]
-            }
-        )
-        bind.execute(
-            sa.update(_triggers).where(_triggers.c.id == row.id).values(action_json=new_json)
-        )
-
-    op.drop_column("triggers", "slack_webhook_id")
+    if _has_slack_webhook_id():
+        op.drop_column("triggers", "slack_webhook_id")
 
 
 def downgrade() -> None:
-    bind = op.get_bind()
-    columns = {c["name"] for c in sa.inspect(bind).get_columns("triggers")}
-    if "slack_webhook_id" not in columns:
+    if not _has_slack_webhook_id():
         op.add_column("triggers", sa.Column("slack_webhook_id", sa.Text, nullable=True))
-
-    rows = bind.execute(sa.select(_triggers.c.id, _triggers.c.action_json)).all()
-    for row in rows:
-        data = _load(row.action_json)
-        actions = data.get("actions")
-        first = actions[0] if isinstance(actions, list) and actions else {}
-        old_json = json.dumps(
-            {"message": first.get("message"), "destination": first.get("type")}
-        )
-        bind.execute(
-            sa.update(_triggers)
-            .where(_triggers.c.id == row.id)
-            .values(action_json=old_json, slack_webhook_id=first.get("slack_webhook_id"))
-        )

--- a/backend/app/db/migrations/versions/0043_trigger_multi_action.py
+++ b/backend/app/db/migrations/versions/0043_trigger_multi_action.py
@@ -10,8 +10,8 @@ Guarded on the column existing: ``0001_initial`` builds a fresh schema from the
 current models (which no longer declare it) while ``0023`` adds it on the
 upgrade path, mirroring ``0023``'s own guard.
 
-Revision ID: 0041
-Revises: 0040
+Revision ID: 0043
+Revises: 0042
 Create Date: 2026-07-01 00:00:00.000000+00:00
 """
 
@@ -23,8 +23,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "0041"
-down_revision: str | None = "0040"
+revision: str = "0043"
+down_revision: str | None = "0042"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -440,6 +440,9 @@ class Trigger(Base):
     scope_path: Mapped[str] = mapped_column(Text, nullable=False)
     kind: Mapped[str] = mapped_column(Text, nullable=False)  # "delta" | "schedule"
     nl_description: Mapped[str] = mapped_column(Text, nullable=False)
+    # ``{"actions": [{"type", "message", "slack_webhook_id"}, ...]}``. ``type``
+    # is a ``trigger_destinations`` slug. The slack channel id (when any) lives
+    # inside the action. The wiki YAML is the source of truth for this shape.
     action_json: Mapped[str] = mapped_column(Text, nullable=False)
     schedule_cron: Mapped[str | None] = mapped_column(Text)
     # IANA timezone name (e.g. "America/Los_Angeles") that ``schedule_cron``
@@ -458,18 +461,13 @@ class Trigger(Base):
     file_path: Mapped[str | None] = mapped_column(Text)
     last_edited_at: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
-    # When ``action_json.destination == "slack"``, the specific user-owned
-    # Slack channel this trigger posts to (FK ``slack_webhooks.id``). Null for
-    # ``event_log`` triggers. Not a secret — the webhook URL itself lives only
-    # on the ``slack_webhooks`` row — so this id is safe to persist to the YAML.
-    slack_webhook_id: Mapped[str | None] = mapped_column(Text)
 
 
 class TriggerDestination(Base):
     """Catalog of where a trigger fire can be delivered.
 
-    The ``id`` is a stable slug (e.g. ``"event_log"``) referenced from each
-    trigger's ``action_json.destination``. ``name`` and ``description`` are
+    The ``id`` is a stable slug (e.g. ``"event_log"``) referenced by each
+    trigger action's ``type``. ``name`` and ``description`` are
     surfaced to the user — including via the ``get_trigger_destinations``
     agent tool. Seeded by migration ``0004``; new destinations are added by
     follow-up migrations as outbound dispatchers come online.
@@ -492,9 +490,9 @@ class SlackWebhook(Base):
 
     Each row is a delivery target a user can point a trigger at: a human
     ``name`` (e.g. "PM Standup") and the secret ``webhook_url``. Webhooks
-    are private to ``owner_user_id``; a trigger references one via
-    ``Trigger.slack_webhook_id`` and only the owner's triggers may use it.
-    The URL is a secret and lives **only** here — never in the wiki git repo.
+    are private to ``owner_user_id``. A slack trigger action references one
+    via its ``slack_webhook_id`` and only the owner's triggers may use it.
+    The URL is a secret and lives **only** here, never in the wiki git repo.
     """
 
     __tablename__ = "slack_webhooks"

--- a/backend/app/llm/agents/tools/create_trigger.py
+++ b/backend/app/llm/agents/tools/create_trigger.py
@@ -18,7 +18,6 @@ def handle(args: dict[str, Any]) -> Any:
     raw_scope = args.get("scope_path", "")
     nl = args.get("trigger_nl_condition")
     message = args.get("trigger_fire_message")
-    destination = args.get("destination", triggers_repo.DEFAULT_DESTINATION)
 
     if not isinstance(nl, str) or not nl.strip():
         return {"error": "trigger_nl_condition is required"}
@@ -41,7 +40,6 @@ def handle(args: dict[str, Any]) -> Any:
             scope_path=scope,
             nl_description=nl.strip(),
             message=message.strip(),
-            destination=destination,
             actor=wiki_utils.author_string(),
         )
     except ValueError as exc:

--- a/backend/app/llm/agents/tools/update_trigger.py
+++ b/backend/app/llm/agents/tools/update_trigger.py
@@ -57,10 +57,6 @@ def handle(args: dict[str, Any]) -> Any:
             return {"error": "trigger_fire_message cannot be empty"}
         kwargs["message"] = msg.strip()
 
-    destination = args.get("destination", _UNSET)
-    if destination is not _UNSET:
-        kwargs["destination"] = destination
-
     if "enabled" in args:
         enabled = args["enabled"]
         if not isinstance(enabled, bool):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,7 @@ from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestEr
 from app.db.session import init_db
 from app.tasks.agent_activity import schedule_all_pending_cleanups
 from app.tasks.queues import QueueFullError
+from app.triggers import reconcile as triggers_reconcile
 from app.triggers import repo as triggers_repo
 from app.utils.logging import setup_logging
 from app.wiki.git import ensure_wiki_repo
@@ -171,6 +172,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     if comment_fts.count() == 0:
         _comments_repo.reindex_all_inline()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
+    triggers_reconcile.reconcile_legacy_slack_triggers()
     triggers_repo.rebuild_from_filesystem()
     schedule_all_pending_cleanups()
     # Cross-process realtime bus: the worker process commits docs, the web

--- a/backend/app/models/destination_config.py
+++ b/backend/app/models/destination_config.py
@@ -1,0 +1,36 @@
+"""HTTP shapes for the per-user destination config registry.
+
+Backs the ``/triggers/destination-configs`` CRUD surface. ``secret`` (e.g. a
+Slack incoming webhook URL) is accepted on create but never returned.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class CreateDestinationConfigRequest(BaseModel):
+    """A named, typed delivery target the caller owns. ``type`` is a
+    ``trigger_destinations`` slug. ``secret`` (e.g. the Slack webhook URL) is
+    stored encrypted and never returned."""
+
+    type: str = Field(min_length=1)
+    name: str = Field(min_length=1, max_length=80)
+    secret: str | None = None
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class DestinationConfigView(BaseModel):
+    """A destination config in list form. The secret is never returned, only
+    whether one is set."""
+
+    id: str
+    type: str
+    name: str
+    has_secret: bool
+    created_at: str | None
+
+
+class DestinationConfigListResponse(BaseModel):
+    configs: list[DestinationConfigView]

--- a/backend/app/models/trigger.py
+++ b/backend/app/models/trigger.py
@@ -22,9 +22,9 @@ class TriggerAction(BaseModel):
 
 
 class CreateTriggerRequest(BaseModel):
-    """``destination`` is a slug from the ``trigger_destinations`` table
-    (default ``"event_log"``). Validation against the destinations
-    catalog happens in the repo for a single source of truth.
+    """``destination_config_id`` references a destination config the caller
+    owns (GET /triggers/destination-configs), or is null for event-log-only
+    fires. Ownership is validated in the repo.
 
     For ``kind="schedule"`` triggers, ``schedule_cron`` and
     ``schedule_timezone`` are required and ``schedule_start_at`` is
@@ -34,10 +34,7 @@ class CreateTriggerRequest(BaseModel):
     scope_path: str = Field(min_length=1)
     nl_description: str = Field(min_length=1)
     message: str = Field(min_length=1)
-    destination: str | None = None
-    # Required when ``destination == "slack"``: the id of one of the caller's
-    # Slack channels (see GET /triggers/slack-webhooks). Ignored otherwise.
-    slack_webhook_id: str | None = None
+    destination_config_id: str | None = None
     kind: str = "delta"
     enabled: bool = True
     schedule_cron: str | None = None
@@ -51,8 +48,7 @@ class UpdateTriggerRequest(BaseModel):
     scope_path: str | None = None
     nl_description: str | None = None
     message: str | None = None
-    destination: str | None = None
-    slack_webhook_id: str | None = None
+    destination_config_id: str | None = None
     enabled: bool | None = None
     schedule_cron: str | None = None
     schedule_timezone: str | None = None
@@ -65,7 +61,7 @@ class UpdateTriggerRequest(BaseModel):
 
 
 class TriggerView(BaseModel):
-    """API view of a trigger row. ``message`` and ``destination`` are
+    """API view of a trigger row. ``message`` and ``destination_config_id`` are
     flattened from ``Trigger.action_json``. Schedule fields are only
     populated for ``kind="schedule"`` triggers."""
 
@@ -75,8 +71,7 @@ class TriggerView(BaseModel):
     kind: str
     nl_description: str
     message: str | None
-    destination: str
-    slack_webhook_id: str | None = None
+    destination_config_id: str | None = None
     enabled: bool
     created_at: str | None
     last_edited_at: str | None
@@ -121,7 +116,7 @@ class TriggerVersionResponse(BaseModel):
     scope_path: str | None
     nl_description: str | None
     message: str | None
-    destination: str | None
+    destination_config_id: str | None
     enabled: bool
     sha: str
     path: str

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -45,8 +45,8 @@ from sqlalchemy import select
 from app.db.models import Event, User
 from app.db.session import session
 from app.slack import client as slack_client
-from app.slack import webhooks as slack_webhooks
 from app.tasks.queues import triggers_queue
+from app.triggers import destination_configs as dest_configs
 from app.triggers import destinations as destinations_repo
 from app.triggers import diff as diff_helper
 from app.triggers import repo as triggers_repo
@@ -326,12 +326,14 @@ def _record_fire(
 ) -> None:
     """Record a ``trigger.fire`` row, then dispatch outbound if configured.
 
-    The events row is always written first, so a fire is never lost even
-    if outbound delivery fails or the destination has no dispatcher. After
-    recording, ``slack`` destinations POST the rendered message to the
-    admin-configured incoming webhook; an unknown destination just logs a
-    warning. (``event_log`` records and stops — that's the whole delivery.)
+    The events row is always written first, so a fire is never lost even if
+    outbound delivery fails. The action's ``destination_config_id`` is resolved
+    through ``destination_configs`` and delivered by the config's type. A null
+    id (event-log) records and stops.
     """
+    config_id = action.destination_config_id
+    config = dest_configs.get(config_id, trigger.owner_user_id) if config_id else None
+    dtype = config["type"] if config else ("event_log" if config_id is None else "unknown")
     event_payload = json.dumps(
         {
             "trigger_id": trigger.id,
@@ -341,7 +343,8 @@ def _record_fire(
             "reason": reason,
             "message": rendered_message,
             "message_instruction": instruction,
-            "destination": action.type,
+            "destination_config_id": config_id,
+            "destination_type": dtype,
         }
     )
     with session() as s:
@@ -354,42 +357,42 @@ def _record_fire(
             )
         )
 
-    if action.type == destinations_repo.SLACK_ID:
+    if config is None:
+        # None is event-log only; a set-but-missing config was deleted or is not
+        # owned, so record the fire and skip outbound.
+        if config_id is not None:
+            log.info(
+                "trigger %s destination config %s missing or not owned; recorded to events only",
+                trigger.id, config_id,
+            )
+        return
+    assert config_id is not None  # config resolved only when config_id is set
+    if dtype == destinations_repo.SLACK_ID:
         _dispatch_to_slack(
-            trigger=trigger, action=action, rendered_message=rendered_message
+            trigger=trigger, config_id=config_id, rendered_message=rendered_message
         )
-    elif action.type != destinations_repo.EVENT_LOG_ID:
+    else:
         log.warning(
-            "trigger %s has destination=%r but no outbound dispatcher is "
-            "wired up; recorded to events only",
-            trigger.id, action.type,
+            "trigger %s destination type %r has no outbound dispatcher; recorded to events only",
+            trigger.id, dtype,
         )
 
 
 def _dispatch_to_slack(
-    *, trigger: TriggerRecord, action: TriggerAction, rendered_message: str
+    *, trigger: TriggerRecord, config_id: str, rendered_message: str
 ) -> None:
-    """POST a fire's rendered message to the trigger's Slack channel.
+    """POST a fire's rendered message to the destination config's Slack channel.
 
-    Resolves ``trigger.slack_webhook_id`` to its owner's webhook URL. No-op
-    when the trigger has no channel set or the webhook was deleted/not owned.
-    Failures are logged and swallowed — the fire is already recorded in the
-    events table, so an unreachable Slack must not fail the task or lose it.
+    Resolves the config's decrypted secret (the incoming webhook URL) via
+    ``destination_configs.get_secret``, which enforces ownership. Failures are
+    logged and swallowed: the fire is already recorded in the events table, so
+    an unreachable Slack must not fail the task or lose it.
     """
-    if not action.slack_webhook_id:
-        log.info(
-            "trigger %s targets slack but has no channel set; recorded to events only",
-            trigger.id,
-        )
-        return
-
-    webhook_url = slack_webhooks.get_url(
-        action.slack_webhook_id, owner_user_id=trigger.owner_user_id
-    )
+    webhook_url = dest_configs.get_secret(config_id, owner_user_id=trigger.owner_user_id)
     if not webhook_url:
         log.info(
-            "trigger %s slack channel %s missing/not owned; recorded to events only",
-            trigger.id, action.slack_webhook_id,
+            "trigger %s slack config %s has no secret; recorded to events only",
+            trigger.id, config_id,
         )
         return
 
@@ -399,6 +402,6 @@ def _dispatch_to_slack(
 
     try:
         slack_client.post_message(webhook_url=webhook_url, text=rendered_message)
-        log.info("trigger %s dispatched to slack channel %s", trigger.id, action.slack_webhook_id)
+        log.info("trigger %s dispatched to slack config %s", trigger.id, config_id)
     except slack_client.SlackApiError:
         log.exception("trigger %s slack dispatch failed", trigger.id)

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -51,6 +51,7 @@ from app.triggers import destinations as destinations_repo
 from app.triggers import diff as diff_helper
 from app.triggers import repo as triggers_repo
 from app.triggers.engine import (
+    TriggerAction,
     TriggerRecord,
     evaluate_delta,
     evaluate_new_file_in_dir,
@@ -131,9 +132,6 @@ def fan_out_trigger_eval(
     fired = 0
     skipped_acl = 0
     for trigger in triggers:
-        instruction = trigger.message or ""
-        destination = trigger.destination
-
         # Re-check the owner's read access at fire-time. The trigger may have
         # been created when the owner had access and then revoked; we don't
         # want a rendered message (which embeds doc body excerpts) landing in
@@ -146,46 +144,50 @@ def fan_out_trigger_eval(
             )
             continue
 
-        if change_kind == ChangeKind.CREATE and trigger.scope_path != doc_path:
-            assert new_file_payload is not None
-            new_file_result = evaluate_new_file_in_dir(
-                trigger, instruction, new_file_payload
-            )
-            if not new_file_result.triggered:
-                continue
-            rendered = new_file_result.message
-            reason = "new file under directory scope"
-            log.info(
-                "trigger fired (new-file-in-dir) id=%s doc=%s",
-                trigger.id, doc_path,
-            )
-        else:
-            match = evaluate_delta(trigger, delta_payload)
-            if not match.matched:
-                continue
-            reason = match.reason
-            rendered = (
-                render_delta_message(instruction, delta_payload, reason=reason)
-                if instruction
-                else ""
-            )
-            log.info(
-                "trigger fired id=%s doc=%s reason=%s",
-                trigger.id, doc_path, reason,
-            )
+        # Each action renders its own message and dispatches to its own
+        # destination. The firing condition is the trigger's, shared by all.
+        for action in trigger.actions:
+            instruction = action.message or ""
+            if change_kind == ChangeKind.CREATE and trigger.scope_path != doc_path:
+                assert new_file_payload is not None
+                new_file_result = evaluate_new_file_in_dir(
+                    trigger, instruction, new_file_payload
+                )
+                if not new_file_result.triggered:
+                    continue
+                rendered = new_file_result.message
+                reason = "new file under directory scope"
+                log.info(
+                    "trigger fired (new-file-in-dir) id=%s doc=%s",
+                    trigger.id, doc_path,
+                )
+            else:
+                match = evaluate_delta(trigger, delta_payload)
+                if not match.matched:
+                    continue
+                reason = match.reason
+                rendered = (
+                    render_delta_message(instruction, delta_payload, reason=reason)
+                    if instruction
+                    else ""
+                )
+                log.info(
+                    "trigger fired id=%s doc=%s reason=%s",
+                    trigger.id, doc_path, reason,
+                )
 
-        fired += 1
-        _record_fire(
-            trigger=trigger,
-            doc_path=doc_path,
-            sha=sha,
-            change_kind=change_kind,
-            reason=reason,
-            instruction=instruction,
-            rendered_message=rendered,
-            destination=destination,
-            actor=actor,
-        )
+            fired += 1
+            _record_fire(
+                trigger=trigger,
+                action=action,
+                doc_path=doc_path,
+                sha=sha,
+                change_kind=change_kind,
+                reason=reason,
+                instruction=instruction,
+                rendered_message=rendered,
+                actor=actor,
+            )
     log.info(
         "fan_out_trigger_eval %s: %d/%d fired (%d skipped on owner ACL)",
         doc_path, fired, len(triggers), skipped_acl,
@@ -259,27 +261,28 @@ def _evaluate_one_schedule(
     if not match.matched:
         return False
 
-    instruction = trigger.message or ""
-    rendered = (
-        render_schedule_message(instruction, payload, reason=match.reason)
-        if instruction
-        else ""
-    )
     log.info(
         "schedule trigger fired id=%s scope=%s reason=%s",
         trigger.id, trigger.scope_path, match.reason,
     )
-    _record_fire(
-        trigger=trigger,
-        doc_path=trigger.scope_path,
-        sha="",
-        change_kind=ChangeKind.SCHEDULE,
-        reason=match.reason,
-        instruction=instruction,
-        rendered_message=rendered,
-        destination=trigger.destination,
-        actor=None,
-    )
+    for action in trigger.actions:
+        instruction = action.message or ""
+        rendered = (
+            render_schedule_message(instruction, payload, reason=match.reason)
+            if instruction
+            else ""
+        )
+        _record_fire(
+            trigger=trigger,
+            action=action,
+            doc_path=trigger.scope_path,
+            sha="",
+            change_kind=ChangeKind.SCHEDULE,
+            reason=match.reason,
+            instruction=instruction,
+            rendered_message=rendered,
+            actor=None,
+        )
     return True
 
 
@@ -312,13 +315,13 @@ def _read_at(ref: str, rel_path: str) -> str:
 def _record_fire(
     *,
     trigger: TriggerRecord,
+    action: TriggerAction,
     doc_path: str,
     sha: str,
     change_kind: ChangeKind,
     reason: str,
     instruction: str,
     rendered_message: str,
-    destination: object,
     actor: str | None,
 ) -> None:
     """Record a ``trigger.fire`` row, then dispatch outbound if configured.
@@ -338,7 +341,7 @@ def _record_fire(
             "reason": reason,
             "message": rendered_message,
             "message_instruction": instruction,
-            "destination": destination,
+            "destination": action.type,
         }
     )
     with session() as s:
@@ -351,17 +354,21 @@ def _record_fire(
             )
         )
 
-    if destination == destinations_repo.SLACK_ID:
-        _dispatch_to_slack(trigger=trigger, rendered_message=rendered_message)
-    elif destination != destinations_repo.EVENT_LOG_ID:
+    if action.type == destinations_repo.SLACK_ID:
+        _dispatch_to_slack(
+            trigger=trigger, action=action, rendered_message=rendered_message
+        )
+    elif action.type != destinations_repo.EVENT_LOG_ID:
         log.warning(
             "trigger %s has destination=%r but no outbound dispatcher is "
             "wired up; recorded to events only",
-            trigger.id, destination,
+            trigger.id, action.type,
         )
 
 
-def _dispatch_to_slack(*, trigger: TriggerRecord, rendered_message: str) -> None:
+def _dispatch_to_slack(
+    *, trigger: TriggerRecord, action: TriggerAction, rendered_message: str
+) -> None:
     """POST a fire's rendered message to the trigger's Slack channel.
 
     Resolves ``trigger.slack_webhook_id`` to its owner's webhook URL. No-op
@@ -369,7 +376,7 @@ def _dispatch_to_slack(*, trigger: TriggerRecord, rendered_message: str) -> None
     Failures are logged and swallowed — the fire is already recorded in the
     events table, so an unreachable Slack must not fail the task or lose it.
     """
-    if not trigger.slack_webhook_id:
+    if not action.slack_webhook_id:
         log.info(
             "trigger %s targets slack but has no channel set; recorded to events only",
             trigger.id,
@@ -377,12 +384,12 @@ def _dispatch_to_slack(*, trigger: TriggerRecord, rendered_message: str) -> None
         return
 
     webhook_url = slack_webhooks.get_url(
-        trigger.slack_webhook_id, owner_user_id=trigger.owner_user_id
+        action.slack_webhook_id, owner_user_id=trigger.owner_user_id
     )
     if not webhook_url:
         log.info(
             "trigger %s slack channel %s missing/not owned; recorded to events only",
-            trigger.id, trigger.slack_webhook_id,
+            trigger.id, action.slack_webhook_id,
         )
         return
 
@@ -392,6 +399,6 @@ def _dispatch_to_slack(*, trigger: TriggerRecord, rendered_message: str) -> None
 
     try:
         slack_client.post_message(webhook_url=webhook_url, text=rendered_message)
-        log.info("trigger %s dispatched to slack channel %s", trigger.id, trigger.slack_webhook_id)
+        log.info("trigger %s dispatched to slack channel %s", trigger.id, action.slack_webhook_id)
     except slack_client.SlackApiError:
         log.exception("trigger %s slack dispatch failed", trigger.id)

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -144,39 +144,39 @@ def fan_out_trigger_eval(
             )
             continue
 
-        # Each action renders its own message and dispatches to its own
-        # destination. The firing condition is the trigger's, shared by all.
+        # Evaluate the firing condition once per trigger, then deliver each
+        # action. Delta renders per action; the new-file eval renders in its
+        # single combined call.
+        if change_kind == ChangeKind.CREATE and trigger.scope_path != doc_path:
+            assert new_file_payload is not None
+            primary = (trigger.actions[0].message or "") if trigger.actions else ""
+            new_file_result = evaluate_new_file_in_dir(
+                trigger, primary, new_file_payload
+            )
+            if not new_file_result.triggered:
+                continue
+            new_file_message: str | None = new_file_result.message
+            reason = "new file under directory scope"
+            log.info("trigger fired (new-file-in-dir) id=%s doc=%s", trigger.id, doc_path)
+        else:
+            match = evaluate_delta(trigger, delta_payload)
+            if not match.matched:
+                continue
+            new_file_message = None
+            reason = match.reason
+            log.info("trigger fired id=%s doc=%s reason=%s", trigger.id, doc_path, reason)
+
+        fired += 1
         for action in trigger.actions:
             instruction = action.message or ""
-            if change_kind == ChangeKind.CREATE and trigger.scope_path != doc_path:
-                assert new_file_payload is not None
-                new_file_result = evaluate_new_file_in_dir(
-                    trigger, instruction, new_file_payload
-                )
-                if not new_file_result.triggered:
-                    continue
-                rendered = new_file_result.message
-                reason = "new file under directory scope"
-                log.info(
-                    "trigger fired (new-file-in-dir) id=%s doc=%s",
-                    trigger.id, doc_path,
-                )
+            if new_file_message is not None:
+                rendered = new_file_message
             else:
-                match = evaluate_delta(trigger, delta_payload)
-                if not match.matched:
-                    continue
-                reason = match.reason
                 rendered = (
                     render_delta_message(instruction, delta_payload, reason=reason)
                     if instruction
                     else ""
                 )
-                log.info(
-                    "trigger fired id=%s doc=%s reason=%s",
-                    trigger.id, doc_path, reason,
-                )
-
-            fired += 1
             _record_fire(
                 trigger=trigger,
                 action=action,

--- a/backend/app/triggers/engine.py
+++ b/backend/app/triggers/engine.py
@@ -39,24 +39,31 @@ from app.triggers.natural_language import render_message as nl_render_message
 from app.triggers.natural_language import (
     render_snapshot_message as nl_render_snapshot_message,
 )
-from app.triggers.repo import _parse_action  # pyright: ignore[reportPrivateUsage]
+from app.triggers.repo import _parse_actions  # pyright: ignore[reportPrivateUsage]
 from app.wiki.filesystem import parent_dirs
 
 log = logging.getLogger(__name__)
 
 
+class TriggerAction(BaseModel):
+    """One delivery action: a destination ``type`` plus the message to render
+    and, for slack, the channel to post to."""
+
+    type: str
+    message: str | None = None
+    slack_webhook_id: str | None = None
+
+
 class TriggerRecord(BaseModel):
-    """Eval-side view of a trigger row. ``message`` and ``destination`` are
-    parsed from ``Trigger.action_json``; raw column shape is hidden."""
+    """Eval-side view of a trigger row. ``actions`` is parsed from
+    ``Trigger.action_json``. The raw column shape is hidden."""
 
     id: str
     owner_user_id: str
     scope_path: str
     kind: str
     nl_description: str
-    message: str | None
-    destination: str
-    slack_webhook_id: str | None = None
+    actions: list[TriggerAction]
     enabled: bool
     file_path: str | None
     created_at: str | None
@@ -68,16 +75,13 @@ class TriggerRecord(BaseModel):
 
 
 def _to_record(t: Trigger) -> TriggerRecord:
-    action = _parse_action(t.action_json)
     return TriggerRecord(
         id=t.id,
         owner_user_id=t.owner_user_id,
         scope_path=t.scope_path,
         kind=t.kind,
         nl_description=t.nl_description,
-        message=action.get("message"),
-        destination=action["destination"],
-        slack_webhook_id=t.slack_webhook_id,
+        actions=[TriggerAction(**a) for a in _parse_actions(t.action_json)],
         enabled=t.enabled,
         file_path=t.file_path,
         created_at=t.created_at,

--- a/backend/app/triggers/engine.py
+++ b/backend/app/triggers/engine.py
@@ -46,12 +46,11 @@ log = logging.getLogger(__name__)
 
 
 class TriggerAction(BaseModel):
-    """One delivery action: a destination ``type`` plus the message to render
-    and, for slack, the channel to post to."""
+    """One delivery action: the message to render plus the destination config to
+    deliver it to. ``destination_config_id`` is None for event-log-only fires."""
 
-    type: str
+    destination_config_id: str | None = None
     message: str | None = None
-    slack_webhook_id: str | None = None
 
 
 class TriggerRecord(BaseModel):

--- a/backend/app/triggers/reconcile.py
+++ b/backend/app/triggers/reconcile.py
@@ -77,6 +77,14 @@ def reconcile_legacy_slack_triggers() -> int:
             and isinstance(owner, str)
         ):
             config_id = _mirror_config_id(webhook_id, owner)
+            if config_id is None:
+                # The trigger degrades to event-log only. Name the drop so
+                # operators can find affected triggers after the migration.
+                log.warning(
+                    "reconcile: %s (owner %s) referenced slack webhook %s which no "
+                    "longer exists; trigger falls back to event-log only",
+                    file_path, owner, webhook_id,
+                )
 
         reshaped = {
             k: v

--- a/backend/app/triggers/reconcile.py
+++ b/backend/app/triggers/reconcile.py
@@ -1,0 +1,96 @@
+"""One-time reconcile of legacy Slack triggers into destination configs.
+
+Before the ``destination_configs`` registry, a trigger's Slack channel lived in
+``slack_webhooks`` and was referenced by a top-level ``slack_webhook_id`` on the
+trigger YAML. This mirrors each such channel into a ``destination_configs`` row
+(once) and rewrites the trigger YAML to reference it by ``destination_config_id``.
+
+Runs at boot before the cache rebuild. Already-reshaped triggers carry an
+``actions`` list and are skipped, and each mirrored config is found by the
+source-webhook marker rather than recreated, so it is a no-op after the first
+boot.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import yaml
+
+from app.slack import webhooks as slack_webhooks
+from app.triggers import destination_configs as dest_configs
+from app.triggers import storage
+from app.wiki import git as wiki_git
+
+log = logging.getLogger(__name__)
+
+# Marker in a mirrored config's config_json linking it to its source webhook, so
+# the mirror is created exactly once.
+_SOURCE_KEY = "from_slack_webhook"
+
+
+def _mirror_config_id(webhook_id: str, owner_user_id: str) -> str | None:
+    """The destination config mirroring ``webhook_id`` for its owner, created on
+    first sight. None if the source webhook is gone or not owned."""
+    for cfg in dest_configs.list_for_user(owner_user_id):
+        config = cfg.get("config")
+        if isinstance(config, dict) and cast(dict[str, Any], config).get(_SOURCE_KEY) == webhook_id:
+            return cast(str, cfg["id"])
+    hook = next(
+        (w for w in slack_webhooks.list_for_user(owner_user_id) if w["id"] == webhook_id),
+        None,
+    )
+    if hook is None:
+        return None
+    return cast(
+        str,
+        dest_configs.create(
+            owner_user_id,
+            type="slack",
+            name=hook["name"],
+            config={_SOURCE_KEY: webhook_id},
+            secret=hook["webhook_url"],
+        )["id"],
+    )
+
+
+def reconcile_legacy_slack_triggers() -> int:
+    """Rewrite trigger YAML still on the legacy single-destination shape into the
+    destination-config shape. Returns the number of files rewritten."""
+    rewritten = 0
+    for file_path in storage.list_all_files():
+        try:
+            loaded: object = yaml.safe_load(wiki_git.read_file(file_path))
+        except Exception:
+            log.warning("reconcile: unreadable trigger %s", file_path, exc_info=True)
+            continue
+        if not isinstance(loaded, dict) or "id" not in loaded or "actions" in loaded:
+            continue  # not a trigger file, or already reshaped
+        raw = cast(dict[str, Any], loaded)
+
+        owner = raw.get("owner_user_id")
+        webhook_id = raw.get("slack_webhook_id")
+        config_id: str | None = None
+        if (
+            raw.get("destination") == "slack"
+            and isinstance(webhook_id, str)
+            and isinstance(owner, str)
+        ):
+            config_id = _mirror_config_id(webhook_id, owner)
+
+        reshaped = {
+            k: v
+            for k, v in raw.items()
+            if k not in ("message", "destination", "slack_webhook_id")
+        }
+        reshaped["actions"] = [
+            {"destination_config_id": config_id, "message": raw.get("message")}
+        ]
+        try:
+            storage.write_trigger(reshaped, file_path=file_path, actor=None)
+            rewritten += 1
+        except Exception:
+            log.exception("reconcile: failed to rewrite %s", file_path)
+    if rewritten:
+        log.info("reconcile: rewrote %d legacy slack trigger(s)", rewritten)
+    return rewritten

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -6,19 +6,19 @@ If the DB write fails after the file commit, ``rebuild_from_filesystem``
 will re-converge the cache; the inverse (file fails after the row) leaves
 nothing behind because the row write is the second step.
 
-Format (every trigger has these three fields plus the standard scope/kind/enabled):
-  * **if** — ``nl_description``: natural-language firing condition.
-  * **message** — the notification body to deliver when the trigger fires.
-  * **destination** — slug of a row in ``trigger_destinations``. Defaults to
-    ``"event_log"`` (record the fire to the events table; no outbound
-    dispatch). New destinations are added by migration as their dispatchers
-    come online — see ``app/triggers/destinations.py``.
+Format (every trigger has a firing condition plus a list of actions):
+  * **if**: ``nl_description``, the natural-language firing condition.
+  * **actions**: a list of ``{type, message, slack_webhook_id}``. ``type`` is a
+    slug from ``trigger_destinations`` (``event_log`` records the fire to the
+    events table, ``slack`` posts to the action's channel). ``message`` is the
+    body rendered on fire.
 
-``message`` and ``destination`` are stored together in the ``action_json``
-column (and the ``action`` block in the YAML file). The repo layer exposes
-them as flat dict keys for callers. Legacy rows where ``destination`` is
-``None`` (predating the destinations catalog) are read as ``"event_log"``
-so callers don't need to special-case the migration boundary.
+Actions live as ``{"actions": [...]}`` in the ``action_json`` column and the
+``actions`` block in the YAML file. Create/update and the HTTP layer are
+single-action for now: they take one ``message``/``destination``/
+``slack_webhook_id`` and build a one-element list. ``_to_dict`` projects the
+first action back to those flat keys. An old single-destination blob reads as
+one action.
 """
 
 from __future__ import annotations
@@ -93,8 +93,15 @@ def _validate_slack_webhook(
     return wid
 
 
-def _action_payload(*, message: str, destination: object) -> str:
-    return json.dumps({"message": message, "destination": destination})
+def _actions_json(actions: list[dict[str, Any]]) -> str:
+    """Serialize the actions list into the ``action_json`` column."""
+    return json.dumps({"actions": actions})
+
+
+def _one_action(
+    *, message: str | None, destination: str, slack_webhook_id: str | None
+) -> list[dict[str, Any]]:
+    return [{"type": destination, "message": message, "slack_webhook_id": slack_webhook_id}]
 
 
 def _validate_schedule_fields(
@@ -149,22 +156,50 @@ def _validate_schedule_fields(
     return None, None, None
 
 
-def _parse_action(raw: str) -> dict[str, Any]:
-    """Parse the ``action_json`` column."""
-    return cast(dict[str, Any], json.loads(raw))
+def _parse_actions(raw: str) -> list[dict[str, Any]]:
+    """Actions stored in ``action_json``. An old single-destination blob
+    (``{"message":.., "destination":..}``) reads as one action."""
+    parsed = cast(dict[str, Any], json.loads(raw))
+    raw_actions = parsed.get("actions")
+    if isinstance(raw_actions, list) and raw_actions:
+        return [
+            {
+                "type": a.get("type"),
+                "message": a.get("message"),
+                "slack_webhook_id": a.get("slack_webhook_id"),
+            }
+            for a in cast(list[dict[str, Any]], raw_actions)
+        ]
+    return [
+        {
+            "type": parsed.get("destination"),
+            "message": parsed.get("message"),
+            "slack_webhook_id": parsed.get("slack_webhook_id"),
+        }
+    ]
+
+
+def _first_message(data: dict[str, Any]) -> object:
+    """The first action's message from a parsed trigger dict."""
+    actions = data.get("actions")
+    if isinstance(actions, list) and actions:
+        return cast(dict[str, Any], actions[0]).get("message")
+    return None
 
 
 def _to_dict(t: Trigger) -> dict[str, Any]:
-    action = _parse_action(t.action_json)
+    actions = _parse_actions(t.action_json)
+    first = actions[0]
     return {
         "id": t.id,
         "owner_user_id": t.owner_user_id,
         "scope_path": t.scope_path,
         "kind": t.kind,
         "nl_description": t.nl_description,
-        "message": action.get("message"),
-        "destination": action["destination"],
-        "slack_webhook_id": t.slack_webhook_id,
+        "actions": actions,
+        "message": first.get("message"),
+        "destination": first["type"],
+        "slack_webhook_id": first.get("slack_webhook_id"),
         "enabled": t.enabled,
         "created_at": t.created_at,
         "last_edited_at": t.last_edited_at,
@@ -219,15 +254,16 @@ def create(
     trigger_id = "trg_" + uuid.uuid4().hex[:12]
     created_at = _now_iso()
     file_path = storage.compute_path(scope_path=scope_path, trigger_id=trigger_id)
+    actions = _one_action(
+        message=message.strip(), destination=destination_id, slack_webhook_id=webhook_id
+    )
     row_dict = {
         "id": trigger_id,
         "owner_user_id": owner_user_id,
         "scope_path": scope_path,
         "kind": kind,
         "nl_description": nl_description,
-        "message": message.strip(),
-        "destination": destination_id,
-        "slack_webhook_id": webhook_id,
+        "actions": actions,
         "enabled": enabled,
         "created_at": created_at,
         "schedule_cron": cron_value,
@@ -244,8 +280,7 @@ def create(
                 scope_path=scope_path,
                 kind=kind,
                 nl_description=nl_description,
-                action_json=_action_payload(message=message.strip(), destination=destination_id),
-                slack_webhook_id=webhook_id,
+                action_json=_actions_json(actions),
                 enabled=enabled,
                 file_path=file_path,
                 created_at=created_at,
@@ -366,6 +401,11 @@ def update(
     ):
         return existing
 
+    new["actions"] = _one_action(
+        message=new["message"],
+        destination=new["destination"],
+        slack_webhook_id=new.get("slack_webhook_id"),
+    )
     new_file_path = storage.compute_path(scope_path=new["scope_path"], trigger_id=trigger_id)
     old_file_path = existing.get("file_path")
     if old_file_path and new_file_path != old_file_path:
@@ -384,10 +424,7 @@ def update(
             return None
         t.scope_path = new["scope_path"]
         t.nl_description = new["nl_description"]
-        t.action_json = _action_payload(
-            message=new["message"] or "", destination=new["destination"]
-        )
-        t.slack_webhook_id = new.get("slack_webhook_id")
+        t.action_json = _actions_json(new["actions"])
         t.enabled = new["enabled"]
         t.file_path = new_file_path
         t.last_edited_at = _now_iso()
@@ -440,7 +477,7 @@ def purge_invalid_triggers(*, actor: str | None = None) -> int:
             log.warning("purge_invalid_triggers: skip unreadable %s", file_path, exc_info=True)
             continue
         if _is_nonempty_string(data.get("nl_description")) and _is_nonempty_string(
-            data.get("message")
+            _first_message(data)
         ):
             continue
         trigger_id = data.get("id") or "?"
@@ -573,7 +610,7 @@ def rebuild_from_filesystem() -> int:
             continue
         if not (
             _is_nonempty_string(data.get("nl_description"))
-            and _is_nonempty_string(data.get("message"))
+            and _is_nonempty_string(_first_message(data))
         ):
             log.warning(
                 "rebuild_from_filesystem: skip %s (missing required field)",
@@ -640,10 +677,14 @@ def rebuild_from_filesystem() -> int:
                 skipped += 1
                 continue
 
-            action_payload = _action_payload(
-                message=data.get("message") or "",
-                destination=_validate_destination(data.get("destination")),
-            )
+            actions_payload = [
+                {
+                    "type": _validate_destination(a.get("type")),
+                    "message": a.get("message"),
+                    "slack_webhook_id": a.get("slack_webhook_id"),
+                }
+                for a in data["actions"]
+            ]
             created_at = data.get("created_at") or fallback_now
             last_edited = data.get("last_edited_at") or created_at
             try:
@@ -668,9 +709,7 @@ def rebuild_from_filesystem() -> int:
                     scope_path=data["scope_path"],
                     kind=data["kind"],
                     nl_description=data["nl_description"],
-                    action_json=action_payload,
-                    # The Slack channel link the UI resolves to a channel name.
-                    slack_webhook_id=data.get("slack_webhook_id"),
+                    action_json=_actions_json(actions_payload),
                     enabled=bool(data.get("enabled", True)),
                     file_path=file_path,
                     created_at=created_at,

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -8,17 +8,15 @@ nothing behind because the row write is the second step.
 
 Format (every trigger has a firing condition plus a list of actions):
   * **if**: ``nl_description``, the natural-language firing condition.
-  * **actions**: a list of ``{type, message, slack_webhook_id}``. ``type`` is a
-    slug from ``trigger_destinations`` (``event_log`` records the fire to the
-    events table, ``slack`` posts to the action's channel). ``message`` is the
-    body rendered on fire.
+  * **actions**: a list of ``{destination_config_id, message}``.
+    ``destination_config_id`` references a ``destination_configs`` row, or is
+    null for event-log-only fires. ``message`` is the body rendered on fire.
 
 Actions live as ``{"actions": [...]}`` in the ``action_json`` column and the
 ``actions`` block in the YAML file. Create/update and the HTTP layer are
-single-action for now: they take one ``message``/``destination``/
-``slack_webhook_id`` and build a one-element list. ``_to_dict`` projects the
-first action back to those flat keys. An old single-destination blob reads as
-one action.
+single-action for now: they take one ``message``/``destination_config_id`` and
+build a one-element list. ``_to_dict`` projects the first action back to those
+flat keys. A legacy single-destination blob reads as one event-log action.
 """
 
 from __future__ import annotations
@@ -36,8 +34,7 @@ from sqlalchemy import delete as sa_delete, or_, select, update as sa_update
 
 from app.db.models import Event, Trigger, User
 from app.db.session import advisory_xact_lock, session
-from app.slack import webhooks as slack_webhooks
-from app.triggers import destinations as destinations_repo
+from app.triggers import destination_configs as dest_configs
 from app.triggers import storage
 
 log = logging.getLogger(__name__)
@@ -52,45 +49,22 @@ _REBUILD_ADVISORY_LOCK = 0x74726967
 
 ALLOWED_KINDS = {"delta", "schedule"}
 
-# Default destination for new triggers — fires go to the events table.
-DEFAULT_DESTINATION = destinations_repo.EVENT_LOG_ID
 
-
-def _validate_destination(destination: object) -> str:
-    """Coerce + validate a destination value into a known slug.
-
-    Returns the canonical slug. Raises ``ValueError`` if the value isn't a
-    string or doesn't match a row in ``trigger_destinations``.
-    """
-    if destination is None:
-        return destinations_repo.EVENT_LOG_ID
-    if not isinstance(destination, str) or not destination.strip():
-        raise ValueError(f"destination must be a destination id string; got {destination!r}")
-    slug = destination.strip()
-    if not destinations_repo.exists(slug):
-        raise ValueError(
-            f"destination {slug!r} not found — call get_trigger_destinations to list available ids"
-        )
-    return slug
-
-
-def _validate_slack_webhook(
-    *, destination: str, slack_webhook_id: object, owner_user_id: str
+def _validate_destination_config(
+    destination_config_id: object, *, owner_user_id: str
 ) -> str | None:
-    """Resolve the Slack channel reference for a trigger.
-
-    A ``slack`` destination requires a ``slack_webhook_id`` that the owner
-    actually owns. Any other destination must not carry one (we null it so a
-    destination flip doesn't leave a dangling reference).
-    """
-    if destination != destinations_repo.SLACK_ID:
+    """None means event-log only. Otherwise the id must reference a
+    destination config the owner owns."""
+    if destination_config_id is None:
         return None
-    if not isinstance(slack_webhook_id, str) or not slack_webhook_id.strip():
-        raise ValueError("a Slack destination requires slack_webhook_id (the channel to post to)")
-    wid = slack_webhook_id.strip()
-    if not slack_webhooks.owned_by(wid, owner_user_id):
-        raise ValueError(f"slack_webhook_id {wid!r} not found")
-    return wid
+    if not isinstance(destination_config_id, str) or not destination_config_id.strip():
+        raise ValueError(
+            f"destination_config_id must be a string or null; got {destination_config_id!r}"
+        )
+    cid = destination_config_id.strip()
+    if not dest_configs.owned_by(cid, owner_user_id):
+        raise ValueError(f"destination_config_id {cid!r} not found")
+    return cid
 
 
 def _actions_json(actions: list[dict[str, Any]]) -> str:
@@ -99,9 +73,9 @@ def _actions_json(actions: list[dict[str, Any]]) -> str:
 
 
 def _one_action(
-    *, message: str | None, destination: str, slack_webhook_id: str | None
+    *, message: str | None, destination_config_id: str | None
 ) -> list[dict[str, Any]]:
-    return [{"type": destination, "message": message, "slack_webhook_id": slack_webhook_id}]
+    return [{"destination_config_id": destination_config_id, "message": message}]
 
 
 def _validate_schedule_fields(
@@ -157,26 +131,19 @@ def _validate_schedule_fields(
 
 
 def _parse_actions(raw: str) -> list[dict[str, Any]]:
-    """Actions stored in ``action_json``. An old single-destination blob
-    (``{"message":.., "destination":..}``) reads as one action."""
+    """Actions stored in ``action_json``. A legacy single-destination blob
+    reads as one event-log action."""
     parsed = cast(dict[str, Any], json.loads(raw))
     raw_actions = parsed.get("actions")
     if isinstance(raw_actions, list) and raw_actions:
         return [
             {
-                "type": a.get("type"),
+                "destination_config_id": a.get("destination_config_id"),
                 "message": a.get("message"),
-                "slack_webhook_id": a.get("slack_webhook_id"),
             }
             for a in cast(list[dict[str, Any]], raw_actions)
         ]
-    return [
-        {
-            "type": parsed.get("destination"),
-            "message": parsed.get("message"),
-            "slack_webhook_id": parsed.get("slack_webhook_id"),
-        }
-    ]
+    return [{"destination_config_id": None, "message": parsed.get("message")}]
 
 
 def _first_message(data: dict[str, Any]) -> object:
@@ -198,8 +165,7 @@ def _to_dict(t: Trigger) -> dict[str, Any]:
         "nl_description": t.nl_description,
         "actions": actions,
         "message": first.get("message"),
-        "destination": first["type"],
-        "slack_webhook_id": first.get("slack_webhook_id"),
+        "destination_config_id": first.get("destination_config_id"),
         "enabled": t.enabled,
         "created_at": t.created_at,
         "last_edited_at": t.last_edited_at,
@@ -221,8 +187,7 @@ def create(
     scope_path: str,
     nl_description: str,
     message: str,
-    destination: object = None,
-    slack_webhook_id: object = None,
+    destination_config_id: object = None,
     kind: str = "delta",
     enabled: bool = True,
     actor: str | None = None,
@@ -238,12 +203,7 @@ def create(
         )
     if not message.strip():
         raise ValueError("message (the fire message) is required and must be a non-empty string")
-    destination_id = _validate_destination(destination)
-    webhook_id = _validate_slack_webhook(
-        destination=destination_id,
-        slack_webhook_id=slack_webhook_id,
-        owner_user_id=owner_user_id,
-    )
+    config_id = _validate_destination_config(destination_config_id, owner_user_id=owner_user_id)
     cron_value, tz_value, start_at_value = _validate_schedule_fields(
         kind=kind,
         schedule_cron=schedule_cron,
@@ -254,9 +214,7 @@ def create(
     trigger_id = "trg_" + uuid.uuid4().hex[:12]
     created_at = _now_iso()
     file_path = storage.compute_path(scope_path=scope_path, trigger_id=trigger_id)
-    actions = _one_action(
-        message=message.strip(), destination=destination_id, slack_webhook_id=webhook_id
-    )
+    actions = _one_action(message=message.strip(), destination_config_id=config_id)
     row_dict = {
         "id": trigger_id,
         "owner_user_id": owner_user_id,
@@ -324,8 +282,7 @@ def update(
     scope_path: str | None = None,
     nl_description: str | None = None,
     message: str | None = None,
-    destination: object = _UNSET,
-    slack_webhook_id: object = _UNSET,
+    destination_config_id: object = _UNSET,
     enabled: bool | None = None,
     actor: str | None = None,
     schedule_cron: str | None = None,
@@ -347,17 +304,10 @@ def update(
         if not message.strip():
             raise ValueError("message must be a non-empty string")
         new["message"] = message.strip()
-    if destination is not _UNSET:
-        new["destination"] = _validate_destination(destination)
-    if slack_webhook_id is not _UNSET:
-        new["slack_webhook_id"] = slack_webhook_id
-    # Re-resolve the channel reference against the *final* destination: a flip
-    # to slack requires a webhook, a flip away from slack nulls it.
-    new["slack_webhook_id"] = _validate_slack_webhook(
-        destination=new["destination"],
-        slack_webhook_id=new.get("slack_webhook_id"),
-        owner_user_id=existing["owner_user_id"],
-    )
+    if destination_config_id is not _UNSET:
+        new["destination_config_id"] = _validate_destination_config(
+            destination_config_id, owner_user_id=existing["owner_user_id"]
+        )
     if enabled is not None:
         new["enabled"] = enabled
     if schedule_cron is not None:
@@ -392,8 +342,7 @@ def update(
         new["scope_path"] == existing["scope_path"]
         and new["nl_description"] == existing["nl_description"]
         and new["message"] == existing["message"]
-        and new["destination"] == existing["destination"]
-        and new.get("slack_webhook_id") == existing.get("slack_webhook_id")
+        and new.get("destination_config_id") == existing.get("destination_config_id")
         and new["enabled"] == existing["enabled"]
         and new.get("schedule_cron") == existing.get("schedule_cron")
         and new.get("schedule_timezone") == existing.get("schedule_timezone")
@@ -402,9 +351,7 @@ def update(
         return existing
 
     new["actions"] = _one_action(
-        message=new["message"],
-        destination=new["destination"],
-        slack_webhook_id=new.get("slack_webhook_id"),
+        message=new["message"], destination_config_id=new.get("destination_config_id")
     )
     new_file_path = storage.compute_path(scope_path=new["scope_path"], trigger_id=trigger_id)
     old_file_path = existing.get("file_path")
@@ -679,9 +626,8 @@ def rebuild_from_filesystem() -> int:
 
             actions_payload = [
                 {
-                    "type": _validate_destination(a.get("type")),
+                    "destination_config_id": a.get("destination_config_id"),
                     "message": a.get("message"),
-                    "slack_webhook_id": a.get("slack_webhook_id"),
                 }
                 for a in data["actions"]
             ]

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -62,19 +62,13 @@ def serialize(trigger: dict[str, Any]) -> str:
         "scope_path": trigger["scope_path"],
         "kind": trigger["kind"],
         "nl_description": trigger["nl_description"],
-        "message": trigger.get("message"),
-        "destination": trigger.get("destination"),
+        "actions": _serialize_actions(trigger["actions"]),
         "enabled": bool(trigger["enabled"]),
         "created_at": trigger.get("created_at"),
     }
-    # Slack channel reference — emitted only for slack-destination triggers so
-    # other YAMLs stay clean. It's an opaque id (not the secret webhook URL,
-    # which lives only on the slack_webhooks row), so it's safe in the repo.
-    if trigger.get("slack_webhook_id") is not None:
-        payload["slack_webhook_id"] = trigger["slack_webhook_id"]
     # Schedule fields are emitted only when the trigger is schedule-kind, so
     # delta YAMLs stay clean. ``schedule_last_fired_at`` is intentionally
-    # *never* written — it's runtime state, and persisting it would commit
+    # *never* written: it's runtime state, and persisting it would commit
     # to the wiki repo on every fire.
     for key in ("schedule_cron", "schedule_timezone", "schedule_start_at"):
         value = trigger.get(key)
@@ -83,21 +77,65 @@ def serialize(trigger: dict[str, Any]) -> str:
     return yaml.safe_dump(payload, sort_keys=False)
 
 
+def _serialize_actions(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """One YAML entry per action, stable key order, empty optionals dropped.
+
+    ``slack_webhook_id`` is an opaque channel reference, not the secret webhook
+    URL (that lives only on the slack_webhooks row), so it's safe in the repo.
+    """
+    out: list[dict[str, Any]] = []
+    for action in actions:
+        entry: dict[str, Any] = {
+            "type": action["type"],
+            "message": action.get("message"),
+        }
+        if action.get("slack_webhook_id") is not None:
+            entry["slack_webhook_id"] = action["slack_webhook_id"]
+        out.append(entry)
+    return out
+
+
 def parse(yaml_text: str) -> dict[str, Any]:
-    """Parse a trigger YAML file. Optional fields default to ``None`` so
-    old or hand-written files without them still load.
+    """Parse a trigger YAML file into the canonical ``actions``-list shape.
+
+    Files written before multi-action carried a single ``message`` /
+    ``destination`` / ``slack_webhook_id`` at the top level. Those load as a
+    one-element action list so old triggers keep firing until rewritten.
     """
     data: object = yaml.safe_load(yaml_text)
     if not isinstance(data, dict) or "id" not in data:
         raise ValueError("invalid trigger file: missing 'id'")
     typed = cast(dict[str, Any], data)
-    typed.setdefault("message", None)
-    typed.setdefault("destination", None)
-    typed.setdefault("slack_webhook_id", None)
+    typed["actions"] = _parse_actions(typed)
+    for legacy in ("message", "destination", "slack_webhook_id"):
+        typed.pop(legacy, None)
     typed.setdefault("schedule_cron", None)
     typed.setdefault("schedule_timezone", None)
     typed.setdefault("schedule_start_at", None)
     return typed
+
+
+def _parse_actions(data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Read the ``actions`` list, or synthesize one action from the legacy
+    single-destination fields."""
+    raw = data.get("actions")
+    if isinstance(raw, list):
+        return [_normalize_action(a) for a in cast(list[dict[str, Any]], raw)]
+    return [
+        {
+            "type": data.get("destination"),
+            "message": data.get("message"),
+            "slack_webhook_id": data.get("slack_webhook_id"),
+        }
+    ]
+
+
+def _normalize_action(action: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": action.get("type"),
+        "message": action.get("message"),
+        "slack_webhook_id": action.get("slack_webhook_id"),
+    }
 
 
 def write_trigger(trigger: dict[str, Any], *, file_path: str, actor: str | None) -> str:

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -78,19 +78,14 @@ def serialize(trigger: dict[str, Any]) -> str:
 
 
 def _serialize_actions(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """One YAML entry per action, stable key order, empty optionals dropped.
-
-    ``slack_webhook_id`` is an opaque channel reference, not the secret webhook
-    URL (that lives only on the slack_webhooks row), so it's safe in the repo.
-    """
+    """One YAML entry per action. ``destination_config_id`` references a
+    ``destination_configs`` row and is absent for event-log actions."""
     out: list[dict[str, Any]] = []
     for action in actions:
-        entry: dict[str, Any] = {
-            "type": action["type"],
-            "message": action.get("message"),
-        }
-        if action.get("slack_webhook_id") is not None:
-            entry["slack_webhook_id"] = action["slack_webhook_id"]
+        entry: dict[str, Any] = {}
+        if action.get("destination_config_id") is not None:
+            entry["destination_config_id"] = action["destination_config_id"]
+        entry["message"] = action.get("message")
         out.append(entry)
     return out
 
@@ -98,9 +93,10 @@ def _serialize_actions(actions: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def parse(yaml_text: str) -> dict[str, Any]:
     """Parse a trigger YAML file into the canonical ``actions``-list shape.
 
-    Files written before multi-action carried a single ``message`` /
-    ``destination`` / ``slack_webhook_id`` at the top level. Those load as a
-    one-element action list so old triggers keep firing until rewritten.
+    Files written before destination configs carried a single ``message`` /
+    ``destination`` / ``slack_webhook_id`` at the top level. Those load as one
+    event-log action here; the reconcile maps any slack channel to its
+    destination config and rewrites the file.
     """
     data: object = yaml.safe_load(yaml_text)
     if not isinstance(data, dict) or "id" not in data:
@@ -116,25 +112,18 @@ def parse(yaml_text: str) -> dict[str, Any]:
 
 
 def _parse_actions(data: dict[str, Any]) -> list[dict[str, Any]]:
-    """Read the ``actions`` list, or synthesize one action from the legacy
-    single-destination fields."""
+    """Read the ``actions`` list, or synthesize one event-log action from a
+    legacy single-destination file (the reconcile fixes slack mappings)."""
     raw = data.get("actions")
     if isinstance(raw, list):
         return [_normalize_action(a) for a in cast(list[dict[str, Any]], raw)]
-    return [
-        {
-            "type": data.get("destination"),
-            "message": data.get("message"),
-            "slack_webhook_id": data.get("slack_webhook_id"),
-        }
-    ]
+    return [{"destination_config_id": None, "message": data.get("message")}]
 
 
 def _normalize_action(action: dict[str, Any]) -> dict[str, Any]:
     return {
-        "type": action.get("type"),
+        "destination_config_id": action.get("destination_config_id"),
         "message": action.get("message"),
-        "slack_webhook_id": action.get("slack_webhook_id"),
     }
 
 

--- a/backend/tests/_seed.py
+++ b/backend/tests/_seed.py
@@ -64,8 +64,15 @@ def seed_trigger(
     schedule_timezone: str | None = None,
     schedule_start_at: str | None = None,
     schedule_last_fired_at: str | None = None,
+    slack_webhook_id: str | None = None,
 ) -> str:
-    action_json = json.dumps({"message": message, "destination": destination})
+    action_json = json.dumps(
+        {
+            "actions": [
+                {"type": destination, "message": message, "slack_webhook_id": slack_webhook_id}
+            ]
+        }
+    )
     with session() as s:
         s.add(
             Trigger(

--- a/backend/tests/_seed.py
+++ b/backend/tests/_seed.py
@@ -57,21 +57,16 @@ def seed_trigger(
     scope_path: str,
     nl_description: str = "fire when status changes",
     message: str | None = None,
-    destination: str = "event_log",
+    destination_config_id: str | None = None,
     enabled: bool = True,
     kind: str = "delta",
     schedule_cron: str | None = None,
     schedule_timezone: str | None = None,
     schedule_start_at: str | None = None,
     schedule_last_fired_at: str | None = None,
-    slack_webhook_id: str | None = None,
 ) -> str:
     action_json = json.dumps(
-        {
-            "actions": [
-                {"type": destination, "message": message, "slack_webhook_id": slack_webhook_id}
-            ]
-        }
+        {"actions": [{"destination_config_id": destination_config_id, "message": message}]}
     )
     with session() as s:
         s.add(

--- a/backend/tests/test_save_to_fire_e2e.py
+++ b/backend/tests/test_save_to_fire_e2e.py
@@ -139,7 +139,8 @@ def test_save_fires_doc_scoped_trigger_to_event_log(signed_in, monkeypatch):
     assert payload["change_kind"] == "edit"
     assert payload["reason"] == "status flipped"
     assert payload["message"] == "[msg] status changed: status flipped"
-    assert payload["destination"] == "event_log"
+    assert payload["destination_type"] == "event_log"
+    assert payload["destination_config_id"] is None
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/tests/test_schedule_triggers.py
+++ b/backend/tests/test_schedule_triggers.py
@@ -45,7 +45,7 @@ def _record(**overrides):
         scope_path="a.md",
         kind="schedule",
         nl_description="x",
-        actions=[TriggerAction(type="event_log", message="m")],
+        actions=[TriggerAction(message="m")],
         enabled=True,
         file_path=None,
         created_at=None,

--- a/backend/tests/test_schedule_triggers.py
+++ b/backend/tests/test_schedule_triggers.py
@@ -37,7 +37,7 @@ class _FakeResp(BaseModel):
 
 
 def _record(**overrides):
-    from app.triggers.engine import TriggerRecord
+    from app.triggers.engine import TriggerAction, TriggerRecord
 
     base = TriggerRecord(
         id="trg_x",
@@ -45,8 +45,7 @@ def _record(**overrides):
         scope_path="a.md",
         kind="schedule",
         nl_description="x",
-        message="m",
-        destination="event_log",
+        actions=[TriggerAction(type="event_log", message="m")],
         enabled=True,
         file_path=None,
         created_at=None,

--- a/backend/tests/test_slack_dispatch.py
+++ b/backend/tests/test_slack_dispatch.py
@@ -1,9 +1,8 @@
-"""Tests for the Slack dispatch branch in ``_record_fire``.
+"""Slack dispatch in ``_record_fire``.
 
-A fire is *always* recorded to the events table; Slack delivery is an
-additive outbound POST that only happens when the destination is ``slack``
-and the trigger references a webhook the owner still owns — and a Slack
-failure must never lose the recorded event.
+A fire is always recorded to the events table. Slack delivery is an additive
+outbound POST that only happens when the action's destination config resolves
+to a slack secret, and a Slack failure must never lose the recorded event.
 """
 from __future__ import annotations
 
@@ -11,8 +10,8 @@ import pytest
 
 from app.models.wiki import ChangeKind
 from app.slack import client as slack_client
-from app.slack import webhooks as slack_webhooks
 from app.tasks.triggers import _record_fire
+from app.triggers import destination_configs as dest_configs
 from app.triggers.engine import TriggerAction, TriggerRecord
 
 from tests._seed import list_events, seed_user
@@ -21,7 +20,7 @@ _HOOK = "https://hooks.slack.com/services/EXAMPLE"
 _OWNER = "usr_1"
 
 
-def _trigger(*, destination: str, slack_webhook_id: str | None = None) -> TriggerRecord:
+def _trigger(*, destination_config_id: str | None) -> TriggerRecord:
     return TriggerRecord(
         id="trg_1",
         owner_user_id=_OWNER,
@@ -29,9 +28,7 @@ def _trigger(*, destination: str, slack_webhook_id: str | None = None) -> Trigge
         kind="delta",
         nl_description="fire when status changes",
         actions=[
-            TriggerAction(
-                type=destination, message="status changed", slack_webhook_id=slack_webhook_id
-            )
+            TriggerAction(destination_config_id=destination_config_id, message="status changed")
         ],
         enabled=True,
         file_path=None,
@@ -72,14 +69,19 @@ def _last_fire() -> dict:
     return fires[0]  # newest first
 
 
-def test_slack_destination_records_event_and_posts(tmp_db, _captured_post):
-    seed_user(_OWNER)
-    wh = slack_webhooks.create(_OWNER, "PM Standup", _HOOK)
+def _slack_config(owner: str = _OWNER, *, secret: str | None = _HOOK) -> str:
+    return dest_configs.create(owner, type="slack", name="PM Standup", secret=secret)["id"]
 
-    _fire(_trigger(destination="slack", slack_webhook_id=wh["id"]))
+
+def test_slack_config_records_event_and_posts(tmp_db, _captured_post):
+    seed_user(_OWNER)
+    cid = _slack_config()
+
+    _fire(_trigger(destination_config_id=cid))
 
     payload = _last_fire()["payload"]
-    assert payload["destination"] == "slack"
+    assert payload["destination_type"] == "slack"
+    assert payload["destination_config_id"] == cid
     assert payload["message"] == "Status flipped to done"
 
     assert len(_captured_post) == 1
@@ -87,46 +89,47 @@ def test_slack_destination_records_event_and_posts(tmp_db, _captured_post):
     assert _captured_post[0]["text"] == "Status flipped to done"
 
 
-def test_slack_without_channel_records_but_does_not_post(tmp_db, _captured_post):
+def test_event_log_records_but_does_not_post(tmp_db, _captured_post):
     seed_user(_OWNER)
 
-    _fire(_trigger(destination="slack", slack_webhook_id=None))
+    _fire(_trigger(destination_config_id=None))
 
-    assert _last_fire()["payload"]["destination"] == "slack"
-    assert _captured_post == []  # no channel → recorded only
-
-
-def test_slack_channel_not_owned_records_but_does_not_post(tmp_db, _captured_post):
-    seed_user(_OWNER)
-    seed_user("usr_other", email="other@x.com")
-    other_wh = slack_webhooks.create("usr_other", "Theirs", _HOOK)
-
-    # trg owner is _OWNER but references another user's webhook → must not post.
-    _fire(_trigger(destination="slack", slack_webhook_id=other_wh["id"]))
-
-    assert _last_fire()["payload"]["destination"] == "slack"
+    assert _last_fire()["payload"]["destination_type"] == "event_log"
     assert _captured_post == []
 
 
-def test_event_log_destination_never_posts(tmp_db, _captured_post):
+def test_slack_config_without_secret_records_but_does_not_post(tmp_db, _captured_post):
     seed_user(_OWNER)
+    cid = _slack_config(secret=None)
 
-    _fire(_trigger(destination="event_log"))
+    _fire(_trigger(destination_config_id=cid))
 
-    assert _last_fire()["payload"]["destination"] == "event_log"
+    assert _last_fire()["payload"]["destination_type"] == "slack"
+    assert _captured_post == []
+
+
+def test_config_not_owned_records_but_does_not_post(tmp_db, _captured_post):
+    seed_user(_OWNER)
+    seed_user("usr_other", email="other@x.com")
+    other_cid = _slack_config("usr_other")
+
+    # trg owner is _OWNER but references another user's config, so it must not post.
+    _fire(_trigger(destination_config_id=other_cid))
+
+    assert _last_fire()["payload"]["destination_type"] == "unknown"
     assert _captured_post == []
 
 
 def test_slack_failure_still_records_event(tmp_db, monkeypatch):
     seed_user(_OWNER)
-    wh = slack_webhooks.create(_OWNER, "PM Standup", _HOOK)
+    cid = _slack_config()
 
     def boom(*, webhook_url: str, text: str) -> None:
         raise slack_client.SlackApiError("slack is down")
 
     monkeypatch.setattr(slack_client, "post_message", boom)
 
-    # Must not raise — the fire is already recorded before dispatch.
-    _fire(_trigger(destination="slack", slack_webhook_id=wh["id"]))
+    # Must not raise: the fire is recorded before dispatch.
+    _fire(_trigger(destination_config_id=cid))
 
-    assert _last_fire()["payload"]["destination"] == "slack"
+    assert _last_fire()["payload"]["destination_type"] == "slack"

--- a/backend/tests/test_slack_dispatch.py
+++ b/backend/tests/test_slack_dispatch.py
@@ -13,7 +13,7 @@ from app.models.wiki import ChangeKind
 from app.slack import client as slack_client
 from app.slack import webhooks as slack_webhooks
 from app.tasks.triggers import _record_fire
-from app.triggers.engine import TriggerRecord
+from app.triggers.engine import TriggerAction, TriggerRecord
 
 from tests._seed import list_events, seed_user
 
@@ -28,9 +28,11 @@ def _trigger(*, destination: str, slack_webhook_id: str | None = None) -> Trigge
         scope_path="projects/foo.md",
         kind="delta",
         nl_description="fire when status changes",
-        message="status changed",
-        destination=destination,
-        slack_webhook_id=slack_webhook_id,
+        actions=[
+            TriggerAction(
+                type=destination, message="status changed", slack_webhook_id=slack_webhook_id
+            )
+        ],
         enabled=True,
         file_path=None,
         created_at=None,
@@ -41,13 +43,13 @@ def _trigger(*, destination: str, slack_webhook_id: str | None = None) -> Trigge
 def _fire(trigger: TriggerRecord, *, message: str = "Status flipped to done") -> None:
     _record_fire(
         trigger=trigger,
+        action=trigger.actions[0],
         doc_path="projects/foo.md",
         sha="abc123",
         change_kind=ChangeKind.EDIT,
         reason="status flipped",
         instruction="say what changed",
         rendered_message=message,
-        destination=trigger.destination,
         actor="U <u@x.com>",
     )
 

--- a/backend/tests/test_trigger_reconcile.py
+++ b/backend/tests/test_trigger_reconcile.py
@@ -62,3 +62,27 @@ def test_reconcile_migrates_event_log_trigger(tmp_repo):
     data = storage.read_trigger(path)
     assert data["actions"] == [{"destination_config_id": None, "message": "hi"}]
     assert dest_configs.list_for_user("usr_1") == []
+
+
+def test_reconcile_warns_when_webhook_missing(tmp_repo, caplog):
+    """A slack trigger whose source webhook is gone degrades to event-log only,
+    loudly: the drop is logged with the file, owner, and webhook id."""
+    import logging
+
+    seed_user("usr_1")
+    path = ".trigger_trg_gone.yaml"
+    _write_legacy(path, {
+        "id": "trg_gone", "owner_user_id": "usr_1", "scope_path": "a.md",
+        "kind": "delta", "nl_description": "fire", "message": "hi",
+        "destination": "slack", "slack_webhook_id": "wh_deleted", "enabled": True,
+    })
+
+    with caplog.at_level(logging.WARNING, logger="app.triggers.reconcile"):
+        assert reconcile_legacy_slack_triggers() == 1
+
+    data = storage.read_trigger(path)
+    assert data["actions"] == [{"destination_config_id": None, "message": "hi"}]
+    assert dest_configs.list_for_user("usr_1") == []
+    warning = next(r for r in caplog.records if "wh_deleted" in r.getMessage())
+    assert path in warning.getMessage()
+    assert "usr_1" in warning.getMessage()

--- a/backend/tests/test_trigger_reconcile.py
+++ b/backend/tests/test_trigger_reconcile.py
@@ -1,0 +1,64 @@
+"""Reconcile of legacy slack triggers into destination configs: a legacy YAML
+that names a slack_webhook_id gets a mirrored destination config and is
+rewritten to reference it, and the pass is idempotent.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from app.slack import webhooks as slack_webhooks
+from app.triggers import destination_configs as dest_configs
+from app.triggers import storage
+from app.triggers.reconcile import reconcile_legacy_slack_triggers
+from app.wiki import git as wiki_git
+
+from tests._seed import seed_user
+
+_HOOK = "https://hooks.slack.com/services/EXAMPLE"
+
+
+def _write_legacy(path: str, body: dict[str, Any]) -> None:
+    wiki_git.commit_file(path, yaml.safe_dump(body, sort_keys=False), f"seed {path}", author=None)
+
+
+def test_reconcile_migrates_slack_trigger(tmp_repo):
+    seed_user("usr_1")
+    wh = slack_webhooks.create("usr_1", "PM Standup", _HOOK)
+    path = ".trigger_trg_legacy.yaml"
+    _write_legacy(path, {
+        "id": "trg_legacy", "owner_user_id": "usr_1", "scope_path": "a.md",
+        "kind": "delta", "nl_description": "fire", "message": "hi",
+        "destination": "slack", "slack_webhook_id": wh["id"], "enabled": True,
+    })
+
+    assert reconcile_legacy_slack_triggers() == 1
+
+    configs = dest_configs.list_for_user("usr_1")
+    assert len(configs) == 1
+    cfg = configs[0]
+    assert cfg["type"] == "slack"
+    assert cfg["name"] == "PM Standup"
+    assert dest_configs.get_secret(cfg["id"], owner_user_id="usr_1") == _HOOK
+
+    data = storage.read_trigger(path)
+    assert data["actions"] == [{"destination_config_id": cfg["id"], "message": "hi"}]
+
+    # Idempotent: a second pass rewrites nothing and creates no duplicate config.
+    assert reconcile_legacy_slack_triggers() == 0
+    assert len(dest_configs.list_for_user("usr_1")) == 1
+
+
+def test_reconcile_migrates_event_log_trigger(tmp_repo):
+    seed_user("usr_1")
+    path = ".trigger_trg_ev.yaml"
+    _write_legacy(path, {
+        "id": "trg_ev", "owner_user_id": "usr_1", "scope_path": "a.md",
+        "kind": "delta", "nl_description": "fire", "message": "hi",
+        "destination": "event_log", "enabled": True,
+    })
+    assert reconcile_legacy_slack_triggers() == 1
+    data = storage.read_trigger(path)
+    assert data["actions"] == [{"destination_config_id": None, "message": "hi"}]
+    assert dest_configs.list_for_user("usr_1") == []

--- a/backend/tests/test_trigger_slack.py
+++ b/backend/tests/test_trigger_slack.py
@@ -1,14 +1,14 @@
-"""Trigger ↔ Slack-channel wiring at the repo layer.
-
-Covers ``_validate_slack_webhook``: a ``slack`` destination requires a
-webhook the owner owns, and a flip away from slack clears the reference.
-Uses ``tmp_repo`` because ``triggers_repo.create`` commits the YAML to git.
+"""Trigger destination-config validation and persistence: a trigger may
+reference a destination config the owner owns, an unowned id is rejected, and
+the reference survives a cache rebuild.
 """
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
-from app.slack import webhooks as slack_webhooks
+from app.triggers import destination_configs as dest_configs
 from app.triggers import repo as triggers_repo
 
 from tests._seed import seed_user
@@ -16,59 +16,49 @@ from tests._seed import seed_user
 _HOOK = "https://hooks.slack.com/services/EXAMPLE"
 
 
-def _create(owner: str, **kw):
+def _create(owner: str, *, destination_config_id: str | None = None) -> dict[str, Any]:
     return triggers_repo.create(
         owner_user_id=owner,
         scope_path="a.md",
-        nl_description="when status changes",
-        message="status changed",
-        **kw,
+        nl_description="fire",
+        message="m",
+        destination_config_id=destination_config_id,
     )
 
 
-def test_slack_trigger_with_owned_webhook(tmp_repo):
+def _slack_config(owner: str) -> str:
+    return dest_configs.create(owner, type="slack", name="PM Standup", secret=_HOOK)["id"]
+
+
+def test_trigger_with_owned_config(tmp_repo):
     seed_user("usr_1")
-    wh = slack_webhooks.create("usr_1", "PM Standup", _HOOK)
-    t = _create("usr_1", destination="slack", slack_webhook_id=wh["id"])
-    assert t["destination"] == "slack"
-    assert t["slack_webhook_id"] == wh["id"]
+    cid = _slack_config("usr_1")
+    t = _create("usr_1", destination_config_id=cid)
+    assert t["destination_config_id"] == cid
 
 
-def test_slack_trigger_without_webhook_rejected(tmp_repo):
+def test_trigger_rejects_unowned_config(tmp_repo):
     seed_user("usr_1")
-    with pytest.raises(ValueError):
-        _create("usr_1", destination="slack")
+    seed_user("usr_2", email="b@x.com")
+    cid = _slack_config("usr_2")
+    with pytest.raises(ValueError, match="destination_config_id"):
+        _create("usr_1", destination_config_id=cid)
 
 
-def test_slack_trigger_rejects_other_users_webhook(tmp_repo):
+def test_flip_to_event_log_clears_config(tmp_repo):
     seed_user("usr_1")
-    seed_user("usr_2", email="two@x.com")
-    wh = slack_webhooks.create("usr_2", "Theirs", _HOOK)
-    with pytest.raises(ValueError):
-        _create("usr_1", destination="slack", slack_webhook_id=wh["id"])
-
-
-def test_flip_to_event_log_clears_webhook(tmp_repo):
-    seed_user("usr_1")
-    wh = slack_webhooks.create("usr_1", "PM Standup", _HOOK)
-    t = _create("usr_1", destination="slack", slack_webhook_id=wh["id"])
-
-    updated = triggers_repo.update(t["id"], destination="event_log")
+    cid = _slack_config("usr_1")
+    t = _create("usr_1", destination_config_id=cid)
+    updated = triggers_repo.update(str(t["id"]), destination_config_id=None)
     assert updated is not None
-    assert updated["destination"] == "event_log"
-    assert updated["slack_webhook_id"] is None
+    assert updated["destination_config_id"] is None
 
 
-def test_rebuild_preserves_slack_webhook_id(tmp_repo):
-    # slack_webhook_id must survive rebuild_from_filesystem so the UI can still
-    # resolve the channel after a cache rebuild (boot, path move).
+def test_rebuild_preserves_destination_config_id(tmp_repo):
     seed_user("usr_1")
-    wh = slack_webhooks.create("usr_1", "PM Standup", _HOOK)
-    t = _create("usr_1", destination="slack", slack_webhook_id=wh["id"])
-
+    cid = _slack_config("usr_1")
+    t = _create("usr_1", destination_config_id=cid)
     triggers_repo.rebuild_from_filesystem()
-
-    rebuilt = triggers_repo.get(t["id"])
+    rebuilt = triggers_repo.get(str(t["id"]))
     assert rebuilt is not None
-    assert rebuilt["destination"] == "slack"
-    assert rebuilt["slack_webhook_id"] == wh["id"]
+    assert rebuilt["destination_config_id"] == cid

--- a/backend/tests/test_trigger_tools.py
+++ b/backend/tests/test_trigger_tools.py
@@ -45,7 +45,7 @@ def test_create_trigger_requires_message(as_user):
     assert "trigger_fire_message" in out["error"]
 
 
-def test_create_trigger_default_destination_is_event_log(as_user):
+def test_create_trigger_defaults_to_event_log(as_user):
     from app.llm.agents.tools.create_trigger import handle
 
     out = handle(
@@ -58,22 +58,7 @@ def test_create_trigger_default_destination_is_event_log(as_user):
     assert "error" not in out, out
     t = out["trigger"]
     assert t["message"] == "Guide rewritten"
-    assert t["destination"] == "event_log"
-
-
-def test_create_trigger_rejects_unknown_destination(as_user):
-    from app.llm.agents.tools.create_trigger import handle
-
-    out = handle(
-        {
-            "scope_path": "guide.md",
-            "trigger_nl_condition": "fire on rewrite",
-            "trigger_fire_message": "x",
-            "destination": "no_such_destination",
-        }
-    )
-    assert "error" in out
-    assert "destination" in out["error"]
+    assert t["destination_config_id"] is None
 
 
 # --------------------------------------------------------------------------- #
@@ -111,25 +96,6 @@ def test_update_trigger_changes_individual_fields(as_user):
 
     out = handle({"trigger_id": tid, "enabled": False})
     assert out["trigger"]["enabled"] is False
-
-
-def test_update_trigger_rejects_unknown_destination(as_user):
-    from app.llm.agents.tools.update_trigger import handle
-
-    tid = _seed_trigger(as_user)
-    out = handle({"trigger_id": tid, "destination": "no_such_destination"})
-    assert "error" in out
-    assert "destination" in out["error"]
-
-
-def test_update_trigger_accepts_explicit_null_destination(as_user):
-    """``null`` is a legacy alias for ``event_log`` — it normalizes, doesn't error."""
-    from app.llm.agents.tools.update_trigger import handle
-
-    tid = _seed_trigger(as_user)
-    out = handle({"trigger_id": tid, "destination": None})
-    assert "error" not in out, out
-    assert out["trigger"]["destination"] == "event_log"
 
 
 def test_update_trigger_rejects_other_users_trigger(as_user, monkeypatch):

--- a/backend/tests/test_triggers_api.py
+++ b/backend/tests/test_triggers_api.py
@@ -37,7 +37,7 @@ def test_create_then_list(client):
     assert body["id"].startswith("trg_")
     assert body["enabled"] is True
     assert body["message"] == "status flipped"
-    assert body["destination"] == "event_log"
+    assert body["destination_config_id"] is None
 
     res = client.get("/api/triggers")
     assert res.status_code == 200
@@ -76,11 +76,11 @@ def test_create_validation_errors(client):
     )
     assert res.status_code == 400
 
-    # unknown destination id
+    # unowned destination config
     res = client.post(
         "/api/triggers",
         json={"scope_path": "a.md", "nl_description": "x", "message": "m",
-              "destination": "no_such_destination"},
+              "destination_config_id": "dst_nonexistent"},
     )
     assert res.status_code == 400
 
@@ -119,11 +119,11 @@ def test_update_disable_then_re_enable(client):
     assert body["nl_description"] == "new"
     assert body["message"] == "m2"
 
-    # destination updates: known ids are ok, unknown ones rejected.
-    res = client.put(f"/api/triggers/{tid}", json={"destination": "event_log"})
+    # destination config updates: null clears it, an unowned id is rejected.
+    res = client.put(f"/api/triggers/{tid}", json={"destination_config_id": None})
     assert res.status_code == 200
     res = client.put(
-        f"/api/triggers/{tid}", json={"destination": "no_such_destination"}
+        f"/api/triggers/{tid}", json={"destination_config_id": "dst_nonexistent"}
     )
     assert res.status_code == 400
 

--- a/backend/tests/test_triggers_fanout.py
+++ b/backend/tests/test_triggers_fanout.py
@@ -29,7 +29,6 @@ def _seed_user_and_trigger(
     scope_path: str,
     tid: str = "trg_1",
     message: str = "tell me when status changes",
-    destination: str = "event_log",
 ) -> None:
     seed_user(uid="usr_1", email="u@x.com", is_admin=True)
     seed_trigger(
@@ -37,7 +36,6 @@ def _seed_user_and_trigger(
         owner_user_id="usr_1",
         scope_path=scope_path,
         message=message,
-        destination=destination,
     )
 
 
@@ -93,7 +91,7 @@ def test_fan_out_records_event_on_match_with_rendered_message(tmp_db, monkeypatc
     # is preserved alongside it for audit / re-render later.
     assert payload["message"] == "projects/foo.md flipped from green to yellow."
     assert payload["message_instruction"] == "tell me when status flips"
-    assert payload["destination"] == "event_log"
+    assert payload["destination_type"] == "event_log"
 
     # Render saw the same payload + reason the matcher produced.
     assert captured["instruction"] == "tell me when status flips"
@@ -319,23 +317,28 @@ def test_fan_out_doc_scope_create_uses_two_phase_flow(tmp_db, monkeypatch):
 
 def test_fan_out_dispatches_each_action(tmp_db, monkeypatch):
     """A multi-action trigger fires once per action: each renders its own
-    message and dispatches to its own destination."""
+    message and dispatches to its own destination config."""
     import json
 
     from app.db.models import Trigger
     from app.db.session import session
     from app.slack import client as slack_client
-    from app.slack import webhooks as slack_webhooks
     from app.tasks import triggers as trig_task
+    from app.triggers import destination_configs as dest_configs
     from app.triggers import engine
 
     seed_user(uid="usr_1", email="u@x.com", is_admin=True)
-    wh = slack_webhooks.create("usr_1", "PM Standup", "https://hooks.slack.com/services/EXAMPLE")
+    cfg = dest_configs.create(
+        "usr_1",
+        type="slack",
+        name="PM Standup",
+        secret="https://hooks.slack.com/services/EXAMPLE",
+    )
     action_json = json.dumps(
         {
             "actions": [
-                {"type": "event_log", "message": "log this", "slack_webhook_id": None},
-                {"type": "slack", "message": "ping slack", "slack_webhook_id": wh["id"]},
+                {"destination_config_id": None, "message": "log this"},
+                {"destination_config_id": cfg["id"], "message": "ping slack"},
             ]
         }
     )
@@ -371,10 +374,10 @@ def test_fan_out_dispatches_each_action(tmp_db, monkeypatch):
     trig_task.fan_out_trigger_eval("projects/foo.md", "deadbeef", "edit", None)
 
     fires = list_events(kind="trigger.fire")
-    assert sorted(f["payload"]["destination"] for f in fires) == ["event_log", "slack"]
-    by_dest = {f["payload"]["destination"]: f["payload"]["message"] for f in fires}
-    assert by_dest["event_log"] == "rendered:log this"
-    assert by_dest["slack"] == "rendered:ping slack"
+    assert sorted(f["payload"]["destination_type"] for f in fires) == ["event_log", "slack"]
+    by_type = {f["payload"]["destination_type"]: f["payload"]["message"] for f in fires}
+    assert by_type["event_log"] == "rendered:log this"
+    assert by_type["slack"] == "rendered:ping slack"
 
     # Only the slack action posts, with its own rendered message.
     assert len(posts) == 1

--- a/backend/tests/test_triggers_fanout.py
+++ b/backend/tests/test_triggers_fanout.py
@@ -315,3 +315,67 @@ def test_fan_out_doc_scope_create_uses_two_phase_flow(tmp_db, monkeypatch):
 
     rows = list_events(kind="trigger.fire")
     assert len(rows) == 1
+
+
+def test_fan_out_dispatches_each_action(tmp_db, monkeypatch):
+    """A multi-action trigger fires once per action: each renders its own
+    message and dispatches to its own destination."""
+    import json
+
+    from app.db.models import Trigger
+    from app.db.session import session
+    from app.slack import client as slack_client
+    from app.slack import webhooks as slack_webhooks
+    from app.tasks import triggers as trig_task
+    from app.triggers import engine
+
+    seed_user(uid="usr_1", email="u@x.com", is_admin=True)
+    wh = slack_webhooks.create("usr_1", "PM Standup", "https://hooks.slack.com/services/EXAMPLE")
+    action_json = json.dumps(
+        {
+            "actions": [
+                {"type": "event_log", "message": "log this", "slack_webhook_id": None},
+                {"type": "slack", "message": "ping slack", "slack_webhook_id": wh["id"]},
+            ]
+        }
+    )
+    with session() as s:
+        s.add(
+            Trigger(
+                id="trg_multi",
+                owner_user_id="usr_1",
+                scope_path="projects/foo.md",
+                kind="delta",
+                nl_description="fire when status changes",
+                action_json=action_json,
+                enabled=True,
+            )
+        )
+
+    _patch_io(monkeypatch, before="status: green\n", after="status: yellow\n")
+    monkeypatch.setattr(
+        engine, "nl_matches", lambda *a, **kw: MatchResult(matched=True, reason="changed")
+    )
+    monkeypatch.setattr(
+        engine,
+        "nl_render_message",
+        lambda instruction, payload, *, reason: f"rendered:{instruction}",
+    )
+    posts: list[dict] = []
+    monkeypatch.setattr(
+        slack_client,
+        "post_message",
+        lambda *, webhook_url, text: posts.append({"webhook_url": webhook_url, "text": text}),
+    )
+
+    trig_task.fan_out_trigger_eval("projects/foo.md", "deadbeef", "edit", None)
+
+    fires = list_events(kind="trigger.fire")
+    assert sorted(f["payload"]["destination"] for f in fires) == ["event_log", "slack"]
+    by_dest = {f["payload"]["destination"]: f["payload"]["message"] for f in fires}
+    assert by_dest["event_log"] == "rendered:log this"
+    assert by_dest["slack"] == "rendered:ping slack"
+
+    # Only the slack action posts, with its own rendered message.
+    assert len(posts) == 1
+    assert posts[0]["text"] == "rendered:ping slack"

--- a/backend/tests/test_triggers_repo.py
+++ b/backend/tests/test_triggers_repo.py
@@ -34,7 +34,7 @@ def test_create_and_get(tmp_repo):
     assert t["enabled"] is True
     assert t["kind"] == "delta"
     assert t["message"] == "status changed"
-    assert t["destination"] == "event_log"
+    assert t["destination_config_id"] is None
 
     fetched = repo.get(t["id"])
     assert fetched == t
@@ -131,17 +131,17 @@ def test_create_rejects_missing_message(tmp_repo):
         )
 
 
-def test_create_rejects_unknown_destination(tmp_repo):
+def test_create_rejects_unowned_destination_config(tmp_repo):
     from app.triggers import repo
 
     uid = seed_user(email="a@b.com")
-    with pytest.raises(ValueError, match="destination"):
+    with pytest.raises(ValueError, match="destination_config_id"):
         repo.create(
             owner_user_id=uid,
             scope_path="a.md",
             nl_description="x",
             message="m",
-            destination="no_such_destination",
+            destination_config_id="dst_nonexistent",
         )
 
 
@@ -247,6 +247,4 @@ def test_parse_actions_reads_legacy_single_destination_blob():
     from app.triggers.repo import _parse_actions
 
     legacy = json.dumps({"message": "hi", "destination": "slack"})
-    assert _parse_actions(legacy) == [
-        {"type": "slack", "message": "hi", "slack_webhook_id": None}
-    ]
+    assert _parse_actions(legacy) == [{"destination_config_id": None, "message": "hi"}]

--- a/backend/tests/test_triggers_repo.py
+++ b/backend/tests/test_triggers_repo.py
@@ -238,3 +238,15 @@ def test_single_doc_rename_relocates_doc_scoped_trigger(tmp_repo):
     assert got is not None
     assert got["scope_path"] == "notes/renamed.md"
     assert got["file_path"] == f"notes/.trigger_{t['id']}_renamed.yaml"
+
+
+def test_parse_actions_reads_legacy_single_destination_blob():
+    """A pre-multi-action ``action_json`` blob loads as one action."""
+    import json
+
+    from app.triggers.repo import _parse_actions
+
+    legacy = json.dumps({"message": "hi", "destination": "slack"})
+    assert _parse_actions(legacy) == [
+        {"type": "slack", "message": "hi", "slack_webhook_id": None}
+    ]

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -17,14 +17,12 @@ import {
   type FrequencyPreset,
 } from "@/lib/cron";
 import {
-  createSlackWebhook,
+  createDestinationConfig,
   createTrigger,
-  getTriggerDestinations,
   updateTrigger,
-  useSlackWebhooks,
+  useDestinationConfigs,
   type Trigger,
   type TriggerCreateInput,
-  type TriggerDestination,
   type TriggerKind,
 } from "@/lib/triggers";
 
@@ -36,14 +34,6 @@ interface Props {
   /** Lock the scope_path input so callers (e.g. doc page) can pin it. */
   lockScope?: boolean;
 }
-
-const FALLBACK_DESTINATIONS: TriggerDestination[] = [
-  {
-    id: "event_log",
-    name: "Event Log",
-    description: "Tracked in the event log only.",
-  },
-];
 
 const EXAMPLE_IF = "the document is updated with a release version";
 const EXAMPLE_SEND =
@@ -60,13 +50,10 @@ export function TriggerModal({
   const [scopePath, setScopePath] = useState("");
   const [ifText, setIfText] = useState("");
   const [sendText, setSendText] = useState("");
-  const [destinations, setDestinations] = useState<TriggerDestination[]>(
-    FALLBACK_DESTINATIONS,
+  const { configs, refresh: refreshConfigs } = useDestinationConfigs();
+  const [destinationConfigId, setDestinationConfigId] = useState<string | null>(
+    null,
   );
-  const [destination, setDestination] = useState(FALLBACK_DESTINATIONS[0].id);
-  const { webhooks: slackWebhooks, refresh: refreshSlackWebhooks } =
-    useSlackWebhooks();
-  const [slackWebhookId, setSlackWebhookId] = useState<string | null>(null);
   const [addingChannel, setAddingChannel] = useState(false);
   const [newChannelName, setNewChannelName] = useState("");
   const [newChannelUrl, setNewChannelUrl] = useState("");
@@ -85,8 +72,7 @@ export function TriggerModal({
     setScopePath(initial?.scope_path ?? "");
     setIfText(initial?.nl_description ?? "");
     setSendText(initial?.message ?? "");
-    setDestination(initial?.destination ?? FALLBACK_DESTINATIONS[0].id);
-    setSlackWebhookId(initial?.slack_webhook_id ?? null);
+    setDestinationConfigId(initial?.destination_config_id ?? null);
     setAddingChannel(false);
     setNewChannelName("");
     setNewChannelUrl("");
@@ -105,32 +91,12 @@ export function TriggerModal({
     initial?.scope_path,
     initial?.nl_description,
     initial?.message,
-    initial?.destination,
-    initial?.slack_webhook_id,
+    initial?.destination_config_id,
     initial?.kind,
     initial?.schedule_cron,
     initial?.schedule_timezone,
     initial?.schedule_start_at,
   ]);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    getTriggerDestinations()
-      .then((rows) => {
-        if (cancelled || rows.length === 0) return;
-        setDestinations(rows);
-        setDestination((cur) =>
-          rows.some((r) => r.id === cur) ? cur : rows[0].id,
-        );
-      })
-      .catch(() => {
-        // Keep fallback list silently.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
 
   if (!open) return null;
 
@@ -148,8 +114,7 @@ export function TriggerModal({
         scope_path: scopePath.trim(),
         nl_description: nl,
         message: msg,
-        destination,
-        slack_webhook_id: destination === "slack" ? slackWebhookId : null,
+        destination_config_id: destinationConfigId,
         kind,
       };
       if (kind === "schedule") {
@@ -170,8 +135,7 @@ export function TriggerModal({
           scope_path: scopePath.trim(),
           nl_description: nl,
           message: msg,
-          destination,
-          slack_webhook_id: destination === "slack" ? slackWebhookId : null,
+          destination_config_id: destinationConfigId,
           schedule_cron: kind === "schedule" ? computedCron : null,
           schedule_timezone: kind === "schedule" ? tz : null,
           schedule_start_at:
@@ -193,27 +157,18 @@ export function TriggerModal({
     scopePath.trim() &&
     ifText.trim() &&
     sendText.trim() &&
-    (kind === "delta" || (computedCron && tz)) &&
-    (destination !== "slack" || Boolean(slackWebhookId));
-  const selectedDest = destinations.find((d) => d.id === destination);
-  const destDescription =
-    destination === "slack" ? "" : (selectedDest?.description ?? "");
+    (kind === "delta" || (computedCron && tz));
+  const selectedConfig = configs.find((c) => c.id === destinationConfigId);
+  const destDescription = selectedConfig
+    ? ""
+    : "Tracked in the event log only.";
 
-  // The "TO" select value encodes a slack channel as ``slack:<id>`` so one
-  // control can pick Event Log or any of the user's channels.
-  const destSelectValue =
-    destination === "slack" && slackWebhookId
-      ? `slack:${slackWebhookId}`
-      : destination;
+  // The "TO" select encodes event-log as an empty value and any destination
+  // config by its id.
+  const destSelectValue = destinationConfigId ?? "";
 
   function onPickDestination(value: string) {
-    if (value.startsWith("slack:")) {
-      setDestination("slack");
-      setSlackWebhookId(value.slice("slack:".length));
-    } else {
-      setDestination(value);
-      setSlackWebhookId(null);
-    }
+    setDestinationConfigId(value === "" ? null : value);
   }
 
   async function onAddChannel() {
@@ -223,10 +178,13 @@ export function TriggerModal({
     setBusy(true);
     setError(null);
     try {
-      const created = await createSlackWebhook(name, url);
-      await refreshSlackWebhooks();
-      setDestination("slack");
-      setSlackWebhookId(created.id);
+      const created = await createDestinationConfig({
+        type: "slack",
+        name,
+        secret: url,
+      });
+      await refreshConfigs();
+      setDestinationConfigId(created.id);
       setAddingChannel(false);
       setNewChannelName("");
       setNewChannelUrl("");
@@ -360,27 +318,16 @@ export function TriggerModal({
             disabled={busy}
             className="box-border w-full cursor-pointer rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
           >
-            {destinations
-              .filter((d) => d.id !== "slack")
-              .map((d) => (
-                <option key={d.id} value={d.id}>
-                  {d.name}
-                </option>
-              ))}
-            {slackWebhooks.map((w) => (
-              <option key={w.id} value={`slack:${w.id}`}>
-                Slack · {w.name}
+            <option value="">Event log</option>
+            {configs.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.type} · {c.name}
               </option>
             ))}
           </select>
           {destDescription && (
             <span className="text-xs leading-[1.4] text-(--text-03)">
               {destDescription}
-            </span>
-          )}
-          {destination === "slack" && !slackWebhookId && (
-            <span className="text-xs leading-[1.4] text-(--status-text-error-05)">
-              Pick a Slack channel, or add one below.
             </span>
           )}
           {!addingChannel ? (

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -11,8 +11,7 @@ export interface Trigger {
   kind: TriggerKind;
   nl_description: string;
   message: string | null;
-  destination: string | null;
-  slack_webhook_id: string | null;
+  destination_config_id: string | null;
   enabled: boolean;
   created_at: string;
   last_edited_at: string;
@@ -35,8 +34,7 @@ export interface TriggerCreateInput {
   scope_path: string;
   nl_description: string;
   message: string;
-  destination?: string | null;
-  slack_webhook_id?: string | null;
+  destination_config_id?: string | null;
   enabled?: boolean;
   kind?: TriggerKind;
   schedule_cron?: string | null;
@@ -48,8 +46,7 @@ export interface TriggerUpdateInput {
   scope_path?: string;
   nl_description?: string;
   message?: string;
-  destination?: string | null;
-  slack_webhook_id?: string | null;
+  destination_config_id?: string | null;
   enabled?: boolean;
   schedule_cron?: string | null;
   schedule_timezone?: string | null;
@@ -100,7 +97,7 @@ export interface TriggerVersion {
   scope_path: string;
   nl_description: string;
   message: string | null;
-  destination: string | null;
+  destination_config_id: string | null;
   enabled: boolean;
   sha: string;
   path: string;
@@ -137,37 +134,42 @@ export function useTriggerDestinations() {
   return data?.destinations ?? [];
 }
 
-// ---- Slack channels (per-user named webhooks) ----
+// ---- Destination configs (per-user typed delivery targets) ----
 
-export interface SlackWebhook {
+export interface DestinationConfig {
   id: string;
+  type: string;
   name: string;
-  webhook_url_hint: string;
+  has_secret: boolean;
   created_at: string | null;
 }
 
-export function useSlackWebhooks() {
+export function useDestinationConfigs() {
   const { data, error, isLoading, mutate } = useSWR<{
-    webhooks: SlackWebhook[];
-  }>("/triggers/slack-webhooks");
+    configs: DestinationConfig[];
+  }>("/triggers/destination-configs");
   return {
-    webhooks: data?.webhooks ?? [],
+    configs: data?.configs ?? [],
     error: error as Error | undefined,
     isLoading,
     refresh: mutate,
   };
 }
 
-export function createSlackWebhook(
-  name: string,
-  webhook_url: string,
-): Promise<SlackWebhook> {
-  return apiFetch<SlackWebhook>("/triggers/slack-webhooks", {
+export function createDestinationConfig(input: {
+  type: string;
+  name: string;
+  secret?: string | null;
+  config?: Record<string, unknown>;
+}): Promise<DestinationConfig> {
+  return apiFetch<DestinationConfig>("/triggers/destination-configs", {
     method: "POST",
-    body: JSON.stringify({ name, webhook_url }),
+    body: JSON.stringify(input),
   });
 }
 
-export function deleteSlackWebhook(id: string): Promise<void> {
-  return apiFetch<void>(`/triggers/slack-webhooks/${id}`, { method: "DELETE" });
+export function deleteDestinationConfig(id: string): Promise<void> {
+  return apiFetch<void>(`/triggers/destination-configs/${id}`, {
+    method: "DELETE",
+  });
 }

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -13,13 +13,12 @@ import { useRequireAuth } from "@/lib/auth";
 import { describeCron } from "@/lib/cron";
 import { formatScopePath } from "@/lib/format";
 import {
-  createSlackWebhook,
-  deleteSlackWebhook,
+  createDestinationConfig,
+  deleteDestinationConfig,
   deleteTrigger,
   getTriggerVersion,
   updateTrigger,
-  useSlackWebhooks,
-  useTriggerDestinations,
+  useDestinationConfigs,
   useTriggers,
   type Trigger,
 } from "@/lib/triggers";
@@ -47,18 +46,11 @@ function formatRelative(iso: string | null | undefined): string {
 export default function TriggersPage() {
   const { user, loading } = useRequireAuth();
   const { triggers, error: listSwrError, refresh } = useTriggers();
-  const destinations = useTriggerDestinations();
-  const { webhooks: slackWebhooks } = useSlackWebhooks();
+  const { configs } = useDestinationConfigs();
   const destinationLabel = (t: Trigger) => {
-    if (t.destination === "slack") {
-      const ch = slackWebhooks.find((w) => w.id === t.slack_webhook_id);
-      return ch ? `Slack · ${ch.name}` : "Slack · (channel removed)";
-    }
-    return (
-      destinations.find((d) => d.id === t.destination)?.name ??
-      t.destination ??
-      "—"
-    );
+    if (!t.destination_config_id) return "Event log";
+    const cfg = configs.find((c) => c.id === t.destination_config_id);
+    return cfg ? `${cfg.type} · ${cfg.name}` : "(destination removed)";
   };
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -262,7 +254,7 @@ export default function TriggersPage() {
           ))}
         </ul>
 
-        <SlackChannelsCard />
+        <DestinationsCard />
       </SettingsLayouts.Body>
 
       <TriggerModal
@@ -299,7 +291,7 @@ export default function TriggersPage() {
               scope_path: version.scope_path,
               nl_description: version.nl_description,
               message: version.message,
-              destination: version.destination,
+              destination_config_id: version.destination_config_id,
               enabled: version.enabled,
               kind: version.kind ?? historyFor.kind,
               schedule_cron: version.schedule_cron,
@@ -319,8 +311,9 @@ export default function TriggersPage() {
   );
 }
 
-function SlackChannelsCard() {
-  const { webhooks, error, isLoading, refresh } = useSlackWebhooks();
+
+function DestinationsCard() {
+  const { configs, error, isLoading, refresh } = useDestinationConfigs();
   const [adding, setAdding] = useState(false);
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
@@ -333,13 +326,19 @@ function SlackChannelsCard() {
     setBusy(true);
     setFormError(null);
     try {
-      await createSlackWebhook(name.trim(), url.trim());
+      await createDestinationConfig({
+        type: "slack",
+        name: name.trim(),
+        secret: url.trim(),
+      });
       await refresh();
       setAdding(false);
       setName("");
       setUrl("");
     } catch (e) {
-      setFormError(e instanceof ApiError ? e.message : "failed to add channel");
+      setFormError(
+        e instanceof ApiError ? e.message : "failed to add destination",
+      );
     } finally {
       setBusy(false);
     }
@@ -349,13 +348,13 @@ function SlackChannelsCard() {
     if (
       !(await confirmDialog({
         title: `Delete "${label}"?`,
-        body: "Triggers posting to it will stop delivering to Slack.",
+        body: "Triggers pointing at it will stop delivering there.",
         confirmLabel: "Delete",
       }))
     )
       return;
     try {
-      await deleteSlackWebhook(id);
+      await deleteDestinationConfig(id);
       await refresh();
     } catch (e) {
       alert(e instanceof ApiError ? e.message : "failed to delete");
@@ -365,22 +364,22 @@ function SlackChannelsCard() {
   return (
     <section className="mt-[28px] rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-4">
       <div className="mb-1 flex items-center justify-between">
-        <h2 className="m-0 text-base">Slack channels</h2>
+        <h2 className="m-0 text-base">Destinations</h2>
         {!adding && (
           <Button size="sm" onClick={() => setAdding(true)}>
-            + Add channel
+            + Add Slack channel
           </Button>
         )}
       </div>
       <p className="mt-0 mb-3 text-[13px] text-(--text-03)">
-        Incoming webhooks you can point a trigger at. Create one in Slack (Apps
-        → Incoming Webhooks), then pick it as a trigger&apos;s destination.
-        Private to you.
+        Delivery targets you can point a trigger at. Create a Slack incoming
+        webhook (Apps &rarr; Incoming Webhooks), then pick it as a
+        trigger&apos;s destination. Private to you.
       </p>
 
       {error && (
         <div className="mb-2 text-[13px] text-(--status-text-error-05)">
-          {error.message || "Failed to load channels."}
+          {error.message || "Failed to load destinations."}
         </div>
       )}
 
@@ -389,7 +388,7 @@ function SlackChannelsCard() {
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Channel name (e.g. PM Standup)"
+            placeholder="Name (e.g. PM Standup)"
             disabled={busy}
             maxLength={80}
             className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
@@ -421,33 +420,34 @@ function SlackChannelsCard() {
         </div>
       )}
 
-      {isLoading && webhooks.length === 0 && !error && <LoadingSpinner />}
+      {isLoading && configs.length === 0 && !error && <LoadingSpinner />}
 
-      {!isLoading && webhooks.length === 0 && !adding && (
+      {!isLoading && configs.length === 0 && !adding && (
         <p className="m-0 text-sm text-(--text-03)">
-          No channels yet — add one to deliver trigger fires to Slack.
+          No destinations yet &mdash; add one to deliver trigger fires to Slack.
         </p>
       )}
 
-      {webhooks.length > 0 && (
+      {configs.length > 0 && (
         <ul className="m-0 list-none p-0">
-          {webhooks.map((w) => (
+          {configs.map((c) => (
             <li
-              key={w.id}
+              key={c.id}
               className="mt-2 flex items-center gap-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]"
             >
               <div className="min-w-0 flex-1">
                 <div className="text-sm font-medium text-(--text-05)">
-                  {w.name}
+                  {c.name}
                 </div>
                 <div className="mt-[2px] font-mono text-xs text-(--text-03)">
-                  {w.webhook_url_hint}
+                  {c.type}
+                  {c.has_secret ? " · secret set" : ""}
                 </div>
               </div>
               <Button
                 size="sm"
                 variant="danger"
-                onClick={() => void onDelete(w.id, w.name)}
+                onClick={() => void onDelete(c.id, c.name)}
               >
                 Delete
               </Button>

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -311,7 +311,6 @@ export default function TriggersPage() {
   );
 }
 
-
 function DestinationsCard() {
   const { configs, error, isLoading, refresh } = useDestinationConfigs();
   const [adding, setAdding] = useState(false);


### PR DESCRIPTION
## Description

Foundation for multi-destination triggers. A trigger's single destination becomes a list of actions, and dispatch loops over them.

- **Shape:** `action_json` and the trigger YAML now hold `{"actions": [{type, message, slack_webhook_id}]}`. A back-compat reader loads old single-destination triggers as one action, so live triggers keep firing.
- **Dispatch:** each action renders its own message and delivers to its own destination. `event_log` records the fire, `slack` posts to the action's channel.
- **Migration 0041:** folds the `slack_webhook_id` column into each action, then drops the column.

The HTTP API and agent tools stay single-action for now. Multi-action authoring is the next PR.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check