### PR TITLE
feat(slack): bot posting, DMs, and the channel picker

### DIFF
--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -26,6 +26,16 @@ log = logging.getLogger(__name__)
 _BOT_SCOPES = "chat:write,chat:write.public,channels:read,groups:read,im:write,users:read,channels:join"
 
 
+class SlackChannel(BaseModel):
+    id: str
+    name: str
+    is_private: bool
+
+
+class SlackChannelsResponse(BaseModel):
+    channels: list[SlackChannel]
+
+
 class SlackConnectStatus(BaseModel):
     configured: bool
     connected: bool
@@ -142,8 +152,8 @@ def connect_callback(
     return _bounce(return_to, outcome="ok")
 
 
-@router.get("/channels")
-def list_channels(user: User = Depends(require_user)) -> dict[str, Any]:
+@router.get("/channels", response_model=SlackChannelsResponse)
+def list_channels(user: User = Depends(require_user)) -> SlackChannelsResponse:
     """Channels the caller's bot connection can post to, for the picker."""
     connection = next(iter(connections.list_for_user(user.id)), None)
     if connection is None:
@@ -155,7 +165,9 @@ def list_channels(user: User = Depends(require_user)) -> dict[str, Any]:
         channels = slack_client.list_channels(bot_token=bot_token)
     except slack_client.SlackApiError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
-    return {"channels": channels}
+    return SlackChannelsResponse(
+        channels=[SlackChannel.model_validate(c) for c in channels]
+    )
 
 
 @router.delete("")

--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -142,6 +142,22 @@ def connect_callback(
     return _bounce(return_to, outcome="ok")
 
 
+@router.get("/channels")
+def list_channels(user: User = Depends(require_user)) -> dict[str, Any]:
+    """Channels the caller's bot connection can post to, for the picker."""
+    connection = next(iter(connections.list_for_user(user.id)), None)
+    if connection is None:
+        raise HTTPException(status_code=404, detail="slack not connected")
+    bot_token = connections.get_bot_token(user.id, str(connection["team_id"]))
+    if not bot_token:
+        raise HTTPException(status_code=404, detail="slack not connected")
+    try:
+        channels = slack_client.list_channels(bot_token=bot_token)
+    except slack_client.SlackApiError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return {"channels": channels}
+
+
 @router.delete("")
 def disconnect(user: User = Depends(require_user)) -> dict[str, bool]:
     """Drop the caller's connection rows.

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -72,13 +72,11 @@ def list_channels(*, bot_token: str) -> list[dict[str, Any]]:
     )
     out: list[dict[str, Any]] = []
     for ch in cast(list[dict[str, Any]], body.get("channels") or []):
-        out.append(
-            {
-                "id": ch.get("id"),
-                "name": ch.get("name"),
-                "is_private": bool(ch.get("is_private")),
-            }
-        )
+        ch_id = ch.get("id")
+        ch_name = ch.get("name")
+        if not isinstance(ch_id, str) or not isinstance(ch_name, str):
+            continue  # unusable in the picker without both
+        out.append({"id": ch_id, "name": ch_name, "is_private": bool(ch.get("is_private"))})
     return out
 
 

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -22,6 +22,66 @@ class SlackApiError(RuntimeError):
     pass
 
 
+def _call_api(bot_token: str, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """POST a Slack Web API method with the bot token. Slack signals failure
+    with HTTP 200 and ``{"ok": false, "error": ...}``, so both transport
+    errors and ok=false raise :class:`SlackApiError`."""
+    try:
+        response = requests.post(
+            f"https://slack.com/api/{method}",
+            headers={"Authorization": f"Bearer {bot_token}"},
+            json=payload,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        body = cast(dict[str, Any], response.json())
+    except requests.RequestException as exc:
+        raise SlackApiError(f"{method} failed: {exc}") from exc
+    if not body.get("ok"):
+        raise SlackApiError(f"{method} rejected: {body.get('error', 'unknown')}")
+    return body
+
+
+def post_chat_message(*, bot_token: str, channel: str, text: str) -> None:
+    """Post ``text`` to a channel (or DM channel) as the bot."""
+    _call_api(bot_token, "chat.postMessage", {"channel": channel, "text": text})
+
+
+def open_dm(*, bot_token: str, slack_user_id: str) -> str:
+    """Open (or fetch) the bot's DM channel with a user; returns its id."""
+    body = _call_api(bot_token, "conversations.open", {"users": slack_user_id})
+    channel = cast(dict[str, Any], body.get("channel") or {})
+    channel_id = channel.get("id")
+    if not isinstance(channel_id, str) or not channel_id:
+        raise SlackApiError("conversations.open returned no channel id")
+    return channel_id
+
+
+def list_channels(*, bot_token: str) -> list[dict[str, Any]]:
+    """Channels the token can see, for the trigger channel picker. One page of
+    200 covers the picker use case; private channels appear only where the bot
+    is a member."""
+    body = _call_api(
+        bot_token,
+        "conversations.list",
+        {
+            "types": "public_channel,private_channel",
+            "exclude_archived": True,
+            "limit": 200,
+        },
+    )
+    out: list[dict[str, Any]] = []
+    for ch in cast(list[dict[str, Any]], body.get("channels") or []):
+        out.append(
+            {
+                "id": ch.get("id"),
+                "name": ch.get("name"),
+                "is_private": bool(ch.get("is_private")),
+            }
+        )
+    return out
+
+
 def exchange_oauth_code(
     *, client_id: str, client_secret: str, code: str, redirect_uri: str
 ) -> dict[str, Any]:

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any, cast
 
 from datetime import datetime, timezone
 
@@ -45,6 +46,7 @@ from sqlalchemy import select
 from app.db.models import Event, User
 from app.db.session import session
 from app.slack import client as slack_client
+from app.slack import connections as slack_connections
 from app.tasks.queues import triggers_queue
 from app.triggers import destination_configs as dest_configs
 from app.triggers import destinations as destinations_repo
@@ -369,7 +371,10 @@ def _record_fire(
     assert config_id is not None  # config resolved only when config_id is set
     if dtype == destinations_repo.SLACK_ID:
         _dispatch_to_slack(
-            trigger=trigger, config_id=config_id, rendered_message=rendered_message
+            trigger=trigger,
+            config=config,
+            doc_path=doc_path,
+            rendered_message=rendered_message,
         )
     else:
         log.warning(
@@ -379,29 +384,73 @@ def _record_fire(
 
 
 def _dispatch_to_slack(
-    *, trigger: TriggerRecord, config_id: str, rendered_message: str
+    *, trigger: TriggerRecord, config: dict[str, object], doc_path: str, rendered_message: str
 ) -> None:
-    """POST a fire's rendered message to the destination config's Slack channel.
+    """Deliver a fire's rendered message to the config's Slack target.
 
-    Resolves the config's decrypted secret (the incoming webhook URL) via
-    ``destination_configs.get_secret``, which enforces ownership. Failures are
-    logged and swallowed: the fire is already recorded in the events table, so
-    an unreachable Slack must not fail the task or lose it.
+    Three target shapes: a legacy incoming webhook (the config's encrypted
+    secret), a bot channel (``config.channel_id``), or a DM to the owner
+    (``config.dm``). Bot targets post through the owner's Slack connection
+    and carry a source line so the recipient can place the message. Failures
+    are logged and swallowed: the fire is already recorded in the events
+    table, so an unreachable Slack must not fail the task or lose it.
     """
-    webhook_url = dest_configs.get_secret(config_id, owner_user_id=trigger.owner_user_id)
-    if not webhook_url:
-        log.info(
-            "trigger %s slack config %s has no secret; recorded to events only",
+    if not rendered_message.strip():
+        log.info("trigger %s slack dispatch skipped: empty message", trigger.id)
+        return
+    config_id = str(config["id"])
+
+    if config.get("has_secret"):
+        webhook_url = dest_configs.get_secret(config_id, owner_user_id=trigger.owner_user_id)
+        if not webhook_url:
+            log.info(
+                "trigger %s slack config %s secret unavailable; recorded to events only",
+                trigger.id, config_id,
+            )
+            return
+        try:
+            slack_client.post_message(webhook_url=webhook_url, text=rendered_message)
+            log.info("trigger %s dispatched to slack webhook config %s", trigger.id, config_id)
+        except slack_client.SlackApiError:
+            log.exception("trigger %s slack webhook dispatch failed", trigger.id)
+        return
+
+    target = cast("dict[str, Any]", config.get("config") or {})
+    channel_id = target.get("channel_id")
+    wants_dm = bool(target.get("dm"))
+    if not channel_id and not wants_dm:
+        log.warning(
+            "trigger %s slack config %s has no delivery target; recorded to events only",
             trigger.id, config_id,
         )
         return
 
-    if not rendered_message.strip():
-        log.info("trigger %s slack dispatch skipped: empty message", trigger.id)
+    connection = next(iter(slack_connections.list_for_user(trigger.owner_user_id)), None)
+    if connection is None:
+        log.info(
+            "trigger %s owner %s has no slack connection; recorded to events only",
+            trigger.id, trigger.owner_user_id,
+        )
+        return
+    bot_token = slack_connections.get_bot_token(
+        trigger.owner_user_id, str(connection["team_id"])
+    )
+    if not bot_token:
+        log.info(
+            "trigger %s slack connection token unavailable; recorded to events only",
+            trigger.id,
+        )
         return
 
+    text = f"{rendered_message}\n— Agent Wiki trigger on {doc_path}"
     try:
-        slack_client.post_message(webhook_url=webhook_url, text=rendered_message)
-        log.info("trigger %s dispatched to slack config %s", trigger.id, config_id)
+        if wants_dm and not channel_id:
+            channel_id = slack_client.open_dm(
+                bot_token=bot_token, slack_user_id=str(connection["slack_user_id"])
+            )
+        slack_client.post_chat_message(
+            bot_token=bot_token, channel=str(channel_id), text=text
+        )
+        log.info("trigger %s dispatched via slack bot config %s", trigger.id, config_id)
     except slack_client.SlackApiError:
-        log.exception("trigger %s slack dispatch failed", trigger.id)
+        log.exception("trigger %s slack bot dispatch failed", trigger.id)

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -72,6 +72,12 @@ def create(
         raise ValueError("name is required")
     if not destinations.exists(type):
         raise ValueError(f"unknown destination type: {type}")
+    if type == destinations.SLACK_ID:
+        cfg = config or {}
+        if not secret and not cfg.get("channel_id") and not cfg.get("dm"):
+            raise ValueError(
+                "a slack destination needs a webhook secret, a channel_id, or dm: true"
+            )
 
     config_id = "dst_" + uuid.uuid4().hex[:12]
     created_at = _now_iso()

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -74,9 +74,13 @@ def create(
         raise ValueError(f"unknown destination type: {type}")
     if type == destinations.SLACK_ID:
         cfg = config or {}
-        if not secret and not cfg.get("channel_id") and not cfg.get("dm"):
+        targets = sum(
+            1 for present in (secret, cfg.get("channel_id"), cfg.get("dm")) if present
+        )
+        if targets != 1:
             raise ValueError(
-                "a slack destination needs a webhook secret, a channel_id, or dm: true"
+                "a slack destination needs exactly one of: a webhook secret, "
+                "a channel_id, or dm: true"
             )
 
     config_id = "dst_" + uuid.uuid4().hex[:12]

--- a/backend/tests/test_destination_configs.py
+++ b/backend/tests/test_destination_configs.py
@@ -43,30 +43,32 @@ def test_create_rejects_empty_name(tmp_db):
 
 def test_create_without_secret(tmp_db):
     seed_user("usr_1")
-    c = configs.create("usr_1", type="slack", name="No secret")
+    c = configs.create("usr_1", type="slack", name="No secret", config={"channel_id": "C1"})
     assert c["has_secret"] is False
     assert configs.get_secret(c["id"], owner_user_id="usr_1") is None
 
 
 def test_config_json_roundtrip(tmp_db):
     seed_user("usr_1")
-    c = configs.create("usr_1", type="slack", name="Tagged", config={"routing_tag": "jira"})
+    c = configs.create(
+        "usr_1", type="slack", name="Tagged", config={"routing_tag": "jira", "channel_id": "C1"}
+    )
     got = configs.get(c["id"], "usr_1")
     assert got is not None
-    assert got["config"] == {"routing_tag": "jira"}
+    assert got["config"] == {"routing_tag": "jira", "channel_id": "C1"}
 
 
 def test_list_is_owner_scoped(tmp_db):
     seed_user("usr_1")
     seed_user("usr_2", email="two@x.com")
-    configs.create("usr_1", type="slack", name="Mine")
+    configs.create("usr_1", type="slack", name="Mine", config={"dm": True})
     assert configs.list_for_user("usr_2") == []
 
 
 def test_delete_is_owner_scoped(tmp_db):
     seed_user("usr_1")
     seed_user("usr_2", email="two@x.com")
-    c = configs.create("usr_1", type="slack", name="Mine")
+    c = configs.create("usr_1", type="slack", name="Mine", config={"dm": True})
 
     assert configs.delete(c["id"], "usr_2") is False  # not the owner
     assert configs.delete(c["id"], "usr_1") is True

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -144,3 +144,33 @@ def test_slack_config_requires_a_target(tmp_db):
     dest_configs.create(_OWNER, type="slack", name="Hook", secret="https://hooks.slack.com/x")
     dest_configs.create(_OWNER, type="slack", name="Chan", config={"channel_id": "C1"})
     dest_configs.create(_OWNER, type="slack", name="Me", config={"dm": True})
+
+
+def test_slack_config_rejects_multiple_targets(tmp_db):
+    seed_user(_OWNER)
+    with pytest.raises(ValueError, match="exactly one"):
+        dest_configs.create(
+            _OWNER, type="slack", name="Both", config={"channel_id": "C1", "dm": True}
+        )
+    with pytest.raises(ValueError, match="exactly one"):
+        dest_configs.create(
+            _OWNER,
+            type="slack",
+            name="Both",
+            secret="https://hooks.slack.com/x",
+            config={"channel_id": "C1"},
+        )
+
+
+def test_list_channels_drops_entries_missing_id_or_name(monkeypatch):
+    captured = {
+        "ok": True,
+        "channels": [
+            {"id": "C1", "name": "eng", "is_private": False},
+            {"id": None, "name": "ghost"},
+            {"id": "C2"},
+        ],
+    }
+    monkeypatch.setattr(slack_client, "_call_api", lambda *a, **kw: captured)
+    out = slack_client.list_channels(bot_token="xoxb-x")
+    assert out == [{"id": "C1", "name": "eng", "is_private": False}]

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -1,0 +1,146 @@
+"""Bot-path Slack delivery: a fire posts to a channel config through the
+owner's connection token, DMs the owner, appends the source line, and always
+degrades to recorded-only when the connection or target is missing."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.models.wiki import ChangeKind
+from app.slack import client as slack_client, connections
+from app.tasks.triggers import _record_fire
+from app.triggers import destination_configs as dest_configs
+from app.triggers.engine import TriggerAction, TriggerRecord
+
+from tests._seed import list_events, seed_user
+
+_OWNER = "usr_1"
+
+
+def _trigger(config_id: str) -> TriggerRecord:
+    return TriggerRecord(
+        id="trg_1",
+        owner_user_id=_OWNER,
+        scope_path="projects/foo.md",
+        kind="delta",
+        nl_description="fire when status changes",
+        actions=[TriggerAction(destination_config_id=config_id, message="status changed")],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+
+def _fire(config_id: str) -> None:
+    t = _trigger(config_id)
+    _record_fire(
+        trigger=t,
+        action=t.actions[0],
+        doc_path="projects/foo.md",
+        sha="abc123",
+        change_kind=ChangeKind.EDIT,
+        reason="status flipped",
+        instruction="say what changed",
+        rendered_message="Status flipped to done",
+        actor=None,
+    )
+
+
+def _connect_owner() -> None:
+    connections.upsert(
+        user_id=_OWNER,
+        team_id="T123",
+        team_name="Onyx Team",
+        slack_user_id="U777",
+        bot_token="xoxb-bot-token-123",
+        scope=None,
+    )
+
+
+@pytest.fixture
+def _bot_posts(monkeypatch):
+    posts: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        slack_client,
+        "post_chat_message",
+        lambda *, bot_token, channel, text: posts.append(
+            {"bot_token": bot_token, "channel": channel, "text": text}
+        ),
+    )
+    return posts
+
+
+def test_channel_config_posts_via_bot(tmp_db, _bot_posts):
+    seed_user(_OWNER)
+    _connect_owner()
+    cfg = dest_configs.create(
+        _OWNER, type="slack", name="Eng", config={"channel_id": "C42"}
+    )
+
+    _fire(cfg["id"])
+
+    assert list_events(kind="trigger.fire")  # recorded regardless
+    assert len(_bot_posts) == 1
+    assert _bot_posts[0]["channel"] == "C42"
+    assert _bot_posts[0]["bot_token"] == "xoxb-bot-token-123"
+    assert _bot_posts[0]["text"].startswith("Status flipped to done")
+    assert "Agent Wiki trigger on projects/foo.md" in _bot_posts[0]["text"]
+
+
+def test_dm_config_opens_dm_and_posts(tmp_db, _bot_posts, monkeypatch):
+    seed_user(_OWNER)
+    _connect_owner()
+    opened: list[str] = []
+    monkeypatch.setattr(
+        slack_client,
+        "open_dm",
+        lambda *, bot_token, slack_user_id: (opened.append(slack_user_id), "D99")[1],
+    )
+    cfg = dest_configs.create(_OWNER, type="slack", name="Me", config={"dm": True})
+
+    _fire(cfg["id"])
+
+    assert opened == ["U777"]
+    assert len(_bot_posts) == 1
+    assert _bot_posts[0]["channel"] == "D99"
+
+
+def test_bot_config_without_connection_records_only(tmp_db, _bot_posts):
+    seed_user(_OWNER)
+    cfg = dest_configs.create(
+        _OWNER, type="slack", name="Eng", config={"channel_id": "C42"}
+    )
+
+    _fire(cfg["id"])
+
+    assert list_events(kind="trigger.fire")
+    assert _bot_posts == []
+
+
+def test_bot_dispatch_failure_still_records(tmp_db, monkeypatch):
+    seed_user(_OWNER)
+    _connect_owner()
+    monkeypatch.setattr(
+        slack_client,
+        "post_chat_message",
+        lambda **kw: (_ for _ in ()).throw(slack_client.SlackApiError("down")),
+    )
+    cfg = dest_configs.create(
+        _OWNER, type="slack", name="Eng", config={"channel_id": "C42"}
+    )
+
+    _fire(cfg["id"])  # must not raise
+
+    assert list_events(kind="trigger.fire")
+
+
+def test_slack_config_requires_a_target(tmp_db):
+    seed_user(_OWNER)
+    with pytest.raises(ValueError, match="channel_id"):
+        dest_configs.create(_OWNER, type="slack", name="Nowhere")
+    # Each valid target shape is accepted.
+    dest_configs.create(_OWNER, type="slack", name="Hook", secret="https://hooks.slack.com/x")
+    dest_configs.create(_OWNER, type="slack", name="Chan", config={"channel_id": "C1"})
+    dest_configs.create(_OWNER, type="slack", name="Me", config={"dm": True})

--- a/backend/tests/test_slack_dispatch.py
+++ b/backend/tests/test_slack_dispatch.py
@@ -98,9 +98,13 @@ def test_event_log_records_but_does_not_post(tmp_db, _captured_post):
     assert _captured_post == []
 
 
-def test_slack_config_without_secret_records_but_does_not_post(tmp_db, _captured_post):
+def test_bot_channel_config_never_hits_webhook_path(tmp_db, _captured_post):
+    """A channel-target config (no secret) must not post through the webhook
+    client, even when the owner has no bot connection."""
     seed_user(_OWNER)
-    cid = _slack_config(secret=None)
+    cid = dest_configs.create(
+        _OWNER, type="slack", name="Chan", config={"channel_id": "C1"}
+    )["id"]
 
     _fire(_trigger(destination_config_id=cid))
 


### PR DESCRIPTION
## Description

Trigger fires now deliver through the Agent Wiki bot.

- A slack destination config carries one of three targets: the legacy webhook secret, a `channel_id`, or `dm: true`. Dispatch discriminates on shape — webhook posts as before; bot targets resolve the owner's connection token and post via `chat.postMessage` (`conversations.open` for DMs), appending a source line naming the doc.
- Every missing precondition (no target, no connection, undecryptable token, Slack error) logs and degrades to recorded-only; the fire event is always written first.
- `GET /api/connectors/slack/channels` lists postable channels off the caller's own token, for the picker.
- Creating a targetless slack config is rejected at the repo, so undeliverable configs can't exist.

Picker/multi-target UI comes with the Connectors settings work.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check