### PR TITLE
feat(email): app-wide SMTP send service with /admin/email and a test send

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import io
 import logging
+import smtplib
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
@@ -658,9 +659,21 @@ def post_email_smtp_test(
         )
     except EmailNotConfiguredError as e:
         return EmailTestResponse(ok=False, detail=str(e))
+    except smtplib.SMTPAuthenticationError:
+        log.warning("admin: test email to %s failed: SMTP auth rejected", to)
+        return EmailTestResponse(
+            ok=False,
+            detail="send failed: SMTP authentication rejected (check the username and app password)",
+        )
+    except (TimeoutError, OSError, smtplib.SMTPConnectError):
+        log.warning("admin: test email to %s failed to connect", to, exc_info=True)
+        return EmailTestResponse(
+            ok=False, detail="send failed: could not connect to the SMTP host (check host and port)"
+        )
     except Exception as e:
-        log.warning("admin: test email to %s failed: %s", to, e)
-        return EmailTestResponse(ok=False, detail=f"send failed: {e}")
+        # Server-side logs keep the detail; the client gets only the class.
+        log.warning("admin: test email to %s failed", to, exc_info=True)
+        return EmailTestResponse(ok=False, detail=f"send failed: {type(e).__name__} (see server logs)")
     return EmailTestResponse(ok=True, detail=f"sent to {to}")
 
 

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import csv
 import io
 import logging
-import smtplib
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
@@ -49,7 +48,7 @@ from app.models.admin import (
 from app.onyx.client import validate_onyx_base_url
 from app.email import service as email_service
 from app.email import settings as email_settings
-from app.email.service import EmailNotConfiguredError
+from app.email.service import EmailSendError
 from app.email.settings import EmailSmtpSettings as EmailSmtpSettingsModel
 from app.slack import app_settings as slack_app_settings
 from app.slack.app_settings import SlackAppSettings as SlackAppSettingsModel
@@ -657,23 +656,8 @@ def post_email_smtp_test(
             text="This is a test message from your Agent Wiki SMTP configuration. "
             "If you are reading it, outbound email works.",
         )
-    except EmailNotConfiguredError as e:
-        return EmailTestResponse(ok=False, detail=str(e))
-    except smtplib.SMTPAuthenticationError:
-        log.warning("admin: test email to %s failed: SMTP auth rejected", to)
-        return EmailTestResponse(
-            ok=False,
-            detail="send failed: SMTP authentication rejected (check the username and app password)",
-        )
-    except (TimeoutError, OSError, smtplib.SMTPConnectError):
-        log.warning("admin: test email to %s failed to connect", to, exc_info=True)
-        return EmailTestResponse(
-            ok=False, detail="send failed: could not connect to the SMTP host (check host and port)"
-        )
-    except Exception as e:
-        # Server-side logs keep the detail; the client gets only the class.
-        log.warning("admin: test email to %s failed", to, exc_info=True)
-        return EmailTestResponse(ok=False, detail=f"send failed: {type(e).__name__} (see server logs)")
+    except EmailSendError as e:
+        return EmailTestResponse(ok=False, detail=f"send failed: {e}")
     return EmailTestResponse(ok=True, detail=f"sent to {to}")
 
 

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -38,10 +38,18 @@ from app.models.admin import (
     UserCounts,
     WebConfigRequest,
     WebView,
+    EmailSmtpConfigRequest,
+    EmailSmtpView,
+    EmailTestRequest,
+    EmailTestResponse,
     SlackAppConfigRequest,
     SlackAppView,
 )
 from app.onyx.client import validate_onyx_base_url
+from app.email import service as email_service
+from app.email import settings as email_settings
+from app.email.service import EmailNotConfiguredError
+from app.email.settings import EmailSmtpSettings as EmailSmtpSettingsModel
 from app.slack import app_settings as slack_app_settings
 from app.slack.app_settings import SlackAppSettings as SlackAppSettingsModel
 from app.tracing import settings as braintrust_settings
@@ -583,6 +591,77 @@ def put_slack_app(
         actor.id, bool(client_id), bool(client_secret),
     )
     return _slack_app_view(slack_app_settings.get())
+
+
+def _email_smtp_view(s: EmailSmtpSettingsModel) -> EmailSmtpView:
+    password = s.password.get_secret_value()
+    return EmailSmtpView(
+        host=s.host,
+        port=s.port,
+        username=s.username,
+        password_set=bool(password),
+        password_hint=_redact(password),
+        from_address=s.from_address,
+    )
+
+
+@router.get("/email-smtp", response_model=EmailSmtpView)
+def get_email_smtp(_actor: User = Depends(require_admin)) -> EmailSmtpView:
+    return _email_smtp_view(email_settings.get())
+
+
+@router.put("/email-smtp", response_model=EmailSmtpView)
+def put_email_smtp(
+    req: EmailSmtpConfigRequest,
+    actor: User = Depends(require_admin),
+) -> EmailSmtpView:
+    current = email_settings.get()
+    # Omitted fields keep their stored value, matching the secret convention.
+    host = req.host.strip() if "host" in req.model_fields_set else current.host
+    port = req.port if "port" in req.model_fields_set else current.port
+    username = req.username.strip() if "username" in req.model_fields_set else current.username
+    from_address = (
+        req.from_address.strip()
+        if "from_address" in req.model_fields_set
+        else current.from_address
+    )
+    if "password" not in req.model_fields_set or req.password == "":
+        password = current.password.get_secret_value()
+    elif req.password is None:
+        password = ""
+    else:
+        password = req.password
+    email_settings.upsert(
+        host=host, port=port, username=username, password=password, from_address=from_address
+    )
+    log.info(
+        "admin: %s updated smtp settings host_set=%s from_set=%s password_set=%s",
+        actor.id, bool(host), bool(from_address), bool(password),
+    )
+    return _email_smtp_view(email_settings.get())
+
+
+@router.post("/email-smtp/test", response_model=EmailTestResponse)
+def post_email_smtp_test(
+    req: EmailTestRequest,
+    actor: User = Depends(require_admin),
+) -> EmailTestResponse:
+    """Synchronous end-to-end send so an admin can prove the account works
+    before any consumer exists."""
+    to = req.to.strip() or actor.email
+    try:
+        email_service.send(
+            to=to,
+            subject="Agent Wiki test email",
+            text="This is a test message from your Agent Wiki SMTP configuration. "
+            "If you are reading it, outbound email works.",
+        )
+    except EmailNotConfiguredError as e:
+        return EmailTestResponse(ok=False, detail=str(e))
+    except Exception as e:
+        log.warning("admin: test email to %s failed: %s", to, e)
+        return EmailTestResponse(ok=False, detail=f"send failed: {e}")
+    return EmailTestResponse(ok=True, detail=f"sent to {to}")
 
 
 def _braintrust_view(s: BraintrustSettings) -> BraintrustView:

--- a/backend/app/db/migrations/versions/0049_email_smtp_settings.py
+++ b/backend/app/db/migrations/versions/0049_email_smtp_settings.py
@@ -1,0 +1,46 @@
+"""email_smtp_settings singleton for the app-wide outbound email account
+
+Guarded on the live inspector because ``0001_initial`` builds fresh
+databases from the current model registry.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-07-02 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0049"
+down_revision: str | None = "0048"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    if "email_smtp_settings" in sa.inspect(op.get_bind()).get_table_names():
+        return
+    op.create_table(
+        "email_smtp_settings",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=False),
+        sa.Column("host", sa.Text, nullable=False, server_default=sa.text("''")),
+        sa.Column("port", sa.Integer, nullable=False, server_default=sa.text("587")),
+        sa.Column("username", sa.Text, nullable=False, server_default=sa.text("''")),
+        sa.Column("password", sa.LargeBinary, nullable=False),
+        sa.Column("from_address", sa.Text, nullable=False, server_default=sa.text("''")),
+        sa.Column(
+            "updated_at",
+            sa.Text,
+            nullable=False,
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("email_smtp_settings")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1405,6 +1405,26 @@ class SlackAppSettings(Base):
     )
 
 
+class EmailSmtpSettings(Base):
+    """Singleton row: the app-wide SMTP credentials for outbound email,
+    configured from /admin/email. Every consumer (trigger destinations,
+    notification emails, verification links) sends through this one account;
+    sending is dark until host and from_address are set."""
+
+    __tablename__ = "email_smtp_settings"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
+    host: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    port: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("587"))
+    username: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    # Secret — AES-GCM encrypted at rest (app/db/crypto.py:EncryptedString).
+    password: Mapped[str] = mapped_column(EncryptedString(), nullable=False)
+    from_address: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+
 class UserSlackConnection(Base):
     """One per user per Slack workspace: the bot token saved by "Connect
     Slack". Follows ``UserOnyxConnection``: the token is AES-GCM encrypted at

--- a/backend/app/email/service.py
+++ b/backend/app/email/service.py
@@ -15,14 +15,19 @@ log = logging.getLogger(__name__)
 _SEND_TIMEOUT_SECONDS = 15
 
 
-class EmailNotConfiguredError(RuntimeError):
+class EmailSendError(RuntimeError):
+    """A send failed. The message is sanitized — safe to surface to API
+    clients; full transport detail goes to the server log."""
+
+
+class EmailNotConfiguredError(EmailSendError):
     """Raised when sending is attempted before /admin/email is set up."""
 
 
 def send(*, to: str, subject: str, text: str, html: str | None = None) -> None:
     """Send one message through the configured SMTP account. Raises
-    ``EmailNotConfiguredError`` when unconfigured and ``smtplib`` errors on
-    transport failure — callers decide whether a failure is fatal."""
+    ``EmailSendError`` (or its ``EmailNotConfiguredError`` subclass) with a
+    client-safe message — callers decide whether a failure is fatal."""
     cfg = email_settings.get()
     if not cfg.configured:
         raise EmailNotConfiguredError("SMTP is not configured (/admin/email)")
@@ -35,15 +40,37 @@ def send(*, to: str, subject: str, text: str, html: str | None = None) -> None:
     if html is not None:
         msg.add_alternative(html, subtype="html")
 
-    context = ssl.create_default_context()
-    # Port 465 is implicit TLS; anything else negotiates STARTTLS.
-    if cfg.port == 465:
-        with smtplib.SMTP_SSL(cfg.host, cfg.port, timeout=_SEND_TIMEOUT_SECONDS, context=context) as smtp:
-            _login_and_send(smtp, cfg, msg)
-    else:
-        with smtplib.SMTP(cfg.host, cfg.port, timeout=_SEND_TIMEOUT_SECONDS) as smtp:
-            smtp.starttls(context=context)
-            _login_and_send(smtp, cfg, msg)
+    try:
+        context = ssl.create_default_context()
+        # Port 465 is implicit TLS; anything else negotiates STARTTLS.
+        if cfg.port == 465:
+            with smtplib.SMTP_SSL(cfg.host, cfg.port, timeout=_SEND_TIMEOUT_SECONDS, context=context) as smtp:
+                _login_and_send(smtp, cfg, msg)
+        else:
+            with smtplib.SMTP(cfg.host, cfg.port, timeout=_SEND_TIMEOUT_SECONDS) as smtp:
+                smtp.starttls(context=context)
+                _login_and_send(smtp, cfg, msg)
+    except smtplib.SMTPAuthenticationError as e:
+        log.warning("email send to %s: SMTP auth rejected", to)
+        raise EmailSendError(
+            "SMTP authentication rejected (check the username and app password)"
+        ) from e
+    except smtplib.SMTPConnectError as e:
+        log.warning("email send to %s failed to connect", to, exc_info=True)
+        raise EmailSendError(
+            "could not connect to the SMTP host (check host and port)"
+        ) from e
+    except smtplib.SMTPException as e:
+        # Server-side logs keep the detail; clients get only the class.
+        log.warning("email send to %s failed", to, exc_info=True)
+        raise EmailSendError(f"{type(e).__name__} (see server logs)") from e
+    except OSError as e:
+        # smtplib exceptions subclass OSError, so bare socket/TLS failures
+        # (refused, timeout, DNS) land here after the SMTP-specific branches.
+        log.warning("email send to %s failed to connect", to, exc_info=True)
+        raise EmailSendError(
+            "could not connect to the SMTP host (check host and port)"
+        ) from e
     log.info("email sent to=%s subject=%r", to, subject)
 
 

--- a/backend/app/email/service.py
+++ b/backend/app/email/service.py
@@ -1,0 +1,54 @@
+"""App-wide outbound email. One send seam for every consumer — trigger
+destinations, notification emails, verification links — from the one
+system address configured at /admin/email."""
+from __future__ import annotations
+
+import logging
+import smtplib
+import ssl
+from email.message import EmailMessage
+
+from app.email import settings as email_settings
+
+log = logging.getLogger(__name__)
+
+_SEND_TIMEOUT_SECONDS = 15
+
+
+class EmailNotConfiguredError(RuntimeError):
+    """Raised when sending is attempted before /admin/email is set up."""
+
+
+def send(*, to: str, subject: str, text: str, html: str | None = None) -> None:
+    """Send one message through the configured SMTP account. Raises
+    ``EmailNotConfiguredError`` when unconfigured and ``smtplib`` errors on
+    transport failure — callers decide whether a failure is fatal."""
+    cfg = email_settings.get()
+    if not cfg.configured:
+        raise EmailNotConfiguredError("SMTP is not configured (/admin/email)")
+
+    msg = EmailMessage()
+    msg["From"] = cfg.from_address
+    msg["To"] = to
+    msg["Subject"] = subject
+    msg.set_content(text)
+    if html is not None:
+        msg.add_alternative(html, subtype="html")
+
+    context = ssl.create_default_context()
+    # Port 465 is implicit TLS; anything else negotiates STARTTLS.
+    if cfg.port == 465:
+        with smtplib.SMTP_SSL(cfg.host, cfg.port, timeout=_SEND_TIMEOUT_SECONDS, context=context) as smtp:
+            _login_and_send(smtp, cfg, msg)
+    else:
+        with smtplib.SMTP(cfg.host, cfg.port, timeout=_SEND_TIMEOUT_SECONDS) as smtp:
+            smtp.starttls(context=context)
+            _login_and_send(smtp, cfg, msg)
+    log.info("email sent to=%s subject=%r", to, subject)
+
+
+def _login_and_send(smtp: smtplib.SMTP, cfg: email_settings.EmailSmtpSettings, msg: EmailMessage) -> None:
+    password = cfg.password.get_secret_value()
+    if cfg.username and password:
+        smtp.login(cfg.username, password)
+    smtp.send_message(msg)

--- a/backend/app/email/settings.py
+++ b/backend/app/email/settings.py
@@ -1,0 +1,68 @@
+"""DB-backed SMTP credentials for outbound email. Configured from /admin/email."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from pydantic import BaseModel, ConfigDict, SecretStr
+
+from app.db.models import EmailSmtpSettings as EmailSmtpSettingsRow
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+
+class EmailSmtpSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    host: str
+    port: int
+    username: str
+    # SecretStr so an incidental repr/str of the settings object redacts it.
+    password: SecretStr
+    from_address: str
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.host and self.from_address)
+
+
+_EMPTY = EmailSmtpSettings(host="", port=587, username="", password=SecretStr(""), from_address="")
+
+
+def get() -> EmailSmtpSettings:
+    with session() as s:
+        row = s.get(EmailSmtpSettingsRow, 1)
+        if row is None:
+            return _EMPTY
+        return EmailSmtpSettings(
+            host=row.host,
+            port=row.port,
+            username=row.username,
+            password=SecretStr(row.password),
+            from_address=row.from_address,
+        )
+
+
+def upsert(*, host: str, port: int, username: str, password: str, from_address: str) -> None:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        row = s.get(EmailSmtpSettingsRow, 1)
+        if row is None:
+            s.add(
+                EmailSmtpSettingsRow(
+                    id=1, host=host, port=port, username=username,
+                    password=password, from_address=from_address, updated_at=now,
+                )
+            )
+        else:
+            row.host = host
+            row.port = port
+            row.username = username
+            row.password = password
+            row.from_address = from_address
+            row.updated_at = now
+    log.info(
+        "email_smtp_settings upserted host_set=%s from_set=%s password_set=%s",
+        bool(host), bool(from_address), bool(password),
+    )

--- a/backend/app/models/admin.py
+++ b/backend/app/models/admin.py
@@ -83,6 +83,17 @@ class SlackAppConfigRequest(BaseModel):
     client_secret: str | None = None
 
 
+class EmailSmtpConfigRequest(BaseModel):
+    """Set the outbound SMTP account. ``password`` follows the masked-secret
+    convention: omitted or empty keeps the stored value, null clears it."""
+
+    host: str = ""
+    port: int = 587
+    username: str = ""
+    password: str | None = None
+    from_address: str = ""
+
+
 class BraintrustConfigRequest(BaseModel):
     """Empty-string ``api_key`` means 'leave existing untouched'; explicit
     ``null`` clears it. The blueprint resolves that semantic. ``enabled``
@@ -213,6 +224,26 @@ class SlackAppView(BaseModel):
     client_id: str
     client_secret_set: bool
     client_secret_hint: str
+
+
+class EmailSmtpView(BaseModel):
+    host: str
+    port: int
+    username: str
+    password_set: bool
+    password_hint: str
+    from_address: str
+
+
+class EmailTestRequest(BaseModel):
+    """Recipient for the admin test send; empty means the acting admin."""
+
+    to: str = ""
+
+
+class EmailTestResponse(BaseModel):
+    ok: bool
+    detail: str
 
 
 class BraintrustView(BaseModel):

--- a/backend/tests/test_email_smtp_settings.py
+++ b/backend/tests/test_email_smtp_settings.py
@@ -101,6 +101,27 @@ def test_test_endpoint_sends_via_smtp_seam(admin_client, monkeypatch):
     assert "test" in msg["Subject"].lower()
 
 
+class _AuthFailSMTP(_FakeSMTP):
+    def login(self, username, password):
+        import smtplib
+
+        raise smtplib.SMTPAuthenticationError(535, b"Username and Password not accepted")
+
+
+def test_auth_failure_reports_sanitized_message(admin_client, monkeypatch):
+    _put(
+        admin_client,
+        host="smtp.gmail.com", port=587, username="wiki@x.com",
+        password="wrong", from_address="wiki@x.com",
+    )
+    monkeypatch.setattr(email_service.smtplib, "SMTP", _AuthFailSMTP)
+    body = admin_client.post("/api/admin/email-smtp/test", json={}).json()
+    assert body["ok"] is False
+    assert "authentication rejected" in body["detail"]
+    # Transport detail stays out of the response.
+    assert "535" not in body["detail"]
+
+
 def test_test_endpoint_reports_unconfigured(admin_client):
     r = admin_client.post("/api/admin/email-smtp/test", json={})
     assert r.status_code == 200

--- a/backend/tests/test_email_smtp_settings.py
+++ b/backend/tests/test_email_smtp_settings.py
@@ -1,0 +1,117 @@
+"""Admin SMTP settings: masked round-trips through /admin/email-smtp, the
+service's configured gate, and the synchronous test-send endpoint with
+smtplib mocked at the seam."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.email import service as email_service
+from app.main import create_app
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def admin_client(tmp_repo):
+    client = TestClient(create_app())
+    seed_user(uid="usr_admin", email="admin@x.com", is_admin=True)
+    login_fastapi(client, "usr_admin")
+    return client
+
+
+def _put(client, **body: Any):
+    r = client.put("/api/admin/email-smtp", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_settings_round_trip_masks_password(admin_client):
+    view = _put(
+        admin_client,
+        host="smtp.gmail.com", port=587, username="wiki@x.com",
+        password="app-password-123", from_address="wiki@x.com",
+    )
+    assert view["host"] == "smtp.gmail.com"
+    assert view["password_set"] is True
+    assert "app-password-123" not in str(view)
+
+    # Omitted/empty password keeps the stored one; null clears it.
+    view = _put(admin_client, host="smtp.other.com")
+    assert view["host"] == "smtp.other.com"
+    assert view["password_set"] is True
+    view = _put(admin_client, password=None)
+    assert view["password_set"] is False
+
+
+def test_send_requires_configuration(tmp_repo):
+    with pytest.raises(email_service.EmailNotConfiguredError):
+        email_service.send(to="a@b.com", subject="s", text="t")
+
+
+class _FakeSMTP:
+    """Captures the login and message instead of talking to a server."""
+
+    sent: list[dict[str, Any]] = []
+
+    def __init__(self, host, port, timeout=None, context=None):
+        self.host, self.port = host, port
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def starttls(self, context=None):
+        self.tls = True
+
+    def login(self, username, password):
+        self.creds = (username, password)
+
+    def send_message(self, msg):
+        _FakeSMTP.sent.append(
+            {"host": self.host, "creds": getattr(self, "creds", None), "msg": msg}
+        )
+
+
+def test_test_endpoint_sends_via_smtp_seam(admin_client, monkeypatch):
+    _put(
+        admin_client,
+        host="smtp.gmail.com", port=587, username="wiki@x.com",
+        password="pw", from_address="wiki@x.com",
+    )
+    _FakeSMTP.sent = []
+    monkeypatch.setattr(email_service.smtplib, "SMTP", _FakeSMTP)
+
+    r = admin_client.post("/api/admin/email-smtp/test", json={"to": ""})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True, body
+    assert "admin@x.com" in body["detail"]  # blank recipient falls back to the actor
+
+    [record] = _FakeSMTP.sent
+    assert record["creds"] == ("wiki@x.com", "pw")
+    msg = record["msg"]
+    assert msg["To"] == "admin@x.com"
+    assert msg["From"] == "wiki@x.com"
+    assert "test" in msg["Subject"].lower()
+
+
+def test_test_endpoint_reports_unconfigured(admin_client):
+    r = admin_client.post("/api/admin/email-smtp/test", json={})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert "not configured" in body["detail"]
+
+
+def test_endpoints_require_admin(tmp_repo):
+    client = TestClient(create_app())
+    seed_user(uid="usr_plain", email="p@x.com")
+    login_fastapi(client, "usr_plain")
+    assert client.get("/api/admin/email-smtp").status_code == 403
+    assert client.post("/api/admin/email-smtp/test", json={}).status_code == 403

--- a/docs/email-setup.md
+++ b/docs/email-setup.md
@@ -1,0 +1,52 @@
+# Outbound email setup
+
+Agent Wiki sends email through one SMTP account that an admin configures at `/admin/email`. Trigger notifications, verification links, and notification emails all go through it. Nothing sends until a host and from address are saved.
+
+The form takes five values: host, port, username, password, and the from address. Every mail provider exposes these. Pick your section below, then use the "Send a test email" button on the same page. It reports success or the exact failure inline.
+
+The password is stored encrypted and is never shown again after saving. Leave the password field blank on later edits to keep the stored value.
+
+## Google Workspace
+
+Use a dedicated service mailbox, not a person's account.
+
+1. In [admin.google.com](https://admin.google.com) go to Directory, then Users, then Add new user. Create something like `wiki@yourdomain.com`. This uses one Workspace seat.
+2. Sign in as that user once to finish onboarding.
+3. Enable 2-Step Verification for it at [myaccount.google.com/security](https://myaccount.google.com/security).
+4. Create an app password at [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords). Copy the 16-character value.
+
+Settings: host `smtp.gmail.com`, port `587`, username and from address both the mailbox address, password the app password.
+
+Gmail rewrites the From header to the authenticated mailbox, so the from address should match the username. Per-mailbox sending is capped by Google (on the order of 2,000 messages per day). If your org enforces security policies, an admin may need to allow app passwords for the account.
+
+## Microsoft 365
+
+1. Create a mailbox such as `wiki@yourdomain.com` in the Microsoft 365 admin center.
+2. SMTP AUTH is disabled by default on many tenants. An admin enables it for just this mailbox: Users, Active users, select the mailbox, Mail, Manage email apps, check Authenticated SMTP.
+
+Settings: host `smtp.office365.com`, port `587`, username and from address both the mailbox address, password the mailbox password.
+
+Microsoft has been tightening basic authentication over time. If sends fail with an auth error despite correct credentials, check the tenant's security defaults and Exchange transport settings.
+
+## Amazon SES
+
+1. Verify your sending domain in the SES console (DKIM records).
+2. Create SMTP credentials in the SES console under SMTP settings. These are distinct from your IAM keys.
+3. If the account is in the SES sandbox, request production access, or verify each recipient while testing.
+
+Settings: host `email-smtp.<region>.amazonaws.com` (for example `email-smtp.us-east-1.amazonaws.com`), port `587`, the generated SMTP username and password, and any from address at your verified domain.
+
+## SendGrid
+
+1. Create an API key with Mail Send permission.
+2. Verify a sender identity or your domain in SendGrid.
+
+Settings: host `smtp.sendgrid.net`, port `587`, username the literal string `apikey`, password the API key, from address your verified sender.
+
+## Internal relay or smarthost
+
+If your network has an SMTP relay that accepts mail from internal services without authentication, set the host and port and leave username and password blank. Agent Wiki skips SMTP login when both are empty. Port `465` uses implicit TLS. Any other port negotiates STARTTLS.
+
+## Deliverability
+
+Send from a domain whose SPF and DKIM records cover the provider you chose. Workspace and M365 domains already have this if the domain is your mail domain. For SES and SendGrid the verification step above sets it up. Without it, mail lands in spam or gets rejected.

--- a/frontend/src/app/admin/email/page.tsx
+++ b/frontend/src/app/admin/email/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 
-import { Button } from "@onyx-ai/opal/components";
+import { Button, InputTypeIn } from "@onyx-ai/opal/components";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { BackLink, PageHeader } from "@/components/common/PageHeader";
@@ -159,33 +159,30 @@ function EmailSmtpForm() {
       <div className="flex gap-3">
         <label className="flex-1">
           <div className="mb-1 text-[13px] font-medium">SMTP host</div>
-          <input
+          <InputTypeIn
             value={host}
             onChange={(e) => setHost(e.target.value)}
             placeholder="smtp.gmail.com"
             required
-            className={inputClass}
           />
         </label>
         <label className="w-[110px]">
           <div className="mb-1 text-[13px] font-medium">Port</div>
-          <input
+          <InputTypeIn
             value={port}
             onChange={(e) => setPort(e.target.value)}
             inputMode="numeric"
             placeholder="587"
-            className={inputClass}
           />
         </label>
       </div>
 
       <label>
         <div className="mb-1 text-[13px] font-medium">Username</div>
-        <input
+        <InputTypeIn
           value={username}
           onChange={(e) => setUsername(e.target.value)}
           placeholder="wiki@yourdomain.com"
-          className={inputClass}
         />
       </label>
 
@@ -210,25 +207,23 @@ function EmailSmtpForm() {
             </Button>
           )}
         </div>
-        <input
+        <InputTypeIn
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           placeholder={
             settings.password_set ? "leave blank to keep" : "app password"
           }
-          className={inputClass}
         />
       </label>
 
       <label>
         <div className="mb-1 text-[13px] font-medium">From address</div>
-        <input
+        <InputTypeIn
           value={fromAddress}
           onChange={(e) => setFromAddress(e.target.value)}
           placeholder="wiki@yourdomain.com"
           required
-          className={inputClass}
         />
       </label>
 
@@ -243,11 +238,10 @@ function EmailSmtpForm() {
       <div className="mt-2 border-t border-(--border-01) pt-4">
         <div className="mb-1 text-[13px] font-medium">Send a test email</div>
         <div className="flex gap-3">
-          <input
+          <InputTypeIn
             value={testTo}
             onChange={(e) => setTestTo(e.target.value)}
             placeholder="leave blank to send to yourself"
-            className={inputClass}
           />
           <Button
             type="button"
@@ -273,6 +267,3 @@ function EmailSmtpForm() {
     </form>
   );
 }
-
-const inputClass =
-  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";

--- a/frontend/src/app/admin/email/page.tsx
+++ b/frontend/src/app/admin/email/page.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+
+import { Button } from "@onyx-ai/opal/components";
+import { useConfirm } from "@/components/common/ConfirmDialog";
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { BackLink, PageHeader } from "@/components/common/PageHeader";
+import { RequireAdmin } from "@/components/RequireAdmin";
+import { apiFetch } from "@/lib/api";
+import { useIsMobile } from "@/lib/viewport";
+
+interface EmailSmtpSettings {
+  host: string;
+  port: number;
+  username: string;
+  password_set: boolean;
+  password_hint: string;
+  from_address: string;
+}
+
+interface EmailTestResult {
+  ok: boolean;
+  detail: string;
+}
+
+export default function AdminEmailPage() {
+  const isMobile = useIsMobile();
+  return (
+    <RequireAdmin>
+      <main
+        className="max-w-[720px]"
+        style={{ padding: isMobile ? "16px 12px" : "24px 32px" }}
+      >
+        <BackLink />
+        <PageHeader
+          title="Outbound email"
+          description="The SMTP account every email the wiki sends goes through — trigger notifications, verification links, and notification emails. Sending stays off until a host and from address are saved."
+        />
+        <EmailSmtpForm />
+      </main>
+    </RequireAdmin>
+  );
+}
+
+function EmailSmtpForm() {
+  const [settings, setSettings] = useState<EmailSmtpSettings | null>(null);
+  const [host, setHost] = useState("");
+  const [port, setPort] = useState("587");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [fromAddress, setFromAddress] = useState("");
+  const [testTo, setTestTo] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<EmailTestResult | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const confirmDialog = useConfirm();
+
+  async function load() {
+    try {
+      const r = await apiFetch<EmailSmtpSettings>("/admin/email-smtp");
+      setSettings(r);
+      setHost(r.host);
+      setPort(String(r.port));
+      setUsername(r.username);
+      setFromAddress(r.from_address);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to load");
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    setTestResult(null);
+    try {
+      const body: Record<string, unknown> = {
+        host,
+        port: Number(port) || 587,
+        username,
+        from_address: fromAddress,
+      };
+      if (password) body.password = password;
+      const r = await apiFetch<EmailSmtpSettings>("/admin/email-smtp", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      });
+      setSettings(r);
+      setPassword("");
+      setSaved("Saved.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function clearPassword() {
+    if (
+      !(await confirmDialog({
+        title: "Clear the SMTP password?",
+        body: "Sending will fail until a new password is set (unless the relay allows unauthenticated mail).",
+        confirmLabel: "Clear password",
+      }))
+    )
+      return;
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const r = await apiFetch<EmailSmtpSettings>("/admin/email-smtp", {
+        method: "PUT",
+        body: JSON.stringify({
+          host,
+          port: Number(port) || 587,
+          username,
+          from_address: fromAddress,
+          password: null,
+        }),
+      });
+      setSettings(r);
+      setPassword("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to clear");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function sendTest() {
+    setTesting(true);
+    setError(null);
+    setTestResult(null);
+    try {
+      const r = await apiFetch<EmailTestResult>("/admin/email-smtp/test", {
+        method: "POST",
+        body: JSON.stringify({ to: testTo }),
+      });
+      setTestResult(r);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "test failed");
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  if (!settings) return <LoadingSpinner />;
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-4">
+      <div className="flex gap-3">
+        <label className="flex-1">
+          <div className="mb-1 text-[13px] font-medium">SMTP host</div>
+          <input
+            value={host}
+            onChange={(e) => setHost(e.target.value)}
+            placeholder="smtp.gmail.com"
+            required
+            className={inputClass}
+          />
+        </label>
+        <label className="w-[110px]">
+          <div className="mb-1 text-[13px] font-medium">Port</div>
+          <input
+            value={port}
+            onChange={(e) => setPort(e.target.value)}
+            inputMode="numeric"
+            placeholder="587"
+            className={inputClass}
+          />
+        </label>
+      </div>
+
+      <label>
+        <div className="mb-1 text-[13px] font-medium">Username</div>
+        <input
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="wiki@yourdomain.com"
+          className={inputClass}
+        />
+      </label>
+
+      <label>
+        <div className="mb-1 flex items-center gap-[6px] text-[13px] font-medium">
+          <span>Password</span>
+          {settings.password_set && (
+            <span className="font-mono text-xs font-normal text-(--text-03)">
+              currently {settings.password_hint}
+            </span>
+          )}
+          <span className="flex-1" />
+          {settings.password_set && (
+            <Button
+              type="button"
+              size="sm"
+              variant="danger"
+              onClick={() => void clearPassword()}
+              disabled={saving}
+            >
+              Clear
+            </Button>
+          )}
+        </div>
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder={
+            settings.password_set ? "leave blank to keep" : "app password"
+          }
+          className={inputClass}
+        />
+      </label>
+
+      <label>
+        <div className="mb-1 text-[13px] font-medium">From address</div>
+        <input
+          value={fromAddress}
+          onChange={(e) => setFromAddress(e.target.value)}
+          placeholder="wiki@yourdomain.com"
+          required
+          className={inputClass}
+        />
+      </label>
+
+      {error && <div className="text-(--status-text-error-05)">{error}</div>}
+      {saved && <div className="text-(--status-text-success-05)">{saved}</div>}
+      <div>
+        <Button type="submit" variant="action" disabled={saving}>
+          {saving ? "Saving…" : "Save"}
+        </Button>
+      </div>
+
+      <div className="mt-2 border-t border-(--border-01) pt-4">
+        <div className="mb-1 text-[13px] font-medium">Send a test email</div>
+        <div className="flex gap-3">
+          <input
+            value={testTo}
+            onChange={(e) => setTestTo(e.target.value)}
+            placeholder="leave blank to send to yourself"
+            className={inputClass}
+          />
+          <Button
+            type="button"
+            variant="default"
+            onClick={() => void sendTest()}
+            disabled={testing || saving}
+          >
+            {testing ? "Sending…" : "Send test"}
+          </Button>
+        </div>
+        {testResult && (
+          <div
+            className={
+              testResult.ok
+                ? "mt-2 text-(--status-text-success-05)"
+                : "mt-2 text-(--status-text-error-05)"
+            }
+          >
+            {testResult.detail}
+          </div>
+        )}
+      </div>
+    </form>
+  );
+}
+
+const inputClass =
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";

--- a/frontend/src/app/admin/email/page.tsx
+++ b/frontend/src/app/admin/email/page.tsx
@@ -35,8 +35,20 @@ export default function AdminEmailPage() {
         <BackLink />
         <PageHeader
           title="Outbound email"
-          description="The SMTP account every email the wiki sends goes through — trigger notifications, verification links, and notification emails. Sending stays off until a host and from address are saved."
+          description="The SMTP account every email the wiki sends goes through: trigger notifications, verification links, and notification emails. Sending stays off until a host and from address are saved."
         />
+        <p className="mb-4 text-[13px] text-(--text-03)">
+          Setup recipes for Google Workspace, Microsoft 365, SES, SendGrid, and
+          internal relays:{" "}
+          <a
+            href="https://github.com/onyx-dot-app/agent-wiki/blob/main/docs/email-setup.md"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            docs/email-setup.md
+          </a>
+        </p>
         <EmailSmtpForm />
       </main>
     </RequireAdmin>

--- a/frontend/src/lib/nav/registry.ts
+++ b/frontend/src/lib/nav/registry.ts
@@ -8,6 +8,7 @@ import {
   SvgGlobe,
   SvgHistory,
   SvgOnyxLogo,
+  SvgMail,
   SvgSlack,
   SvgUser,
   SvgUsers,
@@ -85,7 +86,10 @@ export const ADMIN_NAV_GROUPS = [
   },
   {
     label: "Connectors",
-    entries: [{ href: "/admin/slack", label: "Slack App", icon: SvgSlack }],
+    entries: [
+      { href: "/admin/slack", label: "Slack App", icon: SvgSlack },
+      { href: "/admin/email", label: "Outbound Email", icon: SvgMail },
+    ],
   },
   {
     label: "Statistics",


### PR DESCRIPTION
## Description

The send seam every email consumer will use (trigger destinations, notification emails, verification links). No consumer is wired yet — the service is dark until configured.

- `app/email/service.py`: one `send()` over smtplib. Port 465 implicit TLS, otherwise STARTTLS, 15s timeout, raises when unconfigured.
- `email_smtp_settings` singleton (host, port, username, encrypted password, from address), managed at `/admin/email` with the standard masked-secret conventions. Migration `0049`.
- The admin page has a synchronous "send test email" (blank recipient sends to yourself), so the account is provable end to end before anything consumes it.
- Tests mock `smtplib` at the seam; CI sends no real mail.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check