### PR TITLE
feat(settings): Connectors tab with Slack mute and the Emails modal

### DIFF
--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -40,8 +40,14 @@ class SlackConnectStatus(BaseModel):
     configured: bool
     connected: bool
     team_name: str | None = None
+    team_id: str | None = None
     token_display: str | None = None
+    muted: bool = False
     connect_url: str | None = None
+
+
+class SlackMuteRequest(BaseModel):
+    muted: bool
 
 
 def _require_configured() -> app_settings.SlackAppSettings:
@@ -77,9 +83,25 @@ def get_status(user: User = Depends(require_user)) -> SlackConnectStatus:
         configured=settings.configured,
         connected=first is not None,
         team_name=first["team_name"] if first else None,
+        team_id=first["team_id"] if first else None,
         token_display=first["token_display"] if first else None,
+        muted=bool(first["muted"]) if first else False,
         connect_url=connect_url,
     )
+
+
+@router.put("/mute", response_model=SlackConnectStatus)
+def set_mute(
+    req: SlackMuteRequest, user: User = Depends(require_user)
+) -> SlackConnectStatus:
+    """Pause or resume Slack delivery on the user's connection without
+    disconnecting."""
+    rows = connections.list_for_user(user.id)
+    first = rows[0] if rows else None
+    if first is None:
+        raise HTTPException(status_code=404, detail="not connected")
+    connections.set_muted(user.id, str(first["team_id"]), req.muted)
+    return get_status(user)
 
 
 @router.get("/start")

--- a/backend/app/api/slack_connect.py
+++ b/backend/app/api/slack_connect.py
@@ -48,6 +48,8 @@ class SlackConnectStatus(BaseModel):
 
 class SlackMuteRequest(BaseModel):
     muted: bool
+    # Required when the user has connections in more than one workspace.
+    team_id: str | None = None
 
 
 def _require_configured() -> app_settings.SlackAppSettings:
@@ -94,13 +96,22 @@ def get_status(user: User = Depends(require_user)) -> SlackConnectStatus:
 def set_mute(
     req: SlackMuteRequest, user: User = Depends(require_user)
 ) -> SlackConnectStatus:
-    """Pause or resume Slack delivery on the user's connection without
+    """Pause or resume Slack delivery on one connection without
     disconnecting."""
     rows = connections.list_for_user(user.id)
-    first = rows[0] if rows else None
-    if first is None:
+    if not rows:
         raise HTTPException(status_code=404, detail="not connected")
-    connections.set_muted(user.id, str(first["team_id"]), req.muted)
+    if req.team_id is not None:
+        team_id = req.team_id
+    elif len(rows) == 1:
+        team_id = str(rows[0]["team_id"])
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="multiple Slack workspaces connected; pass team_id",
+        )
+    if not connections.set_muted(user.id, team_id, req.muted):
+        raise HTTPException(status_code=404, detail="not connected")
     return get_status(user)
 
 

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -218,7 +218,14 @@ def resend_verification(
     try:
         email_verification.send_verification_email(config_id, address)
     except email_verification.MintRateLimitedError as exc:
-        raise HTTPException(status_code=429, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "error": str(exc),
+                "retry_after_seconds": exc.retry_after_seconds,
+            },
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
     except EmailSendError as exc:
         view.verification_error = f"verification email failed: {exc}"
     return view

--- a/backend/app/db/migrations/versions/7f2a91c04b11_slack_connection_muted.py
+++ b/backend/app/db/migrations/versions/7f2a91c04b11_slack_connection_muted.py
@@ -4,7 +4,7 @@ Pauses Slack delivery without disconnecting. Guarded with the inspector
 because ``0001_initial`` builds fresh databases from the current models.
 
 Revision ID: 7f2a91c04b11
-Revises: 0075dcbb622e
+Revises: 0076
 Create Date: 2026-07-07 05:20:00.000000+00:00
 """
 from __future__ import annotations
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 
 
 revision: str = "7f2a91c04b11"
-down_revision: str | None = "0075dcbb622e"
+down_revision: str | None = "0076"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/db/migrations/versions/7f2a91c04b11_slack_connection_muted.py
+++ b/backend/app/db/migrations/versions/7f2a91c04b11_slack_connection_muted.py
@@ -1,0 +1,41 @@
+"""slack connection muted flag
+
+Pauses Slack delivery without disconnecting. Guarded with the inspector
+because ``0001_initial`` builds fresh databases from the current models.
+
+Revision ID: 7f2a91c04b11
+Revises: 0075dcbb622e
+Create Date: 2026-07-07 05:20:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "7f2a91c04b11"
+down_revision: str | None = "0075dcbb622e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("user_slack_connections")}
+    if "muted" not in cols:
+        op.add_column(
+            "user_slack_connections",
+            sa.Column(
+                "muted",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("FALSE"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("user_slack_connections", "muted")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1452,6 +1452,11 @@ class UserSlackConnection(Base):
     )
     team_id: Mapped[str] = mapped_column(Text, primary_key=True)
     team_name: Mapped[str | None] = mapped_column(Text)
+    # Pauses Slack delivery without disconnecting; dispatch skips muted
+    # connections and records the fire to events only.
+    muted: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("FALSE")
+    )
     # The connecting user's own Slack id, for DM-yourself delivery and
     # attribution.
     slack_user_id: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,7 +81,10 @@ def _on_http_exception(_request: Request, exc: Exception) -> JSONResponse:
         if isinstance(exc.detail, dict)
         else ErrorResponse(error=str(exc.detail)).model_dump()
     )
-    return JSONResponse(status_code=exc.status_code, content=content)
+    # Preserve semantic headers the endpoint attached (e.g. Retry-After).
+    return JSONResponse(
+        status_code=exc.status_code, content=content, headers=exc.headers
+    )
 
 
 def _on_validation_error(_request: Request, exc: Exception) -> JSONResponse:

--- a/backend/app/slack/connections.py
+++ b/backend/app/slack/connections.py
@@ -42,6 +42,7 @@ def _to_dict(c: UserSlackConnection) -> dict[str, Any]:
         "slack_user_id": c.slack_user_id,
         "token_display": c.token_display,
         "scope": c.scope,
+        "muted": c.muted,
         "created_at": c.created_at,
         "updated_at": c.updated_at,
     }
@@ -99,6 +100,17 @@ def get(user_id: str, team_id: str) -> dict[str, Any] | None:
     with session() as s:
         row = s.get(UserSlackConnection, (user_id, team_id), options=[_DEFER_TOKEN])
         return _to_dict(row) if row else None
+
+
+def set_muted(user_id: str, team_id: str, muted: bool) -> dict[str, Any] | None:
+    """Flip delivery muting on one connection. Returns the updated row."""
+    with session() as s:
+        c = s.get(UserSlackConnection, (user_id, team_id))
+        if c is None:
+            return None
+        c.muted = muted
+        c.updated_at = _now_iso()
+        return _to_dict(c)
 
 
 def delete_connection(user_id: str, team_id: str) -> bool:

--- a/backend/app/slack/connections.py
+++ b/backend/app/slack/connections.py
@@ -87,11 +87,16 @@ def upsert(
 
 
 def list_for_user(user_id: str) -> list[dict[str, Any]]:
+    """Oldest connection first. Status, mute defaulting, and trigger dispatch
+    all treat the first row as "the" connection, so the order must be stable."""
     with session() as s:
         rows = s.scalars(
             select(UserSlackConnection)
             .options(_DEFER_TOKEN)
             .where(UserSlackConnection.user_id == user_id)
+            .order_by(
+                UserSlackConnection.created_at, UserSlackConnection.team_id
+            )
         ).all()
         return [_to_dict(c) for c in rows]
 

--- a/backend/app/slack/connections.py
+++ b/backend/app/slack/connections.py
@@ -13,7 +13,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from cryptography.exceptions import InvalidTag
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.orm import defer
 
 from app.db.models import UserSlackConnection
@@ -102,15 +102,20 @@ def get(user_id: str, team_id: str) -> dict[str, Any] | None:
         return _to_dict(row) if row else None
 
 
-def set_muted(user_id: str, team_id: str, muted: bool) -> dict[str, Any] | None:
-    """Flip delivery muting on one connection. Returns the updated row."""
+def set_muted(user_id: str, team_id: str, muted: bool) -> bool:
+    """Flip delivery muting on one connection without touching the stored
+    token. Returns whether a row matched."""
     with session() as s:
-        c = s.get(UserSlackConnection, (user_id, team_id))
-        if c is None:
-            return None
-        c.muted = muted
-        c.updated_at = _now_iso()
-        return _to_dict(c)
+        matched = s.scalar(
+            update(UserSlackConnection)
+            .where(
+                UserSlackConnection.user_id == user_id,
+                UserSlackConnection.team_id == team_id,
+            )
+            .values(muted=muted, updated_at=_now_iso())
+            .returning(UserSlackConnection.team_id)
+        )
+        return matched is not None
 
 
 def delete_connection(user_id: str, team_id: str) -> bool:

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -478,12 +478,15 @@ def _dispatch_to_slack(
             return
         # Slack webhook URLs embed their workspace id
         # (hooks.slack.com/services/<TEAM>/...), so the mute check targets
-        # exactly the webhook's own workspace. URLs that don't parse fall
-        # back to fail-quiet: any muted connection suppresses the send.
+        # exactly the webhook's own workspace. For URLs that don't parse:
+        # a single connection is the only Slack there is, so its mute
+        # applies; with multiple workspaces an unattributable webhook never
+        # borrows another workspace's mute and keeps sending.
         team_match = re.match(
             r"https://hooks\.slack\.com/services/(T[A-Z0-9]+)/", webhook_url
         )
         connections = slack_connections.list_for_user(trigger.owner_user_id)
+        muted_team = None
         if team_match:
             muted_team = next(
                 (
@@ -493,10 +496,8 @@ def _dispatch_to_slack(
                 ),
                 None,
             )
-        else:
-            muted_team = next(
-                (c["team_id"] for c in connections if c.get("muted")), None
-            )
+        elif len(connections) == 1 and connections[0].get("muted"):
+            muted_team = connections[0]["team_id"]
         if muted_team is not None:
             log.info(
                 "trigger %s slack webhook suppressed: connection %s is muted; "

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -494,16 +494,28 @@ def _dispatch_to_slack(
         )
         return
 
-    connection = next(iter(slack_connections.list_for_user(trigger.owner_user_id)), None)
+    # Resolve the connection the target belongs to: configs stamped with a
+    # team_id use that workspace; legacy configs fall back to the first
+    # connection. Mute is checked on the SAME connection that would deliver,
+    # so muting one workspace never silences another.
+    config_team = target.get("team_id")
+    if config_team:
+        connection = slack_connections.get(trigger.owner_user_id, str(config_team))
+    else:
+        connection = next(
+            iter(slack_connections.list_for_user(trigger.owner_user_id)), None
+        )
     if connection is None:
         log.info(
-            "trigger %s owner %s has no slack connection; recorded to events only",
+            "trigger %s owner %s has no slack connection for this target; "
+            "recorded to events only",
             trigger.id, trigger.owner_user_id,
         )
         return
     if connection.get("muted"):
         log.info(
-            "trigger %s slack connection muted; recorded to events only", trigger.id
+            "trigger %s slack connection %s muted; recorded to events only",
+            trigger.id, connection["team_id"],
         )
         return
     bot_token = slack_connections.get_bot_token(

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any, cast
 
 from datetime import datetime, timezone
@@ -468,31 +469,39 @@ def _dispatch_to_slack(
     config_id = str(config["id"])
 
     if config.get("has_secret"):
-        # Webhooks carry no workspace identity, so they cannot be matched to
-        # a specific connection's mute. Fail quiet: any muted connection
-        # suppresses webhook sends, since the webhook may belong to that
-        # workspace. Owners with no connections have no mute surface and
-        # keep sending.
-        muted_team = next(
-            (
-                c["team_id"]
-                for c in slack_connections.list_for_user(trigger.owner_user_id)
-                if c.get("muted")
-            ),
-            None,
-        )
-        if muted_team is not None:
-            log.info(
-                "trigger %s slack webhook suppressed: connection %s is muted; "
-                "recorded to events only",
-                trigger.id, muted_team,
-            )
-            return
         webhook_url = dest_configs.get_secret(config_id, owner_user_id=trigger.owner_user_id)
         if not webhook_url:
             log.info(
                 "trigger %s slack config %s secret unavailable; recorded to events only",
                 trigger.id, config_id,
+            )
+            return
+        # Slack webhook URLs embed their workspace id
+        # (hooks.slack.com/services/<TEAM>/...), so the mute check targets
+        # exactly the webhook's own workspace. URLs that don't parse fall
+        # back to fail-quiet: any muted connection suppresses the send.
+        team_match = re.match(
+            r"https://hooks\.slack\.com/services/(T[A-Z0-9]+)/", webhook_url
+        )
+        connections = slack_connections.list_for_user(trigger.owner_user_id)
+        if team_match:
+            muted_team = next(
+                (
+                    c["team_id"]
+                    for c in connections
+                    if c["team_id"] == team_match.group(1) and c.get("muted")
+                ),
+                None,
+            )
+        else:
+            muted_team = next(
+                (c["team_id"] for c in connections if c.get("muted")), None
+            )
+        if muted_team is not None:
+            log.info(
+                "trigger %s slack webhook suppressed: connection %s is muted; "
+                "recorded to events only",
+                trigger.id, muted_team,
             )
             return
         try:

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -507,53 +507,68 @@ def _dispatch_to_slack(
         )
         return
 
-    # Resolve the connection the target belongs to: configs stamped with a
-    # team_id use that workspace; legacy configs fall back to the first
-    # connection. Mute is checked on the SAME connection that would deliver,
-    # so muting one workspace never silences another.
+    # Resolve the connection the target belongs to. Configs stamped with a
+    # team_id use exactly that workspace. Legacy unstamped configs try each
+    # of the owner's connections in the stable order until one accepts the
+    # channel (a wrong-workspace token fails without delivering), so the
+    # channel's real workspace wins rather than whichever row happens to be
+    # first. Mute is checked on the SAME connection that would deliver.
     config_team = target.get("team_id")
     if config_team:
-        connection = slack_connections.get(trigger.owner_user_id, str(config_team))
+        stamped = slack_connections.get(trigger.owner_user_id, str(config_team))
+        candidates = [stamped] if stamped else []
     else:
-        connection = next(
-            iter(slack_connections.list_for_user(trigger.owner_user_id)), None
-        )
-    if connection is None:
+        candidates = slack_connections.list_for_user(trigger.owner_user_id)
+    if not candidates:
         log.info(
             "trigger %s owner %s has no slack connection for this target; "
             "recorded to events only",
             trigger.id, trigger.owner_user_id,
         )
         return
-    if connection.get("muted"):
+    unmuted = [c for c in candidates if not c.get("muted")]
+    if not unmuted:
         log.info(
-            "trigger %s slack connection %s muted; recorded to events only",
-            trigger.id, connection["team_id"],
-        )
-        return
-    bot_token = slack_connections.get_bot_token(
-        trigger.owner_user_id, str(connection["team_id"])
-    )
-    if not bot_token:
-        log.info(
-            "trigger %s slack connection token unavailable; recorded to events only",
+            "trigger %s slack connections muted for this target; "
+            "recorded to events only",
             trigger.id,
         )
         return
 
-    # Channel posts name the owner as a real mention; a DM already is the owner.
-    source = f"— Agent Wiki trigger on {doc_path}"
-    if not wants_dm:
-        source += f", for <@{connection['slack_user_id']}>"
-    text = f"{slack_client.to_mrkdwn(rendered_message)}\n{source}"
-    try:
-        if wants_dm and not channel_id:
-            channel_id = slack_client.open_dm(
-                bot_token=bot_token, slack_user_id=str(connection["slack_user_id"])
-            )
-        slack_client.post_chat_message(
-            bot_token=bot_token, channel=str(channel_id), text=text
+    for connection in unmuted:
+        bot_token = slack_connections.get_bot_token(
+            trigger.owner_user_id, str(connection["team_id"])
         )
-        log.info("trigger %s dispatched via slack bot config %s", trigger.id, config_id)
-    except slack_client.SlackApiError:
-        log.exception("trigger %s slack bot dispatch failed", trigger.id)
+        if not bot_token:
+            continue
+        # Channel posts name the owner as a real mention; a DM already is
+        # the owner.
+        source = f"— Agent Wiki trigger on {doc_path}"
+        if not wants_dm:
+            source += f", for <@{connection['slack_user_id']}>"
+        text = f"{slack_client.to_mrkdwn(rendered_message)}\n{source}"
+        try:
+            post_channel = channel_id
+            if wants_dm and not post_channel:
+                post_channel = slack_client.open_dm(
+                    bot_token=bot_token,
+                    slack_user_id=str(connection["slack_user_id"]),
+                )
+            slack_client.post_chat_message(
+                bot_token=bot_token, channel=str(post_channel), text=text
+            )
+            log.info(
+                "trigger %s dispatched via slack bot config %s team %s",
+                trigger.id, config_id, connection["team_id"],
+            )
+            return
+        except slack_client.SlackApiError:
+            log.warning(
+                "trigger %s slack post failed on team %s; trying next connection",
+                trigger.id, connection["team_id"], exc_info=True,
+            )
+    log.error(
+        "trigger %s slack bot dispatch failed on all connections; "
+        "recorded to events only",
+        trigger.id,
+    )

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -468,6 +468,19 @@ def _dispatch_to_slack(
     config_id = str(config["id"])
 
     if config.get("has_secret"):
+        # Webhooks carry no workspace, so the settings page's single mute
+        # toggle (the deterministic first connection) governs them; owners
+        # with no connection at all have no mute surface and keep sending.
+        first = next(
+            iter(slack_connections.list_for_user(trigger.owner_user_id)), None
+        )
+        if first is not None and first.get("muted"):
+            log.info(
+                "trigger %s slack webhook muted via connection %s; "
+                "recorded to events only",
+                trigger.id, first["team_id"],
+            )
+            return
         webhook_url = dest_configs.get_secret(config_id, owner_user_id=trigger.owner_user_id)
         if not webhook_url:
             log.info(

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -468,17 +468,24 @@ def _dispatch_to_slack(
     config_id = str(config["id"])
 
     if config.get("has_secret"):
-        # Webhooks carry no workspace, so the settings page's single mute
-        # toggle (the deterministic first connection) governs them; owners
-        # with no connection at all have no mute surface and keep sending.
-        first = next(
-            iter(slack_connections.list_for_user(trigger.owner_user_id)), None
+        # Webhooks carry no workspace identity, so they cannot be matched to
+        # a specific connection's mute. Fail quiet: any muted connection
+        # suppresses webhook sends, since the webhook may belong to that
+        # workspace. Owners with no connections have no mute surface and
+        # keep sending.
+        muted_team = next(
+            (
+                c["team_id"]
+                for c in slack_connections.list_for_user(trigger.owner_user_id)
+                if c.get("muted")
+            ),
+            None,
         )
-        if first is not None and first.get("muted"):
+        if muted_team is not None:
             log.info(
-                "trigger %s slack webhook muted via connection %s; "
+                "trigger %s slack webhook suppressed: connection %s is muted; "
                 "recorded to events only",
-                trigger.id, first["team_id"],
+                trigger.id, muted_team,
             )
             return
         webhook_url = dest_configs.get_secret(config_id, owner_user_id=trigger.owner_user_id)

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -501,6 +501,11 @@ def _dispatch_to_slack(
             trigger.id, trigger.owner_user_id,
         )
         return
+    if connection.get("muted"):
+        log.info(
+            "trigger %s slack connection muted; recorded to events only", trigger.id
+        )
+        return
     bot_token = slack_connections.get_bot_token(
         trigger.owner_user_id, str(connection["team_id"])
     )

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 
 from app.db.models import DestinationConfig
 from app.db.session import session
+from app.slack import connections as slack_connections
 from app.triggers import destinations
 
 log = logging.getLogger(__name__)
@@ -75,6 +76,13 @@ def create(
         raise ValueError(f"unknown destination type: {type}")
     if type == destinations.SLACK_ID:
         cfg = config or {}
+        # Stamp the workspace the target belongs to (the caller listed its
+        # channels from that connection); dispatch and mute resolve by it.
+        if not cfg.get("team_id"):
+            first = next(iter(slack_connections.list_for_user(user_id)), None)
+            if first is not None:
+                cfg = {**cfg, "team_id": first["team_id"]}
+                config = cfg
         targets = sum(
             1 for present in (secret, cfg.get("channel_id"), cfg.get("dm")) if present
         )

--- a/backend/app/triggers/email_verification.py
+++ b/backend/app/triggers/email_verification.py
@@ -30,6 +30,10 @@ _MINT_COOLDOWN_SECONDS = 60
 class MintRateLimitedError(RuntimeError):
     """A verification email for this config was sent too recently."""
 
+    def __init__(self, message: str, retry_after_seconds: int) -> None:
+        super().__init__(message)
+        self.retry_after_seconds = retry_after_seconds
+
 
 def _iso(dt: datetime) -> str:
     return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -44,14 +48,21 @@ def mint_token(destination_config_id: str) -> str:
     floor = _iso(now - timedelta(seconds=_MINT_COOLDOWN_SECONDS))
     with session() as s:
         recent = s.scalar(
-            select(EmailVerificationToken.token).where(
+            select(EmailVerificationToken.created_at).where(
                 EmailVerificationToken.destination_config_id == destination_config_id,
                 EmailVerificationToken.created_at > floor,
                 EmailVerificationToken.consumed_at.is_(None),
             )
         )
         if recent is not None:
-            raise MintRateLimitedError("a verification email was just sent; wait a minute")
+            sent_at = datetime.strptime(recent, "%Y-%m-%d %H:%M:%S").replace(
+                tzinfo=timezone.utc
+            )
+            elapsed = int((now - sent_at).total_seconds())
+            retry_after = max(1, _MINT_COOLDOWN_SECONDS - elapsed)
+            raise MintRateLimitedError(
+                "a verification email was just sent; wait a minute", retry_after
+            )
         s.execute(
             delete(EmailVerificationToken).where(
                 EmailVerificationToken.destination_config_id == destination_config_id

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -311,7 +311,7 @@ def test_legacy_config_routes_to_the_workspace_that_accepts_the_channel(
     assert posted[0]["channel"] == "C2"
 
 
-def test_any_muted_connection_silences_webhooks_even_when_oldest_is_unmuted(
+def test_unattributable_webhook_with_multiple_workspaces_delivers(
     tmp_db, monkeypatch
 ):
     uid = seed_user(email="u@x.com")
@@ -325,6 +325,8 @@ def test_any_muted_connection_silences_webhooks_even_when_oldest_is_unmuted(
         scope="chat:write",
     )
     slack_connections.set_muted(uid, "T2", True)
+    # Unparseable host: the webhook cannot be attributed, and with two
+    # workspaces neither one's mute may be borrowed.
     cfg = dest_configs.create(
         uid,
         type=destinations_repo.SLACK_ID,
@@ -363,7 +365,7 @@ def test_any_muted_connection_silences_webhooks_even_when_oldest_is_unmuted(
         actor=None,
     )
 
-    assert posted == []
+    assert len(posted) == 1
 
 
 def test_webhook_for_unmuted_workspace_delivers_despite_other_muted(

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -1,0 +1,130 @@
+"""Muting a Slack connection pauses dispatch without disconnecting, and the
+resend-verification 429 carries a Retry-After header for the UI countdown."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.models.wiki import ChangeKind
+from app.slack import connections as slack_connections
+from app.tasks.triggers import _record_fire
+from app.triggers import destination_configs as dest_configs
+from app.triggers import destinations as destinations_repo
+from app.triggers.engine import TriggerAction, TriggerRecord
+
+from tests._auth import login_fastapi
+from tests._seed import list_events, seed_user
+
+
+@pytest.fixture
+def client(tmp_db):
+    return TestClient(create_app())
+
+
+def _connect(uid: str) -> None:
+    slack_connections.upsert(
+        user_id=uid,
+        team_id="T1",
+        team_name="Onyx Team",
+        slack_user_id="U1",
+        bot_token="xoxb-secret",
+        scope="chat:write",
+    )
+
+
+def _slack_trigger(uid: str) -> tuple[TriggerRecord, TriggerAction]:
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="#general",
+        config={"channel_id": "C1"},
+    )
+    action = TriggerAction(destination_config_id=cfg["id"], message="hi")
+    trigger = TriggerRecord(
+        id="trg_1",
+        owner_user_id=uid,
+        scope_path="a.md",
+        kind="delta",
+        nl_description="always",
+        actions=[action],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+    return trigger, action
+
+
+def test_mute_endpoint_roundtrip(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    _connect(uid)
+
+    r = client.put("/api/connectors/slack/mute", json={"muted": True})
+    assert r.status_code == 200
+    assert r.json()["muted"] is True
+    assert r.json()["connected"] is True
+
+    r = client.put("/api/connectors/slack/mute", json={"muted": False})
+    assert r.json()["muted"] is False
+
+
+def test_mute_without_connection_is_404(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    r = client.put("/api/connectors/slack/mute", json={"muted": True})
+    assert r.status_code == 404
+
+
+def test_muted_connection_skips_dispatch_but_records_fire(tmp_db, monkeypatch):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)
+    slack_connections.set_muted(uid, "T1", True)
+    trigger, action = _slack_trigger(uid)
+
+    posted: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "app.tasks.triggers._post_slack_message",
+        lambda **kw: posted.append(kw),
+        raising=False,
+    )
+
+    _record_fire(
+        trigger=trigger,
+        action=action,
+        doc_path="a.md",
+        sha="abc",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="hi",
+        actor=None,
+    )
+
+    assert posted == []
+    kinds = [e["kind"] for e in list_events()]
+    assert "trigger.fire" in kinds
+
+
+def test_resend_429_carries_retry_after(client, monkeypatch):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.EMAIL_ID,
+        name="me",
+        config={"address": "me@x.com"},
+    )
+    monkeypatch.setattr(
+        "app.triggers.email_verification.email_service.send", lambda **kw: None
+    )
+    first = client.post(f"/api/triggers/destination-configs/{cfg['id']}/resend-verify")
+    assert first.status_code == 200
+    second = client.post(f"/api/triggers/destination-configs/{cfg['id']}/resend-verify")
+    assert second.status_code == 429
+    retry = int(second.headers["Retry-After"])
+    assert 1 <= retry <= 60
+    assert second.json()["retry_after_seconds"] == retry

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -364,3 +364,59 @@ def test_any_muted_connection_silences_webhooks_even_when_oldest_is_unmuted(
     )
 
     assert posted == []
+
+
+def test_webhook_for_unmuted_workspace_delivers_despite_other_muted(
+    tmp_db, monkeypatch
+):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)  # T1
+    slack_connections.upsert(
+        user_id=uid,
+        team_id="T2",
+        team_name="Second Team",
+        slack_user_id="U2",
+        bot_token="xoxb-secret-2",
+        scope="chat:write",
+    )
+    slack_connections.set_muted(uid, "T2", True)
+    # Webhook belongs to T1 (unmuted) — T2's mute must not suppress it.
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="webhook",
+        secret="https://hooks.slack.com/services/T1/B000/xyz",  # pragma: allowlist secret
+    )
+    action = TriggerAction(destination_config_id=cfg["id"], message="hi")
+    trigger = TriggerRecord(
+        id="trg_6",
+        owner_user_id=uid,
+        scope_path="a.md",
+        kind="delta",
+        nl_description="always",
+        actions=[action],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+    posted: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "app.tasks.triggers.slack_client.post_message",
+        lambda **kw: posted.append(kw),
+    )
+
+    _record_fire(
+        trigger=trigger,
+        action=action,
+        doc_path="a.md",
+        sha="abc",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="hi",
+        actor=None,
+    )
+
+    assert len(posted) == 1

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -9,7 +9,10 @@ from fastapi.testclient import TestClient
 
 from app.main import create_app
 from app.models.wiki import ChangeKind
+from app.db.models import DestinationConfig
+from app.db.session import session
 from app.slack import connections as slack_connections
+from app.slack import client as slack_client
 from app.tasks.triggers import _record_fire
 from app.triggers import destination_configs as dest_configs
 from app.triggers import destinations as destinations_repo
@@ -242,3 +245,67 @@ def test_muted_connection_silences_webhook_destinations(tmp_db, monkeypatch):
     assert posted == []
     kinds = [e["kind"] for e in list_events()]
     assert "trigger.fire" in kinds
+
+
+def test_legacy_config_routes_to_the_workspace_that_accepts_the_channel(
+    tmp_db, monkeypatch
+):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)  # T1
+    slack_connections.upsert(
+        user_id=uid,
+        team_id="T2",
+        team_name="Second Team",
+        slack_user_id="U2",
+        bot_token="xoxb-secret-2",
+        scope="chat:write",
+    )
+    # Legacy config: no team_id stamp; the channel lives in T2.
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="#general",
+        config={"channel_id": "C2"},
+    )
+    with session() as db:
+        row = db.get(DestinationConfig, cfg["id"])
+        assert row is not None
+        row.config_json = {"channel_id": "C2"}
+
+    action = TriggerAction(destination_config_id=cfg["id"], message="hi")
+    trigger = TriggerRecord(
+        id="trg_4",
+        owner_user_id=uid,
+        scope_path="a.md",
+        kind="delta",
+        nl_description="always",
+        actions=[action],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+    posted: list[dict[str, Any]] = []
+
+    def fake_post(*, bot_token: str, channel: str, text: str) -> None:
+        if bot_token != "xoxb-secret-2":
+            raise slack_client.SlackApiError("channel_not_found")
+        posted.append({"bot_token": bot_token, "channel": channel})
+
+    monkeypatch.setattr("app.tasks.triggers.slack_client.post_chat_message", fake_post)
+
+    _record_fire(
+        trigger=trigger,
+        action=action,
+        doc_path="a.md",
+        sha="abc",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="hi",
+        actor=None,
+    )
+
+    assert len(posted) == 1
+    assert posted[0]["channel"] == "C2"

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -309,3 +309,58 @@ def test_legacy_config_routes_to_the_workspace_that_accepts_the_channel(
 
     assert len(posted) == 1
     assert posted[0]["channel"] == "C2"
+
+
+def test_any_muted_connection_silences_webhooks_even_when_oldest_is_unmuted(
+    tmp_db, monkeypatch
+):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)  # T1 oldest, unmuted
+    slack_connections.upsert(
+        user_id=uid,
+        team_id="T2",
+        team_name="Second Team",
+        slack_user_id="U2",
+        bot_token="xoxb-secret-2",
+        scope="chat:write",
+    )
+    slack_connections.set_muted(uid, "T2", True)
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="webhook",
+        secret="https://hooks.slack.example/T2/abc",
+    )
+    action = TriggerAction(destination_config_id=cfg["id"], message="hi")
+    trigger = TriggerRecord(
+        id="trg_5",
+        owner_user_id=uid,
+        scope_path="a.md",
+        kind="delta",
+        nl_description="always",
+        actions=[action],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+    posted: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "app.tasks.triggers.slack_client.post_message",
+        lambda **kw: posted.append(kw),
+    )
+
+    _record_fire(
+        trigger=trigger,
+        action=action,
+        doc_path="a.md",
+        sha="abc",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="hi",
+        actor=None,
+    )
+
+    assert posted == []

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -195,3 +195,50 @@ def test_slack_config_creation_stamps_team_id(tmp_db):
         config={"channel_id": "C1"},
     )
     assert cfg["config"]["team_id"] == "T1"
+
+
+def test_muted_connection_silences_webhook_destinations(tmp_db, monkeypatch):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)
+    slack_connections.set_muted(uid, "T1", True)
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="webhook",
+        secret="https://hooks.slack.example/T1/abc",
+    )
+    action = TriggerAction(destination_config_id=cfg["id"], message="hi")
+    trigger = TriggerRecord(
+        id="trg_3",
+        owner_user_id=uid,
+        scope_path="a.md",
+        kind="delta",
+        nl_description="always",
+        actions=[action],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+    posted: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "app.tasks.triggers.slack_client.post_message",
+        lambda **kw: posted.append(kw),
+    )
+
+    _record_fire(
+        trigger=trigger,
+        action=action,
+        doc_path="a.md",
+        sha="abc",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="hi",
+        actor=None,
+    )
+
+    assert posted == []
+    kinds = [e["kind"] for e in list_events()]
+    assert "trigger.fire" in kinds

--- a/backend/tests/test_slack_mute_and_resend_retry.py
+++ b/backend/tests/test_slack_mute_and_resend_retry.py
@@ -128,3 +128,70 @@ def test_resend_429_carries_retry_after(client, monkeypatch):
     retry = int(second.headers["Retry-After"])
     assert 1 <= retry <= 60
     assert second.json()["retry_after_seconds"] == retry
+
+
+def test_muted_workspace_does_not_silence_other_workspace(tmp_db, monkeypatch):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)  # T1
+    slack_connections.upsert(
+        user_id=uid,
+        team_id="T2",
+        team_name="Second Team",
+        slack_user_id="U2",
+        bot_token="xoxb-secret-2",
+        scope="chat:write",
+    )
+    slack_connections.set_muted(uid, "T1", True)
+
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="#general",
+        config={"channel_id": "C2", "team_id": "T2"},
+    )
+    action = TriggerAction(destination_config_id=cfg["id"], message="hi")
+    trigger = TriggerRecord(
+        id="trg_2",
+        owner_user_id=uid,
+        scope_path="a.md",
+        kind="delta",
+        nl_description="always",
+        actions=[action],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+    posted: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        "app.tasks.triggers.slack_client.post_chat_message",
+        lambda **kw: posted.append(kw),
+    )
+
+    _record_fire(
+        trigger=trigger,
+        action=action,
+        doc_path="a.md",
+        sha="abc",
+        change_kind=ChangeKind.EDIT,
+        reason="r",
+        instruction="i",
+        rendered_message="hi",
+        actor=None,
+    )
+
+    assert len(posted) == 1
+    assert posted[0]["channel"] == "C2"
+
+
+def test_slack_config_creation_stamps_team_id(tmp_db):
+    uid = seed_user(email="u@x.com")
+    _connect(uid)
+    cfg = dest_configs.create(
+        uid,
+        type=destinations_repo.SLACK_ID,
+        name="#general",
+        config={"channel_id": "C1"},
+    )
+    assert cfg["config"]["team_id"] == "T1"

--- a/backend/tests/test_slack_oauth_connect.py
+++ b/backend/tests/test_slack_oauth_connect.py
@@ -66,7 +66,9 @@ def test_status_reflects_configuration_and_connection(client):
         "configured": False,
         "connected": False,
         "team_name": None,
+        "team_id": None,
         "token_display": None,
+        "muted": False,
         "connect_url": None,
     }
 

--- a/frontend/src/app/app/settings/page.tsx
+++ b/frontend/src/app/app/settings/page.tsx
@@ -30,6 +30,7 @@ import {
   Section as LayoutSection,
   SettingsLayouts,
 } from "@onyx-ai/opal/layouts";
+import { ConnectorsTab } from "@/components/settings/ConnectorsTab";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { apiFetch } from "@/lib/api";
 import { useRequireAuth } from "@/lib/auth";
@@ -61,6 +62,7 @@ const TABS = [
   { key: "wiki", label: "Wiki Preferences" },
   { key: "notifications", label: "Notifications" },
   { key: "account", label: "Account & Access" },
+  { key: "connectors", label: "Connectors" },
 ] as const;
 
 type TabKey = (typeof TABS)[number]["key"];
@@ -180,6 +182,11 @@ function SettingsPageInner() {
                     updateSettings={updateSettings}
                   />
                 </SettingsCard>
+              </SettingsSection>
+            )}
+            {tab === "connectors" && (
+              <SettingsSection title="Connectors">
+                <ConnectorsTab />
               </SettingsSection>
             )}
             {tab === "account" && (

--- a/frontend/src/components/icons/SvgSend.tsx
+++ b/frontend/src/components/icons/SvgSend.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from "react";
+
+/** Send (paper plane) icon from the Onyx UI Library Figma icons — absent
+ * from @onyx-ai/opal's published icon set. Same stroke API as library
+ * icons; swap to the library export when it ships. */
+export function SvgSend(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M14.6667 1.33333L7.33333 8.66667M7.33333 8.66667L1.33333 6L14.6667 1.33333L10 14.6667L7.33333 8.66667Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -29,7 +29,13 @@ export default function Chip({
     <div className="flex items-center gap-0.5 rounded-(--radius-08) bg-(--background-tint-02) px-1 py-0.5">
       {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
       {children && (
-        <span className={truncateLabel ? "max-w-[120px] truncate" : undefined}>
+        <span
+          className={
+            truncateLabel
+              ? "flex max-w-[120px] items-center truncate"
+              : "flex items-center"
+          }
+        >
           <Text
             font={smallLabel ? "secondary-body" : "main-ui-body"}
             color="text-04"
@@ -44,7 +50,7 @@ export default function Chip({
         <SvgAlertTriangle className="size-3.5 shrink-0 text-(--status-warning-05)" />
       )}
       {onRemove && (
-        <span className="[&_svg]:text-(--text-05)">
+        <span className="flex items-center [&_svg]:text-(--text-05)">
           <Button
             type="button"
             prominence="tertiary"

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -60,8 +60,10 @@ export default function Chip({
       {onRemove && (
         <span
           className={cn(
-            "flex items-center [&_svg]:text-(--text-05)",
-            smallLabel && "[&_button]:size-3 [&_svg]:size-2.5",
+            "flex items-center",
+            smallLabel
+              ? "[&_button]:!size-3 [&_svg]:!size-2.5 [&_svg]:text-(--text-04)"
+              : "[&_svg]:text-(--text-05)",
           )}
         >
           <Button

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -9,6 +9,8 @@ export interface ChipProps {
   smallLabel?: boolean;
   /** Warning-coloured indicator icon after the label. */
   error?: boolean;
+  /** Cap the label at 120px with an ellipsis (the mock's mini-tag form). */
+  truncateLabel?: boolean;
 }
 
 /** Port of Onyx's refresh-components Chip (chip/tag with optional remove),
@@ -20,19 +22,22 @@ export default function Chip({
   onRemove,
   smallLabel = true,
   error = false,
+  truncateLabel = false,
 }: ChipProps) {
   return (
     <div className="flex items-center gap-1 rounded-(--radius-08) bg-(--background-tint-02) px-1.5 py-0.5">
       {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
       {children && (
-        <Text
-          font={smallLabel ? "secondary-body" : "main-ui-body"}
-          color="text-03"
-          nowrap
-          maxLines={1}
-        >
-          {children}
-        </Text>
+        <span className={truncateLabel ? "max-w-[120px] truncate" : undefined}>
+          <Text
+            font={smallLabel ? "secondary-body" : "main-ui-body"}
+            color="text-03"
+            nowrap
+            maxLines={1}
+          >
+            {children}
+          </Text>
+        </span>
       )}
       {error && (
         <SvgAlertTriangle className="size-3.5 shrink-0 text-(--status-warning-05)" />

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -14,7 +14,8 @@ export interface ChipProps {
 }
 
 /** Port of Onyx's refresh-components Chip (chip/tag with optional remove),
- * adapted to agent-wiki's Opal Text API. Swap to the library version when it
+ * adapted to agent-wiki's Opal Text API and to the Figma Tag values (dark
+ * text-04 label, tight padding). Swap to the library version when it
  * ships in @onyx-ai/opal. */
 export default function Chip({
   children,
@@ -25,13 +26,13 @@ export default function Chip({
   truncateLabel = false,
 }: ChipProps) {
   return (
-    <div className="flex items-center gap-1 rounded-(--radius-08) bg-(--background-tint-02) px-1.5 py-0.5">
+    <div className="flex items-center gap-0.5 rounded-(--radius-08) bg-(--background-tint-02) px-1 py-0.5">
       {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
       {children && (
         <span className={truncateLabel ? "max-w-[120px] truncate" : undefined}>
           <Text
             font={smallLabel ? "secondary-body" : "main-ui-body"}
-            color="text-03"
+            color="text-04"
             nowrap
             maxLines={1}
           >

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -21,7 +21,7 @@ export default function Chip({
   children,
   icon: Icon,
   onRemove,
-  smallLabel = true,
+  smallLabel = false,
   error = false,
   truncateLabel = false,
 }: ChipProps) {
@@ -44,16 +44,18 @@ export default function Chip({
         <SvgAlertTriangle className="size-3.5 shrink-0 text-(--status-warning-05)" />
       )}
       {onRemove && (
-        <Button
-          type="button"
-          prominence="tertiary"
-          icon={SvgX}
-          size="xs"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove();
-          }}
-        />
+        <span className="[&_svg]:text-(--text-05)">
+          <Button
+            type="button"
+            prominence="tertiary"
+            icon={SvgX}
+            size="xs"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
+          />
+        </span>
       )}
     </div>
   );

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -1,4 +1,5 @@
 import { Button, Text } from "@onyx-ai/opal/components";
+import { cn } from "@onyx-ai/opal/utils";
 import { SvgAlertTriangle, SvgX } from "@onyx-ai/opal/icons";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 
@@ -26,7 +27,14 @@ export default function Chip({
   truncateLabel = false,
 }: ChipProps) {
   return (
-    <div className="flex items-center gap-0.5 rounded-(--radius-08) bg-(--background-tint-02) px-1 py-0.5">
+    <div
+      className={cn(
+        "flex items-center bg-(--background-tint-02)",
+        smallLabel
+          ? "gap-0 rounded-(--radius-04) p-[2px]"
+          : "gap-0.5 rounded-(--radius-08) px-1 py-0.5",
+      )}
+    >
       {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
       {children && (
         <span
@@ -37,7 +45,7 @@ export default function Chip({
           }
         >
           <Text
-            font={smallLabel ? "secondary-body" : "main-ui-body"}
+            font={smallLabel ? "figure-small-value" : "main-ui-body"}
             color="text-04"
             nowrap
             maxLines={1}
@@ -50,12 +58,17 @@ export default function Chip({
         <SvgAlertTriangle className="size-3.5 shrink-0 text-(--status-warning-05)" />
       )}
       {onRemove && (
-        <span className="flex items-center [&_svg]:text-(--text-05)">
+        <span
+          className={cn(
+            "flex items-center [&_svg]:text-(--text-05)",
+            smallLabel && "[&_button]:size-3 [&_svg]:size-2.5",
+          )}
+        >
           <Button
             type="button"
             prominence="tertiary"
             icon={SvgX}
-            size="xs"
+            size={smallLabel ? "fit" : "xs"}
             onClick={(e) => {
               e.stopPropagation();
               onRemove();

--- a/frontend/src/components/inputs/InputChipField.tsx
+++ b/frontend/src/components/inputs/InputChipField.tsx
@@ -68,10 +68,10 @@ export default function InputChipField({
 
   return (
     <div
+      data-variant={disabled ? "disabled" : "primary"}
       className={cn(
-        "flex min-h-9 w-full cursor-text flex-row flex-wrap items-center gap-1 rounded-(--radius-08) p-1.5",
-        "border border-(--border-02) bg-(--background-neutral-00) focus-within:border-(--border-05) focus-within:shadow-[0_0_0_2px_var(--background-tint-04)]",
-        disabled && "pointer-events-none cursor-not-allowed opacity-50",
+        "opal-input min-h-9 cursor-text flex-wrap gap-1",
+        disabled && "pointer-events-none",
         className,
       )}
       onClick={() => inputRef.current?.focus()}

--- a/frontend/src/components/inputs/InputChipField.tsx
+++ b/frontend/src/components/inputs/InputChipField.tsx
@@ -87,17 +87,18 @@ export default function InputChipField({
         </Chip>
       ))}
       {Icon && <Icon className="size-4 shrink-0 text-(--text-04)" />}
-      <span className="min-w-[80px] flex-1 [&_input]:w-full">
-        <InputTypeIn
-          ref={inputRef}
-          variant="internal"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onFocus={onFocus}
-          placeholder={placeholder}
-        />
-      </span>
+      {/* raw-ok: Opal's .opal-input-field contract for a composite input's inner field; nested InputTypeIn double-pads past the 36px Input/Tags height */}
+      <input
+        ref={inputRef}
+        type="text"
+        className="opal-input-field min-w-[80px] flex-1"
+        disabled={disabled}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        placeholder={placeholder}
+      />
     </div>
   );
 }

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -1,0 +1,450 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Button, LinkButton, Text } from "@onyx-ai/opal/components";
+import {
+  SvgVolumeOff,
+  SvgCheckCircle,
+  SvgMail,
+  SvgSlack,
+  SvgTrash,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+import { InputErrorText } from "@onyx-ai/opal/layouts";
+
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { useConfirm } from "@/components/common/ConfirmDialog";
+import { ensureEmailDestination } from "@/lib/emailConnect";
+import {
+  disconnectSlack,
+  setSlackMuted,
+  useSlackConnectStatus,
+} from "@/lib/slackConnect";
+import {
+  deleteDestinationConfig,
+  resendVerification,
+  useDestinationConfigs,
+  type DestinationConfig,
+} from "@/lib/triggers";
+
+/** The Connectors settings tab: the Slack and Emails cards from the mock,
+ * with the Emails card opening the address-management modal. */
+export function ConnectorsTab() {
+  const { status, refresh: refreshSlack, isLoading } = useSlackConnectStatus();
+  const { configs, refresh: refreshConfigs } = useDestinationConfigs();
+  const [emailsOpen, setEmailsOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const confirmDialog = useConfirm();
+
+  const emailConfigs = configs.filter((c) => c.type === "email");
+
+  async function onDisconnect() {
+    if (
+      !(await confirmDialog({
+        title: "Disconnect Slack?",
+        body: "Triggers that send to Slack will stop delivering until you reconnect.",
+        confirmLabel: "Disconnect",
+      }))
+    )
+      return;
+    setError(null);
+    try {
+      await disconnectSlack();
+      await refreshSlack();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to disconnect");
+    }
+  }
+
+  async function onToggleMute() {
+    if (!status) return;
+    setError(null);
+    try {
+      await setSlackMuted(!status.muted);
+      await refreshSlack();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to update");
+    }
+  }
+
+  if (isLoading || !status) return <LoadingSpinner center />;
+
+  return (
+    <div className="flex w-full flex-col gap-4">
+      <ConnectorCard
+        icon={<SvgSlack className="size-5" />}
+        title="Slack"
+        description="Send wiki updates as Slack messages to you and your channels."
+        connected={status.connected}
+        connectHref={
+          status.configured ? (status.connect_url ?? undefined) : undefined
+        }
+        unavailableNote={
+          status.configured
+            ? undefined
+            : "An admin needs to configure the Slack app first."
+        }
+      >
+        {status.connected && (
+          <div className="flex w-full items-center justify-between">
+            <Text font="secondary-body" color="text-03">
+              {`Connected in workspace ${status.team_name ?? "Slack"}${
+                status.muted ? " (muted)" : ""
+              }`}
+            </Text>
+            <span className="flex items-center gap-1">
+              <Button
+                type="button"
+                icon={SvgVolumeOff}
+                size="sm"
+                prominence={status.muted ? "secondary" : "tertiary"}
+                tooltip={
+                  status.muted ? "Resume Slack delivery" : "Mute Slack delivery"
+                }
+                onClick={() => void onToggleMute()}
+              />
+              <Button
+                type="button"
+                size="sm"
+                variant="danger"
+                prominence="secondary"
+                onClick={() => void onDisconnect()}
+              >
+                Disconnect
+              </Button>
+            </span>
+          </div>
+        )}
+      </ConnectorCard>
+
+      <ConnectorCard
+        icon={<SvgMail className="size-5" />}
+        title="Emails"
+        description="Send wiki updates as notifications to your email addresses."
+        connected={emailConfigs.length > 0}
+        onManage={() => setEmailsOpen(true)}
+        manageLabel={emailConfigs.length > 0 ? "Manage" : "Add addresses"}
+      >
+        {emailConfigs.length > 0 && (
+          <div className="flex w-full flex-wrap items-center gap-1">
+            {emailConfigs.map((c) => (
+              <span
+                key={c.id}
+                className="flex items-center rounded-(--radius-04) bg-(--background-tint-02) px-1 py-[2px]"
+              >
+                <Text font="secondary-body" color="text-03" nowrap>
+                  {c.verified_at ? c.name : `${c.name} (unverified)`}
+                </Text>
+              </span>
+            ))}
+          </div>
+        )}
+      </ConnectorCard>
+
+      {error && <InputErrorText type="error">{error}</InputErrorText>}
+
+      {emailsOpen && (
+        <EmailsModal
+          configs={emailConfigs}
+          refresh={refreshConfigs}
+          onClose={() => setEmailsOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function ConnectorCard({
+  icon,
+  title,
+  description,
+  connected,
+  connectHref,
+  unavailableNote,
+  onManage,
+  manageLabel,
+  children,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  connected: boolean;
+  connectHref?: string;
+  unavailableNote?: string;
+  onManage?: () => void;
+  manageLabel?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <div className="box-border flex w-full flex-col gap-2 rounded-(--radius-16) border border-(--border-01) bg-(--background-tint-00) p-4">
+      <div className="flex w-full items-start justify-between gap-2">
+        <div className="flex min-w-0 items-start gap-2">
+          <span className="flex size-6 items-center justify-center">
+            {icon}
+          </span>
+          <div className="min-w-0">
+            <Text font="main-ui-action" color="text-04">
+              {title}
+            </Text>
+            <div>
+              <Text font="secondary-body" color="text-03">
+                {description}
+              </Text>
+            </div>
+          </div>
+        </div>
+        <span className="flex shrink-0 items-center gap-1">
+          {connected ? (
+            <>
+              <Text font="main-ui-action" color="text-04" nowrap>
+                Connected
+              </Text>
+              <SvgCheckCircle className="size-4 text-(--status-success-05)" />
+              {onManage && (
+                <Button
+                  type="button"
+                  size="sm"
+                  prominence="secondary"
+                  onClick={onManage}
+                >
+                  {manageLabel ?? "Manage"}
+                </Button>
+              )}
+            </>
+          ) : connectHref ? (
+            <LinkButton href={connectHref} target="_self">
+              Connect
+            </LinkButton>
+          ) : onManage ? (
+            <Button
+              type="button"
+              size="sm"
+              prominence="secondary"
+              onClick={onManage}
+            >
+              {manageLabel ?? "Connect"}
+            </Button>
+          ) : (
+            <Text font="secondary-body" color="text-03" nowrap>
+              {unavailableNote ?? "Unavailable"}
+            </Text>
+          )}
+        </span>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function EmailsModal({
+  configs,
+  refresh,
+  onClose,
+}: {
+  configs: DestinationConfig[];
+  refresh: () => Promise<unknown>;
+  onClose: () => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sentTo, setSentTo] = useState<string | null>(null);
+  // Per-config resend cooldown deadlines (epoch ms), driven by the server's
+  // retry_after_seconds.
+  const [cooldowns, setCooldowns] = useState<Map<string, number>>(new Map());
+  const [now, setNow] = useState(() => Date.now());
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const hasCooldowns = [...cooldowns.values()].some((t) => t > now);
+  useEffect(() => {
+    if (!hasCooldowns) return;
+    tickRef.current = setInterval(() => setNow(Date.now()), 1000);
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
+  }, [hasCooldowns]);
+
+  function startCooldown(configId: string, seconds: number) {
+    setCooldowns((cur) =>
+      new Map(cur).set(configId, Date.now() + seconds * 1000),
+    );
+    setNow(Date.now());
+  }
+
+  async function onAdd() {
+    const address = draft.trim();
+    if (!address || busy) return;
+    if (!address.includes("@")) {
+      setError("enter a valid email address");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setSentTo(null);
+    try {
+      const { id, verificationError } = await ensureEmailDestination(
+        configs,
+        address,
+      );
+      await refresh();
+      setDraft("");
+      if (verificationError) setError(verificationError);
+      else {
+        setSentTo(address);
+        startCooldown(id, 60);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to add address");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onResend(c: DestinationConfig) {
+    setError(null);
+    setSentTo(null);
+    const result = await resendVerification(c.id);
+    if (result.ok) {
+      setSentTo(c.name);
+      startCooldown(c.id, 60);
+    } else if (result.retryAfterSeconds) {
+      startCooldown(c.id, result.retryAfterSeconds);
+    } else if (result.error) {
+      setError(result.error);
+    }
+  }
+
+  async function onDelete(c: DestinationConfig) {
+    setError(null);
+    try {
+      await deleteDestinationConfig(c.id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to remove");
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-(--mask-03)"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[92vh] w-[min(560px,92vw)] flex-col gap-3 overflow-y-auto rounded-(--radius-12) bg-(--background-tint-00) p-6 shadow-(--shadow-modal)"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex w-full items-center justify-between">
+          <Text font="main-content-emphasis" color="text-04">
+            Emails
+          </Text>
+          <Button
+            type="button"
+            icon={SvgX}
+            size="sm"
+            prominence="tertiary"
+            tooltip="Close"
+            onClick={onClose}
+          />
+        </div>
+        <Text font="secondary-body" color="text-03">
+          Addresses must be verified before triggers can email them. We send a
+          link, and clicking it verifies the address.
+        </Text>
+
+        <div className="flex w-full items-center gap-2">
+          <div className="flex min-h-9 flex-1 items-center rounded-(--radius-08) border border-(--border-02) bg-(--background-neutral-00) px-2 text-[14px] leading-5">
+            {/* raw-ok: bare .opal-input-field; InputTypeIn's own container would double-box this row */}
+            <input
+              className="opal-input-field min-w-0 flex-1"
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void onAdd();
+                }
+              }}
+              placeholder="name@company.com"
+            />
+          </div>
+          <Button
+            type="button"
+            variant="action"
+            disabled={busy || !draft.trim()}
+            onClick={() => void onAdd()}
+          >
+            Send
+          </Button>
+        </div>
+
+        {sentTo && (
+          <Text font="secondary-body" color="status-success-05">
+            {`Verification sent to ${sentTo}. Check that inbox.`}
+          </Text>
+        )}
+        {error && <InputErrorText type="error">{error}</InputErrorText>}
+
+        <div className="flex w-full flex-col">
+          {configs.length === 0 && (
+            <Text font="secondary-body" color="text-03">
+              No addresses yet.
+            </Text>
+          )}
+          {configs.map((c) => {
+            const deadline = cooldowns.get(c.id) ?? 0;
+            const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
+            return (
+              <div
+                key={c.id}
+                className="flex w-full items-center justify-between gap-2 border-b border-(--border-01) py-2 last:border-b-0"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <Text font="main-ui-body" color="text-04" nowrap maxLines={1}>
+                    {c.name}
+                  </Text>
+                  {c.verified_at ? (
+                    <Text
+                      font="secondary-body"
+                      color="status-success-05"
+                      nowrap
+                    >
+                      Verified
+                    </Text>
+                  ) : (
+                    <Text font="secondary-body" color="text-03" nowrap>
+                      Not verified
+                    </Text>
+                  )}
+                </div>
+                <span className="flex shrink-0 items-center gap-1">
+                  {!c.verified_at &&
+                    (remaining > 0 ? (
+                      <Text font="secondary-body" color="text-03" nowrap>
+                        {`Resend in ${remaining}s`}
+                      </Text>
+                    ) : (
+                      <LinkButton onClick={() => void onResend(c)}>
+                        Verify
+                      </LinkButton>
+                    ))}
+                  <Button
+                    type="button"
+                    icon={SvgTrash}
+                    size="sm"
+                    prominence="tertiary"
+                    tooltip="Remove address"
+                    onClick={() => void onDelete(c)}
+                  />
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -45,13 +45,18 @@ function VerifiedIcon(props: React.ComponentProps<typeof SvgCheckCircle>) {
   return (
     <SvgCheckCircle
       {...props}
-      className={cn(props.className, "text-(--status-success-05)")}
+      className={cn(props.className, "size-4")}
+      style={{ color: "var(--status-success-05)" }}
     />
   );
 }
 function PendingIcon(props: React.ComponentProps<typeof SvgClock>) {
   return (
-    <SvgClock {...props} className={cn(props.className, "text-(--text-03)")} />
+    <SvgClock
+      {...props}
+      className={cn(props.className, "size-4")}
+      style={{ color: "var(--text-03)" }}
+    />
   );
 }
 
@@ -493,7 +498,7 @@ function EmailsModal({
 
         <div className="w-full flex-1 p-4">
           <div className="flex w-full flex-col gap-2 rounded-(--radius-12) bg-(--background-tint-00) p-2">
-            <div className="flex w-full items-start gap-1">
+            <div className="flex w-full items-center gap-1">
               <div className="min-w-0 flex-1">
                 <InputChipField
                   chips={drafts}

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -61,7 +61,7 @@ export function ConnectorsTab() {
     if (!status) return;
     setError(null);
     try {
-      await setSlackMuted(!status.muted);
+      await setSlackMuted(!status.muted, status.team_id);
       await refreshSlack();
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to update");
@@ -255,6 +255,14 @@ function EmailsModal({
   const [cooldowns, setCooldowns] = useState<Map<string, number>>(new Map());
   const [now, setNow] = useState(() => Date.now());
   const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Async handlers must not set state once the modal has unmounted.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const hasCooldowns = [...cooldowns.values()].some((t) => t > now);
   useEffect(() => {
@@ -288,6 +296,7 @@ function EmailsModal({
         address,
       );
       await refresh();
+      if (!mountedRef.current) return;
       setDraft("");
       if (verificationError) setError(verificationError);
       else {
@@ -295,9 +304,10 @@ function EmailsModal({
         startCooldown(id, 60);
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to add address");
+      if (mountedRef.current)
+        setError(e instanceof Error ? e.message : "failed to add address");
     } finally {
-      setBusy(false);
+      if (mountedRef.current) setBusy(false);
     }
   }
 
@@ -305,6 +315,7 @@ function EmailsModal({
     setError(null);
     setSentTo(null);
     const result = await resendVerification(c.id);
+    if (!mountedRef.current) return;
     if (result.ok) {
       setSentTo(c.name);
       startCooldown(c.id, 60);
@@ -321,7 +332,8 @@ function EmailsModal({
       await deleteDestinationConfig(c.id);
       await refresh();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "failed to remove");
+      if (mountedRef.current)
+        setError(e instanceof Error ? e.message : "failed to remove");
     }
   }
 

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -397,6 +397,7 @@ function EmailsModal({
           configs,
           d.label,
         );
+        if (!mountedRef.current) return;
         if (verificationError) setError(verificationError);
         else startCooldown(id, 60);
       }

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { Button, LinkButton, Text } from "@onyx-ai/opal/components";
+import {
+  Button,
+  LinkButton,
+  Text,
+  Card,
+  InputTypeIn,
+} from "@onyx-ai/opal/components";
 import {
   SvgVolumeOff,
   SvgCheckCircle,
@@ -11,9 +17,10 @@ import {
   SvgTrash,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { InputErrorText } from "@onyx-ai/opal/layouts";
+import { InputErrorText, Content, ContentAction } from "@onyx-ai/opal/layouts";
 
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { ensureEmailDestination } from "@/lib/emailConnect";
 import {
@@ -73,7 +80,7 @@ export function ConnectorsTab() {
   return (
     <div className="flex w-full flex-col gap-4">
       <ConnectorCard
-        icon={<SvgSlack className="size-5" />}
+        icon={SvgSlack}
         title="Slack"
         description="Send wiki updates as Slack messages to you and your channels."
         connected={status.connected}
@@ -119,7 +126,7 @@ export function ConnectorsTab() {
       </ConnectorCard>
 
       <ConnectorCard
-        icon={<SvgMail className="size-5" />}
+        icon={SvgMail}
         title="Emails"
         description="Send wiki updates as notifications to your email addresses."
         connected={emailConfigs.length > 0}
@@ -166,7 +173,7 @@ function ConnectorCard({
   manageLabel,
   children,
 }: {
-  icon: React.ReactNode;
+  icon: IconFunctionComponent;
   title: string;
   description: string;
   connected: boolean;
@@ -177,63 +184,57 @@ function ConnectorCard({
   children?: React.ReactNode;
 }) {
   return (
-    <div className="box-border flex w-full flex-col gap-2 rounded-(--radius-16) border border-(--border-01) bg-(--background-tint-00) p-4">
-      <div className="flex w-full items-start justify-between gap-2">
-        <div className="flex min-w-0 items-start gap-2">
-          <span className="flex size-6 items-center justify-center">
-            {icon}
-          </span>
-          <div className="min-w-0">
-            <Text font="main-ui-action" color="text-04">
-              {title}
-            </Text>
-            <div>
-              <Text font="secondary-body" color="text-03">
-                {description}
-              </Text>
-            </div>
-          </div>
-        </div>
-        <span className="flex shrink-0 items-center gap-1">
-          {connected ? (
-            <>
-              <Text font="main-ui-action" color="text-04" nowrap>
-                Connected
-              </Text>
-              <SvgCheckCircle className="size-4 text-(--status-success-05)" />
-              {onManage && (
+    <Card padding="md">
+      <div className="flex w-full flex-col gap-2">
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={icon}
+          title={title}
+          description={description}
+          rightChildren={
+            <span className="flex shrink-0 items-center gap-1">
+              {connected ? (
+                <>
+                  <Text font="main-ui-action" color="text-04" nowrap>
+                    Connected
+                  </Text>
+                  <SvgCheckCircle className="size-4 text-(--status-success-05)" />
+                  {onManage && (
+                    <Button
+                      type="button"
+                      size="sm"
+                      prominence="secondary"
+                      onClick={onManage}
+                    >
+                      {manageLabel ?? "Manage"}
+                    </Button>
+                  )}
+                </>
+              ) : connectHref ? (
+                <LinkButton href={connectHref} target="_self">
+                  Connect
+                </LinkButton>
+              ) : onManage ? (
                 <Button
                   type="button"
                   size="sm"
                   prominence="secondary"
                   onClick={onManage}
                 >
-                  {manageLabel ?? "Manage"}
+                  {manageLabel ?? "Connect"}
                 </Button>
+              ) : (
+                <Text font="secondary-body" color="text-03" nowrap>
+                  {unavailableNote ?? "Unavailable"}
+                </Text>
               )}
-            </>
-          ) : connectHref ? (
-            <LinkButton href={connectHref} target="_self">
-              Connect
-            </LinkButton>
-          ) : onManage ? (
-            <Button
-              type="button"
-              size="sm"
-              prominence="secondary"
-              onClick={onManage}
-            >
-              {manageLabel ?? "Connect"}
-            </Button>
-          ) : (
-            <Text font="secondary-body" color="text-03" nowrap>
-              {unavailableNote ?? "Unavailable"}
-            </Text>
-          )}
-        </span>
+            </span>
+          }
+        />
+        {children}
       </div>
-      {children}
-    </div>
+    </Card>
   );
 }
 
@@ -365,10 +366,8 @@ function EmailsModal({
         </Text>
 
         <div className="flex w-full items-center gap-2">
-          <div className="flex min-h-9 flex-1 items-center rounded-(--radius-08) border border-(--border-02) bg-(--background-neutral-00) px-2 text-[14px] leading-5">
-            {/* raw-ok: bare .opal-input-field; InputTypeIn's own container would double-box this row */}
-            <input
-              className="opal-input-field min-w-0 flex-1"
+          <div className="min-w-0 flex-1">
+            <InputTypeIn
               value={draft}
               onChange={(e) => {
                 setDraft(e.target.value);
@@ -414,23 +413,17 @@ function EmailsModal({
                 key={c.id}
                 className="flex w-full items-center justify-between gap-2 border-b border-(--border-01) py-2 last:border-b-0"
               >
-                <div className="flex min-w-0 items-center gap-2">
-                  <Text font="main-ui-body" color="text-04" nowrap maxLines={1}>
-                    {c.name}
-                  </Text>
-                  {c.verified_at ? (
-                    <Text
-                      font="secondary-body"
-                      color="status-success-05"
-                      nowrap
-                    >
-                      Verified
-                    </Text>
-                  ) : (
-                    <Text font="secondary-body" color="text-03" nowrap>
-                      Not verified
-                    </Text>
-                  )}
+                <div className="min-w-0 flex-1">
+                  <Content
+                    sizePreset="main-ui"
+                    variant="section"
+                    title={c.name}
+                    tag={
+                      c.verified_at
+                        ? { title: "Verified", color: "green" }
+                        : { title: "Not verified", color: "amber" }
+                    }
+                  />
                 </div>
                 <span className="flex shrink-0 items-center gap-1">
                   {!c.verified_at &&

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -2,23 +2,25 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { Button, LinkButton, Text } from "@onyx-ai/opal/components";
 import {
-  Button,
-  LinkButton,
-  Text,
-  Card,
-  InputTypeIn,
-} from "@onyx-ai/opal/components";
-import {
-  SvgVolumeOff,
+  SvgArrowExchange,
   SvgCheckCircle,
+  SvgClock,
   SvgMail,
+  SvgSettings,
   SvgSlack,
-  SvgTrash,
+  SvgUnplug,
+  SvgVolumeOff,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { InputErrorText, Content, ContentAction } from "@onyx-ai/opal/layouts";
+import { InputErrorText } from "@onyx-ai/opal/layouts";
+import { cn, markdown } from "@onyx-ai/opal/utils";
 
+import { SvgSend } from "@/components/icons/SvgSend";
+import InputChipField, {
+  type ChipItem,
+} from "@/components/inputs/InputChipField";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { useConfirm } from "@/components/common/ConfirmDialog";
@@ -35,8 +37,12 @@ import {
   type DestinationConfig,
 } from "@/lib/triggers";
 
-/** The Connectors settings tab: the Slack and Emails cards from the mock,
- * with the Emails card opening the address-management modal. */
+const MAX_EMAILS = 5;
+
+/** The Connectors settings tab per the mock: Slack and Emails cards with a
+ * tertiary status affordance top-right, a fold line of icon actions under
+ * it, and connected detail (workspace line / address tags) inset under the
+ * title. The Emails card opens the address-management modal. */
 export function ConnectorsTab() {
   const { status, refresh: refreshSlack, isLoading } = useSlackConnectStatus();
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
@@ -75,14 +81,24 @@ export function ConnectorsTab() {
     }
   }
 
+  async function onRemoveAddress(c: DestinationConfig) {
+    setError(null);
+    try {
+      await deleteDestinationConfig(c.id);
+      await refreshConfigs();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to remove");
+    }
+  }
+
   if (isLoading || !status) return <LoadingSpinner center />;
 
   return (
-    <div className="flex w-full flex-col gap-4">
+    <div className="flex w-full flex-col gap-2">
       <ConnectorCard
         icon={SvgSlack}
         title="Slack"
-        description="Send wiki updates as Slack messages to you and your channels."
+        description="Send wiki updates messages in Slack to you and your channels."
         connected={status.connected}
         connectHref={
           status.configured ? (status.connect_url ?? undefined) : undefined
@@ -92,15 +108,18 @@ export function ConnectorsTab() {
             ? undefined
             : "An admin needs to configure the Slack app first."
         }
-      >
-        {status.connected && (
-          <div className="flex w-full items-center justify-between">
+        detail={
+          status.connected ? (
             <Text font="secondary-body" color="text-03">
-              {`Connected in workspace ${status.team_name ?? "Slack"}${
-                status.muted ? " (muted)" : ""
-              }`}
+              {markdown(
+                `Connected in workspace **${status.team_name ?? "Slack"}**`,
+              )}
             </Text>
-            <span className="flex items-center gap-1">
+          ) : undefined
+        }
+        foldActions={
+          status.connected ? (
+            <>
               <Button
                 type="button"
                 icon={SvgVolumeOff}
@@ -113,41 +132,44 @@ export function ConnectorsTab() {
               />
               <Button
                 type="button"
+                icon={SvgUnplug}
                 size="sm"
-                variant="danger"
-                prominence="secondary"
+                prominence="tertiary"
+                tooltip="Disconnect Server"
                 onClick={() => void onDisconnect()}
-              >
-                Disconnect
-              </Button>
-            </span>
-          </div>
-        )}
-      </ConnectorCard>
+              />
+            </>
+          ) : undefined
+        }
+      />
 
       <ConnectorCard
         icon={SvgMail}
         title="Emails"
-        description="Send wiki updates as notifications to your email addresses."
+        description="Send wiki updates notifications to your email addresses."
         connected={emailConfigs.length > 0}
-        onManage={() => setEmailsOpen(true)}
-        manageLabel={emailConfigs.length > 0 ? "Manage" : "Add addresses"}
-      >
-        {emailConfigs.length > 0 && (
-          <div className="flex w-full flex-wrap items-center gap-1">
-            {emailConfigs.map((c) => (
-              <span
-                key={c.id}
-                className="flex items-center rounded-(--radius-04) bg-(--background-tint-02) px-1 py-[2px]"
-              >
-                <Text font="secondary-body" color="text-03" nowrap>
-                  {c.verified_at ? c.name : `${c.name} (unverified)`}
-                </Text>
-              </span>
-            ))}
-          </div>
-        )}
-      </ConnectorCard>
+        onConnect={() => setEmailsOpen(true)}
+        detail={
+          emailConfigs.length > 0 ? (
+            <AddressTags
+              configs={emailConfigs}
+              onRemove={(c) => void onRemoveAddress(c)}
+            />
+          ) : undefined
+        }
+        foldActions={
+          emailConfigs.length > 0 ? (
+            <Button
+              type="button"
+              icon={SvgSettings}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Manage"
+              onClick={() => setEmailsOpen(true)}
+            />
+          ) : undefined
+        }
+      />
 
       {error && <InputErrorText type="error">{error}</InputErrorText>}
 
@@ -162,82 +184,160 @@ export function ConnectorsTab() {
   );
 }
 
+/** Mock card anatomy: rounded-12 bordered shell with 4px padding, an 8px
+ * title section (20px logo + title/description), connected detail inset
+ * 24px under the title, and a right column of status + fold-line actions.
+ * Connected cards sit on tint-00; disconnected on neutral-01. */
 function ConnectorCard({
-  icon,
+  icon: Icon,
   title,
   description,
   connected,
   connectHref,
+  onConnect,
   unavailableNote,
-  onManage,
-  manageLabel,
-  children,
+  detail,
+  foldActions,
 }: {
   icon: IconFunctionComponent;
   title: string;
   description: string;
   connected: boolean;
   connectHref?: string;
+  onConnect?: () => void;
   unavailableNote?: string;
-  onManage?: () => void;
-  manageLabel?: string;
-  children?: React.ReactNode;
+  detail?: React.ReactNode;
+  foldActions?: React.ReactNode;
 }) {
   return (
-    <Card padding="md">
-      <div className="flex w-full flex-col gap-2">
-        <ContentAction
-          sizePreset="main-ui"
-          variant="section"
-          icon={icon}
-          title={title}
-          description={description}
-          rightChildren={
-            <span className="flex shrink-0 items-center gap-1">
-              {connected ? (
-                <>
-                  <Text font="main-ui-action" color="text-04" nowrap>
-                    Connected
-                  </Text>
-                  <SvgCheckCircle className="size-4 text-(--status-success-05)" />
-                  {onManage && (
-                    <Button
-                      type="button"
-                      size="sm"
-                      prominence="secondary"
-                      onClick={onManage}
-                    >
-                      {manageLabel ?? "Manage"}
-                    </Button>
-                  )}
-                </>
-              ) : connectHref ? (
-                <LinkButton href={connectHref} target="_self">
-                  Connect
-                </LinkButton>
-              ) : onManage ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  prominence="secondary"
-                  onClick={onManage}
-                >
-                  {manageLabel ?? "Connect"}
-                </Button>
-              ) : (
-                <Text font="secondary-body" color="text-03" nowrap>
-                  {unavailableNote ?? "Unavailable"}
-                </Text>
-              )}
+    <div
+      className={cn(
+        "w-full min-w-[280px] rounded-(--radius-12) border border-(--border-01) p-1",
+        connected
+          ? "bg-(--background-tint-00)"
+          : "bg-(--background-neutral-01)",
+      )}
+    >
+      <div className="flex w-full items-start">
+        <div className="flex min-w-0 flex-1 flex-col p-2">
+          <div className="flex w-full max-w-[480px] items-start gap-1">
+            <span className="flex size-5 shrink-0 items-center justify-center">
+              <Icon className="size-[18px]" />
             </span>
-          }
-        />
-        {children}
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="px-[2px]">
+                <Text font="main-ui-action" color="text-04" nowrap>
+                  {title}
+                </Text>
+              </span>
+              <span className="px-[2px]">
+                <Text font="secondary-body" color="text-03">
+                  {description}
+                </Text>
+              </span>
+            </div>
+          </div>
+          {detail && <div className="w-full pt-1 pl-6">{detail}</div>}
+        </div>
+        <div className="flex shrink-0 flex-col items-end">
+          {connected ? (
+            <span className="flex items-center gap-1 p-2">
+              <Text font="main-ui-action" color="text-03" nowrap>
+                Connected
+              </Text>
+              <SvgCheckCircle className="size-4 text-(--status-success-05)" />
+            </span>
+          ) : connectHref ? (
+            <Button
+              size="sm"
+              prominence="tertiary"
+              rightIcon={SvgArrowExchange}
+              href={connectHref}
+            >
+              Connect
+            </Button>
+          ) : onConnect ? (
+            <Button
+              type="button"
+              size="sm"
+              prominence="tertiary"
+              rightIcon={SvgArrowExchange}
+              onClick={onConnect}
+            >
+              Connect
+            </Button>
+          ) : (
+            <span className="p-2">
+              <Text font="secondary-body" color="text-03" nowrap>
+                {unavailableNote ?? "Unavailable"}
+              </Text>
+            </span>
+          )}
+          {foldActions && (
+            <div className="flex items-center justify-end gap-1 p-1">
+              {foldActions}
+            </div>
+          )}
+        </div>
       </div>
-    </Card>
+    </div>
   );
 }
 
+/** The mock's mini address tags: 10px labels on tint-02, truncated at
+ * 120px, first two shown with an overflow "+N" tag carrying a mail glyph. */
+function AddressTags({
+  configs,
+  onRemove,
+}: {
+  configs: DestinationConfig[];
+  onRemove: (c: DestinationConfig) => void;
+}) {
+  const visible = configs.slice(0, 2);
+  const overflow = configs.length - visible.length;
+  return (
+    <div className="flex w-full flex-wrap items-center gap-1">
+      {visible.map((c) => (
+        <span
+          key={c.id}
+          className="flex items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]"
+        >
+          <span className="max-w-[120px] truncate px-[2px]">
+            <Text font="figure-small-value" color="text-04" nowrap>
+              {c.name}
+            </Text>
+          </span>
+          <Button
+            type="button"
+            icon={SvgX}
+            size="2xs"
+            prominence="internal"
+            tooltip={`Remove ${c.name}`}
+            onClick={() => onRemove(c)}
+          />
+        </span>
+      ))}
+      {overflow > 0 && (
+        <span className="flex items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]">
+          <span className="flex size-3 items-center justify-center p-[1px]">
+            <SvgMail className="size-full text-(--text-03)" />
+          </span>
+          <span className="px-[2px]">
+            <Text font="figure-small-value" color="text-04" nowrap>
+              {`+${overflow}`}
+            </Text>
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** The mock's Emails modal: 480px three-zone alert (white header with a
+ * stacked mail icon, content on a raised white panel, white Done footer),
+ * a chip input capped at MAX_EMAILS addresses with a Send button that
+ * appears once drafts exist, and per-address rows with status icon,
+ * verify/cooldown action, and remove. */
 function EmailsModal({
   configs,
   refresh,
@@ -248,9 +348,10 @@ function EmailsModal({
   onClose: () => void;
 }) {
   const [draft, setDraft] = useState("");
+  const [drafts, setDrafts] = useState<ChipItem[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [sentTo, setSentTo] = useState<string | null>(null);
+  const [sentBanner, setSentBanner] = useState(false);
   // Per-config resend cooldown deadlines (epoch ms), driven by the server's
   // retry_after_seconds.
   const [cooldowns, setCooldowns] = useState<Map<string, number>>(new Map());
@@ -281,29 +382,48 @@ function EmailsModal({
     setNow(Date.now());
   }
 
-  async function onAdd() {
-    const address = draft.trim();
-    if (!address || busy) return;
+  const atCap = configs.length + drafts.length >= MAX_EMAILS;
+
+  function addDraft(value: string) {
+    const address = value.trim();
+    if (!address) return;
     if (!address.includes("@")) {
       setError("enter a valid email address");
       return;
     }
+    if (atCap) {
+      setError(`up to ${MAX_EMAILS} addresses`);
+      return;
+    }
+    if (
+      drafts.some((d) => d.label === address) ||
+      configs.some((c) => c.name === address)
+    ) {
+      setDraft("");
+      return;
+    }
+    setDrafts((cur) => [...cur, { id: address, label: address }]);
+    setDraft("");
+    setError(null);
+  }
+
+  async function onSend() {
+    if (busy || drafts.length === 0) return;
     setBusy(true);
     setError(null);
-    setSentTo(null);
     try {
-      const { id, verificationError } = await ensureEmailDestination(
-        configs,
-        address,
-      );
+      for (const d of drafts) {
+        const { id, verificationError } = await ensureEmailDestination(
+          configs,
+          d.label,
+        );
+        if (verificationError) setError(verificationError);
+        else startCooldown(id, 60);
+      }
       await refresh();
       if (!mountedRef.current) return;
-      setDraft("");
-      if (verificationError) setError(verificationError);
-      else {
-        setSentTo(address);
-        startCooldown(id, 60);
-      }
+      setDrafts([]);
+      setSentBanner(true);
     } catch (e) {
       if (mountedRef.current)
         setError(e instanceof Error ? e.message : "failed to add address");
@@ -314,11 +434,10 @@ function EmailsModal({
 
   async function onResend(c: DestinationConfig) {
     setError(null);
-    setSentTo(null);
     const result = await resendVerification(c.id);
     if (!mountedRef.current) return;
     if (result.ok) {
-      setSentTo(c.name);
+      setSentBanner(true);
       startCooldown(c.id, 60);
     } else if (result.retryAfterSeconds) {
       startCooldown(c.id, result.retryAfterSeconds);
@@ -340,114 +459,163 @@ function EmailsModal({
 
   return (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-(--mask-03)"
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-(--mask-03) backdrop-blur-[2px]"
       onClick={onClose}
     >
-      <div
-        className="flex max-h-[92vh] w-[min(560px,92vw)] flex-col gap-3 overflow-y-auto rounded-(--radius-12) bg-(--background-tint-00) p-6 shadow-(--shadow-modal)"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex w-full items-center justify-between">
-          <Text font="main-content-emphasis" color="text-04">
-            Emails
-          </Text>
+      {sentBanner && (
+        <div
+          className="fixed top-6 left-1/2 flex w-[min(480px,92vw)] -translate-x-1/2 items-start gap-2 rounded-(--radius-12) border border-(--status-info-03) bg-(--background-tint-00) p-3 shadow-(--shadow-modal)"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <SvgSend className="mt-[2px] size-4 shrink-0 text-(--status-info-05)" />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <Text font="main-ui-action" color="text-04">
+              Check your email inbox.
+            </Text>
+            <Text font="secondary-body" color="text-03">
+              We&apos;ve sent a verification link to your email address.
+            </Text>
+          </div>
           <Button
             type="button"
             icon={SvgX}
             size="sm"
             prominence="tertiary"
-            tooltip="Close"
-            onClick={onClose}
+            tooltip="Dismiss"
+            onClick={() => setSentBanner(false)}
           />
         </div>
-        <Text font="secondary-body" color="text-03">
-          Addresses must be verified before triggers can email them. We send a
-          link, and clicking it verifies the address.
-        </Text>
-
-        <div className="flex w-full items-center gap-2">
-          <div className="min-w-0 flex-1">
-            <InputTypeIn
-              value={draft}
-              onChange={(e) => {
-                setDraft(e.target.value);
-                setError(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  void onAdd();
-                }
-              }}
-              placeholder="name@company.com"
+      )}
+      <div
+        className="flex max-h-[92vh] w-[min(480px,92vw)] flex-col overflow-y-auto rounded-(--radius-16) border border-(--border-01) bg-(--background-tint-01) shadow-(--shadow-modal)"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="relative flex w-full flex-col items-start gap-1 rounded-t-(--radius-16) bg-(--background-tint-00) p-4">
+          <span className="flex size-7 items-center justify-center">
+            <SvgMail className="size-6 text-(--text-04)" />
+          </span>
+          <span className="px-[2px]">
+            <Text font="heading-h3" color="text-04">
+              Emails
+            </Text>
+          </span>
+          <span className="px-[2px]">
+            <Text font="secondary-body" color="text-03">
+              Send wiki updates notifications to your email addresses.
+            </Text>
+          </span>
+          <span className="absolute top-2 right-2">
+            <Button
+              type="button"
+              icon={SvgX}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Close"
+              onClick={onClose}
             />
-          </div>
-          <Button
-            type="button"
-            variant="action"
-            disabled={busy || !draft.trim()}
-            onClick={() => void onAdd()}
-          >
-            Send
-          </Button>
+          </span>
         </div>
 
-        {sentTo && (
-          <Text font="secondary-body" color="status-success-05">
-            {`Verification sent to ${sentTo}. Check that inbox.`}
-          </Text>
-        )}
-        {error && <InputErrorText type="error">{error}</InputErrorText>}
-
-        <div className="flex w-full flex-col">
-          {configs.length === 0 && (
-            <Text font="secondary-body" color="text-03">
-              No addresses yet.
-            </Text>
-          )}
-          {configs.map((c) => {
-            const deadline = cooldowns.get(c.id) ?? 0;
-            const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
-            return (
-              <div
-                key={c.id}
-                className="flex w-full items-center justify-between gap-2 border-b border-(--border-01) py-2 last:border-b-0"
-              >
-                <div className="min-w-0 flex-1">
-                  <Content
-                    sizePreset="main-ui"
-                    variant="section"
-                    title={c.name}
-                    tag={
-                      c.verified_at
-                        ? { title: "Verified", color: "green" }
-                        : { title: "Not verified", color: "amber" }
-                    }
-                  />
-                </div>
-                <span className="flex shrink-0 items-center gap-1">
-                  {!c.verified_at &&
-                    (remaining > 0 ? (
-                      <Text font="secondary-body" color="text-03" nowrap>
-                        {`Resend in ${remaining}s`}
-                      </Text>
-                    ) : (
-                      <LinkButton onClick={() => void onResend(c)}>
-                        Verify
-                      </LinkButton>
-                    ))}
-                  <Button
-                    type="button"
-                    icon={SvgTrash}
-                    size="sm"
-                    prominence="tertiary"
-                    tooltip="Remove address"
-                    onClick={() => void onDelete(c)}
-                  />
-                </span>
+        <div className="w-full flex-1 p-4">
+          <div className="flex w-full flex-col gap-2 rounded-(--radius-12) bg-(--background-tint-00) p-2">
+            <div className="flex w-full items-start gap-1">
+              <div className="min-w-0 flex-1">
+                <InputChipField
+                  chips={drafts}
+                  onRemoveChip={(id: string) =>
+                    setDrafts((cur) => cur.filter((d) => d.id !== id))
+                  }
+                  onAdd={addDraft}
+                  value={draft}
+                  onChange={setDraft}
+                  placeholder="Add an email…"
+                  disabled={busy}
+                />
               </div>
-            );
-          })}
+              {drafts.length > 0 && (
+                <Button
+                  type="button"
+                  variant="action"
+                  icon={SvgSend}
+                  disabled={busy}
+                  onClick={() => void onSend()}
+                >
+                  Send
+                </Button>
+              )}
+            </div>
+
+            {error && <InputErrorText type="error">{error}</InputErrorText>}
+
+            <div className="flex w-full flex-col gap-1">
+              {configs.map((c) => {
+                const deadline = cooldowns.get(c.id) ?? 0;
+                const remaining = Math.max(
+                  0,
+                  Math.ceil((deadline - now) / 1000),
+                );
+                return (
+                  <div
+                    key={c.id}
+                    className="flex w-full items-start gap-[2px] rounded-(--radius-08) bg-(--background-tint-01) p-[6px]"
+                  >
+                    <div className="flex min-w-0 flex-1 items-start gap-1 p-[2px]">
+                      <span className="flex size-5 shrink-0 items-center justify-center p-[2px]">
+                        {c.verified_at ? (
+                          <SvgCheckCircle className="size-full text-(--status-success-05)" />
+                        ) : (
+                          <SvgClock className="size-full text-(--text-03)" />
+                        )}
+                      </span>
+                      <div className="flex min-w-0 flex-1 flex-col px-[2px]">
+                        <span className="truncate">
+                          <Text font="main-ui-action" color="text-04" nowrap>
+                            {c.name}
+                          </Text>
+                        </span>
+                        <Text font="secondary-body" color="text-03">
+                          {c.verified_at ? "Verified" : "Not verified"}
+                        </Text>
+                      </div>
+                    </div>
+                    {!c.verified_at && (
+                      <Button
+                        type="button"
+                        size="xs"
+                        prominence="secondary"
+                        icon={SvgSend}
+                        disabled={remaining > 0}
+                        onClick={() => void onResend(c)}
+                      >
+                        {remaining > 0 ? `${remaining}s` : "Verify"}
+                      </Button>
+                    )}
+                    <Button
+                      type="button"
+                      icon={SvgX}
+                      size="sm"
+                      prominence="tertiary"
+                      tooltip="Remove address"
+                      onClick={() => void onDelete(c)}
+                    />
+                  </div>
+                );
+              })}
+              <div className="flex w-full items-center gap-2 px-4 py-2">
+                <span className="h-0 min-w-px flex-1 border-t border-(--border-01)" />
+                <Text font="secondary-body" color="text-03" nowrap>
+                  {`${configs.length} ${configs.length === 1 ? "Email" : "Emails"}`}
+                </Text>
+                <span className="h-0 min-w-px flex-1 border-t border-(--border-01)" />
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex h-[68px] w-full items-center justify-end rounded-b-(--radius-16) bg-(--background-tint-00) p-4">
+          <Button type="button" prominence="secondary" onClick={onClose}>
+            Done
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -144,7 +144,7 @@ export function ConnectorsTab() {
               <Button
                 type="button"
                 icon={SvgVolumeOff}
-                size="sm"
+                size="md"
                 prominence={status.muted ? "secondary" : "tertiary"}
                 tooltip={
                   status.muted ? "Resume Slack delivery" : "Mute Slack delivery"
@@ -154,7 +154,7 @@ export function ConnectorsTab() {
               <Button
                 type="button"
                 icon={SvgUnplug}
-                size="sm"
+                size="md"
                 prominence="tertiary"
                 tooltip="Disconnect Server"
                 onClick={() => void onDisconnect()}
@@ -183,7 +183,7 @@ export function ConnectorsTab() {
             <Button
               type="button"
               icon={SvgSettings}
-              size="sm"
+              size="md"
               prominence="tertiary"
               tooltip="Manage"
               onClick={() => setEmailsOpen(true)}
@@ -231,67 +231,69 @@ function ConnectorCard({
   foldActions?: React.ReactNode;
 }) {
   return (
-    <Card
-      padding="xs"
-      rounding="md"
-      border="solid"
-      background={connected ? "light" : "heavy"}
-    >
-      <div className="flex w-full items-start">
-        <div className="flex min-w-0 flex-1 flex-col p-2">
-          <Content
-            sizePreset="main-ui"
-            variant="section"
-            icon={Icon}
-            title={title}
-            description={description}
-          />
-          {detail && (
-            <div className="w-full pt-1 pl-6 [&>span]:block">{detail}</div>
-          )}
+    <div className="w-full [&_.opal-content-md-icon-container_svg]:!size-[18px]">
+      <Card
+        padding="xs"
+        rounding="md"
+        border="solid"
+        background={connected ? "light" : "heavy"}
+      >
+        <div className="flex w-full items-start">
+          <div className="flex min-w-0 flex-1 flex-col p-2">
+            <Content
+              sizePreset="main-ui"
+              variant="section"
+              icon={Icon}
+              title={title}
+              description={description}
+            />
+            {detail && (
+              <div className="w-full pt-1 pl-6 [&>span]:block">{detail}</div>
+            )}
+          </div>
+          <div className="flex shrink-0 flex-col items-end">
+            {connected ? (
+              <span className="flex items-center gap-1 p-2">
+                <Text font="main-ui-action" color="text-03" nowrap>
+                  Connected
+                </Text>
+                <SvgCheckCircle className="size-4 text-(--status-success-05)" />
+              </span>
+            ) : connectHref ? (
+              <Button
+                size="sm"
+                prominence="tertiary"
+                rightIcon={SvgArrowExchange}
+                href={connectHref}
+              >
+                Connect
+              </Button>
+            ) : onConnect ? (
+              <Button
+                type="button"
+                size="sm"
+                prominence="tertiary"
+                rightIcon={SvgArrowExchange}
+                onClick={onConnect}
+              >
+                Connect
+              </Button>
+            ) : (
+              <span className="p-2">
+                <Text font="secondary-body" color="text-03" nowrap>
+                  {unavailableNote ?? "Unavailable"}
+                </Text>
+              </span>
+            )}
+            {foldActions && (
+              <div className="flex items-center justify-end gap-1 p-1">
+                {foldActions}
+              </div>
+            )}
+          </div>
         </div>
-        <div className="flex shrink-0 flex-col items-end">
-          {connected ? (
-            <span className="flex items-center gap-1 p-2">
-              <Text font="main-ui-action" color="text-03" nowrap>
-                Connected
-              </Text>
-              <SvgCheckCircle className="size-4 text-(--status-success-05)" />
-            </span>
-          ) : connectHref ? (
-            <Button
-              size="sm"
-              prominence="tertiary"
-              rightIcon={SvgArrowExchange}
-              href={connectHref}
-            >
-              Connect
-            </Button>
-          ) : onConnect ? (
-            <Button
-              type="button"
-              size="sm"
-              prominence="tertiary"
-              rightIcon={SvgArrowExchange}
-              onClick={onConnect}
-            >
-              Connect
-            </Button>
-          ) : (
-            <span className="p-2">
-              <Text font="secondary-body" color="text-03" nowrap>
-                {unavailableNote ?? "Unavailable"}
-              </Text>
-            </span>
-          )}
-          {foldActions && (
-            <div className="flex items-center justify-end gap-1 p-1">
-              {foldActions}
-            </div>
-          )}
-        </div>
-      </div>
-    </Card>
+      </Card>
+    </div>
   );
 }
 
@@ -309,11 +311,11 @@ function AddressTags({
   return (
     <div className="flex w-full flex-wrap items-center gap-1">
       {visible.map((c) => (
-        <Chip key={c.id} truncateLabel onRemove={() => onRemove(c)}>
+        <Chip key={c.id} smallLabel truncateLabel onRemove={() => onRemove(c)}>
           {c.name}
         </Chip>
       ))}
-      {overflow > 0 && <Chip icon={SvgMail}>{`+${overflow}`}</Chip>}
+      {overflow > 0 && <Chip smallLabel icon={SvgMail}>{`+${overflow}`}</Chip>}
     </div>
   );
 }
@@ -548,16 +550,18 @@ function EmailsModal({
                       rightChildren={
                         <span className="flex shrink-0 items-center gap-1">
                           {!c.verified_at && (
-                            <Button
-                              type="button"
-                              size="xs"
-                              prominence="secondary"
-                              icon={SvgSend}
-                              disabled={remaining > 0}
-                              onClick={() => void onResend(c)}
-                            >
-                              {remaining > 0 ? `${remaining}s` : "Verify"}
-                            </Button>
+                            <span className="flex items-center [&_button]:!h-6 [&_button]:!rounded-(--radius-08) [&_button]:!border-0 [&_button]:!bg-(--background-tint-00) [&_button_span]:!text-[12px] [&_button_span]:!leading-4">
+                              <Button
+                                type="button"
+                                size="xs"
+                                prominence="secondary"
+                                icon={SvgSend}
+                                disabled={remaining > 0}
+                                onClick={() => void onResend(c)}
+                              >
+                                {remaining > 0 ? `${remaining}s` : "Verify"}
+                              </Button>
+                            </span>
                           )}
                           <Button
                             type="button"

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { Button, LinkButton, Text } from "@onyx-ai/opal/components";
+import { Button, Card, Text } from "@onyx-ai/opal/components";
 import {
   SvgArrowExchange,
   SvgCheckCircle,
@@ -14,10 +14,11 @@ import {
   SvgVolumeOff,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { InputErrorText } from "@onyx-ai/opal/layouts";
+import { Content, ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 import { cn, markdown } from "@onyx-ai/opal/utils";
 
 import { SvgSend } from "@/components/icons/SvgSend";
+import Chip from "@/components/inputs/Chip";
 import InputChipField, {
   type ChipItem,
 } from "@/components/inputs/InputChipField";
@@ -38,6 +39,21 @@ import {
 } from "@/lib/triggers";
 
 const MAX_EMAILS = 5;
+
+/** Status-coloured icons for ContentAction's icon slot. */
+function VerifiedIcon(props: React.ComponentProps<typeof SvgCheckCircle>) {
+  return (
+    <SvgCheckCircle
+      {...props}
+      className={cn(props.className, "text-(--status-success-05)")}
+    />
+  );
+}
+function PendingIcon(props: React.ComponentProps<typeof SvgClock>) {
+  return (
+    <SvgClock {...props} className={cn(props.className, "text-(--text-03)")} />
+  );
+}
 
 /** The Connectors settings tab per the mock: Slack and Emails cards with a
  * tertiary status affordance top-right, a fold line of icon actions under
@@ -210,34 +226,24 @@ function ConnectorCard({
   foldActions?: React.ReactNode;
 }) {
   return (
-    <div
-      className={cn(
-        "w-full min-w-[280px] rounded-(--radius-12) border border-(--border-01) p-1",
-        connected
-          ? "bg-(--background-tint-00)"
-          : "bg-(--background-neutral-01)",
-      )}
+    <Card
+      padding="xs"
+      rounding="md"
+      border="solid"
+      background={connected ? "light" : "heavy"}
     >
       <div className="flex w-full items-start">
         <div className="flex min-w-0 flex-1 flex-col p-2">
-          <div className="flex w-full max-w-[480px] items-start gap-1">
-            <span className="flex size-5 shrink-0 items-center justify-center">
-              <Icon className="size-[18px]" />
-            </span>
-            <div className="flex min-w-0 flex-1 flex-col">
-              <span className="px-[2px]">
-                <Text font="main-ui-action" color="text-04" nowrap>
-                  {title}
-                </Text>
-              </span>
-              <span className="px-[2px]">
-                <Text font="secondary-body" color="text-03">
-                  {description}
-                </Text>
-              </span>
-            </div>
-          </div>
-          {detail && <div className="w-full pt-1 pl-6">{detail}</div>}
+          <Content
+            sizePreset="main-ui"
+            variant="section"
+            icon={Icon}
+            title={title}
+            description={description}
+          />
+          {detail && (
+            <div className="w-full pt-1 pl-6 [&>span]:block">{detail}</div>
+          )}
         </div>
         <div className="flex shrink-0 flex-col items-end">
           {connected ? (
@@ -280,7 +286,7 @@ function ConnectorCard({
           )}
         </div>
       </div>
-    </div>
+    </Card>
   );
 }
 
@@ -298,37 +304,11 @@ function AddressTags({
   return (
     <div className="flex w-full flex-wrap items-center gap-1">
       {visible.map((c) => (
-        <span
-          key={c.id}
-          className="flex items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]"
-        >
-          <span className="max-w-[120px] truncate px-[2px]">
-            <Text font="figure-small-value" color="text-04" nowrap>
-              {c.name}
-            </Text>
-          </span>
-          <Button
-            type="button"
-            icon={SvgX}
-            size="2xs"
-            prominence="internal"
-            tooltip={`Remove ${c.name}`}
-            onClick={() => onRemove(c)}
-          />
-        </span>
+        <Chip key={c.id} truncateLabel onRemove={() => onRemove(c)}>
+          {c.name}
+        </Chip>
       ))}
-      {overflow > 0 && (
-        <span className="flex items-center rounded-(--radius-04) bg-(--background-tint-02) p-[2px]">
-          <span className="flex size-3 items-center justify-center p-[1px]">
-            <SvgMail className="size-full text-(--text-03)" />
-          </span>
-          <span className="px-[2px]">
-            <Text font="figure-small-value" color="text-04" nowrap>
-              {`+${overflow}`}
-            </Text>
-          </span>
-        </span>
-      )}
+      {overflow > 0 && <Chip icon={SvgMail}>{`+${overflow}`}</Chip>}
     </div>
   );
 }
@@ -490,20 +470,14 @@ function EmailsModal({
         className="flex max-h-[92vh] w-[min(480px,92vw)] flex-col overflow-y-auto rounded-(--radius-16) border border-(--border-01) bg-(--background-tint-01) shadow-(--shadow-modal)"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="relative flex w-full flex-col items-start gap-1 rounded-t-(--radius-16) bg-(--background-tint-00) p-4">
-          <span className="flex size-7 items-center justify-center">
-            <SvgMail className="size-6 text-(--text-04)" />
-          </span>
-          <span className="px-[2px]">
-            <Text font="heading-h3" color="text-04">
-              Emails
-            </Text>
-          </span>
-          <span className="px-[2px]">
-            <Text font="secondary-body" color="text-03">
-              Send wiki updates notifications to your email addresses.
-            </Text>
-          </span>
+        <div className="relative w-full rounded-t-(--radius-16) bg-(--background-tint-00) p-4">
+          <Content
+            sizePreset="section"
+            variant="heading"
+            icon={SvgMail}
+            title="Emails"
+            description="Send wiki updates notifications to your email addresses."
+          />
           <span className="absolute top-2 right-2">
             <Button
               type="button"
@@ -557,46 +531,38 @@ function EmailsModal({
                 return (
                   <div
                     key={c.id}
-                    className="flex w-full items-start gap-[2px] rounded-(--radius-08) bg-(--background-tint-01) p-[6px]"
+                    className="w-full rounded-(--radius-08) bg-(--background-tint-01) p-[6px]"
                   >
-                    <div className="flex min-w-0 flex-1 items-start gap-1 p-[2px]">
-                      <span className="flex size-5 shrink-0 items-center justify-center p-[2px]">
-                        {c.verified_at ? (
-                          <SvgCheckCircle className="size-full text-(--status-success-05)" />
-                        ) : (
-                          <SvgClock className="size-full text-(--text-03)" />
-                        )}
-                      </span>
-                      <div className="flex min-w-0 flex-1 flex-col px-[2px]">
-                        <span className="truncate">
-                          <Text font="main-ui-action" color="text-04" nowrap>
-                            {c.name}
-                          </Text>
+                    <ContentAction
+                      sizePreset="main-ui"
+                      variant="section"
+                      icon={c.verified_at ? VerifiedIcon : PendingIcon}
+                      title={c.name}
+                      description={c.verified_at ? "Verified" : "Not verified"}
+                      rightChildren={
+                        <span className="flex shrink-0 items-center gap-1">
+                          {!c.verified_at && (
+                            <Button
+                              type="button"
+                              size="xs"
+                              prominence="secondary"
+                              icon={SvgSend}
+                              disabled={remaining > 0}
+                              onClick={() => void onResend(c)}
+                            >
+                              {remaining > 0 ? `${remaining}s` : "Verify"}
+                            </Button>
+                          )}
+                          <Button
+                            type="button"
+                            icon={SvgX}
+                            size="sm"
+                            prominence="tertiary"
+                            tooltip="Remove address"
+                            onClick={() => void onDelete(c)}
+                          />
                         </span>
-                        <Text font="secondary-body" color="text-03">
-                          {c.verified_at ? "Verified" : "Not verified"}
-                        </Text>
-                      </div>
-                    </div>
-                    {!c.verified_at && (
-                      <Button
-                        type="button"
-                        size="xs"
-                        prominence="secondary"
-                        icon={SvgSend}
-                        disabled={remaining > 0}
-                        onClick={() => void onResend(c)}
-                      >
-                        {remaining > 0 ? `${remaining}s` : "Verify"}
-                      </Button>
-                    )}
-                    <Button
-                      type="button"
-                      icon={SvgX}
-                      size="sm"
-                      prominence="tertiary"
-                      tooltip="Remove address"
-                      onClick={() => void onDelete(c)}
+                      }
                     />
                   </div>
                 );

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -12,6 +12,8 @@ export interface SlackConnectStatus {
   team_name: string | null;
   token_display: string | null;
   connect_url: string | null;
+  muted: boolean;
+  team_id: string | null;
 }
 
 export interface SlackChannel {
@@ -72,4 +74,11 @@ export async function ensureSlackDestination(
           config: { channel_id: target.id, channel_name: target.name },
         });
   return { id: created.id, created: true };
+}
+
+export function setSlackMuted(muted: boolean): Promise<SlackConnectStatus> {
+  return apiFetch<SlackConnectStatus>("/connectors/slack/mute", {
+    method: "PUT",
+    body: JSON.stringify({ muted }),
+  });
 }

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -76,9 +76,12 @@ export async function ensureSlackDestination(
   return { id: created.id, created: true };
 }
 
-export function setSlackMuted(muted: boolean): Promise<SlackConnectStatus> {
+export function setSlackMuted(
+  muted: boolean,
+  teamId?: string | null,
+): Promise<SlackConnectStatus> {
   return apiFetch<SlackConnectStatus>("/connectors/slack/mute", {
     method: "PUT",
-    body: JSON.stringify({ muted }),
+    body: JSON.stringify({ muted, team_id: teamId ?? undefined }),
   });
 }

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -1,6 +1,6 @@
 import useSWR from "swr";
 
-import { apiFetch } from "@/lib/api";
+import { ApiError, apiFetch } from "@/lib/api";
 
 export type TriggerKind = "delta" | "schedule";
 
@@ -209,4 +209,30 @@ export function deleteDestinationConfig(id: string): Promise<void> {
   return apiFetch<void>(`/triggers/destination-configs/${id}`, {
     method: "DELETE",
   });
+}
+
+/** Resend the verification email. A 429 resolves with the server's
+ * retry_after_seconds so callers can run a countdown instead of guessing. */
+export async function resendVerification(
+  configId: string,
+): Promise<{ ok: boolean; retryAfterSeconds?: number; error?: string }> {
+  try {
+    await apiFetch<DestinationConfig>(
+      `/triggers/destination-configs/${configId}/resend-verify`,
+      { method: "POST" },
+    );
+    return { ok: true };
+  } catch (e) {
+    if (e instanceof ApiError) {
+      if (e.status === 429) {
+        const data = e.data as { retry_after_seconds?: number } | undefined;
+        return {
+          ok: false,
+          retryAfterSeconds: data?.retry_after_seconds ?? 60,
+        };
+      }
+      return { ok: false, error: e.message };
+    }
+    return { ok: false, error: "request failed" };
+  }
 }


### PR DESCRIPTION
## Description

Adds the Connectors settings tab from the mocks (`1303:47918`, `1374:59061`, `1426:40125`, `1426:41792`), restoring the destination management that left the Triggers page, in the place the design puts it.

The Slack card shows Connect (when the admin has configured the app), or Connected with the workspace name, a mute toggle, and Disconnect. Mute pauses delivery without disconnecting: dispatch skips muted connections before any Slack I/O and still records the fire to the Activity Center, backed by a `muted` column on the connection (inspector-guarded migration) and `PUT /api/connectors/slack/mute`.

The Emails card lists address chips and opens the management modal: add-and-send, Verified / Not verified rows, a Verify resend per unverified address, and delete. Resend rate limits now return `retry_after_seconds` in the 429 body plus a Retry-After header, and the modal runs an honest per-address countdown from it. Fixing that surfaced an app-level bug: the HTTPException handler rebuilt responses without the exception's headers, so semantic headers like Retry-After never reached clients — now preserved.

## How Has This Been Tested?

Four new tests: mute round-trip, mute-without-connection 404, muted-connection dispatch skip that still records the fire, and the 429 carrying matching Retry-After header and body values. Verified live in Chrome: both cards render real connection data, the mute toggle flipped the stored flag and back, and the modal lists verified and unverified addresses. The live resend was deliberately not clicked (it would email a teammate); the countdown mechanics are pinned by the test.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

## Webhook mute decision table

Slack webhook URLs embed their workspace id (hooks.slack.com/services/<TEAM>/), so mute resolution is:

| Case | Behavior |
|---|---|
| URL parses to a team | Exactly that workspace's mute applies |
| URL does not parse, one connection | That connection's mute applies (it is the only Slack there is) |
| URL does not parse, multiple connections | Delivers. The webhook cannot be attributed, and borrowing another workspace's mute silences unrelated destinations |

Real Slack webhooks always parse. The unattributable case is only Slack-compatible endpoints on custom hosts, where a workspace mute has no defined relationship to the endpoint. All four cases are pinned in test_slack_mute_and_resend_retry.py.

Bot-path legacy configs (no team_id stamp) try each unmuted connection in stable order and deliver where the channel is accepted, because a wrong-workspace token fails without sending. Muted connections are never candidates, so a muted workspace cannot deliver, and an unmuted workspace is exactly where the channel lives. New configs are always stamped at creation.