### PR TITLE
feat(coedit): dedicated checkpoint queue + per-session advisory lock

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,6 +22,7 @@
         "API Server",
         "Worker: documents",
         "Worker: triggers",
+        "Worker: coedit",
         "Worker: lightweight_maintenance"
       ],
       "presentation": {
@@ -46,6 +47,7 @@
       "configurations": [
         "Worker: documents",
         "Worker: triggers",
+        "Worker: coedit",
         "Worker: lightweight_maintenance"
       ],
       "presentation": {
@@ -156,6 +158,31 @@
       ],
       "console": "integratedTerminal",
       "consoleTitle": "Worker: triggers Console",
+      "justMyCode": false,
+      "presentation": {
+        "group": "2"
+      }
+    },
+    {
+      // Commits co-edit session buffers to git (with an AI merge on overlap).
+      // Own queue so a checkpoint can't sit behind connector ingest; per-session
+      // safety comes from an advisory lock, so it runs multi-threaded.
+      "name": "Worker: coedit",
+      "type": "debugpy",
+      "request": "launch",
+      "python": "${workspaceFolder}/backend/.venv/bin/python",
+      "module": "app.tasks.run_worker",
+      "cwd": "${workspaceFolder}/backend",
+      "envFile": "${workspaceFolder}/.env",
+      "env": {
+        "LOG_LEVEL": "DEBUG",
+        "PYTHONUNBUFFERED": "1"
+      },
+      "args": [
+        "coedit"
+      ],
+      "console": "integratedTerminal",
+      "consoleTitle": "Worker: coedit Console",
       "justMyCode": false,
       "presentation": {
         "group": "2"

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -25,6 +25,7 @@ from typing import Generator, cast
 
 from sqlalchemy import Engine, Executable, create_engine, text
 from sqlalchemy.engine import CursorResult
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import CONFIG
@@ -179,3 +180,23 @@ def advisory_xact_lock(s: Session, key: int) -> None:
     ``rebuild_from_filesystem``).
     """
     s.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": key})
+
+
+def try_advisory_xact_lock(s: Session, key: int, *, timeout_ms: int) -> bool:
+    """Bounded ``advisory_xact_lock``: wait at most ``timeout_ms`` for the lock.
+
+    Returns True once held; False if another transaction still holds it when the
+    wait elapses (the caller skips and lets a later retry pick the work up). The
+    lock is transaction-scoped and auto-released like ``advisory_xact_lock``; the
+    ``lock_timeout`` is set ``LOCAL`` so it never leaks to the pooled connection.
+    """
+    # set_config(..., is_local=true) == SET LOCAL, but parameterizable.
+    s.execute(text("SELECT set_config('lock_timeout', :ms, true)"), {"ms": str(timeout_ms)})
+    try:
+        s.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": key})
+    except OperationalError:
+        # lock_timeout fired (SQLSTATE 55P03); the statement aborted the
+        # transaction, so roll back to leave the caller's session reusable.
+        s.rollback()
+        return False
+    return True

--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -6,8 +6,10 @@ to git. This wires up *when* that happens:
 * a periodic scan checkpoints dirty sessions that have gone idle or are overdue,
 * the last-participant-leave and explicit-save paths enqueue ``checkpoint_coedit_session``.
 
-Checkpointing does a git commit (and maybe an LLM merge), so it runs on
-``documents_queue`` — never inline in a web request.
+Checkpointing does a git commit (and maybe an LLM merge), so it runs on its
+own ``coedit_queue`` — never inline in a web request. It gets a dedicated queue
+(not ``documents_queue``) so a session's committed page can't go stale behind
+hours of connector ingest; see ``app/tasks/queues.py``.
 """
 
 from __future__ import annotations
@@ -15,7 +17,7 @@ from __future__ import annotations
 import logging
 
 from app.tasks.queue import crontab
-from app.tasks.queues import documents_queue
+from app.tasks.queues import coedit_queue
 from app.wiki import coedit
 from app.wiki.coedit_checkpoint import checkpoint_session
 
@@ -40,7 +42,7 @@ _IDLE_SECONDS = 300
 _MAX_INTERVAL_SECONDS = 900
 
 
-@documents_queue.task()
+@coedit_queue.task()
 def checkpoint_coedit_session(session_id: int) -> None:
     """Commit a session's buffer, then close it if everyone has since left.
 
@@ -53,7 +55,7 @@ def checkpoint_coedit_session(session_id: int) -> None:
         coedit.close_if_clean(session_id)
 
 
-@documents_queue.periodic_task(crontab(minute="*"))
+@coedit_queue.periodic_task(crontab(minute="*"))
 def scan_and_checkpoint() -> None:
     """Enqueue a checkpoint for every dirty session that's idle or overdue."""
     due = coedit.sessions_due_for_checkpoint(

--- a/backend/app/tasks/coedit_rebase.py
+++ b/backend/app/tasks/coedit_rebase.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 
-from app.tasks.queues import documents_queue, lightweight_maintenance_queue
+from app.tasks.queues import coedit_queue, lightweight_maintenance_queue
 from app.wiki import coedit
 from app.wiki.coedit_rebase import RebaseOutcome, rebase_session
 
@@ -24,10 +24,10 @@ log = logging.getLogger(__name__)
 @lightweight_maintenance_queue.task()
 def rebase_coedit_session(session_id: int, head_sha: str) -> None:
     if rebase_session(session_id, head_sha) == RebaseOutcome.CONFLICT:
-        # Overlap → hand to the checkpoint engine's AI-merge (documents_queue).
+        # Overlap → hand to the checkpoint engine's AI-merge (coedit_queue).
         # Enqueue by name rather than importing checkpoint_coedit_session: the
         # import would be circular (checkpoint → wiki.utils → notify → here).
-        documents_queue.enqueue("checkpoint_coedit_session", (session_id,), {})
+        coedit_queue.enqueue("checkpoint_coedit_session", (session_id,), {})
 
 
 def on_wiki_commit(rel_path: str, sha: str) -> None:

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -1,15 +1,16 @@
-"""Three task queues backed by Redis Streams.
+"""Four task queues backed by Redis Streams.
 
-We deliberately split background work into **three independent queues**, each
+We deliberately split background work into **four independent queues**, each
 with its own ``TaskQueue`` instance and its own consumer process. Each queue
 is a Redis Stream (``queue:{name}``) so each queue's backlog is isolated from
 the others. A slow LLM doc-rewrite can't delay a reindex; a flood of
-trigger evaluations can't backpressure connector ingest.
+trigger evaluations can't backpressure connector ingest; a co-edit checkpoint
+can't sit behind an hour of connector ingest.
 
 Each constant below is the canonical entry point for tasks that belong on
-that queue. Don't add a fourth queue without a real reason — the value of
-this split comes from the queues being a small, fixed set that the rest of
-the system can reason about.
+that queue. Keep this a small, fixed set — the value of the split comes from
+the queues being few and reason-about-able. Add one only when a workload's
+latency/throughput profile genuinely conflicts with every existing queue.
 
 Queues:
 
@@ -33,6 +34,17 @@ Queues:
   Onyx Craft launches also ride this queue (each blocks ~10-60s on Onyx
   sandbox provisioning).
 
+* ``coedit_queue`` — **co-edit session checkpoints.** Commits a live session
+  buffer to git and, on a concurrent agent/ingest commit, runs an AI merge —
+  so like ``documents_queue`` it commits and may hit the LLM, and can't live on
+  ``lightweight_maintenance_queue``. It gets its *own* queue because a
+  checkpoint's freshness is user-visible (readers see git HEAD): parked behind
+  hours of connector ingest on ``documents_queue``, a session's committed page
+  goes stale and, in the limit, pins readers to a lagging buffer (the 2026-07-06
+  incident). Runs wider than ``documents`` because per-session safety comes from
+  a Postgres advisory lock (``coedit.checkpoint_lock_key``), not single-threading
+  — different sessions checkpoint in parallel; the same session is serialized.
+
 * ``lightweight_maintenance_queue`` — **fast upkeep tasks.** Sub-second,
   no LLM, no external HTTP, no wiki commits. Anything that fits that
   profile and isn't worth its own queue lives here. The placement rule
@@ -51,7 +63,8 @@ Queues:
 
 Each consumer runs as a separate worker container — see
 ``docker-compose.yml`` (``worker-documents``, ``worker-triggers``,
-``worker-lightweight-maintenance``) and ``app/tasks/run_worker.py``.
+``worker-coedit``, ``worker-lightweight-maintenance``) and
+``app/tasks/run_worker.py``.
 """
 from __future__ import annotations
 
@@ -61,6 +74,7 @@ from app.tasks.queue import QueueFullError, TaskQueue
 __all__ = [
     "QueueFullError",
     "QUEUES",
+    "coedit_queue",
     "documents_queue",
     "lightweight_maintenance_queue",
     "triggers_queue",
@@ -73,6 +87,7 @@ def _make(name: str) -> TaskQueue:
 
 documents_queue = _make("documents")
 triggers_queue = _make("triggers")
+coedit_queue = _make("coedit")
 lightweight_maintenance_queue = _make("lightweight_maintenance")
 
 # Map queue-name → instance, used by run_worker.py to launch the right
@@ -80,5 +95,6 @@ lightweight_maintenance_queue = _make("lightweight_maintenance")
 QUEUES = {
     "documents": documents_queue,
     "triggers": triggers_queue,
+    "coedit": coedit_queue,
     "lightweight_maintenance": lightweight_maintenance_queue,
 }

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -40,8 +40,8 @@ Queues:
   ``lightweight_maintenance_queue``. It gets its *own* queue because a
   checkpoint's freshness is user-visible (readers see git HEAD): parked behind
   hours of connector ingest on ``documents_queue``, a session's committed page
-  goes stale and, in the limit, pins readers to a lagging buffer (the 2026-07-06
-  incident). Runs wider than ``documents`` because per-session safety comes from
+  goes stale and, in the limit, pins readers to a lagging buffer. Runs wider
+  than ``documents`` because per-session safety comes from
   a Postgres advisory lock (``coedit.checkpoint_lock_key``), not single-threading
   — different sessions checkpoint in parallel; the same session is serialized.
 

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -1,7 +1,7 @@
 """Entry point for a worker container.
 
 Run with: ``python -m app.tasks.run_worker <queue>`` where ``<queue>`` is
-one of ``documents``, ``triggers``, or ``lightweight_maintenance``.
+one of ``documents``, ``triggers``, ``coedit``, or ``lightweight_maintenance``.
 Each queue gets its own worker process — see ``app/tasks/queues.py`` for the
 queue rationale.
 
@@ -79,10 +79,15 @@ def _wait_for_db(timeout_s: float = 60.0, poll_s: float = 1.0) -> None:
 
 # Per-queue handler concurrency (= number of worker threads in this process).
 # ``documents`` is LLM-bound; we don't want concurrent provider calls from a
-# single host so it stays at 1. The cheap queues run wider.
+# single host so it stays at 1. The cheap queues run wider. ``coedit`` runs
+# wider than ``documents`` even though it can commit + AI-merge: a checkpoint is
+# mostly a fast git commit (the AI merge fires only on a concurrent-commit
+# overlap), and per-session safety comes from a Postgres advisory lock, not
+# single-threading — so distinct sessions checkpoint in parallel.
 _CONCURRENCY = {
     "documents": 1,
     "triggers": 4,
+    "coedit": 4,
     "lightweight_maintenance": 4,
 }
 
@@ -94,6 +99,7 @@ _METRICS_PORT = {
     "documents": 9091,
     "triggers": 9092,
     "lightweight_maintenance": 9093,
+    "coedit": 9094,
 }
 
 

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -20,6 +20,8 @@ unsaved buffer. See
 from __future__ import annotations
 
 import logging
+from collections.abc import Generator
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any
@@ -29,7 +31,7 @@ from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import CoeditOp, CoeditParticipant, CoeditSession, User
-from app.db.session import session
+from app.db.session import advisory_xact_lock, session
 
 log = logging.getLogger(__name__)
 
@@ -565,6 +567,36 @@ def close_if_clean(session_id: int) -> bool:
             .execution_options(synchronize_session=False)
         ).one_or_none()
         return closed is not None
+
+
+# Namespace for checkpoint advisory-lock keys. The whole DB shares one 64-bit
+# advisory keyspace (see triggers/repo.py's _REBUILD_ADVISORY_LOCK), so pack a
+# tag into the high 32 bits to keep checkpoint keys in their own band and off
+# any bare small-integer key. Assumes session_id < 2**32 (a serial won't reach
+# 4 billion).
+_CHECKPOINT_LOCK_NS = 0xC0ED
+
+
+def checkpoint_lock_key(session_id: int) -> int:
+    return (_CHECKPOINT_LOCK_NS << 32) | session_id
+
+
+@contextmanager
+def checkpoint_lock(session_id: int) -> Generator[None]:
+    """Serialize checkpoints of one session across concurrent workers.
+
+    Different sessions still checkpoint in parallel — the lock is keyed on
+    session_id — but two workers that both dequeued a checkpoint for the *same*
+    session run one at a time, so the loser re-reads a clean/closed session and
+    no-ops instead of committing the same buffer twice. Uses a *transaction*-
+    scoped advisory lock (auto-released on commit/rollback), so a worker that
+    dies mid-checkpoint can't strand it. Chosen over ``SELECT ... FOR UPDATE`` on
+    the session row because that row is written by every live ``apply_op`` — a
+    row lock held across the checkpoint's (possibly LLM) merge would freeze live
+    editing; an abstract advisory lock doesn't. See ``coedit_checkpoint``."""
+    with session() as s:
+        advisory_xact_lock(s, checkpoint_lock_key(session_id))
+        yield
 
 
 def rename_path(old_path: str, new_path: str) -> None:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -31,7 +31,7 @@ from sqlalchemy import func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import CoeditOp, CoeditParticipant, CoeditSession, User
-from app.db.session import advisory_xact_lock, session
+from app.db.session import session, try_advisory_xact_lock
 
 log = logging.getLogger(__name__)
 
@@ -575,6 +575,13 @@ def close_if_clean(session_id: int) -> bool:
 # any bare small-integer key. Assumes session_id < 2**32 (a serial won't reach
 # 4 billion).
 _CHECKPOINT_LOCK_NS = 0xC0ED
+# Cap how long a duplicate checkpoint waits for the in-progress one. Comfortably
+# above a normal checkpoint (a git commit is ms; an AI merge is seconds) so a
+# waiter still blocks long enough to pick up the committed result and no-op —
+# but bounded, so a pathologically slow/hung merge can't pin a waiter (and its
+# worker thread) indefinitely. On timeout the waiter skips; the periodic scan
+# re-enqueues if the session is still dirty.
+_CHECKPOINT_LOCK_TIMEOUT_MS = 30_000
 
 
 def checkpoint_lock_key(session_id: int) -> int:
@@ -582,11 +589,13 @@ def checkpoint_lock_key(session_id: int) -> int:
 
 
 @contextmanager
-def checkpoint_lock(session_id: int) -> Generator[None]:
+def checkpoint_lock(session_id: int) -> Generator[bool]:
     """Serialize checkpoints of one session across concurrent workers.
 
-    Different sessions still checkpoint in parallel — the lock is keyed on
-    session_id — but two workers that both dequeued a checkpoint for the *same*
+    Yields True if this caller holds the lock (proceed), False if another worker
+    held it past ``_CHECKPOINT_LOCK_TIMEOUT_MS`` (skip — a later trigger/scan
+    retries). Different sessions still checkpoint in parallel (the lock is keyed
+    on session_id); two workers that both dequeued a checkpoint for the *same*
     session run one at a time, so the loser re-reads a clean/closed session and
     no-ops instead of committing the same buffer twice. Uses a *transaction*-
     scoped advisory lock (auto-released on commit/rollback), so a worker that
@@ -595,8 +604,9 @@ def checkpoint_lock(session_id: int) -> Generator[None]:
     row lock held across the checkpoint's (possibly LLM) merge would freeze live
     editing; an abstract advisory lock doesn't. See ``coedit_checkpoint``."""
     with session() as s:
-        advisory_xact_lock(s, checkpoint_lock_key(session_id))
-        yield
+        yield try_advisory_xact_lock(
+            s, checkpoint_lock_key(session_id), timeout_ms=_CHECKPOINT_LOCK_TIMEOUT_MS
+        )
 
 
 def rename_path(old_path: str, new_path: str) -> None:

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -70,7 +70,12 @@ def checkpoint_session(session_id: int) -> str | None:
     blocks, then re-reads a clean/closed session and no-ops (see
     ``coedit.checkpoint_lock``). Distinct sessions still checkpoint in parallel.
     """
-    with coedit.checkpoint_lock(session_id):
+    with coedit.checkpoint_lock(session_id) as acquired:
+        if not acquired:
+            # Another worker is checkpointing this session and held the lock past
+            # the wait cap. Skip — the periodic scan re-enqueues if still dirty.
+            log.info("coedit checkpoint: session %s busy; skipping (scan retries)", session_id)
+            return None
         return _checkpoint_locked(session_id)
 
 

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -64,7 +64,19 @@ def checkpoint_session(session_id: int) -> str | None:
     (``version == checkpointed_version``), or the merge collapses to the current
     HEAD. Reconciles concurrent agent/ingest commits via the gateway's 3-way +
     AI merge. Idempotent: after a successful commit the session is marked clean.
+
+    Serialized per session by an advisory lock, so two workers that both dequeued
+    a checkpoint for the same session can't both commit the buffer — the loser
+    blocks, then re-reads a clean/closed session and no-ops (see
+    ``coedit.checkpoint_lock``). Distinct sessions still checkpoint in parallel.
     """
+    with coedit.checkpoint_lock(session_id):
+        return _checkpoint_locked(session_id)
+
+
+def _checkpoint_locked(session_id: int) -> str | None:
+    """Body of ``checkpoint_session``, run while holding the session's checkpoint
+    advisory lock so the read-guard-commit sequence is atomic across workers."""
     sess = coedit.get_session(session_id)
     if sess is None:
         return None  # gone

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from app.auth import users as users_repo
 from app.main import create_app
-from app.tasks.queues import documents_queue
+from app.tasks.queues import coedit_queue
 from app.wiki import acl, coedit, git
 
 from tests._auth import login_fastapi
@@ -111,7 +111,7 @@ def test_leave_last_participant_checkpoints(client):
     )
 
     # The last leave enqueues a checkpoint; immediate_mode runs it inline.
-    with documents_queue.immediate_mode():
+    with coedit_queue.immediate_mode():
         assert client.post("/api/coedit/leave", json={"session_id": sid}).status_code == 200
 
     assert git.read_file(_PATH) == "hi world"
@@ -128,7 +128,7 @@ def test_checkpoint_endpoint_commits_buffer(client):
         json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
     )
 
-    with documents_queue.immediate_mode():
+    with coedit_queue.immediate_mode():
         resp = client.post("/api/coedit/checkpoint", json={"session_id": sid})
     assert resp.status_code == 200
     assert resp.json() == {"queued": True}

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -12,6 +12,7 @@ from sqlalchemy import text
 from app.auth import users as users_repo
 from app.db.models import DocumentTemplate
 from app.db.session import session as db_session
+from app.db.session import try_advisory_xact_lock
 from app.tasks import coedit_checkpoint as coedit_checkpoint_task
 from app.tasks.queues import coedit_queue
 from app.wiki import coedit, coedit_checkpoint, drafts
@@ -285,10 +286,24 @@ def test_checkpoint_lock_serializes_same_session_only(repo):
             ).scalar()
         )
 
-    with coedit.checkpoint_lock(sid):
+    with coedit.checkpoint_lock(sid) as acquired:
+        assert acquired is True  # uncontended → held
         with db_session() as s2:  # a second connection
             assert try_lock(s2, sid) is False  # same session's key is held
             assert try_lock(s2, other) is True  # a different session's is free
     # Released on context exit (transaction-scoped) — the key is takeable again.
     with db_session() as s3:
         assert try_lock(s3, sid) is True
+
+
+def test_checkpoint_lock_times_out_when_held(repo):
+    # A duplicate checkpoint that can't get the lock within the cap yields False
+    # (→ the task skips and no-ops) rather than blocking forever.
+    base = 2_000_000 + os.getpid() % 1_000_000
+    with coedit.checkpoint_lock(base) as acquired:
+        assert acquired is True
+        with db_session() as s2:
+            got = try_advisory_xact_lock(
+                s2, coedit.checkpoint_lock_key(base), timeout_ms=100
+            )
+        assert got is False  # held elsewhere → bounded wait elapsed

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -4,13 +4,16 @@ trailers. DB + real git (the ``tmp_repo`` fixture).
 """
 from __future__ import annotations
 
+import os
+
 import pytest
+from sqlalchemy import text
 
 from app.auth import users as users_repo
 from app.db.models import DocumentTemplate
 from app.db.session import session as db_session
 from app.tasks import coedit_checkpoint as coedit_checkpoint_task
-from app.tasks.queues import documents_queue
+from app.tasks.queues import coedit_queue
 from app.wiki import coedit, coedit_checkpoint, drafts
 from app.wiki import git as wiki_git
 
@@ -170,7 +173,7 @@ def test_task_checkpoints_then_closes_when_empty(repo):
     coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
     coedit.leave(sess.id, uid)  # last participant gone
 
-    with documents_queue.immediate_mode():
+    with coedit_queue.immediate_mode():
         coedit_checkpoint_task.checkpoint_coedit_session(sess.id)
 
     assert wiki_git.read_file(_PATH) == "hi world"
@@ -185,7 +188,7 @@ def test_task_keeps_session_open_when_participants_remain(repo):
     coedit.join(sess.id, uid)
     coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
 
-    with documents_queue.immediate_mode():
+    with coedit_queue.immediate_mode():
         coedit_checkpoint_task.checkpoint_coedit_session(sess.id)
 
     assert wiki_git.read_file(_PATH) == "hi world"
@@ -205,7 +208,7 @@ def test_scan_checkpoints_due_sessions(repo, monkeypatch):
     coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
     coedit.leave(sess.id, uid)
 
-    with documents_queue.immediate_mode():
+    with coedit_queue.immediate_mode():
         coedit_checkpoint_task.scan_and_checkpoint()
 
     assert wiki_git.read_file(_PATH) == "hi world"
@@ -255,10 +258,37 @@ def test_duplicate_queued_checkpoints_commit_once(repo):
     coedit.leave(sess.id, uid)  # last participant gone → eligible to close
 
     before = len(wiki_git.history(_PATH))
-    with documents_queue.immediate_mode():
+    with coedit_queue.immediate_mode():
         coedit_checkpoint_task.checkpoint_coedit_session(sess.id)  # commits + closes
         coedit_checkpoint_task.checkpoint_coedit_session(sess.id)  # duplicate → no-op
         coedit_checkpoint_task.checkpoint_coedit_session(sess.id)  # duplicate → no-op
     after = len(wiki_git.history(_PATH))
     assert after - before == 1  # exactly one "Co-editing checkpoint" commit
     assert wiki_git.read_file(_PATH) == "hi world"
+
+
+def test_checkpoint_lock_serializes_same_session_only(repo):
+    # The advisory lock is what makes concurrency > 1 safe: while one worker
+    # holds a session's checkpoint lock, another connection can't take the same
+    # session's key (so a concurrent duplicate blocks, then no-ops), but a
+    # *different* session's key is free (distinct sessions checkpoint in
+    # parallel). Session ids are offset by PID so parallel xdist workers don't
+    # collide on the DB-global advisory keyspace.
+    base = 1_000_000 + os.getpid() % 1_000_000
+    sid, other = base, base + 1
+
+    def try_lock(s, session_id: int) -> bool:
+        return bool(
+            s.execute(
+                text("SELECT pg_try_advisory_xact_lock(:k)"),
+                {"k": coedit.checkpoint_lock_key(session_id)},
+            ).scalar()
+        )
+
+    with coedit.checkpoint_lock(sid):
+        with db_session() as s2:  # a second connection
+            assert try_lock(s2, sid) is False  # same session's key is held
+            assert try_lock(s2, other) is True  # a different session's is free
+    # Released on context exit (transaction-scoped) — the key is takeable again.
+    with db_session() as s3:
+        assert try_lock(s3, sid) is True

--- a/backend/tests/test_coedit_rebase.py
+++ b/backend/tests/test_coedit_rebase.py
@@ -9,7 +9,7 @@ import pytest
 from app.auth import users as users_repo
 from app.models.wiki import ChangeKind
 from app.tasks import coedit_rebase as coedit_rebase_task
-from app.tasks.queues import documents_queue, lightweight_maintenance_queue
+from app.tasks.queues import coedit_queue, lightweight_maintenance_queue
 from app.wiki import coedit, coedit_checkpoint, coedit_rebase
 from app.wiki import git as wiki_git
 from app.wiki.utils import commit_and_fan_out
@@ -141,12 +141,12 @@ def test_conflict_hands_off_to_checkpoint_by_name(repo, monkeypatch):
     # no import of app.tasks.coedit_checkpoint is needed (would be circular).
     calls: list[int] = []
     monkeypatch.setitem(
-        documents_queue.handlers, "checkpoint_coedit_session", lambda sid: calls.append(sid)
+        coedit_queue.handlers, "checkpoint_coedit_session", lambda sid: calls.append(sid)
     )
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     sid, new_sha = _seed_conflict(uid)
 
-    with lightweight_maintenance_queue.immediate_mode(), documents_queue.immediate_mode():
+    with lightweight_maintenance_queue.immediate_mode(), coedit_queue.immediate_mode():
         coedit_rebase_task.rebase_coedit_session(sid, new_sha)
 
     assert calls == [sid]

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.27
+version: 0.3.28
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,12 +1,12 @@
 {{- /*
 One Deployment per queue. The backend's `app.tasks.run_worker`
-requires a queue argument (`documents`, `triggers`, or
+requires a queue argument (`documents`, `triggers`, `coedit`, or
 `lightweight_maintenance`), and each queue gets its own consumer
 process to keep slow LLM doc work from backpressuring fast paths like
-the BM25 reindex or agent-activity expiration cleanup.
+the BM25 reindex, co-edit checkpoints, or agent-activity cleanup.
 */ -}}
 {{- /* Per-queue Prometheus port — must match _METRICS_PORT in app/tasks/run_worker.py. */ -}}
-{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 -}}
+{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "coedit" 9094 -}}
 {{- range $queue := .Values.worker.queues }}
 ---
 apiVersion: apps/v1

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -112,12 +112,13 @@ worker:
   # co-schedule, AND the per-queue periodic-task scheduler runs in-process
   # (running multiple replicas would double-fire the cron tasks).
   replicaCount: 1
-  # Three Redis Stream queues, one consumer process each. Match
-  # `backend/app/tasks/queues.py:QUEUES`. Don't add a fourth without
-  # corresponding code.
+  # Four Redis Stream queues, one consumer process each. Match
+  # `backend/app/tasks/queues.py:QUEUES` (and the $metricsPorts dict in
+  # worker-deployment.yaml). Adding one requires corresponding code.
   queues:
     - documents
     - triggers
+    - coedit
     - lightweight_maintenance
   resources:
     requests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,29 @@ services:
       opensearch:
         condition: service_healthy
 
+  worker-coedit:
+    profiles: ["app"]
+    build: ./backend
+    command: ["python", "-m", "app.tasks.run_worker", "coedit"]
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
+      - REDIS_URL=redis://redis:6379/0
+      - OPENSEARCH_URL=http://opensearch:9200
+      - WIKI_DIR=/data/wiki
+      - DEV_MODE=true
+    volumes:
+      - ./local_data:/data
+    depends_on:
+      backend:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy
+
   worker-lightweight-maintenance:
     profiles: ["app"]
     build: ./backend


### PR DESCRIPTION
## What

Give co-edit checkpoints their **own queue and worker**, run it at concurrency > 1, and make that safe with a **per-session advisory lock**.

## Why (2026-07-06 incident, defects 1 + the concurrent-duplicate gap)

`checkpoint_coedit_session` / `scan_and_checkpoint` ran on `documents_queue` (concurrency 1), behind connector-ingest LLM work. A backed-up documents queue delayed checkpoints, so a session's committed page went stale and readers were pinned to a lagging buffer — the incident's precondition. (PR-A made the *read* safe regardless; this makes the checkpoint *fast* so the visibility gap closes.)

## Changes

**New `coedit_queue` + worker**
- `app/tasks/queues.py`: fourth `TaskQueue`; docstring explains why it can't share `documents` (freshness is user-visible) or `lightweight_maintenance` (it commits + may AI-merge).
- `coedit_checkpoint.py` / `coedit_rebase.py`: the checkpoint task, the periodic scan, and the rebase-conflict hand-off now target `coedit_queue`.
- `run_worker.py`: `coedit` at **concurrency 4** (vs documents' 1) + metrics port **9094**.
- Wired through `docker-compose.yml` (`worker-coedit`), the helm chart (`values.yaml` queue list + `worker-deployment.yaml` `$metricsPorts`), and `.vscode/launch.json`.

**Per-session serialization (`coedit.checkpoint_lock`)**
- Concurrency 4 means two workers can dequeue a checkpoint for the *same* session and both pass the status guard before either commits (the guard only dedupes *sequential* redelivery). A **transaction-scoped Postgres advisory lock** keyed on `session_id` serializes them: the loser blocks, re-reads a clean/closed session, and no-ops. Distinct sessions still run in parallel.
- Reuses the existing `advisory_xact_lock` seam (no new raw SQL). Key is namespaced (`0xC0ED << 32 | session_id`) to avoid colliding with the trigger-rebuild lock in the DB-global advisory keyspace.
- Chosen over `SELECT … FOR UPDATE` on the session row: that row is written by every live `apply_op`, so a row lock held across the checkpoint's (possibly LLM) merge would **freeze live editing**. An abstract advisory lock doesn't.

## Tests

- `test_checkpoint_lock_serializes_same_session_only` — deterministic: while the lock is held, a second connection can't take the same session's key but *can* take a different session's; released on context exit. (Session ids offset by PID so parallel xdist workers don't collide on the global keyspace.)
- Existing checkpoint/api/rebase tests updated to `coedit_queue`; 87 coedit/rebase/reindex tests pass; ruff + whole-project basedpyright clean; `helm template` renders all four workers (coedit on 9094); `docker compose config` shows `worker-coedit`.

Notes: pool is default QueuePool (5 + 10 overflow); a checkpoint holds ≤ 2 connections (lock txn + commit), so concurrency 4 ≤ 8 is well within budget. Helm `replicaCount` stays 1 per queue (RWO PVC + in-process scheduler); concurrency comes from the in-process thread pool, and the lock also guards a future replica bump.

Fix series: A ✅ (read serves HEAD on conflict) · B ✅ (closed-session no-op) · **C (this)** · D (queue depth/age observability).