### PR TITLE
feat(coedit): route human editing through a co-edit session (frontend)

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -10,7 +10,6 @@ import {
   type FormEvent,
 } from "react";
 import { createPortal } from "react-dom";
-import { diffLines } from "diff";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import useSWR from "swr";
@@ -56,7 +55,7 @@ import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
-import { apiFetch, ApiError } from "@/lib/api";
+import { apiFetch } from "@/lib/api";
 import { listComments } from "@/lib/comments";
 import {
   paintCommentHighlights,
@@ -66,7 +65,8 @@ import {
 } from "@/lib/commentAnchor";
 import { rehypeSourcePos } from "@/lib/rehypeSourcePos";
 import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
-import { useRequireAuth } from "@/lib/auth";
+import { useAuth, useRequireAuth } from "@/lib/auth";
+import { useCoeditSession } from "@/lib/useCoeditSession";
 import {
   useHeaderActionsHost,
   useRightPanelHost,
@@ -110,20 +110,6 @@ interface FileResponse {
   body: string;
   ref?: string;
   head_sha?: string | null;
-}
-
-interface DraftResponse {
-  path: string;
-  base_sha: string;
-  content: string;
-  updated_at: string;
-}
-
-interface ConflictState {
-  draftBody: string;
-  currentBody: string;
-  currentSha: string;
-  baseSha: string;
 }
 
 export default function WikiRoute() {
@@ -1282,8 +1268,8 @@ function FileViewer({ path }: { path: string }) {
   const host = useHeaderActionsHost();
   const rightHost = useRightPanelHost();
   const { setDrafting, requestExpand } = useDrafting();
+  const { user } = useAuth();
   const [body, setBody] = useState("");
-  const [draft, setDraft] = useState("");
   const [editing, setEditing] = useState(false);
   const [filenameDraft, setFilenameDraft] = useState("");
   const [saving, setSaving] = useState(false);
@@ -1573,19 +1559,6 @@ function FileViewer({ path }: { path: string }) {
   const [applyingTemplateId, setApplyingTemplateId] = useState<string | null>(
     null,
   );
-  // Conflict resolution: set when a save returns 409.
-  const [conflict, setConflict] = useState<ConflictState | null>(null);
-  // Resume banner: set when entering edit mode and a matching draft exists.
-  const [pendingResumeDraft, setPendingResumeDraft] =
-    useState<DraftResponse | null>(null);
-  const [resuming, setResuming] = useState(false);
-  const [consolidating, setConsolidating] = useState(false);
-  // Debounce timer ref for auto-saving the draft to the server.
-  const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Incremented on each startEdit() call and on cancel; lets async
-  // continuations inside startEdit bail out if editing was cancelled first.
-  const editSessionRef = useRef(0);
-
   const loadLatest = useCallback(() => {
     setLoading(true);
     setError(null);
@@ -1595,7 +1568,6 @@ function FileViewer({ path }: { path: string }) {
     apiFetch<FileResponse>(`/wiki/file?path=${encodeURIComponent(path)}`)
       .then((r) => {
         setBody(r.body);
-        setDraft(r.body);
         setHeadSha(r.head_sha ?? null);
       })
       .catch((e) => setError(e instanceof Error ? e.message : "failed to load"))
@@ -1659,10 +1631,10 @@ function FileViewer({ path }: { path: string }) {
     if (!liveDoc) return;
     // Re-check the gate at apply time — an in-flight fetch from before
     // the user toggled `editing` can still resolve here and would
-    // otherwise clobber their textarea draft.
+    // otherwise clobber the live session buffer. While editing, the
+    // co-edit SSE stream is the source of truth, not this poll.
     if (editing || viewingSha !== null) return;
     setBody((prev) => (prev === liveDoc.body ? prev : liveDoc.body));
-    setDraft((prev) => (prev === liveDoc.body ? prev : liveDoc.body));
     setHeadSha(liveDoc.head_sha ?? null);
   }, [liveDoc, editing, viewingSha]);
 
@@ -1729,29 +1701,6 @@ function FileViewer({ path }: { path: string }) {
   useEffect(() => {
     return () => setDrafting(null);
   }, [setDrafting]);
-
-  // Auto-save the draft to the server while the user is editing.
-  // Debounced 5s so we don't hammer the API on every keystroke.
-  // Only fires when the draft differs from the saved body.
-  useEffect(() => {
-    if (!editing) return;
-    if (draft === body) return;
-    const baseSha = viewingSha ?? headSha;
-    if (!baseSha) return;
-    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
-    autoSaveTimer.current = setTimeout(() => {
-      void apiFetch("/wiki/file/autosave", {
-        method: "PUT",
-        body: JSON.stringify({ path, base_sha: baseSha, content: draft }),
-      }).catch(() => {
-        // Auto-save failures are silent — the user still has the draft
-        // locally and can save manually.
-      });
-    }, 5000);
-    return () => {
-      if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
-    };
-  }, [draft, editing, path, headSha, viewingSha]);
 
   const refreshAgents = useCallback(() => {
     setAgentsError(null);
@@ -1839,6 +1788,29 @@ function FileViewer({ path }: { path: string }) {
     }
   }
 
+  // Live co-editing session: clicking Edit joins the page's session and binds
+  // the textarea to the shared buffer; Save checkpoints, Cancel discards, a
+  // disconnect leaves. Only the current version is co-edited (the Edit button is
+  // hidden while viewing an old commit).
+  const coedit = useCoeditSession({
+    path,
+    enabled: editing,
+    committedBody: body,
+    myUserId: user?.id ?? null,
+    onEnd: () => {
+      setEditing(false);
+      setViewingSha(null);
+      void apiFetch<FileResponse>(`/wiki/file?path=${encodeURIComponent(path)}`)
+        .then((fresh) => {
+          setBody(fresh.body);
+          setHeadSha(fresh.head_sha ?? null);
+        })
+        .catch(() => {});
+      void refreshComments();
+      void refreshDraftState();
+    },
+  });
+
   const segments = path.split("/");
   const parentSlug = segments.slice(0, -1).join("/");
   const currentBasename = segments[segments.length - 1] ?? path;
@@ -1848,7 +1820,7 @@ function FileViewer({ path }: { path: string }) {
   const filenameValid = !!filenameNoExt && !filenameNoExt.includes("/");
   const renamed =
     editing && filenameValid && filenameNoExt !== currentBasenameNoExt;
-  const bodyChanged = editing && draft !== body;
+  const bodyChanged = editing && coedit.active && coedit.buffer !== body;
   const dirty = editing && (bodyChanged || renamed);
   // `viewingVersion`: a history version is displayed in the main pane.
   // `viewingOld`: that version is not the newest commit for this file
@@ -1897,43 +1869,14 @@ function FileViewer({ path }: { path: string }) {
     };
   }, [dirty]);
 
-  async function startEdit() {
+  function startEdit() {
+    // Entering edit mode joins the page's co-edit session (see the
+    // useCoeditSession hook, gated on `editing`), which seeds the buffer from
+    // current HEAD. The Edit button is hidden while viewing an old commit, so
+    // editing always targets the current version.
     setFilenameDraft(currentBasenameNoExt);
     setError(null);
-    const session = ++editSessionRef.current;
-    if (viewingOld && viewingSha) {
-      // Editing from an older version forks it: load that version's body
-      // into the editor. `viewingSha` stays set so save/autosave use it as
-      // base_sha and the server records the rollback. Skip the resume-draft
-      // check — any saved draft was based on a different version.
-      try {
-        const r = await apiFetch<FileResponse>(
-          `/wiki/file?path=${encodeURIComponent(path)}&ref=${encodeURIComponent(viewingSha)}`,
-        );
-        if (editSessionRef.current !== session) return;
-        setDraft(r.body);
-        setEditing(true);
-      } catch (e) {
-        setError(
-          e instanceof Error ? e.message : "failed to load version for edit",
-        );
-      }
-      return;
-    }
     setEditing(true);
-    // Check for an existing in-progress draft from a previous session.
-    try {
-      const saved = await apiFetch<DraftResponse | null>(
-        `/wiki/file/autosave?path=${encodeURIComponent(path)}`,
-      );
-      if (editSessionRef.current !== session) return;
-      if (!saved) return;
-      // Show the Resume banner regardless of whether the draft is stale.
-      // Rebase (if needed) runs when the user clicks Resume.
-      setPendingResumeDraft(saved);
-    } catch {
-      // Draft fetch failure is non-fatal — user just starts fresh.
-    }
   }
 
   async function onSave() {
@@ -1943,18 +1886,19 @@ function FileViewer({ path }: { path: string }) {
     }
     setSaving(true);
     setError(null);
+    // Snapshot what we're committing so the viewer shows it immediately; the
+    // checkpoint commit runs on a worker, and the SWR poll (re-enabled once
+    // editing is false) reconciles with the actual merged result.
+    const finalText = coedit.buffer;
     try {
-      if (bodyChanged) {
-        const baseSha = viewingSha ?? headSha;
-        await apiFetch("/wiki/file", {
-          method: "PUT",
-          body: JSON.stringify({
-            path,
-            body: draft,
-            ...(baseSha ? { base_sha: baseSha } : {}),
-          }),
-        });
-      }
+      // Commit the session buffer to git (checkpoint), then leave. onEnd exits
+      // edit mode + refreshes comments/drafting; co-editing removes the
+      // human-vs-human conflict, so there's no 409 path here.
+      await coedit.save();
+      setBody(finalText);
+      setDiffData(null);
+      if (historyOpen) refreshHistory();
+      else setCommits(null);
       if (renamed) {
         const finalName = filenameNoExt + ".md";
         const newRel = parentSlug ? `${parentSlug}/${finalName}` : finalName;
@@ -1962,67 +1906,10 @@ function FileViewer({ path }: { path: string }) {
           method: "POST",
           body: JSON.stringify({ old_path: path, new_path: newRel }),
         });
-        // Navigation will remount FileViewer with the new path; loadLatest
-        // there resets editing/body/headSha. Bail out before touching state.
         router.push(`/app/wiki/${newRel}`);
-        return;
       }
-      setEditing(false);
-      setViewingSha(null);
-      setConflict(null);
-      setPendingResumeDraft(null);
-      // Optimistically show what the user submitted. The fetch below may
-      // overwrite with the auto-merged body, but if it fails the viewer
-      // still shows the content that was just committed rather than the
-      // stale pre-edit body.
-      setBody(draft);
-      setDraft(draft);
-      setDiffData(null);
-      // History changed (new commit + possible deprecations) — refetch.
-      if (historyOpen) refreshHistory();
-      else setCommits(null);
-      // Pick up the committed body and head_sha. Overwrite the optimistic
-      // draft above with the actual merged result when the server auto-merged
-      // concurrent edits. Failures are silent — the optimistic value is a
-      // correct fallback since the PUT already succeeded.
-      try {
-        const fresh = await apiFetch<FileResponse>(
-          `/wiki/file?path=${encodeURIComponent(path)}`,
-        );
-        setHeadSha(fresh.head_sha ?? null);
-        setBody(fresh.body);
-        setDraft(fresh.body);
-      } catch {
-        // fresh fetch failed — body already shows the local draft
-      }
-      // The commit re-anchored comments server-side; refetch so the panel +
-      // highlights reflect the drift (won't re-open the panel — guarded).
-      void refreshComments();
-      // The server clears the draft row when the body diverges from
-      // the template snapshot — re-sync our context so the chat widget
-      // winds down drafting (banner + mode + conversation revert
-      // together after its debounce).
-      await refreshDraftState();
     } catch (e) {
-      if (e instanceof ApiError && e.status === 409) {
-        // Conflict: page changed since we opened it. Fetch current HEAD
-        // and show the conflict resolution panel.
-        try {
-          const current = await apiFetch<FileResponse>(
-            `/wiki/file?path=${encodeURIComponent(path)}`,
-          );
-          setConflict({
-            draftBody: draft,
-            currentBody: current.body,
-            currentSha: current.head_sha ?? headSha ?? "",
-            baseSha: viewingSha ?? headSha ?? "",
-          });
-        } catch {
-          setError("Save conflict — could not load current version.");
-        }
-      } else {
-        setError(e instanceof Error ? e.message : "save failed");
-      }
+      setError(e instanceof Error ? e.message : "save failed");
     } finally {
       setSaving(false);
     }
@@ -2033,7 +1920,7 @@ function FileViewer({ path }: { path: string }) {
     setError(null);
     try {
       const full = await getTemplate(template.id);
-      setDraft(full.body);
+      coedit.onChange(full.body);
       setAppliedTemplateBody(full.body);
       setAppliedTemplateId(template.id);
       await setDraftTemplate(path, template.id);
@@ -2046,7 +1933,7 @@ function FileViewer({ path }: { path: string }) {
   }
 
   async function onPickBlank() {
-    setDraft("");
+    coedit.onChange("");
     setAppliedTemplateBody(null);
     setAppliedTemplateId(null);
     setError(null);
@@ -2063,87 +1950,12 @@ function FileViewer({ path }: { path: string }) {
   }
 
   function onCancel() {
-    editSessionRef.current++;
-    setDraft(body);
+    // Discard resets the shared buffer to the committed body and leaves the
+    // session, so the leave-time checkpoint is a no-op (nothing lands in git).
+    // onEnd exits edit mode + refreshes.
     setFilenameDraft(currentBasenameNoExt);
-    setEditing(false);
     setError(null);
-    setConflict(null);
-    setPendingResumeDraft(null);
-    setResuming(false);
-    setConsolidating(false);
-    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
-    // Server-side draft is intentionally kept on cancel so the user can
-    // resume from the same point next time they enter edit mode.
-  }
-
-  async function onAiConsolidate() {
-    if (!conflict) return;
-    setConsolidating(true);
-    setError(null);
-    try {
-      const result = await apiFetch<{ merged: string }>("/wiki/file/merge", {
-        method: "POST",
-        body: JSON.stringify({
-          path,
-          base_sha: conflict.baseSha,
-          current_body: conflict.currentBody,
-          draft_body: conflict.draftBody,
-        }),
-      });
-      setDraft(result.merged);
-      setHeadSha(conflict.currentSha);
-      setViewingSha(null);
-      setConflict(null);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "AI consolidation failed");
-    } finally {
-      setConsolidating(false);
-    }
-  }
-
-  async function onKeepMine() {
-    if (!conflict) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await apiFetch("/wiki/file", {
-        method: "PUT",
-        body: JSON.stringify({
-          path,
-          body: conflict.draftBody,
-          base_sha: conflict.currentSha,
-        }),
-      });
-      setDraft(conflict.draftBody);
-      setBody(conflict.draftBody);
-      setConflict(null);
-      setEditing(false);
-      if (historyOpen) refreshHistory();
-      else setCommits(null);
-      const fresh = await apiFetch<FileResponse>(
-        `/wiki/file?path=${encodeURIComponent(path)}`,
-      );
-      setHeadSha(fresh.head_sha ?? null);
-      await refreshDraftState();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "save failed");
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function onUseCurrent() {
-    if (!conflict) return;
-    setDraft(conflict.currentBody);
-    setBody(conflict.currentBody);
-    setHeadSha(conflict.currentSha);
-    setViewingSha(null);
-    setConflict(null);
-    setEditing(false);
-    void apiFetch(`/wiki/file/autosave?path=${encodeURIComponent(path)}`, {
-      method: "DELETE",
-    }).catch(() => {});
+    void coedit.discard();
   }
 
   // Page actions live in the single pinned header (WikiHeader), not a second
@@ -2207,12 +2019,16 @@ function FileViewer({ path }: { path: string }) {
           setPolicyOpen(true);
         }}
       />
-      <Button
-        icon={SvgEdit}
-        variant="action"
-        tooltip="Edit"
-        onClick={startEdit}
-      />
+      {/* Editing always targets current HEAD via a co-edit session, so hide
+          Edit while viewing an older commit — "Back to latest" first. */}
+      {!viewingOld && (
+        <Button
+          icon={SvgEdit}
+          variant="action"
+          tooltip="Edit"
+          onClick={startEdit}
+        />
+      )}
     </>
   ) : null;
 
@@ -2268,148 +2084,11 @@ function FileViewer({ path }: { path: string }) {
           <span>
             Viewing an older version
             {viewingSha ? ` (${viewingSha.slice(0, 7)})` : ""}.
-            {editing &&
-              " Saving will replace the current version and mark the in-between revisions as deprecated."}
           </span>
           <div className="flex-1" />
           <Button size="sm" onClick={loadLatest}>
             Back to latest
           </Button>
-        </div>
-      )}
-
-      {editing && pendingResumeDraft && (
-        <div className="mb-3 flex items-center gap-3 rounded-(--border-radius-08) border border-(--status-info-02) bg-(--status-info-01) px-3 py-2 text-[13px] text-(--status-text-info-05)">
-          <span>You have unsaved changes from a previous session.</span>
-          <div className="flex-1" />
-          <Button
-            size="sm"
-            disabled={resuming}
-            onClick={() => {
-              if (pendingResumeDraft.base_sha === headSha) {
-                // Fresh draft — restore directly.
-                setDraft(pendingResumeDraft.content);
-                setPendingResumeDraft(null);
-                return;
-              }
-              // Stale draft — attempt 3-way rebase first.
-              setResuming(true);
-              void apiFetch<DraftResponse>("/wiki/file/autosave/rebase", {
-                method: "POST",
-                body: JSON.stringify({ path }),
-              })
-                .then((rebased) => {
-                  setDraft(rebased.content);
-                  setPendingResumeDraft(null);
-                })
-                .catch((e: unknown) => {
-                  if (e instanceof ApiError && e.status === 409) {
-                    const detail = e.data as {
-                      current_body: string;
-                      draft_body: string;
-                      current_sha: string;
-                    };
-                    setConflict({
-                      draftBody: detail.draft_body,
-                      currentBody: detail.current_body,
-                      currentSha: detail.current_sha,
-                      baseSha: pendingResumeDraft.base_sha,
-                    });
-                    setPendingResumeDraft(null);
-                  }
-                })
-                .finally(() => setResuming(false));
-            }}
-          >
-            {resuming ? "Rebasing…" : "Resume"}
-          </Button>
-          <Button
-            size="sm"
-            onClick={() => {
-              setPendingResumeDraft(null);
-              void apiFetch(
-                `/wiki/file/autosave?path=${encodeURIComponent(path)}`,
-                { method: "DELETE" },
-              ).catch(() => {});
-            }}
-          >
-            Discard
-          </Button>
-        </div>
-      )}
-
-      {editing && conflict && (
-        <div className="mb-3 overflow-hidden rounded-(--border-radius-08) border border-(--status-warning-02)">
-          <div className="flex items-center gap-3 bg-(--status-warning-01) px-3 py-2 text-[13px] text-(--status-text-warning-05)">
-            <span>This page was updated while you were editing.</span>
-            <div className="flex-1" />
-            <Button
-              size="sm"
-              onClick={() => void onKeepMine()}
-              disabled={saving}
-            >
-              Keep mine
-            </Button>
-            <Button size="sm" onClick={onUseCurrent}>
-              Use current
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => void onAiConsolidate()}
-              disabled={consolidating || saving}
-            >
-              {consolidating ? "Merging…" : "Merge with AI"}
-            </Button>
-            <Button size="sm" onClick={() => setConflict(null)}>
-              Edit manually
-            </Button>
-          </div>
-          <div className="grid grid-cols-2 gap-0">
-            {(() => {
-              const currentHunks = diffLines(
-                conflict.draftBody,
-                conflict.currentBody,
-              );
-              const draftHunks = diffLines(
-                conflict.currentBody,
-                conflict.draftBody,
-              );
-              const preClass =
-                "m-0 text-xs leading-[1.5] font-mono whitespace-pre-wrap break-words max-h-[240px] overflow-y-auto";
-              const labelClass =
-                "text-[11px] font-semibold text-(--text-03) mb-[6px] uppercase tracking-[0.05em]";
-              return (
-                <>
-                  <div className="border-r border-(--border-01) p-3">
-                    <div className={labelClass}>Current version</div>
-                    <pre className={preClass}>
-                      {currentHunks.map((part, i) => (
-                        <span
-                          key={i}
-                          className={`${part.added ? "bg-(--status-success-01)" : "bg-transparent"} ${part.removed ? "text-transparent select-none" : "text-(--text-04)"}`}
-                        >
-                          {part.value}
-                        </span>
-                      ))}
-                    </pre>
-                  </div>
-                  <div className="p-3">
-                    <div className={labelClass}>Your draft</div>
-                    <pre className={preClass}>
-                      {draftHunks.map((part, i) => (
-                        <span
-                          key={i}
-                          className={`${part.added ? "bg-(--status-warning-01)" : "bg-transparent"} ${part.removed ? "text-transparent select-none" : "text-(--text-04)"}`}
-                        >
-                          {part.value}
-                        </span>
-                      ))}
-                    </pre>
-                  </div>
-                </>
-              );
-            })()}
-          </div>
         </div>
       )}
 
@@ -2436,10 +2115,10 @@ function FileViewer({ path }: { path: string }) {
                       // to discard without losing user work: truly blank, or
                       // still verbatim equal to the template the user just
                       // applied (so they can keep swapping templates).
-                      const isBlank = draft.trim() === "";
+                      const isBlank = coedit.buffer.trim() === "";
                       const matchesApplied =
                         appliedTemplateBody !== null &&
-                        draft === appliedTemplateBody;
+                        coedit.buffer === appliedTemplateBody;
                       const showGallery =
                         (isBlank || matchesApplied) &&
                         templates !== null &&
@@ -2457,8 +2136,8 @@ function FileViewer({ path }: { path: string }) {
                       );
                     })()}
                     <textarea
-                      value={draft}
-                      onChange={(e) => setDraft(e.target.value)}
+                      value={coedit.buffer}
+                      onChange={(e) => coedit.onChange(e.target.value)}
                       spellCheck={false}
                       placeholder="Start typing, or pick a template above…"
                       className="box-border min-h-0 w-full flex-1 resize-none rounded-(--border-radius-08) border border-(--border-01) p-4 font-mono text-sm leading-[1.6] outline-none"

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -1634,6 +1634,9 @@ function FileViewer({ path }: { path: string }) {
     // otherwise clobber the live session buffer. While editing, the
     // co-edit SSE stream is the source of truth, not this poll.
     if (editing || viewingSha !== null) return;
+    // The read is session-aware: while a co-edit session is open, /wiki/file
+    // serves the live buffer (a quick HEAD+buffer merge), so this poll reflects
+    // saved edits immediately — no dependency on the async checkpoint commit.
     setBody((prev) => (prev === liveDoc.body ? prev : liveDoc.body));
     setHeadSha(liveDoc.head_sha ?? null);
   }, [liveDoc, editing, viewingSha]);
@@ -1800,12 +1803,10 @@ function FileViewer({ path }: { path: string }) {
     onEnd: () => {
       setEditing(false);
       setViewingSha(null);
-      void apiFetch<FileResponse>(`/wiki/file?path=${encodeURIComponent(path)}`)
-        .then((fresh) => {
-          setBody(fresh.body);
-          setHeadSha(fresh.head_sha ?? null);
-        })
-        .catch(() => {});
+      // Don't refetch the body here. onSave sets it optimistically; the SWR
+      // poll then reconciles against the session-aware read (which serves the
+      // live buffer while the session is open), so there's no stale flash and
+      // no wait on the async checkpoint commit.
       void refreshComments();
       void refreshDraftState();
     },
@@ -1887,8 +1888,8 @@ function FileViewer({ path }: { path: string }) {
     setSaving(true);
     setError(null);
     // Snapshot what we're committing so the viewer shows it immediately; the
-    // checkpoint commit runs on a worker, and the SWR poll (re-enabled once
-    // editing is false) reconciles with the actual merged result.
+    // checkpoint commit runs on a worker, but the session-aware read serves the
+    // live buffer meanwhile, so the SWR poll keeps showing this content.
     const finalText = coedit.buffer;
     try {
       // Commit the session buffer to git (checkpoint), then leave. onEnd exits

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -1821,7 +1821,10 @@ function FileViewer({ path }: { path: string }) {
   const filenameValid = !!filenameNoExt && !filenameNoExt.includes("/");
   const renamed =
     editing && filenameValid && filenameNoExt !== currentBasenameNoExt;
-  const bodyChanged = editing && coedit.active && coedit.buffer !== body;
+  // The hook seeds its buffer with the committed body on Edit (before the join
+  // resolves), so this is accurate even during join latency — no need to gate
+  // on `coedit.active`, which would falsely disable Save mid-join.
+  const bodyChanged = editing && coedit.buffer !== body;
   const dirty = editing && (bodyChanged || renamed);
   // `viewingVersion`: a history version is displayed in the main pane.
   // `viewingOld`: that version is not the newest commit for this file
@@ -1894,7 +1897,9 @@ function FileViewer({ path }: { path: string }) {
     try {
       // Commit the session buffer to git (checkpoint), then leave. onEnd exits
       // edit mode + refreshes comments/drafting; co-editing removes the
-      // human-vs-human conflict, so there's no 409 path here.
+      // human-vs-human conflict, so there's no 409 path here. On a rename-only
+      // save the buffer is unchanged, so the checkpoint is a no-op server-side
+      // (version == checkpointed_version) — no empty commit before the move.
       await coedit.save();
       setBody(finalText);
       setDiffData(null);

--- a/frontend/src/lib/useCoeditSession.ts
+++ b/frontend/src/lib/useCoeditSession.ts
@@ -88,29 +88,33 @@ export function useCoeditSession(opts: {
     if (pumpPromise.current) return pumpPromise.current;
     if (sessionId.current === null) return Promise.resolve();
     const run = (async () => {
-      try {
-        while (sessionId.current !== null) {
-          const change = diffToChange(serverBuffer.current, bufferRef.current);
-          if (change === null) return; // caught up
-          const sent = bufferRef.current;
-          try {
-            const { version: v } = await sendOp(
-              sessionId.current,
-              version.current,
-              [change],
-            );
-            version.current = v;
-            serverBuffer.current = sent;
-          } catch (err) {
-            if (err instanceof ApiError && err.status === 409) await resync();
-            return; // stop this drain; a resync (or transient failure) handled it
-          }
+      while (sessionId.current !== null) {
+        const change = diffToChange(serverBuffer.current, bufferRef.current);
+        if (change === null) return; // caught up
+        const sent = bufferRef.current;
+        try {
+          const { version: v } = await sendOp(
+            sessionId.current,
+            version.current,
+            [change],
+          );
+          version.current = v;
+          serverBuffer.current = sent;
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 409) await resync();
+          return; // stop this drain; a resync (or transient failure) handled it
         }
-      } finally {
-        pumpPromise.current = null;
       }
     })();
+    // Set the in-flight handle *before* attaching the completion hook. A drain
+    // that finds no change resolves synchronously; clearing the handle from an
+    // inline `finally` would run before this assignment and leave a resolved
+    // promise stuck in `pumpPromise` — poisoning every future pump (ops would
+    // silently stop sending). The `=== run` guard clears only our own run.
     pumpPromise.current = run;
+    void run.finally(() => {
+      if (pumpPromise.current === run) pumpPromise.current = null;
+    });
     return run;
   }, [resync]);
 

--- a/frontend/src/lib/useCoeditSession.ts
+++ b/frontend/src/lib/useCoeditSession.ts
@@ -60,6 +60,7 @@ export function useCoeditSession(opts: {
   const pumpPromise = useRef<Promise<void> | null>(null); // in-flight op drain
   const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abort = useRef<AbortController | null>(null);
+  const joinPromise = useRef<Promise<void> | null>(null); // in-flight join
 
   const setBuffer = useCallback((next: string) => {
     bufferRef.current = next;
@@ -174,6 +175,11 @@ export function useCoeditSession(opts: {
   }, []);
 
   const save = useCallback(async () => {
+    // A Save clicked during the join round-trip must not no-op: wait for the
+    // join to resolve so the session exists (and pre-join edits are flushed).
+    if (sessionId.current === null && joinPromise.current) {
+      await joinPromise.current;
+    }
     const sid = sessionId.current;
     if (sid === null) return;
     // Drain pending edits before committing so a keystroke typed inside the
@@ -217,25 +223,38 @@ export function useCoeditSession(opts: {
     abort.current = ctrl;
     let cancelled = false;
 
-    (async () => {
+    // Seed the buffer with the committed body immediately so the textarea shows
+    // content (and callers' `buffer !== committedBody` dirty check is accurate)
+    // during the join round-trip, rather than a blank flash.
+    const seed = committedBody;
+    serverBuffer.current = seed;
+    setBuffer(seed);
+
+    const run = (async () => {
       try {
         const snap = await joinSession(path);
         if (cancelled) return;
         sessionId.current = snap.session_id;
         version.current = snap.version;
         serverBuffer.current = snap.buffer;
-        setBuffer(snap.buffer);
+        // Adopt the server buffer unless the user already typed into the seed —
+        // don't clobber edits made during the join; pump() sends their diff.
+        if (bufferRef.current === seed) setBuffer(snap.buffer);
         setParticipants(snap.participants);
         setActive(true);
+        // Flush anything typed during the join window before streaming.
+        void pump();
         // Long-lived stream; resolves when the server closes or we abort.
         await streamSession(snap.session_id, onFrame, ctrl.signal);
       } catch {
         // join failed or stream ended; leave edit mode gracefully
       }
     })();
+    joinPromise.current = run;
 
     return () => {
       cancelled = true;
+      joinPromise.current = null;
       stop();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## What

Cuts `FileViewer` over to **Model A**: all human editing goes through a live co-edit session (frontend half of the "Edit = session" arc).

- **Edit** → joins the page's co-edit session (`useCoeditSession`); the `<textarea>` binds to the shared session buffer. The buffer is seeded with the committed body immediately so there's no blank flash during the join.
- **Save** → checkpoints the buffer to git + leaves the session (`coedit.save()`), then handles rename via `/wiki/move`.
- **Cancel** → `coedit.discard()`: resets the shared buffer to the committed body (leave-time checkpoint is a no-op) + leaves.

## Removed (edit path no longer needs them)

Live convergence eliminates human-vs-human conflicts and the per-user private draft:
- the 5s `/file/autosave` debounce effect
- the resume banner (+ `/file/autosave/rebase`)
- the inline conflict panel + `onKeepMine` / `onUseCurrent` / `onAiConsolidate` (+ `/file/merge`) — human-vs-agent is reconciled by the checkpoint's 3-way merge + a `resync`
- the orphaned `draft` state, `ConflictState`/`DraftResponse` types, and the `diffLines`/`ApiError` imports they used

Edit is hidden while viewing an older commit (editing always targets current HEAD). The not-editing SWR poll still surfaces MCP/agent edits.

## Depends on #331 (merged)

Reads are **session-aware** (#331): while a session is open, `GET /wiki/file` serves the live buffer, so a Save shows immediately without waiting on the async checkpoint commit. This PR relies on that.

## Fixes found during local testing (later commits)

- **Show saved text immediately** — `onSave` sets the body optimistically; `onEnd` no longer refetches the pre-commit HEAD (which raced and flashed stale content). SWR reconciles against the session-aware read.
- **Save during join latency** — the buffer is seeded with the committed body on Edit so `bodyChanged` is accurate before the join resolves (dropped the `coedit.active` gate); pre-join edits are preserved + flushed; `save()` awaits the in-flight join. Also documented that a rename-only save is a no-op checkpoint server-side (`version == checkpointed_version`), so no empty commit.
- **`pump()` self-poisoning (ops silently dropped)** — `pumpPromise.current = run` was assigned *after* invoking the async drain, but a drain with no pending change resolves synchronously and its inline `finally` cleared the handle first, stranding a resolved promise in `pumpPromise` and making every later pump a no-op. This dropped all ops after the first flush — most visibly on **re-Edit** (sessions stuck at `version 0`, edits never committed). Fixed by setting the handle before attaching completion and clearing it via `run.finally(() => { if (current === run) current = null })`.

## Test

- `bun run typecheck` clean.
- Manual + headless (CDP) cycle on the local stack: Edit → type → Save shows immediately; **re-Edit → type → Save** round-trips correctly (ops fire on every edit, both edits persist); rename-only save produces no empty commit; two tabs converge live.

## Not in this PR

- Backend draft endpoints (`/file/autosave*`, `/file/merge`, `git.py` draft helpers) are retired in the **PR3** follow-up.
- Remote carets / selection / typing (CodeMirror) come in **PR4+**; this is the textarea MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)