### PR TITLE
feat(llm): inject today's date into updater prompts

### DIFF
--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import NamedTuple
 
 from app.ingest.models import WikiUpdateCandidate
@@ -16,6 +17,16 @@ class TextEdit(NamedTuple):
 
 NO_CHANGE_SENTINEL = "NO_CHANGE"
 IRRELEVANT_SENTINEL = "IRRELEVANT"
+
+
+def today_str() -> str:
+    """Current UTC date for updater prompts, e.g. ``2026-07-06 (Monday)``.
+
+    The weekday matters: pages with week-keyed sections ("Week of ...") need it
+    to place an update in the right week.
+    """
+    now = datetime.now(timezone.utc)
+    return f"{now:%Y-%m-%d} ({now:%A})"
 
 
 def batch_by_chars(

--- a/backend/app/llm/agents/common.py
+++ b/backend/app/llm/agents/common.py
@@ -24,6 +24,13 @@ def today_str() -> str:
 
     The weekday matters: pages with week-keyed sections ("Week of ...") need it
     to place an update in the right week.
+
+    UTC rather than a user timezone: the ingest reconciler fans one document
+    out to pages owned by different users, so no single user timezone applies.
+    The tradeoff is that work done in a US evening is stamped with the next
+    day (and near a Monday, the next week). If dates should follow the org's
+    wall clock instead, thread an admin-configured org timezone through this
+    one seam — every updater prompt reads its date from here.
     """
     now = datetime.now(timezone.utc)
     return f"{now:%Y-%m-%d} ({now:%A})"

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -21,7 +21,13 @@ from typing import Any, NamedTuple, cast
 from app.ingest.models import WikiUpdateCandidate
 from app.llm import client
 from app.llm.client import ToolCall
-from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, apply_edits, batch_by_chars
+from app.llm.agents.common import (
+    IRRELEVANT_SENTINEL,
+    TextEdit,
+    apply_edits,
+    batch_by_chars,
+    today_str,
+)
 from app.metrics import (
     ingest_reconciler_cached_input_tokens,
     ingest_reconciler_input_tokens,
@@ -180,6 +186,7 @@ def _reconcile_batch(
         title=title or "(no title)",
         url=url or "",
         source=source,
+        today=today_str(),
         content=content,
     )
     candidates = load_prompt("ingest_batch_reconciler.candidates").format(

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -133,6 +133,10 @@ def batch_reconcile(
 
     # Worth caching the incoming doc only when sibling batches will reread it.
     cache_doc = len(batches) > 1
+    # One date for the whole run: sibling batches must agree on it (a run
+    # crossing midnight would otherwise date-place one document's updates
+    # inconsistently, and a differing doc message would defeat cache_doc).
+    today = today_str()
     results: list[str | None] = []
     for batch in batches:
         results.extend(
@@ -144,6 +148,7 @@ def batch_reconcile(
                 batch=batch,
                 model=model,
                 cache_doc=cache_doc,
+                today=today,
             )
         )
 
@@ -168,6 +173,7 @@ def _reconcile_batch(
     batch: list[WikiUpdateCandidate],
     model: str,
     cache_doc: bool,
+    today: str,
 ) -> list[str | None]:
     def _format_candidate(index: int, c: WikiUpdateCandidate) -> str:
         header = f"[{index + 1}] {c.hit.path}"
@@ -186,7 +192,7 @@ def _reconcile_batch(
         title=title or "(no title)",
         url=url or "",
         source=source,
-        today=today_str(),
+        today=today,
         content=content,
     )
     candidates = load_prompt("ingest_batch_reconciler.candidates").format(

--- a/backend/app/llm/agents/nl_updater.py
+++ b/backend/app/llm/agents/nl_updater.py
@@ -12,7 +12,7 @@ from typing import Any
 from sqlalchemy.exc import OperationalError
 
 from app.llm import client
-from app.llm.agents.common import NO_CHANGE_SENTINEL, strip_outer_fence
+from app.llm.agents.common import NO_CHANGE_SENTINEL, strip_outer_fence, today_str
 from app.llm.prompts import load_prompt
 from app.tracing import trace_flow
 from app.wiki import update_policy
@@ -56,6 +56,7 @@ def process_instruction(wiki_path: str, current_body: str, payload: dict[str, An
     input = load_prompt("wiki_updater.mcp.input").format(
         wiki_path=wiki_path,
         source=source,
+        today=today_str(),
         current_body=current_body,
         payload=payload,
         update_instruction=instruction_section,

--- a/backend/app/llm/prompts/ingest_batch_reconciler.doc.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.doc.md
@@ -1,6 +1,7 @@
 External source: {source}
 Document title: {title}
 Document URL: {url}
+Today's date: {today}
 
 --- Incoming document ---
 {content}

--- a/backend/app/llm/prompts/wiki_updater.mcp.input.md
+++ b/backend/app/llm/prompts/wiki_updater.mcp.input.md
@@ -1,5 +1,6 @@
 Wiki page: {wiki_path}
 Update source: {source}
+Today's date: {today}
 
 --- Current page body ---
 {current_body}

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from app.db.fts import SearchHit
 from app.ingest.models import WikiUpdateCandidate
-from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, batch_by_chars
+from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, batch_by_chars, today_str
 from app.llm.agents.ingest_batch_reconciler import (
     _parse_tool_results,
     batch_reconcile,
@@ -355,6 +355,22 @@ def test_update_instruction_rendered_in_prompt(mock_client):
     )
     user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
     assert "Update instruction for this page: Keep it terse." in user_msg
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_today_date_rendered_in_prompt(mock_client):
+    # Real load_prompt so the doc header block is actually rendered.
+    mock_client.complete.return_value = _llm_response(
+        {"results": [{"candidate_index": 1, "action": "no_change"}]}
+    )
+    before = today_str()
+    batch_reconcile(
+        title="T", url="", content="doc", source="s",
+        candidates=[_candidate("page.md")], model="m",
+    )
+    after = today_str()
+    user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
+    assert f"Today's date: {before}" in user_msg or f"Today's date: {after}" in user_msg
 
 
 @patch("app.llm.agents.ingest_batch_reconciler.client")

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -183,6 +183,28 @@ def test_nl_updater_omits_section_when_no_policy(tmp_db, monkeypatch):
     assert "Update instruction for this page" not in captured["messages"][1]["content"]
 
 
+def test_nl_updater_includes_today_date(tmp_db, monkeypatch):
+    from app.llm.agents import nl_updater
+    from app.llm.agents.common import today_str
+    from app.llm.client import CompletionResult
+
+    captured: dict[str, Any] = {}
+
+    def fake_complete(*, messages, **kwargs):
+        captured["messages"] = messages
+        return CompletionResult(text="NO_CHANGE", tool_calls=[], stop_reason="end_turn")
+
+    monkeypatch.setattr(nl_updater.client, "complete", fake_complete)
+    before = today_str()
+    nl_updater.process_instruction(
+        wiki_path="a/page.md", current_body="# A", payload={"instruction": "x"},
+        source="test",
+    )
+    after = today_str()
+    user_msg = captured["messages"][1]["content"]
+    assert f"Today's date: {before}" in user_msg or f"Today's date: {after}" in user_msg
+
+
 def test_nl_updater_proceeds_when_policy_store_unavailable(monkeypatch):
     """No DB (offline eval): an unreachable policy store must not fail the update."""
     from sqlalchemy.exc import OperationalError


### PR DESCRIPTION
## What

The two updater agents had no access to the current date, so any date-stamped structure (weekly "Week of ..." sections, dated status lines) relied on the pushed content happening to contain a date.

- New `today_str()` helper in `app/llm/agents/common.py` — UTC date plus weekday, e.g. `2026-07-06 (Monday)`. The weekday lets the model place updates in the correct week on week-keyed pages.
- `Today's date: {today}` header line in both updater prompts:
  - `ingest_batch_reconciler.doc.md` (connector/ingest reconciliation)
  - `wiki_updater.mcp.input.md` (NL updater / `update_doc_nl`)
- Wired at the two format call sites.

## Why

Pages maintained via update policy increasingly need dated placement — the immediate driver is keeping `Customers/POCs/Current Prospects` organized by weekly Prospects Review sections, but `Customers/Overview.md`-style "Week of" pages have the same dependency.

In the reconciler, the date lands in the doc message that is cache-marked across sibling batches; it is constant within a run, so prompt caching is unaffected.

## Tests

- `test_today_date_rendered_in_prompt` (reconciler, real prompt rendering)
- `test_nl_updater_includes_today_date`

Both tolerate a midnight rollover mid-test. 51 passed across the two touched test files; ruff + basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)