### PR TITLE
feat(coedit): live co-editing signals in the textarea editor

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -66,6 +66,7 @@ import {
 import { rehypeSourcePos } from "@/lib/rehypeSourcePos";
 import { remarkBareSpaceLinks } from "@/lib/remarkBareSpaceLinks";
 import { useAuth, useRequireAuth } from "@/lib/auth";
+import type { CoeditParticipant } from "@/lib/coedit";
 import { useCoeditSession } from "@/lib/useCoeditSession";
 import {
   useHeaderActionsHost,
@@ -2116,6 +2117,11 @@ function FileViewer({ path }: { path: string }) {
                       onChange={setFilenameDraft}
                       disabled={saving}
                     />
+                    <CoeditPresenceBar
+                      participants={coedit.participants}
+                      typing={coedit.typing}
+                      selfUserId={user?.id ?? null}
+                    />
                     {(() => {
                       // Cards visible while the body is still "empty enough"
                       // to discard without losing user work: truly blank, or
@@ -2143,7 +2149,23 @@ function FileViewer({ path }: { path: string }) {
                     })()}
                     <textarea
                       value={coedit.buffer}
-                      onChange={(e) => coedit.onChange(e.target.value)}
+                      onChange={(e) => {
+                        coedit.onChange(e.target.value);
+                        // An edit → I'm typing; report caret + typing so peers
+                        // see a live "typing…" signal (carets await CodeMirror).
+                        coedit.reportSelection(
+                          e.target.selectionStart,
+                          e.target.selectionEnd,
+                          true,
+                        );
+                      }}
+                      onSelect={(e) =>
+                        coedit.reportSelection(
+                          e.currentTarget.selectionStart,
+                          e.currentTarget.selectionEnd,
+                          false,
+                        )
+                      }
                       spellCheck={false}
                       placeholder="Start typing, or pick a template above…"
                       className="box-border min-h-0 w-full flex-1 resize-none rounded-(--border-radius-08) border border-(--border-01) p-4 font-mono text-sm leading-[1.6] outline-none"
@@ -2605,6 +2627,41 @@ function DestinationSelect({
         </div>
       </Popover.Content>
     </Popover>
+  );
+}
+
+// Co-editing presence while editing: who else is in the session and who's
+// typing right now. Remote carets aren't drawn in a plain textarea (that waits
+// for CodeMirror) — but edits already merge into the shared buffer live, so
+// this makes the collaboration visible. Renders nothing when you're alone.
+function CoeditPresenceBar({
+  participants,
+  typing,
+  selfUserId,
+}: {
+  participants: CoeditParticipant[];
+  typing: string[];
+  selfUserId: string | null;
+}) {
+  const others = participants.filter((p) => p.user_id !== selfUserId);
+  if (others.length === 0) return null;
+  const typingSet = new Set(typing);
+  return (
+    <div className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-(--text-03)">
+      <span
+        className="inline-block h-[7px] w-[7px] rounded-full bg-(--status-success-05)"
+        aria-hidden
+      />
+      {others.map((p) => (
+        <span key={p.user_id} className="inline-flex items-center gap-1">
+          <span className="font-medium text-(--text-04)">{p.user_display}</span>
+          {typingSet.has(p.user_id) && (
+            <span className="text-(--text-03) italic">typing…</span>
+          )}
+        </span>
+      ))}
+      <span>also editing</span>
+    </div>
   );
 }
 

--- a/frontend/src/lib/useCoeditSession.ts
+++ b/frontend/src/lib/useCoeditSession.ts
@@ -23,17 +23,29 @@ import {
   getSession,
   joinSession,
   leaveSession,
+  sendCursor,
   sendOp,
   streamSession,
 } from "./coedit";
 
 const FLUSH_DELAY_MS = 150;
+// Pace outbound cursor/typing pings; drop intermediates (design: ~75ms).
+const CURSOR_THROTTLE_MS = 80;
+// Send a final "stopped typing" ping this long after the last keystroke.
+const TYPING_IDLE_MS = 1500;
+// Clear a peer's "typing" badge if their pings go silent (crash / lost tab).
+const TYPING_EXPIRY_MS = 4000;
 
 export interface UseCoeditSession {
   active: boolean;
   buffer: string;
   participants: CoeditParticipant[];
+  /** user_ids of peers currently typing (excludes self). */
+  typing: string[];
   onChange: (next: string) => void;
+  /** Report the local caret/selection so peers see presence; `typing` marks an
+   * active edit (vs. a plain caret move). Throttled + coalesced internally. */
+  reportSelection: (anchor: number, head: number, typing: boolean) => void;
   save: () => Promise<void>;
   discard: () => Promise<void>;
 }
@@ -49,6 +61,7 @@ export function useCoeditSession(opts: {
 
   const [buffer, setBufferState] = useState("");
   const [participants, setParticipants] = useState<CoeditParticipant[]>([]);
+  const [typing, setTyping] = useState<string[]>([]);
   const [active, setActive] = useState(false);
 
   // Live state kept in refs so the stream callback and flush loop read the
@@ -60,6 +73,20 @@ export function useCoeditSession(opts: {
   const pumpPromise = useRef<Promise<void> | null>(null); // in-flight op drain
   const flushTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abort = useRef<AbortController | null>(null);
+  // Outbound cursor/typing: throttle handle, the latest un-sent ping, the last
+  // caret (for the trailing "stopped typing"), and the idle timer.
+  const cursorThrottle = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingCursor = useRef<{
+    anchor: number;
+    head: number;
+    typing: boolean;
+  } | null>(null);
+  const lastCursor = useRef<{ anchor: number; head: number } | null>(null);
+  const typingIdle = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Inbound: per-peer expiry timers so a silent "typing" peer clears.
+  const typingTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
+    new Map(),
+  );
   const joinPromise = useRef<Promise<void> | null>(null); // in-flight join
 
   const setBuffer = useCallback((next: string) => {
@@ -131,10 +158,70 @@ export function useCoeditSession(opts: {
     [setBuffer, scheduleFlush],
   );
 
+  const reportSelection = useCallback(
+    (anchor: number, head: number, isTyping: boolean) => {
+      if (sessionId.current === null) return;
+      lastCursor.current = { anchor, head };
+      pendingCursor.current = { anchor, head, typing: isTyping };
+      const send = () => {
+        const c = pendingCursor.current;
+        pendingCursor.current = null;
+        if (c && sessionId.current !== null) {
+          void sendCursor(sessionId.current, c.anchor, c.head, c.typing).catch(
+            () => {},
+          );
+        }
+      };
+      if (!cursorThrottle.current) {
+        send();
+        cursorThrottle.current = setTimeout(() => {
+          cursorThrottle.current = null;
+          if (pendingCursor.current) send();
+        }, CURSOR_THROTTLE_MS);
+      }
+      // Trailing "stopped typing" so a peer's badge clears when I pause.
+      if (typingIdle.current) clearTimeout(typingIdle.current);
+      if (isTyping) {
+        typingIdle.current = setTimeout(() => {
+          typingIdle.current = null;
+          const lc = lastCursor.current;
+          if (sessionId.current !== null && lc) {
+            void sendCursor(sessionId.current, lc.anchor, lc.head, false).catch(
+              () => {},
+            );
+          }
+        }, TYPING_IDLE_MS);
+      }
+    },
+    [],
+  );
+
   const onFrame = useCallback(
     (frame: CoeditFrame) => {
       if (frame.type === "presence") {
         setParticipants(frame.participants);
+        return;
+      }
+      if (frame.type === "cursor") {
+        // Presence signal only (no remote caret rendering in a textarea): track
+        // who's typing. Skip our own echo.
+        if (myUserId !== null && frame.user_id === myUserId) return;
+        const uid = frame.user_id;
+        const existing = typingTimers.current.get(uid);
+        if (existing) clearTimeout(existing);
+        typingTimers.current.delete(uid);
+        if (frame.typing) {
+          setTyping((prev) => (prev.includes(uid) ? prev : [...prev, uid]));
+          typingTimers.current.set(
+            uid,
+            setTimeout(() => {
+              typingTimers.current.delete(uid);
+              setTyping((prev) => prev.filter((u) => u !== uid));
+            }, TYPING_EXPIRY_MS),
+          );
+        } else {
+          setTyping((prev) => prev.filter((u) => u !== uid));
+        }
         return;
       }
       if (frame.type === "resync") {
@@ -160,7 +247,6 @@ export function useCoeditSession(opts: {
         serverBuffer.current = next;
         setBuffer(next);
       }
-      // cursor frames are ignored until the CodeMirror editor renders carets
     },
     [myUserId, resync, setBuffer],
   );
@@ -170,6 +256,18 @@ export function useCoeditSession(opts: {
       clearTimeout(flushTimer.current);
       flushTimer.current = null;
     }
+    if (cursorThrottle.current) {
+      clearTimeout(cursorThrottle.current);
+      cursorThrottle.current = null;
+    }
+    if (typingIdle.current) {
+      clearTimeout(typingIdle.current);
+      typingIdle.current = null;
+    }
+    for (const t of typingTimers.current.values()) clearTimeout(t);
+    typingTimers.current.clear();
+    pendingCursor.current = null;
+    setTyping([]);
     abort.current?.abort();
     abort.current = null;
     const sid = sessionId.current;
@@ -264,5 +362,14 @@ export function useCoeditSession(opts: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, path]);
 
-  return { active, buffer, participants, onChange, save, discard };
+  return {
+    active,
+    buffer,
+    participants,
+    typing,
+    onChange,
+    reportSelection,
+    save,
+    discard,
+  };
 }

--- a/frontend/src/lib/useCoeditSession.ts
+++ b/frontend/src/lib/useCoeditSession.ts
@@ -43,9 +43,11 @@ export interface UseCoeditSession {
   /** user_ids of peers currently typing (excludes self). */
   typing: string[];
   onChange: (next: string) => void;
-  /** Report the local caret/selection so peers see presence; `typing` marks an
-   * active edit (vs. a plain caret move). Throttled + coalesced internally. */
-  reportSelection: (anchor: number, head: number, typing: boolean) => void;
+  /** Report the local caret/selection so peers see presence. `isEdit=true`
+   * (from an edit) marks "typing…" and arms its auto-clear; `isEdit=false` (a
+   * caret move) reports position without changing the typing state. Throttled
+   * + coalesced internally. */
+  reportSelection: (anchor: number, head: number, isEdit: boolean) => void;
   save: () => Promise<void>;
   discard: () => Promise<void>;
 }
@@ -159,10 +161,16 @@ export function useCoeditSession(opts: {
   );
 
   const reportSelection = useCallback(
-    (anchor: number, head: number, isTyping: boolean) => {
+    (anchor: number, head: number, isEdit: boolean) => {
       if (sessionId.current === null) return;
       lastCursor.current = { anchor, head };
-      pendingCursor.current = { anchor, head, typing: isTyping };
+      // A caret move (isEdit=false) must not clobber the "typing…" a recent
+      // edit set — browsers fire `select` right after every `input`, so
+      // onSelect lands one keystroke behind onChange. Derive typing from
+      // whether the idle timer is still pending (i.e. we edited recently);
+      // only an actual edit re-marks it and (re)arms the trailing clear.
+      const typing = isEdit || typingIdle.current !== null;
+      pendingCursor.current = { anchor, head, typing };
       const send = () => {
         const c = pendingCursor.current;
         pendingCursor.current = null;
@@ -179,9 +187,10 @@ export function useCoeditSession(opts: {
           if (pendingCursor.current) send();
         }, CURSOR_THROTTLE_MS);
       }
-      // Trailing "stopped typing" so a peer's badge clears when I pause.
-      if (typingIdle.current) clearTimeout(typingIdle.current);
-      if (isTyping) {
+      // Trailing "stopped typing" so a peer's badge clears when I pause. Only an
+      // edit (re)arms it; a caret move leaves the existing timer running.
+      if (isEdit) {
+        if (typingIdle.current) clearTimeout(typingIdle.current);
         typingIdle.current = setTimeout(() => {
           typingIdle.current = null;
           const lc = lastCursor.current;


### PR DESCRIPTION
## What

A middle step toward the rich editor: while editing, surface **who else is co-editing and who's typing**, without waiting on CodeMirror. Remote carets can't be drawn inside a plain `<textarea>` (that's the CodeMirror piece), but the rest of the "Google-Docs feel" signals are here — and remote edits already merge live via the shared buffer.

- **Presence bar** — "Ada, Bo also editing" from the session roster (`coedit.participants`), shown while editing; renders nothing when you're alone.
- **Live "typing…"** per peer, from `cursor` frames. The textarea reports its caret/selection on edit (typing) and on selection change (idle) through a new hook method `reportSelection`, throttled + coalesced (~80ms) with a trailing "stopped typing" ping. Peer badges expire (~4s) if pings go silent (crash/lost tab).
- **Remote edits** already splice into the shared buffer (inbound `op` frames), so co-editors see each other's text with no new work here.

## Hook (`useCoeditSession`)

- New `typing: string[]` (peer user_ids currently typing) and `reportSelection(anchor, head, typing)`.
- Sends own cursor/typing via `POST /coedit/cursor` (throttled); tracks inbound peer typing with per-peer expiry timers; all cleared in `stop()`.

## Not in this PR

Remote **caret/selection rendering** and follow-user — those need CodeMirror (the offsets are already on the wire via `cursor` frames, so it's render-only work later). Client-side pending-op rebase on resync also lands with CodeMirror.

## Test

- `bun run typecheck` clean.
- Two-participant headless run: B joining shows "Peer Bee also editing"; B typing → "Peer Bee typing… also editing"; B stops → badge clears; A typing broadcasts `cursor` + `op`. All verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)