### PR TITLE
fix(coedit): theme-aware editor caret (dark-mode visibility)

### DIFF
--- a/frontend/src/components/coedit/CoeditEditor.tsx
+++ b/frontend/src/components/coedit/CoeditEditor.tsx
@@ -146,8 +146,8 @@ const baseTheme = EditorView.theme({
   },
   ".cm-content": { padding: "1rem", caretColor: "var(--text-05)" },
   ".cm-line": { padding: "0" },
-  // Own caret + drawn cursor follow the theme (the default is black, invisible
-  // in dark mode). Native selection also uses a theme token for contrast.
+  // Own caret + drawn cursor follow the theme token; native selection uses a
+  // theme tint for contrast.
   ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--text-05)" },
   "&.cm-focused .cm-selectionBackground, ::selection": {
     backgroundColor: "var(--background-tint-03)",

--- a/frontend/src/components/coedit/CoeditEditor.tsx
+++ b/frontend/src/components/coedit/CoeditEditor.tsx
@@ -144,8 +144,14 @@ const baseTheme = EditorView.theme({
       "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
     lineHeight: "1.6",
   },
-  ".cm-content": { padding: "1rem" },
+  ".cm-content": { padding: "1rem", caretColor: "var(--text-05)" },
   ".cm-line": { padding: "0" },
+  // Own caret + drawn cursor follow the theme (the default is black, invisible
+  // in dark mode). Native selection also uses a theme token for contrast.
+  ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--text-05)" },
+  "&.cm-focused .cm-selectionBackground, ::selection": {
+    backgroundColor: "var(--background-tint-03)",
+  },
   ".cm-coedit-caret": {
     display: "inline-block",
     width: "0",


### PR DESCRIPTION
## What

The co-edit editor's own caret was **black and invisible in dark mode**. Since the editor doesn't use `drawSelection`, CodeMirror renders the native browser caret, which defaults to black rather than following the theme.

Fix: set `caret-color` + the `.cm-cursor` border to `var(--text-05)` so the caret follows light/dark, and give the native text selection a themed tint (`var(--background-tint-03)`) for contrast.

## Context

This fix was written during #334 but merged **after** that PR closed, so it didn't make it in — bringing it on its own. Remote peer carets were already theme-safe (per-user identity colors).

## Test

- `bun run typecheck` clean.
- Verified under emulated `prefers-color-scheme: dark`: caret-color resolves to the light text color (`rgba(255,255,255,0.95)`) instead of black.
<img width="308" height="266" alt="Screenshot 2026-07-02 at 1 00 34 PM" src="https://github.com/user-attachments/assets/c2a4919e-26b1-420f-9446-5f99fdd8bb94" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)