### PR TITLE
feat(coedit): collapse same-session checkpoints via git tip-amend (5c)

### DIFF
--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 def _tip_is_ours(head_sha: str, session_id: int) -> bool:
     """True if the repo tip is *this* session's own checkpoint commit — it
     carries our ``Coedit-session`` trailer, which means nothing else has
-    committed since, so the next checkpoint can amend it in place (5c)."""
+    committed since, so the next checkpoint can amend it in place."""
     return f"Coedit-session: {session_id}" in wiki_git.commit_message_of(head_sha).splitlines()
 
 
@@ -59,7 +59,7 @@ def _commit_message(session_id: int, *, primary_author_id: str | None) -> str:
         if u is not None:
             trailers.append(f"Co-authored-by: {u['name'] or u['email']} <{u['email']}>")
     # Tag the commit with the session id so the next checkpoint recognizes this
-    # tip as ours and amends it in place (collapse) rather than stacking (5c).
+    # tip as ours and amends it in place (collapse) rather than stacking.
     trailers.append(f"Coedit-session: {session_id}")
     lines.append("")
     lines.extend(trailers)
@@ -70,7 +70,7 @@ def checkpoint_session(session_id: int) -> str | None:
     """Commit a dirty session's buffer to git; return the new sha (or None).
 
     Collapses a run of same-session checkpoints into one commit by amending the
-    tip when it's still ours (5c); commits anew when an external commit broke the
+    tip when it's still ours; commits anew when an external commit broke the
     run, reconciling it via the gateway's 3-way + AI merge. No-op (returns None)
     when the session is gone, clean (``version == checkpointed_version``), or the
     merge collapses to the current HEAD. Idempotent: after a successful commit the
@@ -85,7 +85,7 @@ def checkpoint_session(session_id: int) -> str | None:
     author = _user(primary_id) if primary_id else None
     message = _commit_message(session_id, primary_author_id=primary_id)
 
-    # Collapse (5c): if the repo tip is *this session's* last checkpoint (nothing
+    # Collapse: if the repo tip is *this session's* last checkpoint (nothing
     # committed since), amend it in place so a run of checkpoints stays one
     # commit. If anything else committed — an agent, another session — the tip
     # isn't ours (or HEAD moves under the amend's CAS), so we commit anew through

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -25,9 +25,17 @@ from app.auth import users as users_repo
 from app.models.wiki import ChangeKind
 from app.wiki import coedit, coedit_channel
 from app.wiki import git as wiki_git
-from app.wiki.utils import commit_and_fan_out
+from app.wiki import notify as wiki_notify
+from app.wiki.utils import author_string, commit_and_fan_out
 
 log = logging.getLogger(__name__)
+
+
+def _tip_is_ours(head_sha: str, session_id: int) -> bool:
+    """True if the repo tip is *this* session's own checkpoint commit — it
+    carries our ``Coedit-session`` trailer, which means nothing else has
+    committed since, so the next checkpoint can amend it in place (5c)."""
+    return f"Coedit-session: {session_id}" in wiki_git.commit_message_of(head_sha).splitlines()
 
 
 def _user(user_id: str) -> User | None:
@@ -50,94 +58,105 @@ def _commit_message(session_id: int, *, primary_author_id: str | None) -> str:
         u = users_repo.get_by_id(p.user_id)
         if u is not None:
             trailers.append(f"Co-authored-by: {u['name'] or u['email']} <{u['email']}>")
-    if trailers:
-        lines.append("")
-        lines.extend(trailers)
+    # Tag the commit with the session id so the next checkpoint recognizes this
+    # tip as ours and amends it in place (collapse) rather than stacking (5c).
+    trailers.append(f"Coedit-session: {session_id}")
+    lines.append("")
+    lines.extend(trailers)
     return "\n".join(lines)
 
 
 def checkpoint_session(session_id: int) -> str | None:
     """Commit a dirty session's buffer to git; return the new sha (or None).
 
-    No-op (returns None) when the session is gone, clean
-    (``version == checkpointed_version``), or the merge collapses to the current
-    HEAD. Reconciles concurrent agent/ingest commits via the gateway's 3-way +
-    AI merge. Idempotent: after a successful commit the session is marked clean.
+    Collapses a run of same-session checkpoints into one commit by amending the
+    tip when it's still ours (5c); commits anew when an external commit broke the
+    run, reconciling it via the gateway's 3-way + AI merge. No-op (returns None)
+    when the session is gone, clean (``version == checkpointed_version``), or the
+    merge collapses to the current HEAD. Idempotent: after a successful commit the
+    session is marked clean.
     """
     sess = coedit.get_session(session_id)
     if sess is None or sess.version == sess.checkpointed_version:
         return None  # gone or nothing new to commit
 
     path = sess.path
-    # Merge base = the page content at the last checkpoint. None when the
-    # session was opened on a not-yet-existing page (→ create).
-    base_body = wiki_git.read_file_opt(path, ref=sess.base_sha) if sess.base_sha else None
-    change_kind = ChangeKind.EDIT if sess.base_sha else ChangeKind.CREATE
-
     primary_id = coedit.last_op_author(session_id)
     author = _user(primary_id) if primary_id else None
     message = _commit_message(session_id, primary_author_id=primary_id)
 
+    # Collapse (5c): if the repo tip is *this session's* last checkpoint (nothing
+    # committed since), amend it in place so a run of checkpoints stays one
+    # commit. If anything else committed — an agent, another session — the tip
+    # isn't ours (or HEAD moves under the amend's CAS), so we commit anew through
+    # the merge gateway, which starts a fresh run.
+    head = wiki_git.head_sha()
+    committed_body = sess.buffer_text
+    new_sha: str | None = None
+
     # System-initiated write: the editors' write permission was already enforced
     # when they joined/POSTed ops, so skip the ACL gate; not "agent activity".
     with set_current_user(author):
-        result = commit_and_fan_out(
-            path,
-            sess.buffer_text,
-            message,
-            change_kind=change_kind,
-            base_body=base_body,
-            ai_merge=True,
-            skip_acl=True,
-            record_activity=False,
-            # This is the session's own commit — don't fold it back into the
-            # session as an inbound rebase (we sync the merged result below).
-            trigger_coedit_rebase=False,
-        )
+        if head is not None and _tip_is_ours(head, session_id):
+            try:
+                amended = wiki_git.amend_head(
+                    path, sess.buffer_text, message,
+                    author=author_string(), expected_head=head,
+                )
+                # Amending needs no merge (nothing committed since our tip); run
+                # the same post-write fan-out a normal commit would, unless the
+                # buffer already matched the tip (amend_head returned it unchanged).
+                if amended != head:
+                    wiki_notify.after_doc_write(
+                        path, amended, ChangeKind.EDIT, author_string(),
+                        trigger_coedit_rebase=False,
+                    )
+                new_sha = amended
+            except wiki_git.GitHeadMovedError:
+                new_sha = None  # an external commit landed under us → new commit
 
-    if result is not None:
-        # Sync the committed content back into the buffer. When the commit-time
-        # 3-way merge folded in a concurrent agent/ingest commit, result.new_body
-        # differs from the buffer we committed; writing it back (and broadcasting
-        # the delta) keeps the live buffer == git and stops a later checkpoint
-        # from re-committing the pre-merge buffer and dropping the agent's edit.
-        res = coedit.rebase_onto(
-            session_id,
-            base_version=sess.version,
-            merged_text=result.new_body,
-            new_base_sha=result.sha,
-            checkpointed=True,
-        )
-        if res is None:
-            # A human op raced in during the commit, so the buffer moved past
-            # what we committed. Leave base_sha / checkpointed_version untouched:
-            # the session stays dirty and the next checkpoint does a proper 3-way
-            # merge (base=old, current=HEAD, incoming=newer buffer) that preserves
-            # the folded-in agent edit. Advancing base_sha to result.sha here
-            # would make that next merge base==current and drop the agent's edit.
-            log.info(
-                "coedit checkpoint: concurrent op during commit of %s; reconciling next checkpoint",
-                path,
+        if new_sha is None:
+            # New commit: first checkpoint of a run, or an external commit broke
+            # the run. Reconcile any such commit via the gateway's 3-way + AI merge.
+            base_body = wiki_git.read_file_opt(path, ref=sess.base_sha) if sess.base_sha else None
+            change_kind = ChangeKind.EDIT if sess.base_sha else ChangeKind.CREATE
+            result = commit_and_fan_out(
+                path, sess.buffer_text, message,
+                change_kind=change_kind, base_body=base_body, ai_merge=True,
+                skip_acl=True, record_activity=False, trigger_coedit_rebase=False,
             )
-        elif res.changed:
-            # The commit-time merge folded in a concurrent agent commit; tell
-            # participants to reload the merged buffer.
-            coedit_channel.broadcast_resync(session_id, res.session.version)
-        return result.sha
+            if result is None:
+                # No-op merge (buffer already matches HEAD content). Mark clean
+                # against current HEAD so we don't re-attempt this version forever.
+                head2 = wiki_git.head_sha_for_path(path)
+                if head2 is not None:
+                    coedit.mark_checkpointed(session_id, base_sha=head2, version=sess.version)
+                else:
+                    log.warning(
+                        "coedit checkpoint: no-op merge but no HEAD for %s (session %s); left dirty",
+                        path, session_id,
+                    )
+                return None
+            new_sha, committed_body = result.sha, result.new_body
 
-    # None = the merge produced exactly the current HEAD (buffer already matches
-    # committed content). Still mark clean against current HEAD so we don't
-    # re-attempt this version forever.
-    head = wiki_git.head_sha_for_path(path)
-    if head is not None:
-        coedit.mark_checkpointed(session_id, base_sha=head, version=sess.version)
-    else:
-        # Shouldn't happen — a no-op merge implies HEAD exists. Surface it rather
-        # than silently leaving the session dirty and re-entering this path on
-        # every future trigger.
-        log.warning(
-            "coedit checkpoint: no-op merge but no HEAD for %s (session %s); left dirty",
+    # Sync the committed content back into the buffer + advance base_sha /
+    # checkpointed_version. When the merge folded in a concurrent agent commit,
+    # committed_body differs from the buffer we started with, so participants get
+    # a resync. If a human op raced in during the commit, the version CAS misses
+    # (res is None) and we leave the session dirty for the next checkpoint — never
+    # advancing base_sha past content the buffer doesn't have.
+    res = coedit.rebase_onto(
+        session_id,
+        base_version=sess.version,
+        merged_text=committed_body,
+        new_base_sha=new_sha,
+        checkpointed=True,
+    )
+    if res is None:
+        log.info(
+            "coedit checkpoint: concurrent op during commit of %s; reconciling next checkpoint",
             path,
-            session_id,
         )
-    return None
+    elif res.changed:
+        coedit_channel.broadcast_resync(session_id, res.session.version)
+    return new_sha

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -184,6 +184,73 @@ def commit_file(
 _COMMIT_RETRY_MAX = 3
 
 
+def commit_message_of(sha: str) -> str:
+    """Full commit message (subject + body) of ``sha``, or ``""`` if unknown."""
+    res = _run(["log", "-1", "--format=%B", sha], check=False)
+    return res.stdout.rstrip("\n") if res.returncode == 0 else ""
+
+
+def amend_head(
+    rel_path: str,
+    body: str,
+    message: str,
+    author: str | None = None,
+    *,
+    expected_head: str,
+) -> str:
+    """Amend the tip commit in place with ``body`` at ``rel_path``; return the SHA.
+
+    Unlike :func:`commit_file` this **rewrites** HEAD (``git commit --amend``)
+    instead of adding a commit — the co-edit checkpoint uses it to collapse a run
+    of same-session checkpoints into one evolving commit. ``git commit --amend``
+    only ever touches the branch tip, so this is valid only when our last
+    checkpoint is still HEAD (nothing else committed since); the caller checks
+    that (a ``Coedit-session`` trailer on HEAD) before calling.
+
+    ``expected_head`` is a required CAS: under :func:`commit_lock` we re-check the
+    repo HEAD and raise ``GitHeadMovedError`` if anything advanced it (an agent /
+    another session), so we never amend a commit that isn't the one we intended.
+    The caller falls back to a normal commit on that error.
+
+    Returns the amended SHA, or the unchanged HEAD SHA when ``body`` already
+    matches the tip's content (nothing to amend).
+
+    Amending rewrites history — deliberately confined to provisional co-edit
+    checkpoint tips; see the Co-Editing design.
+    """
+    full = Path(CONFIG.wiki_dir) / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    with commit_lock():
+        current_head = _run(["rev-parse", "HEAD"], check=False).stdout.strip()
+        if current_head != expected_head:
+            raise GitHeadMovedError(rel_path, current_head)
+        full.write_text(body)
+        _run(["add", rel_path])
+        if _run(["diff", "--cached", "--quiet"], check=False).returncode == 0:
+            log.debug("amend_head no-op (no diff) %s sha=%s", rel_path, current_head[:8])
+            return current_head
+        env_args = ["--author", author] if author else []
+        for attempt in range(_COMMIT_RETRY_MAX + 1):
+            try:
+                _run(["commit", "--amend", "-m", message, *env_args])
+                break
+            except subprocess.CalledProcessError as e:
+                out = ((e.stderr or "") + (e.stdout or "")).lower()
+                if "cannot lock ref" in out or ("unable to create" in out and ".lock" in out):
+                    if attempt >= _COMMIT_RETRY_MAX:
+                        raise GitCommitLockError(rel_path) from e
+                    log.info(
+                        "amend_head: lock race for %s, retrying (%d/%d)",
+                        rel_path, attempt + 1, _COMMIT_RETRY_MAX,
+                    )
+                    time.sleep(0.05 * (attempt + 1))
+                    continue
+                raise
+        sha = _run(["rev-parse", "HEAD"]).stdout.strip()
+    log.debug("amend_head %s sha=%s author=%s", rel_path, sha[:8], author or "default")
+    return sha
+
+
 def move_and_commit(
     old_rel_path: str,
     new_rel_path: str,
@@ -398,6 +465,14 @@ def _numstat_by_sha(rel_path: str, limit: int) -> dict[str, tuple[int, int]]:
 def head_sha_for_path(rel_path: str) -> str | None:
     """SHA of the most recent commit that touched ``rel_path``, or None."""
     out = _run(["log", "-n1", "--pretty=format:%H", "--", rel_path], check=False).stdout.strip()
+    return out or None
+
+
+def head_sha() -> str | None:
+    """SHA at the repo tip (``HEAD``), or None on an empty repo. Unlike
+    :func:`head_sha_for_path` this is the branch tip regardless of which path the
+    last commit touched — it's what ``git commit --amend`` would rewrite."""
+    out = _run(["rev-parse", "HEAD"], check=False).stdout.strip()
     return out or None
 
 

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -136,6 +136,66 @@ def test_checkpoint_merges_concurrent_agent_commit(repo):
     assert wiki_git.read_file(_PATH) == "ONE\ntwo\nthree\nfour\nFIVE\n"
 
 
+def test_amend_head_replaces_tip_and_enforces_cas(repo):
+    sha1 = wiki_git.commit_file(_PATH, "one\n", "c1", author="A <a@x.com>")
+    n = len(wiki_git.history(_PATH))
+    sha2 = wiki_git.amend_head(_PATH, "ONE\n", "c1 amended", author="A <a@x.com>", expected_head=sha1)
+    assert sha2 != sha1
+    assert wiki_git.read_file(_PATH) == "ONE\n"
+    assert len(wiki_git.history(_PATH)) == n  # replaced the tip, didn't add a commit
+    # CAS: HEAD moved on, so amending against the stale expected_head is refused.
+    wiki_git.commit_file(_PATH, "two\n", "c2", author="A <a@x.com>")
+    with pytest.raises(wiki_git.GitHeadMovedError):
+        wiki_git.amend_head(_PATH, "x\n", "m", author="A <a@x.com>", expected_head=sha2)
+
+
+def test_consecutive_checkpoints_collapse_via_amend(repo):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("v0\n")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="v0\n")
+    coedit.join(sess.id, uid)
+
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(1, 2, "1")], author_user_id=uid)
+    sha1 = coedit_checkpoint.checkpoint_session(sess.id)
+    n1 = len(wiki_git.history(_PATH))
+
+    coedit.apply_op(sess.id, base_version=1, changes=[_ch(1, 2, "2")], author_user_id=uid)
+    sha2 = coedit_checkpoint.checkpoint_session(sess.id)
+    n2 = len(wiki_git.history(_PATH))
+
+    # Second checkpoint amended the tip in place — same commit count, new SHA.
+    assert n2 == n1
+    assert sha2 is not None and sha2 != sha1
+    assert wiki_git.read_file(_PATH) == "v2\n"
+    st = coedit.get_active_session(_PATH)
+    assert st is not None and st.base_sha == sha2 and st.checkpointed_version == st.version
+
+
+def test_external_commit_breaks_run_starts_new_commit(repo):
+    # Distant, non-overlapping edits so the merge is clean (no LLM).
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("one\ntwo\nthree\nfour\nfive\n")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="one\ntwo\nthree\nfour\nfive\n")
+    coedit.join(sess.id, uid)
+
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 3, "ONE")], author_user_id=uid)
+    coedit_checkpoint.checkpoint_session(sess.id)  # our tip: "ONE\ntwo\nthree\nfour\nfive\n"
+    # An external agent commits between checkpoints (last line) → run broken.
+    wiki_git.commit_file(
+        _PATH, "ONE\ntwo\nthree\nfour\nFIVE\n", "agent edit", author="Agent <a@x.com>"
+    )
+    n_before = len(wiki_git.history(_PATH))
+
+    # Human edits a distant line (third) → next checkpoint 3-way merges, new commit.
+    coedit.apply_op(sess.id, base_version=1, changes=[_ch(8, 13, "THREE")], author_user_id=uid)
+    coedit_checkpoint.checkpoint_session(sess.id)
+    n_after = len(wiki_git.history(_PATH))
+
+    # HEAD wasn't ours → a NEW commit (not an amend), and the merge kept both edits.
+    assert n_after == n_before + 1
+    assert wiki_git.read_file(_PATH) == "ONE\ntwo\nTHREE\nfour\nFIVE\n"
+
+
 def test_task_checkpoints_then_closes_when_empty(repo):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     sha = _seed_page("hello world")


### PR DESCRIPTION
## What

A run of checkpoints from a single co-edit session now collapses into **one git commit** instead of stacking one per checkpoint — so we can checkpoint often (fresh HEAD for agents) without exploding history.

Each checkpoint tags its commit with a `Coedit-session: <id>` trailer. The next checkpoint checks the repo tip: if it still carries *this* session's trailer (⇒ nothing else committed since), it **amends the tip in place**; otherwise (first checkpoint of a run, or an agent/other commit landed and broke the run) it commits anew through the existing 3-way-merge gateway, starting a fresh run.

## How

- **`git.amend_head(rel_path, body, message, author, *, expected_head)`** — `git commit --amend` under `commit_lock`, with a **required HEAD CAS**: re-checks `HEAD == expected_head` and raises `GitHeadMovedError` if anything advanced it, so we never amend a commit that isn't ours. Plus `git.head_sha()` (repo tip) and `git.commit_message_of()`.
- **`checkpoint_session`** — amend-vs-new decision via `_tip_is_ours` (trailer on HEAD). On `GitHeadMovedError` (an external commit slipped in under the CAS) it falls back to the new-commit path. Both paths then `rebase_onto(checkpointed=True)` to sync `base_sha`/`checkpointed_version` (same version-CAS + resync as #313). The amend path runs the same `after_doc_write` fan-out a normal commit would.
- **Additive-history relaxation** — amend rewrites the tip SHA, confined to *provisional co-edit tips* (guarded by the trailer + HEAD CAS), documented in the wrapper.

## Coordination (why it's safe)

- `git commit --amend` only touches the branch tip, so amend is used **only when our checkpoint is still HEAD**. Any other commit (agent, another session) makes the tip not-ours → new commit. The HEAD CAS closes the TOCTOU (external commit between the trailer check and the amend → abort → fall back).
- Our checkpoint/amend commits pass `trigger_coedit_rebase=False`, so they never enqueue a live-rebase against our own tip.
- Buffer/`base_sha` still coordinate through the optimistic version-CAS in `rebase_onto` (a raced human op leaves the session dirty for the next checkpoint) and the `is_ancestor` guard from #313. No new locks.

## Scope

In: the collapse mechanism + amend infra. **Out (→ 5d):** deferring trigger fan-out to run-finalization and re-tightening the checkpoint timers — timers stay coarse (5m/15m) and triggers still fire per checkpoint, so nothing regresses here.

## Tests

- `git.amend_head` replaces the tip (commit count unchanged) + enforces the HEAD CAS.
- Consecutive same-session checkpoints collapse to one commit (amend; same count, new SHA, latest content).
- An external commit between checkpoints starts a **new** commit (run boundary) and the merge keeps both edits.
- All existing checkpoint tests still pass (86 coedit+git green; ruff + basedpyright clean).

*(Note: some `test_wiki_drafts` tests fail locally with a 503 = LLM-not-configured; verified they fail identically on `main` with this branch stashed — a local-env artifact, unrelated to this change.)*