### PR TITLE
feat(slack): connect button, channel picker, and DM destinations in the UI

### DIFF
--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -55,6 +55,7 @@ Raw SQL is permitted only in narrowly scoped DB-extension wrappers (FTS, task qu
 - No raw hex colors, radii, or shadows in React components — pull from the centralized theme module. If a shade isn't there, add it there first.
 - No `background: "white"` (or any literal); use `color.bg.page`.
 - One `Button` component per app surface; prefer the OPAL primitives (`Button`, `Tag`) for new components. Don't roll a new bespoke `<button style={{...}}>` for primary/secondary/danger chrome.
+- New UI must compose from OPAL components, not token-styled raw controls: `InputTypeIn` for inputs, `SelectButton`/`Popover`/`PopoverMenu`/`LineItemButton` for pickers and dropdowns. Flag any raw `<input>`/`<select>`/`<textarea>` in new components unless OPAL has no equivalent.
 - Modal scrims use `color.overlay`; modal shadow uses `shadow.modal`. Don't introduce slate-tinted or pure-black scrims.
 
 ## Network — Only via `apiFetch`

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -47,6 +47,7 @@ def _config_view(row: dict[str, Any]) -> DestinationConfigView:
         id=row["id"],
         type=row["type"],
         name=row["name"],
+        config=cast("dict[str, Any]", row.get("config") or {}),
         has_secret=bool(row.get("has_secret")),
         created_at=row.get("created_at"),
     )

--- a/backend/app/models/destination_config.py
+++ b/backend/app/models/destination_config.py
@@ -23,11 +23,13 @@ class CreateDestinationConfigRequest(BaseModel):
 
 class DestinationConfigView(BaseModel):
     """A destination config in list form. The secret is never returned, only
-    whether one is set."""
+    whether one is set. ``config`` is the non-secret per-type settings (e.g.
+    a slack channel reference), which the UI needs for dedup and display."""
 
     id: str
     type: str
     name: str
+    config: dict[str, Any] = Field(default_factory=dict)
     has_secret: bool
     created_at: str | None
 

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -9,11 +9,25 @@ lost just because Slack is unreachable.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, cast
 
 import requests
 
 log = logging.getLogger(__name__)
+
+# Standard markdown -> Slack mrkdwn, the high-value cases only: Slack renders
+# **bold** and [text](url) literally, and has no heading syntax.
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
+_HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
+
+
+def to_mrkdwn(text: str) -> str:
+    """Convert common markdown constructs to Slack's mrkdwn dialect."""
+    text = _BOLD_RE.sub(r"*\1*", text)
+    text = _LINK_RE.sub(r"<\2|\1>", text)
+    return _HEADING_RE.sub(r"*\1*", text)
 
 _REQUEST_TIMEOUT_SECONDS = 15
 

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from typing import Any, cast
 
 import requests
@@ -73,27 +74,50 @@ def open_dm(*, bot_token: str, slack_user_id: str) -> str:
     return channel_id
 
 
+_GET_ATTEMPTS = 3
+_GET_TIMEOUT_SECONDS = 30  # bulk reads (conversations.list) run slow on big workspaces
+_MAX_RETRY_AFTER_SECONDS = 30
+
+
 def _call_api_get(bot_token: str, method: str, params: dict[str, str]) -> dict[str, Any]:
     """GET a Slack Web API read method with query params. Read methods take
-    form/query encoding, not JSON bodies (which they silently ignore)."""
-    try:
-        response = requests.get(
-            f"https://slack.com/api/{method}",
-            headers={"Authorization": f"Bearer {bot_token}"},
-            params=params,
-            timeout=_REQUEST_TIMEOUT_SECONDS,
-        )
-        response.raise_for_status()
-        body = cast(dict[str, Any], response.json())
-    except requests.RequestException as exc:
-        raise SlackApiError(f"{method} failed: {exc}") from exc
-    if not body.get("ok"):
-        raise SlackApiError(f"{method} rejected: {body.get('error', 'unknown')}")
-    return body
+    form/query encoding, not JSON bodies (which they silently ignore).
+    Retries timeouts/connection errors with backoff and honors Retry-After
+    on 429s."""
+    last_exc: Exception | None = None
+    for attempt in range(_GET_ATTEMPTS):
+        try:
+            response = requests.get(
+                f"https://slack.com/api/{method}",
+                headers={"Authorization": f"Bearer {bot_token}"},
+                params=params,
+                timeout=_GET_TIMEOUT_SECONDS,
+            )
+            if response.status_code == 429:
+                retry_after = min(
+                    int(response.headers.get("Retry-After", "1") or 1),
+                    _MAX_RETRY_AFTER_SECONDS,
+                )
+                log.info("%s rate limited; retrying in %ds", method, retry_after)
+                time.sleep(retry_after)
+                continue
+            response.raise_for_status()
+            body = cast(dict[str, Any], response.json())
+        except (requests.Timeout, requests.ConnectionError) as exc:
+            last_exc = exc
+            log.warning("%s attempt %d/%d failed: %s", method, attempt + 1, _GET_ATTEMPTS, exc)
+            time.sleep(2**attempt)
+            continue
+        except requests.RequestException as exc:
+            raise SlackApiError(f"{method} failed: {exc}") from exc
+        if not body.get("ok"):
+            raise SlackApiError(f"{method} rejected: {body.get('error', 'unknown')}")
+        return body
+    raise SlackApiError(f"{method} failed after {_GET_ATTEMPTS} attempts: {last_exc}")
 
 
-# Hard ceiling on picker pagination: 50 pages of 200 = 10k channels.
-_CHANNEL_PAGE_LIMIT = 50
+# Hard ceiling on picker pagination: 10 pages of 1000 = 10k channels.
+_CHANNEL_PAGE_LIMIT = 10
 
 
 def list_channels(*, bot_token: str) -> list[dict[str, Any]]:
@@ -106,7 +130,7 @@ def list_channels(*, bot_token: str) -> list[dict[str, Any]]:
         params = {
             "types": "public_channel,private_channel",
             "exclude_archived": "true",
-            "limit": "200",
+            "limit": "1000",
         }
         if cursor:
             params["cursor"] = cursor

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -17,7 +17,9 @@ import requests
 log = logging.getLogger(__name__)
 
 # Standard markdown -> Slack mrkdwn, the high-value cases only: Slack renders
-# **bold** and [text](url) literally, and has no heading syntax.
+# **bold** and [text](url) literally. Heading markers are stripped to plain
+# text (notifications carry no headings), before bold so `## **x**` can't
+# nest emphasis.
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 _HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
@@ -25,9 +27,9 @@ _HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
 
 def to_mrkdwn(text: str) -> str:
     """Convert common markdown constructs to Slack's mrkdwn dialect."""
+    text = _HEADING_RE.sub(r"\1", text)
     text = _BOLD_RE.sub(r"*\1*", text)
-    text = _LINK_RE.sub(r"<\2|\1>", text)
-    return _HEADING_RE.sub(r"*\1*", text)
+    return _LINK_RE.sub(r"<\2|\1>", text)
 
 _REQUEST_TIMEOUT_SECONDS = 15
 

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -57,27 +57,59 @@ def open_dm(*, bot_token: str, slack_user_id: str) -> str:
     return channel_id
 
 
+def _call_api_get(bot_token: str, method: str, params: dict[str, str]) -> dict[str, Any]:
+    """GET a Slack Web API read method with query params. Read methods take
+    form/query encoding, not JSON bodies (which they silently ignore)."""
+    try:
+        response = requests.get(
+            f"https://slack.com/api/{method}",
+            headers={"Authorization": f"Bearer {bot_token}"},
+            params=params,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        body = cast(dict[str, Any], response.json())
+    except requests.RequestException as exc:
+        raise SlackApiError(f"{method} failed: {exc}") from exc
+    if not body.get("ok"):
+        raise SlackApiError(f"{method} rejected: {body.get('error', 'unknown')}")
+    return body
+
+
+# Hard ceiling on picker pagination: 50 pages of 200 = 10k channels.
+_CHANNEL_PAGE_LIMIT = 50
+
+
 def list_channels(*, bot_token: str) -> list[dict[str, Any]]:
-    """Channels the token can see, for the trigger channel picker. One page of
-    200 covers the picker use case; private channels appear only where the bot
-    is a member."""
-    body = _call_api(
-        bot_token,
-        "conversations.list",
-        {
-            "types": "public_channel,private_channel",
-            "exclude_archived": True,
-            "limit": 200,
-        },
-    )
+    """Every channel the token can deliver to, for the picker: all non-archived
+    public channels plus private ones the bot is a member of. Paginates the
+    full cursor chain and returns the list sorted by name."""
     out: list[dict[str, Any]] = []
-    for ch in cast(list[dict[str, Any]], body.get("channels") or []):
-        ch_id = ch.get("id")
-        ch_name = ch.get("name")
-        if not isinstance(ch_id, str) or not isinstance(ch_name, str):
-            continue  # unusable in the picker without both
-        out.append({"id": ch_id, "name": ch_name, "is_private": bool(ch.get("is_private"))})
-    return out
+    cursor = ""
+    for _ in range(_CHANNEL_PAGE_LIMIT):
+        params = {
+            "types": "public_channel,private_channel",
+            "exclude_archived": "true",
+            "limit": "200",
+        }
+        if cursor:
+            params["cursor"] = cursor
+        body = _call_api_get(bot_token, "conversations.list", params)
+        for ch in cast(list[dict[str, Any]], body.get("channels") or []):
+            ch_id = ch.get("id")
+            ch_name = ch.get("name")
+            if not isinstance(ch_id, str) or not isinstance(ch_name, str):
+                continue  # unusable in the picker without both
+            out.append(
+                {"id": ch_id, "name": ch_name, "is_private": bool(ch.get("is_private"))}
+            )
+        meta = cast(dict[str, Any], body.get("response_metadata") or {})
+        cursor = str(meta.get("next_cursor") or "")
+        if not cursor:
+            break
+    else:
+        log.warning("conversations.list pagination hit the %d-page cap", _CHANNEL_PAGE_LIMIT)
+    return sorted(out, key=lambda c: str(c["name"]))
 
 
 def exchange_oauth_code(

--- a/backend/app/tasks/periodic.py
+++ b/backend/app/tasks/periodic.py
@@ -29,7 +29,9 @@ from app.tasks.triggers import evaluate_due_schedule_triggers
 log = logging.getLogger(__name__)
 
 
-@triggers_queue.periodic_task(crontab(minute="*/5"))
+# Every-minute scan: a no-op pass is one indexed query, and per-minute
+# ticks keep a trigger's fire within ~1min of its cron time.
+@triggers_queue.periodic_task(crontab())
 def evaluate_scheduled_triggers() -> None:
     now = datetime.now(timezone.utc)
     evaluate_due_schedule_triggers(now)

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -25,7 +25,7 @@ Queues:
   scheduled).** All trigger evaluation, both event-driven and time-based.
   Post-commit fan-out (``fan_out_trigger_eval``) runs the SQL match against
   ``doc_path`` plus every parent directory and dispatches one or two LLM
-  calls per matched trigger. The 5-min cron ``evaluate_scheduled_triggers``
+  calls per matched trigger. The every-minute cron ``evaluate_scheduled_triggers``
   (kind=schedule triggers due now) lives here too — same evaluator, same
   code paths, different ignition. Kept separate from ``documents_queue``
   because trigger eval is read-only (no commits) and we want one queue's

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -442,7 +442,11 @@ def _dispatch_to_slack(
         )
         return
 
-    text = f"{rendered_message}\n— Agent Wiki trigger on {doc_path}"
+    # Channel posts name the owner as a real mention; a DM already is the owner.
+    source = f"— Agent Wiki trigger on {doc_path}"
+    if not wants_dm:
+        source += f", for <@{connection['slack_user_id']}>"
+    text = f"{rendered_message}\n{source}"
     try:
         if wants_dm and not channel_id:
             channel_id = slack_client.open_dm(

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -409,7 +409,9 @@ def _dispatch_to_slack(
             )
             return
         try:
-            slack_client.post_message(webhook_url=webhook_url, text=rendered_message)
+            slack_client.post_message(
+                webhook_url=webhook_url, text=slack_client.to_mrkdwn(rendered_message)
+            )
             log.info("trigger %s dispatched to slack webhook config %s", trigger.id, config_id)
         except slack_client.SlackApiError:
             log.exception("trigger %s slack webhook dispatch failed", trigger.id)
@@ -446,7 +448,7 @@ def _dispatch_to_slack(
     source = f"— Agent Wiki trigger on {doc_path}"
     if not wants_dm:
         source += f", for <@{connection['slack_user_id']}>"
-    text = f"{rendered_message}\n{source}"
+    text = f"{slack_client.to_mrkdwn(rendered_message)}\n{source}"
     try:
         if wants_dm and not channel_id:
             channel_id = slack_client.open_dm(

--- a/backend/app/triggers/natural_language.py
+++ b/backend/app/triggers/natural_language.py
@@ -174,6 +174,8 @@ reference the latest version directly.
 internal IDs, or explanations of your reasoning. Output only the \
 delivered message text.
   * Plain text or markdown is fine. No greetings, no signoff.
+  * Delivery appends its own attribution line naming the source \
+document — do not add a title or repeat the document name.
 
 Always respond by calling the `render` tool exactly once.\
 """
@@ -323,6 +325,8 @@ scoped to the SCHEDULED CHECK scope.
 internal IDs, or explanations of your reasoning. Output only the \
 delivered message text.
   * Plain text or markdown is fine. No greetings, no signoff.
+  * Delivery appends its own attribution line naming the source \
+document — do not add a title or repeat the document name.
 
 Always respond by calling the `render` tool exactly once.\
 """

--- a/backend/app/utils/logging.py
+++ b/backend/app/utils/logging.py
@@ -45,6 +45,11 @@ def setup_logging(level: str | int | None = None) -> None:
     # Tame noisy third-party loggers; flip to DEBUG via env if needed.
     logging.getLogger("werkzeug").setLevel(logging.INFO)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+    # botocore DEBUG logs full request headers (bearer tokens included) and
+    # every stream chunk — never allow it below INFO.
+    logging.getLogger("botocore").setLevel(logging.INFO)
+    logging.getLogger("boto3").setLevel(logging.INFO)
+    logging.getLogger("urllib3").setLevel(logging.INFO)
 
     _configured = True
 

--- a/backend/tests/test_logging_setup.py
+++ b/backend/tests/test_logging_setup.py
@@ -1,0 +1,14 @@
+"""setup_logging keeps AWS/HTTP client loggers at INFO even under a DEBUG
+root, so botocore can never dump request auth headers into the logs."""
+from __future__ import annotations
+
+import logging
+
+from app.utils.logging import setup_logging
+
+
+def test_third_party_loggers_capped_under_debug():
+    setup_logging(level="DEBUG")
+    assert logging.getLogger().level == logging.DEBUG
+    for name in ("botocore", "boto3", "urllib3"):
+        assert logging.getLogger(name).getEffectiveLevel() >= logging.INFO

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -171,6 +171,28 @@ def test_list_channels_drops_entries_missing_id_or_name(monkeypatch):
             {"id": "C2"},
         ],
     }
-    monkeypatch.setattr(slack_client, "_call_api", lambda *a, **kw: captured)
+    monkeypatch.setattr(slack_client, "_call_api_get", lambda *a, **kw: captured)
     out = slack_client.list_channels(bot_token="xoxb-x")
     assert out == [{"id": "C1", "name": "eng", "is_private": False}]
+
+
+def test_list_channels_paginates_and_sorts(monkeypatch):
+    pages = [
+        {
+            "ok": True,
+            "channels": [{"id": "C2", "name": "zeta"}],
+            "response_metadata": {"next_cursor": "page2"},
+        },
+        {"ok": True, "channels": [{"id": "C1", "name": "alpha"}]},
+    ]
+    seen_params: list[dict[str, str]] = []
+
+    def fake_get(token, method, params):
+        seen_params.append(params)
+        return pages[len(seen_params) - 1]
+
+    monkeypatch.setattr(slack_client, "_call_api_get", fake_get)
+    out = slack_client.list_channels(bot_token="xoxb-x")
+    assert [c["name"] for c in out] == ["alpha", "zeta"]
+    assert "cursor" not in seen_params[0]
+    assert seen_params[1]["cursor"] == "page2"

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -208,7 +208,8 @@ def test_to_mrkdwn_converts_common_markdown():
         slack_client.to_mrkdwn("see [the doc](https://x.io/d) now")
         == "see <https://x.io/d|the doc> now"
     )
-    assert slack_client.to_mrkdwn("## Heading\nbody") == "*Heading*\nbody"
+    assert slack_client.to_mrkdwn("## Heading\nbody") == "Heading\nbody"
+    assert slack_client.to_mrkdwn("## **Title**\nbody") == "*Title*\nbody"
     # Already-mrkdwn single asterisks and mentions pass through untouched.
     assert slack_client.to_mrkdwn("*fine* <@U1>") == "*fine* <@U1>"
 

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -87,6 +87,8 @@ def test_channel_config_posts_via_bot(tmp_db, _bot_posts):
     assert _bot_posts[0]["bot_token"] == "xoxb-bot-token-123"
     assert _bot_posts[0]["text"].startswith("Status flipped to done")
     assert "Agent Wiki trigger on projects/foo.md" in _bot_posts[0]["text"]
+    # Channel posts mention the owner for attribution.
+    assert "<@U777>" in _bot_posts[0]["text"]
 
 
 def test_dm_config_opens_dm_and_posts(tmp_db, _bot_posts, monkeypatch):
@@ -105,6 +107,8 @@ def test_dm_config_opens_dm_and_posts(tmp_db, _bot_posts, monkeypatch):
     assert opened == ["U777"]
     assert len(_bot_posts) == 1
     assert _bot_posts[0]["channel"] == "D99"
+    # A DM is already the owner; no self-mention.
+    assert "<@U777>" not in _bot_posts[0]["text"]
 
 
 def test_bot_config_without_connection_records_only(tmp_db, _bot_posts):

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -233,3 +233,56 @@ def test_bot_post_converts_markdown(tmp_db, _bot_posts, monkeypatch):
         actor=None,
     )
     assert _bot_posts[0]["text"].startswith("*bold title*\nbody")
+
+
+def test_call_api_get_retries_timeout_then_succeeds(monkeypatch):
+    import requests as req_mod
+
+    calls: list[int] = []
+
+    class _Resp:
+        status_code = 200
+        headers: dict = {}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True, "channels": []}
+
+    def fake_get(*a, **kw):
+        calls.append(1)
+        if len(calls) == 1:
+            raise req_mod.Timeout("read timed out")
+        return _Resp()
+
+    monkeypatch.setattr(slack_client.requests, "get", fake_get)
+    monkeypatch.setattr(slack_client.time, "sleep", lambda s: None)
+    body = slack_client._call_api_get("xoxb-x", "conversations.list", {})
+    assert body["ok"] is True
+    assert len(calls) == 2
+
+
+def test_call_api_get_honors_retry_after(monkeypatch):
+    slept: list[float] = []
+
+    class _Limited:
+        status_code = 429
+        headers = {"Retry-After": "2"}
+
+    class _Ok:
+        status_code = 200
+        headers: dict = {}
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    responses = [_Limited(), _Ok()]
+    monkeypatch.setattr(slack_client.requests, "get", lambda *a, **kw: responses.pop(0))
+    monkeypatch.setattr(slack_client.time, "sleep", lambda s: slept.append(s))
+    body = slack_client._call_api_get("xoxb-x", "conversations.list", {})
+    assert body["ok"] is True
+    assert slept == [2]

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -200,3 +200,35 @@ def test_list_channels_paginates_and_sorts(monkeypatch):
     assert [c["name"] for c in out] == ["alpha", "zeta"]
     assert "cursor" not in seen_params[0]
     assert seen_params[1]["cursor"] == "page2"
+
+
+def test_to_mrkdwn_converts_common_markdown():
+    assert slack_client.to_mrkdwn("**fun_poem.md**") == "*fun_poem.md*"
+    assert (
+        slack_client.to_mrkdwn("see [the doc](https://x.io/d) now")
+        == "see <https://x.io/d|the doc> now"
+    )
+    assert slack_client.to_mrkdwn("## Heading\nbody") == "*Heading*\nbody"
+    # Already-mrkdwn single asterisks and mentions pass through untouched.
+    assert slack_client.to_mrkdwn("*fine* <@U1>") == "*fine* <@U1>"
+
+
+def test_bot_post_converts_markdown(tmp_db, _bot_posts, monkeypatch):
+    seed_user(_OWNER)
+    _connect_owner()
+    cfg = dest_configs.create(
+        _OWNER, type="slack", name="Eng", config={"channel_id": "C42"}
+    )
+    t = _trigger(cfg["id"])
+    _record_fire(
+        trigger=t,
+        action=t.actions[0],
+        doc_path="projects/foo.md",
+        sha="abc123",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="**bold title**\nbody",
+        actor=None,
+    )
+    assert _bot_posts[0]["text"].startswith("*bold title*\nbody")

--- a/frontend/STANDARDS.md
+++ b/frontend/STANDARDS.md
@@ -121,9 +121,16 @@ if (!(await confirmDialog({
 `window.confirm` left is the unsaved-changes navigation guard in the wiki
 page, which must synchronously block a click event.
 
-## Inputs / selects — consistent border and radius
+## Inputs / selects — Opal components first
 
-Form inputs and `<select>` controls use:
+New UI composes from `@onyx-ai/opal/components` rather than raw controls:
+`InputTypeIn` for text/search inputs, `SelectButton` + `Popover`/`PopoverMenu`
++ `LineItemButton` for pickers and dropdowns, `Switch`, `Checkbox`, `Tabs`.
+A raw `<input>`/`<select>` in new code is a review flag — reach for it only
+where Opal has no equivalent, and then style it per the rules below.
+
+Where a raw control is genuinely required, form inputs and `<select>`
+controls use:
 
 - border: `1px solid var(--border-01)` (use `var(--border-02)` only
   for emphasis — most inputs should be `border-01`)

--- a/frontend/src/components/triggers/SlackDestinationPicker.tsx
+++ b/frontend/src/components/triggers/SlackDestinationPicker.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import {
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  PopoverMenu,
+} from "@onyx-ai/opal/components";
+import { SvgBubbleText, SvgCheck, SvgHash, SvgUser } from "@onyx-ai/opal/icons";
+
+import {
+  ensureSlackDestination,
+  getSlackChannels,
+  type SlackChannel,
+} from "@/lib/slackConnect";
+import type { DestinationConfig } from "@/lib/triggers";
+
+interface Props {
+  /** The trigger element that opens the picker. */
+  children: React.ReactNode;
+  configs: DestinationConfig[];
+  /** Include the Event log + existing-config entries (trigger modal). */
+  includeExisting?: boolean;
+  /** Currently selected config id (null = event log). */
+  value?: string | null;
+  connected: boolean;
+  disabled?: boolean;
+  /** Called with the picked config id (null = event log). Channel and DM picks
+   * find-or-create their destination config first. */
+  onPick: (configId: string | null) => void | Promise<void>;
+  onError: (message: string) => void;
+}
+
+export function SlackDestinationPicker({
+  children,
+  configs,
+  includeExisting = false,
+  value,
+  connected,
+  disabled,
+  onPick,
+  onError,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [channels, setChannels] = useState<SlackChannel[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function onOpenChange(next: boolean) {
+    setOpen(next);
+    if (next && connected && channels === null) {
+      try {
+        setChannels(await getSlackChannels());
+      } catch (e) {
+        onError(e instanceof Error ? e.message : "failed to load channels");
+      }
+    }
+  }
+
+  async function pick(configId: string | null) {
+    await onPick(configId);
+    setOpen(false);
+    setSearch("");
+  }
+
+  async function pickChannel(ch: SlackChannel) {
+    setBusy(true);
+    try {
+      const { id } = await ensureSlackDestination(configs, {
+        kind: "channel",
+        id: ch.id,
+        name: ch.name,
+      });
+      await pick(id);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "failed to add channel");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function pickDm() {
+    setBusy(true);
+    try {
+      const { id } = await ensureSlackDestination(configs, { kind: "dm" });
+      await pick(id);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "failed to add DM");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const q = search.trim().toLowerCase();
+  const configuredChannelIds = useMemo(
+    () => new Set(configs.map((c) => c.config.channel_id).filter(Boolean)),
+    [configs],
+  );
+  const filteredConfigs = includeExisting
+    ? configs.filter((c) => !q || c.name.toLowerCase().includes(q))
+    : [];
+  const filteredChannels = (channels ?? []).filter(
+    (ch) =>
+      !configuredChannelIds.has(ch.id) &&
+      (!q || ch.name.toLowerCase().includes(q)),
+  );
+
+  return (
+    <Popover open={open} onOpenChange={(v) => void onOpenChange(v)}>
+      <Popover.Trigger asChild disabled={disabled}>
+        {children}
+      </Popover.Trigger>
+      <Popover.Content width="fit" align="start" sideOffset={4}>
+        <PopoverMenu>
+          <InputTypeIn
+            searchIcon
+            variant="internal"
+            placeholder="Search channels…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          {includeExisting && !q && (
+            <LineItemButton
+              icon={SvgBubbleText}
+              title="Event log only"
+              sizePreset="main-ui"
+              variant="body"
+              state={value === null ? "selected" : "empty"}
+              rightChildren={
+                value === null ? <SvgCheck size={16} /> : undefined
+              }
+              onClick={() => void pick(null)}
+            />
+          )}
+          {filteredConfigs.map((c) => (
+            <LineItemButton
+              key={c.id}
+              icon={c.config.dm ? SvgUser : SvgHash}
+              title={c.name}
+              sizePreset="main-ui"
+              variant="body"
+              state={value === c.id ? "selected" : "empty"}
+              rightChildren={
+                value === c.id ? <SvgCheck size={16} /> : undefined
+              }
+              onClick={() => void pick(c.id)}
+            />
+          ))}
+          {connected && !configs.some((c) => c.config.dm === true) && (
+            <LineItemButton
+              icon={SvgUser}
+              title="DM me"
+              sizePreset="main-ui"
+              variant="body"
+              state="empty"
+              onClick={() => void pickDm()}
+            />
+          )}
+          {connected && channels === null && (
+            <LineItemButton
+              title="Loading channels…"
+              sizePreset="main-ui"
+              variant="body"
+              state="empty"
+              onClick={() => undefined}
+            />
+          )}
+          {filteredChannels.map((ch) => (
+            <LineItemButton
+              key={ch.id}
+              icon={SvgHash}
+              title={`${ch.name}${ch.is_private ? " (private)" : ""}`}
+              sizePreset="main-ui"
+              variant="body"
+              state="empty"
+              onClick={() => {
+                if (!busy) void pickChannel(ch);
+              }}
+            />
+          ))}
+        </PopoverMenu>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/frontend/src/components/triggers/SlackDestinationPicker.tsx
+++ b/frontend/src/components/triggers/SlackDestinationPicker.tsx
@@ -155,7 +155,9 @@ export function SlackDestinationPicker({
               sizePreset="main-ui"
               variant="body"
               state="empty"
-              onClick={() => void pickDm()}
+              onClick={() => {
+                if (!busy) void pickDm();
+              }}
             />
           )}
           {connected && channels === null && (

--- a/frontend/src/components/triggers/SlackDestinationPicker.tsx
+++ b/frontend/src/components/triggers/SlackDestinationPicker.tsx
@@ -54,6 +54,7 @@ export function SlackDestinationPicker({
       try {
         setChannels(await getSlackChannels());
       } catch (e) {
+        setChannels([]); // drop the loading row; the error line explains
         onError(e instanceof Error ? e.message : "failed to load channels");
       }
     }

--- a/frontend/src/components/triggers/SlackDestinationPicker.tsx
+++ b/frontend/src/components/triggers/SlackDestinationPicker.tsx
@@ -46,16 +46,20 @@ export function SlackDestinationPicker({
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [channels, setChannels] = useState<SlackChannel[] | null>(null);
+  const [loadingChannels, setLoadingChannels] = useState(false);
   const [busy, setBusy] = useState(false);
 
   async function onOpenChange(next: boolean) {
     setOpen(next);
-    if (next && connected && channels === null) {
+    // channels stays null on failure so the next open retries the fetch.
+    if (next && connected && channels === null && !loadingChannels) {
+      setLoadingChannels(true);
       try {
         setChannels(await getSlackChannels());
       } catch (e) {
-        setChannels([]); // drop the loading row; the error line explains
         onError(e instanceof Error ? e.message : "failed to load channels");
+      } finally {
+        setLoadingChannels(false);
       }
     }
   }
@@ -161,7 +165,7 @@ export function SlackDestinationPicker({
               }}
             />
           )}
-          {connected && channels === null && (
+          {loadingChannels && (
             <LineItemButton
               title="Loading channels…"
               sizePreset="main-ui"

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -16,8 +16,11 @@ import {
   utcIsoToLocalInput,
   type FrequencyPreset,
 } from "@/lib/cron";
+import { SelectButton } from "@onyx-ai/opal/components";
+
+import { SlackDestinationPicker } from "@/components/triggers/SlackDestinationPicker";
+import { useSlackConnectStatus } from "@/lib/slackConnect";
 import {
-  createDestinationConfig,
   createTrigger,
   updateTrigger,
   useDestinationConfigs,
@@ -51,12 +54,10 @@ export function TriggerModal({
   const [ifText, setIfText] = useState("");
   const [sendText, setSendText] = useState("");
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
+  const { status: slackStatus } = useSlackConnectStatus();
   const [destinationConfigId, setDestinationConfigId] = useState<string | null>(
     null,
   );
-  const [addingChannel, setAddingChannel] = useState(false);
-  const [newChannelName, setNewChannelName] = useState("");
-  const [newChannelUrl, setNewChannelUrl] = useState("");
   const [kind, setKind] = useState<TriggerKind>("delta");
   const [scheduleParts, setScheduleParts] = useState(defaultScheduleParts());
   const [customCron, setCustomCron] = useState("");
@@ -74,9 +75,6 @@ export function TriggerModal({
     const firstAction = initial?.actions?.[0];
     setSendText(firstAction?.message ?? "");
     setDestinationConfigId(firstAction?.destination_config_id ?? null);
-    setAddingChannel(false);
-    setNewChannelName("");
-    setNewChannelUrl("");
     setKind((initial?.kind as TriggerKind) ?? "delta");
     const parts = cronToParts(initial?.schedule_cron ?? null);
     setScheduleParts(parts);
@@ -162,38 +160,6 @@ export function TriggerModal({
   const destDescription = selectedConfig
     ? ""
     : "Tracked in the event log only.";
-
-  // The "TO" select encodes event-log as an empty value and any destination
-  // config by its id.
-  const destSelectValue = destinationConfigId ?? "";
-
-  function onPickDestination(value: string) {
-    setDestinationConfigId(value === "" ? null : value);
-  }
-
-  async function onAddChannel() {
-    const name = newChannelName.trim();
-    const url = newChannelUrl.trim();
-    if (!name || !url) return;
-    setBusy(true);
-    setError(null);
-    try {
-      const created = await createDestinationConfig({
-        type: "slack",
-        name,
-        secret: url,
-      });
-      await refreshConfigs();
-      setDestinationConfigId(created.id);
-      setAddingChannel(false);
-      setNewChannelName("");
-      setNewChannelUrl("");
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to add channel");
-    } finally {
-      setBusy(false);
-    }
-  }
 
   return (
     <div
@@ -312,71 +278,26 @@ export function TriggerModal({
           <span className="text-[11px] font-bold tracking-[0.06em] text-(--text-03) uppercase">
             To
           </span>
-          <select
-            value={destSelectValue}
-            onChange={(e) => onPickDestination(e.target.value)}
+          <SlackDestinationPicker
+            configs={configs}
+            includeExisting
+            value={destinationConfigId}
+            connected={Boolean(slackStatus?.connected)}
             disabled={busy}
-            className="box-border w-full cursor-pointer rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+            onPick={async (id) => {
+              setDestinationConfigId(id);
+              await refreshConfigs();
+            }}
+            onError={(m) => setError(m)}
           >
-            <option value="">Event log</option>
-            {configs.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.type} · {c.name}
-              </option>
-            ))}
-          </select>
+            <SelectButton size="sm" state="empty" width="full">
+              {selectedConfig ? selectedConfig.name : "Event log"}
+            </SelectButton>
+          </SlackDestinationPicker>
           {destDescription && (
             <span className="text-xs leading-[1.4] text-(--text-03)">
               {destDescription}
             </span>
-          )}
-          {!addingChannel ? (
-            <button
-              type="button"
-              onClick={() => setAddingChannel(true)}
-              disabled={busy}
-              className="mt-[6px] cursor-pointer self-start border-none bg-transparent p-0 text-[13px] text-(--text-inverted-05)"
-            >
-              + Add Slack channel
-            </button>
-          ) : (
-            <div className="mt-2 flex flex-col gap-2 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) p-[10px]">
-              <input
-                value={newChannelName}
-                onChange={(e) => setNewChannelName(e.target.value)}
-                placeholder="Channel name (e.g. PM Standup)"
-                disabled={busy}
-                className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
-              />
-              <input
-                value={newChannelUrl}
-                onChange={(e) => setNewChannelUrl(e.target.value)}
-                placeholder="https://hooks.slack.com/services/…"
-                disabled={busy}
-                className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
-              />
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  variant="action"
-                  size="sm"
-                  disabled={
-                    busy || !newChannelName.trim() || !newChannelUrl.trim()
-                  }
-                  onClick={() => void onAddChannel()}
-                >
-                  Add channel
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={busy}
-                  onClick={() => setAddingChannel(false)}
-                >
-                  Cancel
-                </Button>
-              </div>
-            </div>
           )}
         </label>
 

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -285,6 +285,7 @@ export function TriggerModal({
             connected={Boolean(slackStatus?.connected)}
             disabled={busy}
             onPick={async (id) => {
+              setError(null);
               setDestinationConfigId(id);
               await refreshConfigs();
             }}

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -1,0 +1,41 @@
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+
+export interface SlackConnectStatus {
+  configured: boolean;
+  connected: boolean;
+  team_name: string | null;
+  token_display: string | null;
+  connect_url: string | null;
+}
+
+export interface SlackChannel {
+  id: string;
+  name: string;
+  is_private: boolean;
+}
+
+export function useSlackConnectStatus() {
+  const { data, error, isLoading, mutate } =
+    useSWR<SlackConnectStatus>("/connectors/slack");
+  return {
+    status: data ?? null,
+    error: error as Error | undefined,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+export async function getSlackChannels(): Promise<SlackChannel[]> {
+  const r = await apiFetch<{ channels: SlackChannel[] }>(
+    "/connectors/slack/channels",
+  );
+  return r.channels;
+}
+
+export function disconnectSlack(): Promise<{ disconnected: boolean }> {
+  return apiFetch<{ disconnected: boolean }>("/connectors/slack", {
+    method: "DELETE",
+  });
+}

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -1,6 +1,10 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import {
+  createDestinationConfig,
+  type DestinationConfig,
+} from "@/lib/triggers";
 
 export interface SlackConnectStatus {
   configured: boolean;
@@ -39,11 +43,6 @@ export function disconnectSlack(): Promise<{ disconnected: boolean }> {
     method: "DELETE",
   });
 }
-
-import {
-  createDestinationConfig,
-  type DestinationConfig,
-} from "@/lib/triggers";
 
 export type SlackTarget =
   | { kind: "channel"; id: string; name: string }

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -39,3 +39,36 @@ export function disconnectSlack(): Promise<{ disconnected: boolean }> {
     method: "DELETE",
   });
 }
+
+import {
+  createDestinationConfig,
+  type DestinationConfig,
+} from "@/lib/triggers";
+
+export type SlackTarget = { kind: "channel"; id: string; name: string } | { kind: "dm" };
+
+/** Reuse the matching destination config or create it, returning its id. */
+export async function ensureSlackDestination(
+  configs: DestinationConfig[],
+  target: SlackTarget,
+): Promise<{ id: string; created: boolean }> {
+  const existing = configs.find((c) =>
+    target.kind === "dm"
+      ? c.config.dm === true
+      : c.config.channel_id === target.id,
+  );
+  if (existing) return { id: existing.id, created: false };
+  const created =
+    target.kind === "dm"
+      ? await createDestinationConfig({
+          type: "slack",
+          name: "DM me",
+          config: { dm: true },
+        })
+      : await createDestinationConfig({
+          type: "slack",
+          name: `#${target.name}`,
+          config: { channel_id: target.id, channel_name: target.name },
+        });
+  return { id: created.id, created: true };
+}

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -45,7 +45,9 @@ import {
   type DestinationConfig,
 } from "@/lib/triggers";
 
-export type SlackTarget = { kind: "channel"; id: string; name: string } | { kind: "dm" };
+export type SlackTarget =
+  | { kind: "channel"; id: string; name: string }
+  | { kind: "dm" };
 
 /** Reuse the matching destination config or create it, returning its id. */
 export async function ensureSlackDestination(

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -146,6 +146,7 @@ export interface DestinationConfig {
   id: string;
   type: string;
   name: string;
+  config: Record<string, unknown>;
   has_secret: boolean;
   created_at: string | null;
 }

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -13,6 +13,12 @@ import { useRequireAuth } from "@/lib/auth";
 import { describeCron } from "@/lib/cron";
 import { formatScopePath } from "@/lib/format";
 import {
+  disconnectSlack,
+  getSlackChannels,
+  useSlackConnectStatus,
+  type SlackChannel,
+} from "@/lib/slackConnect";
+import {
   createDestinationConfig,
   deleteDestinationConfig,
   deleteTrigger,
@@ -319,25 +325,40 @@ export default function TriggersPage() {
 
 function DestinationsCard() {
   const { configs, error, isLoading, refresh } = useDestinationConfigs();
-  const [adding, setAdding] = useState(false);
+  const { status: slack, refresh: refreshSlack } = useSlackConnectStatus();
+  const [mode, setMode] = useState<"closed" | "channel" | "webhook">("closed");
+  const [channels, setChannels] = useState<SlackChannel[] | null>(null);
+  const [channelId, setChannelId] = useState("");
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const confirmDialog = useConfirm();
 
-  async function onAdd() {
-    if (!name.trim() || !url.trim()) return;
+  async function openChannelPicker() {
+    setMode("channel");
+    setFormError(null);
+    if (channels === null) {
+      try {
+        setChannels(await getSlackChannels());
+      } catch (e) {
+        setFormError(
+          e instanceof ApiError ? e.message : "failed to load channels",
+        );
+      }
+    }
+  }
+
+  async function addConfig(
+    input: Parameters<typeof createDestinationConfig>[0],
+  ) {
     setBusy(true);
     setFormError(null);
     try {
-      await createDestinationConfig({
-        type: "slack",
-        name: name.trim(),
-        secret: url.trim(),
-      });
+      await createDestinationConfig(input);
       await refresh();
-      setAdding(false);
+      setMode("closed");
+      setChannelId("");
       setName("");
       setUrl("");
     } catch (e) {
@@ -347,6 +368,38 @@ function DestinationsCard() {
     } finally {
       setBusy(false);
     }
+  }
+
+  function onAddChannel() {
+    const ch = (channels ?? []).find((c) => c.id === channelId);
+    if (!ch) return;
+    void addConfig({
+      type: "slack",
+      name: `#${ch.name}`,
+      config: { channel_id: ch.id, channel_name: ch.name },
+    });
+  }
+
+  function onAddDm() {
+    void addConfig({ type: "slack", name: "DM me", config: { dm: true } });
+  }
+
+  function onAddWebhook() {
+    if (!name.trim() || !url.trim()) return;
+    void addConfig({ type: "slack", name: name.trim(), secret: url.trim() });
+  }
+
+  async function onDisconnect() {
+    if (
+      !(await confirmDialog({
+        title: "Disconnect Slack?",
+        body: "Channel and DM destinations will stop delivering until you reconnect.",
+        confirmLabel: "Disconnect",
+      }))
+    )
+      return;
+    await disconnectSlack();
+    await refreshSlack();
   }
 
   async function onDelete(id: string, label: string) {
@@ -366,21 +419,69 @@ function DestinationsCard() {
     }
   }
 
+  const connected = Boolean(slack?.connected);
+
   return (
     <section className="mt-[28px] rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-4">
       <div className="mb-1 flex items-center justify-between">
         <h2 className="m-0 text-base">Destinations</h2>
-        {!adding && (
-          <Button size="sm" onClick={() => setAdding(true)}>
-            + Add Slack channel
-          </Button>
-        )}
+        <div className="flex gap-2">
+          {mode === "closed" && connected && (
+            <>
+              <Button size="sm" onClick={() => void openChannelPicker()}>
+                + Channel
+              </Button>
+              <Button size="sm" onClick={() => void onAddDm()} disabled={busy}>
+                + DM me
+              </Button>
+            </>
+          )}
+          {mode === "closed" && (
+            <Button size="sm" onClick={() => setMode("webhook")}>
+              + Webhook
+            </Button>
+          )}
+        </div>
       </div>
       <p className="mt-0 mb-3 text-[13px] text-(--text-03)">
-        Delivery targets you can point a trigger at. Create a Slack incoming
-        webhook (Apps &rarr; Incoming Webhooks), then pick it as a
-        trigger&apos;s destination. Private to you.
+        Delivery targets you can point a trigger at. Private to you.
       </p>
+
+      {slack?.configured && (
+        <div className="mb-3 flex items-center justify-between rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) px-[14px] py-3">
+          {connected ? (
+            <>
+              <div className="text-[13px]">
+                Connected to <strong>{slack?.team_name ?? "Slack"}</strong>
+              </div>
+              <Button
+                size="sm"
+                variant="danger"
+                onClick={() => void onDisconnect()}
+              >
+                Disconnect
+              </Button>
+            </>
+          ) : (
+            <>
+              <div className="text-[13px]">
+                Connect Slack to deliver to channels or DMs as the Agent Wiki
+                bot.
+              </div>
+              <Button
+                size="sm"
+                variant="action"
+                onClick={() => {
+                  if (slack?.connect_url)
+                    window.location.href = `${slack.connect_url}?return_to=/app/triggers`;
+                }}
+              >
+                Connect Slack
+              </Button>
+            </>
+          )}
+        </div>
+      )}
 
       {error && (
         <div className="mb-2 text-[13px] text-(--status-text-error-05)">
@@ -388,7 +489,46 @@ function DestinationsCard() {
         </div>
       )}
 
-      {adding && (
+      {mode === "channel" && (
+        <div className="mb-3 flex flex-col gap-2 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) p-3">
+          <select
+            value={channelId}
+            onChange={(e) => setChannelId(e.target.value)}
+            disabled={busy || channels === null}
+            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm"
+          >
+            <option value="">
+              {channels === null ? "Loading channels…" : "Pick a channel"}
+            </option>
+            {(channels ?? []).map((c) => (
+              <option key={c.id} value={c.id}>
+                #{c.name}
+                {c.is_private ? " (private)" : ""}
+              </option>
+            ))}
+          </select>
+          {formError && (
+            <div className="text-[13px] text-(--status-text-error-05)">
+              {formError}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="action"
+              disabled={busy || !channelId}
+              onClick={onAddChannel}
+            >
+              {busy ? "Adding…" : "Add channel"}
+            </Button>
+            <Button size="sm" disabled={busy} onClick={() => setMode("closed")}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {mode === "webhook" && (
         <div className="mb-3 flex flex-col gap-2 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) p-3">
           <input
             value={name}
@@ -413,21 +553,28 @@ function DestinationsCard() {
           <div className="flex gap-2">
             <Button
               size="sm"
+              variant="action"
               disabled={busy || !name.trim() || !url.trim()}
-              onClick={() => void onAdd()}
+              onClick={onAddWebhook}
             >
               {busy ? "Adding…" : "Add"}
             </Button>
-            <Button size="sm" disabled={busy} onClick={() => setAdding(false)}>
+            <Button size="sm" disabled={busy} onClick={() => setMode("closed")}>
               Cancel
             </Button>
           </div>
         </div>
       )}
 
+      {formError && mode === "closed" && (
+        <div className="mb-2 text-[13px] text-(--status-text-error-05)">
+          {formError}
+        </div>
+      )}
+
       {isLoading && configs.length === 0 && !error && <LoadingSpinner />}
 
-      {!isLoading && configs.length === 0 && !adding && (
+      {!isLoading && configs.length === 0 && mode === "closed" && (
         <p className="m-0 text-sm text-(--text-03)">
           No destinations yet &mdash; add one to deliver trigger fires to Slack.
         </p>
@@ -446,7 +593,7 @@ function DestinationsCard() {
                 </div>
                 <div className="mt-[2px] font-mono text-xs text-(--text-03)">
                   {c.type}
-                  {c.has_secret ? " · secret set" : ""}
+                  {c.has_secret ? " · webhook" : " · bot"}
                 </div>
               </div>
               <Button

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -12,12 +12,8 @@ import { TriggerModal } from "@/components/triggers/TriggerModal";
 import { useRequireAuth } from "@/lib/auth";
 import { describeCron } from "@/lib/cron";
 import { formatScopePath } from "@/lib/format";
-import {
-  disconnectSlack,
-  getSlackChannels,
-  useSlackConnectStatus,
-  type SlackChannel,
-} from "@/lib/slackConnect";
+import { SlackDestinationPicker } from "@/components/triggers/SlackDestinationPicker";
+import { disconnectSlack, useSlackConnectStatus } from "@/lib/slackConnect";
 import {
   createDestinationConfig,
   deleteDestinationConfig,
@@ -326,28 +322,12 @@ export default function TriggersPage() {
 function DestinationsCard() {
   const { configs, error, isLoading, refresh } = useDestinationConfigs();
   const { status: slack, refresh: refreshSlack } = useSlackConnectStatus();
-  const [mode, setMode] = useState<"closed" | "channel" | "webhook">("closed");
-  const [channels, setChannels] = useState<SlackChannel[] | null>(null);
-  const [channelId, setChannelId] = useState("");
+  const [mode, setMode] = useState<"closed" | "webhook">("closed");
   const [name, setName] = useState("");
   const [url, setUrl] = useState("");
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const confirmDialog = useConfirm();
-
-  async function openChannelPicker() {
-    setMode("channel");
-    setFormError(null);
-    if (channels === null) {
-      try {
-        setChannels(await getSlackChannels());
-      } catch (e) {
-        setFormError(
-          e instanceof ApiError ? e.message : "failed to load channels",
-        );
-      }
-    }
-  }
 
   async function addConfig(
     input: Parameters<typeof createDestinationConfig>[0],
@@ -358,7 +338,6 @@ function DestinationsCard() {
       await createDestinationConfig(input);
       await refresh();
       setMode("closed");
-      setChannelId("");
       setName("");
       setUrl("");
     } catch (e) {
@@ -368,20 +347,6 @@ function DestinationsCard() {
     } finally {
       setBusy(false);
     }
-  }
-
-  function onAddChannel() {
-    const ch = (channels ?? []).find((c) => c.id === channelId);
-    if (!ch) return;
-    void addConfig({
-      type: "slack",
-      name: `#${ch.name}`,
-      config: { channel_id: ch.id, channel_name: ch.name },
-    });
-  }
-
-  function onAddDm() {
-    void addConfig({ type: "slack", name: "DM me", config: { dm: true } });
   }
 
   function onAddWebhook() {
@@ -401,7 +366,6 @@ function DestinationsCard() {
     setFormError(null);
     try {
       await disconnectSlack();
-      setChannels(null);
       await refreshSlack();
     } catch (e) {
       setFormError(e instanceof ApiError ? e.message : "failed to disconnect");
@@ -433,17 +397,26 @@ function DestinationsCard() {
         <h2 className="m-0 text-base">Destinations</h2>
         <div className="flex gap-2">
           {mode === "closed" && connected && (
-            <>
-              <Button size="sm" onClick={() => void openChannelPicker()}>
-                + Channel
+            <SlackDestinationPicker
+              configs={configs}
+              connected={connected}
+              disabled={busy}
+              onPick={async () => {
+                await refresh();
+              }}
+              onError={setFormError}
+            >
+              <Button size="sm" disabled={busy}>
+                + Slack
               </Button>
-              <Button size="sm" onClick={() => void onAddDm()} disabled={busy}>
-                + DM me
-              </Button>
-            </>
+            </SlackDestinationPicker>
           )}
           {mode === "closed" && (
-            <Button size="sm" onClick={() => setMode("webhook")}>
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={() => setMode("webhook")}
+            >
               + Webhook
             </Button>
           )}
@@ -501,45 +474,6 @@ function DestinationsCard() {
       {error && (
         <div className="mb-2 text-[13px] text-(--status-text-error-05)">
           {error.message || "Failed to load destinations."}
-        </div>
-      )}
-
-      {mode === "channel" && (
-        <div className="mb-3 flex flex-col gap-2 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) p-3">
-          <select
-            value={channelId}
-            onChange={(e) => setChannelId(e.target.value)}
-            disabled={busy || channels === null}
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm"
-          >
-            <option value="">
-              {channels === null ? "Loading channels…" : "Pick a channel"}
-            </option>
-            {(channels ?? []).map((c) => (
-              <option key={c.id} value={c.id}>
-                #{c.name}
-                {c.is_private ? " (private)" : ""}
-              </option>
-            ))}
-          </select>
-          {formError && (
-            <div className="text-[13px] text-(--status-text-error-05)">
-              {formError}
-            </div>
-          )}
-          <div className="flex gap-2">
-            <Button
-              size="sm"
-              variant="action"
-              disabled={busy || !channelId}
-              onClick={onAddChannel}
-            >
-              {busy ? "Adding…" : "Add channel"}
-            </Button>
-            <Button size="sm" disabled={busy} onClick={() => setMode("closed")}>
-              Cancel
-            </Button>
-          </div>
         </div>
       )}
 

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -402,6 +402,7 @@ function DestinationsCard() {
               connected={connected}
               disabled={busy}
               onPick={async () => {
+                setFormError(null);
                 await refresh();
               }}
               onError={setFormError}

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -398,8 +398,14 @@ function DestinationsCard() {
       }))
     )
       return;
-    await disconnectSlack();
-    await refreshSlack();
+    setFormError(null);
+    try {
+      await disconnectSlack();
+      setChannels(null);
+      await refreshSlack();
+    } catch (e) {
+      setFormError(e instanceof ApiError ? e.message : "failed to disconnect");
+    }
   }
 
   async function onDelete(id: string, label: string) {
@@ -451,8 +457,15 @@ function DestinationsCard() {
         <div className="mb-3 flex items-center justify-between rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) px-[14px] py-3">
           {connected ? (
             <>
-              <div className="text-[13px]">
-                Connected to <strong>{slack?.team_name ?? "Slack"}</strong>
+              <div>
+                <div className="text-[13px]">
+                  Connected to <strong>{slack?.team_name ?? "Slack"}</strong>
+                </div>
+                {slack?.token_display && (
+                  <div className="mt-[2px] font-mono text-xs text-(--text-03)">
+                    {slack.token_display}
+                  </div>
+                )}
               </div>
               <Button
                 size="sm"
@@ -472,8 +485,10 @@ function DestinationsCard() {
                 size="sm"
                 variant="action"
                 onClick={() => {
-                  if (slack?.connect_url)
-                    window.location.href = `${slack.connect_url}?return_to=/app/triggers`;
+                  if (!slack?.connect_url) return;
+                  const target = new URL(slack.connect_url);
+                  target.searchParams.set("return_to", "/app/triggers");
+                  window.location.href = target.toString();
                 }}
               >
                 Connect Slack


### PR DESCRIPTION
## Description

Frontend slice that makes the Slack track clickable end to end.

- The Destinations card gains a Slack connection strip: Connect button (driven by the status endpoint's `connect_url`, bouncing back to `/app/triggers`), or team name + Disconnect when linked. Hidden until an admin saves the app credentials.
- Three add flows: pick a channel from the bot's picker endpoint, one-click "DM me", or the existing webhook form. All funnel through the same config-create call.
- List rows label bot vs webhook targets from `has_secret`.

Verified: tsc + prettier clean; the card renders behind auth, so the visual pass is a one-click check at `/app/triggers` on a signed-in session (local `next dev` serves this branch).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check