### PR TITLE
fix(triggers): mirror every slack channel into destination_configs at boot

### DIFF
--- a/backend/app/slack/webhooks.py
+++ b/backend/app/slack/webhooks.py
@@ -38,6 +38,14 @@ def _to_dict(w: SlackWebhook) -> dict[str, Any]:
     }
 
 
+def list_all() -> list[dict[str, Any]]:
+    """Every stored webhook across all owners. Reconcile-only: no HTTP
+    surface exposes this."""
+    with session() as s:
+        rows = s.scalars(select(SlackWebhook)).all()
+        return [_to_dict(w) for w in rows]
+
+
 def list_for_user(user_id: str) -> list[dict[str, Any]]:
     """A user's webhooks, newest first."""
     with session() as s:

--- a/backend/app/slack/webhooks.py
+++ b/backend/app/slack/webhooks.py
@@ -39,11 +39,13 @@ def _to_dict(w: SlackWebhook) -> dict[str, Any]:
 
 
 def list_all() -> list[dict[str, Any]]:
-    """Every stored webhook across all owners. Reconcile-only: no HTTP
-    surface exposes this."""
+    """id/owner/name of every stored webhook across all owners. The secret URL
+    is deliberately not selected. Reconcile-only: no HTTP surface exposes this."""
     with session() as s:
-        rows = s.scalars(select(SlackWebhook)).all()
-        return [_to_dict(w) for w in rows]
+        rows = s.execute(
+            select(SlackWebhook.id, SlackWebhook.owner_user_id, SlackWebhook.name)
+        ).all()
+        return [{"id": r.id, "owner_user_id": r.owner_user_id, "name": r.name} for r in rows]
 
 
 def list_for_user(user_id: str) -> list[dict[str, Any]]:

--- a/backend/app/triggers/reconcile.py
+++ b/backend/app/triggers/reconcile.py
@@ -60,8 +60,18 @@ def reconcile_legacy_slack_triggers() -> int:
     """Mirror every stored Slack channel into ``destination_configs``, then
     rewrite trigger YAML still on the legacy single-destination shape into the
     destination-config shape. Returns the number of files rewritten."""
+    by_owner: dict[str, list[str]] = {}
     for hook in slack_webhooks.list_all():
-        _mirror_config_id(hook["id"], hook["owner_user_id"])
+        by_owner.setdefault(hook["owner_user_id"], []).append(hook["id"])
+    for owner, hook_ids in by_owner.items():
+        # One config listing per owner; steady-state boots create nothing.
+        mirrored = {
+            cast(dict[str, Any], c.get("config") or {}).get(_SOURCE_KEY)
+            for c in dest_configs.list_for_user(owner)
+        }
+        for hook_id in hook_ids:
+            if hook_id not in mirrored:
+                _mirror_config_id(hook_id, owner)
 
     rewritten = 0
     for file_path in storage.list_all_files():

--- a/backend/app/triggers/reconcile.py
+++ b/backend/app/triggers/reconcile.py
@@ -1,9 +1,11 @@
-"""One-time reconcile of legacy Slack triggers into destination configs.
+"""One-time reconcile of legacy Slack channels into destination configs.
 
-Before the ``destination_configs`` registry, a trigger's Slack channel lived in
-``slack_webhooks`` and was referenced by a top-level ``slack_webhook_id`` on the
-trigger YAML. This mirrors each such channel into a ``destination_configs`` row
-(once) and rewrites the trigger YAML to reference it by ``destination_config_id``.
+Before the ``destination_configs`` registry, a user's Slack channels lived in
+``slack_webhooks`` and a trigger referenced one by a top-level
+``slack_webhook_id`` on its YAML. This mirrors every stored channel into a
+``destination_configs`` row (once) so none disappear from the destinations UI,
+and rewrites legacy trigger YAML to reference the mirror by
+``destination_config_id``.
 
 Runs at boot before the cache rebuild. Already-reshaped triggers carry an
 ``actions`` list and are skipped, and each mirrored config is found by the
@@ -55,8 +57,12 @@ def _mirror_config_id(webhook_id: str, owner_user_id: str) -> str | None:
 
 
 def reconcile_legacy_slack_triggers() -> int:
-    """Rewrite trigger YAML still on the legacy single-destination shape into the
+    """Mirror every stored Slack channel into ``destination_configs``, then
+    rewrite trigger YAML still on the legacy single-destination shape into the
     destination-config shape. Returns the number of files rewritten."""
+    for hook in slack_webhooks.list_all():
+        _mirror_config_id(hook["id"], hook["owner_user_id"])
+
     rewritten = 0
     for file_path in storage.list_all_files():
         try:

--- a/backend/tests/test_trigger_reconcile.py
+++ b/backend/tests/test_trigger_reconcile.py
@@ -86,3 +86,21 @@ def test_reconcile_warns_when_webhook_missing(tmp_repo, caplog):
     warning = next(r for r in caplog.records if "wh_deleted" in r.getMessage())
     assert path in warning.getMessage()
     assert "usr_1" in warning.getMessage()
+
+
+def test_reconcile_mirrors_unattached_channels(tmp_repo):
+    """A stored Slack channel with no trigger referencing it still gets a
+    destination config, so it stays visible in the destinations UI."""
+    seed_user("usr_1")
+    slack_webhooks.create("usr_1", "Unattached", _HOOK)
+
+    reconcile_legacy_slack_triggers()
+
+    configs = dest_configs.list_for_user("usr_1")
+    assert [c["name"] for c in configs] == ["Unattached"]
+    assert configs[0]["type"] == "slack"
+    assert dest_configs.get_secret(configs[0]["id"], owner_user_id="usr_1") == _HOOK
+
+    # Idempotent: a second pass creates no duplicate.
+    reconcile_legacy_slack_triggers()
+    assert len(dest_configs.list_for_user("usr_1")) == 1


### PR DESCRIPTION
## Description

Needed before tonight's deploy.

The boot reconcile only mirrored Slack channels referenced by a legacy trigger. Channels users registered but never attached to a trigger stay in the dead `slack_webhooks` table and vanish from the destinations UI after the registry cutover.

Fix: mirror every stored `slack_webhooks` row into `destination_configs` before rewriting trigger YAML. Idempotent via the existing `from_slack_webhook` marker.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check