### PR TITLE
feat(slack): connection schema for the Slack app

### DIFF
--- a/backend/app/db/migrations/versions/0045_slack_connections.py
+++ b/backend/app/db/migrations/versions/0045_slack_connections.py
@@ -1,0 +1,73 @@
+"""slack connection tables
+
+Adds ``user_slack_connections`` (one encrypted bot token per user per
+workspace) and ``slack_connect_states`` (single-use CSRF state for the
+Connect-Slack handshake).
+
+Guarded on the live inspector because ``0001_initial`` runs
+``Base.metadata.create_all`` against the current model registry, so a fresh
+database already has both tables.
+
+Revision ID: 0045
+Revises: 0044
+Create Date: 2026-07-01 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0045"
+down_revision: str | None = "0044"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NOW = sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')")
+
+
+def upgrade() -> None:
+    tables = set(sa.inspect(op.get_bind()).get_table_names())
+
+    if "user_slack_connections" not in tables:
+        op.create_table(
+            "user_slack_connections",
+            sa.Column(
+                "user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column("team_id", sa.Text, primary_key=True),
+            sa.Column("team_name", sa.Text, nullable=True),
+            sa.Column("slack_user_id", sa.Text, nullable=False),
+            # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+            sa.Column("bot_token", sa.LargeBinary, nullable=False),
+            sa.Column("token_display", sa.Text, nullable=False),
+            sa.Column("scope", sa.Text, nullable=True),
+            sa.Column("created_at", sa.Text, nullable=False, server_default=_NOW),
+            sa.Column("updated_at", sa.Text, nullable=False, server_default=_NOW),
+        )
+
+    if "slack_connect_states" not in tables:
+        op.create_table(
+            "slack_connect_states",
+            sa.Column("state", sa.Text, primary_key=True),
+            sa.Column(
+                "user_id",
+                sa.Text,
+                sa.ForeignKey("users.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("return_to", sa.Text, nullable=True),
+            sa.Column("expires_at", sa.Text, nullable=False),
+            sa.Column("consumed_at", sa.Text, nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("slack_connect_states")
+    op.drop_table("user_slack_connections")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1394,6 +1394,47 @@ class CraftConnectState(Base):
     consumed_at: Mapped[str | None] = mapped_column(Text)
 
 
+class UserSlackConnection(Base):
+    """One per user per Slack workspace: the bot token saved by "Connect
+    Slack". Follows ``UserOnyxConnection``: the token is AES-GCM encrypted at
+    rest, there is no refresh flow, and on a decrypt failure or revocation the
+    row is dropped and the user re-connects."""
+
+    __tablename__ = "user_slack_connections"
+
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    team_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    team_name: Mapped[str | None] = mapped_column(Text)
+    # The connecting user's own Slack id, for DM-yourself delivery and
+    # attribution.
+    slack_user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    bot_token: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    # Masked form for display — never the raw token.
+    token_display: Mapped[str] = mapped_column(Text, nullable=False)
+    scope: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+
+
+class SlackConnectState(Base):
+    """Single-use CSRF state for the Connect-Slack handshake. Mirrors
+    ``CraftConnectState`` minus PKCE: Slack's OAuth v2 authenticates the
+    exchange with the client secret, so no code_verifier is stored."""
+
+    __tablename__ = "slack_connect_states"
+
+    state: Mapped[str] = mapped_column(Text, primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    # Relative path to bounce the browser back to after the callback.
+    return_to: Mapped[str | None] = mapped_column(Text)
+    expires_at: Mapped[str] = mapped_column(Text, nullable=False)
+    consumed_at: Mapped[str | None] = mapped_column(Text)
+
+
 class Notification(Base):
     """Persistent per-user notification (header bell / inbox).
 

--- a/backend/app/slack/connect_state.py
+++ b/backend/app/slack/connect_state.py
@@ -25,7 +25,7 @@ _STATE_TTL_SECONDS = 600
 
 
 def _iso(dt: datetime) -> str:
-    return dt.strftime("%Y-%m-%d %H:%M:%S")
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _now_iso() -> str:

--- a/backend/app/slack/connect_state.py
+++ b/backend/app/slack/connect_state.py
@@ -1,0 +1,76 @@
+"""Single-use CSRF state for the Connect-Slack handshake.
+
+Mirrors ``app/onyx/connect.py``'s mint/consume pair minus PKCE: Slack's OAuth
+v2 authenticates the code exchange with the client secret, so only the state
+token needs minting and single-use consumption.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import delete, select
+
+from app.db.models import SlackConnectState
+from app.db.session import session
+from app.onyx.connect import normalize_return_to
+
+log = logging.getLogger(__name__)
+
+_STATE_PREFIX = "slkst_"
+_STATE_TTL_SECONDS = 600
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _now_iso() -> str:
+    return _iso(datetime.now(timezone.utc))
+
+
+def mint_state(*, user_id: str, return_to: str | None) -> str:
+    """Create a state row and return the state token.
+
+    Clears any prior state rows for this user first — one connect handshake
+    in flight per user, so abandoned ones don't accumulate.
+    """
+    state = _STATE_PREFIX + secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc)
+    with session() as s:
+        s.execute(delete(SlackConnectState).where(SlackConnectState.user_id == user_id))
+        s.add(
+            SlackConnectState(
+                state=state,
+                user_id=user_id,
+                return_to=normalize_return_to(return_to),
+                expires_at=_iso(now + timedelta(seconds=_STATE_TTL_SECONDS)),
+            )
+        )
+    log.info("slack connect state minted user=%s", user_id)
+    return state
+
+
+def consume_state(state: str, *, user_id: str) -> dict[str, Any] | None:
+    """Atomically claim a state row. None on unknown/expired/replayed/foreign."""
+    if not state.startswith(_STATE_PREFIX):
+        return None
+    now_iso = _now_iso()
+    with session() as s:
+        row = s.scalar(
+            select(SlackConnectState).where(SlackConnectState.state == state).with_for_update()
+        )
+        if row is None:
+            return None
+        if row.user_id != user_id:
+            log.warning(
+                "slack connect state user mismatch state_user=%s caller=%s", row.user_id, user_id
+            )
+            return None
+        if row.consumed_at is not None or row.expires_at <= now_iso:
+            return None
+        row.consumed_at = now_iso
+        return {"return_to": row.return_to}

--- a/backend/app/slack/connections.py
+++ b/backend/app/slack/connections.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from cryptography.exceptions import InvalidTag
 from sqlalchemy import delete, select
+from sqlalchemy.orm import defer
 
 from app.db.models import UserSlackConnection
 from app.db.session import session
@@ -24,6 +25,12 @@ log = logging.getLogger(__name__)
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+# Read paths that don't need the token defer its column so the row loads
+# without decrypting — an undecryptable token (key rotation) must read as
+# "not connected", not raise from every status call.
+_DEFER_TOKEN = defer(UserSlackConnection.bot_token)
 
 
 def _to_dict(c: UserSlackConnection) -> dict[str, Any]:
@@ -51,7 +58,9 @@ def upsert(
 ) -> None:
     now = _now_iso()
     with session() as s:
-        row = s.get(UserSlackConnection, (user_id, team_id))
+        # Deferred token: the old value is overwritten, never read, so a
+        # re-connect still works after a key rotation.
+        row = s.get(UserSlackConnection, (user_id, team_id), options=[_DEFER_TOKEN])
         if row is None:
             s.add(
                 UserSlackConnection(
@@ -79,20 +88,22 @@ def upsert(
 def list_for_user(user_id: str) -> list[dict[str, Any]]:
     with session() as s:
         rows = s.scalars(
-            select(UserSlackConnection).where(UserSlackConnection.user_id == user_id)
+            select(UserSlackConnection)
+            .options(_DEFER_TOKEN)
+            .where(UserSlackConnection.user_id == user_id)
         ).all()
         return [_to_dict(c) for c in rows]
 
 
 def get(user_id: str, team_id: str) -> dict[str, Any] | None:
     with session() as s:
-        row = s.get(UserSlackConnection, (user_id, team_id))
+        row = s.get(UserSlackConnection, (user_id, team_id), options=[_DEFER_TOKEN])
         return _to_dict(row) if row else None
 
 
 def delete_connection(user_id: str, team_id: str) -> bool:
     with session() as s:
-        row = s.get(UserSlackConnection, (user_id, team_id))
+        row = s.get(UserSlackConnection, (user_id, team_id), options=[_DEFER_TOKEN])
         if row is None:
             return False
         s.delete(row)

--- a/backend/app/slack/connections.py
+++ b/backend/app/slack/connections.py
@@ -1,0 +1,122 @@
+"""Repo for ``user_slack_connections`` — one encrypted bot token per user per
+workspace.
+
+Follows ``app/onyx/connections.py``: reads/writes are plaintext here while the
+DB stores AES-GCM ciphertext, and a decrypt failure (key rotation) is treated
+as "not connected" — the stale row is dropped and the user re-connects.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import delete, select
+
+from app.db.models import UserSlackConnection
+from app.db.session import session
+from app.onyx.connections import mask_token
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _to_dict(c: UserSlackConnection) -> dict[str, Any]:
+    # Token deliberately omitted. Resolve it via ``get_bot_token``.
+    return {
+        "user_id": c.user_id,
+        "team_id": c.team_id,
+        "team_name": c.team_name,
+        "slack_user_id": c.slack_user_id,
+        "token_display": c.token_display,
+        "scope": c.scope,
+        "created_at": c.created_at,
+        "updated_at": c.updated_at,
+    }
+
+
+def upsert(
+    *,
+    user_id: str,
+    team_id: str,
+    team_name: str | None,
+    slack_user_id: str,
+    bot_token: str,
+    scope: str | None,
+) -> None:
+    now = _now_iso()
+    with session() as s:
+        row = s.get(UserSlackConnection, (user_id, team_id))
+        if row is None:
+            s.add(
+                UserSlackConnection(
+                    user_id=user_id,
+                    team_id=team_id,
+                    team_name=team_name,
+                    slack_user_id=slack_user_id,
+                    bot_token=bot_token,
+                    token_display=mask_token(bot_token),
+                    scope=scope,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        else:
+            row.team_name = team_name
+            row.slack_user_id = slack_user_id
+            row.bot_token = bot_token
+            row.token_display = mask_token(bot_token)
+            row.scope = scope
+            row.updated_at = now
+    log.info("slack connection upserted user=%s team=%s", user_id, team_id)
+
+
+def list_for_user(user_id: str) -> list[dict[str, Any]]:
+    with session() as s:
+        rows = s.scalars(
+            select(UserSlackConnection).where(UserSlackConnection.user_id == user_id)
+        ).all()
+        return [_to_dict(c) for c in rows]
+
+
+def get(user_id: str, team_id: str) -> dict[str, Any] | None:
+    with session() as s:
+        row = s.get(UserSlackConnection, (user_id, team_id))
+        return _to_dict(row) if row else None
+
+
+def delete_connection(user_id: str, team_id: str) -> bool:
+    with session() as s:
+        row = s.get(UserSlackConnection, (user_id, team_id))
+        if row is None:
+            return False
+        s.delete(row)
+    log.info("slack connection deleted user=%s team=%s", user_id, team_id)
+    return True
+
+
+def get_bot_token(user_id: str, team_id: str) -> str | None:
+    """Decrypt the bot token, owner-scoped. A decrypt failure (key rotation)
+    drops the row and reads as not-connected."""
+    try:
+        with session() as s:
+            row = s.get(UserSlackConnection, (user_id, team_id))
+            return row.bot_token if row else None
+    except InvalidTag:
+        log.warning(
+            "slack connection token undecryptable (key rotated?); dropping user=%s team=%s",
+            user_id, team_id,
+        )
+        with session() as s:
+            s.execute(
+                delete(UserSlackConnection).where(
+                    UserSlackConnection.user_id == user_id,
+                    UserSlackConnection.team_id == team_id,
+                )
+            )
+        return None

--- a/backend/tests/test_slack_connections.py
+++ b/backend/tests/test_slack_connections.py
@@ -124,3 +124,51 @@ def test_mint_clears_prior_state(tmp_db):
     first = connect_state.mint_state(user_id="usr_1", return_to=None)
     connect_state.mint_state(user_id="usr_1", return_to=None)
     assert connect_state.consume_state(first, user_id="usr_1") is None
+
+
+def _corrupt_stored_token(user_id: str) -> None:
+    """Overwrite the ciphertext so any decrypt raises InvalidTag, simulating a
+    rotated encryption key."""
+    raw_tbl = sa.table(
+        "user_slack_connections",
+        sa.column("user_id", sa.Text),
+        sa.column("bot_token", sa.LargeBinary),
+    )
+    with session() as s:
+        s.execute(
+            sa.update(raw_tbl)
+            .where(raw_tbl.c.user_id == user_id)
+            .values(bot_token=b"\x00" * 40)
+        )
+
+
+def test_undecryptable_token_reads_as_not_connected(tmp_db):
+    seed_user("usr_1")
+    _connect()
+    _corrupt_stored_token("usr_1")
+
+    # Status reads never touch the token column, so they still work.
+    assert connections.get("usr_1", "T123") is not None
+    assert len(connections.list_for_user("usr_1")) == 1
+
+    # Resolving the token drops the stale row and reads as not-connected.
+    assert connections.get_bot_token("usr_1", "T123") is None
+    assert connections.get("usr_1", "T123") is None
+
+    # Re-connecting after the drop works.
+    _connect()
+    assert connections.get_bot_token("usr_1", "T123") == _TOKEN
+
+
+def test_upsert_and_delete_survive_undecryptable_token(tmp_db):
+    seed_user("usr_1")
+    _connect()
+    _corrupt_stored_token("usr_1")
+
+    # Overwriting never reads the old ciphertext.
+    _connect()
+    assert connections.get_bot_token("usr_1", "T123") == _TOKEN
+
+    _corrupt_stored_token("usr_1")
+    assert connections.delete_connection("usr_1", "T123") is True
+    assert connections.list_for_user("usr_1") == []

--- a/backend/tests/test_slack_connections.py
+++ b/backend/tests/test_slack_connections.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 import sqlalchemy as sa
 
+from app.db.models import SlackConnectState
 from app.db.session import session
 from app.slack import connect_state, connections
 
@@ -43,9 +44,16 @@ def test_upsert_get_and_masking(tmp_db):
 def test_token_is_ciphertext_at_rest(tmp_db):
     seed_user("usr_1")
     _connect()
+    # A LargeBinary-typed shadow of the table reads the stored bytes without
+    # the EncryptedString decorator transparently decrypting them.
+    raw_tbl = sa.table(
+        "user_slack_connections",
+        sa.column("user_id", sa.Text),
+        sa.column("bot_token", sa.LargeBinary),
+    )
     with session() as s:
         raw = s.execute(
-            sa.text("SELECT bot_token FROM user_slack_connections WHERE user_id = 'usr_1'")
+            sa.select(raw_tbl.c.bot_token).where(raw_tbl.c.user_id == "usr_1")
         ).scalar_one()
     assert _TOKEN.encode() not in bytes(raw)
 
@@ -105,10 +113,9 @@ def test_state_expires(tmp_db):
     state = connect_state.mint_state(user_id="usr_1", return_to=None)
     past = (datetime.now(timezone.utc) - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
     with session() as s:
-        s.execute(
-            sa.text("UPDATE slack_connect_states SET expires_at = :e WHERE state = :st"),
-            {"e": past, "st": state},
-        )
+        row = s.get(SlackConnectState, state)
+        assert row is not None
+        row.expires_at = past
     assert connect_state.consume_state(state, user_id="usr_1") is None
 
 

--- a/backend/tests/test_slack_connections.py
+++ b/backend/tests/test_slack_connections.py
@@ -1,0 +1,119 @@
+"""Slack connection storage: bot tokens round-trip encrypted per (user, team),
+reads are owner-scoped, and connect states are single-use with a TTL."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import sqlalchemy as sa
+
+from app.db.session import session
+from app.slack import connect_state, connections
+
+from tests._seed import seed_user
+
+_TOKEN = "xoxb-agentwiki-test-token-0123456789"
+
+
+def _connect(uid: str = "usr_1", team: str = "T123") -> None:
+    connections.upsert(
+        user_id=uid,
+        team_id=team,
+        team_name="Onyx Team",
+        slack_user_id="U777",
+        bot_token=_TOKEN,
+        scope="chat:write,im:write",
+    )
+
+
+def test_upsert_get_and_masking(tmp_db):
+    seed_user("usr_1")
+    _connect()
+
+    row = connections.get("usr_1", "T123")
+    assert row is not None
+    assert row["team_name"] == "Onyx Team"
+    assert row["slack_user_id"] == "U777"
+    assert "bot_token" not in row
+    assert _TOKEN not in row["token_display"]
+    assert row["token_display"].startswith(_TOKEN[:12])
+
+    assert connections.get_bot_token("usr_1", "T123") == _TOKEN
+
+
+def test_token_is_ciphertext_at_rest(tmp_db):
+    seed_user("usr_1")
+    _connect()
+    with session() as s:
+        raw = s.execute(
+            sa.text("SELECT bot_token FROM user_slack_connections WHERE user_id = 'usr_1'")
+        ).scalar_one()
+    assert _TOKEN.encode() not in bytes(raw)
+
+
+def test_upsert_replaces_existing(tmp_db):
+    seed_user("usr_1")
+    _connect()
+    connections.upsert(
+        user_id="usr_1",
+        team_id="T123",
+        team_name="Renamed",
+        slack_user_id="U778",
+        bot_token="xoxb-rotated-token-9876543210xyz",
+        scope=None,
+    )
+    rows = connections.list_for_user("usr_1")
+    assert len(rows) == 1
+    assert rows[0]["team_name"] == "Renamed"
+    assert connections.get_bot_token("usr_1", "T123") == "xoxb-rotated-token-9876543210xyz"
+
+
+def test_get_is_owner_scoped(tmp_db):
+    seed_user("usr_1")
+    seed_user("usr_2", email="b@x.com")
+    _connect()
+    assert connections.get("usr_2", "T123") is None
+    assert connections.get_bot_token("usr_2", "T123") is None
+
+
+def test_delete_connection(tmp_db):
+    seed_user("usr_1")
+    _connect()
+    assert connections.delete_connection("usr_1", "T123") is True
+    assert connections.get("usr_1", "T123") is None
+    assert connections.delete_connection("usr_1", "T123") is False
+
+
+def test_state_mint_and_single_consume(tmp_db):
+    seed_user("usr_1")
+    state = connect_state.mint_state(user_id="usr_1", return_to="/settings")
+    out = connect_state.consume_state(state, user_id="usr_1")
+    assert out == {"return_to": "/settings"}
+    # Replay is rejected.
+    assert connect_state.consume_state(state, user_id="usr_1") is None
+
+
+def test_state_rejects_foreign_user_and_garbage(tmp_db):
+    seed_user("usr_1")
+    seed_user("usr_2", email="b@x.com")
+    state = connect_state.mint_state(user_id="usr_1", return_to=None)
+    assert connect_state.consume_state(state, user_id="usr_2") is None
+    assert connect_state.consume_state("not-a-state", user_id="usr_1") is None
+
+
+def test_state_expires(tmp_db):
+    seed_user("usr_1")
+    state = connect_state.mint_state(user_id="usr_1", return_to=None)
+    past = (datetime.now(timezone.utc) - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        s.execute(
+            sa.text("UPDATE slack_connect_states SET expires_at = :e WHERE state = :st"),
+            {"e": past, "st": state},
+        )
+    assert connect_state.consume_state(state, user_id="usr_1") is None
+
+
+def test_mint_clears_prior_state(tmp_db):
+    seed_user("usr_1")
+    first = connect_state.mint_state(user_id="usr_1", return_to=None)
+    connect_state.mint_state(user_id="usr_1", return_to=None)
+    assert connect_state.consume_state(first, user_id="usr_1") is None


### PR DESCRIPTION
## Description

Schema for the Slack app connect flow. No endpoints yet.

- `user_slack_connections`: one AES-GCM-encrypted bot token per user per workspace, with masked display hint. Decrypt failure drops the row and reads as not-connected, mirroring the Craft connection pattern.
- `slack_connect_states`: single-use CSRF state with a 10-minute TTL. No PKCE — Slack's OAuth v2 authenticates the code exchange with the client secret.
- Repos mirror `app/onyx/connections.py` / `connect.py`; migration `0045` is guarded on the live inspector like `0039`.

The OAuth connect flow and bot posting build on this.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check