### PR TITLE
fix(triggers): minute-level schedule scan, no doc-name dup, cap botocore logging

### DIFF
--- a/backend/app/tasks/periodic.py
+++ b/backend/app/tasks/periodic.py
@@ -29,7 +29,9 @@ from app.tasks.triggers import evaluate_due_schedule_triggers
 log = logging.getLogger(__name__)
 
 
-@triggers_queue.periodic_task(crontab(minute="*/5"))
+# Every-minute scan: a no-op pass is one indexed query, and per-minute
+# ticks keep a trigger's fire within ~1min of its cron time.
+@triggers_queue.periodic_task(crontab())
 def evaluate_scheduled_triggers() -> None:
     now = datetime.now(timezone.utc)
     evaluate_due_schedule_triggers(now)

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -25,7 +25,7 @@ Queues:
   scheduled).** All trigger evaluation, both event-driven and time-based.
   Post-commit fan-out (``fan_out_trigger_eval``) runs the SQL match against
   ``doc_path`` plus every parent directory and dispatches one or two LLM
-  calls per matched trigger. The 5-min cron ``evaluate_scheduled_triggers``
+  calls per matched trigger. The every-minute cron ``evaluate_scheduled_triggers``
   (kind=schedule triggers due now) lives here too — same evaluator, same
   code paths, different ignition. Kept separate from ``documents_queue``
   because trigger eval is read-only (no commits) and we want one queue's

--- a/backend/app/triggers/natural_language.py
+++ b/backend/app/triggers/natural_language.py
@@ -174,6 +174,8 @@ reference the latest version directly.
 internal IDs, or explanations of your reasoning. Output only the \
 delivered message text.
   * Plain text or markdown is fine. No greetings, no signoff.
+  * Delivery appends its own attribution line naming the source \
+document — do not add a title or repeat the document name.
 
 Always respond by calling the `render` tool exactly once.\
 """
@@ -323,6 +325,8 @@ scoped to the SCHEDULED CHECK scope.
 internal IDs, or explanations of your reasoning. Output only the \
 delivered message text.
   * Plain text or markdown is fine. No greetings, no signoff.
+  * Delivery appends its own attribution line naming the source \
+document — do not add a title or repeat the document name.
 
 Always respond by calling the `render` tool exactly once.\
 """

--- a/backend/app/utils/logging.py
+++ b/backend/app/utils/logging.py
@@ -45,6 +45,11 @@ def setup_logging(level: str | int | None = None) -> None:
     # Tame noisy third-party loggers; flip to DEBUG via env if needed.
     logging.getLogger("werkzeug").setLevel(logging.INFO)
     logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+    # botocore DEBUG logs full request headers (bearer tokens included) and
+    # every stream chunk — never allow it below INFO.
+    logging.getLogger("botocore").setLevel(logging.INFO)
+    logging.getLogger("boto3").setLevel(logging.INFO)
+    logging.getLogger("urllib3").setLevel(logging.INFO)
 
     _configured = True
 

--- a/backend/tests/test_logging_setup.py
+++ b/backend/tests/test_logging_setup.py
@@ -1,0 +1,14 @@
+"""setup_logging keeps AWS/HTTP client loggers at INFO even under a DEBUG
+root, so botocore can never dump request auth headers into the logs."""
+from __future__ import annotations
+
+import logging
+
+from app.utils.logging import setup_logging
+
+
+def test_third_party_loggers_capped_under_debug():
+    setup_logging(level="DEBUG")
+    assert logging.getLogger().level == logging.DEBUG
+    for name in ("botocore", "boto3", "urllib3"):
+        assert logging.getLogger(name).getEffectiveLevel() >= logging.INFO


### PR DESCRIPTION
## Description

Three trigger-pipeline issues found while live-testing Slack delivery.

- Schedule triggers fired up to 5 minutes late: the scan cron ran on a `*/5` grid, so any trigger whose cron minute was off-grid waited for the next tick. The scan now runs every minute. A no-op pass is one indexed query.
- Fired messages duplicated the doc name (LLM-added title plus our appended source line). Both render prompts now state that delivery appends an attribution line naming the document, so the model stops adding its own title.
- `LOG_LEVEL=DEBUG` put the root logger at DEBUG, and botocore then logged every stream chunk and full request headers, bearer token included. botocore/boto3/urllib3 are now capped at INFO under any level, with a test pinning the cap.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check