### PR TITLE
feat(triggers): Triggers page redesign per the Figma mock

### DIFF
--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -156,6 +156,11 @@ def _fire_view(row: Any) -> TriggerFireView:
         reason=str(payload.get("reason") or ""),
         message=str(payload.get("message") or ""),
         destination_type=str(payload.get("destination_type") or ""),
+        destination_config_id=(
+            str(payload["destination_config_id"])
+            if payload.get("destination_config_id")
+            else None
+        ),
     )
 
 

--- a/backend/app/models/trigger.py
+++ b/backend/app/models/trigger.py
@@ -101,6 +101,7 @@ class TriggerFireView(BaseModel):
     reason: str
     message: str
     destination_type: str
+    destination_config_id: str | None
 
 
 class TriggerFiresResponse(BaseModel):

--- a/frontend/src/components/triggers/TriggerCard.tsx
+++ b/frontend/src/components/triggers/TriggerCard.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, Switch, Text } from "@onyx-ai/opal/components";
+import { markdown } from "@onyx-ai/opal/utils";
+import {
+  SvgActivity,
+  SvgBook,
+  SvgChevronDown,
+  SvgChevronUp,
+  SvgFile,
+  SvgFolder,
+  SvgInfo,
+  SvgMail,
+  SvgSettings,
+  SvgSlack,
+  SvgWorkflow,
+} from "@onyx-ai/opal/icons";
+
+import { formatScopePath } from "@/lib/format";
+import type { DestinationConfig, Trigger, TriggerFire } from "@/lib/triggers";
+
+function scopeIcon(scope: string) {
+  if (scope === "/" || scope === "") return SvgBook;
+  return scope.endsWith(".md") ? SvgFile : SvgFolder;
+}
+
+function destinationIcon(type: string) {
+  if (type === "slack") return SvgSlack;
+  if (type === "email") return SvgMail;
+  return SvgActivity;
+}
+
+/** The card's per-fire "Sent message to X · N ago" line names the config the
+ * fire was recorded against; a deleted config degrades to the type name. */
+function fireDestinationName(
+  fire: TriggerFire,
+  configs: DestinationConfig[],
+): string {
+  if (fire.destination_type === "event_log" || !fire.destination_config_id)
+    return "Activity Center";
+  const cfg = configs.find((c) => c.id === fire.destination_config_id);
+  return cfg?.name ?? fire.destination_type;
+}
+
+interface Props {
+  trigger: Trigger;
+  fires: TriggerFire[];
+  configs: DestinationConfig[];
+  ownerName: string;
+  busy?: boolean;
+  formatRelative: (iso: string | null | undefined) => string;
+  onToggle: () => void;
+  onEdit: () => void;
+  onHistory: () => void;
+}
+
+/** One trigger on the Triggers page: scope chip + owner header with the
+ * enable switch, then either the recent-fire lines (expandable messages)
+ * or the IF/Then summary when the trigger has never fired. */
+export function TriggerCard({
+  trigger: t,
+  fires,
+  configs,
+  ownerName,
+  busy,
+  formatRelative,
+  onToggle,
+  onEdit,
+  onHistory,
+}: Props) {
+  // The newest fire opens expanded on enabled triggers, per the mock.
+  const [expanded, setExpanded] = useState<Set<number>>(
+    () => new Set(t.enabled && fires[0] ? [fires[0].event_id] : []),
+  );
+
+  const destinationTypes = [
+    ...new Set(
+      t.actions.map((a) => {
+        if (!a.destination_config_id) return "event_log";
+        const cfg = configs.find((c) => c.id === a.destination_config_id);
+        return cfg?.type ?? "event_log";
+      }),
+    ),
+  ];
+
+  const ScopeIcon = scopeIcon(t.scope_path);
+
+  function toggleRow(eventId: number) {
+    setExpanded((cur) => {
+      const next = new Set(cur);
+      if (next.has(eventId)) next.delete(eventId);
+      else next.add(eventId);
+      return next;
+    });
+  }
+
+  return (
+    <div
+      className={`box-border w-full rounded-(--radius-16) border border-(--border-01) p-3 ${
+        t.enabled ? "bg-(--background-tint-00)" : "bg-(--background-tint-01)"
+      } ${busy ? "pointer-events-none opacity-60" : ""}`}
+    >
+      <div className="flex w-full items-center p-[2px]">
+        <div className="flex min-w-0 flex-1 items-center gap-1 p-[2px]">
+          <span
+            className="flex max-w-[220px] items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]"
+            title={t.scope_path || "Whole wiki"}
+          >
+            <span className="flex size-4 items-center justify-center p-[2px]">
+              <ScopeIcon className="size-3 text-(--text-03)" />
+            </span>
+            <span className="min-w-0 px-[2px]">
+              <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
+                {t.scope_path
+                  ? formatScopePath(t.scope_path).replace(/^\//, "")
+                  : "Whole wiki"}
+              </Text>
+            </span>
+          </span>
+          <span className="flex size-4 items-center justify-center p-[2px]">
+            <SvgWorkflow className="size-3 text-(--text-03)" />
+          </span>
+          <span className="flex items-center px-[2px]">
+            <span className="flex size-5 items-center justify-center rounded-full border border-(--border-01) bg-(--background-neutral-inverted-00)">
+              <Text font="secondary-action" color="text-inverted-05">
+                {(ownerName[0] ?? "?").toUpperCase()}
+              </Text>
+            </span>
+            {destinationTypes.map((type) => {
+              const Icon = destinationIcon(type);
+              return (
+                <span
+                  key={type}
+                  className="-ml-1 flex size-5 items-center justify-center rounded-full border border-(--border-01) bg-(--background-neutral-00)"
+                >
+                  <Icon className="size-3 text-(--text-04)" />
+                </span>
+              );
+            })}
+          </span>
+          <span className="min-w-0 px-[2px]">
+            <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
+              {`${ownerName} (you)`}
+            </Text>
+          </span>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            icon={SvgInfo}
+            size="sm"
+            prominence="tertiary"
+            tooltip="Details and history"
+            onClick={onHistory}
+            disabled={busy}
+          />
+          <Button
+            type="button"
+            icon={SvgSettings}
+            size="sm"
+            prominence="tertiary"
+            tooltip="Edit trigger"
+            onClick={onEdit}
+            disabled={busy}
+          />
+          <Switch
+            checked={t.enabled}
+            onCheckedChange={onToggle}
+            disabled={busy}
+          />
+        </div>
+      </div>
+
+      <div className="flex w-full flex-col p-1">
+        {fires.length === 0 ? (
+          <div className="flex w-full items-start gap-[2px]">
+            <div className="flex min-w-0 flex-1 flex-col py-[2px]">
+              <span className="px-[2px]">
+                <Text font="secondary-body" color="text-03">
+                  {markdown(`**IF** ${t.nl_description}`)}
+                </Text>
+              </span>
+              {t.actions.map((a, i) => {
+                const cfg = a.destination_config_id
+                  ? configs.find((c) => c.id === a.destination_config_id)
+                  : null;
+                const dest = a.destination_config_id
+                  ? (cfg?.name ?? "(destination removed)")
+                  : "Activity Center";
+                return (
+                  <span
+                    key={`${a.destination_config_id ?? "event_log"}-${i}`}
+                    className="px-[2px]"
+                  >
+                    <Text font="secondary-body" color="text-03">
+                      {markdown(`Then send message to **${dest}**`)}
+                    </Text>
+                  </span>
+                );
+              })}
+              {t.actions[0]?.message && (
+                <span className="px-[2px]">
+                  <Text font="secondary-action" color="text-03">
+                    {t.actions[0].message}
+                  </Text>
+                </span>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-[2px]">
+              <span className="px-[2px]">
+                <Text font="secondary-body" color="text-03" nowrap>
+                  No runs yet
+                </Text>
+              </span>
+              <span className="flex size-5 items-center justify-center">
+                <span className="size-2 rounded-full border border-(--border-02)" />
+              </span>
+            </div>
+          </div>
+        ) : (
+          fires.map((f) => {
+            const isOpen = expanded.has(f.event_id);
+            const Chevron = isOpen ? SvgChevronUp : SvgChevronDown;
+            return (
+              <div key={f.event_id} className="flex w-full flex-col">
+                <div className="flex w-full items-center gap-[2px]">
+                  <div className="flex min-w-0 flex-1 items-center py-[2px]">
+                    <span className="shrink-0 px-[2px]">
+                      <Text font="secondary-body" color="text-03" nowrap>
+                        Sent message to
+                      </Text>
+                    </span>
+                    <span className="min-w-0 px-[2px]">
+                      <Text
+                        font="secondary-action"
+                        color="text-03"
+                        nowrap
+                        maxLines={1}
+                      >
+                        {fireDestinationName(f, configs)}
+                      </Text>
+                    </span>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-[2px]">
+                    <span className="px-[2px]">
+                      <Text font="secondary-body" color="text-03" nowrap>
+                        {formatRelative(f.ts)}
+                      </Text>
+                    </span>
+                    {/* raw-ok: 20px inline chevron; Opal Button's smallest container oversizes this row */}
+                    <button
+                      type="button"
+                      onClick={() => toggleRow(f.event_id)}
+                      aria-expanded={isOpen}
+                      title="Details"
+                      className="flex size-5 cursor-pointer items-center justify-center rounded-(--radius-08) border-0 bg-transparent p-[2px] hover:bg-(--background-tint-02)"
+                    >
+                      <Chevron className="size-3.5 text-(--text-03)" />
+                    </button>
+                  </div>
+                </div>
+                {isOpen && f.message && (
+                  <div className="w-full pr-5 pb-1">
+                    <Text font="main-ui-body" color="text-03">
+                      {markdown(f.message)}
+                    </Text>
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/triggers/TriggerCard.tsx
+++ b/frontend/src/components/triggers/TriggerCard.tsx
@@ -70,10 +70,11 @@ export function TriggerCard({
   onEdit,
   onHistory,
 }: Props) {
-  // The newest fire opens expanded on enabled triggers, per the mock.
-  const [expanded, setExpanded] = useState<Set<number>>(
-    () => new Set(t.enabled && fires[0] ? [fires[0].event_id] : []),
-  );
+  // The newest fire renders expanded on enabled triggers (per the mock);
+  // clicks override per row. Derived, since fires arrive after mount.
+  const [overrides, setOverrides] = useState<Map<number, boolean>>(new Map());
+  const isRowOpen = (f: TriggerFire) =>
+    overrides.get(f.event_id) ?? (t.enabled && f === fires[0]);
 
   const destinationTypes = [
     ...new Set(
@@ -87,13 +88,8 @@ export function TriggerCard({
 
   const ScopeIcon = scopeIcon(t.scope_path);
 
-  function toggleRow(eventId: number) {
-    setExpanded((cur) => {
-      const next = new Set(cur);
-      if (next.has(eventId)) next.delete(eventId);
-      else next.add(eventId);
-      return next;
-    });
+  function toggleRow(f: TriggerFire) {
+    setOverrides((cur) => new Map(cur).set(f.event_id, !isRowOpen(f)));
   }
 
   return (
@@ -221,7 +217,7 @@ export function TriggerCard({
           </div>
         ) : (
           fires.map((f) => {
-            const isOpen = expanded.has(f.event_id);
+            const isOpen = isRowOpen(f);
             const Chevron = isOpen ? SvgChevronUp : SvgChevronDown;
             return (
               <div key={f.event_id} className="flex w-full flex-col">
@@ -252,7 +248,7 @@ export function TriggerCard({
                     {/* raw-ok: 20px inline chevron; Opal Button's smallest container oversizes this row */}
                     <button
                       type="button"
-                      onClick={() => toggleRow(f.event_id)}
+                      onClick={() => toggleRow(f)}
                       aria-expanded={isOpen}
                       title="Details"
                       className="flex size-5 cursor-pointer items-center justify-center rounded-(--radius-08) border-0 bg-transparent p-[2px] hover:bg-(--background-tint-02)"

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -57,6 +57,9 @@ interface Props {
   initial?: Partial<Trigger>;
   onClose: () => void;
   onSaved: (t: Trigger) => void;
+  /** Shown as a Delete button in the footer on edit; the caller owns the
+   * confirm + request and closes the panel by resolving. */
+  onDelete?: () => void | Promise<void>;
   /** Lock the scope_path input so callers (e.g. doc page) can pin it. */
   lockScope?: boolean;
 }
@@ -110,6 +113,7 @@ export function TriggerPanel({
   initial,
   onClose,
   onSaved,
+  onDelete,
   lockScope,
 }: Props) {
   const isEdit = Boolean(initial?.id);
@@ -416,6 +420,17 @@ export function TriggerPanel({
               )}
             </Text>
           </div>
+          {isEdit && onDelete && (
+            <Button
+              type="button"
+              variant="danger"
+              prominence="secondary"
+              disabled={busy}
+              onClick={() => void onDelete()}
+            >
+              Delete
+            </Button>
+          )}
           <Button type="submit" variant="action" disabled={busy || !canSave}>
             {busy ? "Saving…" : isEdit ? "Save" : "Create"}
           </Button>

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -102,6 +102,7 @@ export interface TriggerFire {
   reason: string;
   message: string;
   destination_type: string;
+  destination_config_id: string | null;
 }
 
 export async function getTriggerFires(opts?: {

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -2,32 +2,27 @@
 
 import { useState } from "react";
 
-import { Button } from "@onyx-ai/opal/components";
-import { SvgPlus, SvgWorkflow } from "@onyx-ai/opal/icons";
+import useSWR from "swr";
+
+import { Button, Tabs, Text } from "@onyx-ai/opal/components";
+import { SvgPlusCircle, SvgSearch, SvgWorkflow } from "@onyx-ai/opal/icons";
 import { SettingsLayouts } from "@onyx-ai/opal/layouts";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { TriggerHistoryModal } from "@/components/triggers/TriggerHistoryModal";
 import { TriggerPanel } from "@/components/triggers/TriggerPanel";
 import { useRequireAuth } from "@/lib/auth";
-import { describeCron } from "@/lib/cron";
-import { formatScopePath } from "@/lib/format";
-import { SlackDestinationPicker } from "@/components/triggers/SlackDestinationPicker";
-import { disconnectSlack, useSlackConnectStatus } from "@/lib/slackConnect";
+import { TriggerCard } from "@/components/triggers/TriggerCard";
 import {
-  createDestinationConfig,
-  deleteDestinationConfig,
   deleteTrigger,
+  getTriggerFires,
   getTriggerVersion,
   updateTrigger,
   useDestinationConfigs,
   useTriggers,
   type Trigger,
+  type TriggerFire,
 } from "@/lib/triggers";
-import { ApiError } from "@/lib/api";
-
-const sentenceTagCn =
-  "shrink-0 text-[10px] font-semibold px-[6px] py-[1px] rounded-(--border-radius-04) bg-(--background-tint-03) text-(--text-05) uppercase tracking-[0.3px]";
 
 function formatRelative(iso: string | null | undefined): string {
   if (!iso) return "";
@@ -49,13 +44,26 @@ export default function TriggersPage() {
   const { user, loading } = useRequireAuth();
   const { triggers, error: listSwrError, refresh } = useTriggers();
   const { configs } = useDestinationConfigs();
-  const destinationLabel = (t: Trigger) => {
-    if (t.actions.length > 1) return `${t.actions.length} destinations`;
-    const configId = t.actions[0]?.destination_config_id;
-    if (!configId) return "Event log";
-    const cfg = configs.find((c) => c.id === configId);
-    return cfg ? `${cfg.type} · ${cfg.name}` : "(destination removed)";
-  };
+  const [kindTab, setKindTab] = useState<"delta" | "schedule">("delta");
+  const [search, setSearch] = useState("");
+  const { data: firesData } = useSWR("/triggers/fires?per_trigger=3", () =>
+    getTriggerFires({ perTrigger: 3 }),
+  );
+  const firesByTrigger = new Map<string, TriggerFire[]>();
+  for (const f of firesData ?? []) {
+    const cur = firesByTrigger.get(f.trigger_id);
+    if (cur) cur.push(f);
+    else firesByTrigger.set(f.trigger_id, [f]);
+  }
+  const q = search.trim().toLowerCase();
+  const visible = triggers.filter(
+    (t) =>
+      t.kind === kindTab &&
+      (!q ||
+        t.scope_path.toLowerCase().includes(q) ||
+        t.nl_description.toLowerCase().includes(q) ||
+        t.actions.some((a) => (a.message ?? "").toLowerCase().includes(q))),
+  );
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [modalOpen, setModalOpen] = useState(false);
@@ -122,148 +130,77 @@ export default function TriggersPage() {
         divider
       />
       <SettingsLayouts.Body>
-        <div className="mb-4 flex justify-end">
+        <Tabs
+          value={kindTab}
+          onValueChange={(v) => setKindTab(v as "delta" | "schedule")}
+          variant="contained"
+        >
+          <Tabs.List>
+            <Tabs.Trigger value="delta">Run on Wiki Updates</Tabs.Trigger>
+            <Tabs.Trigger value="schedule">Recurring Schedule</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs>
+        <div className="flex w-full items-center gap-3 px-2 py-3">
+          <div className="flex min-w-[160px] flex-1 items-center gap-1 rounded-(--radius-08) p-[6px] text-[14px] leading-5">
+            <span className="flex size-6 items-center justify-center p-1">
+              <SvgSearch className="size-4 text-(--text-03)" />
+            </span>
+            {/* raw-ok: bare .opal-input-field; the borderless search bar composite has no Opal component */}
+            <input
+              className="opal-input-field min-w-0 flex-1"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search triggers…"
+            />
+          </div>
           <Button
-            icon={SvgPlus}
+            variant="action"
+            rightIcon={SvgPlusCircle}
             onClick={() => {
               setEditing(null);
               setModalOpen(true);
             }}
           >
-            New trigger
+            Add Trigger
           </Button>
         </div>
         {listError && (
-          <div className="mb-3 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+          <div className="mb-3 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
             {listError}
           </div>
         )}
 
-        {triggers.length === 0 && !listError && (
-          <p className="text-sm text-(--text-03)">
-            No triggers yet. Create one to start watching documents for changes.
-          </p>
+        {visible.length === 0 && !listError && (
+          <div className="px-2 py-4">
+            <Text font="main-ui-body" color="text-03">
+              {q
+                ? "No triggers match the search."
+                : kindTab === "delta"
+                  ? "No update triggers yet. Add one to start watching pages for changes."
+                  : "No scheduled triggers yet. Add one to run checks on a recurring schedule."}
+            </Text>
+          </div>
         )}
 
-        <ul className="m-0 list-none p-0">
-          {triggers.map((t) => (
-            <li
+        <div className="flex w-full flex-col gap-2">
+          {visible.map((t) => (
+            <TriggerCard
               key={t.id}
-              className={`mb-[10px] rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-[14px] ${busyId === t.id ? "opacity-60" : "opacity-100"}`}
-            >
-              <div className="mb-[10px] flex flex-wrap items-center justify-between gap-3">
-                <div className="flex min-w-0 flex-wrap items-baseline gap-[10px] font-mono text-xs text-(--text-03)">
-                  <span title={t.scope_path}>
-                    {formatScopePath(t.scope_path)}
-                  </span>
-                  <span className="text-[11px] text-(--text-02)">{t.id}</span>
-                  {t.last_edited_at && (
-                    <span
-                      title={new Date(t.last_edited_at).toLocaleString()}
-                      className="text-[11px] text-(--text-02)"
-                    >
-                      edited {formatRelative(t.last_edited_at)}
-                    </span>
-                  )}
-                </div>
-                <div className="flex shrink-0 flex-wrap items-center gap-1.5">
-                  <span
-                    className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-[2px] text-[11px] font-semibold tracking-[0.3px] ${t.enabled ? "border-(--border-01) bg-(--background-tint-03) text-(--text-05)" : "border-(--border-01) bg-(--background-tint-02) text-(--text-03)"}`}
-                  >
-                    <span
-                      aria-hidden
-                      className={`h-[6px] w-[6px] rounded-full ${t.enabled ? "bg-(--status-text-success-05)" : "bg-(--text-02)"}`}
-                    />
-                    {t.enabled ? "ENABLED" : "DISABLED"}
-                  </span>
-                  <Button
-                    size="sm"
-                    onClick={() => onToggle(t)}
-                    disabled={busyId === t.id}
-                  >
-                    {t.enabled ? "Disable" : "Enable"}
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      setEditing(t);
-                      setModalOpen(true);
-                    }}
-                    disabled={busyId === t.id}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={() => setHistoryFor(t)}
-                    disabled={busyId === t.id}
-                  >
-                    History
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="danger"
-                    onClick={() => onDelete(t)}
-                    disabled={busyId === t.id}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              </div>
-              <div className="text-sm leading-[1.55] text-(--text-05)">
-                {t.kind === "schedule" && (
-                  <div className="mb-[6px] flex items-baseline gap-2">
-                    <span className={sentenceTagCn}>WHEN</span>
-                    <span className="min-w-0 flex-1">
-                      {describeCron(t.schedule_cron, t.schedule_timezone)}
-                      {t.schedule_start_at && (
-                        <>
-                          {" "}
-                          <span className="text-xs text-(--text-03)">
-                            · starting{" "}
-                            {new Date(t.schedule_start_at).toLocaleString()}
-                          </span>
-                        </>
-                      )}
-                      {t.schedule_last_fired_at && (
-                        <>
-                          {" "}
-                          <span className="text-xs text-(--text-02)">
-                            · last checked{" "}
-                            {formatRelative(t.schedule_last_fired_at)}
-                          </span>
-                        </>
-                      )}
-                    </span>
-                  </div>
-                )}
-                <div className="flex items-baseline gap-2">
-                  <span className={sentenceTagCn}>IF</span>
-                  <span className="min-w-0 flex-1">{t.nl_description}</span>
-                </div>
-                {t.actions
-                  .filter((a) => a.message)
-                  .map((a, i) => (
-                    <div
-                      key={`${a.destination_config_id ?? "event_log"}-${a.message}-${i}`}
-                      className="mt-[6px] flex items-baseline gap-2"
-                    >
-                      <span className={sentenceTagCn}>THEN SEND</span>
-                      <span className="min-w-0 flex-1">{a.message}</span>
-                    </div>
-                  ))}
-                <div className="mt-[6px] flex items-baseline gap-2">
-                  <span className={sentenceTagCn}>TO</span>
-                  <span className="min-w-0 flex-1 text-(--text-04)">
-                    {destinationLabel(t)}
-                  </span>
-                </div>
-              </div>
-            </li>
+              trigger={t}
+              fires={firesByTrigger.get(t.id) ?? []}
+              configs={configs}
+              ownerName={user.name || user.email}
+              busy={busyId === t.id}
+              formatRelative={formatRelative}
+              onToggle={() => void onToggle(t)}
+              onEdit={() => {
+                setEditing(t);
+                setModalOpen(true);
+              }}
+              onHistory={() => setHistoryFor(t)}
+            />
           ))}
-        </ul>
-
-        <DestinationsCard />
+        </div>
       </SettingsLayouts.Body>
 
       <TriggerPanel
@@ -316,247 +253,5 @@ export default function TriggersPage() {
         }}
       />
     </SettingsLayouts.Root>
-  );
-}
-
-function DestinationsCard() {
-  const { configs, error, isLoading, refresh } = useDestinationConfigs();
-  const { status: slack, refresh: refreshSlack } = useSlackConnectStatus();
-  const [mode, setMode] = useState<"closed" | "webhook">("closed");
-  const [name, setName] = useState("");
-  const [url, setUrl] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [formError, setFormError] = useState<string | null>(null);
-  const confirmDialog = useConfirm();
-
-  async function addConfig(
-    input: Parameters<typeof createDestinationConfig>[0],
-  ) {
-    setBusy(true);
-    setFormError(null);
-    try {
-      await createDestinationConfig(input);
-      await refresh();
-      setMode("closed");
-      setName("");
-      setUrl("");
-    } catch (e) {
-      setFormError(
-        e instanceof ApiError ? e.message : "failed to add destination",
-      );
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  function onAddWebhook() {
-    if (!name.trim() || !url.trim()) return;
-    void addConfig({ type: "slack", name: name.trim(), secret: url.trim() });
-  }
-
-  async function onDisconnect() {
-    if (
-      !(await confirmDialog({
-        title: "Disconnect Slack?",
-        body: "Channel and DM destinations will stop delivering until you reconnect.",
-        confirmLabel: "Disconnect",
-      }))
-    )
-      return;
-    setFormError(null);
-    try {
-      await disconnectSlack();
-      await refreshSlack();
-    } catch (e) {
-      setFormError(e instanceof ApiError ? e.message : "failed to disconnect");
-    }
-  }
-
-  async function onDelete(id: string, label: string) {
-    if (
-      !(await confirmDialog({
-        title: `Delete "${label}"?`,
-        body: "Triggers pointing at it will stop delivering there.",
-        confirmLabel: "Delete",
-      }))
-    )
-      return;
-    try {
-      await deleteDestinationConfig(id);
-      await refresh();
-    } catch (e) {
-      alert(e instanceof ApiError ? e.message : "failed to delete");
-    }
-  }
-
-  const connected = Boolean(slack?.connected);
-
-  return (
-    <section className="mt-[28px] rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-4">
-      <div className="mb-1 flex items-center justify-between">
-        <h2 className="m-0 text-base">Destinations</h2>
-        <div className="flex gap-2">
-          {mode === "closed" && connected && (
-            <SlackDestinationPicker
-              configs={configs}
-              connected={connected}
-              disabled={busy}
-              onPick={async () => {
-                setFormError(null);
-                await refresh();
-              }}
-              onError={setFormError}
-            >
-              <Button size="sm" disabled={busy}>
-                + Slack
-              </Button>
-            </SlackDestinationPicker>
-          )}
-          {mode === "closed" && (
-            <Button
-              size="sm"
-              disabled={busy}
-              onClick={() => setMode("webhook")}
-            >
-              + Webhook
-            </Button>
-          )}
-        </div>
-      </div>
-      <p className="mt-0 mb-3 text-[13px] text-(--text-03)">
-        Delivery targets you can point a trigger at. Private to you.
-      </p>
-
-      {slack?.configured && (
-        <div className="mb-3 flex items-center justify-between rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) px-[14px] py-3">
-          {connected ? (
-            <>
-              <div>
-                <div className="text-[13px]">
-                  Connected to <strong>{slack?.team_name ?? "Slack"}</strong>
-                </div>
-                {slack?.token_display && (
-                  <div className="mt-[2px] font-mono text-xs text-(--text-03)">
-                    {slack.token_display}
-                  </div>
-                )}
-              </div>
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() => void onDisconnect()}
-              >
-                Disconnect
-              </Button>
-            </>
-          ) : (
-            <>
-              <div className="text-[13px]">
-                Connect Slack to deliver to channels or DMs as the Agent Wiki
-                bot.
-              </div>
-              <Button
-                size="sm"
-                variant="action"
-                onClick={() => {
-                  if (!slack?.connect_url) return;
-                  const target = new URL(slack.connect_url);
-                  target.searchParams.set("return_to", "/app/triggers");
-                  window.location.href = target.toString();
-                }}
-              >
-                Connect Slack
-              </Button>
-            </>
-          )}
-        </div>
-      )}
-
-      {error && (
-        <div className="mb-2 text-[13px] text-(--status-text-error-05)">
-          {error.message || "Failed to load destinations."}
-        </div>
-      )}
-
-      {mode === "webhook" && (
-        <div className="mb-3 flex flex-col gap-2 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) p-3">
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Name (e.g. PM Standup)"
-            disabled={busy}
-            maxLength={80}
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
-          />
-          <input
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            placeholder="https://hooks.slack.com/services/…"
-            disabled={busy}
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
-          />
-          {formError && (
-            <div className="text-[13px] text-(--status-text-error-05)">
-              {formError}
-            </div>
-          )}
-          <div className="flex gap-2">
-            <Button
-              size="sm"
-              variant="action"
-              disabled={busy || !name.trim() || !url.trim()}
-              onClick={onAddWebhook}
-            >
-              {busy ? "Adding…" : "Add"}
-            </Button>
-            <Button size="sm" disabled={busy} onClick={() => setMode("closed")}>
-              Cancel
-            </Button>
-          </div>
-        </div>
-      )}
-
-      {formError && mode === "closed" && (
-        <div className="mb-2 text-[13px] text-(--status-text-error-05)">
-          {formError}
-        </div>
-      )}
-
-      {isLoading && configs.length === 0 && !error && <LoadingSpinner />}
-
-      {!isLoading && configs.length === 0 && mode === "closed" && (
-        <p className="m-0 text-sm text-(--text-03)">
-          No destinations yet &mdash; add one to deliver trigger fires to Slack.
-        </p>
-      )}
-
-      {configs.length > 0 && (
-        <ul className="m-0 list-none p-0">
-          {configs.map((c) => (
-            <li
-              key={c.id}
-              className="mt-2 flex items-center gap-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-(--text-05)">
-                  {c.name}
-                </div>
-                <div className="mt-[2px] font-mono text-xs text-(--text-03)">
-                  {c.type}
-                  {c.has_secret ? " · webhook" : " · bot"}
-                </div>
-              </div>
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() => void onDelete(c.id, c.name)}
-              >
-                Delete
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-    </section>
   );
 }

--- a/frontend/src/views/triggers/TriggersPage.tsx
+++ b/frontend/src/views/triggers/TriggersPage.tsx
@@ -95,7 +95,7 @@ export default function TriggersPage() {
     }
   }
 
-  async function onDelete(t: Trigger) {
+  async function onDelete(t: Trigger): Promise<boolean> {
     if (
       !(await confirmDialog({
         title: "Delete this trigger?",
@@ -103,7 +103,7 @@ export default function TriggersPage() {
         confirmLabel: "Delete",
       }))
     )
-      return;
+      return false;
     setBusyId(t.id);
     setMutationError(null);
     try {
@@ -114,8 +114,10 @@ export default function TriggersPage() {
         }),
         { revalidate: true },
       );
+      return true;
     } catch (e) {
       setMutationError(e instanceof Error ? e.message : "delete failed");
+      return false;
     } finally {
       setBusyId(null);
     }
@@ -206,6 +208,16 @@ export default function TriggersPage() {
       <TriggerPanel
         open={modalOpen}
         initial={editing ?? undefined}
+        onDelete={
+          editing
+            ? async () => {
+                if (await onDelete(editing)) {
+                  setModalOpen(false);
+                  setEditing(null);
+                }
+              }
+            : undefined
+        }
         onClose={() => {
           setModalOpen(false);
           setEditing(null);


### PR DESCRIPTION
## Description

Rebuilds the Triggers page as the mock's card feed (Figma node `36:19460`). Contained tabs split update triggers from scheduled ones, a borderless search bar filters cards, and Add Trigger opens the New Trigger side panel. Each trigger is a card: scope chip, owner and destination avatar cluster, quiet info/gear controls (history modal and edit panel) with an enable Switch, and recent fire lines from the fires API. Fire messages expand per row via the chevron, rendered as inline markdown. A trigger that has never fired shows the IF/Then summary with a "No runs yet" badge. Disabled triggers render on the tint-01 shell with the switch off.

The fire view gains `destination_config_id` so each line names the exact config it delivered to (type-matching could name the wrong address when several configs share a type). The Destinations card leaves the page per the mocks; connector management lands on the Settings Connectors page in the next PR.

## How Has This Been Tested?

New field covered in `test_triggers_fires_api.py` (6 green). Verified live in Chrome against real triggers: tab switching, fire lines with correct per-config addressing, chevron expansion, disabled rendering, search, and Add Trigger opening the panel.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check