### PR TITLE
feat(coedit): per-connection client_id on ops (collab groundwork)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -119,13 +119,16 @@ def op(req: OpRequest, user: User = Depends(require_user)) -> OpResponse:
             base_version=req.base_version,
             changes=req.changes,
             author_user_id=user.id,
+            client_id=req.client_id,
         )
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
     if out is None:
         raise HTTPException(status_code=409, detail="stale base_version; re-sync and retry")
     coedit.touch(req.session_id, user.id)
-    coedit_channel.broadcast_op(req.session_id, out.version, req.changes, user.id)
+    coedit_channel.broadcast_op(
+        req.session_id, out.version, req.changes, user.id, client_id=req.client_id
+    )
     return OpResponse(version=out.version)
 
 
@@ -197,6 +200,7 @@ def ops(
             Operation(
                 version=r.seq,
                 author=r.author_user_id,
+                client_id=r.client_id,
                 changes=[coedit.Change.model_validate(c) for c in r.changes],
             )
             for r in result.ops

--- a/backend/app/db/migrations/versions/0049_coedit_ops_client_id.py
+++ b/backend/app/db/migrations/versions/0049_coedit_ops_client_id.py
@@ -1,0 +1,34 @@
+"""coedit_ops client_id
+
+Adds a nullable per-connection client id to the co-edit op log, so a
+collaborative client can distinguish its own echoed op from a peer's.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-07-03
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0049"
+down_revision: str | None = "0048"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Guarded: the bootstrap 0001 migration builds the full current schema via
+    # create_all (already including this column on a fresh DB), so only add it
+    # where an older DB lacks it.
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("coedit_ops")}
+    if "client_id" not in cols:
+        op.add_column("coedit_ops", sa.Column("client_id", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("coedit_ops", "client_id")

--- a/backend/app/db/migrations/versions/0050_coedit_ops_client_id.py
+++ b/backend/app/db/migrations/versions/0050_coedit_ops_client_id.py
@@ -3,8 +3,8 @@
 Adds a nullable per-connection client id to the co-edit op log, so a
 collaborative client can distinguish its own echoed op from a peer's.
 
-Revision ID: 0049
-Revises: 0048
+Revision ID: 0050
+Revises: 0049
 Create Date: 2026-07-03
 """
 from __future__ import annotations
@@ -14,8 +14,8 @@ from collections.abc import Sequence
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "0049"
-down_revision: str | None = "0048"
+revision: str = "0050"
+down_revision: str | None = "0049"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -972,6 +972,11 @@ class CoeditOp(Base):
         Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     base_version: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    # Opaque per-connection id (one editor tab), distinct from author_user_id
+    # (a user with two tabs shares one user id). Lets a collaborative client
+    # tell its own echoed op from a peer's — confirm vs. rebase. Nullable:
+    # non-collab writers (or older clients) don't set it.
+    client_id: Mapped[str | None] = mapped_column(Text)
     op_payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -30,6 +30,10 @@ class OpRequest(BaseModel):
     # malformed op is a 400 (the app's RequestValidationError handler) before it
     # reaches the repo.
     changes: list[Change]
+    # Opaque per-connection id (one editor tab). Lets a collaborative client
+    # recognize its own op when it echoes back. Optional — non-collab clients
+    # omit it.
+    client_id: str | None = None
 
 
 class OpResponse(BaseModel):
@@ -69,6 +73,7 @@ class Operation(BaseModel):
 
     version: int  # the new buffer version after this operation applies (coedit_ops.seq)
     author: str  # author_user_id
+    client_id: str | None  # originating connection (collab); None for non-collab ops
     changes: list[Change]
 
 

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -32,8 +32,9 @@ class OpRequest(BaseModel):
     changes: list[Change]
     # Opaque per-connection id (one editor tab). Lets a collaborative client
     # recognize its own op when it echoes back. Optional — non-collab clients
-    # omit it.
-    client_id: str | None = None
+    # omit it. Bounded: it's a UUID/tab id, and it's persisted + echoed to every
+    # participant, so cap it to keep a client from bloating the log / bus.
+    client_id: str | None = Field(default=None, max_length=256)
 
 
 class OpResponse(BaseModel):

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -234,6 +234,7 @@ class OpRow(BaseModel):
 
     seq: int  # the session version this op produced
     author_user_id: str
+    client_id: str | None  # the connection that produced it (collab); may be None
     base_version: int
     changes: list[dict[str, Any]]
     created_at: str
@@ -352,6 +353,7 @@ def apply_op(
     base_version: int,
     changes: list[Change],
     author_user_id: str,
+    client_id: str | None = None,
 ) -> SessionRow | None:
     """Apply an edit op to the buffer and log it, atomically.
 
@@ -397,6 +399,7 @@ def apply_op(
                 seq=new_version,
                 author_user_id=author_user_id,
                 base_version=base_version,
+                client_id=client_id,
                 op_payload={"changes": [c.model_dump(by_alias=True) for c in changes]},
             )
         )
@@ -436,6 +439,7 @@ def ops_since_with_head(session_id: int, after_version: int) -> OpsSince:
                 OpRow(
                     seq=o.seq,
                     author_user_id=o.author_user_id,
+                    client_id=o.client_id,
                     base_version=o.base_version,
                     changes=list(o.op_payload.get("changes", [])),
                     created_at=o.created_at,

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -176,6 +176,7 @@ def broadcast_op(
     version: int,
     changes: list[Change],
     author_user_id: str,
+    client_id: str | None = None,
 ) -> None:
     """Broadcast an applied edit op to the session's other connections.
 
@@ -183,6 +184,9 @@ def broadcast_op(
     the serialized payload would exceed the bus's NOTIFY cap (a large paste),
     fall back to a ``resync`` signal — peers re-fetch the buffer via
     ``GET /coedit/session`` instead of us dropping the update.
+
+    ``client_id`` (the originating connection) rides along so a collaborative
+    client can tell its own echoed op from a peer's.
     """
     frame: Frame = {
         "type": "op",
@@ -190,6 +194,7 @@ def broadcast_op(
         "version": version,
         "changes": [c.model_dump(by_alias=True) for c in changes],
         "author": author_user_id,
+        "client_id": client_id,
     }
     if not bus.payload_fits(_bus_payload(coedit_session_id, frame)):
         frame = {"type": "resync", "session_id": coedit_session_id, "version": version}

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -340,9 +340,10 @@ def test_op_client_id_round_trips_to_ops(client):
     assert op["client_id"] == "cli_abc"
 
     # Omitting client_id (non-collab client) is fine — it's null.
-    client.post(
+    resp2 = client.post(
         "/api/coedit/op",
         json={"session_id": sid, "base_version": 1, "changes": [{"from": 0, "to": 0, "insert": "Y"}]},
     )
+    assert resp2.status_code == 200
     ops = client.get(f"/api/coedit/ops?session_id={sid}&since_version=1").json()["ops"]
     assert ops[0]["client_id"] is None

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -318,3 +318,31 @@ def test_ops_404_when_no_active_session(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     assert client.get("/api/coedit/ops?session_id=99999&since_version=0").status_code == 404
+
+
+def test_op_client_id_round_trips_to_ops(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page("abc\n")
+    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    # Op tagged with a per-connection client id.
+    resp = client.post(
+        "/api/coedit/op",
+        json={
+            "session_id": sid,
+            "base_version": 0,
+            "changes": [{"from": 0, "to": 0, "insert": "X"}],
+            "client_id": "cli_abc",
+        },
+    )
+    assert resp.status_code == 200
+    op = client.get(f"/api/coedit/ops?session_id={sid}&since_version=0").json()["ops"][0]
+    assert op["client_id"] == "cli_abc"
+
+    # Omitting client_id (non-collab client) is fine — it's null.
+    client.post(
+        "/api/coedit/op",
+        json={"session_id": sid, "base_version": 1, "changes": [{"from": 0, "to": 0, "insert": "Y"}]},
+    )
+    ops = client.get(f"/api/coedit/ops?session_id={sid}&since_version=1").json()["ops"]
+    assert ops[0]["client_id"] is None

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -59,7 +59,7 @@ def _change(frm: int, to: int, insert: str) -> coedit.Change:
 def test_broadcast_op_delivers_op_frame():
     coedit_channel.reset_for_tests()
     conn = coedit_channel.connect(4, "usr_a")
-    coedit_channel.broadcast_op(4, 3, [_change(0, 1, "x")], "usr_a")
+    coedit_channel.broadcast_op(4, 3, [_change(0, 1, "x")], "usr_a", client_id="cli_1")
     frame = coedit_channel.drain(conn.queue, 0.5)
     assert frame == {
         "type": "op",
@@ -67,6 +67,7 @@ def test_broadcast_op_delivers_op_frame():
         "version": 3,
         "changes": [{"from": 0, "to": 1, "insert": "x"}],
         "author": "usr_a",
+        "client_id": "cli_1",
     }
 
 


### PR DESCRIPTION
## What

Adds an opaque **per-connection `client_id`** to the edit-op path. It's the one backend prerequisite for the `@codemirror/collab` frontend PR (approach A): collab tags every update with a client id so it can distinguish its **own** echoed op (→ confirm) from a **peer's** (→ rebase). This is distinct from `author_user_id` — one user with two tabs shares a user id but needs two client ids.

## Changes

- **`coedit_ops.client_id`** column (nullable) + **migration 0049** (guarded `add_column`, matching the `0001` create_all bootstrap pattern so a fresh test DB doesn't double-add).
- Threaded through: `apply_op(..., client_id=)` → `OpRow` → `ops_since_with_head`; the SSE op frame (`broadcast_op`); and the HTTP surface — `OpRequest.client_id` in, `Operation.client_id` out of `GET /coedit/ops`.

## Backward compatible

`client_id` is **optional** on the request and **nullable** in responses/log. Existing non-collab writers omit it and behave exactly as before. No existing endpoint contract changes shape (only adds a field).

## Test

- `test_op_client_id_round_trips_to_ops`: op tagged with a `client_id` comes back on `/ops`; omitting it yields `null`.
- `test_broadcast_op_delivers_op_frame`: the op frame carries `client_id`.
- 82 coedit tests pass; whole-project ruff + basedpyright clean.

Next: the frontend `@codemirror/collab` PR (push via `/op` with `client_id`, pull via `/ops`, feed SSE op frames through `receiveUpdates`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)