### PR TITLE
feat(ingest): pass pushed document metadata to the updater LLM

### DIFF
--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -119,7 +119,7 @@ def _format_metadata(metadata: dict[str, Any] | None) -> str:
         return ""
     lines: list[str] = []
     for key, value in metadata.items():
-        values: list[Any] = value if isinstance(value, list) else [value]
+        values = cast(list[Any], value) if isinstance(value, list) else [value]
         rendered = ", ".join(" ".join(str(v).split()) for v in values if str(v).strip())
         if rendered:
             lines.append(f"{key}: {rendered}")

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -16,6 +16,7 @@ Batches fail independently.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, NamedTuple, cast
 
 from app.ingest.models import WikiUpdateCandidate
@@ -44,6 +45,13 @@ _RECONCILER_MAX_TOKENS = 8192
 # Source metadata is a small header, not document content — cap the rendered
 # block so an abusive value can't crowd candidates out of the char budget.
 _METADATA_MAX_CHARS = 2_000
+# Connector metadata is arbitrary — redact anything credential-shaped before
+# it reaches the prompt: keys with secret-like names are dropped entirely, and
+# URL query strings (where signed-URL secrets live) are stripped from values.
+_SENSITIVE_KEY_RE = re.compile(
+    r"(?i)(token|secret|passw|credential|api[_-]?key|auth|signature|cookie|session)"
+)
+_URL_QUERY_RE = re.compile(r"(https?://[^\s?]+)\?\S*")
 
 _SUBMIT_TOOL: dict[str, Any] = {
     "name": "submit_results",
@@ -111,16 +119,22 @@ def _format_metadata(metadata: dict[str, Any] | None) -> str:
     """Render pushed source metadata (e.g. a PR's state/author/labels) as a
     ``Document metadata:`` header block for the doc prompt.
 
-    One ``key: value`` line per key — list values joined with commas, inner
-    whitespace collapsed so a multiline value can't break the line-per-key
-    structure. Returns "" when there is nothing to show.
+    One ``key: value`` line per key — whitespace collapsed in both keys and
+    values so neither can break the line-per-key structure, list values
+    joined with commas. Keys matching ``_SENSITIVE_KEY_RE`` are dropped and
+    URL query strings are stripped from values, so credential-shaped fields
+    never reach the prompt. Returns "" when there is nothing to show.
     """
     if not metadata:
         return ""
     lines: list[str] = []
     for key, value in metadata.items():
+        key = " ".join(key.split())
+        if not key or _SENSITIVE_KEY_RE.search(key):
+            continue
         values = cast(list[Any], value) if isinstance(value, list) else [value]
         rendered = ", ".join(" ".join(str(v).split()) for v in values if str(v).strip())
+        rendered = _URL_QUERY_RE.sub(r"\1", rendered)
         if rendered:
             lines.append(f"{key}: {rendered}")
     if not lines:

--- a/backend/app/llm/agents/ingest_batch_reconciler.py
+++ b/backend/app/llm/agents/ingest_batch_reconciler.py
@@ -41,6 +41,9 @@ log = logging.getLogger(__name__)
 
 _RECONCILER_BUDGET_CHARS = 200_000
 _RECONCILER_MAX_TOKENS = 8192
+# Source metadata is a small header, not document content — cap the rendered
+# block so an abusive value can't crowd candidates out of the char budget.
+_METADATA_MAX_CHARS = 2_000
 
 _SUBMIT_TOOL: dict[str, Any] = {
     "name": "submit_results",
@@ -104,6 +107,30 @@ class BatchReconcileResult(NamedTuple):
     llm_calls: int
 
 
+def _format_metadata(metadata: dict[str, Any] | None) -> str:
+    """Render pushed source metadata (e.g. a PR's state/author/labels) as a
+    ``Document metadata:`` header block for the doc prompt.
+
+    One ``key: value`` line per key — list values joined with commas, inner
+    whitespace collapsed so a multiline value can't break the line-per-key
+    structure. Returns "" when there is nothing to show.
+    """
+    if not metadata:
+        return ""
+    lines: list[str] = []
+    for key, value in metadata.items():
+        values: list[Any] = value if isinstance(value, list) else [value]
+        rendered = ", ".join(" ".join(str(v).split()) for v in values if str(v).strip())
+        if rendered:
+            lines.append(f"{key}: {rendered}")
+    if not lines:
+        return ""
+    block = "Document metadata:\n" + "\n".join(lines)
+    if len(block) > _METADATA_MAX_CHARS:
+        block = block[:_METADATA_MAX_CHARS] + "… (truncated)"
+    return block
+
+
 def batch_reconcile(
     *,
     title: str | None,
@@ -112,6 +139,7 @@ def batch_reconcile(
     source: str,
     candidates: list[WikiUpdateCandidate],
     model: str,
+    metadata: dict[str, Any] | None = None,
 ) -> BatchReconcileResult:
     """Reconcile all candidates in one or more LLM calls.
 
@@ -128,7 +156,8 @@ def batch_reconcile(
     if not candidates:
         return BatchReconcileResult(results=[], llm_calls=0)
 
-    candidate_budget = max(_RECONCILER_BUDGET_CHARS - len(content), 0)
+    metadata_block = _format_metadata(metadata)
+    candidate_budget = max(_RECONCILER_BUDGET_CHARS - len(content) - len(metadata_block), 0)
     batches = batch_by_chars(candidates, candidate_budget)
 
     # Worth caching the incoming doc only when sibling batches will reread it.
@@ -145,6 +174,7 @@ def batch_reconcile(
                 url=url,
                 content=content,
                 source=source,
+                metadata_block=metadata_block,
                 batch=batch,
                 model=model,
                 cache_doc=cache_doc,
@@ -170,6 +200,7 @@ def _reconcile_batch(
     url: str,
     content: str,
     source: str,
+    metadata_block: str,
     batch: list[WikiUpdateCandidate],
     model: str,
     cache_doc: bool,
@@ -193,6 +224,7 @@ def _reconcile_batch(
         url=url or "",
         source=source,
         today=today,
+        metadata=metadata_block,
         content=content,
     )
     candidates = load_prompt("ingest_batch_reconciler.candidates").format(

--- a/backend/app/llm/prompts/ingest_batch_reconciler.doc.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.doc.md
@@ -2,7 +2,7 @@ External source: {source}
 Document title: {title}
 Document URL: {url}
 Today's date: {today}
-
+{metadata}
 --- Incoming document ---
 {content}
 --- End ---

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -15,8 +15,8 @@ source system. Extract only the fact that changed — the what, not the why.
 
 The document header may include a `Document metadata:` block — structured
 fields from the source system. Treat them as authoritative facts about the
-source: e.g. only describe a pull request as merged if its metadata says it
-is, and use the author fields when the page tracks who did what.
+source: e.g. only describe a PR as merged when `merged: True`, and use the
+author fields when the page tracks who did what.
 
 ## Relevance check — do this first for each page
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -14,10 +14,9 @@ Most of that length is rationale, history, and context that belongs in the
 source system. Extract only the fact that changed — the what, not the why.
 
 The document header may include a `Document metadata:` block — structured
-fields from the source system (for a pull request: `state`, `merged`, the
-author's `user` login, `labels`, …). Treat these fields as authoritative
-facts about the source, and let them qualify how you describe it: only call
-a PR merged/shipped when `merged: True` — an open PR is proposed work, not a
+fields from the source system. Treat these fields as authoritative facts
+about the source, and let them qualify how you describe it: only call a PR
+merged/shipped when `merged: True` — an open PR is proposed work, not a
 landed change — and use the author fields when the page tracks who did what.
 
 ## Relevance check — do this first for each page

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -14,10 +14,9 @@ Most of that length is rationale, history, and context that belongs in the
 source system. Extract only the fact that changed — the what, not the why.
 
 The document header may include a `Document metadata:` block — structured
-fields from the source system. Treat these fields as authoritative facts
-about the source, and let them qualify how you describe it: only call a PR
-merged/shipped when `merged: True` — an open PR is proposed work, not a
-landed change — and use the author fields when the page tracks who did what.
+fields from the source system. Treat them as authoritative facts about the
+source: e.g. only describe a PR as merged when `merged: True`, and use the
+author fields when the page tracks who did what.
 
 ## Relevance check — do this first for each page
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -13,6 +13,13 @@ External documents are often much longer than the wiki pages they affect.
 Most of that length is rationale, history, and context that belongs in the
 source system. Extract only the fact that changed — the what, not the why.
 
+The document header may include a `Document metadata:` block — structured
+fields from the source system (for a pull request: `state`, `merged`, the
+author's `user` login, `labels`, …). Treat these fields as authoritative
+facts about the source, and let them qualify how you describe it: only call
+a PR merged/shipped when `merged: True` — an open PR is proposed work, not a
+landed change — and use the author fields when the page tracks who did what.
+
 ## Relevance check — do this first for each page
 
 Ask: does the external document directly describe the same system, process,

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -15,8 +15,8 @@ source system. Extract only the fact that changed — the what, not the why.
 
 The document header may include a `Document metadata:` block — structured
 fields from the source system. Treat them as authoritative facts about the
-source: e.g. only describe a PR as merged when `merged: True`, and use the
-author fields when the page tracks who did what.
+source: e.g. only describe a pull request as merged if its metadata says it
+is, and use the author fields when the page tracks who did what.
 
 ## Relevance check — do this first for each page
 

--- a/backend/app/llm/prompts/ingest_batch_reconciler.system.md
+++ b/backend/app/llm/prompts/ingest_batch_reconciler.system.md
@@ -15,8 +15,7 @@ source system. Extract only the fact that changed — the what, not the why.
 
 The document header may include a `Document metadata:` block — structured
 fields from the source system. Treat them as authoritative facts about the
-source: e.g. only describe a pull request as merged if its metadata says it
-is, and use the author fields when the page tracks who did what.
+source.
 
 ## Relevance check — do this first for each page
 

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -303,8 +303,8 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
         ingest_outcomes_total.labels(outcome="filtered", wiki_path="").inc()
         return
 
-    _meta: dict[str, Any] = push.get("metadata") or {}
-    url: str = str(push.get("url") or _meta.get("url") or "")
+    metadata: dict[str, Any] = push.get("metadata") or {}
+    url: str = str(push.get("url") or metadata.get("url") or "")
 
     def _record_search_drops(
         dropped: list[ingest_search.SearchHit],
@@ -521,6 +521,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
             source=source_label,
             candidates=readable,
             model=llm_s.model,
+            metadata=metadata,
         )
         ingest_batch_reconciler_duration_seconds.observe(time.monotonic() - t_batch)
     else:

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -8,6 +8,8 @@ from app.db.fts import SearchHit
 from app.ingest.models import WikiUpdateCandidate
 from app.llm.agents.common import IRRELEVANT_SENTINEL, TextEdit, batch_by_chars, today_str
 from app.llm.agents.ingest_batch_reconciler import (
+    _METADATA_MAX_CHARS,
+    _format_metadata,
     _parse_tool_results,
     batch_reconcile,
 )
@@ -384,3 +386,69 @@ def test_no_instruction_line_when_absent(mock_client):
     )
     user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
     assert "Update instruction for this page" not in user_msg
+
+
+# --------------------------------------------------------------------------- #
+# Source metadata rendering                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_format_metadata_empty_and_none():
+    assert _format_metadata(None) == ""
+    assert _format_metadata({}) == ""
+    assert _format_metadata({"k": []}) == ""
+
+
+def test_format_metadata_joins_lists_and_collapses_whitespace():
+    block = _format_metadata({
+        "merged": ["True"],
+        "labels": ["bug", "p0"],
+        "notes": "line one\nline two",
+    })
+    assert block == (
+        "Document metadata:\n"
+        "merged: True\n"
+        "labels: bug, p0\n"
+        "notes: line one line two"
+    )
+
+
+def test_format_metadata_truncates_oversized_block():
+    block = _format_metadata({"k": "x" * (2 * _METADATA_MAX_CHARS)})
+    assert block.endswith("… (truncated)")
+    assert len(block) <= _METADATA_MAX_CHARS + len("… (truncated)")
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_metadata_rendered_in_prompt(mock_client):
+    # Real load_prompt so the doc header block is actually rendered.
+    mock_client.complete.return_value = _llm_response(
+        {"results": [{"candidate_index": 1, "action": "no_change"}]}
+    )
+    batch_reconcile(
+        title="123: Fix flaky test", url="https://github.com/o/r/pull/123",
+        content="PR body", source="github",
+        candidates=[_candidate("page.md")], model="m",
+        metadata={
+            "object_type": ["PullRequest"],
+            "merged": ["True"],
+            "user": ["{'login': 'roshan'}"],
+        },
+    )
+    user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
+    assert "Document metadata:" in user_msg
+    assert "merged: True" in user_msg
+    assert "user: {'login': 'roshan'}" in user_msg
+
+
+@patch("app.llm.agents.ingest_batch_reconciler.client")
+def test_no_metadata_block_when_absent(mock_client):
+    mock_client.complete.return_value = _llm_response(
+        {"results": [{"candidate_index": 1, "action": "no_change"}]}
+    )
+    batch_reconcile(
+        title="T", url="", content="doc", source="s",
+        candidates=[_candidate("page.md")], model="m",
+    )
+    user_msg = mock_client.complete.call_args.kwargs["messages"][1]["content"]
+    assert "Document metadata:" not in user_msg

--- a/backend/tests/test_ingest_batch_reconciler.py
+++ b/backend/tests/test_ingest_batch_reconciler.py
@@ -413,6 +413,31 @@ def test_format_metadata_joins_lists_and_collapses_whitespace():
     )
 
 
+def test_format_metadata_drops_sensitive_keys():
+    block = _format_metadata({
+        "state": "open",
+        "access_token": "ghp_abc123",
+        "Webhook-Secret": "shh",
+        "API_KEY": "k",
+        "session_id": "s",
+    })
+    assert block == "Document metadata:\nstate: open"
+
+
+def test_format_metadata_strips_url_query_strings():
+    block = _format_metadata({
+        "download": "https://s3.example.com/f.pdf?X-Amz-Signature=abc&X-Amz-Credential=xyz",
+    })
+    assert block == "Document metadata:\ndownload: https://s3.example.com/f.pdf"
+
+
+def test_format_metadata_collapses_whitespace_in_keys():
+    # A key with embedded newlines must not split the block into extra
+    # header-like lines the model would read as separate fields.
+    block = _format_metadata({"merged: True\nstate": "open"})
+    assert block == "Document metadata:\nmerged: True state: open"
+
+
 def test_format_metadata_truncates_oversized_block():
     block = _format_metadata({"k": "x" * (2 * _METADATA_MAX_CHARS)})
     assert block.endswith("… (truncated)")

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -302,6 +302,18 @@ def test_new_body_commits(mock_search, mock_reconcile, mock_read, mock_commit, m
     mock_notify.assert_called_once()
 
 
+@patch("app.tasks.wiki_update.wiki_git.read_file", return_value="old body")
+@patch("app.tasks.wiki_update.ingest_batch_reconciler.batch_reconcile")
+@patch("app.tasks.wiki_update.ingest_search.candidates")
+def test_push_metadata_passed_to_reconciler(mock_search, mock_reconcile, mock_read, monkeypatch):
+    monkeypatch.setattr("app.tasks.wiki_update.get_llm_settings", lambda: _settings_with_model())
+    mock_search.return_value = _cs([_hit("page.md", "Page", 5.0)])
+    mock_reconcile.return_value = ([None], 1)
+    meta = {"object_type": ["PullRequest"], "merged": ["True"]}
+    _run(_make_push(source="github", metadata=meta))
+    assert mock_reconcile.call_args.kwargs["metadata"] == meta
+
+
 @patch("app.tasks.wiki_update.wiki_git.head_sha_for_path", return_value="headsha")
 @patch("app.wiki.utils.wiki_notify.after_doc_write")
 @patch("app.tasks.wiki_update.wiki_git.commit_file", return_value="sha123")


### PR DESCRIPTION
## Summary

The Onyx `DOCUMENT_PUSH` hook sends per-document `metadata` with every push (for a GitHub PR: `state`, `merged`, author `user` login, `labels`, commit/file counts, …), but agent-wiki only read `metadata.url` as a URL fallback — the batch-reconciler (updater) prompt was built from just title/url/source/content. The updater couldn't tell a merged PR from an open one, or attribute work to its author. (Surfaced in Slack: ingestion updates driven by Roshan's PRs with no metadata context.)

## Changes

- `wiki_update._reconcile_pushed_document` now passes the pushed `metadata` dict through to `ingest_batch_reconciler.batch_reconcile`.
- The reconciler renders it as a `Document metadata:` block in the doc prompt header — one `key: value` line per key, list values comma-joined, inner whitespace collapsed, block capped at 2k chars (and counted against the batch char budget).
- System prompt: new paragraph telling the model to treat the metadata fields as authoritative facts about the source — e.g. only describe a PR as merged/shipped when `merged: True`, and use author fields where the page tracks who did what.
- Empty/absent metadata renders nothing — the prompt is byte-identical to before for pushes without metadata.

## Testing

- `_format_metadata` unit tests: empty/None, list joining + whitespace collapse, oversized-value truncation.
- Real-prompt rendering tests: metadata block present with fields, absent when no metadata.
- Pipeline test: push `metadata` is passed through to `batch_reconcile`.
- Full `test_ingest_batch_reconciler.py` + `test_ingest_pipeline.py`: 71 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)