### PR TITLE
fix(coedit): checkpoint no-ops on a closed session (dedupe queued duplicates)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -99,7 +99,7 @@ def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bo
 
 def _require_active(session_id: int, user: User, action: str) -> coedit.SessionRow:
     sess = coedit.get_session(session_id)
-    if sess is None or sess.status != "active":
+    if sess is None or sess.status != coedit.SessionStatus.ACTIVE.value:
         raise HTTPException(status_code=404, detail="no active session")
     require_can(action, sess.path, user)
     return sess
@@ -220,7 +220,7 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
     ``leave`` once the user's last connection for the session closes.
     """
     sess = coedit.get_session(session_id)
-    if sess is None or sess.status != "active":
+    if sess is None or sess.status != coedit.SessionStatus.ACTIVE.value:
         raise HTTPException(status_code=404, detail="no active session")
     # Opening the stream makes the user a session participant (roster +
     # heartbeat + commit attribution), so it requires write — symmetric with

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -49,6 +50,16 @@ def _iso(ts: datetime) -> str:
 # --------------------------------------------------------------------------- #
 # Row shapes                                                                  #
 # --------------------------------------------------------------------------- #
+
+
+class SessionStatus(str, Enum):
+    """Lifecycle state of a co-edit session. Single source of truth for the
+    valid `coedit_sessions.status` values; the DB CHECK constraint in
+    `app/db/models.py` mirrors these (`str, Enum` so members serialize as their
+    string value, matching the `CommentStatus` pattern in `app/models/comment.py`)."""
+
+    ACTIVE = "active"  # accepting ops; exactly one per path (partial unique index)
+    CLOSED = "closed"  # finalized after a clean checkpoint; never re-commits
 
 
 class SessionRow(BaseModel):
@@ -125,7 +136,7 @@ def get_active_session(path: str) -> SessionRow | None:
     with session() as s:
         row = s.scalar(
             select(CoeditSession).where(
-                CoeditSession.path == path, CoeditSession.status == "active"
+                CoeditSession.path == path, CoeditSession.status == SessionStatus.ACTIVE.value
             )
         )
         return _session_row(row) if row is not None else None
@@ -149,7 +160,7 @@ def open_session(path: str, *, base_sha: str | None, initial_buffer: str = "") -
     with session() as s:
         existing = s.scalar(
             select(CoeditSession).where(
-                CoeditSession.path == path, CoeditSession.status == "active"
+                CoeditSession.path == path, CoeditSession.status == SessionStatus.ACTIVE.value
             )
         )
         if existing is not None:
@@ -164,7 +175,7 @@ def open_session(path: str, *, base_sha: str | None, initial_buffer: str = "") -
             buffer_text=initial_buffer,
             version=0,
             base_sha=base_sha,
-            status="active",
+            status=SessionStatus.ACTIVE.value,
             created_at=now,
             updated_at=now,
         )
@@ -176,7 +187,7 @@ def open_session(path: str, *, base_sha: str | None, initial_buffer: str = "") -
             s.rollback()
             winner = s.scalar(
                 select(CoeditSession).where(
-                    CoeditSession.path == path, CoeditSession.status == "active"
+                    CoeditSession.path == path, CoeditSession.status == SessionStatus.ACTIVE.value
                 )
             )
             if winner is None:  # pragma: no cover - winner closed in the gap
@@ -206,7 +217,7 @@ def set_buffer(session_id: int, *, base_version: int, buffer_text: str) -> Sessi
             .where(
                 CoeditSession.id == session_id,
                 CoeditSession.version == base_version,
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
             )
             .values(buffer_text=buffer_text, version=base_version + 1, updated_at=now)
             .returning(CoeditSession)
@@ -317,7 +328,7 @@ def rebase_onto(
             select(CoeditSession.buffer_text).where(
                 CoeditSession.id == session_id,
                 CoeditSession.version == base_version,
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
             )
         ).scalar_one_or_none()
         if current is None:
@@ -336,7 +347,7 @@ def rebase_onto(
             .where(
                 CoeditSession.id == session_id,
                 CoeditSession.version == base_version,
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
             )
             .values(**values)
             .returning(CoeditSession)
@@ -370,7 +381,7 @@ def apply_op(
         current = s.execute(
             select(CoeditSession.buffer_text).where(
                 CoeditSession.id == session_id,
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
                 CoeditSession.version == base_version,
             )
         ).scalar_one_or_none()
@@ -385,7 +396,7 @@ def apply_op(
             .where(
                 CoeditSession.id == session_id,
                 CoeditSession.version == base_version,
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
             )
             .values(buffer_text=new_buffer, version=new_version, updated_at=now)
             .returning(CoeditSession)
@@ -489,7 +500,7 @@ def sessions_due_for_checkpoint(
         rows = s.scalars(
             select(CoeditSession)
             .where(
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
                 CoeditSession.version > CoeditSession.checkpointed_version,
                 or_(
                     # settled: no edit for ``idle_seconds``
@@ -525,8 +536,8 @@ def close_session(session_id: int) -> None:
     """Mark a session closed, freeing the path for a new active session."""
     with session() as s:
         sess = s.get(CoeditSession, session_id)
-        if sess is not None and sess.status != "closed":
-            sess.status = "closed"
+        if sess is not None and sess.status != SessionStatus.CLOSED.value:
+            sess.status = SessionStatus.CLOSED.value
             sess.updated_at = _iso(_now())
 
 
@@ -546,10 +557,10 @@ def close_if_clean(session_id: int) -> bool:
             update(CoeditSession)
             .where(
                 CoeditSession.id == session_id,
-                CoeditSession.status == "active",
+                CoeditSession.status == SessionStatus.ACTIVE.value,
                 CoeditSession.version == CoeditSession.checkpointed_version,
             )
-            .values(status="closed", updated_at=_iso(_now()))
+            .values(status=SessionStatus.CLOSED.value, updated_at=_iso(_now()))
             .returning(CoeditSession.id)
             .execution_options(synchronize_session=False)
         ).one_or_none()

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -66,8 +66,32 @@ def checkpoint_session(session_id: int) -> str | None:
     AI merge. Idempotent: after a successful commit the session is marked clean.
     """
     sess = coedit.get_session(session_id)
-    if sess is None or sess.version == sess.checkpointed_version:
-        return None  # gone or nothing new to commit
+    if sess is None:
+        return None  # gone
+    if sess.status != "active":
+        # A closed session is finalized — never re-commit it. This is what
+        # dedupes queued duplicates: once the first checkpoint commits and the
+        # task closes the session, every other queued copy no-ops here instead
+        # of re-committing the same buffer. (Previously a closed session still
+        # committed, and rebase_onto's status='active' CAS then failed to mark
+        # it checkpointed, so N queued copies each committed — the 2026-07-06
+        # incident's 4× clobber.) A closed session should already be clean
+        # (close only follows a clean checkpoint); if it's somehow dirty, log
+        # loudly rather than clobber HEAD with its stale buffer — the edits stay
+        # in the buffer for manual recovery.
+        if sess.version != sess.checkpointed_version:
+            log.warning(
+                "coedit checkpoint: session %s is %s but dirty (v%d != "
+                "checkpointed v%d); skipping — buffer left uncommitted, needs "
+                "manual reconciliation",
+                session_id,
+                sess.status,
+                sess.version,
+                sess.checkpointed_version,
+            )
+        return None
+    if sess.version == sess.checkpointed_version:
+        return None  # nothing new to commit
 
     path = sess.path
     # Merge base = the page content at the last checkpoint. None when the

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -68,17 +68,13 @@ def checkpoint_session(session_id: int) -> str | None:
     sess = coedit.get_session(session_id)
     if sess is None:
         return None  # gone
-    if sess.status != "active":
-        # A closed session is finalized — never re-commit it. This is what
-        # dedupes queued duplicates: once the first checkpoint commits and the
-        # task closes the session, every other queued copy no-ops here instead
-        # of re-committing the same buffer. (Previously a closed session still
-        # committed, and rebase_onto's status='active' CAS then failed to mark
-        # it checkpointed, so N queued copies each committed — the 2026-07-06
-        # incident's 4× clobber.) A closed session should already be clean
-        # (close only follows a clean checkpoint); if it's somehow dirty, log
-        # loudly rather than clobber HEAD with its stale buffer — the edits stay
-        # in the buffer for manual recovery.
+    if sess.status != coedit.SessionStatus.ACTIVE.value:
+        # A closed session is finalized — never re-commit it. This dedupes
+        # queued duplicates: once the first checkpoint commits and closes the
+        # session, every other queued copy no-ops here. A closed session should
+        # already be clean (close follows a clean checkpoint); if it's somehow
+        # dirty, log and skip rather than clobber HEAD with its stale buffer —
+        # the edits stay in the buffer for manual recovery.
         if sess.version != sess.checkpointed_version:
             log.warning(
                 "coedit checkpoint: session %s is %s but dirty (v%d != "

--- a/backend/app/wiki/coedit_rebase.py
+++ b/backend/app/wiki/coedit_rebase.py
@@ -47,7 +47,7 @@ def rebase_session(session_id: int, head_sha: str) -> RebaseOutcome:
     ``app/tasks/coedit_rebase.py``, which acts on a ``CONFLICT`` outcome).
     """
     sess = coedit.get_session(session_id)
-    if sess is None or sess.status != "active" or sess.base_sha == head_sha:
+    if sess is None or sess.status != coedit.SessionStatus.ACTIVE.value or sess.base_sha == head_sha:
         return RebaseOutcome.SKIP
     # A stale task can carry a head_sha the session has already moved past: a
     # concurrent checkpoint, or a later commit's rebase, may have advanced

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -222,3 +222,43 @@ def test_commit_message_credits_other_participants_as_coauthors(repo):
     msg = coedit_checkpoint._commit_message(sess.id, primary_author_id=b)
     assert "Co-authored-by: Ada <ada@x.com>" in msg
     assert "bo@x.com" not in msg
+
+
+def test_checkpoint_skips_closed_dirty_session(repo):
+    # A closed session with un-checkpointed edits must NOT be re-committed — it
+    # would clobber newer HEAD with a stale buffer (the 2026-07-06 incident).
+    # Its edits stay in the buffer for manual recovery.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+    # An agent lands a newer commit after the buffer's base.
+    newer = wiki_git.commit_file(_PATH, "hello world v2", "agent", author="A <a@x.com>")
+    coedit.close_session(sess.id)  # closed while still dirty (v1, checkpointed v0)
+
+    assert coedit_checkpoint.checkpoint_session(sess.id) is None  # skipped
+    # HEAD is untouched — the stale buffer did not clobber the agent's commit.
+    assert wiki_git.head_sha_for_path(_PATH) == newer
+    assert wiki_git.read_file(_PATH) == "hello world v2"
+
+
+def test_duplicate_queued_checkpoints_commit_once(repo):
+    # Two queued checkpoint tasks for the same session must produce ONE commit:
+    # the first commits + closes; the second no-ops on the now-closed session
+    # (previously each re-committed → the incident's 4x clobber).
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+    coedit.leave(sess.id, uid)  # last participant gone → eligible to close
+
+    before = len(wiki_git.history(_PATH))
+    with documents_queue.immediate_mode():
+        coedit_checkpoint_task.checkpoint_coedit_session(sess.id)  # commits + closes
+        coedit_checkpoint_task.checkpoint_coedit_session(sess.id)  # duplicate → no-op
+        coedit_checkpoint_task.checkpoint_coedit_session(sess.id)  # duplicate → no-op
+    after = len(wiki_git.history(_PATH))
+    assert after - before == 1  # exactly one "Co-editing checkpoint" commit
+    assert wiki_git.read_file(_PATH) == "hi world"


### PR DESCRIPTION
## What

Guard `checkpoint_session` on `status`: a **closed** session is finalized and never re-commits.

## Why (2026-07-06 incident, defect 3)

A checkpoint can be enqueued more than once for the same session — the periodic scan, the last-participant-leave trigger, and an explicit save can all fire. Previously every queued copy re-committed the buffer:

- The first copy committed and closed the session.
- The remaining copies still ran `commit_and_fan_out`, but `rebase_onto`'s `status='active'` CAS then failed to mark them checkpointed — so **N queued copies each committed the same buffer**: the incident's 4× clobber.

## Fix

- `status != "active"` → return `None` (no-op). This is what dedupes the queued duplicates.
- A closed session should already be clean (close only follows a clean checkpoint). If it's somehow **dirty**, log loudly and skip rather than clobber HEAD with a stale buffer — the edits stay in the buffer for manual recovery.
- The existing `version == checkpointed_version` (nothing-new) no-op is preserved.

## Tests

- `test_checkpoint_skips_closed_dirty_session`
- `test_duplicate_queued_checkpoints_commit_once`
- full `test_coedit_checkpoint.py` green (12), ruff + basedpyright clean.

Part of the incident fix series: A (read serves HEAD on conflict, merged) → **B (this)** → C (dedicated checkpoint queue) → D (queue observability).