### PR TITLE
feat(coedit): session-aware wiki file read (serve the live buffer)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -59,6 +59,7 @@ from app.triggers import repo as triggers_repo
 from app.wiki import (
     acl,
     agent_activity,
+    coedit,
     diff as wiki_diff,
     drafts as wiki_drafts,
     filesystem,
@@ -214,6 +215,35 @@ def get_document_by_path(
         except wiki_git.UnknownSha as exc:
             raise HTTPException(status_code=404, detail="not found at ref") from exc
         return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref)
+    # Session-aware live read: when a co-edit session is open on this page, its
+    # Postgres buffer holds the freshest edits. The checkpoint that commits the
+    # buffer to git runs asynchronously, so HEAD lags — reading it would show
+    # stale content right after a save. Serve a quick, display-only 3-way merge
+    # of HEAD + the live buffer so a viewer sees both committed edits and
+    # in-session edits without waiting on the commit. Best-effort and
+    # non-authoritative (no LLM, nothing persisted): on a merge conflict, prefer
+    # the live buffer. This is a UI read; git stays the source of truth for
+    # committed pages.
+    sess = coedit.get_active_session(rel)
+    if sess is not None:
+        body = sess.buffer_text
+        # Fast path: if HEAD hasn't moved since the session opened (the common
+        # case — live-rebase folds inbound agent commits into the buffer and
+        # advances base_sha), the buffer already reflects everything, so skip
+        # the merge subprocess. Only when HEAD has advanced past the session's
+        # base do we quick-merge the committed change over the buffer for
+        # display; on conflict, prefer the buffer (the authoritative resolution
+        # happens at checkpoint).
+        if sess.base_sha is not None and sess.base_sha != head_sha:
+            base = wiki_git.read_file_opt(rel, ref=sess.base_sha) or ""
+            current = wiki_git.read_file_opt(rel) or ""
+            try:
+                merge = wiki_git.merge_content(base, current, sess.buffer_text)
+                if merge.clean:
+                    body = merge.merged
+            except RuntimeError:
+                pass
+        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha)
     abs_path = filesystem.absolute(rel)
     if not abs_path.is_file():
         raise HTTPException(status_code=404, detail="not found")

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -242,7 +242,12 @@ def get_document_by_path(
                 if merge.clean:
                     body = merge.merged
             except RuntimeError:
-                pass
+                log.warning(
+                    "coedit read: merge_content failed for %s (base_sha=%s); serving buffer verbatim",
+                    rel,
+                    sess.base_sha,
+                    exc_info=True,
+                )
         return GetDocumentResponse(path=rel, body=body, head_sha=head_sha)
     abs_path = filesystem.absolute(rel)
     if not abs_path.is_file():

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -239,3 +239,49 @@ def test_op_requires_write(client):
         json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "x"}]},
     )
     assert resp.status_code == 403
+
+
+def _apply_op(client, sid: int, base_version: int, changes: list[dict]) -> int:
+    resp = client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": base_version, "changes": changes},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["version"]
+
+
+def test_file_read_serves_live_buffer_during_session(client):
+    # GET /wiki/file is session-aware: while a session is open, it serves the
+    # live Postgres buffer, so an edit is visible immediately — no dependency on
+    # the async checkpoint commit (git HEAD is unchanged here).
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    sha = _seed_page("# Setup\n\nhello\n")
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    _apply_op(client, sid, 0, [{"from": 0, "to": len("# Setup\n\nhello\n"), "insert": "LIVE\n"}])
+
+    resp = client.get(f"/api/wiki/file?path={_PATH}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["body"] == "LIVE\n"  # buffer, not committed HEAD
+    assert body["head_sha"] == sha  # HEAD still the pre-session commit
+    # git working tree is untouched — nothing was committed.
+    assert git.read_file(_PATH) == "# Setup\n\nhello\n"
+
+
+def test_file_read_merges_agent_commit_over_live_buffer(client):
+    # Safety net: when an agent commits to git after the session opened (HEAD
+    # moves past base_sha), the read quick-merges the committed change over the
+    # buffer so a viewer sees both the in-session edit and the agent's edit.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    doc = "one\ntwo\nthree\nfour\nfive\n"
+    _seed_page(doc)
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    # Human edits the first line in the buffer...
+    _apply_op(client, sid, 0, [{"from": 0, "to": 3, "insert": "ONE"}])
+    # ...an agent commits a distant, non-overlapping change out of band.
+    git.commit_file(_PATH, "one\ntwo\nthree\nfour\nFIVE\n", message="agent", author="A <a@x.com>")
+
+    body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
+    assert body == "ONE\ntwo\nthree\nfour\nFIVE\n"  # both edits, no LLM, no commit


### PR DESCRIPTION
## What

Makes `GET /wiki/file` **session-aware**: when a co-edit session is open on a page, serve its live Postgres buffer instead of the git working tree.

The checkpoint that commits the buffer to git runs **asynchronously** (queued to the documents worker), so HEAD lags right after an edit/save. Reading HEAD shows stale content — the source of the "saved edit doesn't show up / shows up a few seconds later" bug. Serving the buffer makes in-session edits visible immediately, **with no dependency on the commit**.

## How

- **Fast path** — if HEAD hasn't moved since the session opened (`base_sha == head_sha`, the common case, since live-rebase folds inbound agent commits into the buffer and advances `base_sha`), return the buffer directly. No subprocess on the hot read path (viewers poll ~1.5s).
- **Safety-net merge** — only when HEAD has advanced past the session's base do we quick-merge the committed change over the buffer with `git merge-file` (no LLM). On conflict, prefer the buffer.
- **Best-effort, non-authoritative** — nothing is persisted on the read path; the real 3-way + AI resolution still happens at checkpoint (Layer 2). git stays the source of truth for committed pages.

Only the live (no-`ref`) read is affected; historical `?ref=` reads are unchanged.

## Why separate / ordering

This is the **read-path half** of the co-editing "Edit = session" work. The FileViewer cutover (**#330**) depends on it: without this, a save optimistically shows the buffer but the next `/wiki/file` poll reads stale HEAD and clobbers it. **Land this before #330.**

## Test

- `tests/test_coedit_api.py::test_file_read_serves_live_buffer_during_session` — edit in a session (no checkpoint) → read returns the buffer, HEAD unchanged, working tree untouched.
- `tests/test_coedit_api.py::test_file_read_merges_agent_commit_over_live_buffer` — agent commits a distant change mid-session → read quick-merges both edits (no commit, no LLM).
- Whole-project ruff + basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)