### PR TITLE
feat(slack): OAuth connect flow and admin app credentials

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -547,10 +547,11 @@ def regenerate_ingest_key(
 
 
 def _slack_app_view(s: SlackAppSettingsModel) -> SlackAppView:
+    secret = s.client_secret.get_secret_value()
     return SlackAppView(
         client_id=s.client_id,
-        client_secret_set=bool(s.client_secret),
-        client_secret_hint=_redact(s.client_secret),
+        client_secret_set=bool(secret),
+        client_secret_hint=_redact(secret),
     )
 
 
@@ -566,7 +567,7 @@ def put_slack_app(
 ) -> SlackAppView:
     current = slack_app_settings.get()
     if "client_secret" not in req.model_fields_set or req.client_secret == "":
-        client_secret = current.client_secret
+        client_secret = current.client_secret.get_secret_value()
     elif req.client_secret is None:
         client_secret = ""
     else:

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -566,16 +566,21 @@ def put_slack_app(
     actor: User = Depends(require_admin),
 ) -> SlackAppView:
     current = slack_app_settings.get()
+    # Omitted fields keep their stored value, matching the secret convention.
+    if "client_id" in req.model_fields_set:
+        client_id = req.client_id.strip()
+    else:
+        client_id = current.client_id
     if "client_secret" not in req.model_fields_set or req.client_secret == "":
         client_secret = current.client_secret.get_secret_value()
     elif req.client_secret is None:
         client_secret = ""
     else:
         client_secret = req.client_secret
-    slack_app_settings.upsert(client_id=req.client_id.strip(), client_secret=client_secret)
+    slack_app_settings.upsert(client_id=client_id, client_secret=client_secret)
     log.info(
         "admin: %s updated slack app settings client_id_set=%s secret_set=%s",
-        actor.id, bool(req.client_id.strip()), bool(client_secret),
+        actor.id, bool(client_id), bool(client_secret),
     )
     return _slack_app_view(slack_app_settings.get())
 

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -38,8 +38,12 @@ from app.models.admin import (
     UserCounts,
     WebConfigRequest,
     WebView,
+    SlackAppConfigRequest,
+    SlackAppView,
 )
 from app.onyx.client import validate_onyx_base_url
+from app.slack import app_settings as slack_app_settings
+from app.slack.app_settings import SlackAppSettings as SlackAppSettingsModel
 from app.tracing import settings as braintrust_settings
 from app.tracing.settings import BraintrustSettings
 from app.web import settings as web_settings
@@ -540,6 +544,39 @@ def regenerate_ingest_key(
 # --------------------------------------------------------------------------- #
 # Braintrust tracing settings                                                 #
 # --------------------------------------------------------------------------- #
+
+
+def _slack_app_view(s: SlackAppSettingsModel) -> SlackAppView:
+    return SlackAppView(
+        client_id=s.client_id,
+        client_secret_set=bool(s.client_secret),
+        client_secret_hint=_redact(s.client_secret),
+    )
+
+
+@router.get("/slack-app", response_model=SlackAppView)
+def get_slack_app(_actor: User = Depends(require_admin)) -> SlackAppView:
+    return _slack_app_view(slack_app_settings.get())
+
+
+@router.put("/slack-app", response_model=SlackAppView)
+def put_slack_app(
+    req: SlackAppConfigRequest,
+    actor: User = Depends(require_admin),
+) -> SlackAppView:
+    current = slack_app_settings.get()
+    if "client_secret" not in req.model_fields_set or req.client_secret == "":
+        client_secret = current.client_secret
+    elif req.client_secret is None:
+        client_secret = ""
+    else:
+        client_secret = req.client_secret
+    slack_app_settings.upsert(client_id=req.client_id.strip(), client_secret=client_secret)
+    log.info(
+        "admin: %s updated slack app settings client_id_set=%s secret_set=%s",
+        actor.id, bool(req.client_id.strip()), bool(client_secret),
+    )
+    return _slack_app_view(slack_app_settings.get())
 
 
 def _braintrust_view(s: BraintrustSettings) -> BraintrustView:

--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -113,12 +113,17 @@ def connect_callback(
     try:
         body = slack_client.exchange_oauth_code(
             client_id=settings.client_id,
-            client_secret=settings.client_secret,
+            client_secret=settings.client_secret.get_secret_value(),
             code=code,
             redirect_uri=_callback_url(),
         )
     except slack_client.SlackApiError:
         log.exception("slack connect exchange failed user=%s", user.id)
+        return _bounce(return_to, outcome="error")
+    bot_token = body.get("access_token")
+    if not isinstance(bot_token, str) or not bot_token:
+        # ok=true without a token is a malformed response, not a crash.
+        log.error("slack connect exchange returned ok without access_token user=%s", user.id)
         return _bounce(return_to, outcome="error")
     team = cast(dict[str, Any], body.get("team") or {})
     authed_user = cast(dict[str, Any], body.get("authed_user") or {})
@@ -127,7 +132,7 @@ def connect_callback(
         team_id=str(team.get("id") or ""),
         team_name=cast(str | None, team.get("name")),
         slack_user_id=str(authed_user.get("id") or ""),
-        bot_token=str(body["access_token"]),
+        bot_token=bot_token,
         scope=cast(str | None, body.get("scope")),
     )
     return _bounce(return_to, outcome="ok")

--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -1,0 +1,146 @@
+"""Connect-Slack OAuth flow, mirroring the Craft connect shape.
+
+Paths match the redirect URL registered on the Slack app
+(``/api/connectors/slack/callback``), so the app config never needs editing.
+The flow is dark (404) until an admin sets the app credentials at /admin/slack.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+from urllib.parse import quote, urlencode
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from app.auth import User
+from app.auth.deps import require_user
+from app.config import CONFIG
+from app.slack import app_settings, client as slack_client, connect_state, connections
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+# Must stay a subset of the scopes on the registered app manifest.
+_BOT_SCOPES = "chat:write,chat:write.public,channels:read,groups:read,im:write,users:read,channels:join"
+
+
+class SlackConnectStatus(BaseModel):
+    configured: bool
+    connected: bool
+    team_name: str | None = None
+    token_display: str | None = None
+    connect_url: str | None = None
+
+
+def _require_configured() -> app_settings.SlackAppSettings:
+    """404 while the feature is dark; otherwise the app credentials."""
+    settings = app_settings.get()
+    if not settings.configured:
+        raise HTTPException(status_code=404, detail="slack app not configured")
+    return settings
+
+
+def _callback_url() -> str:
+    return f"{CONFIG.public_base_url}/api/connectors/slack/callback"
+
+
+def _bounce(return_to: str | None, *, outcome: str) -> RedirectResponse:
+    """Send the browser back into the app after the connect flow."""
+    path = connect_state.normalize_return_to(return_to) or "/"
+    sep = "&" if "?" in path else "?"
+    return RedirectResponse(
+        f"{CONFIG.public_base_url}{path}{sep}slack_connect={outcome}", status_code=302
+    )
+
+
+@router.get("", response_model=SlackConnectStatus)
+def get_status(user: User = Depends(require_user)) -> SlackConnectStatus:
+    settings = app_settings.get()
+    rows = connections.list_for_user(user.id)
+    first = rows[0] if rows else None
+    connect_url = None
+    if settings.configured:
+        connect_url = f"{CONFIG.public_base_url}/api/connectors/slack/start"
+    return SlackConnectStatus(
+        configured=settings.configured,
+        connected=first is not None,
+        team_name=first["team_name"] if first else None,
+        token_display=first["token_display"] if first else None,
+        connect_url=connect_url,
+    )
+
+
+@router.get("/start")
+def connect_start(
+    return_to: str | None = None,
+    user: User = Depends(require_user),
+) -> RedirectResponse:
+    settings = _require_configured()
+    state = connect_state.mint_state(user_id=user.id, return_to=return_to)
+    query = urlencode(
+        {
+            "client_id": settings.client_id,
+            "scope": _BOT_SCOPES,
+            "state": state,
+            "redirect_uri": _callback_url(),
+        },
+        quote_via=quote,
+    )
+    return RedirectResponse(
+        f"https://slack.com/oauth/v2/authorize?{query}", status_code=302
+    )
+
+
+@router.get("/callback")
+def connect_callback(
+    state: str,
+    code: str | None = None,
+    error: str | None = None,
+    user: User = Depends(require_user),
+) -> RedirectResponse:
+    settings = _require_configured()
+    claimed = connect_state.consume_state(state, user_id=user.id)
+    if claimed is None:
+        log.warning("slack connect callback rejected (bad state) user=%s", user.id)
+        return _bounce(None, outcome="error")
+    return_to = claimed["return_to"]
+    if error or not code:
+        # Slack sends error=access_denied when the user cancels the consent.
+        log.info("slack connect declined user=%s error=%s", user.id, error)
+        return _bounce(return_to, outcome="declined")
+    try:
+        body = slack_client.exchange_oauth_code(
+            client_id=settings.client_id,
+            client_secret=settings.client_secret,
+            code=code,
+            redirect_uri=_callback_url(),
+        )
+    except slack_client.SlackApiError:
+        log.exception("slack connect exchange failed user=%s", user.id)
+        return _bounce(return_to, outcome="error")
+    team = cast(dict[str, Any], body.get("team") or {})
+    authed_user = cast(dict[str, Any], body.get("authed_user") or {})
+    connections.upsert(
+        user_id=user.id,
+        team_id=str(team.get("id") or ""),
+        team_name=cast(str | None, team.get("name")),
+        slack_user_id=str(authed_user.get("id") or ""),
+        bot_token=str(body["access_token"]),
+        scope=cast(str | None, body.get("scope")),
+    )
+    return _bounce(return_to, outcome="ok")
+
+
+@router.delete("")
+def disconnect(user: User = Depends(require_user)) -> dict[str, bool]:
+    """Drop the caller's connection rows.
+
+    Deliberately no ``auth.revoke``: the bot token is workspace-shared, so
+    revoking it would sever every other connected user in the workspace.
+    """
+    removed = False
+    for row in connections.list_for_user(user.id):
+        removed = connections.delete_connection(user.id, row["team_id"]) or removed
+    return {"disconnected": removed}

--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -106,10 +106,14 @@ def connect_callback(
         log.warning("slack connect callback rejected (bad state) user=%s", user.id)
         return _bounce(None, outcome="error")
     return_to = claimed["return_to"]
-    if error or not code:
-        # Slack sends error=access_denied when the user cancels the consent.
-        log.info("slack connect declined user=%s error=%s", user.id, error)
+    if error == "access_denied":
+        # The one error code that means the user cancelled the consent screen.
+        log.info("slack connect declined user=%s", user.id)
         return _bounce(return_to, outcome="declined")
+    if error or not code:
+        # Any other error code (or a missing code) is a failure, not a decline.
+        log.warning("slack connect failed user=%s error=%s", user.id, error)
+        return _bounce(return_to, outcome="error")
     try:
         body = slack_client.exchange_oauth_code(
             client_id=settings.client_id,

--- a/backend/app/db/migrations/versions/0046_slack_app_settings.py
+++ b/backend/app/db/migrations/versions/0046_slack_app_settings.py
@@ -1,0 +1,49 @@
+"""slack app settings singleton
+
+Adds ``slack_app_settings``: the agent-wiki Slack app's OAuth client id and
+encrypted client secret, configured from /admin/slack.
+
+Guarded on the live inspector because ``0001_initial`` runs
+``Base.metadata.create_all`` against the current model registry, so a fresh
+database already has the table.
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-07-01 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0046"
+down_revision: str | None = "0045"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if "slack_app_settings" not in sa.inspect(op.get_bind()).get_table_names():
+        op.create_table(
+            "slack_app_settings",
+            sa.Column("id", sa.Integer, primary_key=True, autoincrement=False),
+            sa.Column("client_id", sa.Text, nullable=False, server_default=sa.text("''")),
+            # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+            sa.Column("client_secret", sa.LargeBinary, nullable=False),
+            sa.Column(
+                "updated_at",
+                sa.Text,
+                nullable=False,
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("slack_app_settings")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1394,6 +1394,21 @@ class CraftConnectState(Base):
     consumed_at: Mapped[str | None] = mapped_column(Text)
 
 
+class SlackAppSettings(Base):
+    """Singleton row: the agent-wiki Slack app's OAuth credentials, configured
+    from /admin/slack. The connect flow is dark until both are set."""
+
+    __tablename__ = "slack_app_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
+    client_id: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+    client_secret: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+
 class UserSlackConnection(Base):
     """One per user per Slack workspace: the bot token saved by "Connect
     Slack". Follows ``UserOnyxConnection``: the token is AES-GCM encrypted at

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,7 @@ from app.api import (
     user,
     users,
     webhooks,
+    slack_connect,
 )
 from app.auth import PermissionDenied
 from app.auth.deps import CurrentUserMiddleware
@@ -229,6 +230,7 @@ def create_app() -> FastAPI:
     app.include_router(update_policy.router, prefix="/api")
     app.include_router(launchers.router, prefix="/api")
     app.include_router(craft.router, prefix="/api/craft")
+    app.include_router(slack_connect.router, prefix="/api/connectors/slack")
     app.include_router(notifications.router, prefix="/api/notifications")
     app.include_router(installer.router, prefix="/api")
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -74,6 +74,15 @@ class IngestConfigRequest(BaseModel):
     auto_update_cap: int | None = Field(default=None, ge=0)
 
 
+class SlackAppConfigRequest(BaseModel):
+    """Set the Slack app OAuth credentials. ``client_secret`` follows the
+    masked-secret convention: omitted or empty keeps the stored value, null
+    clears it."""
+
+    client_id: str = ""
+    client_secret: str | None = None
+
+
 class BraintrustConfigRequest(BaseModel):
     """Empty-string ``api_key`` means 'leave existing untouched'; explicit
     ``null`` clears it. The blueprint resolves that semantic. ``enabled``
@@ -198,6 +207,12 @@ class IngestView(BaseModel):
 
 class RegenerateKeyResponse(BaseModel):
     api_key: str
+
+
+class SlackAppView(BaseModel):
+    client_id: str
+    client_secret_set: bool
+    client_secret_hint: str
 
 
 class BraintrustView(BaseModel):

--- a/backend/app/slack/app_settings.py
+++ b/backend/app/slack/app_settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timezone
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, SecretStr
 
 from app.db.models import SlackAppSettings as SlackAppSettingsRow
 from app.db.session import session
@@ -16,14 +16,15 @@ class SlackAppSettings(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     client_id: str
-    client_secret: str
+    # SecretStr so an incidental repr/str of the settings object redacts it.
+    client_secret: SecretStr
 
     @property
     def configured(self) -> bool:
-        return bool(self.client_id and self.client_secret)
+        return bool(self.client_id and self.client_secret.get_secret_value())
 
 
-_EMPTY = SlackAppSettings(client_id="", client_secret="")
+_EMPTY = SlackAppSettings(client_id="", client_secret=SecretStr(""))
 
 
 def get() -> SlackAppSettings:
@@ -31,7 +32,9 @@ def get() -> SlackAppSettings:
         row = s.get(SlackAppSettingsRow, 1)
         if row is None:
             return _EMPTY
-        return SlackAppSettings(client_id=row.client_id, client_secret=row.client_secret)
+        return SlackAppSettings(
+            client_id=row.client_id, client_secret=SecretStr(row.client_secret)
+        )
 
 
 def upsert(*, client_id: str, client_secret: str) -> None:

--- a/backend/app/slack/app_settings.py
+++ b/backend/app/slack/app_settings.py
@@ -1,0 +1,52 @@
+"""DB-backed Slack app OAuth credentials. Configured from /admin/slack."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict
+
+from app.db.models import SlackAppSettings as SlackAppSettingsRow
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+
+class SlackAppSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    client_id: str
+    client_secret: str
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.client_id and self.client_secret)
+
+
+_EMPTY = SlackAppSettings(client_id="", client_secret="")
+
+
+def get() -> SlackAppSettings:
+    with session() as s:
+        row = s.get(SlackAppSettingsRow, 1)
+        if row is None:
+            return _EMPTY
+        return SlackAppSettings(client_id=row.client_id, client_secret=row.client_secret)
+
+
+def upsert(*, client_id: str, client_secret: str) -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        row = s.get(SlackAppSettingsRow, 1)
+        if row is None:
+            s.add(
+                SlackAppSettingsRow(
+                    id=1, client_id=client_id, client_secret=client_secret, updated_at=now
+                )
+            )
+        else:
+            row.client_id = client_id
+            row.client_secret = client_secret
+            row.updated_at = now
+    log.info("slack_app_settings upserted client_id_set=%s secret_set=%s",
+             bool(client_id), bool(client_secret))

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -9,6 +9,7 @@ lost just because Slack is unreachable.
 from __future__ import annotations
 
 import logging
+from typing import Any, cast
 
 import requests
 
@@ -19,6 +20,36 @@ _REQUEST_TIMEOUT_SECONDS = 15
 
 class SlackApiError(RuntimeError):
     pass
+
+
+def exchange_oauth_code(
+    *, client_id: str, client_secret: str, code: str, redirect_uri: str
+) -> dict[str, Any]:
+    """Exchange an OAuth authorization code at ``oauth.v2.access``.
+
+    Returns Slack's parsed response body (bot ``access_token``, ``scope``,
+    ``team``, ``authed_user``). Slack signals failure with HTTP 200 and
+    ``{"ok": false, "error": ...}``, so both transport errors and ok=false
+    raise :class:`SlackApiError`.
+    """
+    try:
+        response = requests.post(
+            "https://slack.com/api/oauth.v2.access",
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code,
+                "redirect_uri": redirect_uri,
+            },
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        body = cast(dict[str, Any], response.json())
+    except requests.RequestException as exc:
+        raise SlackApiError(f"oauth exchange failed: {exc}") from exc
+    if not body.get("ok"):
+        raise SlackApiError(f"oauth exchange rejected: {body.get('error', 'unknown')}")
+    return body
 
 
 def post_message(*, webhook_url: str, text: str) -> None:

--- a/backend/tests/test_slack_oauth_connect.py
+++ b/backend/tests/test_slack_oauth_connect.py
@@ -1,0 +1,178 @@
+"""Connect-Slack OAuth flow: admin-configured credentials gate the flow, the
+callback exchanges the code and stores the connection, and state misuse
+bounces with an error instead of connecting."""
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.slack import app_settings, connections
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_repo):
+    return TestClient(create_app())
+
+_EXCHANGE_OK = {
+    "ok": True,
+    "access_token": "xoxb-exchanged-token-123456789",
+    "scope": "chat:write,im:write",
+    "team": {"id": "T123", "name": "Onyx Team"},
+    "authed_user": {"id": "U777"},
+}
+
+
+def _configure() -> None:
+    app_settings.upsert(client_id="123.456", client_secret="shhh-secret")
+
+
+def _admin(client) -> str:
+    uid = seed_user(uid="usr_admin", email="admin@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    return uid
+
+
+def test_admin_settings_roundtrip_masks_secret(client):
+    _admin(client)
+    res = client.put(
+        "/api/admin/slack-app",
+        json={"client_id": "123.456", "client_secret": "shhh-secret-long-enough"},
+    )
+    assert res.status_code == 200, res.json()
+    body = res.json()
+    assert body["client_id"] == "123.456"
+    assert body["client_secret_set"] is True
+    assert "shhh" not in body["client_secret_hint"] or len(body["client_secret_hint"]) < 12
+
+    # Empty secret keeps the stored value; explicit null clears it.
+    res = client.put("/api/admin/slack-app", json={"client_id": "123.456", "client_secret": ""})
+    assert res.json()["client_secret_set"] is True
+    res = client.put("/api/admin/slack-app", json={"client_id": "123.456", "client_secret": None})
+    assert res.json()["client_secret_set"] is False
+
+
+def test_status_reflects_configuration_and_connection(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+
+    res = client.get("/api/connectors/slack")
+    assert res.json() == {
+        "configured": False,
+        "connected": False,
+        "team_name": None,
+        "token_display": None,
+        "connect_url": None,
+    }
+
+    _configure()
+    connections.upsert(
+        user_id=uid, team_id="T123", team_name="Onyx Team",
+        slack_user_id="U777", bot_token="xoxb-abc", scope=None,
+    )
+    body = client.get("/api/connectors/slack").json()
+    assert body["configured"] is True
+    assert body["connected"] is True
+    assert body["team_name"] == "Onyx Team"
+
+
+def test_start_is_dark_until_configured(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    res = client.get("/api/connectors/slack/start", follow_redirects=False)
+    assert res.status_code == 404
+
+
+def test_start_redirects_to_slack_authorize(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    _configure()
+    res = client.get("/api/connectors/slack/start", follow_redirects=False)
+    assert res.status_code == 302
+    target = urlparse(res.headers["location"])
+    assert target.hostname == "slack.com"
+    assert target.path == "/oauth/v2/authorize"
+    q = parse_qs(target.query)
+    assert q["client_id"] == ["123.456"]
+    assert q["state"][0].startswith("slkst_")
+    assert q["redirect_uri"][0].endswith("/api/connectors/slack/callback")
+
+
+def _start_and_get_state(client) -> str:
+    res = client.get("/api/connectors/slack/start", follow_redirects=False)
+    return parse_qs(urlparse(res.headers["location"]).query)["state"][0]
+
+
+def test_callback_stores_connection(client, monkeypatch):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    _configure()
+    state = _start_and_get_state(client)
+
+    captured: dict = {}
+
+    def fake_exchange(**kwargs):
+        captured.update(kwargs)
+        return _EXCHANGE_OK
+
+    monkeypatch.setattr(
+        "app.api.slack_connect.slack_client.exchange_oauth_code", fake_exchange
+    )
+    res = client.get(
+        f"/api/connectors/slack/callback?code=c0de&state={state}",
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "slack_connect=ok" in res.headers["location"]
+    assert captured["code"] == "c0de"
+
+    row = connections.get(uid, "T123")
+    assert row is not None
+    assert row["team_name"] == "Onyx Team"
+    assert row["slack_user_id"] == "U777"
+    assert connections.get_bot_token(uid, "T123") == _EXCHANGE_OK["access_token"]
+
+
+def test_callback_rejects_bad_state(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    _configure()
+    res = client.get(
+        "/api/connectors/slack/callback?code=c0de&state=slkst_bogus",
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "slack_connect=error" in res.headers["location"]
+    assert connections.list_for_user(uid) == []
+
+
+def test_callback_handles_user_decline(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    _configure()
+    state = _start_and_get_state(client)
+    res = client.get(
+        f"/api/connectors/slack/callback?error=access_denied&state={state}",
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "slack_connect=declined" in res.headers["location"]
+    assert connections.list_for_user(uid) == []
+
+
+def test_disconnect_removes_rows(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    connections.upsert(
+        user_id=uid, team_id="T123", team_name=None,
+        slack_user_id="U1", bot_token="xoxb-a", scope=None,
+    )
+    res = client.delete("/api/connectors/slack")
+    assert res.json() == {"disconnected": True}
+    assert connections.list_for_user(uid) == []
+    assert client.delete("/api/connectors/slack").json() == {"disconnected": False}

--- a/backend/tests/test_slack_oauth_connect.py
+++ b/backend/tests/test_slack_oauth_connect.py
@@ -176,3 +176,32 @@ def test_disconnect_removes_rows(client):
     assert res.json() == {"disconnected": True}
     assert connections.list_for_user(uid) == []
     assert client.delete("/api/connectors/slack").json() == {"disconnected": False}
+
+
+def test_settings_repr_redacts_secret():
+    from pydantic import SecretStr
+
+    s = app_settings.SlackAppSettings(
+        client_id="123.456", client_secret=SecretStr("shhh-secret")
+    )
+    assert "shhh-secret" not in repr(s)
+    assert "shhh-secret" not in str(s)
+    assert s.configured
+
+
+def test_callback_bounces_on_ok_without_token(client, monkeypatch):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    _configure()
+    state = _start_and_get_state(client)
+    monkeypatch.setattr(
+        "app.api.slack_connect.slack_client.exchange_oauth_code",
+        lambda **kw: {"ok": True, "team": {"id": "T123"}},
+    )
+    res = client.get(
+        f"/api/connectors/slack/callback?code=c0de&state={state}",
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "slack_connect=error" in res.headers["location"]
+    assert connections.list_for_user(uid) == []

--- a/backend/tests/test_slack_oauth_connect.py
+++ b/backend/tests/test_slack_oauth_connect.py
@@ -205,3 +205,17 @@ def test_callback_bounces_on_ok_without_token(client, monkeypatch):
     assert res.status_code == 302
     assert "slack_connect=error" in res.headers["location"]
     assert connections.list_for_user(uid) == []
+
+
+def test_callback_treats_non_decline_error_as_failure(client):
+    uid = seed_user("usr_1")
+    login_fastapi(client, uid)
+    _configure()
+    state = _start_and_get_state(client)
+    res = client.get(
+        f"/api/connectors/slack/callback?error=invalid_scope&state={state}",
+        follow_redirects=False,
+    )
+    assert res.status_code == 302
+    assert "slack_connect=error" in res.headers["location"]
+    assert connections.list_for_user(uid) == []

--- a/backend/tests/test_slack_oauth_connect.py
+++ b/backend/tests/test_slack_oauth_connect.py
@@ -219,3 +219,17 @@ def test_callback_treats_non_decline_error_as_failure(client):
     assert res.status_code == 302
     assert "slack_connect=error" in res.headers["location"]
     assert connections.list_for_user(uid) == []
+
+
+def test_admin_put_secret_only_keeps_client_id(client):
+    _admin(client)
+    client.put(
+        "/api/admin/slack-app",
+        json={"client_id": "123.456", "client_secret": "shhh-secret-long-enough"},
+    )
+    # Rotating just the secret must not wipe the stored client id.
+    body = client.put(
+        "/api/admin/slack-app", json={"client_secret": "rotated-secret-value"}
+    ).json()
+    assert body["client_id"] == "123.456"
+    assert body["client_secret_set"] is True

--- a/frontend/src/app/admin/slack/page.tsx
+++ b/frontend/src/app/admin/slack/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+
+import { Button } from "@onyx-ai/opal/components";
+import { useConfirm } from "@/components/common/ConfirmDialog";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { BackLink, PageHeader } from "@/components/common/PageHeader";
+import { RequireAdmin } from "@/components/RequireAdmin";
+import { apiFetch } from "@/lib/api";
+import { useIsMobile } from "@/lib/viewport";
+
+interface SlackAppSettings {
+  client_id: string;
+  client_secret_set: boolean;
+  client_secret_hint: string;
+}
+
+export default function AdminSlackPage() {
+  const isMobile = useIsMobile();
+  return (
+    <RequireAdmin>
+      <main
+        className="max-w-[720px]"
+        style={{ padding: isMobile ? "16px 12px" : "24px 32px" }}
+      >
+        <BackLink />
+        <PageHeader
+          title="Slack app"
+          description="OAuth credentials for the Agent Wiki Slack app (Basic Information → App Credentials on api.slack.com). The Connect Slack flow stays hidden until both are saved."
+        />
+        <SlackAppForm />
+      </main>
+    </RequireAdmin>
+  );
+}
+
+function SlackAppForm() {
+  const [settings, setSettings] = useState<SlackAppSettings | null>(null);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const confirmDialog = useConfirm();
+
+  async function load() {
+    try {
+      const r = await apiFetch<SlackAppSettings>("/admin/slack-app");
+      setSettings(r);
+      setClientId(r.client_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to load");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const body: Record<string, unknown> = { client_id: clientId };
+      if (clientSecret) body.client_secret = clientSecret;
+      const r = await apiFetch<SlackAppSettings>("/admin/slack-app", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+      setSettings(r);
+      setClientSecret("");
+      setSaved("Saved.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clearSecret() {
+    if (
+      !(await confirmDialog({
+        title: "Clear the Slack client secret?",
+        body: "The Connect Slack flow will be hidden until a new secret is set.",
+        confirmLabel: "Clear secret",
+      }))
+    )
+      return;
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const r = await apiFetch<SlackAppSettings>("/admin/slack-app", {
+        method: "PUT",
+        body: JSON.stringify({ client_id: clientId, client_secret: null }),
+      });
+      setSettings(r);
+      setClientSecret("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to clear");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!settings) return <LoadingSpinner />;
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <label>
+        <div className="mb-1 text-[13px] font-medium">Client ID</div>
+        <input
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          placeholder="1234567890.1234567890123"
+          required
+          className={inputClass}
+        />
+      </label>
+
+      <label>
+        <div className="mb-1 flex items-center gap-[6px] text-[13px] font-medium">
+          <span>Client secret</span>
+          {settings.client_secret_set && (
+            <span className="font-mono text-xs font-normal text-(--text-03)">
+              currently {settings.client_secret_hint}
+            </span>
+          )}
+          <span className="flex-1" />
+          {settings.client_secret_set && (
+            <Button
+              type="button"
+              size="sm"
+              variant="danger"
+              onClick={() => void clearSecret()}
+              disabled={saving}
+            >
+              Clear
+            </Button>
+          )}
+        </div>
+        <input
+          type="password"
+          value={clientSecret}
+          onChange={(e) => setClientSecret(e.target.value)}
+          placeholder={
+            settings.client_secret_set
+              ? "leave blank to keep"
+              : "secret from api.slack.com"
+          }
+          className={inputClass}
+        />
+      </label>
+
+      {error && <div className="text-(--status-text-error-05)">{error}</div>}
+      {saved && <div className="text-(--status-text-success-05)">{saved}</div>}
+      <div>
+        <Button type="submit" variant="action" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+const inputClass =
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";

--- a/frontend/src/lib/nav/registry.ts
+++ b/frontend/src/lib/nav/registry.ts
@@ -8,6 +8,7 @@ import {
   SvgGlobe,
   SvgHistory,
   SvgOnyxLogo,
+  SvgSlack,
   SvgUser,
   SvgUsers,
   SvgWorkflow,
@@ -81,6 +82,10 @@ export const ADMIN_NAV_GROUPS = [
       { href: "/admin/users", label: "Users", icon: SvgUser },
       { href: "/admin/groups", label: "Groups", icon: SvgUsers },
     ],
+  },
+  {
+    label: "Connectors",
+    entries: [{ href: "/admin/slack", label: "Slack App", icon: SvgSlack }],
   },
   {
     label: "Statistics",


### PR DESCRIPTION
## Description

Stacked on #318. Users link their Slack account.

- `GET /api/connectors/slack/start` mints single-use CSRF state and redirects to Slack authorize; `/callback` exchanges the code at `oauth.v2.access` and stores the #318 connection row. Callback path matches the redirect URL registered on the Slack app.
- Flow is dark (404) until an admin saves the app Client ID + encrypted secret at `/admin/slack` (new admin endpoints, page, Connectors nav group).
- Disconnect drops the caller's rows without `auth.revoke` — the bot token is workspace-shared, revoking would sever every other connected user.
- Handles user-declined consent (`error=access_denied`) as a distinct bounce.

Posting through the bot (dispatch, channel picker) comes next.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check