### PR TITLE
fix(triggers): scope trigger payloads to the trigger's docs

### DIFF
--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -93,20 +93,34 @@ def fan_out_trigger_eval(
     after = _read_at(sha, doc_path)
     before = _read_at(f"{sha}^", doc_path)
 
-    # Build the wiki snapshot once and reuse it for every trigger on this
-    # commit. Each trigger pays its own per-call eval (and render-on-match).
-    wiki_snapshot = diff_helper.build_wiki_snapshot()
-    delta_payload = diff_helper.build_payload(
-        doc_path=doc_path,
-        change_kind=change_kind,
-        before=before,
-        after=after,
-        wiki_snapshot=wiki_snapshot,
-    )
-    new_file_payload: str | None = None
-    if change_kind == ChangeKind.CREATE:
-        new_file_payload = diff_helper.build_new_file_payload(
-            doc_path=doc_path, body=after, wiki_snapshot=wiki_snapshot
+    # Payloads are scoped per trigger: each carries only the docs under that
+    # trigger's scope plus the shared change view. One scope block is built
+    # per distinct scope on this commit.
+    scope_blocks: dict[str, str] = {}
+
+    def _scope_block(scope_path: str) -> str:
+        block = scope_blocks.get(scope_path)
+        if block is None:
+            block = diff_helper.build_scope_block(scope_path)
+            scope_blocks[scope_path] = block
+        return block
+
+    def _delta_payload(scope_path: str) -> str:
+        return diff_helper.build_payload(
+            doc_path=doc_path,
+            change_kind=change_kind,
+            before=before,
+            after=after,
+            scope_path=scope_path,
+            scope_block=_scope_block(scope_path),
+        )
+
+    def _new_file_payload(scope_path: str) -> str:
+        return diff_helper.build_new_file_payload(
+            doc_path=doc_path,
+            body=after,
+            scope_path=scope_path,
+            scope_block=_scope_block(scope_path),
         )
 
     # Cache owner ACL flags by user id — most fan-outs touch a handful of
@@ -150,10 +164,9 @@ def fan_out_trigger_eval(
         # action. Delta renders per action; the new-file eval renders in its
         # single combined call.
         if change_kind == ChangeKind.CREATE and trigger.scope_path != doc_path:
-            assert new_file_payload is not None
             primary = (trigger.actions[0].message or "") if trigger.actions else ""
             new_file_result = evaluate_new_file_in_dir(
-                trigger, primary, new_file_payload
+                trigger, primary, _new_file_payload(trigger.scope_path)
             )
             if not new_file_result.triggered:
                 continue
@@ -161,7 +174,7 @@ def fan_out_trigger_eval(
             reason = "new file under directory scope"
             log.info("trigger fired (new-file-in-dir) id=%s doc=%s", trigger.id, doc_path)
         else:
-            match = evaluate_delta(trigger, delta_payload)
+            match = evaluate_delta(trigger, _delta_payload(trigger.scope_path))
             if not match.matched:
                 continue
             new_file_message = None
@@ -175,7 +188,9 @@ def fan_out_trigger_eval(
                 rendered = new_file_message
             else:
                 rendered = (
-                    render_delta_message(instruction, delta_payload, reason=reason)
+                    render_delta_message(
+                        instruction, _delta_payload(trigger.scope_path), reason=reason
+                    )
                     if instruction
                     else ""
                 )
@@ -211,7 +226,6 @@ def evaluate_due_schedule_triggers(now: datetime) -> int:
         return 0
 
     log.info("schedule eval: %d due trigger(s)", len(triggers))
-    wiki_snapshot = diff_helper.build_wiki_snapshot()
     now_iso = now.astimezone(timezone.utc).isoformat(timespec="seconds")
 
     fired = 0
@@ -222,7 +236,6 @@ def evaluate_due_schedule_triggers(now: datetime) -> int:
                 trigger,
                 now_iso=now_iso,
                 since_iso=since_iso,
-                wiki_snapshot=wiki_snapshot,
             ):
                 fired += 1
         finally:
@@ -238,7 +251,6 @@ def _evaluate_one_schedule(
     *,
     now_iso: str,
     since_iso: str,
-    wiki_snapshot: str,
 ) -> bool:
     """Evaluate a single schedule trigger; record a ``trigger.fire`` event
     on match. Returns True if it fired.
@@ -257,7 +269,6 @@ def _evaluate_one_schedule(
         scope_path=trigger.scope_path,
         when_iso=now_iso,
         since_iso=since_iso,
-        wiki_snapshot=wiki_snapshot,
     )
     match = evaluate_schedule(trigger, payload)
     if not match.matched:

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -228,14 +228,21 @@ def evaluate_due_schedule_triggers(now: datetime) -> int:
     log.info("schedule eval: %d due trigger(s)", len(triggers))
     now_iso = now.astimezone(timezone.utc).isoformat(timespec="seconds")
 
+    # One scope block per distinct scope this tick — due triggers often share one.
+    scope_blocks: dict[str, str] = {}
+
     fired = 0
     for trigger in triggers:
         try:
             since_iso = schedule_window_start(trigger, now).isoformat(timespec="seconds")
+            scope = trigger.scope_path
+            if scope not in scope_blocks:
+                scope_blocks[scope] = diff_helper.build_scope_block(scope)
             if _evaluate_one_schedule(
                 trigger,
                 now_iso=now_iso,
                 since_iso=since_iso,
+                scope_block=scope_blocks[scope],
             ):
                 fired += 1
         finally:
@@ -251,6 +258,7 @@ def _evaluate_one_schedule(
     *,
     now_iso: str,
     since_iso: str,
+    scope_block: str,
 ) -> bool:
     """Evaluate a single schedule trigger; record a ``trigger.fire`` event
     on match. Returns True if it fired.
@@ -267,6 +275,7 @@ def _evaluate_one_schedule(
 
     payload = diff_helper.build_schedule_payload(
         scope_path=trigger.scope_path,
+        scope_block=scope_block,
         when_iso=now_iso,
         since_iso=since_iso,
     )

--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -156,6 +156,7 @@ def build_schedule_payload(
     scope_path: str,
     when_iso: str,
     since_iso: str | None = None,
+    scope_block: str | None = None,
 ) -> str:
     """Payload for a schedule-kind trigger evaluation.
 
@@ -168,7 +169,7 @@ def build_schedule_payload(
     block names the scope and tick time.
     """
     scope_label = scope_path or "(whole wiki)"
-    parts = [build_scope_block(scope_path)]
+    parts = [scope_block if scope_block is not None else build_scope_block(scope_path)]
     if since_iso is not None:
         parts.append(build_changes_since(scope_path=scope_path, since_iso=since_iso))
     parts.append(

--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -51,18 +51,18 @@ _DIFF_DENSITY_FALLBACK = 0.5
 _CHANGES_TOTAL_BUDGET = 60_000
 
 
-def build_wiki_snapshot() -> str:
-    """Concat every tracked `.md` doc's current body. Bounded by budgets above.
-
-    Walks ``git ls-files`` so the snapshot reflects committed state, not the
-    working tree (matters during a fan-out: BEFORE/AFTER read at SHAs while
-    the snapshot reads HEAD-equivalent paths).
+def build_scope_block(scope_path: str) -> str:
+    """The current bodies of the doc(s) under the trigger's scope — the
+    payload's lead block. A ``.md`` scope is that one doc; a folder scope is
+    every doc under it; an empty scope is the whole wiki. Bounded by budgets
+    above; walks ``git ls-files`` so the block reflects committed state.
     """
-    chunks: list[str] = ["=== WIKI (latest version) ==="]
+    label = scope_path or "(whole wiki)"
+    chunks: list[str] = [f"=== SCOPED DOCS (latest version) ===\nScope: {label}\n"]
     total = len(chunks[0])
     truncated = 0
     for path in wiki_git.list_paths():
-        if not path.endswith(".md"):
+        if not path.endswith(".md") or not _in_scope(path, scope_path):
             continue
         if total >= _WIKI_TOTAL_BUDGET:
             truncated += 1
@@ -70,14 +70,15 @@ def build_wiki_snapshot() -> str:
         try:
             body = wiki_git.read_file(path)
         except Exception:
-            log.warning("snapshot: skip unreadable %s", path, exc_info=True)
+            log.warning("scope block: skip unreadable %s", path, exc_info=True)
             continue
-        body = _truncate(body, _PER_DOC_BUDGET)
-        block = f"--- {path}\n{body.rstrip()}\n"
+        block = f"--- {path}\n{_truncate(body, _PER_DOC_BUDGET).rstrip()}\n"
         chunks.append(block)
         total += len(block)
     if truncated:
         chunks.append(f"[truncated {truncated} more docs to fit budget]\n")
+    if len(chunks) == 1:
+        chunks.append("(no docs found under this scope)\n")
     return "\n".join(chunks)
 
 
@@ -117,16 +118,18 @@ def build_new_file_payload(
     *,
     doc_path: str,
     body: str,
-    wiki_snapshot: str | None = None,
+    scope_path: str,
+    scope_block: str | None = None,
 ) -> str:
     """Payload for directory-scoped triggers when a brand-new file appears.
 
     No diff section — the diff would just be the body with ``+`` on every
-    line, which is noise. Show the new file as itself instead.
+    line, which is noise. Show the new file as itself instead. The payload
+    carries only the trigger's scoped docs, never the whole wiki.
     """
-    snapshot = wiki_snapshot if wiki_snapshot is not None else build_wiki_snapshot()
+    lead = scope_block if scope_block is not None else build_scope_block(scope_path)
     nf = build_new_file_view(doc_path=doc_path, body=body)
-    return f"{snapshot}\n\n{nf}"
+    return f"{lead}\n\n{nf}"
 
 
 def build_payload(
@@ -135,19 +138,17 @@ def build_payload(
     change_kind: ChangeKind,
     before: str,
     after: str,
-    wiki_snapshot: str | None = None,
+    scope_path: str,
+    scope_block: str | None = None,
 ) -> str:
-    """Compose the full evaluator/renderer payload.
-
-    ``wiki_snapshot`` is built once per fan-out (it's the same for every
-    trigger on a given commit) and threaded through. If omitted we build
-    it inline — convenient for tests / direct invocation.
-    """
-    snapshot = wiki_snapshot if wiki_snapshot is not None else build_wiki_snapshot()
+    """Compose the full evaluator/renderer payload: the trigger's scoped docs
+    plus the change view. ``scope_block`` lets a fan-out reuse one block per
+    distinct scope instead of rebuilding it for every trigger."""
+    lead = scope_block if scope_block is not None else build_scope_block(scope_path)
     change = build_change_view(
         doc_path=doc_path, change_kind=change_kind, before=before, after=after
     )
-    return f"{snapshot}\n\n{change}"
+    return f"{lead}\n\n{change}"
 
 
 def build_schedule_payload(
@@ -155,22 +156,19 @@ def build_schedule_payload(
     scope_path: str,
     when_iso: str,
     since_iso: str | None = None,
-    wiki_snapshot: str | None = None,
 ) -> str:
     """Payload for a schedule-kind trigger evaluation.
 
-    A schedule tick isn't tied to a single commit, so we give the LLM the
-    full wiki snapshot for overall-state conditions. When ``since_iso`` is
-    provided (the previous tick / last fire), we also append a CHANGES
-    SINCE LAST CHECK block — the diffs committed under ``scope_path`` over
-    ``[since_iso, when_iso]`` — so the trigger can reason about *change*
-    over the window ("a new doc appeared", "X was updated since yesterday")
-    and not just current state. The trailing SCHEDULED CHECK block names
-    the scope and tick time.
+    A schedule tick isn't tied to a single commit, so the payload leads with
+    the scoped docs' current bodies for overall-state conditions. When
+    ``since_iso`` is provided (the previous tick / last fire), a CHANGES
+    SINCE LAST CHECK block follows — the diffs committed under ``scope_path``
+    over ``[since_iso, when_iso]`` — so the trigger can reason about *change*
+    over the window and not just current state. The trailing SCHEDULED CHECK
+    block names the scope and tick time.
     """
-    snapshot = wiki_snapshot if wiki_snapshot is not None else build_wiki_snapshot()
     scope_label = scope_path or "(whole wiki)"
-    parts = [snapshot]
+    parts = [build_scope_block(scope_path)]
     if since_iso is not None:
         parts.append(build_changes_since(scope_path=scope_path, since_iso=since_iso))
     parts.append(

--- a/backend/app/triggers/engine.py
+++ b/backend/app/triggers/engine.py
@@ -241,7 +241,7 @@ def _previous_tick(t: TriggerRecord, now_utc: datetime) -> datetime:
 def evaluate_delta(trigger: TriggerRecord, payload: str) -> MatchResult:
     """Phase 1 LLM check: does this delta satisfy ``trigger.nl_description``?
 
-    ``payload`` is the combined wiki-snapshot + change view from
+    ``payload`` is the combined scoped-docs + change view from
     ``app.triggers.diff.build_payload``. The reason is a one-line
     justification suitable for the events log.
     """
@@ -258,7 +258,7 @@ def render_delta_message(
 def evaluate_schedule(trigger: TriggerRecord, payload: str) -> MatchResult:
     """Phase 1 LLM check for a schedule tick.
 
-    ``payload`` is the wiki-snapshot + changes-since-last-check diff +
+    ``payload`` is the scoped docs + changes-since-last-check diff +
     scheduled-check block from ``app.triggers.diff.build_schedule_payload``.
     The prompt evaluates change-over-time conditions against the diff and
     overall-state conditions against the snapshot.

--- a/backend/app/triggers/natural_language.py
+++ b/backend/app/triggers/natural_language.py
@@ -13,7 +13,7 @@ on edits. Two phases:
   final notification text the user (or downstream system) sees.
 
 The shared ``payload`` (built by ``app.triggers.diff.build_payload``) is
-the whole wiki at the latest version followed by a ``+/-`` view of the
+the docs under the trigger's scope followed by a ``+/-`` view of the
 changed doc. The eval prompt tells the model to focus on the diff unless
 the description is clearly about overall state.
 
@@ -28,7 +28,7 @@ on every line, so we skip it entirely:
   into one round-trip.
 
 The new-file payload (``app.triggers.diff.build_new_file_payload``) is
-the wiki snapshot followed by the new file's path and full body — no
+the scoped docs followed by the new file's path and full body — no
 diff section.
 """
 from __future__ import annotations
@@ -72,14 +72,15 @@ trigger description.
 
 The user message gives you, in order:
   1. The trigger description ("if …").
-  2. A snapshot of the whole wiki at its latest version (for context on \
-how the changed doc relates to its siblings).
+  2. A SCOPED DOCS block: the current bodies of the document(s) under \
+the trigger's scope (context on how the changed doc relates to its \
+neighbors).
   3. A CHANGE block with the path, change kind, and the +/- diff (or full \
 body, for new files / wholesale rewrites).
 
 How to evaluate:
   * Triggers should typically be evaluated against the **diff** — what \
-was added, removed, or rewritten in this change. The wiki snapshot is \
+was added, removed, or rewritten in this change. The scoped docs are \
 context, not the primary signal.
   * Only evaluate against the overall current state of the document(s) \
 when the trigger description is clearly about state rather than an \
@@ -121,7 +122,7 @@ _REPORT_TOOL = {
 def matches(nl_description: str, payload: str) -> MatchResult:
     """Phase 1: did the change satisfy the trigger's NL description?
 
-    ``payload`` is the combined wiki-snapshot + change view from
+    ``payload`` is the combined scoped-docs + change view from
     ``app.triggers.diff.build_payload``.
     """
     user_msg = f"Trigger description (if):\n{nl_description}\n\n{payload}"
@@ -161,13 +162,14 @@ the final text a human (or downstream system) will see.
 The user message gives you, in order:
   1. The owner's message instruction ("send …").
   2. A one-line "match reason" produced by the firing-condition check.
-  3. A snapshot of the whole wiki at its latest version (context).
+  3. A SCOPED DOCS block: the current bodies of the document(s) under \
+the trigger's scope (context).
   4. A CHANGE block with the path, change kind, and the +/- diff.
 
 Guidance:
   * Follow the owner's instruction. Keep the message concise and \
 specific — quote concrete values from the change where useful.
-  * Ground the message in the diff first; treat the wiki snapshot as \
+  * Ground the message in the diff first; treat the scoped docs as \
 context. If the instruction is clearly about overall state, you can \
 reference the latest version directly.
   * Do not include meta-commentary ("the trigger fired because…"), \
@@ -244,7 +246,8 @@ periodically rather than on a single edit.
 
 The user message gives you, in order:
   1. The trigger description ("if …").
-  2. A snapshot of the whole wiki at its latest version.
+  2. A SCOPED DOCS block: the full current bodies of the document(s) \
+under the trigger's scope. This is the primary material.
   3. A CHANGES SINCE LAST CHECK block: the diffs (new files, edits, \
 rewrites, deletions) committed under the trigger's scope since the \
 previous scheduled check. It reads "(no changes in this window)" when \
@@ -257,7 +260,7 @@ How to evaluate:
 against the CHANGES SINCE LAST CHECK block. If that block reports no \
 changes, such a trigger does NOT fire.
   * If the trigger describes overall STATE ("X is still marked blocked", \
-"there is no owner listed"), evaluate it against the current snapshot, \
+"there is no owner listed"), evaluate it against the SCOPED DOCS block, \
 focusing on the document(s) under the listed scope.
   * Be conservative: false positives are louder than false negatives. \
 If the wiki doesn't clearly satisfy the description, say no.
@@ -274,7 +277,7 @@ def matches_snapshot(nl_description: str, payload: str) -> MatchResult:
     """Phase 1 for schedule triggers: does current wiki state satisfy the
     trigger?
 
-    ``payload`` is the wiki-snapshot + CHANGES SINCE LAST CHECK diff +
+    ``payload`` is the scoped docs + CHANGES SINCE LAST CHECK diff +
     SCHEDULED CHECK block from ``app.triggers.diff.build_schedule_payload``.
     """
     user_msg = f"Trigger description (if):\n{nl_description}\n\n{payload}"
@@ -310,7 +313,8 @@ to produce the final text a human (or downstream system) will see.
 The user message gives you, in order:
   1. The owner's message instruction ("send …").
   2. A one-line "match reason" produced by the firing-condition check.
-  3. A snapshot of the whole wiki at its latest version.
+  3. A SCOPED DOCS block: the full current bodies of the document(s) \
+under the trigger's scope. Quote from here.
   4. A CHANGES SINCE LAST CHECK block: what changed under the scope since \
 the previous check (may read "(no changes in this window)").
   5. A SCHEDULED CHECK block naming the trigger's scope and tick time.
@@ -386,12 +390,13 @@ before.
 The user message gives you, in order:
   1. The trigger description ("if …").
   2. The owner's message instruction ("send …").
-  3. A snapshot of the whole wiki at its latest version (context).
+  3. A SCOPED DOCS block: the current bodies of the document(s) under \
+the trigger's scope (context).
   4. A NEW FILE block with the path and full body of the just-created \
 document.
 
 How to evaluate:
-  * Decide ``triggered`` by reading the new file. Use the wiki snapshot \
+  * Decide ``triggered`` by reading the new file. Use the scoped docs \
 only as context — the primary signal is the new file's content.
   * Be conservative: if the file does not clearly satisfy the trigger \
 description, set ``triggered`` to false.
@@ -441,7 +446,7 @@ def evaluate_new_file_in_dir(
 ) -> NewFileEvalResult:
     """Single-call combined evaluate + render for the new-file-in-dir case.
 
-    ``payload`` is the wiki snapshot + NEW FILE block from
+    ``payload`` is the scoped docs + NEW FILE block from
     ``app.triggers.diff.build_new_file_payload``.
 
     On LLM error or unparseable output, returns ``triggered=False`` with an

--- a/backend/tests/test_triggers_diff.py
+++ b/backend/tests/test_triggers_diff.py
@@ -61,7 +61,7 @@ def test_change_view_falls_back_to_full_body_for_high_density_rewrite():
 
 
 # --------------------------------------------------------------------------- #
-# build_wiki_snapshot                                                         #
+# build_scope_block                                                           #
 # --------------------------------------------------------------------------- #
 
 
@@ -75,14 +75,32 @@ def repo_with_docs(tmp_repo, tmp_config):
     return tmp_config
 
 
-def test_wiki_snapshot_lists_md_files_with_bodies(repo_with_docs):
-    snap = diff_helper.build_wiki_snapshot()
-    assert "=== WIKI (latest version) ===" in snap
+def test_scope_block_root_lists_md_files_with_bodies(repo_with_docs):
+    snap = diff_helper.build_scope_block("")
+    assert "=== SCOPED DOCS (latest version) ===" in snap
     assert "--- a.md" in snap
     assert "alpha body" in snap
     assert "--- auth/passwords.md" in snap
-    # YAML trigger files are skipped — snapshot is .md only
+    # YAML trigger files are skipped — the block is .md only
     assert ".trigger_x.yaml" not in snap
+
+
+def test_scope_block_doc_scope_contains_only_that_doc(repo_with_docs):
+    snap = diff_helper.build_scope_block("auth/passwords.md")
+    assert "--- auth/passwords.md" in snap
+    assert "--- a.md" not in snap
+    assert "alpha body" not in snap
+
+
+def test_scope_block_folder_scope_contains_only_docs_under_it(repo_with_docs):
+    snap = diff_helper.build_scope_block("auth")
+    assert "--- auth/passwords.md" in snap
+    assert "--- a.md" not in snap
+
+
+def test_scope_block_unknown_scope_says_so(repo_with_docs):
+    snap = diff_helper.build_scope_block("nowhere/missing.md")
+    assert "(no docs found under this scope)" in snap
 
 
 # --------------------------------------------------------------------------- #
@@ -90,31 +108,35 @@ def test_wiki_snapshot_lists_md_files_with_bodies(repo_with_docs):
 # --------------------------------------------------------------------------- #
 
 
-def test_payload_combines_snapshot_then_change(repo_with_docs):
+def test_payload_combines_scoped_docs_then_change(repo_with_docs):
     payload = diff_helper.build_payload(
         doc_path="a.md",
         change_kind=ChangeKind.EDIT,
         before="# A\n\nalpha body\n",
         after="# A\n\nalpha body updated\n",
+        scope_path="a.md",
     )
-    snap_idx = payload.index("WIKI (latest version)")
+    scope_idx = payload.index("SCOPED DOCS (latest version)")
     change_idx = payload.index("=== CHANGE ===")
-    assert snap_idx < change_idx
+    assert scope_idx < change_idx
     assert "alpha body updated" in payload
+    # Scoped: sibling docs stay out of the payload.
+    assert "auth/passwords.md" not in payload
 
 
-def test_payload_accepts_prebuilt_snapshot(repo_with_docs):
-    custom = "=== WIKI (latest version) ===\n--- stub.md\nstub body\n"
+def test_payload_accepts_prebuilt_scope_block(repo_with_docs):
+    custom = "=== SCOPED DOCS (latest version) ===\n--- stub.md\nstub body\n"
     payload = diff_helper.build_payload(
         doc_path="a.md",
         change_kind=ChangeKind.EDIT,
         before="x\n",
         after="y\n",
-        wiki_snapshot=custom,
+        scope_path="a.md",
+        scope_block=custom,
     )
     assert payload.startswith(custom)
     assert "stub body" in payload
-    # Real wiki not consulted when snapshot is passed in
+    # Real wiki not consulted when the block is passed in
     assert "alpha body" not in payload
 
 
@@ -137,21 +159,22 @@ def test_new_file_view_shows_path_and_body_no_diff():
     assert "BEFORE:" not in out
 
 
-def test_new_file_payload_combines_snapshot_then_new_file(repo_with_docs):
+def test_new_file_payload_combines_scoped_docs_then_new_file(repo_with_docs):
     payload = diff_helper.build_new_file_payload(
-        doc_path="projects/foo.md", body="# Foo\n"
+        doc_path="auth/new.md", body="# Foo\n", scope_path="auth"
     )
-    snap_idx = payload.index("WIKI (latest version)")
+    scope_idx = payload.index("SCOPED DOCS (latest version)")
     nf_idx = payload.index("=== NEW FILE ===")
-    assert snap_idx < nf_idx
-    assert "alpha body" in payload  # real snapshot was used
-    assert "Path: projects/foo.md" in payload
+    assert scope_idx < nf_idx
+    assert "auth/passwords.md" in payload  # scope docs present
+    assert "alpha body" not in payload  # out-of-scope doc absent
+    assert "Path: auth/new.md" in payload
 
 
-def test_new_file_payload_accepts_prebuilt_snapshot(repo_with_docs):
-    custom = "=== WIKI (latest version) ===\n--- stub.md\nstub body\n"
+def test_new_file_payload_accepts_prebuilt_scope_block(repo_with_docs):
+    custom = "=== SCOPED DOCS (latest version) ===\n--- stub.md\nstub body\n"
     payload = diff_helper.build_new_file_payload(
-        doc_path="projects/foo.md", body="# Foo\n", wiki_snapshot=custom
+        doc_path="auth/new.md", body="# Foo\n", scope_path="auth", scope_block=custom
     )
     assert payload.startswith(custom)
     assert "alpha body" not in payload
@@ -276,17 +299,32 @@ def test_changes_since_follows_rename(tmp_repo, tmp_config):
 
 def test_schedule_payload_without_since_has_no_changes_block(repo_with_docs):
     payload = diff_helper.build_schedule_payload(scope_path="", when_iso="2026-06-03T09:00:00+00:00")
-    assert "=== WIKI (latest version) ===" in payload
+    assert "=== SCOPED DOCS (latest version) ===" in payload
     assert "=== SCHEDULED CHECK ===" in payload
     assert "CHANGES SINCE LAST CHECK" not in payload
 
 
-def test_schedule_payload_with_since_orders_snapshot_changes_check(repo_with_docs):
+def test_schedule_payload_with_since_orders_scoped_changes_check(repo_with_docs):
     since = _iso(datetime.now(timezone.utc) - timedelta(hours=1))
     payload = diff_helper.build_schedule_payload(
         scope_path="", when_iso="2026-06-03T09:00:00+00:00", since_iso=since
     )
-    snap_idx = payload.index("WIKI (latest version)")
+    scope_idx = payload.index("SCOPED DOCS (latest version)")
     chg_idx = payload.index("CHANGES SINCE LAST CHECK")
     chk_idx = payload.index("=== SCHEDULED CHECK ===")
-    assert snap_idx < chg_idx < chk_idx
+    assert scope_idx < chg_idx < chk_idx
+
+
+def test_schedule_payload_doc_scope_carries_doc_despite_large_siblings(repo_with_docs, monkeypatch):
+    """The scoped doc is always in the payload, no matter how much wiki
+    exists alphabetically before it."""
+    from app.wiki import git as wiki_git
+
+    wiki_git.commit_file("0_early/huge.md", "# Huge\n" + "x" * 50_000, "seed", author=None)
+    monkeypatch.setattr(diff_helper, "_WIKI_TOTAL_BUDGET", 10_000)
+
+    payload = diff_helper.build_schedule_payload(
+        scope_path="auth/passwords.md", when_iso="2026-06-03T09:00:00+00:00"
+    )
+    assert "--- auth/passwords.md" in payload
+    assert "0_early/huge.md" not in payload

--- a/backend/tests/test_triggers_fanout.py
+++ b/backend/tests/test_triggers_fanout.py
@@ -49,7 +49,9 @@ def _patch_io(monkeypatch, before: str, after: str) -> None:
 
     monkeypatch.setattr(trig_task, "_read_at", fake_read)
     monkeypatch.setattr(
-        diff_helper, "build_wiki_snapshot", lambda: "=== WIKI (latest version) ===\n"
+        diff_helper,
+        "build_scope_block",
+        lambda scope_path: f"=== SCOPED DOCS (latest version) ===\nScope: {scope_path or '(whole wiki)'}\n",
     )
 
 
@@ -96,7 +98,7 @@ def test_fan_out_records_event_on_match_with_rendered_message(tmp_db, monkeypatc
     # Render saw the same payload + reason the matcher produced.
     assert captured["instruction"] == "tell me when status flips"
     assert captured["reason"] == "green→yellow"
-    assert "WIKI (latest version)" in captured["payload"]
+    assert "SCOPED DOCS (latest version)" in captured["payload"]
     assert "Path: projects/foo.md" in captured["payload"]
 
 

--- a/backend/tests/test_triggers_natural_language.py
+++ b/backend/tests/test_triggers_natural_language.py
@@ -44,7 +44,7 @@ def test_matches_returns_verdict_from_tool_call(monkeypatch):
     monkeypatch.setattr(natural_language, "complete", fake_complete)
 
     payload = (
-        "=== WIKI (latest version) ===\n"
+        "=== SCOPED DOCS (latest version) ===\n"
         "--- projects/foo.md\nstatus: yellow\n\n"
         "=== CHANGE ===\nPath: projects/foo.md\nKind: edit\n\n"
         "<unified diff>\n-status: green\n+status: yellow\n</unified diff>\n"
@@ -56,7 +56,7 @@ def test_matches_returns_verdict_from_tool_call(monkeypatch):
 
     user_msg = captured["messages"][-1]["content"]
     assert "Trigger description" in user_msg
-    assert "WIKI (latest version)" in user_msg
+    assert "SCOPED DOCS (latest version)" in user_msg
     assert "CHANGE" in user_msg
     assert captured["tools"][0]["name"] == "report"
 
@@ -221,7 +221,7 @@ def test_new_file_in_dir_parses_json_object(monkeypatch):
     res = natural_language.evaluate_new_file_in_dir(
         "fire when a new project doc lands",
         "tell me about new projects",
-        "=== WIKI (latest version) ===\n\n=== NEW FILE ===\nPath: p/foo.md\n\n# Foo\n",
+        "=== SCOPED DOCS (latest version) ===\n\n=== NEW FILE ===\nPath: p/foo.md\n\n# Foo\n",
     )
     triggered, msg = res.triggered, res.message
     assert triggered is True


### PR DESCRIPTION
## Description

Bug: a scheduled trigger scoped to `Individual Notes/Nik Standup.md` kept reporting the page as unreadable on dev-wiki, despite the page having content.

Cause: every trigger payload led with a whole-wiki snapshot capped at 200k chars, assembled in `git ls-files` order. On a large wiki the alphabetically-earlier docs exhaust the budget, so the scoped doc never reaches the LLM — the trigger's scope was only a label, not a filter.

Fix: payloads now carry only the docs under the trigger's scope, on all three paths (delta, new-file-in-dir, schedule). A `.md` scope is that doc, a folder scope is the docs under it, an empty scope remains the budgeted whole wiki. Scoping reuses the same `_in_scope` predicate as the changes filter, the fan-out builds one scope block per distinct scope per commit, and the prompts describe the `SCOPED DOCS` block. A regression test pins that a scoped doc survives an arbitrarily large alphabetically-earlier sibling.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check