### PR TITLE
feat(email): verify-link flow and the trigger email dispatcher

### DIFF
--- a/backend/app/api/email_verify.py
+++ b/backend/app/api/email_verify.py
@@ -1,0 +1,45 @@
+"""Public landing endpoint for email verification links.
+
+Deliberately unauthenticated: the link may be opened in an inbox that is not
+the config owner's, and the click is the consent. The single-use expiring
+token is the capability."""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+from app.triggers import email_verification
+
+log = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Agent Wiki</title></head>
+<body style="font-family: system-ui, sans-serif; max-width: 480px; margin: 15vh auto; text-align: center;">
+<h2>{heading}</h2><p>{body}</p>
+</body></html>"""
+
+
+@router.get("/verify", response_class=HTMLResponse)
+def verify_email(token: str = "") -> HTMLResponse:
+    config_id = email_verification.verify(token) if token else None
+    if config_id is None:
+        return HTMLResponse(
+            _PAGE.format(
+                heading="Link invalid or expired",
+                body="This verification link was already used, has expired, "
+                "or is not valid. Ask for a new one from the wiki's "
+                "notification settings.",
+            ),
+            status_code=400,
+        )
+    return HTMLResponse(
+        _PAGE.format(
+            heading="Address verified",
+            body="This address can now receive Agent Wiki notifications. "
+            "You can close this tab.",
+        )
+    )

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -113,7 +113,9 @@ def create_destination_config(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     view = _config_view(row)
-    if req.type == destinations_repo.EMAIL_ID:
+    # Idempotent create can return an existing row; a verified address needs
+    # no fresh link.
+    if req.type == destinations_repo.EMAIL_ID and not row.get("verified_at"):
         view.verification_error = _send_verify_link(row)
     return view
 

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -26,7 +26,9 @@ from app.models.trigger import (
     TriggerView,
     UpdateTriggerRequest,
 )
+from app.email.service import EmailSendError
 from app.triggers import destination_configs as dest_configs
+from app.triggers import email_verification
 from app.triggers import destinations as destinations_repo
 from app.triggers import repo as triggers_repo
 from app.triggers import storage as triggers_storage
@@ -110,7 +112,44 @@ def create_destination_config(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return _config_view(row)
+    view = _config_view(row)
+    if req.type == destinations_repo.EMAIL_ID:
+        view.verification_error = _send_verify_link(row)
+    return view
+
+
+def _send_verify_link(row: dict[str, Any]) -> str | None:
+    """Fire the verify email for an email config; a failure is reported on
+    the view, not raised — the config itself was created."""
+    address = str(cast("dict[str, Any]", row.get("config") or {}).get("address") or "")
+    try:
+        email_verification.send_verification_email(str(row["id"]), address)
+    except email_verification.MintRateLimitedError as exc:
+        return str(exc)
+    except EmailSendError as exc:
+        return f"verification email failed: {exc}"
+    return None
+
+
+@router.post(
+    "/destination-configs/{config_id}/resend-verify",
+    response_model=DestinationConfigView,
+)
+def resend_verification(
+    config_id: str, user: User = Depends(require_user)
+) -> DestinationConfigView:
+    row = dest_configs.get(config_id, user.id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="not found")
+    if row.get("type") != destinations_repo.EMAIL_ID:
+        raise HTTPException(status_code=400, detail="not an email destination")
+    if row.get("verified_at"):
+        raise HTTPException(status_code=400, detail="already verified")
+    view = _config_view(row)
+    view.verification_error = _send_verify_link(row)
+    if view.verification_error and "just sent" in view.verification_error:
+        raise HTTPException(status_code=429, detail=view.verification_error)
+    return view
 
 
 @router.delete(

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -145,10 +145,14 @@ def resend_verification(
         raise HTTPException(status_code=400, detail="not an email destination")
     if row.get("verified_at"):
         raise HTTPException(status_code=400, detail="already verified")
+    address = str(cast("dict[str, Any]", row.get("config") or {}).get("address") or "")
     view = _config_view(row)
-    view.verification_error = _send_verify_link(row)
-    if view.verification_error and "just sent" in view.verification_error:
-        raise HTTPException(status_code=429, detail=view.verification_error)
+    try:
+        email_verification.send_verification_email(config_id, address)
+    except email_verification.MintRateLimitedError as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
+    except EmailSendError as exc:
+        view.verification_error = f"verification email failed: {exc}"
     return view
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.api import (
     craft,
     documents,
     wiki,
+    email_verify,
     events,
     health,
     installer,
@@ -223,6 +224,7 @@ def create_app() -> FastAPI:
     app.include_router(mcp_connections.router, prefix="/api/mcp/connections")
     app.include_router(mcp_tokens.router, prefix="/api/mcp/tokens")
     app.include_router(webhooks.router, prefix="/api/webhooks")
+    app.include_router(email_verify.router, prefix="/api/email")
     app.include_router(admin.router, prefix="/api/admin")
     app.include_router(templates.admin_router, prefix="/api/admin/templates")
     app.include_router(templates.router, prefix="/api/templates")

--- a/backend/app/models/destination_config.py
+++ b/backend/app/models/destination_config.py
@@ -32,6 +32,9 @@ class DestinationConfigView(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
     has_secret: bool
     verified_at: str | None = None
+    # Set when a verify-link send attempted at create/resend time failed;
+    # the config exists either way.
+    verification_error: str | None = None
     created_at: str | None
 
 

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -40,10 +40,13 @@ import logging
 from typing import Any, cast
 
 from datetime import datetime, timezone
+from urllib.parse import quote
 
 from sqlalchemy import select
 
+from app.config import CONFIG
 from app.db.models import Event, User
+from app.email import service as email_service
 from app.db.session import session
 from app.slack import client as slack_client
 from app.slack import connections as slack_connections
@@ -396,11 +399,55 @@ def _record_fire(
             doc_path=doc_path,
             rendered_message=rendered_message,
         )
+    elif dtype == destinations_repo.EMAIL_ID:
+        _dispatch_to_email(
+            trigger=trigger,
+            config=config,
+            doc_path=doc_path,
+            rendered_message=rendered_message,
+        )
     else:
         log.warning(
             "trigger %s destination type %r has no outbound dispatcher; recorded to events only",
             trigger.id, dtype,
         )
+
+
+def _dispatch_to_email(
+    *, trigger: TriggerRecord, config: dict[str, object], doc_path: str, rendered_message: str
+) -> None:
+    """Deliver a fire's rendered message to the config's verified address.
+
+    Unverified addresses are skipped — verification is what stops the wiki
+    being used to mail strangers. Failures are logged and swallowed: the
+    fire is already recorded in the events table.
+    """
+    if not rendered_message.strip():
+        log.info("trigger %s email dispatch skipped: empty message", trigger.id)
+        return
+    if not config.get("verified_at"):
+        log.info(
+            "trigger %s email config %s unverified; recorded to events only",
+            trigger.id, config["id"],
+        )
+        return
+    address = str(cast("dict[str, Any]", config.get("config") or {}).get("address") or "")
+    if not address:
+        log.warning("trigger %s email config %s has no address", trigger.id, config["id"])
+        return
+    doc_link = f"{CONFIG.public_base_url}/app/wiki/{quote(doc_path)}"
+    text = (
+        f"{rendered_message}\n\n— Agent Wiki trigger on {doc_path}\n{doc_link}"
+    )
+    try:
+        email_service.send(
+            to=address,
+            subject=f"Agent Wiki: {doc_path}",
+            text=text,
+        )
+        log.info("trigger %s dispatched to email config %s", trigger.id, config["id"])
+    except email_service.EmailSendError:
+        log.exception("trigger %s email dispatch failed", trigger.id)
 
 
 def _dispatch_to_slack(

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -87,6 +87,15 @@ def create(
         address = ((config or {}).get("address") or "")
         if not isinstance(address, str) or "@" not in address.strip():
             raise ValueError("an email destination needs config.address")
+        # Idempotent per address: re-adding returns the existing row instead
+        # of minting a duplicate (and a duplicate verification email).
+        normalized = address.strip().lower()
+        for existing in list_for_user(user_id):
+            if (
+                existing["type"] == destinations.EMAIL_ID
+                and str(existing["config"].get("address") or "").lower() == normalized
+            ):
+                return existing
 
     config_id = "dst_" + uuid.uuid4().hex[:12]
     created_at = _now_iso()

--- a/backend/app/triggers/email_verification.py
+++ b/backend/app/triggers/email_verification.py
@@ -13,14 +13,22 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import delete, select
 
+from app.config import CONFIG
 from app.db.models import DestinationConfig, EmailVerificationToken
 from app.db.session import session
+from app.email import service as email_service
 
 log = logging.getLogger(__name__)
 
 _TOKEN_PREFIX = "evt_"
 # Email links get opened from an inbox, not a same-minute redirect — a day.
 _TOKEN_TTL_SECONDS = 24 * 60 * 60
+# Floor between verification sends per config; the send costs real mail.
+_MINT_COOLDOWN_SECONDS = 60
+
+
+class MintRateLimitedError(RuntimeError):
+    """A verification email for this config was sent too recently."""
 
 
 def _iso(dt: datetime) -> str:
@@ -29,10 +37,21 @@ def _iso(dt: datetime) -> str:
 
 def mint_token(destination_config_id: str) -> str:
     """Create a verification token for the config, clearing any prior one so
-    a single token is outstanding per destination."""
+    a single token is outstanding per destination. Raises
+    ``MintRateLimitedError`` inside the cooldown window."""
     token = _TOKEN_PREFIX + secrets.token_urlsafe(32)
     now = datetime.now(timezone.utc)
+    floor = _iso(now - timedelta(seconds=_MINT_COOLDOWN_SECONDS))
     with session() as s:
+        recent = s.scalar(
+            select(EmailVerificationToken.token).where(
+                EmailVerificationToken.destination_config_id == destination_config_id,
+                EmailVerificationToken.created_at > floor,
+                EmailVerificationToken.consumed_at.is_(None),
+            )
+        )
+        if recent is not None:
+            raise MintRateLimitedError("a verification email was just sent; wait a minute")
         s.execute(
             delete(EmailVerificationToken).where(
                 EmailVerificationToken.destination_config_id == destination_config_id
@@ -49,11 +68,14 @@ def mint_token(destination_config_id: str) -> str:
     return token
 
 
-def verify(token: str, *, owner_user_id: str) -> str | None:
+def verify(token: str) -> str | None:
     """Claim a token and stamp its config verified in one transaction.
-    Returns the config id, or None on unknown/expired/replayed tokens. A
-    foreign-owner attempt leaves the token unconsumed so the real owner can
-    still verify."""
+    Returns the config id, or None on unknown/expired/replayed tokens.
+
+    Deliberately unauthenticated: the link may land in an inbox that isn't
+    the config owner's (adding someone else's address), and the click there
+    is the consent. The single-use, expiring, unguessable token is the
+    capability."""
     if not token.startswith(_TOKEN_PREFIX):
         return None
     now_iso = _iso(datetime.now(timezone.utc))
@@ -66,12 +88,34 @@ def verify(token: str, *, owner_user_id: str) -> str | None:
         if row is None or row.consumed_at is not None or row.expires_at <= now_iso:
             return None
         config = s.get(DestinationConfig, row.destination_config_id)
-        if config is None or config.owner_user_id != owner_user_id:
-            log.warning(
-                "email verification rejected: config %s not owned by %s",
-                row.destination_config_id, owner_user_id,
-            )
+        if config is None:
             return None
         row.consumed_at = now_iso
         config.verified_at = now_iso
         return config.id
+
+
+def send_verification_email(destination_config_id: str, address: str) -> None:
+    """Mint a token and mail its verify link to ``address``. Raises
+    ``MintRateLimitedError`` inside the cooldown and ``EmailSendError`` when
+    the send itself fails (token is cleared so a retry isn't rate-limited)."""
+    token = mint_token(destination_config_id)
+    link = f"{CONFIG.public_base_url}/api/email/verify?token={token}"
+    try:
+        email_service.send(
+            to=address,
+            subject="Verify this address for Agent Wiki notifications",
+            text=(
+                "Someone added this address as an Agent Wiki notification "
+                "destination. Click to confirm you want to receive them:\n\n"
+                f"{link}\n\nThe link expires in 24 hours. If this wasn't "
+                "expected, ignore this email and nothing will be sent here."
+            ),
+        )
+    except email_service.EmailSendError:
+        with session() as s:
+            s.execute(
+                delete(EmailVerificationToken).where(EmailVerificationToken.token == token)
+            )
+        raise
+    log.info("verification email sent config=%s", destination_config_id)

--- a/backend/tests/test_email_dispatch.py
+++ b/backend/tests/test_email_dispatch.py
@@ -1,0 +1,101 @@
+"""Email dispatch in ``_record_fire``: only verified addresses receive mail,
+the fire is recorded either way, and a send failure never loses the event."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.email import service as email_service
+from app.models.wiki import ChangeKind
+from app.tasks.triggers import _record_fire
+from app.triggers import destination_configs as dest_configs
+from app.triggers import email_verification
+from app.triggers.engine import TriggerAction, TriggerRecord
+
+from tests._seed import list_events, seed_user
+
+_OWNER = "usr_1"
+
+
+def _email_config(*, verified: bool) -> str:
+    cfg = dest_configs.create(
+        _OWNER, type="email", name="Me", config={"address": "nik@example.com"}
+    )
+    if verified:
+        token = email_verification.mint_token(cfg["id"])
+        assert email_verification.verify(token) == cfg["id"]
+    return cfg["id"]
+
+
+def _trigger(config_id: str) -> TriggerRecord:
+    return TriggerRecord(
+        id="trg_1",
+        owner_user_id=_OWNER,
+        scope_path="projects/foo.md",
+        kind="delta",
+        nl_description="fire when status changes",
+        actions=[TriggerAction(destination_config_id=config_id, message="status changed")],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+
+def _fire(trigger: TriggerRecord) -> None:
+    _record_fire(
+        trigger=trigger,
+        action=trigger.actions[0],
+        doc_path="projects/foo.md",
+        sha="abc123",
+        change_kind=ChangeKind.EDIT,
+        reason="status flipped",
+        instruction="say what changed",
+        rendered_message="Status flipped to done",
+        actor="U <u@x.com>",
+    )
+
+
+@pytest.fixture
+def _sent(monkeypatch):
+    calls: list[dict[str, Any]] = []
+
+    def fake_send(*, to: str, subject: str, text: str, html: str | None = None) -> None:
+        calls.append({"to": to, "subject": subject, "text": text})
+
+    monkeypatch.setattr("app.tasks.triggers.email_service.send", fake_send)
+    return calls
+
+
+def test_verified_address_receives_message_with_doc_link(tmp_db, _sent):
+    seed_user(uid=_OWNER)
+    _fire(_trigger(_email_config(verified=True)))
+
+    [call] = _sent
+    assert call["to"] == "nik@example.com"
+    assert "projects/foo.md" in call["subject"]
+    assert "Status flipped to done" in call["text"]
+    assert "/app/wiki/projects/foo.md" in call["text"]
+    assert len(list_events(kind="trigger.fire")) == 1
+
+
+def test_unverified_address_is_recorded_only(tmp_db, _sent):
+    seed_user(uid=_OWNER)
+    _fire(_trigger(_email_config(verified=False)))
+
+    assert _sent == []
+    rows = list_events(kind="trigger.fire")
+    assert len(rows) == 1
+    assert rows[0]["payload"]["destination_type"] == "email"
+
+
+def test_send_failure_keeps_the_recorded_fire(tmp_db, monkeypatch):
+    seed_user(uid=_OWNER)
+
+    def boom(**kwargs):
+        raise email_service.EmailSendError("could not connect")
+
+    monkeypatch.setattr("app.tasks.triggers.email_service.send", boom)
+    _fire(_trigger(_email_config(verified=True)))
+    assert len(list_events(kind="trigger.fire")) == 1

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -35,6 +35,18 @@ def test_create_returns_unverified(tmp_db):
     assert row["verified_at"] is None
 
 
+def test_create_same_address_is_idempotent(tmp_db):
+    seed_user("usr_1")
+    first = dest_configs.create(
+        "usr_1", type="email", name="Me", config={"address": "nik@example.com"}
+    )
+    again = dest_configs.create(
+        "usr_1", type="email", name="Dup", config={"address": "NIK@example.com"}
+    )
+    assert again["id"] == first["id"]
+    assert len(dest_configs.list_for_user("usr_1")) == 1
+
+
 def test_email_config_requires_address(tmp_db):
     seed_user("usr_1")
     with pytest.raises(ValueError, match="address"):

--- a/backend/tests/test_email_verification.py
+++ b/backend/tests/test_email_verification.py
@@ -43,29 +43,34 @@ def test_email_config_requires_address(tmp_db):
         dest_configs.create("usr_1", type="email", name="Bad", config={"address": "not-an-email"})
 
 
+def _age_token(token: str, *, seconds: int) -> None:
+    past = (datetime.now(timezone.utc) - timedelta(seconds=seconds)).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        s.execute(
+            update(EmailVerificationToken)
+            .where(EmailVerificationToken.token == token)
+            .values(created_at=past)
+        )
+
+
 def test_verify_stamps_config_and_is_single_use(tmp_db):
     seed_user("usr_1")
     cfg_id = _email_config()
     assert _get(cfg_id)["verified_at"] is None
 
     token = email_verification.mint_token(cfg_id)
-    assert email_verification.verify(token, owner_user_id="usr_1") == cfg_id
+    assert email_verification.verify(token) == cfg_id
     assert _get(cfg_id)["verified_at"] is not None
 
     # Replay is rejected.
-    assert email_verification.verify(token, owner_user_id="usr_1") is None
+    assert email_verification.verify(token) is None
 
 
-def test_verify_rejects_foreign_owner_and_garbage(tmp_db):
+def test_verify_rejects_garbage(tmp_db):
     seed_user("usr_1")
-    seed_user("usr_2", email="two@x.com")
-    cfg_id = _email_config()
-    token = email_verification.mint_token(cfg_id)
-    assert email_verification.verify(token, owner_user_id="usr_2") is None
-    assert email_verification.verify("not-a-token", owner_user_id="usr_1") is None
-    # A foreign attempt must not burn the token: the real owner still verifies.
-    assert email_verification.verify(token, owner_user_id="usr_1") == cfg_id
-    assert _get(cfg_id)["verified_at"] is not None
+    _email_config()
+    assert email_verification.verify("not-a-token") is None
+    assert email_verification.verify("") is None
 
 
 def test_verify_rejects_expired_token(tmp_db):
@@ -79,13 +84,16 @@ def test_verify_rejects_expired_token(tmp_db):
             .where(EmailVerificationToken.token == token)
             .values(expires_at=past)
         )
-    assert email_verification.verify(token, owner_user_id="usr_1") is None
+    assert email_verification.verify(token) is None
     assert _get(cfg_id)["verified_at"] is None
 
 
-def test_remint_invalidates_prior_token(tmp_db):
+def test_mint_is_rate_limited_then_remint_invalidates_prior(tmp_db):
     seed_user("usr_1")
     cfg_id = _email_config()
     first = email_verification.mint_token(cfg_id)
+    with pytest.raises(email_verification.MintRateLimitedError):
+        email_verification.mint_token(cfg_id)
+    _age_token(first, seconds=120)
     email_verification.mint_token(cfg_id)
-    assert email_verification.verify(first, owner_user_id="usr_1") is None
+    assert email_verification.verify(first) is None

--- a/backend/tests/test_email_verify_flow.py
+++ b/backend/tests/test_email_verify_flow.py
@@ -1,0 +1,86 @@
+"""End-to-end email destination verification over HTTP: creating an email
+config sends a verify link, the public link stamps the config, replays are
+rejected, and resends are rate-limited."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.email import service as email_service
+from app.main import create_app
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_repo):
+    c = TestClient(create_app())
+    seed_user(uid="usr_1", email="me@x.com")
+    login_fastapi(c, "usr_1")
+    return c
+
+
+@pytest.fixture
+def outbox(monkeypatch):
+    calls: list[dict[str, Any]] = []
+
+    def fake_send(*, to: str, subject: str, text: str, html: str | None = None) -> None:
+        calls.append({"to": to, "subject": subject, "text": text})
+
+    monkeypatch.setattr(email_service, "send", fake_send)
+    return calls
+
+
+def _create(client, address: str = "friend@example.com") -> dict[str, Any]:
+    r = client.post(
+        "/api/triggers/destination-configs",
+        json={"type": "email", "name": "Friend", "config": {"address": address}},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _token_from(outbox) -> str:
+    m = re.search(r"token=(evt_[\w-]+)", outbox[-1]["text"])
+    assert m, outbox[-1]["text"]
+    return m.group(1)
+
+
+def test_create_sends_link_and_public_click_verifies(client, outbox):
+    view = _create(client)
+    assert view["verification_error"] is None
+    assert view["verified_at"] is None
+    assert outbox[-1]["to"] == "friend@example.com"
+
+    r = client.get(f"/api/email/verify?token={_token_from(outbox)}")
+    assert r.status_code == 200
+    assert "verified" in r.text.lower()
+
+    rows = client.get("/api/triggers/destination-configs").json()["configs"]
+    assert rows[0]["verified_at"] is not None
+
+    # Replay lands on the failure page.
+    assert client.get(f"/api/email/verify?token={_token_from(outbox)}").status_code == 400
+
+
+def test_resend_is_rate_limited_and_blocked_after_verify(client, outbox):
+    view = _create(client)
+    cfg_id = view["id"]
+    assert client.post(f"/api/triggers/destination-configs/{cfg_id}/resend-verify").status_code == 429
+
+    client.get(f"/api/email/verify?token={_token_from(outbox)}")
+    assert client.post(f"/api/triggers/destination-configs/{cfg_id}/resend-verify").status_code == 400
+
+
+def test_send_failure_reports_on_view_and_frees_retry(client, monkeypatch):
+    def boom(**kwargs):
+        raise email_service.EmailSendError("SMTP is not configured (/admin/email)")
+
+    monkeypatch.setattr(email_service, "send", boom)
+    view = _create(client)
+    assert view["verification_error"] is not None
+    assert "not configured" in view["verification_error"]

--- a/backend/tests/test_email_verify_flow.py
+++ b/backend/tests/test_email_verify_flow.py
@@ -76,6 +76,17 @@ def test_resend_is_rate_limited_and_blocked_after_verify(client, outbox):
     assert client.post(f"/api/triggers/destination-configs/{cfg_id}/resend-verify").status_code == 400
 
 
+def test_readding_verified_address_sends_nothing(client, outbox):
+    view = _create(client)
+    client.get(f"/api/email/verify?token={_token_from(outbox)}")
+    sends_before = len(outbox)
+
+    again = _create(client)
+    assert again["id"] == view["id"]
+    assert again["verification_error"] is None
+    assert len(outbox) == sends_before
+
+
 def test_send_failure_reports_on_view_and_frees_retry(client, monkeypatch):
     def boom(**kwargs):
         raise email_service.EmailSendError("SMTP is not configured (/admin/email)")

--- a/frontend/src/components/triggers/SlackDestinationPicker.tsx
+++ b/frontend/src/components/triggers/SlackDestinationPicker.tsx
@@ -16,7 +16,6 @@ import {
   SvgUser,
 } from "@onyx-ai/opal/icons";
 
-import { ensureEmailDestination } from "@/lib/emailConnect";
 import {
   ensureSlackDestination,
   getSlackChannels,
@@ -37,6 +36,9 @@ interface Props {
   /** Called with the picked config id (null = event log). Channel and DM picks
    * find-or-create their destination config first. */
   onPick: (configId: string | null) => void | Promise<void>;
+  /** When set, an "Email…" option closes the picker and defers to the caller,
+   * which owns the address input rendered beneath its trigger control. */
+  onPickEmail?: () => void;
   onError: (message: string) => void;
 }
 
@@ -48,6 +50,7 @@ export function SlackDestinationPicker({
   connected,
   disabled,
   onPick,
+  onPickEmail,
   onError,
 }: Props) {
   const [open, setOpen] = useState(false);
@@ -55,8 +58,6 @@ export function SlackDestinationPicker({
   const [channels, setChannels] = useState<SlackChannel[] | null>(null);
   const [loadingChannels, setLoadingChannels] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [addingEmail, setAddingEmail] = useState(false);
-  const [emailInput, setEmailInput] = useState("");
 
   async function onOpenChange(next: boolean) {
     setOpen(next);
@@ -77,29 +78,6 @@ export function SlackDestinationPicker({
     await onPick(configId);
     setOpen(false);
     setSearch("");
-    setAddingEmail(false);
-    setEmailInput("");
-  }
-
-  async function pickEmail() {
-    const address = emailInput.trim();
-    if (!address.includes("@")) {
-      onError("enter a valid email address");
-      return;
-    }
-    setBusy(true);
-    try {
-      const { id, verificationError } = await ensureEmailDestination(
-        configs,
-        address,
-      );
-      await pick(id);
-      if (verificationError) onError(verificationError);
-    } catch (e) {
-      onError(e instanceof Error ? e.message : "failed to add address");
-    } finally {
-      setBusy(false);
-    }
   }
 
   async function pickChannel(ch: SlackChannel) {
@@ -203,26 +181,17 @@ export function SlackDestinationPicker({
               }}
             />
           )}
-          {!addingEmail && (
+          {onPickEmail && (
             <LineItemButton
               icon={SvgMail}
-              title="Email an address…"
+              title="Email…"
               sizePreset="main-ui"
               variant="body"
               state="empty"
-              onClick={() => setAddingEmail(true)}
-            />
-          )}
-          {addingEmail && (
-            <InputTypeIn
-              autoFocus
-              variant="internal"
-              placeholder="name@example.com — Enter to add"
-              value={emailInput}
-              onChange={(e) => setEmailInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !busy) void pickEmail();
-                if (e.key === "Escape") setAddingEmail(false);
+              onClick={() => {
+                setOpen(false);
+                setSearch("");
+                onPickEmail();
               }}
             />
           )}

--- a/frontend/src/components/triggers/SlackDestinationPicker.tsx
+++ b/frontend/src/components/triggers/SlackDestinationPicker.tsx
@@ -8,8 +8,15 @@ import {
   Popover,
   PopoverMenu,
 } from "@onyx-ai/opal/components";
-import { SvgBubbleText, SvgCheck, SvgHash, SvgUser } from "@onyx-ai/opal/icons";
+import {
+  SvgBubbleText,
+  SvgCheck,
+  SvgHash,
+  SvgMail,
+  SvgUser,
+} from "@onyx-ai/opal/icons";
 
+import { ensureEmailDestination } from "@/lib/emailConnect";
 import {
   ensureSlackDestination,
   getSlackChannels,
@@ -48,6 +55,8 @@ export function SlackDestinationPicker({
   const [channels, setChannels] = useState<SlackChannel[] | null>(null);
   const [loadingChannels, setLoadingChannels] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [addingEmail, setAddingEmail] = useState(false);
+  const [emailInput, setEmailInput] = useState("");
 
   async function onOpenChange(next: boolean) {
     setOpen(next);
@@ -68,6 +77,29 @@ export function SlackDestinationPicker({
     await onPick(configId);
     setOpen(false);
     setSearch("");
+    setAddingEmail(false);
+    setEmailInput("");
+  }
+
+  async function pickEmail() {
+    const address = emailInput.trim();
+    if (!address.includes("@")) {
+      onError("enter a valid email address");
+      return;
+    }
+    setBusy(true);
+    try {
+      const { id, verificationError } = await ensureEmailDestination(
+        configs,
+        address,
+      );
+      await pick(id);
+      if (verificationError) onError(verificationError);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : "failed to add address");
+    } finally {
+      setBusy(false);
+    }
   }
 
   async function pickChannel(ch: SlackChannel) {
@@ -122,7 +154,7 @@ export function SlackDestinationPicker({
           <InputTypeIn
             searchIcon
             variant="internal"
-            placeholder="Search channels…"
+            placeholder="Search…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
           />
@@ -142,8 +174,14 @@ export function SlackDestinationPicker({
           {filteredConfigs.map((c) => (
             <LineItemButton
               key={c.id}
-              icon={c.config.dm ? SvgUser : SvgHash}
-              title={c.name}
+              icon={
+                c.type === "email" ? SvgMail : c.config.dm ? SvgUser : SvgHash
+              }
+              title={
+                c.type === "email" && !c.verified_at
+                  ? `${c.name} (unverified)`
+                  : c.name
+              }
               sizePreset="main-ui"
               variant="body"
               state={value === c.id ? "selected" : "empty"}
@@ -162,6 +200,29 @@ export function SlackDestinationPicker({
               state="empty"
               onClick={() => {
                 if (!busy) void pickDm();
+              }}
+            />
+          )}
+          {!addingEmail && (
+            <LineItemButton
+              icon={SvgMail}
+              title="Email an address…"
+              sizePreset="main-ui"
+              variant="body"
+              state="empty"
+              onClick={() => setAddingEmail(true)}
+            />
+          )}
+          {addingEmail && (
+            <InputTypeIn
+              autoFocus
+              variant="internal"
+              placeholder="name@example.com — Enter to add"
+              value={emailInput}
+              onChange={(e) => setEmailInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !busy) void pickEmail();
+                if (e.key === "Escape") setAddingEmail(false);
               }}
             />
           )}

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -184,6 +184,16 @@ export function TriggerModal({
         ? ""
         : "Tracked in the event log only.";
 
+  function unfocusEmailInput() {
+    // Deferred past the re-render: the readOnly variant swap can replace the
+    // input node, and blurring the pre-swap node leaves the new one focused.
+    requestAnimationFrame(() => {
+      emailInputRef.current?.blur();
+      const active = document.activeElement;
+      if (active instanceof HTMLInputElement) active.blur();
+    });
+  }
+
   async function commitEmail() {
     if (emailCommitting) return;
     const address = emailDraft.trim();
@@ -198,7 +208,7 @@ export function TriggerModal({
         address.toLowerCase()
     ) {
       setEmailMode(false);
-      emailInputRef.current?.blur();
+      unfocusEmailInput();
       return;
     }
     setError(null);
@@ -210,7 +220,7 @@ export function TriggerModal({
       );
       setDestinationConfigId(id);
       setEmailMode(false);
-      emailInputRef.current?.blur();
+      unfocusEmailInput();
       await refreshConfigs();
       if (verificationError) setError(verificationError);
     } catch (e) {

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState, type FormEvent } from "react";
 
-import { Button } from "@onyx-ai/opal/components";
+import { Button, InputTypeIn } from "@onyx-ai/opal/components";
 import {
   PRESET_OPTIONS,
   WEEKDAY_NAMES,
@@ -19,6 +19,7 @@ import {
 import { SelectButton } from "@onyx-ai/opal/components";
 
 import { SlackDestinationPicker } from "@/components/triggers/SlackDestinationPicker";
+import { ensureEmailDestination } from "@/lib/emailConnect";
 import { useSlackConnectStatus } from "@/lib/slackConnect";
 import {
   createTrigger,
@@ -65,8 +66,19 @@ export function TriggerModal({
   const [startAtLocal, setStartAtLocal] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [emailMode, setEmailMode] = useState(false);
+  const [emailDraft, setEmailDraft] = useState("");
 
   const tzOptions = useMemo(() => listTimezones(), []);
+
+  // Selecting an email destination (edit flow or picker) fills the input
+  // beneath the picker with its address.
+  const selectedForDraft = configs.find((c) => c.id === destinationConfigId);
+  useEffect(() => {
+    if (selectedForDraft?.type === "email") {
+      setEmailDraft(String(selectedForDraft.config.address ?? ""));
+    }
+  }, [selectedForDraft]);
 
   useEffect(() => {
     if (!open) return;
@@ -157,9 +169,36 @@ export function TriggerModal({
     sendText.trim() &&
     (kind === "delta" || (computedCron && tz));
   const selectedConfig = configs.find((c) => c.id === destinationConfigId);
-  const destDescription = selectedConfig
-    ? ""
-    : "Tracked in the event log only.";
+  const selectedIsEmail = selectedConfig?.type === "email";
+  const destDescription = selectedIsEmail
+    ? selectedConfig?.verified_at
+      ? `Fires will be emailed to ${selectedConfig.name}.`
+      : `A verification link was sent to ${selectedConfig?.name}. Delivery starts once it is clicked.`
+    : emailMode
+      ? "Type the address and press Enter."
+      : selectedConfig
+        ? ""
+        : "Tracked in the event log only.";
+
+  async function commitEmail() {
+    const address = emailDraft.trim();
+    if (!address.includes("@")) {
+      setError("enter a valid email address");
+      return;
+    }
+    setError(null);
+    try {
+      const { id, verificationError } = await ensureEmailDestination(
+        configs,
+        address,
+      );
+      setDestinationConfigId(id);
+      await refreshConfigs();
+      if (verificationError) setError(verificationError);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to add address");
+    }
+  }
 
   return (
     <div
@@ -286,15 +325,38 @@ export function TriggerModal({
             disabled={busy}
             onPick={async (id) => {
               setError(null);
+              setEmailMode(false);
               setDestinationConfigId(id);
               await refreshConfigs();
+            }}
+            onPickEmail={() => {
+              setError(null);
+              setEmailMode(true);
             }}
             onError={(m) => setError(m)}
           >
             <SelectButton size="sm" state="empty" width="full">
-              {selectedConfig ? selectedConfig.name : "Event log"}
+              {emailMode && !selectedIsEmail
+                ? "Email"
+                : selectedConfig
+                  ? selectedConfig.name
+                  : "Event log"}
             </SelectButton>
           </SlackDestinationPicker>
+          {(emailMode || selectedIsEmail) && (
+            <InputTypeIn
+              autoFocus={emailMode && !selectedIsEmail}
+              placeholder="name@example.com — Enter to add"
+              value={emailDraft}
+              onChange={(e) => setEmailDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void commitEmail();
+                }
+              }}
+            />
+          )}
           {destDescription && (
             <span className="text-xs leading-[1.4] text-(--text-03)">
               {destDescription}

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
 
 import { Button, InputTypeIn } from "@onyx-ai/opal/components";
 import {
@@ -69,7 +69,6 @@ export function TriggerModal({
   const [emailMode, setEmailMode] = useState(false);
   const [emailDraft, setEmailDraft] = useState("");
   const [emailCommitting, setEmailCommitting] = useState(false);
-  const emailInputRef = useRef<HTMLInputElement>(null);
 
   const tzOptions = useMemo(() => listTimezones(), []);
 
@@ -184,16 +183,6 @@ export function TriggerModal({
         ? ""
         : "Tracked in the event log only.";
 
-  function unfocusEmailInput() {
-    // Deferred past the re-render: the readOnly variant swap can replace the
-    // input node, and blurring the pre-swap node leaves the new one focused.
-    requestAnimationFrame(() => {
-      emailInputRef.current?.blur();
-      const active = document.activeElement;
-      if (active instanceof HTMLInputElement) active.blur();
-    });
-  }
-
   async function commitEmail() {
     if (emailCommitting) return;
     const address = emailDraft.trim();
@@ -208,7 +197,6 @@ export function TriggerModal({
         address.toLowerCase()
     ) {
       setEmailMode(false);
-      unfocusEmailInput();
       return;
     }
     setError(null);
@@ -220,7 +208,6 @@ export function TriggerModal({
       );
       setDestinationConfigId(id);
       setEmailMode(false);
-      unfocusEmailInput();
       await refreshConfigs();
       if (verificationError) setError(verificationError);
     } catch (e) {
@@ -373,18 +360,13 @@ export function TriggerModal({
                   : "Event log"}
             </SelectButton>
           </SlackDestinationPicker>
-          {(emailMode || selectedIsEmail) && (
+          {emailMode && (
             <InputTypeIn
-              ref={emailInputRef}
-              autoFocus={emailMode}
-              variant={emailMode ? undefined : "readOnly"}
+              autoFocus
               placeholder="name@example.com — Enter to add"
               value={emailDraft}
-              onChange={(e) => {
-                if (emailMode) setEmailDraft(e.target.value);
-              }}
+              onChange={(e) => setEmailDraft(e.target.value)}
               onKeyDown={(e) => {
-                if (!emailMode) return;
                 if (e.key === "Enter") {
                   e.preventDefault();
                   void commitEmail();

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -191,12 +191,13 @@ export function TriggerModal({
       setError("enter a valid email address");
       return;
     }
-    // Re-committing the already-selected address is a no-op.
+    // Re-committing the already-selected address just exits edit mode.
     if (
       selectedIsEmail &&
       String(selectedConfig?.config.address ?? "").toLowerCase() ===
         address.toLowerCase()
     ) {
+      setEmailMode(false);
       emailInputRef.current?.blur();
       return;
     }
@@ -208,6 +209,7 @@ export function TriggerModal({
         address,
       );
       setDestinationConfigId(id);
+      setEmailMode(false);
       emailInputRef.current?.blur();
       await refreshConfigs();
       if (verificationError) setError(verificationError);
@@ -364,14 +366,22 @@ export function TriggerModal({
           {(emailMode || selectedIsEmail) && (
             <InputTypeIn
               ref={emailInputRef}
-              autoFocus={emailMode && !selectedIsEmail}
+              autoFocus={emailMode}
+              variant={emailMode ? undefined : "readOnly"}
               placeholder="name@example.com — Enter to add"
               value={emailDraft}
-              onChange={(e) => setEmailDraft(e.target.value)}
+              onChange={(e) => {
+                if (emailMode) setEmailDraft(e.target.value);
+              }}
               onKeyDown={(e) => {
+                if (!emailMode) return;
                 if (e.key === "Enter") {
                   e.preventDefault();
                   void commitEmail();
+                }
+                if (e.key === "Escape") {
+                  setEmailMode(false);
+                  setEmailDraft(String(selectedConfig?.config.address ?? ""));
                 }
               }}
             />

--- a/frontend/src/components/triggers/TriggerModal.tsx
+++ b/frontend/src/components/triggers/TriggerModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 
 import { Button, InputTypeIn } from "@onyx-ai/opal/components";
 import {
@@ -68,6 +68,8 @@ export function TriggerModal({
   const [error, setError] = useState<string | null>(null);
   const [emailMode, setEmailMode] = useState(false);
   const [emailDraft, setEmailDraft] = useState("");
+  const [emailCommitting, setEmailCommitting] = useState(false);
+  const emailInputRef = useRef<HTMLInputElement>(null);
 
   const tzOptions = useMemo(() => listTimezones(), []);
 
@@ -96,6 +98,8 @@ export function TriggerModal({
     setTz(initial?.schedule_timezone ?? browserTimezone());
     setStartAtLocal(utcIsoToLocalInput(initial?.schedule_start_at ?? null));
     setError(null);
+    setEmailMode(false);
+    setEmailDraft("");
   }, [
     open,
     initial?.id,
@@ -181,22 +185,36 @@ export function TriggerModal({
         : "Tracked in the event log only.";
 
   async function commitEmail() {
+    if (emailCommitting) return;
     const address = emailDraft.trim();
     if (!address.includes("@")) {
       setError("enter a valid email address");
       return;
     }
+    // Re-committing the already-selected address is a no-op.
+    if (
+      selectedIsEmail &&
+      String(selectedConfig?.config.address ?? "").toLowerCase() ===
+        address.toLowerCase()
+    ) {
+      emailInputRef.current?.blur();
+      return;
+    }
     setError(null);
+    setEmailCommitting(true);
     try {
       const { id, verificationError } = await ensureEmailDestination(
         configs,
         address,
       );
       setDestinationConfigId(id);
+      emailInputRef.current?.blur();
       await refreshConfigs();
       if (verificationError) setError(verificationError);
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to add address");
+    } finally {
+      setEmailCommitting(false);
     }
   }
 
@@ -345,6 +363,7 @@ export function TriggerModal({
           </SlackDestinationPicker>
           {(emailMode || selectedIsEmail) && (
             <InputTypeIn
+              ref={emailInputRef}
               autoFocus={emailMode && !selectedIsEmail}
               placeholder="name@example.com — Enter to add"
               value={emailDraft}

--- a/frontend/src/lib/emailConnect.ts
+++ b/frontend/src/lib/emailConnect.ts
@@ -1,0 +1,22 @@
+import { createDestinationConfig, type DestinationConfig } from "@/lib/triggers";
+
+/** Reuse the config for this address or create it (which sends the verify
+ * link). Returns the id plus any verification-send error to surface. */
+export async function ensureEmailDestination(
+  configs: DestinationConfig[],
+  address: string,
+): Promise<{ id: string; verificationError: string | null }> {
+  const normalized = address.trim().toLowerCase();
+  const existing = configs.find(
+    (c) =>
+      c.type === "email" &&
+      String(c.config.address ?? "").toLowerCase() === normalized,
+  );
+  if (existing) return { id: existing.id, verificationError: null };
+  const created = await createDestinationConfig({
+    type: "email",
+    name: normalized,
+    config: { address: normalized },
+  });
+  return { id: created.id, verificationError: created.verification_error ?? null };
+}

--- a/frontend/src/lib/emailConnect.ts
+++ b/frontend/src/lib/emailConnect.ts
@@ -1,4 +1,7 @@
-import { createDestinationConfig, type DestinationConfig } from "@/lib/triggers";
+import {
+  createDestinationConfig,
+  type DestinationConfig,
+} from "@/lib/triggers";
 
 /** Reuse the config for this address or create it (which sends the verify
  * link). Returns the id plus any verification-send error to surface. */
@@ -18,5 +21,8 @@ export async function ensureEmailDestination(
     name: normalized,
     config: { address: normalized },
   });
-  return { id: created.id, verificationError: created.verification_error ?? null };
+  return {
+    id: created.id,
+    verificationError: created.verification_error ?? null,
+  };
 }

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -148,6 +148,8 @@ export interface DestinationConfig {
   name: string;
   config: Record<string, unknown>;
   has_secret: boolean;
+  verified_at?: string | null;
+  verification_error?: string | null;
   created_at: string | null;
 }
 


### PR DESCRIPTION
## Description

Wires the email destination end to end on top of the merged schema (#336) and send service (#338).

- Creating an email destination mints a single-use 24h token (60s resend cooldown) and mails the verify link. A send failure is reported on the response and clears the token so retry isn't rate-limited.
- `GET /api/email/verify?token=` is public and returns a small HTML page. Deliberately unauthenticated: the link may land in a non-owner's inbox (adding someone else's address), and the click there is the consent — the unguessable expiring token is the capability. `verify()` drops the owner check accordingly.
- `POST /destination-configs/{id}/resend-verify`: 429 inside the cooldown, 400 if verified or not email.
- Dispatch delivers fires to verified addresses (subject + message + doc link) and skips unverified ones. The fire is recorded before any outbound attempt, failures logged and swallowed, matching the Slack dispatcher.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check