### PR TITLE
fix(slack): render markdown list markers as real bullets, suppress link unfurls

### DIFF
--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -18,17 +18,20 @@ import requests
 log = logging.getLogger(__name__)
 
 # Standard markdown -> Slack mrkdwn, the high-value cases only: Slack renders
-# **bold** and [text](url) literally. Heading markers are stripped to plain
-# text (notifications carry no headings), before bold so `## **x**` can't
-# nest emphasis.
+# **bold**, [text](url), and `- item` list markers literally (mrkdwn has no
+# list syntax — real bullet characters are the convention). Heading markers
+# are stripped to plain text (notifications carry no headings), before bold
+# so `## **x**` can't nest emphasis.
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 _HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
+_BULLET_RE = re.compile(r"^(\s*)[-*+]\s+", re.MULTILINE)
 
 
 def to_mrkdwn(text: str) -> str:
     """Convert common markdown constructs to Slack's mrkdwn dialect."""
     text = _HEADING_RE.sub(r"\1", text)
+    text = _BULLET_RE.sub(r"\1• ", text)
     text = _BOLD_RE.sub(r"*\1*", text)
     return _LINK_RE.sub(r"<\2|\1>", text)
 
@@ -60,8 +63,18 @@ def _call_api(bot_token: str, method: str, payload: dict[str, Any]) -> dict[str,
 
 
 def post_chat_message(*, bot_token: str, channel: str, text: str) -> None:
-    """Post ``text`` to a channel (or DM channel) as the bot."""
-    _call_api(bot_token, "chat.postMessage", {"channel": channel, "text": text})
+    """Post ``text`` to a channel (or DM channel) as the bot. Link unfurls
+    are suppressed — notification posts should not grow preview cards."""
+    _call_api(
+        bot_token,
+        "chat.postMessage",
+        {
+            "channel": channel,
+            "text": text,
+            "unfurl_links": False,
+            "unfurl_media": False,
+        },
+    )
 
 
 def open_dm(*, bot_token: str, slack_user_id: str) -> str:

--- a/backend/app/slack/client.py
+++ b/backend/app/slack/client.py
@@ -25,7 +25,8 @@ log = logging.getLogger(__name__)
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*")
 _LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 _HEADING_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
-_BULLET_RE = re.compile(r"^(\s*)[-*+]\s+", re.MULTILINE)
+# [ \t]+ not \s+: a bare marker line must not consume its own newline.
+_BULLET_RE = re.compile(r"^([ \t]*)[-*+][ \t]+", re.MULTILINE)
 
 
 def to_mrkdwn(text: str) -> str:

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -202,6 +202,15 @@ def test_list_channels_paginates_and_sorts(monkeypatch):
     assert seen_params[1]["cursor"] == "page2"
 
 
+def test_to_mrkdwn_converts_list_markers_to_bullets():
+    assert slack_client.to_mrkdwn("- item 1\n- item 2") == "• item 1\n• item 2"
+    assert slack_client.to_mrkdwn("* starred\n+ plussed") == "• starred\n• plussed"
+    # Nested indentation is preserved.
+    assert slack_client.to_mrkdwn("- top\n  - nested") == "• top\n  • nested"
+    # Bold at line start is emphasis, not a list marker.
+    assert slack_client.to_mrkdwn("**bold** lead") == "*bold* lead"
+
+
 def test_to_mrkdwn_converts_common_markdown():
     assert slack_client.to_mrkdwn("**fun_poem.md**") == "*fun_poem.md*"
     assert (
@@ -233,6 +242,19 @@ def test_bot_post_converts_markdown(tmp_db, _bot_posts, monkeypatch):
         actor=None,
     )
     assert _bot_posts[0]["text"].startswith("*bold title*\nbody")
+
+
+def test_post_chat_message_suppresses_unfurls(monkeypatch):
+    captured: dict = {}
+    monkeypatch.setattr(
+        slack_client,
+        "_call_api",
+        lambda token, method, payload: captured.update({"method": method, **payload}),
+    )
+    slack_client.post_chat_message(bot_token="xoxb-x", channel="C1", text="hi")
+    assert captured["method"] == "chat.postMessage"
+    assert captured["unfurl_links"] is False
+    assert captured["unfurl_media"] is False
 
 
 def test_call_api_get_retries_timeout_then_succeeds(monkeypatch):

--- a/backend/tests/test_slack_bot_dispatch.py
+++ b/backend/tests/test_slack_bot_dispatch.py
@@ -209,6 +209,8 @@ def test_to_mrkdwn_converts_list_markers_to_bullets():
     assert slack_client.to_mrkdwn("- top\n  - nested") == "• top\n  • nested"
     # Bold at line start is emphasis, not a list marker.
     assert slack_client.to_mrkdwn("**bold** lead") == "*bold* lead"
+    # A bare marker line keeps its newline; lines don't merge.
+    assert slack_client.to_mrkdwn("-\nnext line") == "-\nnext line"
 
 
 def test_to_mrkdwn_converts_common_markdown():
@@ -245,7 +247,7 @@ def test_bot_post_converts_markdown(tmp_db, _bot_posts, monkeypatch):
 
 
 def test_post_chat_message_suppresses_unfurls(monkeypatch):
-    captured: dict = {}
+    captured: dict[str, Any] = {}
     monkeypatch.setattr(
         slack_client,
         "_call_api",


### PR DESCRIPTION
## Description

Two formatting gaps in Slack-bound trigger messages.

- Slack's mrkdwn has no list syntax, so markdown `- item` lines posted as literal dashes. The converter now turns leading `-`, `*`, `+` markers into `•` with indentation preserved; bold-at-line-start is untouched (the marker rule requires trailing whitespace).
- `chat.postMessage` unfurled every converted link, growing preview cards under notifications. Posts now set `unfurl_links`/`unfurl_media` false.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check