### PR TITLE
feat(email): verification schema for email destinations

### DIFF
--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -49,6 +49,7 @@ def _config_view(row: dict[str, Any]) -> DestinationConfigView:
         name=row["name"],
         config=cast("dict[str, Any]", row.get("config") or {}),
         has_secret=bool(row.get("has_secret")),
+        verified_at=row.get("verified_at"),
         created_at=row.get("created_at"),
     )
 

--- a/backend/app/db/migrations/versions/0047_email_verification.py
+++ b/backend/app/db/migrations/versions/0047_email_verification.py
@@ -1,0 +1,75 @@
+"""email destination verification: verified_at, tokens, catalog row
+
+Adds ``verified_at`` to ``destination_configs`` and the
+``email_verification_tokens`` table, and seeds the ``email`` row in the
+``trigger_destinations`` catalog. Schema changes are guarded on the live
+inspector because ``0001_initial`` builds fresh databases from the current
+model registry; the catalog seed is idempotent and always runs.
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2026-07-02 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0047"
+down_revision: str | None = "0046"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    cols = {c["name"] for c in inspector.get_columns("destination_configs")}
+    if "verified_at" not in cols:
+        op.add_column("destination_configs", sa.Column("verified_at", sa.Text, nullable=True))
+
+    if "email_verification_tokens" not in inspector.get_table_names():
+        op.create_table(
+            "email_verification_tokens",
+            sa.Column("token", sa.Text, primary_key=True),
+            sa.Column(
+                "destination_config_id",
+                sa.Text,
+                sa.ForeignKey("destination_configs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("expires_at", sa.Text, nullable=False),
+            sa.Column("consumed_at", sa.Text, nullable=True),
+            sa.Column(
+                "created_at",
+                sa.Text,
+                nullable=False,
+                server_default=sa.text(
+                    "to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"
+                ),
+            ),
+        )
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO trigger_destinations (id, name, description) "
+            "VALUES (:id, :name, :description) "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {
+            "id": "email",
+            "name": "Email",
+            "description": "Sent to a verified email address.",
+        },
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("email_verification_tokens")
+    op.drop_column("destination_configs", "verified_at")
+    op.get_bind().execute(sa.text("DELETE FROM trigger_destinations WHERE id = 'email'"))

--- a/backend/app/db/migrations/versions/0048_email_verification.py
+++ b/backend/app/db/migrations/versions/0048_email_verification.py
@@ -6,8 +6,8 @@ Adds ``verified_at`` to ``destination_configs`` and the
 inspector because ``0001_initial`` builds fresh databases from the current
 model registry; the catalog seed is idempotent and always runs.
 
-Revision ID: 0047
-Revises: 0046
+Revision ID: 0048
+Revises: 0047
 Create Date: 2026-07-02 00:00:00.000000+00:00
 """
 
@@ -19,8 +19,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision: str = "0047"
-down_revision: str | None = "0046"
+revision: str = "0048"
+down_revision: str | None = "0047"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -510,9 +510,28 @@ class DestinationConfig(Base):
     )
     # Optional secret — AES-GCM encrypted at rest (bytea). See app/db/crypto.py.
     secret: Mapped[str | None] = mapped_column(EncryptedString())
+    # Set when the destination's address proved reachable (email verify flow).
+    # Types without a verification step leave it null.
+    verified_at: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
 
     __table_args__ = (Index("idx_destination_configs_owner", "owner_user_id"),)
+
+
+class EmailVerificationToken(Base):
+    """Single-use token mailed to an email destination's address. Mirrors
+    ``SlackConnectState``: minted once per config (re-mint clears prior),
+    consumed exactly once, TTL-bounded."""
+
+    __tablename__ = "email_verification_tokens"
+
+    token: Mapped[str] = mapped_column(Text, primary_key=True)
+    destination_config_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("destination_configs.id", ondelete="CASCADE"), nullable=False
+    )
+    expires_at: Mapped[str] = mapped_column(Text, nullable=False)
+    consumed_at: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/models/destination_config.py
+++ b/backend/app/models/destination_config.py
@@ -31,6 +31,7 @@ class DestinationConfigView(BaseModel):
     name: str
     config: dict[str, Any] = Field(default_factory=dict)
     has_secret: bool
+    verified_at: str | None = None
     created_at: str | None
 
 

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -110,6 +110,7 @@ def create(
         "name": name,
         "config": config or {},
         "has_secret": secret is not None,
+        "verified_at": None,
         "created_at": created_at,
     }
 

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -142,16 +142,6 @@ def owned_by(config_id: str, user_id: str) -> bool:
         return d is not None and d.owner_user_id == user_id
 
 
-def mark_verified(config_id: str, *, owner_user_id: str) -> bool:
-    """Stamp ``verified_at`` on the owner's config. False if not found/owned."""
-    with session() as s:
-        row = s.get(DestinationConfig, config_id)
-        if row is None or row.owner_user_id != owner_user_id:
-            return False
-        row.verified_at = _now_iso()
-    return True
-
-
 def get_secret(config_id: str, *, owner_user_id: str) -> str | None:
     """Resolve a config id to its decrypted secret, enforcing ownership.
 

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -42,6 +42,7 @@ def _to_dict(d: DestinationConfig) -> dict[str, Any]:
         "name": d.name,
         "config": d.config_json,
         "has_secret": d.secret is not None,
+        "verified_at": d.verified_at,
         "created_at": d.created_at,
     }
 
@@ -82,6 +83,10 @@ def create(
                 "a slack destination needs exactly one of: a webhook secret, "
                 "a channel_id, or dm: true"
             )
+    if type == destinations.EMAIL_ID:
+        address = ((config or {}).get("address") or "")
+        if not isinstance(address, str) or "@" not in address.strip():
+            raise ValueError("an email destination needs config.address")
 
     config_id = "dst_" + uuid.uuid4().hex[:12]
     created_at = _now_iso()
@@ -135,6 +140,16 @@ def owned_by(config_id: str, user_id: str) -> bool:
     with session() as s:
         d = s.get(DestinationConfig, config_id)
         return d is not None and d.owner_user_id == user_id
+
+
+def mark_verified(config_id: str, *, owner_user_id: str) -> bool:
+    """Stamp ``verified_at`` on the owner's config. False if not found/owned."""
+    with session() as s:
+        row = s.get(DestinationConfig, config_id)
+        if row is None or row.owner_user_id != owner_user_id:
+            return False
+        row.verified_at = _now_iso()
+    return True
 
 
 def get_secret(config_id: str, *, owner_user_id: str) -> str | None:

--- a/backend/app/triggers/destinations.py
+++ b/backend/app/triggers/destinations.py
@@ -31,6 +31,10 @@ EVENT_LOG_ID = "event_log"
 # "don't spread the literal" rationale as ``EVENT_LOG_ID``.
 SLACK_ID = "slack"
 
+# Slug of the email destination (seeded by migration 0047). Fires deliver to
+# the config's verified address; unverified configs are recorded-only.
+EMAIL_ID = "email"
+
 
 def _to_dict(d: TriggerDestination) -> dict[str, Any]:
     return {

--- a/backend/app/triggers/destinations.py
+++ b/backend/app/triggers/destinations.py
@@ -31,7 +31,7 @@ EVENT_LOG_ID = "event_log"
 # "don't spread the literal" rationale as ``EVENT_LOG_ID``.
 SLACK_ID = "slack"
 
-# Slug of the email destination (seeded by migration 0047). Fires deliver to
+# Slug of the email destination (seeded by migration 0048). Fires deliver to
 # the config's verified address; unverified configs are recorded-only.
 EMAIL_ID = "email"
 

--- a/backend/app/triggers/email_verification.py
+++ b/backend/app/triggers/email_verification.py
@@ -1,0 +1,75 @@
+"""Single-use verification tokens for email destination configs.
+
+Mirrors the connect-state pattern: minted once per config (re-mint clears
+prior tokens), consumed exactly once, TTL-bounded. Consuming a valid token
+stamps the config's ``verified_at`` — unverified email destinations are
+recorded-only at dispatch.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, select
+
+from app.db.models import EmailVerificationToken
+from app.db.session import session
+from app.triggers import destination_configs as dest_configs
+
+log = logging.getLogger(__name__)
+
+_TOKEN_PREFIX = "evt_"
+# Email links get opened from an inbox, not a same-minute redirect — a day.
+_TOKEN_TTL_SECONDS = 24 * 60 * 60
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def mint_token(destination_config_id: str) -> str:
+    """Create a verification token for the config, clearing any prior one so
+    a single token is outstanding per destination."""
+    token = _TOKEN_PREFIX + secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc)
+    with session() as s:
+        s.execute(
+            delete(EmailVerificationToken).where(
+                EmailVerificationToken.destination_config_id == destination_config_id
+            )
+        )
+        s.add(
+            EmailVerificationToken(
+                token=token,
+                destination_config_id=destination_config_id,
+                expires_at=_iso(now + timedelta(seconds=_TOKEN_TTL_SECONDS)),
+            )
+        )
+    log.info("email verification token minted config=%s", destination_config_id)
+    return token
+
+
+def verify(token: str, *, owner_user_id: str) -> str | None:
+    """Atomically claim a token and stamp its config verified. Returns the
+    config id, or None on unknown/expired/replayed/foreign tokens."""
+    if not token.startswith(_TOKEN_PREFIX):
+        return None
+    now_iso = _iso(datetime.now(timezone.utc))
+    with session() as s:
+        row = s.scalar(
+            select(EmailVerificationToken)
+            .where(EmailVerificationToken.token == token)
+            .with_for_update()
+        )
+        if row is None or row.consumed_at is not None or row.expires_at <= now_iso:
+            return None
+        row.consumed_at = now_iso
+        config_id = row.destination_config_id
+    if not dest_configs.mark_verified(config_id, owner_user_id=owner_user_id):
+        log.warning(
+            "email verification token consumed but config %s not owned by %s",
+            config_id, owner_user_id,
+        )
+        return None
+    return config_id

--- a/backend/app/triggers/email_verification.py
+++ b/backend/app/triggers/email_verification.py
@@ -13,9 +13,8 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, select
 
-from app.db.models import EmailVerificationToken
+from app.db.models import DestinationConfig, EmailVerificationToken
 from app.db.session import session
-from app.triggers import destination_configs as dest_configs
 
 log = logging.getLogger(__name__)
 
@@ -51,8 +50,10 @@ def mint_token(destination_config_id: str) -> str:
 
 
 def verify(token: str, *, owner_user_id: str) -> str | None:
-    """Atomically claim a token and stamp its config verified. Returns the
-    config id, or None on unknown/expired/replayed/foreign tokens."""
+    """Claim a token and stamp its config verified in one transaction.
+    Returns the config id, or None on unknown/expired/replayed tokens. A
+    foreign-owner attempt leaves the token unconsumed so the real owner can
+    still verify."""
     if not token.startswith(_TOKEN_PREFIX):
         return None
     now_iso = _iso(datetime.now(timezone.utc))
@@ -64,12 +65,13 @@ def verify(token: str, *, owner_user_id: str) -> str | None:
         )
         if row is None or row.consumed_at is not None or row.expires_at <= now_iso:
             return None
+        config = s.get(DestinationConfig, row.destination_config_id)
+        if config is None or config.owner_user_id != owner_user_id:
+            log.warning(
+                "email verification rejected: config %s not owned by %s",
+                row.destination_config_id, owner_user_id,
+            )
+            return None
         row.consumed_at = now_iso
-        config_id = row.destination_config_id
-    if not dest_configs.mark_verified(config_id, owner_user_id=owner_user_id):
-        log.warning(
-            "email verification token consumed but config %s not owned by %s",
-            config_id, owner_user_id,
-        )
-        return None
-    return config_id
+        config.verified_at = now_iso
+        return config.id

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -27,6 +27,14 @@ def _email_config(owner: str = "usr_1", address: str = "nik@example.com") -> str
     )["id"]
 
 
+def test_create_returns_unverified(tmp_db):
+    seed_user("usr_1")
+    row = dest_configs.create(
+        "usr_1", type="email", name="Me", config={"address": "nik@example.com"}
+    )
+    assert row["verified_at"] is None
+
+
 def test_email_config_requires_address(tmp_db):
     seed_user("usr_1")
     with pytest.raises(ValueError, match="address"):

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -1,0 +1,79 @@
+"""Email destination verification: configs require an address, tokens are
+single-use and TTL-bounded, and consuming a valid token stamps verified_at."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import update
+
+from app.db.models import EmailVerificationToken
+from app.db.session import session
+from app.triggers import destination_configs as dest_configs
+from app.triggers import email_verification
+
+from tests._seed import seed_user
+
+
+def _get(cfg_id: str) -> dict:
+    row = dest_configs.get(cfg_id, "usr_1")
+    assert row is not None
+    return row
+
+
+def _email_config(owner: str = "usr_1", address: str = "nik@example.com") -> str:
+    return dest_configs.create(
+        owner, type="email", name="Me", config={"address": address}
+    )["id"]
+
+
+def test_email_config_requires_address(tmp_db):
+    seed_user("usr_1")
+    with pytest.raises(ValueError, match="address"):
+        dest_configs.create("usr_1", type="email", name="No address")
+    with pytest.raises(ValueError, match="address"):
+        dest_configs.create("usr_1", type="email", name="Bad", config={"address": "not-an-email"})
+
+
+def test_verify_stamps_config_and_is_single_use(tmp_db):
+    seed_user("usr_1")
+    cfg_id = _email_config()
+    assert _get(cfg_id)["verified_at"] is None
+
+    token = email_verification.mint_token(cfg_id)
+    assert email_verification.verify(token, owner_user_id="usr_1") == cfg_id
+    assert _get(cfg_id)["verified_at"] is not None
+
+    # Replay is rejected.
+    assert email_verification.verify(token, owner_user_id="usr_1") is None
+
+
+def test_verify_rejects_foreign_owner_and_garbage(tmp_db):
+    seed_user("usr_1")
+    seed_user("usr_2", email="two@x.com")
+    token = email_verification.mint_token(_email_config())
+    assert email_verification.verify(token, owner_user_id="usr_2") is None
+    assert email_verification.verify("not-a-token", owner_user_id="usr_1") is None
+
+
+def test_verify_rejects_expired_token(tmp_db):
+    seed_user("usr_1")
+    cfg_id = _email_config()
+    token = email_verification.mint_token(cfg_id)
+    past = (datetime.now(timezone.utc) - timedelta(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        s.execute(
+            update(EmailVerificationToken)
+            .where(EmailVerificationToken.token == token)
+            .values(expires_at=past)
+        )
+    assert email_verification.verify(token, owner_user_id="usr_1") is None
+    assert _get(cfg_id)["verified_at"] is None
+
+
+def test_remint_invalidates_prior_token(tmp_db):
+    seed_user("usr_1")
+    cfg_id = _email_config()
+    first = email_verification.mint_token(cfg_id)
+    email_verification.mint_token(cfg_id)
+    assert email_verification.verify(first, owner_user_id="usr_1") is None

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -51,9 +51,13 @@ def test_verify_stamps_config_and_is_single_use(tmp_db):
 def test_verify_rejects_foreign_owner_and_garbage(tmp_db):
     seed_user("usr_1")
     seed_user("usr_2", email="two@x.com")
-    token = email_verification.mint_token(_email_config())
+    cfg_id = _email_config()
+    token = email_verification.mint_token(cfg_id)
     assert email_verification.verify(token, owner_user_id="usr_2") is None
     assert email_verification.verify("not-a-token", owner_user_id="usr_1") is None
+    # A foreign attempt must not burn the token: the real owner still verifies.
+    assert email_verification.verify(token, owner_user_id="usr_1") == cfg_id
+    assert _get(cfg_id)["verified_at"] is not None
 
 
 def test_verify_rejects_expired_token(tmp_db):


### PR DESCRIPTION
## Description

Schema for the email destination track. No send service or endpoints yet.

- `verified_at` on `destination_configs`: stamped when the address proves reachable; unverified email destinations will be recorded-only at dispatch.
- `email_verification_tokens`: single-use, 24h TTL, one outstanding per config (re-mint clears prior). `verify()` claims the token, checks ownership, and stamps the config in one transaction; a foreign-owner attempt leaves the token unconsumed.
- Seeds the `email` catalog row; creating an email config requires `config.address`.

Migration is `0048` on top of #327's `0047`.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check