### PR TITLE
feat(triggers): recent-fires API (GET /api/triggers/fires)

### DIFF
--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -1,11 +1,16 @@
 """FastAPI port of ``app/api/triggers.py`` (Phase 3)."""
 from __future__ import annotations
 
+import json
 import logging
 import re
 from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy import func, select
+
+from app.db.models import Event as EventRow, Trigger
+from app.db.session import session as db_session
 
 from app.auth import User, require_can
 from app.auth.deps import require_user
@@ -20,6 +25,8 @@ from app.models.trigger import (
     TriggerCommit,
     TriggerDestinationsResponse,
     TriggerDestinationView,
+    TriggerFiresResponse,
+    TriggerFireView,
     TriggerHistoryResponse,
     TriggerListResponse,
     TriggerVersionResponse,
@@ -96,6 +103,58 @@ def list_destination_configs(
     """The caller's own destination configs. Secrets are never returned."""
     rows = dest_configs.list_for_user(user.id)
     return DestinationConfigListResponse(configs=[_config_view(r) for r in rows])
+
+
+@router.get("/fires", response_model=TriggerFiresResponse)
+def list_fires(
+    user: User = Depends(require_user),
+    trigger_id: str | None = None,
+    per_trigger: int = Query(3, ge=1, le=50),
+    limit: int = Query(200, ge=1, le=500),
+) -> TriggerFiresResponse:
+    """Recent ``trigger.fire`` events for the caller's triggers, capped
+    per trigger so one busy trigger can't starve the rest. ``trigger_id``
+    narrows to a single trigger (its fires up to ``limit``)."""
+    owned = select(Trigger.id).where(Trigger.owner_user_id == user.id)
+    ranked = (
+        select(
+            EventRow,
+            func.row_number()
+            .over(partition_by=EventRow.target, order_by=EventRow.id.desc())
+            .label("rn"),
+        )
+        .where(EventRow.kind == "trigger.fire", EventRow.target.in_(owned))
+    )
+    if trigger_id:
+        ranked = ranked.where(EventRow.target == trigger_id)
+    sub = ranked.subquery()
+    cap = limit if trigger_id else per_trigger
+    stmt = (
+        select(sub)
+        .where(sub.c.rn <= cap)
+        .order_by(sub.c.id.desc())
+        .limit(limit)
+    )
+    with db_session() as s:
+        rows = s.execute(stmt).all()
+    return TriggerFiresResponse(fires=[_fire_view(r) for r in rows])
+
+
+def _fire_view(row: Any) -> TriggerFireView:
+    try:
+        payload: dict[str, Any] = json.loads(row.payload_json or "{}")
+    except json.JSONDecodeError:
+        payload = {}
+    return TriggerFireView(
+        event_id=row.id,
+        trigger_id=row.target or "",
+        ts=row.ts,
+        doc_path=str(payload.get("doc_path") or ""),
+        change_kind=str(payload.get("change_kind") or ""),
+        reason=str(payload.get("reason") or ""),
+        message=str(payload.get("message") or ""),
+        destination_type=str(payload.get("destination_type") or ""),
+    )
 
 
 @router.post(

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -142,9 +142,11 @@ def list_fires(
 
 def _fire_view(row: Any) -> TriggerFireView:
     try:
-        payload: dict[str, Any] = json.loads(row.payload_json or "{}")
+        parsed: Any = json.loads(row.payload_json or "{}")
     except json.JSONDecodeError:
-        payload = {}
+        parsed = {}
+    # valid non-object JSON (array, string, number) must not 500 the list
+    payload: dict[str, Any] = cast(dict[str, Any], parsed) if isinstance(parsed, dict) else {}
     return TriggerFireView(
         event_id=row.id,
         trigger_id=row.target or "",

--- a/backend/app/models/trigger.py
+++ b/backend/app/models/trigger.py
@@ -90,6 +90,23 @@ class TriggerListResponse(BaseModel):
     triggers: list[TriggerView]
 
 
+class TriggerFireView(BaseModel):
+    """One recorded ``trigger.fire`` event, flattened from the events row."""
+
+    event_id: int
+    trigger_id: str
+    ts: str
+    doc_path: str
+    change_kind: str
+    reason: str
+    message: str
+    destination_type: str
+
+
+class TriggerFiresResponse(BaseModel):
+    fires: list[TriggerFireView]
+
+
 class TriggerCommit(BaseModel):
     sha: str
     author: str

--- a/backend/tests/test_triggers_fires_api.py
+++ b/backend/tests/test_triggers_fires_api.py
@@ -8,6 +8,9 @@ from fastapi.testclient import TestClient
 
 from app.main import create_app
 
+from app.db.models import Event
+from app.db.session import session
+
 from tests._auth import login_fastapi
 from tests._seed import insert_event, seed_trigger, seed_user
 
@@ -81,6 +84,21 @@ def test_trigger_id_filter_uses_limit_not_per_trigger_cap(client):
     body = client.get("/api/triggers/fires?trigger_id=trg_a&per_trigger=2").json()
     assert len(body["fires"]) == 6
     assert {f["trigger_id"] for f in body["fires"]} == {"trg_a"}
+
+
+def test_non_object_payload_json_degrades_to_empty_fields(client):
+    uid = seed_user(email="usr_1@x.com")
+    login_fastapi(client, uid)
+    seed_trigger(tid="trg_a", owner_user_id=uid, scope_path="a.md", message="m")
+    with session() as s:
+        s.add(Event(kind="trigger.fire", target="trg_a", payload_json="[1, 2]"))
+
+    r = client.get("/api/triggers/fires")
+    assert r.status_code == 200
+    fire = r.json()["fires"][0]
+    assert fire["trigger_id"] == "trg_a"
+    assert fire["doc_path"] == ""
+    assert fire["message"] == ""
 
 
 def test_payload_flattened_and_malformed_payload_safe(client):

--- a/backend/tests/test_triggers_fires_api.py
+++ b/backend/tests/test_triggers_fires_api.py
@@ -1,0 +1,98 @@
+"""``GET /api/triggers/fires`` must cap fires per trigger (one busy trigger
+can't starve the rest), scope to the caller's own triggers, and flatten the
+event payload into the fire view."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+
+from tests._auth import login_fastapi
+from tests._seed import insert_event, seed_trigger, seed_user
+
+
+@pytest.fixture
+def client(tmp_db):
+    return TestClient(create_app())
+
+
+def _fire_payload(**over):
+    p = {
+        "doc_path": "notes/a.md",
+        "change_kind": "update",
+        "reason": "status changed",
+        "message": "hello",
+        "destination_type": "slack",
+    }
+    p.update(over)
+    return p
+
+
+def test_unauthenticated_is_401(client):
+    assert client.get("/api/triggers/fires").status_code == 401
+
+
+def test_per_trigger_cap_and_ordering(client):
+    uid = seed_user(email="usr_1@x.com")
+    login_fastapi(client, uid)
+    seed_trigger(tid="trg_busy", owner_user_id=uid, scope_path="a.md", message="m")
+    seed_trigger(tid="trg_quiet", owner_user_id=uid, scope_path="b.md", message="m")
+    for i in range(5):
+        insert_event("trigger.fire", "trg_busy", _fire_payload(reason=f"busy {i}"))
+    insert_event("trigger.fire", "trg_quiet", _fire_payload(reason="quiet 0"))
+
+    body = client.get("/api/triggers/fires?per_trigger=3").json()
+    by_trigger: dict[str, list[dict]] = {}
+    for f in body["fires"]:
+        by_trigger.setdefault(f["trigger_id"], []).append(f)
+
+    assert len(by_trigger["trg_busy"]) == 3
+    assert len(by_trigger["trg_quiet"]) == 1
+    # newest first within and across triggers
+    assert [f["reason"] for f in by_trigger["trg_busy"]] == [
+        "busy 4", "busy 3", "busy 2",
+    ]
+    assert body["fires"][0]["reason"] == "quiet 0"
+
+
+def test_scoped_to_own_triggers(client):
+    uid = seed_user(email="usr_1@x.com")
+    other = seed_user(uid="u_other", email="other@x.com")
+    login_fastapi(client, uid)
+    seed_trigger(tid="trg_mine", owner_user_id=uid, scope_path="a.md", message="m")
+    seed_trigger(tid="trg_theirs", owner_user_id=other, scope_path="b.md", message="m")
+    insert_event("trigger.fire", "trg_mine", _fire_payload())
+    insert_event("trigger.fire", "trg_theirs", _fire_payload())
+
+    body = client.get("/api/triggers/fires").json()
+    assert [f["trigger_id"] for f in body["fires"]] == ["trg_mine"]
+
+
+def test_trigger_id_filter_uses_limit_not_per_trigger_cap(client):
+    uid = seed_user(email="usr_1@x.com")
+    login_fastapi(client, uid)
+    seed_trigger(tid="trg_a", owner_user_id=uid, scope_path="a.md", message="m")
+    seed_trigger(tid="trg_b", owner_user_id=uid, scope_path="b.md", message="m")
+    for i in range(6):
+        insert_event("trigger.fire", "trg_a", _fire_payload(reason=f"a {i}"))
+    insert_event("trigger.fire", "trg_b", _fire_payload(reason="b 0"))
+
+    body = client.get("/api/triggers/fires?trigger_id=trg_a&per_trigger=2").json()
+    assert len(body["fires"]) == 6
+    assert {f["trigger_id"] for f in body["fires"]} == {"trg_a"}
+
+
+def test_payload_flattened_and_malformed_payload_safe(client):
+    uid = seed_user(email="usr_1@x.com")
+    login_fastapi(client, uid)
+    seed_trigger(tid="trg_a", owner_user_id=uid, scope_path="a.md", message="m")
+    insert_event("trigger.fire", "trg_a", _fire_payload())
+
+    fire = client.get("/api/triggers/fires").json()["fires"][0]
+    assert fire["doc_path"] == "notes/a.md"
+    assert fire["change_kind"] == "update"
+    assert fire["destination_type"] == "slack"
+    assert fire["message"] == "hello"
+    assert isinstance(fire["event_id"], int)
+    assert fire["ts"]

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -93,6 +93,33 @@ export function deleteTrigger(id: string): Promise<void> {
   return apiFetch<void>(`/triggers/${id}`, { method: "DELETE" });
 }
 
+export interface TriggerFire {
+  event_id: number;
+  trigger_id: string;
+  ts: string;
+  doc_path: string;
+  change_kind: string;
+  reason: string;
+  message: string;
+  destination_type: string;
+}
+
+export async function getTriggerFires(opts?: {
+  triggerId?: string;
+  perTrigger?: number;
+  limit?: number;
+}): Promise<TriggerFire[]> {
+  const params = new URLSearchParams();
+  if (opts?.triggerId) params.set("trigger_id", opts.triggerId);
+  if (opts?.perTrigger) params.set("per_trigger", String(opts.perTrigger));
+  if (opts?.limit) params.set("limit", String(opts.limit));
+  const qs = params.toString();
+  const r = await apiFetch<{ fires: TriggerFire[] }>(
+    `/triggers/fires${qs ? `?${qs}` : ""}`,
+  );
+  return r.fires;
+}
+
 export async function getTriggerHistory(id: string): Promise<TriggerCommit[]> {
   const r = await apiFetch<{ commits: TriggerCommit[] }>(
     `/triggers/${id}/history`,


### PR DESCRIPTION
## Description

Adds `GET /api/triggers/fires`, serving the `trigger.fire` events rows for the caller's triggers. A window `row_number` caps results per trigger (default 3) so one busy trigger can't starve the rest of the Triggers page; passing `trigger_id` narrows to a single trigger and uses the full `limit` instead, which is the history-flyout query. Payloads are flattened into a typed fire view (doc path, change kind, reason, message, destination type) with malformed payload rows degrading to empty fields.

Reuses the events rows `_record_fire` already writes — no new table. Ownership scoping mirrors `/api/events`. The route is declared ahead of the `/{trigger_id}` matchers so `fires` can't be captured as an id. Includes the typed frontend accessor (`getTriggerFires`) for the upcoming Triggers page redesign, which consumes this per the Figma mocks.

## How Has This Been Tested?

New `test_triggers_fires_api.py`: per-trigger cap + ordering, owner scoping, `trigger_id` limit semantics, payload flattening. Live smoke on dev: the route resolves and gates.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check