### PR TITLE
feat(coedit): checkpoint triggers — periodic scan, on-last-leave, explicit save (step 5b)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -17,6 +17,7 @@ from fastapi.responses import StreamingResponse
 from app.auth import User, require_can
 from app.auth.deps import require_user
 from app.models.coedit import (
+    CheckpointRequest,
     CursorRequest,
     JoinRequest,
     JoinResponse,
@@ -69,11 +70,22 @@ def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
     )
 
 
+def _checkpoint_if_last_left(session_id: int) -> None:
+    """Enqueue a final checkpoint when the last participant has left, so the
+    session's buffer lands in git without waiting for the periodic scan."""
+    if coedit.list_participants(session_id):
+        return
+    from app.tasks.coedit_checkpoint import checkpoint_coedit_session
+
+    checkpoint_coedit_session(session_id)
+
+
 @router.post("/leave")
 def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bool]:
     """Explicitly leave a session (e.g. closing the editor)."""
     coedit.leave(req.session_id, user.id)
     coedit_channel.broadcast_presence(req.session_id)
+    _checkpoint_if_last_left(req.session_id)
     return {"ok": True}
 
 
@@ -128,6 +140,20 @@ def cursor(req: CursorRequest, user: User = Depends(require_user)) -> dict[str, 
         typing=req.typing,
     )
     return {"ok": True}
+
+
+@router.post("/checkpoint")
+def checkpoint(req: CheckpointRequest, user: User = Depends(require_user)) -> dict[str, bool]:
+    """Explicit save: enqueue a checkpoint of the session's buffer to git.
+
+    Async (the commit + any merge run on the worker), so this returns once
+    queued rather than blocking on the git write.
+    """
+    _require_active(req.session_id, user, "write")
+    from app.tasks.coedit_checkpoint import checkpoint_coedit_session
+
+    checkpoint_coedit_session(req.session_id)
+    return {"queued": True}
 
 
 @router.get("/session")
@@ -197,6 +223,7 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
             if not coedit_channel.user_still_connected(session_id, user.id):
                 coedit.leave(session_id, user.id)
                 coedit_channel.broadcast_presence(session_id)
+                _checkpoint_if_last_left(session_id)
             log.info("coedit sse closed session=%s user=%s", session_id, user.id)
 
     return StreamingResponse(

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -26,6 +26,7 @@ from app.models.coedit import (
     OpResponse,
     ParticipantOut,
 )
+from app.tasks.coedit_checkpoint import checkpoint_coedit_session
 from app.wiki import coedit, coedit_channel, git
 
 router = APIRouter()
@@ -72,12 +73,17 @@ def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
 
 def _checkpoint_if_last_left(session_id: int) -> None:
     """Enqueue a final checkpoint when the last participant has left, so the
-    session's buffer lands in git without waiting for the periodic scan."""
+    session's buffer lands in git without waiting for the periodic scan.
+
+    Best-effort: the participant row is already gone, so a failed enqueue (e.g.
+    a full queue) must not fail the leave. The periodic scan is the backstop —
+    the session is dirty, so it's recovered (checkpointed + closed) once idle."""
     if coedit.list_participants(session_id):
         return
-    from app.tasks.coedit_checkpoint import checkpoint_coedit_session
-
-    checkpoint_coedit_session(session_id)
+    try:
+        checkpoint_coedit_session(session_id)
+    except Exception:
+        log.exception("coedit: checkpoint enqueue failed on last-leave for session %s", session_id)
 
 
 @router.post("/leave")
@@ -150,8 +156,6 @@ def checkpoint(req: CheckpointRequest, user: User = Depends(require_user)) -> di
     queued rather than blocking on the git write.
     """
     _require_active(req.session_id, user, "write")
-    from app.tasks.coedit_checkpoint import checkpoint_coedit_session
-
     checkpoint_coedit_session(req.session_id)
     return {"queued": True}
 

--- a/backend/app/db/migrations/versions/0042_coedit_normalize_timestamps.py
+++ b/backend/app/db/migrations/versions/0042_coedit_normalize_timestamps.py
@@ -1,0 +1,41 @@
+"""coedit_sessions: normalize legacy space-separated timestamps to _iso
+
+Sessions created before open_session started stamping created_at/updated_at in
+_iso format carry the space-separated server-default (``YYYY-MM-DD HH:MM:SS``).
+sessions_due_for_checkpoint compares those columns lexicographically against
+_iso cutoffs (``YYYY-MM-DDTHH:MM:SS+00:00``); a space sorts before ``T``, so a
+legacy row would look overdue immediately. Rewrite any such rows to _iso so the
+string comparison is well-ordered.
+
+Revision ID: 0042
+Revises: 0041
+Create Date: 2026-07-01 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+
+
+revision: str = "0042"
+down_revision: str | None = "0041"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # A legacy value has no 'T' separator; convert 'YYYY-MM-DD HH:MM:SS' to
+    # 'YYYY-MM-DDTHH:MM:SS+00:00'. Rows already in _iso (which contain 'T') are
+    # skipped, so this is idempotent.
+    for col in ("created_at", "updated_at", "last_checkpoint_at"):
+        op.execute(
+            f"UPDATE coedit_sessions "
+            f"SET {col} = replace({col}, ' ', 'T') || '+00:00' "
+            f"WHERE {col} IS NOT NULL AND position('T' in {col}) = 0"
+        )
+
+
+def downgrade() -> None:
+    # No-op: _iso timestamps are a valid superset; nothing to roll back.
+    pass

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -19,6 +19,10 @@ class LeaveRequest(BaseModel):
     session_id: int
 
 
+class CheckpointRequest(BaseModel):
+    session_id: int
+
+
 class OpRequest(BaseModel):
     session_id: int
     base_version: int

--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -45,10 +45,12 @@ def checkpoint_coedit_session(session_id: int) -> None:
     """Commit a session's buffer, then close it if everyone has since left.
 
     Re-checks participants after committing so a rejoin during the (brief)
-    enqueue window keeps the session open."""
+    enqueue window keeps the session open. Closes only if still clean, so a late
+    op landing after the checkpoint isn't sealed in a closed session (see
+    ``close_if_clean``)."""
     checkpoint_session(session_id)
     if not coedit.list_participants(session_id):
-        coedit.close_session(session_id)
+        coedit.close_if_clean(session_id)
 
 
 @documents_queue.periodic_task(crontab(minute="*"))

--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -1,0 +1,52 @@
+"""Checkpoint triggers — when the co-edit checkpoint engine fires.
+
+The engine (``app/wiki/coedit_checkpoint.py``) commits a session's live buffer
+to git. This wires up *when* that happens:
+
+* a periodic scan checkpoints dirty sessions that have gone idle or are overdue,
+* the last-participant-leave and explicit-save paths enqueue ``checkpoint_coedit_session``.
+
+Checkpointing does a git commit (and maybe an LLM merge), so it runs on
+``documents_queue`` — never inline in a web request.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.tasks.queue import crontab
+from app.tasks.queues import documents_queue
+from app.wiki import coedit
+from app.wiki.coedit_checkpoint import checkpoint_session
+
+log = logging.getLogger(__name__)
+
+# Commit a session ~after it settles, and never let a continuously-edited
+# session go uncommitted longer than the cap. The periodic scan is minute-
+# granular, so these are effectively "within a minute of going idle / of the
+# cap"; the on-last-leave path commits promptly without waiting for the scan.
+_IDLE_SECONDS = 20
+_MAX_INTERVAL_SECONDS = 120
+
+
+@documents_queue.task()
+def checkpoint_coedit_session(session_id: int) -> None:
+    """Commit a session's buffer, then close it if everyone has since left.
+
+    Re-checks participants after committing so a rejoin during the (brief)
+    enqueue window keeps the session open."""
+    checkpoint_session(session_id)
+    if not coedit.list_participants(session_id):
+        coedit.close_session(session_id)
+
+
+@documents_queue.periodic_task(crontab(minute="*"))
+def scan_and_checkpoint() -> None:
+    """Enqueue a checkpoint for every dirty session that's idle or overdue."""
+    due = coedit.sessions_due_for_checkpoint(
+        idle_seconds=_IDLE_SECONDS, max_interval_seconds=_MAX_INTERVAL_SECONDS
+    )
+    for sess in due:
+        checkpoint_coedit_session(sess.id)
+    if due:
+        log.info("coedit checkpoint scan: enqueued %d session(s)", len(due))

--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -21,12 +21,23 @@ from app.wiki.coedit_checkpoint import checkpoint_session
 
 log = logging.getLogger(__name__)
 
-# Commit a session ~after it settles, and never let a continuously-edited
-# session go uncommitted longer than the cap. The periodic scan is minute-
-# granular, so these are effectively "within a minute of going idle / of the
-# cap"; the on-last-leave path commits promptly without waiting for the scan.
-_IDLE_SECONDS = 20
-_MAX_INTERVAL_SECONDS = 120
+# Keep git history proportional to editing *sessions*, not keystrokes. The
+# live buffer in Postgres is the durable "stash"; git commits only mark real
+# boundaries, so history stays at ~one commit per session. The primary trigger
+# is on-last-leave; these timers are coarse backstops, not autosave.
+#
+# Idle: no *edit* for this long → flush and commit. Catches a session that
+# never formally closes (a tab left open keeps the SSE alive, so leave never
+# fires) once editing has clearly stopped.
+#
+# Max-interval: the only timer that commits *mid-session* during genuinely
+# continuous editing — a safety valve so agents/readers reading git HEAD don't
+# see a multi-hour session's stale content indefinitely. Coarse on purpose;
+# a marathon session yields a handful of commits, not a stream.
+#
+# The scan is minute-granular, so both fire "within a minute of" the threshold.
+_IDLE_SECONDS = 300
+_MAX_INTERVAL_SECONDS = 900
 
 
 @documents_queue.task()

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -30,6 +30,7 @@ from app.utils.logging import setup_logging
 _TASK_MODULES = (
     "app.tasks.agent_activity",
     "app.tasks.chat_title",
+    "app.tasks.coedit_checkpoint",
     "app.tasks.craft",
     "app.tasks.wiki_update",
     "app.tasks.expire_launch_artifacts",

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -20,11 +20,11 @@ unsaved buffer. See
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import func, select, update
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import CoeditOp, CoeditParticipant, CoeditSession, User
@@ -140,12 +140,19 @@ def open_session(path: str, *, base_sha: str | None, initial_buffer: str = "") -
         )
         if existing is not None:
             return _session_row(existing)
+        # Stamp created_at/updated_at in _iso (T-separated, +00:00) rather than
+        # letting the space-separated server_default fill them: sessions_due_for_
+        # checkpoint compares these against _iso cutoffs, and mixing the two
+        # string formats breaks the lexicographic ordering.
+        now = _iso(_now())
         fresh = CoeditSession(
             path=path,
             buffer_text=initial_buffer,
             version=0,
             base_sha=base_sha,
             status="active",
+            created_at=now,
+            updated_at=now,
         )
         s.add(fresh)
         try:
@@ -356,6 +363,42 @@ def mark_checkpointed(session_id: int, *, base_sha: str, version: int) -> None:
             )
             .execution_options(synchronize_session=False)
         )
+
+
+def sessions_due_for_checkpoint(
+    *, idle_seconds: int, max_interval_seconds: int
+) -> list[SessionRow]:
+    """Active, *dirty* sessions the periodic worker should checkpoint: either
+    idle (no edit for ``idle_seconds``) or overdue (not committed within
+    ``max_interval_seconds``, or never). All three compared columns
+    (``updated_at``, ``last_checkpoint_at``, ``created_at``) are written in
+    ``_iso`` format, so the lexicographic string comparisons are well-ordered.
+    """
+    now = _now()
+    idle_cutoff = _iso(now - timedelta(seconds=idle_seconds))
+    overdue_cutoff = _iso(now - timedelta(seconds=max_interval_seconds))
+    with session() as s:
+        rows = s.scalars(
+            select(CoeditSession)
+            .where(
+                CoeditSession.status == "active",
+                CoeditSession.version > CoeditSession.checkpointed_version,
+                or_(
+                    # settled: no edit for ``idle_seconds``
+                    CoeditSession.updated_at <= idle_cutoff,
+                    # overdue: not committed within ``max_interval_seconds`` —
+                    # measured from the last checkpoint, or session start if
+                    # never checkpointed (so a never-idle session still commits,
+                    # but a just-opened one isn't grabbed mid-typing).
+                    func.coalesce(
+                        CoeditSession.last_checkpoint_at, CoeditSession.created_at
+                    )
+                    <= overdue_cutoff,
+                ),
+            )
+            .order_by(CoeditSession.updated_at.asc())
+        ).all()
+        return [_session_row(r) for r in rows]
 
 
 def last_op_author(session_id: int) -> str | None:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -422,6 +422,32 @@ def close_session(session_id: int) -> None:
             sess.updated_at = _iso(_now())
 
 
+def close_if_clean(session_id: int) -> bool:
+    """Close the session only if it's clean (``version == checkpointed_version``).
+    Returns True if it closed.
+
+    Atomic, to avoid orphaning a late edit: after a checkpoint commits, an op can
+    still land (the session is ``active`` until this runs) and re-dirty the
+    buffer. The conditional ``UPDATE`` closes only when nothing new arrived — if
+    an op bumped ``version`` in the window, it matches no row and the session
+    stays active, so the periodic scan re-checkpoints the new edit rather than
+    sealing it in a closed session.
+    """
+    with session() as s:
+        closed = s.scalars(
+            update(CoeditSession)
+            .where(
+                CoeditSession.id == session_id,
+                CoeditSession.status == "active",
+                CoeditSession.version == CoeditSession.checkpointed_version,
+            )
+            .values(status="closed", updated_at=_iso(_now()))
+            .returning(CoeditSession.id)
+            .execution_options(synchronize_session=False)
+        ).one_or_none()
+        return closed is not None
+
+
 def rename_path(old_path: str, new_path: str) -> None:
     """Re-point sessions when a page moves (called from the move lifecycle)."""
     with session() as s:

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.auth import users as users_repo
 from app.main import create_app
+from app.tasks.queues import documents_queue
 from app.wiki import acl, coedit, git
 
 from tests._auth import login_fastapi
@@ -97,6 +98,55 @@ def test_leave_removes_participant(client):
     resp = client.post("/api/coedit/leave", json={"session_id": sid})
     assert resp.status_code == 200
     assert coedit.list_participants(sid) == []
+
+
+def test_leave_last_participant_checkpoints(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page("hello world")
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
+    )
+
+    # The last leave enqueues a checkpoint; immediate_mode runs it inline.
+    with documents_queue.immediate_mode():
+        assert client.post("/api/coedit/leave", json={"session_id": sid}).status_code == 200
+
+    assert git.read_file(_PATH) == "hi world"
+    assert coedit.get_active_session(_PATH) is None
+
+
+def test_checkpoint_endpoint_commits_buffer(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page("hello world")
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
+    )
+
+    with documents_queue.immediate_mode():
+        resp = client.post("/api/coedit/checkpoint", json={"session_id": sid})
+    assert resp.status_code == 200
+    assert resp.json() == {"queued": True}
+    assert git.read_file(_PATH) == "hi world"
+    # An explicit checkpoint doesn't close a session with an active participant.
+    assert coedit.get_active_session(_PATH) is not None
+
+
+def test_checkpoint_requires_write(client):
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
+    _seed_page()
+    acl.set_owner(_PATH, owner)  # owner-only
+    login_fastapi(client, owner)
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+
+    login_fastapi(client, other)
+    assert client.post("/api/coedit/checkpoint", json={"session_id": sid}).status_code == 403
 
 
 def _login_and_join(client, email="ada@x.com") -> int:

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import pytest
 
 from app.auth import users as users_repo
+from app.tasks import coedit_checkpoint as coedit_checkpoint_task
+from app.tasks.queues import documents_queue
 from app.wiki import coedit, coedit_checkpoint
 from app.wiki import git as wiki_git
 
@@ -75,6 +77,56 @@ def test_checkpoint_merges_concurrent_agent_commit(repo):
 
     # 3-way merge keeps both non-overlapping edits.
     assert wiki_git.read_file(_PATH) == "ONE\ntwo\nthree\nfour\nFIVE\n"
+
+
+def test_task_checkpoints_then_closes_when_empty(repo):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+    coedit.leave(sess.id, uid)  # last participant gone
+
+    with documents_queue.immediate_mode():
+        coedit_checkpoint_task.checkpoint_coedit_session(sess.id)
+
+    assert wiki_git.read_file(_PATH) == "hi world"
+    # No participants remained → the task closed the session.
+    assert coedit.get_active_session(_PATH) is None
+
+
+def test_task_keeps_session_open_when_participants_remain(repo):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+
+    with documents_queue.immediate_mode():
+        coedit_checkpoint_task.checkpoint_coedit_session(sess.id)
+
+    assert wiki_git.read_file(_PATH) == "hi world"
+    # A participant is still editing → session stays active.
+    st = coedit.get_active_session(_PATH)
+    assert st is not None
+    assert st.checkpointed_version == 1
+
+
+def test_scan_checkpoints_due_sessions(repo, monkeypatch):
+    # Force the scan's idle threshold to zero so a just-edited session is due.
+    monkeypatch.setattr(coedit_checkpoint_task, "_IDLE_SECONDS", 0)
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+    coedit.leave(sess.id, uid)
+
+    with documents_queue.immediate_mode():
+        coedit_checkpoint_task.scan_and_checkpoint()
+
+    assert wiki_git.read_file(_PATH) == "hi world"
+    assert coedit.get_active_session(_PATH) is None
 
 
 def test_commit_message_credits_other_participants_as_coauthors(repo):

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -146,6 +146,50 @@ def test_mark_checkpointed_never_regresses(users):
     assert fetched.base_sha == "sha6"
 
 
+def _due_ids(**kw) -> set[int]:
+    return {s.id for s in coedit.sessions_due_for_checkpoint(**kw)}
+
+
+def test_due_excludes_clean_session(users):
+    # Never edited (version == checkpointed_version) → never a checkpoint
+    # candidate, even with zero cutoffs.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="x")
+    assert _due_ids(idle_seconds=0, max_interval_seconds=0) == set()
+    assert s.id not in _due_ids(idle_seconds=0, max_interval_seconds=0)
+
+
+def test_due_includes_idle_dirty_session(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    # idle_seconds=0 → any past edit counts as settled; max_interval large so
+    # the idle branch alone is what selects it.
+    assert s.id in _due_ids(idle_seconds=0, max_interval_seconds=3600)
+
+
+def test_due_excludes_recently_edited_session(users):
+    # Dirty but just edited and never checkpointed: not idle, and not overdue
+    # (measured from session start) → not grabbed mid-typing.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    assert s.id not in _due_ids(idle_seconds=3600, max_interval_seconds=3600)
+
+
+def test_due_includes_overdue_active_session(users):
+    # Still actively edited (not idle) but past the max interval since session
+    # start → forced so a never-idle session can't stay uncommitted forever.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    assert s.id in _due_ids(idle_seconds=3600, max_interval_seconds=0)
+
+
+def test_due_excludes_session_clean_since_last_checkpoint(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    coedit.mark_checkpointed(s.id, base_sha="sha", version=1)
+    # version == checkpointed_version again → no longer dirty.
+    assert _due_ids(idle_seconds=0, max_interval_seconds=0) == set()
+
+
 def test_close_frees_path_for_new_session(users):
     first = coedit.open_session(_PATH, base_sha=None)
     coedit.close_session(first.id)

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 import pytest
 
+from sqlalchemy import text
+
 from app.db.models import CoeditSession
+from app.db.session import session as db_session
 from app.wiki import coedit
 from tests._seed import count_rows, seed_user
 
@@ -180,6 +183,36 @@ def test_due_includes_overdue_active_session(users):
     s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
     coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
     assert s.id in _due_ids(idle_seconds=3600, max_interval_seconds=0)
+
+
+def test_legacy_space_separated_created_at_normalized_not_overdue(users):
+    # A pre-migration row carries the space-separated server-default created_at.
+    # Space sorts before 'T', so before normalization such a fresh, never-
+    # checkpointed dirty session looks overdue against an _iso cutoff.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    with db_session() as sess:
+        sess.execute(
+            text(
+                "UPDATE coedit_sessions "
+                "SET created_at = replace(replace(created_at, 'T', ' '), '+00:00', '') "
+                "WHERE id = :i"
+            ),
+            {"i": s.id},
+        )
+    # Documents the bug the migration fixes: falsely overdue while well inside
+    # the max interval.
+    assert s.id in _due_ids(idle_seconds=3600, max_interval_seconds=3600)
+
+    # Migration 0042's normalization.
+    with db_session() as sess:
+        sess.execute(
+            text(
+                "UPDATE coedit_sessions SET created_at = replace(created_at, ' ', 'T') || '+00:00' "
+                "WHERE position('T' in created_at) = 0"
+            )
+        )
+    assert s.id not in _due_ids(idle_seconds=3600, max_interval_seconds=3600)
 
 
 def test_due_excludes_session_clean_since_last_checkpoint(users):

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -190,6 +190,24 @@ def test_due_excludes_session_clean_since_last_checkpoint(users):
     assert _due_ids(idle_seconds=0, max_interval_seconds=0) == set()
 
 
+def test_close_if_clean_closes_a_clean_session(users):
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    coedit.mark_checkpointed(s.id, base_sha="sha", version=1)  # version == checkpointed
+    assert coedit.close_if_clean(s.id) is True
+    assert coedit.get_active_session(_PATH) is None
+
+
+def test_close_if_clean_skips_a_dirty_session(users):
+    # A late op after the checkpoint (version > checkpointed_version) must not be
+    # sealed in a closed session — close_if_clean leaves it active for the scan.
+    s = coedit.open_session(_PATH, base_sha=None, initial_buffer="hi")
+    coedit.apply_op(s.id, base_version=0, changes=[_ch(0, 2, "yo")], author_user_id="usr_a")
+    assert coedit.close_if_clean(s.id) is False
+    active = coedit.get_active_session(_PATH)
+    assert active is not None and active.id == s.id
+
+
 def test_close_frees_path_for_new_session(users):
     first = coedit.open_session(_PATH, base_sha=None)
     coedit.close_session(first.id)


### PR DESCRIPTION
## What

Step 5b of co-editing: wires up **when** the checkpoint engine (step 5a, #310) commits a live session's buffer to git. Backend only.

Three triggers:

1. **Periodic scan** — `scan_and_checkpoint` (a per-minute `documents_queue.periodic_task`) enqueues a checkpoint for every dirty session that has either gone **idle** (no edit for 20s) or is **overdue** (uncommitted for >120s).
2. **On last participant leaves** — `POST /api/coedit/leave` and the SSE stream's `finally` (on last-connection close) enqueue a final checkpoint so the buffer lands in git promptly, without waiting for the scan.
3. **Explicit save** — `POST /api/coedit/checkpoint` (write-gated) for a manual save.

All three go through `checkpoint_coedit_session` (a `documents_queue` task): it commits the buffer via the 5a engine, then closes the session if no participants remain (re-checked after the commit so a rejoin in the enqueue window keeps it open). Checkpointing does a git commit + possible LLM merge, so it always runs on the worker — never inline in a web request.

## Details

- `coedit.sessions_due_for_checkpoint(idle_seconds, max_interval_seconds)` — the due-query. "Overdue" is measured from the last checkpoint, or from session start (`created_at`) if never checkpointed, so a just-opened session isn't grabbed mid-typing while a continuously-edited one still commits within the cap.
- `open_session` now stamps `created_at`/`updated_at` in `_iso` format instead of the space-separated `server_default`, so the due-query's lexicographic string comparisons are well-ordered (matches how every other cutoff-compared column in the codebase is app-written).

## Tests

- Repo: `sessions_due_for_checkpoint` — clean excluded, idle included, recently-edited excluded (not grabbed mid-typing), overdue included, clean-since-last-checkpoint excluded.
- Task: checkpoint-then-close when empty, keep-open when participants remain, scan checkpoints due sessions.
- API: last-leave checkpoints + closes, explicit `/checkpoint` commits, `/checkpoint` requires write.

Whole-project ruff + basedpyright clean.

## Out of scope

Frontend editor; live-rebase of inbound agent commits into open sessions; folding drafts into the session store (step 6).