### PR TITLE
feat(triggers): Activity History flyout entries per the Figma mock

### DIFF
--- a/frontend/src/components/triggers/TriggerCard.tsx
+++ b/frontend/src/components/triggers/TriggerCard.tsx
@@ -211,8 +211,8 @@ export function TriggerCard({
                   </div>
                 </div>
                 {isOpen && f.message && (
-                  <div className="w-full pr-5 pb-1">
-                    <Text as="p" font="main-ui-body" color="text-03">
+                  <div className="w-full pr-5 pb-1 [&>span]:block">
+                    <Text font="main-ui-body" color="text-03">
                       {markdown(f.message)}
                     </Text>
                   </div>

--- a/frontend/src/components/triggers/TriggerCard.tsx
+++ b/frontend/src/components/triggers/TriggerCard.tsx
@@ -5,32 +5,15 @@ import { useState } from "react";
 import { Button, Switch, Text } from "@onyx-ai/opal/components";
 import { markdown } from "@onyx-ai/opal/utils";
 import {
-  SvgActivity,
-  SvgBook,
   SvgChevronDown,
   SvgChevronUp,
-  SvgFile,
-  SvgFolder,
   SvgInfo,
-  SvgMail,
   SvgSettings,
-  SvgSlack,
   SvgWorkflow,
 } from "@onyx-ai/opal/icons";
 
-import { formatScopePath } from "@/lib/format";
+import { AvatarCluster, ScopeChip } from "@/components/triggers/fireParts";
 import type { DestinationConfig, Trigger, TriggerFire } from "@/lib/triggers";
-
-function scopeIcon(scope: string) {
-  if (scope === "/" || scope === "") return SvgBook;
-  return scope.endsWith(".md") ? SvgFile : SvgFolder;
-}
-
-function destinationIcon(type: string) {
-  if (type === "slack") return SvgSlack;
-  if (type === "email") return SvgMail;
-  return SvgActivity;
-}
 
 /** The card's per-fire "Sent message to X · N ago" line names the config the
  * fire was recorded against; a deleted config degrades to the type name. */
@@ -86,8 +69,6 @@ export function TriggerCard({
     ),
   ];
 
-  const ScopeIcon = scopeIcon(t.scope_path);
-
   function toggleRow(f: TriggerFire) {
     setOverrides((cur) => new Map(cur).set(f.event_id, !isRowOpen(f)));
   }
@@ -100,42 +81,14 @@ export function TriggerCard({
     >
       <div className="flex w-full items-center p-[2px]">
         <div className="flex min-w-0 flex-1 items-center gap-1 p-[2px]">
-          <span
-            className="flex max-w-[220px] items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]"
-            title={t.scope_path || "Whole wiki"}
-          >
-            <span className="flex size-4 items-center justify-center p-[2px]">
-              <ScopeIcon className="size-3 text-(--text-03)" />
-            </span>
-            <span className="min-w-0 px-[2px]">
-              <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
-                {t.scope_path
-                  ? formatScopePath(t.scope_path).replace(/^\//, "")
-                  : "Whole wiki"}
-              </Text>
-            </span>
-          </span>
+          <ScopeChip scope={t.scope_path} />
           <span className="flex size-4 items-center justify-center p-[2px]">
             <SvgWorkflow className="size-3 text-(--text-03)" />
           </span>
-          <span className="flex items-center px-[2px]">
-            <span className="flex size-5 items-center justify-center rounded-full border border-(--border-01) bg-(--background-neutral-inverted-00)">
-              <Text font="secondary-action" color="text-inverted-05">
-                {(ownerName[0] ?? "?").toUpperCase()}
-              </Text>
-            </span>
-            {destinationTypes.map((type) => {
-              const Icon = destinationIcon(type);
-              return (
-                <span
-                  key={type}
-                  className="-ml-1 flex size-5 items-center justify-center rounded-full border border-(--border-01) bg-(--background-neutral-00)"
-                >
-                  <Icon className="size-3 text-(--text-04)" />
-                </span>
-              );
-            })}
-          </span>
+          <AvatarCluster
+            ownerName={ownerName}
+            destinationTypes={destinationTypes}
+          />
           <span className="min-w-0 px-[2px]">
             <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
               {`${ownerName} (you)`}
@@ -259,7 +212,7 @@ export function TriggerCard({
                 </div>
                 {isOpen && f.message && (
                   <div className="w-full pr-5 pb-1">
-                    <Text font="main-ui-body" color="text-03">
+                    <Text as="p" font="main-ui-body" color="text-03">
                       {markdown(f.message)}
                     </Text>
                   </div>

--- a/frontend/src/components/triggers/fireParts.tsx
+++ b/frontend/src/components/triggers/fireParts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Text } from "@onyx-ai/opal/components";
+import { Tag, Text } from "@onyx-ai/opal/components";
 import {
   SvgActivity,
   SvgBook,
@@ -23,30 +23,26 @@ export function destinationIcon(type: string) {
   return SvgActivity;
 }
 
-/** The tinted page/folder tag shared by trigger cards and activity rows.
- * Custom spans: Opal ships no passive tag/badge primitive (FilterButton is
- * its only chip and is interactive-only). */
+/** The page/folder tag shared by trigger cards and activity rows. The
+ * wrapper span only bounds width for long paths and carries the full-path
+ * hover title. */
 export function ScopeChip({ scope }: { scope: string }) {
-  const Icon = scopeIcon(scope);
   return (
     <span
-      className="flex max-w-[220px] items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]"
+      className="flex max-w-[220px] items-center overflow-hidden"
       title={scope || "Whole wiki"}
     >
-      <span className="flex size-4 items-center justify-center p-[2px]">
-        <Icon className="size-3 text-(--text-03)" />
-      </span>
-      <span className="min-w-0 px-[2px]">
-        <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
-          {scope ? formatScopePath(scope).replace(/^\//, "") : "Whole wiki"}
-        </Text>
-      </span>
+      <Tag
+        icon={scopeIcon(scope)}
+        title={scope ? formatScopePath(scope).replace(/^\//, "") : "Whole wiki"}
+      />
     </span>
   );
 }
 
 /** Overlapping 20px owner-initial + destination-type circles. Custom spans:
- * Opal ships no avatar primitive. */
+ * Opal ships no avatar primitive (checked alias-tolerant across the dist —
+ * only Table's qualifier-column docs mention avatars). */
 export function AvatarCluster({
   ownerName,
   destinationTypes,

--- a/frontend/src/components/triggers/fireParts.tsx
+++ b/frontend/src/components/triggers/fireParts.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Text } from "@onyx-ai/opal/components";
+import {
+  SvgActivity,
+  SvgBook,
+  SvgFile,
+  SvgFolder,
+  SvgMail,
+  SvgSlack,
+} from "@onyx-ai/opal/icons";
+
+import { formatScopePath } from "@/lib/format";
+
+export function scopeIcon(scope: string) {
+  if (scope === "/" || scope === "") return SvgBook;
+  return scope.endsWith(".md") ? SvgFile : SvgFolder;
+}
+
+export function destinationIcon(type: string) {
+  if (type === "slack") return SvgSlack;
+  if (type === "email") return SvgMail;
+  return SvgActivity;
+}
+
+/** The tinted page/folder tag shared by trigger cards and activity rows. */
+export function ScopeChip({ scope }: { scope: string }) {
+  const Icon = scopeIcon(scope);
+  return (
+    <span
+      className="flex max-w-[220px] items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]"
+      title={scope || "Whole wiki"}
+    >
+      <span className="flex size-4 items-center justify-center p-[2px]">
+        <Icon className="size-3 text-(--text-03)" />
+      </span>
+      <span className="min-w-0 px-[2px]">
+        <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
+          {scope ? formatScopePath(scope).replace(/^\//, "") : "Whole wiki"}
+        </Text>
+      </span>
+    </span>
+  );
+}
+
+/** Overlapping 20px owner-initial + destination-type circles. */
+export function AvatarCluster({
+  ownerName,
+  destinationTypes,
+}: {
+  ownerName: string;
+  destinationTypes: string[];
+}) {
+  return (
+    <span className="flex items-center px-[2px]">
+      <span className="flex size-5 items-center justify-center rounded-full border border-(--border-01) bg-(--background-neutral-inverted-00)">
+        <Text font="secondary-action" color="text-inverted-05">
+          {(ownerName[0] ?? "?").toUpperCase()}
+        </Text>
+      </span>
+      {destinationTypes.map((type) => {
+        const Icon = destinationIcon(type);
+        return (
+          <span
+            key={type}
+            className="-ml-1 flex size-5 items-center justify-center rounded-full border border-(--border-01) bg-(--background-neutral-00)"
+          >
+            <Icon className="size-3 text-(--text-04)" />
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/frontend/src/components/triggers/fireParts.tsx
+++ b/frontend/src/components/triggers/fireParts.tsx
@@ -23,7 +23,9 @@ export function destinationIcon(type: string) {
   return SvgActivity;
 }
 
-/** The tinted page/folder tag shared by trigger cards and activity rows. */
+/** The tinted page/folder tag shared by trigger cards and activity rows.
+ * Custom spans: Opal ships no passive tag/badge primitive (FilterButton is
+ * its only chip and is interactive-only). */
 export function ScopeChip({ scope }: { scope: string }) {
   const Icon = scopeIcon(scope);
   return (
@@ -43,7 +45,8 @@ export function ScopeChip({ scope }: { scope: string }) {
   );
 }
 
-/** Overlapping 20px owner-initial + destination-type circles. */
+/** Overlapping 20px owner-initial + destination-type circles. Custom spans:
+ * Opal ships no avatar primitive. */
 export function AvatarCluster({
   ownerName,
   destinationTypes,

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import {
   Button,
+  LineItemButton,
   Divider,
   InputTypeIn,
   Tag,
@@ -154,32 +155,27 @@ function ActivityRow({
         </div>
       </div>
       <div className="flex w-full flex-col p-1 pt-0">
-        <div className="flex w-full items-center gap-[2px]">
-          <div className="flex min-w-0 flex-1 items-center py-[2px]">
-            <span className="shrink-0 px-[2px]">
-              <Text font="secondary-body" color="text-03" nowrap>
-                {prefix}
-              </Text>
-            </span>
-            <span className="min-w-0 px-[2px]">
-              <Text font="secondary-action" color="text-03" nowrap maxLines={1}>
-                {subject}
-              </Text>
-            </span>
+        {body ? (
+          <LineItemButton
+            title={markdown(`${prefix} **${subject}**`)}
+            sizePreset="secondary"
+            variant="body"
+            state="empty"
+            width="full"
+            onClick={() => setOverride(!open)}
+            rightChildren={
+              <span className="flex size-5 items-center justify-center">
+                <Chevron className="size-3.5 text-(--text-03)" />
+              </span>
+            }
+          />
+        ) : (
+          <div className="flex w-full items-center px-[2px] py-[2px]">
+            <Text font="secondary-body" color="text-03" nowrap maxLines={1}>
+              {markdown(`${prefix} **${subject}**`)}
+            </Text>
           </div>
-          {body && (
-            /* raw-ok: 20px inline chevron; Opal Button's smallest container oversizes this row */
-            <button
-              type="button"
-              onClick={() => setOverride(!open)}
-              aria-expanded={open}
-              title="Details"
-              className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-(--radius-08) border-0 bg-transparent p-[2px] hover:bg-(--background-tint-02)"
-            >
-              <Chevron className="size-3.5 text-(--text-03)" />
-            </button>
-          )}
-        </div>
+        )}
         {open && body && (
           <div className="w-full pr-5 pb-1 [&>span]:block">
             <Text font="main-ui-body" color="text-03">

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -98,11 +98,16 @@ function eventTexts(event: AppEvent): {
       body: p.message || p.reason || null,
     };
   }
-  // Unknown kinds stay legible instead of masquerading as trigger fires.
+  // Unknown kinds stay legible instead of masquerading as trigger fires,
+  // and their payload stays inspectable when it has no message/reason.
+  const payloadKeys = Object.keys(event.payload ?? {});
   return {
     prefix: "Event",
     subject: event.kind,
-    body: p.message || p.reason || null,
+    body:
+      p.message ||
+      p.reason ||
+      (payloadKeys.length ? JSON.stringify(event.payload) : null),
   };
 }
 

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -86,13 +86,21 @@ function eventTexts(event: AppEvent): {
       body: `Hit the limit of ${p.cap ?? "?"} auto-updates in 24 hours, so further auto-updates are paused for now.`,
     };
   }
-  const verb =
-    p.destination_type === "event_log" || !p.destination_type
-      ? "Sent a notification to"
-      : "Sent a message to";
+  if (event.kind === "trigger.fire") {
+    const verb =
+      p.destination_type === "event_log" || !p.destination_type
+        ? "Sent a notification to"
+        : "Sent a message to";
+    return {
+      prefix: verb,
+      subject: destinationName(p.destination_type),
+      body: p.message || p.reason || null,
+    };
+  }
+  // Unknown kinds stay legible instead of masquerading as trigger fires.
   return {
-    prefix: verb,
-    subject: destinationName(p.destination_type),
+    prefix: "Event",
+    subject: event.kind,
     body: p.message || p.reason || null,
   };
 }
@@ -173,8 +181,8 @@ function ActivityRow({
           )}
         </div>
         {open && body && (
-          <div className="w-full pr-5 pb-1">
-            <Text as="p" font="main-ui-body" color="text-03">
+          <div className="w-full pr-5 pb-1 [&>span]:block">
+            <Text font="main-ui-body" color="text-03">
               {markdown(body)}
             </Text>
           </div>

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -1,141 +1,184 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Divider, InputTypeIn, Tag } from "@onyx-ai/opal/components";
+import {
+  Button,
+  Divider,
+  InputTypeIn,
+  Tag,
+  Text,
+} from "@onyx-ai/opal/components";
 import { SvgEmpty, SvgNotFound } from "@onyx-ai/opal/illustrations";
-import { SvgActivity, SvgX } from "@onyx-ai/opal/icons";
+import {
+  SvgActivity,
+  SvgChevronDown,
+  SvgChevronUp,
+  SvgWorkflow,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+import { markdown } from "@onyx-ai/opal/utils";
 import { Content, IllustrationContent, Section } from "@onyx-ai/opal/layouts";
 import { timeAgo } from "@onyx-ai/opal/time";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { AvatarCluster, ScopeChip } from "@/components/triggers/fireParts";
 import {
   isNewActivity,
   toEventIso,
   useEvents,
   type AppEvent,
 } from "@/lib/activities";
-import { formatScopePath } from "@/lib/format";
+import { useAuth } from "@/lib/auth";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 
-interface TriggerFirePayload {
+interface ActivityPayload {
   doc_path?: string;
   change_kind?: string;
   reason?: string;
-}
-
-interface FrequentUpdatesPayload {
-  doc_path?: string;
+  message?: string;
+  destination_type?: string;
   count?: number;
   threshold?: number;
-}
-
-interface AutoUpdateCappedPayload {
-  doc_path?: string;
-  count?: number;
   cap?: number;
 }
 
 // Searchable text for an event regardless of kind.
 function eventHaystack(event: AppEvent): string {
-  const p = event.payload as TriggerFirePayload & FrequentUpdatesPayload;
-  return [p.doc_path, p.change_kind, p.reason, event.target, event.kind]
+  const p = event.payload as ActivityPayload;
+  return [
+    p.doc_path,
+    p.change_kind,
+    p.reason,
+    p.message,
+    event.target,
+    event.kind,
+  ]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
 }
 
-interface ActivityCardProps {
-  event: AppEvent;
+function destinationName(type: string | undefined): string {
+  if (type === "slack") return "Slack";
+  if (type === "email") return "Email";
+  return "Activity Center";
 }
 
-const cardClass =
-  "mx-3 my-1.5 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-3 py-2.5";
-
-function FrequentUpdatesCard({ event }: ActivityCardProps) {
-  const p = event.payload as FrequentUpdatesPayload;
-  return (
-    <div className={cardClass}>
-      <div className="mb-1 flex items-start justify-between gap-2">
-        <span className="truncate font-mono text-xs text-(--text-04)">
-          {p.doc_path ? formatScopePath(p.doc_path) : "(no path)"}
-        </span>
-        <span className="shrink-0">
-          <Tag title="Frequent" color="amber" />
-        </span>
-      </div>
-      <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
-        Auto-updated {p.count ?? "?"} times in the past 24 hours
-        {p.threshold ? ` (warns at ${p.threshold}).` : "."}
-      </p>
-      <div className="flex items-center justify-end">
-        <span className="text-[11px] text-(--text-02)">
-          {timeAgo(toEventIso(event.ts))}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function AutoUpdateCappedCard({ event }: ActivityCardProps) {
-  const p = event.payload as AutoUpdateCappedPayload;
-  return (
-    <div className={cardClass}>
-      <div className="mb-1 flex items-start justify-between gap-2">
-        <span className="truncate font-mono text-xs text-(--text-04)">
-          {p.doc_path ? formatScopePath(p.doc_path) : "(no path)"}
-        </span>
-        <span className="shrink-0">
-          <Tag title="Capped" color="red" />
-        </span>
-      </div>
-      <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
-        Auto-update paused — hit the limit of {p.cap ?? "?"} updates in 24
-        hours.
-      </p>
-      <div className="flex items-center justify-end">
-        <span className="text-[11px] text-(--text-02)">
-          {timeAgo(toEventIso(event.ts))}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function ActivityCard({ event }: ActivityCardProps) {
+/** Collapsed one-liner (prefix + bold subject) + expandable body per kind. */
+function eventTexts(event: AppEvent): {
+  prefix: string;
+  subject: string;
+  body: string | null;
+} {
+  const p = event.payload as ActivityPayload;
   if (event.kind === "wiki.frequent_updates") {
-    return <FrequentUpdatesCard event={event} />;
+    return {
+      prefix: "Frequent auto-updates on",
+      subject: p.doc_path ?? "a page",
+      body: `Auto-updated ${p.count ?? "?"} times in the past 24 hours${
+        p.threshold ? ` (warns at ${p.threshold})` : ""
+      }.`,
+    };
   }
   if (event.kind === "wiki.auto_update_capped") {
-    return <AutoUpdateCappedCard event={event} />;
+    return {
+      prefix: "Auto-updates paused on",
+      subject: p.doc_path ?? "a page",
+      body: `Hit the limit of ${p.cap ?? "?"} auto-updates in 24 hours, so further auto-updates are paused for now.`,
+    };
   }
-  const p = event.payload as TriggerFirePayload;
+  const verb =
+    p.destination_type === "event_log" || !p.destination_type
+      ? "Sent a notification to"
+      : "Sent a message to";
+  return {
+    prefix: verb,
+    subject: destinationName(p.destination_type),
+    body: p.message || p.reason || null,
+  };
+}
+
+function ActivityRow({
+  event,
+  ownerName,
+}: {
+  event: AppEvent;
+  ownerName: string;
+}) {
+  const p = event.payload as ActivityPayload;
+  const fresh = isNewActivity(event.ts);
+  const { prefix, subject, body } = eventTexts(event);
+  const [override, setOverride] = useState<boolean | null>(null);
+  // New entries open expanded, older ones collapsed; the chevron overrides.
+  const open = override ?? (fresh && body !== null);
+  const Chevron = open ? SvgChevronUp : SvgChevronDown;
+
+  const destinationTypes =
+    event.kind === "trigger.fire" ? [p.destination_type ?? "event_log"] : [];
+
   return (
-    <div className={cardClass}>
-      <div className="mb-1 flex items-start justify-between gap-2">
-        {p.doc_path ? (
-          <span className="truncate font-mono text-xs text-(--text-04)">
-            {formatScopePath(p.doc_path)}
+    <div className="flex w-full flex-col px-3 py-1">
+      <div className="flex w-full items-center p-[2px]">
+        <div className="flex min-w-0 flex-1 items-center gap-1 p-[2px]">
+          <ScopeChip scope={p.doc_path ?? event.target ?? ""} />
+          <span className="flex size-4 items-center justify-center p-[2px]">
+            {event.kind === "trigger.fire" ? (
+              <SvgWorkflow className="size-3 text-(--text-03)" />
+            ) : (
+              <SvgActivity className="size-3 text-(--text-03)" />
+            )}
           </span>
-        ) : (
-          <em className="text-xs text-(--text-02)">(no path)</em>
-        )}
-        {p.change_kind && (
-          <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-1.5 py-[2px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
-            {p.change_kind}
+          <AvatarCluster
+            ownerName={ownerName}
+            destinationTypes={destinationTypes}
+          />
+        </div>
+        <div className="flex shrink-0 items-center gap-1 p-[2px]">
+          <Text font="secondary-body" color="text-03" nowrap>
+            {timeAgo(toEventIso(event.ts)) ?? ""}
+          </Text>
+          <span className="flex size-5 items-center justify-center">
+            {fresh ? (
+              <span className="size-[6px] rounded-full bg-(--action-link-05)" />
+            ) : (
+              <span className="size-2 rounded-full border border-(--border-02)" />
+            )}
           </span>
-        )}
+        </div>
       </div>
-      {p.reason && (
-        <p className="mb-1.5 line-clamp-2 text-xs text-(--text-04)">
-          {p.reason}
-        </p>
-      )}
-      <div className="flex items-center justify-between">
-        <span className="text-[11px] text-(--text-02)">
-          trigger {event.target ?? "?"}
-        </span>
-        <span className="text-[11px] text-(--text-02)">
-          {timeAgo(toEventIso(event.ts))}
-        </span>
+      <div className="flex w-full flex-col p-1 pt-0">
+        <div className="flex w-full items-center gap-[2px]">
+          <div className="flex min-w-0 flex-1 items-center py-[2px]">
+            <span className="shrink-0 px-[2px]">
+              <Text font="secondary-body" color="text-03" nowrap>
+                {prefix}
+              </Text>
+            </span>
+            <span className="min-w-0 px-[2px]">
+              <Text font="secondary-action" color="text-03" nowrap maxLines={1}>
+                {subject}
+              </Text>
+            </span>
+          </div>
+          {body && (
+            /* raw-ok: 20px inline chevron; Opal Button's smallest container oversizes this row */
+            <button
+              type="button"
+              onClick={() => setOverride(!open)}
+              aria-expanded={open}
+              title="Details"
+              className="flex size-5 shrink-0 cursor-pointer items-center justify-center rounded-(--radius-08) border-0 bg-transparent p-[2px] hover:bg-(--background-tint-02)"
+            >
+              <Chevron className="size-3.5 text-(--text-03)" />
+            </button>
+          )}
+        </div>
+        {open && body && (
+          <div className="w-full pr-5 pb-1">
+            <Text as="p" font="main-ui-body" color="text-03">
+              {markdown(body)}
+            </Text>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -143,6 +186,8 @@ function ActivityCard({ event }: ActivityCardProps) {
 
 export default function ActivitiesPanel() {
   const { toggleActivities } = useLeftPanel();
+  const { user } = useAuth();
+  const ownerName = user?.name || user?.email || "?";
   const [query, setQuery] = useState("");
   const { events, isLoading } = useEvents(
     { limit: 100 },
@@ -159,7 +204,7 @@ export default function ActivitiesPanel() {
   const olderEvents = filtered.filter((ev) => !isNewActivity(ev.ts));
 
   return (
-    <div className="flex h-full w-(--activities-view) flex-col rounded-(--border-radius-12) border border-(--border-01) p-1">
+    <div className="flex h-full w-(--activities-view) flex-col rounded-(--radius-12) border border-(--border-01) p-1">
       {/* Header */}
       <Section
         flexDirection="row"
@@ -230,7 +275,7 @@ export default function ActivitiesPanel() {
               <Divider title="New" />
             </div>
             {newEvents.map((ev) => (
-              <ActivityCard key={ev.id} event={ev} />
+              <ActivityRow key={ev.id} event={ev} ownerName={ownerName} />
             ))}
           </>
         )}
@@ -241,7 +286,7 @@ export default function ActivitiesPanel() {
               <Divider title="Older" />
             </div>
             {olderEvents.map((ev) => (
-              <ActivityCard key={ev.id} event={ev} />
+              <ActivityRow key={ev.id} event={ev} ownerName={ownerName} />
             ))}
           </>
         )}


### PR DESCRIPTION
## Description

Rebuilds the Activity History flyout's entries to the mock (`37:81552`). Each row now speaks the trigger cards' language: scope chip, kind glyph, and the owner/destination avatar cluster on the left, relative time with a read dot on the right (blue fill for new, hollow for older), then a collapsed "Sent a message to Slack" line with a chevron and the expandable message body. New entries open expanded by default; the frequent-update and cap events render through the same row shape. The panel chrome (header, new-count badge, search, New/Older dividers, empty states) was already Opal and stays.

The chip and avatar cluster move into a shared `fireParts` module used by both the trigger cards and the flyout, so the two surfaces stay in lockstep. One rendering bug fixed along the way, found by DOM measurement: `markdown()` inside Text's inline span leaves whitespace nodes around the block children ReactMarkdown emits, which render as phantom line boxes (a 20px line measured 68px). Message bodies now render as block paragraphs and the one-liners compose plain Texts, on both surfaces.

## How Has This Been Tested?

Verified live in Chrome against the mock: new entries expanded with tight messages and blue dots, older entries collapsed with hollow dots, chevron expands in place, search and dividers intact. tsc and prettier clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check