### PR TITLE
feat(coedit): clear template-draft state on checkpoint

### DIFF
--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -124,11 +124,9 @@ def checkpoint_session(session_id: int) -> str | None:
             # The commit-time merge folded in a concurrent agent commit; tell
             # participants to reload the merged buffer.
             coedit_channel.broadcast_resync(session_id, res.session.version)
-        # Drafting state: if the committed body diverged from a template
-        # snapshot, the page is now the user's own — clear the row so the chat
-        # banner drops and the template's system prompt stops applying. Human
-        # edits commit through here (not PUT /file) once editing is session-based,
-        # so this must run at the checkpoint, mirroring the PUT /file save path.
+        # Clear the template-drafting row once the committed body diverges from
+        # the snapshot — the page is now the user's own, so the chat banner and
+        # the template's system-prompt override should no longer apply.
         wiki_drafts.clear_if_diverged(path, result.new_body)
         return result.sha
 

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -24,6 +24,7 @@ from app.auth import User, set_current_user
 from app.auth import users as users_repo
 from app.models.wiki import ChangeKind
 from app.wiki import coedit, coedit_channel
+from app.wiki import drafts as wiki_drafts
 from app.wiki import git as wiki_git
 from app.wiki.utils import commit_and_fan_out
 
@@ -123,6 +124,12 @@ def checkpoint_session(session_id: int) -> str | None:
             # The commit-time merge folded in a concurrent agent commit; tell
             # participants to reload the merged buffer.
             coedit_channel.broadcast_resync(session_id, res.session.version)
+        # Drafting state: if the committed body diverged from a template
+        # snapshot, the page is now the user's own — clear the row so the chat
+        # banner drops and the template's system prompt stops applying. Human
+        # edits commit through here (not PUT /file) once editing is session-based,
+        # so this must run at the checkpoint, mirroring the PUT /file save path.
+        wiki_drafts.clear_if_diverged(path, result.new_body)
         return result.sha
 
     # None = the merge produced exactly the current HEAD (buffer already matches

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -136,6 +136,34 @@ def test_checkpoint_merges_concurrent_agent_commit(repo):
     assert wiki_git.read_file(_PATH) == "ONE\ntwo\nthree\nfour\nFIVE\n"
 
 
+def test_checkpoint_clears_template_draft_when_body_diverges(repo):
+    # A page created from a template has a document_drafts row; once a human's
+    # committed edit diverges from the template snapshot, the row must clear.
+    # Human edits commit via the checkpoint (not PUT /file), so the checkpoint
+    # must do this — mirroring the PUT /file save path.
+    from app.db.models import DocumentTemplate
+    from app.db.session import session as db_session
+    from app.wiki import drafts
+
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    tmpl_body = "# Template\n"
+    with db_session() as s:
+        s.add(DocumentTemplate(id="tmpl_x", name="X", body=tmpl_body))
+    sha = _seed_page(tmpl_body)
+    drafts.create(
+        path=_PATH, template_id="tmpl_x", template_body_snapshot=tmpl_body, created_by_user_id=uid
+    )
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer=tmpl_body)
+    coedit.join(sess.id, uid)
+    coedit.apply_op(
+        sess.id, base_version=0, changes=[_ch(0, len(tmpl_body), "# Mine\n")], author_user_id=uid
+    )
+
+    coedit_checkpoint.checkpoint_session(sess.id)
+
+    assert drafts.get(_PATH) is None  # diverged from the template → row cleared
+
+
 def test_task_checkpoints_then_closes_when_empty(repo):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     sha = _seed_page("hello world")

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -7,9 +7,11 @@ from __future__ import annotations
 import pytest
 
 from app.auth import users as users_repo
+from app.db.models import DocumentTemplate
+from app.db.session import session as db_session
 from app.tasks import coedit_checkpoint as coedit_checkpoint_task
 from app.tasks.queues import documents_queue
-from app.wiki import coedit, coedit_checkpoint
+from app.wiki import coedit, coedit_checkpoint, drafts
 from app.wiki import git as wiki_git
 
 _PATH = "guides/setup.md"
@@ -141,10 +143,6 @@ def test_checkpoint_clears_template_draft_when_body_diverges(repo):
     # committed edit diverges from the template snapshot, the row must clear.
     # Human edits commit via the checkpoint (not PUT /file), so the checkpoint
     # must do this — mirroring the PUT /file save path.
-    from app.db.models import DocumentTemplate
-    from app.db.session import session as db_session
-    from app.wiki import drafts
-
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     tmpl_body = "# Template\n"
     with db_session() as s:


### PR DESCRIPTION
## What

Prep for routing human editing through co-edit sessions (Model A: no private drafts). When a session's checkpoint commits the buffer to git, also clear the **template-drafting** state (`document_drafts`) if the committed body has diverged from the template snapshot — mirroring what `PUT /file` does today (`app/api/wiki.py:281`).

Once human edits commit via `checkpoint_session` (not `PUT /file`), that clear must happen at the checkpoint, or the chat drafting banner and the template's system-prompt override would linger after a user has made the page their own.

## Change
- `app/wiki/coedit_checkpoint.py`: after a successful commit, call `wiki_drafts.clear_if_diverged(path, result.new_body)`.
- Additive and backward-compatible: `PUT /file` still does its own clear; this only adds the call on the checkpoint path (dormant until the frontend routes editing through sessions).

## Test
- `test_checkpoint_clears_template_draft_when_body_diverges`: seed a template + `document_drafts` row, open a session, edit to diverge, checkpoint → the row is cleared.
- Full coedit suite green; ruff + basedpyright clean.

Part of the co-editing "Edit = session" arc (this is the small backend pre-req; the frontend cutover follows).