### PR TITLE
refactor(triggers): store action_json as jsonb

### DIFF
--- a/backend/app/db/migrations/versions/0044_action_json_jsonb.py
+++ b/backend/app/db/migrations/versions/0044_action_json_jsonb.py
@@ -1,0 +1,56 @@
+"""flip triggers.action_json from text to jsonb
+
+The column holds the actions structure and every reader treats it as a dict,
+so store it natively: no per-read parse, and it becomes queryable. Existing
+text rows are valid JSON, so a plain ``::jsonb`` cast converts them.
+
+Guarded on the live column type: a schema built fresh from the current models
+is already jsonb, an upgraded database still has text.
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-07-01 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "0044"
+down_revision: str | None = "0043"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _column_type() -> str:
+    cols = sa.inspect(op.get_bind()).get_columns("triggers")
+    return str(next(c["type"] for c in cols if c["name"] == "action_json")).lower()
+
+
+def upgrade() -> None:
+    if "json" not in _column_type():
+        op.alter_column(
+            "triggers",
+            "action_json",
+            existing_type=sa.Text(),
+            type_=JSONB(),
+            existing_nullable=False,
+            postgresql_using="action_json::jsonb",
+        )
+
+
+def downgrade() -> None:
+    if "json" in _column_type():
+        op.alter_column(
+            "triggers",
+            "action_json",
+            existing_type=JSONB(),
+            type_=sa.Text(),
+            existing_nullable=False,
+            postgresql_using="action_json::text",
+        )

--- a/backend/app/db/migrations/versions/0044_action_json_jsonb.py
+++ b/backend/app/db/migrations/versions/0044_action_json_jsonb.py
@@ -29,7 +29,10 @@ depends_on: str | Sequence[str] | None = None
 
 def _column_type() -> str:
     cols = sa.inspect(op.get_bind()).get_columns("triggers")
-    return str(next(c["type"] for c in cols if c["name"] == "action_json")).lower()
+    col = next((c for c in cols if c["name"] == "action_json"), None)
+    if col is None:
+        raise RuntimeError("triggers.action_json column not found")
+    return str(col["type"]).lower()
 
 
 def upgrade() -> None:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -440,10 +440,10 @@ class Trigger(Base):
     scope_path: Mapped[str] = mapped_column(Text, nullable=False)
     kind: Mapped[str] = mapped_column(Text, nullable=False)  # "delta" | "schedule"
     nl_description: Mapped[str] = mapped_column(Text, nullable=False)
-    # ``{"actions": [{"type", "message", "slack_webhook_id"}, ...]}``. ``type``
-    # is a ``trigger_destinations`` slug. The slack channel id (when any) lives
-    # inside the action. The wiki YAML is the source of truth for this shape.
-    action_json: Mapped[str] = mapped_column(Text, nullable=False)
+    # ``{"actions": [{"destination_config_id", "message"}, ...]}``. Each action
+    # references a ``destination_configs`` row (null id = event-log only). The
+    # wiki YAML is the source of truth for this shape.
+    action_json: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     schedule_cron: Mapped[str | None] = mapped_column(Text)
     # IANA timezone name (e.g. "America/Los_Angeles") that ``schedule_cron``
     # is interpreted in. Required when ``kind="schedule"``.

--- a/backend/app/triggers/destinations.py
+++ b/backend/app/triggers/destinations.py
@@ -1,6 +1,6 @@
 """Trigger destinations repo.
 
-A *destination* is the catalog row a trigger's ``action_json.destination``
+A *destination* is the catalog row a destination config's ``type``
 points at — i.e. where a fire is delivered. The seeded ``event_log``
 destination means "record the fire to the events table; don't dispatch
 outbound." Future destinations (webhook, agent message, …) get added by

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -67,9 +67,9 @@ def _validate_destination_config(
     return cid
 
 
-def _actions_json(actions: list[dict[str, Any]]) -> str:
-    """Serialize the actions list into the ``action_json`` column."""
-    return json.dumps({"actions": actions})
+def _actions_json(actions: list[dict[str, Any]]) -> dict[str, Any]:
+    """The ``action_json`` column value wrapping the actions list."""
+    return {"actions": actions}
 
 
 def _one_action(
@@ -130,10 +130,9 @@ def _validate_schedule_fields(
     return None, None, None
 
 
-def _parse_actions(raw: str) -> list[dict[str, Any]]:
+def _parse_actions(parsed: dict[str, Any]) -> list[dict[str, Any]]:
     """Actions stored in ``action_json``. A legacy single-destination blob
     reads as one event-log action."""
-    parsed = cast(dict[str, Any], json.loads(raw))
     raw_actions = parsed.get("actions")
     if isinstance(raw_actions, list) and raw_actions:
         return [

--- a/backend/tests/_seed.py
+++ b/backend/tests/_seed.py
@@ -65,9 +65,9 @@ def seed_trigger(
     schedule_start_at: str | None = None,
     schedule_last_fired_at: str | None = None,
 ) -> str:
-    action_json = json.dumps(
-        {"actions": [{"destination_config_id": destination_config_id, "message": message}]}
-    )
+    action_json = {
+        "actions": [{"destination_config_id": destination_config_id, "message": message}]
+    }
     with session() as s:
         s.add(
             Trigger(

--- a/backend/tests/test_action_json_jsonb_migration.py
+++ b/backend/tests/test_action_json_jsonb_migration.py
@@ -1,0 +1,51 @@
+"""0044 migration: a text ``action_json`` column holding JSON strings converts
+to jsonb in place.
+
+Normal test schemas get the column as jsonb straight from ``0001_initial``'s
+``create_all``, so the text->jsonb branch never runs there. This test
+reproduces a pre-0044 database by rewinding the column to text and the alembic
+stamp to 0043, then runs the real ``init_db()`` so 0044 actually converts.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from app.db.session import init_db, session
+from app.triggers import repo as triggers_repo
+
+from tests._seed import seed_trigger, seed_user
+
+
+def _rewind_to_text() -> None:
+    with session() as s:
+        s.execute(
+            sa.text(
+                "ALTER TABLE triggers ALTER COLUMN action_json "
+                "TYPE text USING action_json::text"
+            )
+        )
+        s.execute(sa.text("UPDATE alembic_version SET version_num = '0043'"))
+
+
+def test_text_action_json_converts_to_jsonb(tmp_db: object) -> None:
+    seed_user("usr_1")
+    seed_trigger(
+        tid="trg_1", owner_user_id="usr_1", scope_path="a.md", message="hi"
+    )
+    _rewind_to_text()
+
+    init_db()
+
+    with session() as s:
+        col_type = s.execute(
+            sa.text(
+                "SELECT data_type FROM information_schema.columns "
+                "WHERE table_schema = current_schema() "
+                "AND table_name = 'triggers' AND column_name = 'action_json'"
+            )
+        ).scalar_one()
+    assert col_type == "jsonb"
+
+    t = triggers_repo.get("trg_1")
+    assert t is not None
+    assert t["actions"] == [{"destination_config_id": None, "message": "hi"}]

--- a/backend/tests/test_triggers_fanout.py
+++ b/backend/tests/test_triggers_fanout.py
@@ -318,8 +318,6 @@ def test_fan_out_doc_scope_create_uses_two_phase_flow(tmp_db, monkeypatch):
 def test_fan_out_dispatches_each_action(tmp_db, monkeypatch):
     """A multi-action trigger fires once per action: each renders its own
     message and dispatches to its own destination config."""
-    import json
-
     from app.db.models import Trigger
     from app.db.session import session
     from app.slack import client as slack_client
@@ -334,14 +332,12 @@ def test_fan_out_dispatches_each_action(tmp_db, monkeypatch):
         name="PM Standup",
         secret="https://hooks.slack.com/services/EXAMPLE",
     )
-    action_json = json.dumps(
-        {
-            "actions": [
-                {"destination_config_id": None, "message": "log this"},
-                {"destination_config_id": cfg["id"], "message": "ping slack"},
-            ]
-        }
-    )
+    action_json = {
+        "actions": [
+            {"destination_config_id": None, "message": "log this"},
+            {"destination_config_id": cfg["id"], "message": "ping slack"},
+        ]
+    }
     with session() as s:
         s.add(
             Trigger(

--- a/backend/tests/test_triggers_repo.py
+++ b/backend/tests/test_triggers_repo.py
@@ -242,9 +242,7 @@ def test_single_doc_rename_relocates_doc_scoped_trigger(tmp_repo):
 
 def test_parse_actions_reads_legacy_single_destination_blob():
     """A pre-multi-action ``action_json`` blob loads as one action."""
-    import json
-
     from app.triggers.repo import _parse_actions
 
-    legacy = json.dumps({"message": "hi", "destination": "slack"})
+    legacy = {"message": "hi", "destination": "slack"}
     assert _parse_actions(legacy) == [{"destination_config_id": None, "message": "hi"}]


### PR DESCRIPTION
## Description

Follow-up to #311. Every reader treats `triggers.action_json` as a dict, so store it natively.

- Column flips from `Text` to `JSONB`; repo helpers pass dicts straight through, dropping the `json.dumps`/`json.loads` round-trip.
- Migration `0044` casts existing text rows in place (`::jsonb`), guarded on the live column type since fresh schemas already get jsonb from `create_all`.
- Conversion path covered by a rewind-and-upgrade migration test, same pattern as the `0030` encryption test.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check