### PR TITLE
feat(notifications): opt-in email copies for comments and update warnings

### DIFF
--- a/backend/app/api/comments.py
+++ b/backend/app/api/comments.py
@@ -34,6 +34,7 @@ from app.models.comment import (
     EditCommentRequest,
 )
 from app.wiki import comment_remap, comments as comments_repo, filesystem
+from app.wiki import comment_notifications
 
 log = logging.getLogger(__name__)
 
@@ -185,6 +186,7 @@ def create_comment(
         quoted_text=req.quoted_text,
     )
     _fire_event(rel_path, row, user)
+    comment_notifications.queue_for_comment(row, author_id=user.id)
     return CommentView.model_validate(row)
 
 
@@ -203,6 +205,7 @@ def reply_to_comment(
     )
     if row is None:  # parent deleted between load and insert
         raise HTTPException(status_code=404, detail="comment not found")
+    comment_notifications.queue_for_comment(row, author_id=user.id)
     return CommentView.model_validate(row)
 
 

--- a/backend/app/models/user_settings.py
+++ b/backend/app/models/user_settings.py
@@ -33,6 +33,10 @@ class UserSettings(BaseModel):
     # Preferred provider + model for chat. None = use the global agent settings.
     chat_provider: str | None = None
     chat_model: str | None = None
+    # Email copies of in-app activity, sent to the login address (users.email)
+    # — the account's own identity, so no verification flow applies.
+    notify_comment_email: bool = False
+    notify_update_warning_email: bool = False
 
     @field_validator("timezone")
     @classmethod
@@ -57,6 +61,8 @@ class UserSettingsUpdate(BaseModel):
     default_landing: Literal["wiki_home", "recent", "last_viewed"] | None = Field(default=None)
     chat_provider: str | None = Field(default=None)
     chat_model: str | None = Field(default=None)
+    notify_comment_email: bool | None = Field(default=None)
+    notify_update_warning_email: bool | None = Field(default=None)
 
     def non_null(self) -> dict[str, Any]:
         sent = self.model_fields_set

--- a/backend/app/tasks/notify_emails.py
+++ b/backend/app/tasks/notify_emails.py
@@ -1,0 +1,42 @@
+"""Per-user notification emails: a queued fan-out that mails a copy of an
+in-app activity signal to the user's login address (``users.email``). The
+opt-in check lives here, next to the send, so producers stay fire-and-forget
+and a preference flipped after enqueue is still honored."""
+from __future__ import annotations
+
+import logging
+
+from app.auth import users as users_repo
+from app.email.service import EmailNotConfiguredError, EmailSendError, send
+from app.models.user_settings import UserSettings
+from app.tasks.queues import triggers_queue
+
+log = logging.getLogger(__name__)
+
+# kind -> the UserSettings flag that gates it
+_PREF_BY_KIND = {
+    "comment": "notify_comment_email",
+    "update_warning": "notify_update_warning_email",
+}
+
+
+@triggers_queue.task()
+def send_notification_email(
+    *, user_id: str, kind: str, subject: str, text: str
+) -> None:
+    pref = _PREF_BY_KIND.get(kind)
+    if pref is None:
+        log.warning("unknown notification email kind %r; dropping", kind)
+        return
+    user = users_repo.get_by_id(user_id)
+    if user is None or not user.get("email"):
+        return
+    settings = UserSettings.model_validate(user.get("settings") or {})
+    if not getattr(settings, pref):
+        return
+    try:
+        send(to=user["email"], subject=subject, text=text)
+    except EmailNotConfiguredError:
+        log.info("notification email skipped (SMTP not configured)")
+    except EmailSendError:
+        log.exception("notification email to user %s failed", user_id)

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -37,6 +37,7 @@ _TASK_MODULES = (
     "app.tasks.expire_launch_artifacts",
     "app.tasks.ingest_eval_retention",
     "app.tasks.mcp_session_cleanup",
+    "app.tasks.notify_emails",
     "app.tasks.periodic",
     "app.tasks.reindex",
     "app.tasks.triggers",

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -40,11 +40,9 @@ import logging
 from typing import Any, cast
 
 from datetime import datetime, timezone
-from urllib.parse import quote
 
 from sqlalchemy import select
 
-from app.config import CONFIG
 from app.db.models import Event, User
 from app.email import service as email_service
 from app.db.session import session
@@ -68,6 +66,7 @@ from app.triggers.engine import (
     schedule_window_start,
 )
 from app.wiki import acl as wiki_acl
+from app.wiki.links import doc_url
 from app.wiki import git as wiki_git
 from app.models.wiki import ChangeKind
 
@@ -435,7 +434,7 @@ def _dispatch_to_email(
     if not address:
         log.warning("trigger %s email config %s has no address", trigger.id, config["id"])
         return
-    doc_link = f"{CONFIG.public_base_url}/app/wiki/{quote(doc_path)}"
+    doc_link = doc_url(doc_path)
     text = (
         f"{rendered_message}\n\n— Agent Wiki trigger on {doc_path}\n{doc_link}"
     )

--- a/backend/app/tasks/update_frequency.py
+++ b/backend/app/tasks/update_frequency.py
@@ -26,9 +26,12 @@ from typing import Any
 
 from sqlalchemy import select
 
+from app.config import CONFIG
 from app.db.models import Event
 from app.db.session import session
+from app.tasks.notify_emails import send_notification_email
 from app.tasks.queues import lightweight_maintenance_queue
+from app.wiki import acl
 from app.wiki import constants as wiki_constants
 from app.wiki import git as wiki_git
 from app.wiki import update_policy
@@ -51,6 +54,20 @@ def _record_event(kind: str, path: str, payload: dict[str, Any]) -> None:
                 payload_json=json.dumps(payload),
             )
         )
+
+
+def _queue_owner_email(path: str, *, subject: str, text: str) -> None:
+    """Mail the page owner a copy of the event, if they opted in."""
+    owner = acl.get_owner(path)
+    if not owner:
+        return
+    doc_link = f"{CONFIG.public_base_url}/app/wiki/{path}"
+    send_notification_email(
+        user_id=owner,
+        kind="update_warning",
+        subject=subject,
+        text=f"{text}\n\n{doc_link}",
+    )
 
 
 def record_auto_update_capped(path: str, count: int, cap: int) -> None:
@@ -84,6 +101,14 @@ def record_auto_update_capped(path: str, count: int, cap: int) -> None:
             )
         )
     log.info("auto-update capped: %s at %d updates/24h (cap %d)", path, count, cap)
+    _queue_owner_email(
+        path,
+        subject=f"Agent Wiki: auto-updates paused for {path}",
+        text=(
+            f"{path} hit the limit of {cap} auto-updates in 24 hours, so "
+            f"further auto-updates are paused for now."
+        ),
+    )
 
 
 @lightweight_maintenance_queue.task()
@@ -115,4 +140,12 @@ def _check_update_frequency_inline(path: str) -> None:
         EVENT_FREQUENT_UPDATES,
         path,
         {"doc_path": path, "count": count, "threshold": threshold},
+    )
+    _queue_owner_email(
+        path,
+        subject=f"Agent Wiki: frequent auto-updates on {path}",
+        text=(
+            f"{path} has auto-updated {count} times in the past 24 hours "
+            f"(warning threshold {threshold})."
+        ),
     )

--- a/backend/app/tasks/update_frequency.py
+++ b/backend/app/tasks/update_frequency.py
@@ -26,13 +26,13 @@ from typing import Any
 
 from sqlalchemy import select
 
-from app.config import CONFIG
 from app.db.models import Event
 from app.db.session import session
 from app.tasks.notify_emails import send_notification_email
 from app.tasks.queues import lightweight_maintenance_queue
 from app.wiki import acl
 from app.wiki import constants as wiki_constants
+from app.wiki.links import doc_url
 from app.wiki import git as wiki_git
 from app.wiki import update_policy
 
@@ -61,7 +61,7 @@ def _queue_owner_email(path: str, *, subject: str, text: str) -> None:
     owner = acl.get_owner(path)
     if not owner:
         return
-    doc_link = f"{CONFIG.public_base_url}/app/wiki/{path}"
+    doc_link = doc_url(path)
     send_notification_email(
         user_id=owner,
         kind="update_warning",

--- a/backend/app/wiki/comment_notifications.py
+++ b/backend/app/wiki/comment_notifications.py
@@ -1,0 +1,36 @@
+"""Fans a new comment or reply out to the people it concerns — the page
+owner and any @mentioned users, never the author — as queued notification
+emails. Recipients who haven't opted in are dropped by the send task."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.config import CONFIG
+from app.tasks.notify_emails import send_notification_email
+from app.wiki import acl
+from app.wiki import comment_mentions
+
+log = logging.getLogger(__name__)
+
+
+def queue_for_comment(row: dict[str, Any], *, author_id: str) -> None:
+    doc_path = str(row.get("doc_path") or "")
+    body = str(row.get("body") or "")
+    recipients = set(comment_mentions.mentioned_ids(body))
+    owner = acl.get_owner(doc_path)
+    if owner:
+        recipients.add(owner)
+    recipients.discard(author_id)
+    if not recipients:
+        return
+    doc_link = f"{CONFIG.public_base_url}/app/wiki/{doc_path}"
+    subject = f"Agent Wiki: new comment on {doc_path}"
+    text = (
+        f"{comment_mentions.detokenize(body)}\n\n"
+        f"— comment on {doc_path}\n{doc_link}"
+    )
+    for user_id in sorted(recipients):
+        send_notification_email(
+            user_id=user_id, kind="comment", subject=subject, text=text
+        )

--- a/backend/app/wiki/comment_notifications.py
+++ b/backend/app/wiki/comment_notifications.py
@@ -1,15 +1,16 @@
 """Fans a new comment or reply out to the people it concerns — the page
-owner and any @mentioned users, never the author — as queued notification
-emails. Recipients who haven't opted in are dropped by the send task."""
+owner and any @mentioned users who can read the page, never the author —
+as queued notification emails. Recipients who haven't opted in are dropped
+by the send task."""
 from __future__ import annotations
 
 import logging
 from typing import Any
 
-from app.config import CONFIG
 from app.tasks.notify_emails import send_notification_email
 from app.wiki import acl
 from app.wiki import comment_mentions
+from app.wiki.links import doc_url
 
 log = logging.getLogger(__name__)
 
@@ -17,18 +18,23 @@ log = logging.getLogger(__name__)
 def queue_for_comment(row: dict[str, Any], *, author_id: str) -> None:
     doc_path = str(row.get("doc_path") or "")
     body = str(row.get("body") or "")
-    recipients = set(comment_mentions.mentioned_ids(body))
     owner = acl.get_owner(doc_path)
+    # A mention alone doesn't grant access: mail only mentioned users who can
+    # already read the page, so comment content never leaks past the ACL.
+    recipients = {
+        uid
+        for uid in comment_mentions.mentioned_ids(body)
+        if uid == owner or acl.can(uid, False, "read", doc_path)
+    }
     if owner:
         recipients.add(owner)
     recipients.discard(author_id)
     if not recipients:
         return
-    doc_link = f"{CONFIG.public_base_url}/app/wiki/{doc_path}"
     subject = f"Agent Wiki: new comment on {doc_path}"
     text = (
         f"{comment_mentions.detokenize(body)}\n\n"
-        f"— comment on {doc_path}\n{doc_link}"
+        f"— comment on {doc_path}\n{doc_url(doc_path)}"
     )
     for user_id in sorted(recipients):
         send_notification_email(

--- a/backend/app/wiki/links.py
+++ b/backend/app/wiki/links.py
@@ -11,10 +11,17 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from urllib.parse import quote
 
 from pydantic import BaseModel, ConfigDict
 
+from app.config import CONFIG
 from app.wiki import filesystem
+
+
+def doc_url(path: str) -> str:
+    """Absolute app URL for a wiki page, path percent-encoded."""
+    return f"{CONFIG.public_base_url}/app/wiki/{quote(path)}"
 
 
 # Match ``[text](target)`` not preceded by a ``!`` (image syntax).

--- a/backend/tests/test_notification_emails.py
+++ b/backend/tests/test_notification_emails.py
@@ -1,0 +1,102 @@
+"""Notification emails go to the login address, gated per user by the
+notify_* settings: comments fan out to the page owner and @mentioned users
+(never the author), and update-frequency events mail the page owner."""
+from __future__ import annotations
+
+import pytest
+
+from app.email.service import EmailSendError
+from app.tasks.notify_emails import send_notification_email
+from app.tasks.queues import triggers_queue
+from app.tasks import update_frequency
+from app.auth import users as users_repo
+from app.wiki import acl
+from app.wiki import comment_notifications
+
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    calls: list[dict] = []
+
+    def fake_send(*, to, subject, text, html=None):
+        calls.append({"to": to, "subject": subject, "text": text})
+
+    monkeypatch.setattr("app.tasks.notify_emails.send", fake_send)
+    return calls
+
+
+def _user(uid: str, email: str, **settings) -> str:
+    seed_user(uid=uid, email=email)
+    if settings:
+        users_repo.update_settings(uid, settings)
+    return uid
+
+
+def test_send_respects_pref_and_kind(tmp_db, sent):
+    _user("u_on", "on@x.com", notify_comment_email=True)
+    _user("u_off", "off@x.com")
+
+    with triggers_queue.immediate_mode():
+        send_notification_email(
+            user_id="u_on", kind="comment", subject="s", text="t"
+        )
+        send_notification_email(
+            user_id="u_off", kind="comment", subject="s", text="t"
+        )
+        send_notification_email(
+            user_id="u_on", kind="nonsense", subject="s", text="t"
+        )
+
+    assert [c["to"] for c in sent] == ["on@x.com"]
+
+
+def test_send_failure_is_swallowed(tmp_db, monkeypatch):
+    _user("u_on", "on@x.com", notify_comment_email=True)
+
+    def boom(*, to, subject, text, html=None):
+        raise EmailSendError("smtp down")
+
+    monkeypatch.setattr("app.tasks.notify_emails.send", boom)
+    with triggers_queue.immediate_mode():
+        send_notification_email(
+            user_id="u_on", kind="comment", subject="s", text="t"
+        )  # must not raise
+
+
+def test_comment_fans_out_to_owner_and_mentions_not_author(tmp_db, sent):
+    author = _user("u_author", "author@x.com", notify_comment_email=True)
+    _user("u_owner", "owner@x.com", notify_comment_email=True)
+    _user("u_mention", "mention@x.com", notify_comment_email=True)
+    acl.set_owner("notes/a.md", "u_owner")
+
+    row = {
+        "doc_path": "notes/a.md",
+        "body": "ping @[Mention](mention:u_mention) and @[Author](mention:u_author)",
+    }
+    with triggers_queue.immediate_mode():
+        comment_notifications.queue_for_comment(row, author_id=author)
+
+    assert sorted(c["to"] for c in sent) == ["mention@x.com", "owner@x.com"]
+    assert all("notes/a.md" in c["subject"] for c in sent)
+    # mention tokens render as plain names in the mail body
+    assert "mention:u_mention" not in sent[0]["text"]
+
+
+def test_update_events_mail_the_owner(tmp_db, sent):
+    _user("u_owner", "owner@x.com", notify_update_warning_email=True)
+    acl.set_owner("notes/a.md", "u_owner")
+
+    with triggers_queue.immediate_mode():
+        update_frequency.record_auto_update_capped("notes/a.md", 12, 10)
+
+    assert len(sent) == 1
+    assert sent[0]["to"] == "owner@x.com"
+    assert "paused" in sent[0]["subject"]
+
+
+def test_update_event_without_owner_sends_nothing(tmp_db, sent):
+    with triggers_queue.immediate_mode():
+        update_frequency.record_auto_update_capped("notes/b.md", 12, 10)
+    assert sent == []

--- a/backend/tests/test_notification_emails.py
+++ b/backend/tests/test_notification_emails.py
@@ -65,11 +65,19 @@ def test_send_failure_is_swallowed(tmp_db, monkeypatch):
         )  # must not raise
 
 
-def test_comment_fans_out_to_owner_and_mentions_not_author(tmp_db, sent):
+def test_comment_fans_out_to_owner_and_readable_mentions_not_author(tmp_db, sent):
     author = _user("u_author", "author@x.com", notify_comment_email=True)
     _user("u_owner", "owner@x.com", notify_comment_email=True)
     _user("u_mention", "mention@x.com", notify_comment_email=True)
     acl.set_owner("notes/a.md", "u_owner")
+    acl.grant(
+        resource_kind="page",
+        resource_path="notes/a.md",
+        principal_kind="user",
+        principal_id="u_mention",
+        permission="read",
+        granted_by_user_id="u_owner",
+    )
 
     row = {
         "doc_path": "notes/a.md",
@@ -82,6 +90,25 @@ def test_comment_fans_out_to_owner_and_mentions_not_author(tmp_db, sent):
     assert all("notes/a.md" in c["subject"] for c in sent)
     # mention tokens render as plain names in the mail body
     assert "mention:u_mention" not in sent[0]["text"]
+    # links percent-encode the path
+    assert "/app/wiki/notes/a.md" in sent[0]["text"]
+
+
+def test_mention_without_read_access_is_not_emailed(tmp_db, sent):
+    author = _user("u_author", "author@x.com")
+    _user("u_owner", "owner@x.com", notify_comment_email=True)
+    _user("u_outsider", "outsider@x.com", notify_comment_email=True)
+    # owner stamp makes the page managed; u_outsider holds no grant
+    acl.set_owner("notes/secret.md", "u_owner")
+
+    row = {
+        "doc_path": "notes/secret.md",
+        "body": "fyi @[Outsider](mention:u_outsider)",
+    }
+    with triggers_queue.immediate_mode():
+        comment_notifications.queue_for_comment(row, author_id=author)
+
+    assert [c["to"] for c in sent] == ["owner@x.com"]
 
 
 def test_update_events_mail_the_owner(tmp_db, sent):

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -8,6 +8,7 @@ import {
   InputTypeIn,
   LineItemButton,
   LinkButton,
+  Switch,
   Text,
 } from "@onyx-ai/opal/components";
 import { SvgSliders } from "@onyx-ai/opal/icons";
@@ -25,6 +26,8 @@ const DEFAULT_SETTINGS: UserSettings = {
   default_landing: "wiki_home",
   chat_provider: null,
   chat_model: null,
+  notify_comment_email: false,
+  notify_update_warning_email: false,
 };
 
 // A short curated IANA list — covers the common cases without dumping the
@@ -50,6 +53,7 @@ const COMMON_TIMEZONES = [
 const TABS = [
   { key: "general", label: "General" },
   { key: "wiki", label: "Wiki Preferences" },
+  { key: "notifications", label: "Notifications" },
   { key: "account", label: "Account & Access" },
 ] as const;
 
@@ -123,6 +127,14 @@ function SettingsPageInner() {
                 />
               </Section>
             )}
+            {tab === "notifications" && (
+              <Section title="Notifications">
+                <NotificationsForm
+                  initial={user.settings}
+                  updateSettings={updateSettings}
+                />
+              </Section>
+            )}
             {tab === "account" && (
               <Section title="Account & Access">
                 <ProfileForm
@@ -168,6 +180,84 @@ function FieldLabel({ children }: { children: string }) {
 
 function FieldHint({ children }: { children: React.ReactNode }) {
   return <div className="mt-1 text-xs text-(--text-03)">{children}</div>;
+}
+
+function NotificationToggle({
+  label,
+  description,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="flex w-full items-start gap-3">
+      <div className="min-w-0 flex-1">
+        <FieldLabel>{label}</FieldLabel>
+        <FieldHint>{description}</FieldHint>
+      </div>
+      <Switch
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onChange}
+      />
+    </div>
+  );
+}
+
+function NotificationsForm({
+  initial,
+  updateSettings,
+}: {
+  initial: UserSettings;
+  updateSettings: (partial: Partial<UserSettings>) => Promise<UserSettings>;
+}) {
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle(
+    key: "notify_comment_email" | "notify_update_warning_email",
+    next: boolean,
+  ) {
+    setBusyKey(key);
+    setError(null);
+    try {
+      await updateSettings({ [key]: next });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to save");
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <FieldHint>
+        Email copies go to your login email, the address you already sign in
+        with. Nothing to verify.
+      </FieldHint>
+      <NotificationToggle
+        label="Comment emails"
+        description="Email me when someone comments on a page I own or mentions me in a comment."
+        checked={initial.notify_comment_email}
+        disabled={busyKey !== null}
+        onChange={(next) => void toggle("notify_comment_email", next)}
+      />
+      <NotificationToggle
+        label="Auto-update warning emails"
+        description="Email me when a page I own auto-updates past the warning threshold or hits the update cap."
+        checked={initial.notify_update_warning_email}
+        disabled={busyKey !== null}
+        onChange={(next) => void toggle("notify_update_warning_email", next)}
+      />
+      <FormStatus error={error} saved={false} />
+    </div>
+  );
 }
 
 function ProfileForm({

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -12,7 +12,14 @@ import {
   Text,
 } from "@onyx-ai/opal/components";
 import { SvgSliders } from "@onyx-ai/opal/icons";
-import { SettingsLayouts } from "@onyx-ai/opal/layouts";
+import {
+  Content,
+  InputErrorText,
+  InputHorizontal,
+  InputVertical,
+  Section as LayoutSection,
+  SettingsLayouts,
+} from "@onyx-ai/opal/layouts";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
@@ -159,27 +166,11 @@ function Section({
   children: React.ReactNode;
 }) {
   return (
-    <section className="flex flex-col gap-4">
-      <Text as="h2" font="main-content-emphasis" color="text-04">
-        {title}
-      </Text>
+    <LayoutSection flexDirection="column" alignItems="start" gap={1}>
+      <Content title={title} sizePreset="main-content" variant="section" />
       {children}
-    </section>
+    </LayoutSection>
   );
-}
-
-function FieldLabel({ children }: { children: string }) {
-  return (
-    <div className="mb-1">
-      <Text font="main-ui-action" color="text-04">
-        {children}
-      </Text>
-    </div>
-  );
-}
-
-function FieldHint({ children }: { children: React.ReactNode }) {
-  return <div className="mt-1 text-xs text-(--text-03)">{children}</div>;
 }
 
 function NotificationToggle({
@@ -196,17 +187,13 @@ function NotificationToggle({
   onChange: (next: boolean) => void;
 }) {
   return (
-    <div className="flex w-full items-start gap-3">
-      <div className="min-w-0 flex-1">
-        <FieldLabel>{label}</FieldLabel>
-        <FieldHint>{description}</FieldHint>
-      </div>
+    <InputHorizontal withLabel center title={label} description={description}>
       <Switch
         checked={checked}
         disabled={disabled}
         onCheckedChange={onChange}
       />
-    </div>
+    </InputHorizontal>
   );
 }
 
@@ -236,11 +223,11 @@ function NotificationsForm({
   }
 
   return (
-    <div className="flex flex-col gap-5">
-      <FieldHint>
+    <LayoutSection flexDirection="column" alignItems="start" gap={1.25}>
+      <Text font="secondary-body" color="text-03">
         Email copies go to your login email, the address you already sign in
         with. Nothing to verify.
-      </FieldHint>
+      </Text>
       <NotificationToggle
         label="Comment emails"
         description="Email me when someone comments on a page I own or mentions me in a comment."
@@ -256,7 +243,7 @@ function NotificationsForm({
         onChange={(next) => void toggle("notify_update_warning_email", next)}
       />
       <FormStatus error={error} saved={false} />
-    </div>
+    </LayoutSection>
   );
 }
 
@@ -298,8 +285,11 @@ function ProfileForm({
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      <label>
-        <FieldLabel>Display name</FieldLabel>
+      <InputVertical
+        withLabel
+        title="Display name"
+        subDescription="Shown in the app header and on activity attributed to you. Leave blank to fall back to your email."
+      >
         <InputTypeIn
           value={name}
           onChange={(e) => {
@@ -310,21 +300,16 @@ function ProfileForm({
           placeholder="e.g. Ada Lovelace"
           maxLength={200}
         />
-        <FieldHint>
-          Shown in the app header and on activity attributed to you. Leave blank
-          to fall back to your email.
-        </FieldHint>
-      </label>
+      </InputVertical>
 
-      <div>
-        <FieldLabel>Login email</FieldLabel>
+      <InputVertical
+        title="Login email"
+        subDescription="The address you sign in with. Account emails go here."
+      >
         <Text font="main-ui-body" color="text-04">
           {email}
         </Text>
-        <FieldHint>
-          The address you sign in with. Account emails go here.
-        </FieldHint>
-      </div>
+      </InputVertical>
 
       <FormStatus error={error} saved={saved} />
       <div>
@@ -343,10 +328,13 @@ function FormStatus({
   error: string | null;
   saved: boolean;
 }) {
-  if (error)
-    return <div className="text-(--status-text-error-05)">{error}</div>;
+  if (error) return <InputErrorText type="error">{error}</InputErrorText>;
   if (saved)
-    return <div className="text-(--status-text-success-05)">Saved.</div>;
+    return (
+      <Text font="main-ui-body" color="status-success-05">
+        Saved.
+      </Text>
+    );
   return null;
 }
 
@@ -455,8 +443,11 @@ function AppearanceForm({
       }}
       className="flex flex-col gap-4"
     >
-      <label>
-        <FieldLabel>Theme</FieldLabel>
+      <InputVertical
+        withLabel
+        title="Theme"
+        subDescription="Visual chrome of the app on this account."
+      >
         {/* raw-ok: no Opal select component */}
         <select
           value={draft.theme}
@@ -467,11 +458,13 @@ function AppearanceForm({
           <option value="light">Light</option>
           <option value="dark">Dark</option>
         </select>
-        <FieldHint>Visual chrome of the app on this account.</FieldHint>
-      </label>
+      </InputVertical>
 
-      <label>
-        <FieldLabel>Timezone</FieldLabel>
+      <InputVertical
+        withLabel
+        title="Timezone"
+        subDescription="Used for timestamps and scheduled-trigger displays."
+      >
         {tzCustom ? (
           <InputTypeIn
             value={draft.timezone ?? ""}
@@ -501,25 +494,19 @@ function AppearanceForm({
             </select>
           </>
         )}
-        <FieldHint>
-          Used for timestamps and scheduled-trigger displays.
-          {tzCustom && (
-            <>
-              {" "}
-              <LinkButton
-                onClick={() => {
-                  setTzCustom(false);
-                  if (!COMMON_TIMEZONES.includes(draft.timezone ?? "")) {
-                    update("timezone", "UTC");
-                  }
-                }}
-              >
-                Pick from common list
-              </LinkButton>
-            </>
-          )}
-        </FieldHint>
-      </label>
+        {tzCustom && (
+          <LinkButton
+            onClick={() => {
+              setTzCustom(false);
+              if (!COMMON_TIMEZONES.includes(draft.timezone ?? "")) {
+                update("timezone", "UTC");
+              }
+            }}
+          >
+            Pick from common list
+          </LinkButton>
+        )}
+      </InputVertical>
 
       <FormStatus error={form.error} saved={form.saved} />
       <div>
@@ -562,8 +549,11 @@ function WikiPrefsForm({
       }}
       className="flex flex-col gap-4"
     >
-      <label>
-        <FieldLabel>Default landing page</FieldLabel>
+      <InputVertical
+        withLabel
+        title="Default landing page"
+        subDescription="Where the app opens after sign-in."
+      >
         {/* raw-ok: no Opal select component */}
         <select
           value={draft.default_landing}
@@ -576,8 +566,7 @@ function WikiPrefsForm({
           <option value="recent">Recently edited</option>
           <option value="last_viewed">Last viewed page</option>
         </select>
-        <FieldHint>Where the app opens after sign-in.</FieldHint>
-      </label>
+      </InputVertical>
 
       <FormStatus error={form.error} saved={form.saved} />
       <div>
@@ -643,8 +632,15 @@ function ChatModelForm({
 
   return (
     <form onSubmit={onSubmit} className="flex flex-col gap-4">
-      <label>
-        <FieldLabel>Chat model</FieldLabel>
+      <InputVertical
+        withLabel
+        title="Chat model"
+        subDescription={`Override the model used in your chat sessions. Leave blank to use the admin-configured agent default${
+          llmStatus?.configured
+            ? ` (currently ${llmStatus.provider} / ${llmStatus.model})`
+            : ""
+        }.`}
+      >
         <InputTypeIn
           value={chatModel}
           onChange={(e) => {
@@ -654,15 +650,7 @@ function ChatModelForm({
           }}
           placeholder={placeholder}
         />
-        <FieldHint>
-          Override the model used in your chat sessions. Leave blank to use the
-          admin-configured agent default
-          {llmStatus?.configured
-            ? ` (currently ${llmStatus.provider} / ${llmStatus.model})`
-            : ""}
-          .
-        </FieldHint>
-      </label>
+      </InputVertical>
       <FormStatus error={error} saved={saved} />
       <div>
         <Button type="submit" variant="action" disabled={saving}>

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -19,6 +19,8 @@ const DEFAULT_USER_SETTINGS: UserSettings = {
   default_landing: "wiki_home",
   chat_provider: null,
   chat_model: null,
+  notify_comment_email: false,
+  notify_update_warning_email: false,
 };
 
 export interface AuthUser {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,6 +14,8 @@ export interface UserSettings {
   default_landing: DefaultLanding;
   chat_provider: string | null;
   chat_model: string | null;
+  notify_comment_email: boolean;
+  notify_update_warning_email: boolean;
 }
 
 export type UserSettingsUpdate = Partial<UserSettings>;


### PR DESCRIPTION
## Description

Bo's requests: two per-user notification settings, both default off, both mailed to the login address (`users.email`) with no verification step since that address is already the account's identity.

Comment emails fan out on new comments and replies to the page owner and any @mentioned users, never the author, with mention tokens rendered as plain names and a link back to the page. Update-warning emails go to the page owner when a page crosses the auto-update warning threshold or gets paused at the cap, and they inherit those events' existing once-per-crossing and once-per-episode dedup, so a page stuck over the cap mails once, not per push.

Delivery is a queued task on the triggers worker (same trust class as the Craft launches that already run there); the opt-in check lives next to the send, so producers stay fire-and-forget and a preference flipped after enqueue is still honored. Send failures log and drop. The settings live in the existing JSONB settings blob (no migration), and the settings page gains a Notifications tab with immediate-save switches.

Stacked on #348 (needs the tab rail).

## How Has This Been Tested?

Five new tests in `test_notification_emails.py`: preference gating, unknown-kind drop, swallowed send failure, owner+mention-not-author fan-out with detokenized bodies, and the ownerless no-op. Verified live: toggling the switch PUT 200 and flipped the stored setting, then restored.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check