### PR TITLE
feat(coedit/fe): session client + useCoeditSession hook (Edit=session foundation)

### DIFF
--- a/frontend/src/lib/coedit.ts
+++ b/frontend/src/lib/coedit.ts
@@ -103,7 +103,9 @@ export function sendCursor(
   });
 }
 
-export function checkpointSession(sessionId: number): Promise<{ queued: boolean }> {
+export function checkpointSession(
+  sessionId: number,
+): Promise<{ queued: boolean }> {
   return apiFetch("/coedit/checkpoint", {
     method: "POST",
     body: JSON.stringify({ session_id: sessionId }),
@@ -128,13 +130,17 @@ export function streamSession(
 /** Diff `oldStr` → `newStr` into one range change (trim common prefix/suffix),
  * or null if unchanged. Offsets are UTF-16 code units (JS-native), matching the
  * server. Coarse (one span), which is all the server needs. */
-export function diffToChange(oldStr: string, newStr: string): CoeditChange | null {
+export function diffToChange(
+  oldStr: string,
+  newStr: string,
+): CoeditChange | null {
   if (oldStr === newStr) return null;
   const oldLen = oldStr.length;
   const newLen = newStr.length;
   const maxPre = Math.min(oldLen, newLen);
   let pre = 0;
-  while (pre < maxPre && oldStr.charCodeAt(pre) === newStr.charCodeAt(pre)) pre++;
+  while (pre < maxPre && oldStr.charCodeAt(pre) === newStr.charCodeAt(pre))
+    pre++;
   const maxSuf = Math.min(oldLen, newLen) - pre;
   let suf = 0;
   while (
@@ -143,7 +149,11 @@ export function diffToChange(oldStr: string, newStr: string): CoeditChange | nul
   ) {
     suf++;
   }
-  return { from: pre, to: oldLen - suf, insert: newStr.slice(pre, newLen - suf) };
+  return {
+    from: pre,
+    to: oldLen - suf,
+    insert: newStr.slice(pre, newLen - suf),
+  };
 }
 
 /** Apply a range change to a string (UTF-16 offsets). */

--- a/frontend/src/lib/coedit.ts
+++ b/frontend/src/lib/coedit.ts
@@ -1,0 +1,152 @@
+/** Client for the co-editing session API (`/api/coedit/*`).
+ *
+ * A page is edited by joining a live session: the shared buffer lives on the
+ * server, edits are sent as range-change ops, and inbound ops/presence/resync
+ * arrive over an SSE stream. Save (checkpoint) commits the buffer to git; save
+ * or disconnect leaves the session. See the backend in `app/api/coedit.py` and
+ * the design in `design/Co-Editing.md`.
+ *
+ * Offsets are UTF-16 code units — which is exactly what JS string indexing and
+ * `slice` use, so `diffToChange`/`applyChange` interoperate with the server
+ * (`Change` in `app/wiki/coedit.py`) without conversion.
+ */
+import { apiFetch, apiStream } from "./api";
+
+/** One range-replacement edit: replace `[from, to)` (UTF-16) with `insert`. */
+export interface CoeditChange {
+  from: number;
+  to: number;
+  insert: string;
+}
+
+export interface CoeditParticipant {
+  user_id: string;
+  user_display: string;
+  joined_at: string;
+  last_seen_at: string;
+}
+
+/** Snapshot returned by join / session (the live buffer + roster). */
+export interface CoeditSession {
+  session_id: number;
+  buffer: string;
+  version: number;
+  base_sha: string | null;
+  participants: CoeditParticipant[];
+}
+
+/** Frames pushed over the SSE stream (`coedit_channel.py`). */
+export type CoeditFrame =
+  | { type: "presence"; session_id: number; participants: CoeditParticipant[] }
+  | {
+      type: "op";
+      session_id: number;
+      version: number;
+      changes: CoeditChange[];
+      author: string | null;
+    }
+  | {
+      type: "cursor";
+      session_id: number;
+      user_id: string;
+      user_display: string;
+      anchor: number;
+      head: number;
+      typing: boolean;
+    }
+  | { type: "resync"; session_id: number; version: number };
+
+export function joinSession(path: string): Promise<CoeditSession> {
+  return apiFetch("/coedit/join", {
+    method: "POST",
+    body: JSON.stringify({ path }),
+  });
+}
+
+export function getSession(sessionId: number): Promise<CoeditSession> {
+  return apiFetch(`/coedit/session?session_id=${sessionId}`);
+}
+
+export function leaveSession(sessionId: number): Promise<void> {
+  return apiFetch("/coedit/leave", {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+}
+
+/** Apply an edit op. Resolves to the new version, or throws `ApiError` with
+ * status 409 when `baseVersion` is stale (caller re-syncs via `getSession`). */
+export function sendOp(
+  sessionId: number,
+  baseVersion: number,
+  changes: CoeditChange[],
+): Promise<{ version: number }> {
+  return apiFetch("/coedit/op", {
+    method: "POST",
+    body: JSON.stringify({
+      session_id: sessionId,
+      base_version: baseVersion,
+      changes,
+    }),
+  });
+}
+
+export function sendCursor(
+  sessionId: number,
+  anchor: number,
+  head: number,
+  typing: boolean,
+): Promise<void> {
+  return apiFetch("/coedit/cursor", {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, anchor, head, typing }),
+  });
+}
+
+export function checkpointSession(sessionId: number): Promise<{ queued: boolean }> {
+  return apiFetch("/coedit/checkpoint", {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId }),
+  });
+}
+
+/** Open the SSE stream; `onFrame` fires per frame until `signal` aborts (or the
+ * server closes). Opening the stream also joins the caller as a participant. */
+export function streamSession(
+  sessionId: number,
+  onFrame: (frame: CoeditFrame) => void,
+  signal: AbortSignal,
+): Promise<void> {
+  return apiStream(
+    `/coedit/stream?session_id=${sessionId}`,
+    { method: "GET" },
+    (data) => onFrame(data as CoeditFrame),
+    signal,
+  );
+}
+
+/** Diff `oldStr` → `newStr` into one range change (trim common prefix/suffix),
+ * or null if unchanged. Offsets are UTF-16 code units (JS-native), matching the
+ * server. Coarse (one span), which is all the server needs. */
+export function diffToChange(oldStr: string, newStr: string): CoeditChange | null {
+  if (oldStr === newStr) return null;
+  const oldLen = oldStr.length;
+  const newLen = newStr.length;
+  const maxPre = Math.min(oldLen, newLen);
+  let pre = 0;
+  while (pre < maxPre && oldStr.charCodeAt(pre) === newStr.charCodeAt(pre)) pre++;
+  const maxSuf = Math.min(oldLen, newLen) - pre;
+  let suf = 0;
+  while (
+    suf < maxSuf &&
+    oldStr.charCodeAt(oldLen - 1 - suf) === newStr.charCodeAt(newLen - 1 - suf)
+  ) {
+    suf++;
+  }
+  return { from: pre, to: oldLen - suf, insert: newStr.slice(pre, newLen - suf) };
+}
+
+/** Apply a range change to a string (UTF-16 offsets). */
+export function applyChange(str: string, c: CoeditChange): string {
+  return str.slice(0, c.from) + c.insert + str.slice(c.to);
+}

--- a/frontend/src/lib/useCoeditSession.ts
+++ b/frontend/src/lib/useCoeditSession.ts
@@ -57,10 +57,9 @@ export function useCoeditSession(opts: {
   const version = useRef(0);
   const serverBuffer = useRef(""); // last text the server has acked
   const bufferRef = useRef(""); // mirrors `buffer` state for diffing
-  const inFlight = useRef(false);
+  const pumpPromise = useRef<Promise<void> | null>(null); // in-flight op drain
   const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abort = useRef<AbortController | null>(null);
-  const endedRef = useRef(false);
 
   const setBuffer = useCallback((next: string) => {
     bufferRef.current = next;
@@ -74,39 +73,50 @@ export function useCoeditSession(opts: {
       const snap = await getSession(sid);
       version.current = snap.version;
       serverBuffer.current = snap.buffer;
-      inFlight.current = false;
       setBuffer(snap.buffer);
     } catch {
       // stream/heartbeat will surface a persistent failure; ignore transient
     }
   }, [setBuffer]);
 
-  // Send the pending diff (serverBuffer → bufferRef) if idle; coalesces via a
-  // single in-flight op and re-flushes when the ack lands.
-  const flush = useCallback(() => {
-    const sid = sessionId.current;
-    if (sid === null || inFlight.current) return;
-    const change = diffToChange(serverBuffer.current, bufferRef.current);
-    if (change === null) return;
-    const sent = bufferRef.current;
-    inFlight.current = true;
-    sendOp(sid, version.current, [change])
-      .then(({ version: v }) => {
-        version.current = v;
-        serverBuffer.current = sent;
-        inFlight.current = false;
-        if (bufferRef.current !== serverBuffer.current) flush();
-      })
-      .catch((err) => {
-        inFlight.current = false;
-        if (err instanceof ApiError && err.status === 409) void resync();
-      });
+  // Drainable op sender: while the local buffer is ahead of the server, send
+  // the diff and await the ack, looping until caught up. Only one pump runs at
+  // a time; `pump()` returns the in-flight run's promise, so `save` can await it
+  // to guarantee every keystroke reached the server before checkpointing.
+  const pump = useCallback((): Promise<void> => {
+    if (pumpPromise.current) return pumpPromise.current;
+    if (sessionId.current === null) return Promise.resolve();
+    const run = (async () => {
+      try {
+        while (sessionId.current !== null) {
+          const change = diffToChange(serverBuffer.current, bufferRef.current);
+          if (change === null) return; // caught up
+          const sent = bufferRef.current;
+          try {
+            const { version: v } = await sendOp(
+              sessionId.current,
+              version.current,
+              [change],
+            );
+            version.current = v;
+            serverBuffer.current = sent;
+          } catch (err) {
+            if (err instanceof ApiError && err.status === 409) await resync();
+            return; // stop this drain; a resync (or transient failure) handled it
+          }
+        }
+      } finally {
+        pumpPromise.current = null;
+      }
+    })();
+    pumpPromise.current = run;
+    return run;
   }, [resync]);
 
   const scheduleFlush = useCallback(() => {
     if (flushTimer.current) clearTimeout(flushTimer.current);
-    flushTimer.current = setTimeout(flush, FLUSH_DELAY_MS);
-  }, [flush]);
+    flushTimer.current = setTimeout(() => void pump(), FLUSH_DELAY_MS);
+  }, [pump]);
 
   const onChange = useCallback(
     (next: string) => {
@@ -127,10 +137,15 @@ export function useCoeditSession(opts: {
         return;
       }
       if (frame.type === "op") {
-        if (frame.author === myUserId) return; // our own echo, already applied
+        // Skip our own echo — but only when we actually have an id, else a
+        // null-authored server op would be dropped when myUserId is unresolved.
+        if (myUserId !== null && frame.author === myUserId) return;
         // Only splice when we're fully caught up (no unsent local edits and no
-        // op in flight); otherwise re-fetch to avoid applying at stale offsets.
-        if (inFlight.current || bufferRef.current !== serverBuffer.current) {
+        // op draining); otherwise re-fetch to avoid applying at stale offsets.
+        if (
+          pumpPromise.current !== null ||
+          bufferRef.current !== serverBuffer.current
+        ) {
           void resync();
           return;
         }
@@ -161,18 +176,21 @@ export function useCoeditSession(opts: {
   const save = useCallback(async () => {
     const sid = sessionId.current;
     if (sid === null) return;
-    // Flush any tail edit synchronously-ish before committing, then checkpoint.
+    // Drain pending edits before committing so a keystroke typed inside the
+    // debounce window still reaches git. Cancel the timer, then await the pump
+    // (kicking one for the tail diff) so the server has the full buffer.
     if (flushTimer.current) {
       clearTimeout(flushTimer.current);
       flushTimer.current = null;
     }
+    await pump();
     try {
       await checkpointSession(sid);
     } finally {
       stop();
       onEnd?.();
     }
-  }, [stop, onEnd]);
+  }, [pump, stop, onEnd]);
 
   const discard = useCallback(async () => {
     const sid = sessionId.current;
@@ -195,7 +213,6 @@ export function useCoeditSession(opts: {
   // Join + stream while enabled; leave on disable/unmount.
   useEffect(() => {
     if (!enabled) return;
-    endedRef.current = false;
     const ctrl = new AbortController();
     abort.current = ctrl;
     let cancelled = false;

--- a/frontend/src/lib/useCoeditSession.ts
+++ b/frontend/src/lib/useCoeditSession.ts
@@ -1,0 +1,228 @@
+/** React hook that binds a text buffer to a live co-edit session.
+ *
+ * On `enabled`, it joins the session for `path`, streams inbound frames, and
+ * exposes `buffer` + `onChange` for a plain `<textarea>`. Local edits are sent
+ * as coalesced range-change ops (one in flight); inbound ops are spliced in;
+ * anything it can't cleanly reconcile (a 409 stale op, a `resync` frame, or a
+ * remote op arriving while the local buffer has unsent edits) falls back to a
+ * full re-fetch — correct, occasionally jumpy (the textarea MVP; CodeMirror +
+ * pending-op rebase smooth this later). Save checkpoints + leaves; discard
+ * resets to the committed body + leaves; unmount leaves.
+ *
+ * Offsets are UTF-16 (JS-native), matching the server — see `coedit.ts`.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ApiError } from "./api";
+import {
+  applyChange,
+  checkpointSession,
+  type CoeditFrame,
+  type CoeditParticipant,
+  diffToChange,
+  getSession,
+  joinSession,
+  leaveSession,
+  sendOp,
+  streamSession,
+} from "./coedit";
+
+const FLUSH_DELAY_MS = 150;
+
+export interface UseCoeditSession {
+  active: boolean;
+  buffer: string;
+  participants: CoeditParticipant[];
+  onChange: (next: string) => void;
+  save: () => Promise<void>;
+  discard: () => Promise<void>;
+}
+
+export function useCoeditSession(opts: {
+  path: string;
+  enabled: boolean;
+  committedBody: string;
+  myUserId: string | null;
+  onEnd?: () => void;
+}): UseCoeditSession {
+  const { path, enabled, committedBody, myUserId, onEnd } = opts;
+
+  const [buffer, setBufferState] = useState("");
+  const [participants, setParticipants] = useState<CoeditParticipant[]>([]);
+  const [active, setActive] = useState(false);
+
+  // Live state kept in refs so the stream callback and flush loop read the
+  // latest without re-subscribing.
+  const sessionId = useRef<number | null>(null);
+  const version = useRef(0);
+  const serverBuffer = useRef(""); // last text the server has acked
+  const bufferRef = useRef(""); // mirrors `buffer` state for diffing
+  const inFlight = useRef(false);
+  const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abort = useRef<AbortController | null>(null);
+  const endedRef = useRef(false);
+
+  const setBuffer = useCallback((next: string) => {
+    bufferRef.current = next;
+    setBufferState(next);
+  }, []);
+
+  const resync = useCallback(async () => {
+    const sid = sessionId.current;
+    if (sid === null) return;
+    try {
+      const snap = await getSession(sid);
+      version.current = snap.version;
+      serverBuffer.current = snap.buffer;
+      inFlight.current = false;
+      setBuffer(snap.buffer);
+    } catch {
+      // stream/heartbeat will surface a persistent failure; ignore transient
+    }
+  }, [setBuffer]);
+
+  // Send the pending diff (serverBuffer → bufferRef) if idle; coalesces via a
+  // single in-flight op and re-flushes when the ack lands.
+  const flush = useCallback(() => {
+    const sid = sessionId.current;
+    if (sid === null || inFlight.current) return;
+    const change = diffToChange(serverBuffer.current, bufferRef.current);
+    if (change === null) return;
+    const sent = bufferRef.current;
+    inFlight.current = true;
+    sendOp(sid, version.current, [change])
+      .then(({ version: v }) => {
+        version.current = v;
+        serverBuffer.current = sent;
+        inFlight.current = false;
+        if (bufferRef.current !== serverBuffer.current) flush();
+      })
+      .catch((err) => {
+        inFlight.current = false;
+        if (err instanceof ApiError && err.status === 409) void resync();
+      });
+  }, [resync]);
+
+  const scheduleFlush = useCallback(() => {
+    if (flushTimer.current) clearTimeout(flushTimer.current);
+    flushTimer.current = setTimeout(flush, FLUSH_DELAY_MS);
+  }, [flush]);
+
+  const onChange = useCallback(
+    (next: string) => {
+      setBuffer(next);
+      scheduleFlush();
+    },
+    [setBuffer, scheduleFlush],
+  );
+
+  const onFrame = useCallback(
+    (frame: CoeditFrame) => {
+      if (frame.type === "presence") {
+        setParticipants(frame.participants);
+        return;
+      }
+      if (frame.type === "resync") {
+        void resync();
+        return;
+      }
+      if (frame.type === "op") {
+        if (frame.author === myUserId) return; // our own echo, already applied
+        // Only splice when we're fully caught up (no unsent local edits and no
+        // op in flight); otherwise re-fetch to avoid applying at stale offsets.
+        if (inFlight.current || bufferRef.current !== serverBuffer.current) {
+          void resync();
+          return;
+        }
+        let next = serverBuffer.current;
+        for (const c of frame.changes) next = applyChange(next, c);
+        version.current = frame.version;
+        serverBuffer.current = next;
+        setBuffer(next);
+      }
+      // cursor frames are ignored until the CodeMirror editor renders carets
+    },
+    [myUserId, resync, setBuffer],
+  );
+
+  const stop = useCallback(() => {
+    if (flushTimer.current) {
+      clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    abort.current?.abort();
+    abort.current = null;
+    const sid = sessionId.current;
+    sessionId.current = null;
+    setActive(false);
+    if (sid !== null) void leaveSession(sid).catch(() => {});
+  }, []);
+
+  const save = useCallback(async () => {
+    const sid = sessionId.current;
+    if (sid === null) return;
+    // Flush any tail edit synchronously-ish before committing, then checkpoint.
+    if (flushTimer.current) {
+      clearTimeout(flushTimer.current);
+      flushTimer.current = null;
+    }
+    try {
+      await checkpointSession(sid);
+    } finally {
+      stop();
+      onEnd?.();
+    }
+  }, [stop, onEnd]);
+
+  const discard = useCallback(async () => {
+    const sid = sessionId.current;
+    if (sid !== null) {
+      // Reset the shared buffer to the committed body so the leave-time
+      // checkpoint is a no-op (nothing of this edit lands in git).
+      const change = diffToChange(serverBuffer.current, committedBody);
+      if (change !== null) {
+        try {
+          await sendOp(sid, version.current, [change]);
+        } catch {
+          // best-effort; if it races, the checkpoint merge reconciles
+        }
+      }
+    }
+    stop();
+    onEnd?.();
+  }, [committedBody, stop, onEnd]);
+
+  // Join + stream while enabled; leave on disable/unmount.
+  useEffect(() => {
+    if (!enabled) return;
+    endedRef.current = false;
+    const ctrl = new AbortController();
+    abort.current = ctrl;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const snap = await joinSession(path);
+        if (cancelled) return;
+        sessionId.current = snap.session_id;
+        version.current = snap.version;
+        serverBuffer.current = snap.buffer;
+        setBuffer(snap.buffer);
+        setParticipants(snap.participants);
+        setActive(true);
+        // Long-lived stream; resolves when the server closes or we abort.
+        await streamSession(snap.session_id, onFrame, ctrl.signal);
+      } catch {
+        // join failed or stream ended; leave edit mode gracefully
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, path]);
+
+  return { active, buffer, participants, onChange, save, discard };
+}


### PR DESCRIPTION
## What

First slice of the frontend "**Edit = session**" cutover — the transport layer, ahead of wiring it into the wiki editor. No user-visible change yet (no consumer); this is the reviewable foundation the `FileViewer` cutover (next FE PR) builds on.

## Files
- **`src/lib/coedit.ts`** — typed calls for the co-edit API (`join`/`leave`/`op`/`cursor`/`checkpoint`/`session`) and `streamSession`, which reuses the existing `apiStream` with `method: "GET"` for the SSE `/stream` (keepalive comment lines are ignored; `data:` frames parsed). Plus `diffToChange` / `applyChange`, which work in **UTF-16 code units** — JS-native (string indexing/`slice`), matching the server's `Change` offsets, so no conversion.
- **`src/lib/useCoeditSession.ts`** — a hook that:
  - joins on `enabled`, opens the stream, exposes `buffer` + `onChange` for a plain `<textarea>` and `participants` for a presence badge;
  - coalesces local edits into **one in-flight** range-change op (`base_version` CAS), and re-flushes on ack;
  - splices inbound `op` frames (skipping our own echo by author), updates `presence`;
  - falls back to a full **re-fetch** on 409 / `resync` / when a remote op arrives while the local buffer has unsent edits — correct, occasionally jumpy (the textarea MVP; CodeMirror + pending-op rebase smooth this in a later PR);
  - `save()` = checkpoint + leave; `discard()` = reset the shared buffer to the committed body + leave (so the leave-time checkpoint is a no-op); unmount leaves.

## Verify
- `bun run typecheck` clean.

## Next
`FileViewer` cutover (PR2b): bind the edit textarea to `useCoeditSession`, switch Save→checkpoint / Cancel→discard, add the presence badge, and remove the draft-autosave effect, resume banner, and inline conflict panel (co-editing removes the human conflict path).