### PR TITLE
feat(triggers): reject scopes that don't exist in the wiki, with a did-you-mean hint

### DIFF
--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -56,10 +56,10 @@ def _config_view(row: dict[str, Any]) -> DestinationConfigView:
     )
 
 
-def _normalize_scope_path(raw: str) -> str:
+def _normalize_scope_path(raw: str, user: User) -> str:
     if not raw.strip():
         raise ValueError("scope_path is required")
-    return triggers_storage.normalize_scope_path(raw)
+    return triggers_storage.normalize_scope_path(raw, reader=user)
 
 
 def _to_view(row: dict[str, Any]) -> TriggerView:
@@ -176,7 +176,7 @@ def create_trigger(
     req: CreateTriggerRequest, user: User = Depends(require_user),
 ) -> TriggerView:
     try:
-        scope_path = _normalize_scope_path(req.scope_path)
+        scope_path = _normalize_scope_path(req.scope_path, user)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -234,7 +234,7 @@ def update_trigger(
 
     if "scope_path" in sent_fields:
         try:
-            kwargs["scope_path"] = _normalize_scope_path(req.scope_path or "")
+            kwargs["scope_path"] = _normalize_scope_path(req.scope_path or "", user)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -56,10 +56,10 @@ def _config_view(row: dict[str, Any]) -> DestinationConfigView:
     )
 
 
-def _normalize_scope_path(raw: str, user: User) -> str:
+def _normalize_scope_path(raw: str) -> str:
     if not raw.strip():
         raise ValueError("scope_path is required")
-    return triggers_storage.normalize_scope_path(raw, reader=user)
+    return triggers_storage.normalize_scope_path(raw)
 
 
 def _to_view(row: dict[str, Any]) -> TriggerView:
@@ -176,7 +176,7 @@ def create_trigger(
     req: CreateTriggerRequest, user: User = Depends(require_user),
 ) -> TriggerView:
     try:
-        scope_path = _normalize_scope_path(req.scope_path, user)
+        scope_path = _normalize_scope_path(req.scope_path)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -203,10 +203,7 @@ def create_trigger(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     view = _to_view(trigger)
-    if not triggers_storage.scope_exists(scope_path):
-        view.scope_warning = (
-            f"{scope_path!r} does not exist yet; the trigger fires when it is created"
-        )
+    view.scope_warning = triggers_storage.scope_warning_for(scope_path, reader=user)
     log.info(
         "trigger created id=%s owner=%s scope=%s kind=%s enabled=%s",
         trigger.get("id"), user.id, scope_path, req.kind, req.enabled,
@@ -234,7 +231,7 @@ def update_trigger(
 
     if "scope_path" in sent_fields:
         try:
-            kwargs["scope_path"] = _normalize_scope_path(req.scope_path or "", user)
+            kwargs["scope_path"] = _normalize_scope_path(req.scope_path or "")
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -277,9 +274,9 @@ def update_trigger(
         trigger_id, user.id, sorted(kwargs.keys()),
     )
     view = _to_view(updated)
-    if "scope_path" in kwargs and not triggers_storage.scope_exists(kwargs["scope_path"]):
-        view.scope_warning = (
-            f"{kwargs['scope_path']!r} does not exist yet; the trigger fires when it is created"
+    if "scope_path" in kwargs:
+        view.scope_warning = triggers_storage.scope_warning_for(
+            kwargs["scope_path"], reader=user
         )
     return view
 

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -202,11 +202,16 @@ def create_trigger(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    view = _to_view(trigger)
+    if not triggers_storage.scope_exists(scope_path):
+        view.scope_warning = (
+            f"{scope_path!r} does not exist yet; the trigger fires when it is created"
+        )
     log.info(
         "trigger created id=%s owner=%s scope=%s kind=%s enabled=%s",
         trigger.get("id"), user.id, scope_path, req.kind, req.enabled,
     )
-    return _to_view(trigger)
+    return view
 
 
 @router.put("/{trigger_id}", response_model=TriggerView)
@@ -271,7 +276,12 @@ def update_trigger(
         "trigger updated id=%s owner=%s fields=%s",
         trigger_id, user.id, sorted(kwargs.keys()),
     )
-    return _to_view(updated)
+    view = _to_view(updated)
+    if "scope_path" in kwargs and not triggers_storage.scope_exists(kwargs["scope_path"]):
+        view.scope_warning = (
+            f"{kwargs['scope_path']!r} does not exist yet; the trigger fires when it is created"
+        )
+    return view
 
 
 @router.delete("/{trigger_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/llm/agents/tools/create_trigger.py
+++ b/backend/app/llm/agents/tools/create_trigger.py
@@ -25,7 +25,7 @@ def handle(args: dict[str, Any]) -> Any:
     if not isinstance(raw_scope, str):
         return {"error": "scope_path must be a string"}
     try:
-        scope = triggers_storage.normalize_scope_path(raw_scope, reader=user)
+        scope = triggers_storage.normalize_scope_path(raw_scope)
     except ValueError as exc:
         return {"error": f"invalid scope_path: {exc}"}
 
@@ -43,8 +43,7 @@ def handle(args: dict[str, Any]) -> Any:
     except ValueError as exc:
         return {"error": str(exc)}
     result: dict[str, object] = {"trigger": trigger}
-    if not triggers_storage.scope_exists(scope):
-        result["scope_warning"] = (
-            f"{scope!r} does not exist yet; the trigger fires when it is created"
-        )
+    warning = triggers_storage.scope_warning_for(scope, reader=user)
+    if warning:
+        result["scope_warning"] = warning
     return result

--- a/backend/app/llm/agents/tools/create_trigger.py
+++ b/backend/app/llm/agents/tools/create_trigger.py
@@ -42,4 +42,9 @@ def handle(args: dict[str, Any]) -> Any:
         )
     except ValueError as exc:
         return {"error": str(exc)}
-    return {"trigger": trigger}
+    result: dict[str, object] = {"trigger": trigger}
+    if not triggers_storage.scope_exists(scope):
+        result["scope_warning"] = (
+            f"{scope!r} does not exist yet; the trigger fires when it is created"
+        )
+    return result

--- a/backend/app/llm/agents/tools/create_trigger.py
+++ b/backend/app/llm/agents/tools/create_trigger.py
@@ -25,7 +25,7 @@ def handle(args: dict[str, Any]) -> Any:
     if not isinstance(raw_scope, str):
         return {"error": "scope_path must be a string"}
     try:
-        scope = triggers_storage.normalize_scope_path(raw_scope)
+        scope = triggers_storage.normalize_scope_path(raw_scope, reader=user)
     except ValueError as exc:
         return {"error": f"invalid scope_path: {exc}"}
 

--- a/backend/app/llm/agents/tools/update_trigger.py
+++ b/backend/app/llm/agents/tools/update_trigger.py
@@ -75,4 +75,9 @@ def handle(args: dict[str, Any]) -> Any:
         updated = triggers_repo.update(trigger_id, actor=wiki_utils.author_string(), **kwargs)
     except ValueError as exc:
         return {"error": str(exc)}
-    return {"trigger": updated}
+    result: dict[str, object] = {"trigger": updated}
+    if "scope_path" in kwargs and not triggers_storage.scope_exists(kwargs["scope_path"]):
+        result["scope_warning"] = (
+            f"{kwargs['scope_path']!r} does not exist yet; the trigger fires when it is created"
+        )
+    return result

--- a/backend/app/llm/agents/tools/update_trigger.py
+++ b/backend/app/llm/agents/tools/update_trigger.py
@@ -36,7 +36,7 @@ def handle(args: dict[str, Any]) -> Any:
         if not isinstance(raw, str):
             return {"error": "scope_path must be a string"}
         try:
-            scope = triggers_storage.normalize_scope_path(raw, reader=user)
+            scope = triggers_storage.normalize_scope_path(raw)
         except ValueError as exc:
             return {"error": f"invalid scope_path: {exc}"}
         kwargs["scope_path"] = scope
@@ -76,8 +76,8 @@ def handle(args: dict[str, Any]) -> Any:
     except ValueError as exc:
         return {"error": str(exc)}
     result: dict[str, object] = {"trigger": updated}
-    if "scope_path" in kwargs and not triggers_storage.scope_exists(kwargs["scope_path"]):
-        result["scope_warning"] = (
-            f"{kwargs['scope_path']!r} does not exist yet; the trigger fires when it is created"
-        )
+    if "scope_path" in kwargs:
+        warning = triggers_storage.scope_warning_for(kwargs["scope_path"], reader=user)
+        if warning:
+            result["scope_warning"] = warning
     return result

--- a/backend/app/llm/agents/tools/update_trigger.py
+++ b/backend/app/llm/agents/tools/update_trigger.py
@@ -36,7 +36,7 @@ def handle(args: dict[str, Any]) -> Any:
         if not isinstance(raw, str):
             return {"error": "scope_path must be a string"}
         try:
-            scope = triggers_storage.normalize_scope_path(raw)
+            scope = triggers_storage.normalize_scope_path(raw, reader=user)
         except ValueError as exc:
             return {"error": f"invalid scope_path: {exc}"}
         kwargs["scope_path"] = scope

--- a/backend/app/models/trigger.py
+++ b/backend/app/models/trigger.py
@@ -67,6 +67,8 @@ class TriggerView(BaseModel):
     """API view of a trigger row. ``actions`` comes from
     ``Trigger.action_json``. Schedule fields are only populated for
     ``kind="schedule"`` triggers."""
+    # Transient, set by create/update when the scope doesn't exist yet.
+    scope_warning: str | None = None
 
     id: str
     owner_user_id: str

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -29,7 +29,9 @@ def normalize_scope_path(raw: str) -> str:
 
     Triggers accept a leading slash for "the whole wiki" — the rest of the
     wiki tooling represents that as the empty string, so we collapse to
-    ``""`` here before handing off to ``filesystem.safe_rel_path``.
+    ``""`` here before handing off to ``filesystem.safe_rel_path``. The scope
+    must exist in the wiki: payloads are built from the docs under it, so a
+    typo'd scope would fire against nothing.
     """
     stripped = raw.strip()
     if stripped in ("", "/"):
@@ -38,7 +40,33 @@ def normalize_scope_path(raw: str) -> str:
         stripped = stripped.lstrip("/")
         if stripped == "":
             return ""
-    return filesystem.safe_rel_path(stripped)
+    scope = filesystem.safe_rel_path(stripped)
+
+    paths = wiki_git.list_paths()
+    if scope.endswith(".md"):
+        if scope in paths:
+            return scope
+    elif any(p.startswith(scope.rstrip("/") + "/") for p in paths):
+        return scope
+
+    hint = _nearest_path(scope, paths)
+    suffix = f" — did you mean {hint!r}?" if hint else ""
+    raise ValueError(f"scope path {scope!r} does not exist in the wiki{suffix}")
+
+
+def _nearest_path(scope: str, paths: list[str]) -> str | None:
+    """A tracked path whose letters match ``scope`` ignoring case and
+    separators — catches the space-vs-underscore class of typo."""
+    def key(s: str) -> str:
+        return "".join(ch for ch in s.casefold() if ch.isalnum())
+
+    want = key(scope)
+    if not want:
+        return None
+    for p in paths:
+        if p.endswith(".md") and key(p) == want:
+            return p
+    return None
 
 
 def compute_path(*, scope_path: str, trigger_id: str) -> str:

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -24,22 +24,12 @@ def kind_of_scope(scope_path: str) -> str:
     return "doc" if scope_path.endswith(".md") else "dir"
 
 
-def normalize_scope_path(raw: str, *, reader: Any | None = None) -> str:
+def normalize_scope_path(raw: str) -> str:
     """Validate a trigger scope path. Treats ``/`` and ``""`` as the wiki root.
 
     Triggers accept a leading slash for "the whole wiki" — the rest of the
     wiki tooling represents that as the empty string, so we collapse to
     ``""`` here before handing off to ``filesystem.safe_rel_path``.
-
-    A scope that doesn't exist yet is allowed — watching a path for creation
-    is a supported flow — but a scope that near-misses an existing doc
-    (same letters, different separators or case) is a typo that would fire
-    against nothing, so it is rejected with the real path suggested. The
-    hint is only offered when ``reader`` (an object with ``id`` and
-    ``is_admin``) can read the near-miss: an unreadable doc must behave
-    exactly like a nonexistent one, or the error becomes an existence oracle
-    for private paths. Callers can pair this with ``scope_exists`` to warn
-    on not-yet-created scopes.
     """
     stripped = raw.strip()
     if stripped in ("", "/"):
@@ -48,30 +38,48 @@ def normalize_scope_path(raw: str, *, reader: Any | None = None) -> str:
         stripped = stripped.lstrip("/")
         if stripped == "":
             return ""
-    scope = filesystem.safe_rel_path(stripped)
+    return filesystem.safe_rel_path(stripped)
 
-    if reader is not None and not scope_exists(scope):
-        hint = _nearest_path(scope, wiki_git.list_paths())
-        if (
-            hint is not None
-            and hint != scope
-            and wiki_acl.can(reader.id, reader.is_admin, "read", hint)
-        ):
-            raise ValueError(
-                f"scope path {scope!r} does not exist in the wiki — did you mean {hint!r}?"
-            )
-    return scope
+
+def scope_warning_for(scope: str, *, reader: Any) -> str | None:
+    """The authoring warning for a scope that doesn't exist yet, or None.
+
+    Watching a path for creation is supported, so nothing here blocks — but
+    the warning names a near-miss (an existing doc with the same letters and
+    different separators or case) so a typo'd scope is visible the moment
+    it's authored instead of silently firing against nothing. The hint is
+    only offered when ``reader`` (an object with ``id`` and ``is_admin``)
+    can read the near-miss: an unreadable doc must behave exactly like a
+    nonexistent one, or the warning becomes an existence oracle for private
+    paths.
+    """
+    if scope_exists(scope):
+        return None
+    hint = _nearest_path(scope, wiki_git.list_paths())
+    if (
+        hint is not None
+        and hint != scope
+        and wiki_acl.can(reader.id, reader.is_admin, "read", hint)
+    ):
+        return (
+            f"{scope!r} does not exist yet — did you mean {hint!r}? "
+            "The trigger fires only if a doc is created at the exact path."
+        )
+    return f"{scope!r} does not exist yet; the trigger fires when it is created"
 
 
 def scope_exists(scope: str) -> bool:
-    """Whether the scope resolves to anything today: the wiki root, a tracked
-    ``.md`` doc, or a folder containing tracked docs."""
+    """Whether the scope resolves to any watchable content today: the wiki
+    root, a tracked ``.md`` doc, or a folder containing tracked ``.md`` docs.
+    Only docs count — payloads are built from them, and a folder holding just
+    a trigger's own YAML file has nothing to watch."""
     if not scope:
         return True
     paths = wiki_git.list_paths()
     if scope.endswith(".md"):
         return scope in paths
-    return any(p.startswith(scope.rstrip("/") + "/") for p in paths)
+    prefix = scope.rstrip("/") + "/"
+    return any(p.endswith(".md") and p.startswith(prefix) for p in paths)
 
 
 def _nearest_path(scope: str, paths: list[str]) -> str | None:

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -29,9 +29,13 @@ def normalize_scope_path(raw: str) -> str:
 
     Triggers accept a leading slash for "the whole wiki" — the rest of the
     wiki tooling represents that as the empty string, so we collapse to
-    ``""`` here before handing off to ``filesystem.safe_rel_path``. The scope
-    must exist in the wiki: payloads are built from the docs under it, so a
-    typo'd scope would fire against nothing.
+    ``""`` here before handing off to ``filesystem.safe_rel_path``.
+
+    A scope that doesn't exist yet is allowed — watching a path for creation
+    is a supported flow — but a scope that near-misses an existing doc
+    (same letters, different separators or case) is a typo that would fire
+    against nothing, so it is rejected with the real path suggested. Callers
+    can pair this with ``scope_exists`` to warn on not-yet-created scopes.
     """
     stripped = raw.strip()
     if stripped in ("", "/"):
@@ -42,16 +46,24 @@ def normalize_scope_path(raw: str) -> str:
             return ""
     scope = filesystem.safe_rel_path(stripped)
 
+    if not scope_exists(scope):
+        hint = _nearest_path(scope, wiki_git.list_paths())
+        if hint is not None and hint != scope:
+            raise ValueError(
+                f"scope path {scope!r} does not exist in the wiki — did you mean {hint!r}?"
+            )
+    return scope
+
+
+def scope_exists(scope: str) -> bool:
+    """Whether the scope resolves to anything today: the wiki root, a tracked
+    ``.md`` doc, or a folder containing tracked docs."""
+    if not scope:
+        return True
     paths = wiki_git.list_paths()
     if scope.endswith(".md"):
-        if scope in paths:
-            return scope
-    elif any(p.startswith(scope.rstrip("/") + "/") for p in paths):
-        return scope
-
-    hint = _nearest_path(scope, paths)
-    suffix = f" — did you mean {hint!r}?" if hint else ""
-    raise ValueError(f"scope path {scope!r} does not exist in the wiki{suffix}")
+        return scope in paths
+    return any(p.startswith(scope.rstrip("/") + "/") for p in paths)
 
 
 def _nearest_path(scope: str, paths: list[str]) -> str | None:

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 
 import yaml
 
-from app.wiki import filesystem, git as wiki_git
+from app.wiki import acl as wiki_acl, filesystem, git as wiki_git
 
 
 def kind_of_scope(scope_path: str) -> str:
@@ -24,7 +24,7 @@ def kind_of_scope(scope_path: str) -> str:
     return "doc" if scope_path.endswith(".md") else "dir"
 
 
-def normalize_scope_path(raw: str) -> str:
+def normalize_scope_path(raw: str, *, reader: Any | None = None) -> str:
     """Validate a trigger scope path. Treats ``/`` and ``""`` as the wiki root.
 
     Triggers accept a leading slash for "the whole wiki" — the rest of the
@@ -34,8 +34,12 @@ def normalize_scope_path(raw: str) -> str:
     A scope that doesn't exist yet is allowed — watching a path for creation
     is a supported flow — but a scope that near-misses an existing doc
     (same letters, different separators or case) is a typo that would fire
-    against nothing, so it is rejected with the real path suggested. Callers
-    can pair this with ``scope_exists`` to warn on not-yet-created scopes.
+    against nothing, so it is rejected with the real path suggested. The
+    hint is only offered when ``reader`` (an object with ``id`` and
+    ``is_admin``) can read the near-miss: an unreadable doc must behave
+    exactly like a nonexistent one, or the error becomes an existence oracle
+    for private paths. Callers can pair this with ``scope_exists`` to warn
+    on not-yet-created scopes.
     """
     stripped = raw.strip()
     if stripped in ("", "/"):
@@ -46,9 +50,13 @@ def normalize_scope_path(raw: str) -> str:
             return ""
     scope = filesystem.safe_rel_path(stripped)
 
-    if not scope_exists(scope):
+    if reader is not None and not scope_exists(scope):
         hint = _nearest_path(scope, wiki_git.list_paths())
-        if hint is not None and hint != scope:
+        if (
+            hint is not None
+            and hint != scope
+            and wiki_acl.can(reader.id, reader.is_admin, "read", hint)
+        ):
             raise ValueError(
                 f"scope path {scope!r} does not exist in the wiki — did you mean {hint!r}?"
             )

--- a/backend/tests/_seed.py
+++ b/backend/tests/_seed.py
@@ -163,3 +163,11 @@ __all__ = [
     "seed_trigger",
     "seed_user",
 ]
+
+
+def seed_docs(*paths: str) -> None:
+    """Commit placeholder docs so trigger scopes resolve during authoring."""
+    from app.wiki import git as wiki_git
+
+    for path in paths:
+        wiki_git.commit_file(path, f"# {path}\n\nseeded\n", "seed", author=None)

--- a/backend/tests/test_trigger_tools.py
+++ b/backend/tests/test_trigger_tools.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 import pytest
 
-from tests._seed import seed_user
+from tests._seed import seed_docs, seed_user
 
 
 @pytest.fixture
 def as_user(tmp_repo, monkeypatch):
     """Seed a user and stub current_user so the tool handlers see them."""
+    seed_docs("a.md", "b.md", "guide.md", "public.md", "private/secret.md")
     uid = seed_user(email="u@x.com")
 
     class FakeUser:

--- a/backend/tests/test_trigger_tools.py
+++ b/backend/tests/test_trigger_tools.py
@@ -39,6 +39,20 @@ def as_user(tmp_repo, monkeypatch):
 # --------------------------------------------------------------------------- #
 
 
+def test_create_trigger_warns_on_not_yet_created_scope(as_user):
+    from app.llm.agents.tools.create_trigger import handle
+
+    out = handle(
+        {
+            "scope_path": "roadmap/q3.md",
+            "trigger_nl_condition": "always",
+            "actions": [{"message": "hi"}],
+        }
+    )
+    assert "error" not in out, out
+    assert "does not exist yet" in out["scope_warning"]
+
+
 def test_create_trigger_requires_actions(as_user):
     from app.llm.agents.tools.create_trigger import handle
 

--- a/backend/tests/test_triggers_api.py
+++ b/backend/tests/test_triggers_api.py
@@ -426,6 +426,27 @@ def test_create_rejects_near_miss_scope_with_hint(client):
     assert "fun_poem.md" in r.json()["error"]
 
 
+def test_near_miss_hint_never_reveals_unreadable_docs(client):
+    """A near-miss against a doc the caller can't read behaves exactly like
+    a nonexistent scope — no rejection, no hint — so the error can't be used
+    as an existence oracle for private paths."""
+    owner = seed_user(uid="usr_own", email="own@x.com")
+    _lock_path_to(owner, "private/secret.md")
+
+    probe = seed_user(uid="usr_probe", email="probe@x.com")
+    login_fastapi(client, probe)
+    r = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "private/secret md",
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "hi"}],
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert "secret.md" not in (r.json()["scope_warning"] or "")
+
+
 def test_create_allows_not_yet_created_scope_with_warning(client):
     """Watching a path for creation is supported: no near-miss means the
     trigger is created, carrying a warning that the doc doesn't exist yet."""

--- a/backend/tests/test_triggers_api.py
+++ b/backend/tests/test_triggers_api.py
@@ -408,7 +408,7 @@ def test_list_destinations_returns_event_log(client):
     assert event_log["description"]
 
 
-def test_create_rejects_nonexistent_scope_with_hint(client):
+def test_create_rejects_near_miss_scope_with_hint(client):
     """A typo'd scope (space for underscore) is rejected at authoring time
     with the real path suggested."""
     uid = seed_user(email="hint@x.com")
@@ -424,3 +424,33 @@ def test_create_rejects_nonexistent_scope_with_hint(client):
     assert r.status_code == 400
     assert "does not exist" in r.json()["error"]
     assert "fun_poem.md" in r.json()["error"]
+
+
+def test_create_allows_not_yet_created_scope_with_warning(client):
+    """Watching a path for creation is supported: no near-miss means the
+    trigger is created, carrying a warning that the doc doesn't exist yet."""
+    uid = seed_user(email="future@x.com")
+    login_fastapi(client, uid)
+    r = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "roadmap/q3.md",
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "hi"}],
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert "does not exist yet" in (body["scope_warning"] or "")
+
+    # Existing scopes carry no warning.
+    r2 = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "a.md",
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "hi"}],
+        },
+    )
+    assert r2.status_code == 201
+    assert r2.json()["scope_warning"] is None

--- a/backend/tests/test_triggers_api.py
+++ b/backend/tests/test_triggers_api.py
@@ -7,11 +7,14 @@ from fastapi.testclient import TestClient
 from app.main import create_app
 
 from tests._auth import login_fastapi
-from tests._seed import seed_user
+from tests._seed import seed_docs, seed_user
 
 
 @pytest.fixture
 def client(tmp_repo):
+    seed_docs(
+        "a.md", "b.md", "projects/foo.md", "private/secret.md", "public.md", "fun_poem.md"
+    )
     return TestClient(create_app())
 
 
@@ -403,3 +406,21 @@ def test_list_destinations_returns_event_log(client):
     event_log = next(d for d in body["destinations"] if d["id"] == "event_log")
     assert event_log["name"]
     assert event_log["description"]
+
+
+def test_create_rejects_nonexistent_scope_with_hint(client):
+    """A typo'd scope (space for underscore) is rejected at authoring time
+    with the real path suggested."""
+    uid = seed_user(email="hint@x.com")
+    login_fastapi(client, uid)
+    r = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "fun poem.md",
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "hi"}],
+        },
+    )
+    assert r.status_code == 400
+    assert "does not exist" in r.json()["error"]
+    assert "fun_poem.md" in r.json()["error"]

--- a/backend/tests/test_triggers_api.py
+++ b/backend/tests/test_triggers_api.py
@@ -408,9 +408,10 @@ def test_list_destinations_returns_event_log(client):
     assert event_log["description"]
 
 
-def test_create_rejects_near_miss_scope_with_hint(client):
-    """A typo'd scope (space for underscore) is rejected at authoring time
-    with the real path suggested."""
+def test_create_warns_on_near_miss_scope_with_hint(client):
+    """A typo'd scope (space for underscore) creates successfully but the
+    response warns with the real path suggested — watch-for-creation stays
+    possible for genuinely colliding names."""
     uid = seed_user(email="hint@x.com")
     login_fastapi(client, uid)
     r = client.post(
@@ -421,9 +422,10 @@ def test_create_rejects_near_miss_scope_with_hint(client):
             "actions": [{"destination_config_id": None, "message": "hi"}],
         },
     )
-    assert r.status_code == 400
-    assert "does not exist" in r.json()["error"]
-    assert "fun_poem.md" in r.json()["error"]
+    assert r.status_code == 201, r.text
+    warning = r.json()["scope_warning"] or ""
+    assert "does not exist yet" in warning
+    assert "fun_poem.md" in warning
 
 
 def test_near_miss_hint_never_reveals_unreadable_docs(client):
@@ -444,7 +446,9 @@ def test_near_miss_hint_never_reveals_unreadable_docs(client):
         },
     )
     assert r.status_code == 201, r.text
-    assert "secret.md" not in (r.json()["scope_warning"] or "")
+    warning = r.json()["scope_warning"] or ""
+    assert "does not exist yet" in warning
+    assert "secret.md" not in warning
 
 
 def test_create_allows_not_yet_created_scope_with_warning(client):


### PR DESCRIPTION
## Description

Two triggers today were scoped to paths that don't exist (`fun poem.md` vs `fun_poem.md`, `Individual Notes / Nik Standup.md` with spaces). Since #328, payloads carry only the docs under the scope, so a typo'd scope renders "no content found" fires with nothing to catch it.

- Authoring never blocks: watch-for-creation is a supported flow, and separator-insensitive matching false-positives on legitimate names (`todo.md` vs `to-do.md`).
- Instead, create/update responses (HTTP API and agent tools, one shared builder) carry a `scope_warning` when the scope has no watchable docs yet. When the scope near-misses an existing doc, the warning names it ("did you mean `fun_poem.md`?") — and the hint is offered only when the caller can read that doc, so the warning can't be used as an existence oracle for private paths.
- `scope_exists` counts only `.md` docs: a folder holding just a trigger's own YAML has nothing to watch.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check