### PR TITLE
refactor(triggers): compose panel and action editor from Opal layouts

### DIFF
--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -29,7 +29,7 @@ export default function Chip({
   return (
     <div
       className={cn(
-        "flex items-center bg-(--background-tint-02)",
+        "flex max-w-full min-w-0 items-center bg-(--background-tint-02)",
         smallLabel
           ? "gap-0 rounded-(--radius-04) p-[2px]"
           : "gap-0.5 rounded-(--radius-08) px-1 py-0.5",
@@ -40,8 +40,8 @@ export default function Chip({
         <span
           className={
             truncateLabel
-              ? "flex max-w-[120px] items-center truncate"
-              : "flex items-center"
+              ? "block max-w-[120px] min-w-0 truncate"
+              : "block min-w-0 truncate"
           }
         >
           <Text

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -27,7 +27,14 @@ export default function Chip({
   truncateLabel = false,
 }: ChipProps) {
   return (
-    <Tooltip tooltip={children} side="top">
+    <Tooltip
+      tooltip={
+        children ? (
+          <span className="font-secondary-body break-all">{children}</span>
+        ) : undefined
+      }
+      side="top"
+    >
       <div
         className={cn(
           "flex max-w-full min-w-0 items-center bg-(--background-tint-02)",

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@onyx-ai/opal/components";
+import { Button, Text, Tooltip } from "@onyx-ai/opal/components";
 import { cn } from "@onyx-ai/opal/utils";
 import { SvgAlertTriangle, SvgX } from "@onyx-ai/opal/icons";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
@@ -27,57 +27,59 @@ export default function Chip({
   truncateLabel = false,
 }: ChipProps) {
   return (
-    <div
-      className={cn(
-        "flex max-w-full min-w-0 items-center bg-(--background-tint-02)",
-        smallLabel
-          ? "gap-0 rounded-(--radius-04) p-[2px]"
-          : "gap-0.5 rounded-(--radius-08) px-1 py-0.5",
-      )}
-    >
-      {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
-      {children && (
-        <span
-          className={
-            truncateLabel
-              ? "block max-w-[120px] min-w-0 truncate"
-              : "block min-w-0 truncate"
-          }
-        >
-          <Text
-            font={smallLabel ? "figure-small-value" : "main-ui-body"}
-            color="text-04"
-            nowrap
-            maxLines={1}
+    <Tooltip tooltip={children} side="top">
+      <div
+        className={cn(
+          "flex max-w-full min-w-0 items-center bg-(--background-tint-02)",
+          smallLabel
+            ? "gap-0 rounded-(--radius-04) p-[2px]"
+            : "gap-0.5 rounded-(--radius-08) px-1 py-0.5",
+        )}
+      >
+        {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
+        {children && (
+          <span
+            className={
+              truncateLabel
+                ? "block max-w-[120px] min-w-0 truncate"
+                : "block min-w-0 truncate"
+            }
           >
-            {children}
-          </Text>
-        </span>
-      )}
-      {error && (
-        <SvgAlertTriangle className="size-3.5 shrink-0 text-(--status-warning-05)" />
-      )}
-      {onRemove && (
-        <span
-          className={cn(
-            "flex items-center",
-            smallLabel
-              ? "[&_button]:!size-3 [&_svg]:!size-2.5 [&_svg]:text-(--text-04)"
-              : "[&_svg]:text-(--text-05)",
-          )}
-        >
-          <Button
-            type="button"
-            prominence="tertiary"
-            icon={SvgX}
-            size={smallLabel ? "fit" : "xs"}
-            onClick={(e) => {
-              e.stopPropagation();
-              onRemove();
-            }}
-          />
-        </span>
-      )}
-    </div>
+            <Text
+              font={smallLabel ? "figure-small-value" : "main-ui-body"}
+              color="text-04"
+              nowrap
+              maxLines={1}
+            >
+              {children}
+            </Text>
+          </span>
+        )}
+        {error && (
+          <SvgAlertTriangle className="size-3.5 shrink-0 text-(--status-warning-05)" />
+        )}
+        {onRemove && (
+          <span
+            className={cn(
+              "flex items-center",
+              smallLabel
+                ? "[&_button]:!size-3 [&_svg]:!size-2.5 [&_svg]:text-(--text-04)"
+                : "[&_svg]:text-(--text-05)",
+            )}
+          >
+            <Button
+              type="button"
+              prominence="tertiary"
+              icon={SvgX}
+              size={smallLabel ? "fit" : "xs"}
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove();
+              }}
+            />
+          </span>
+        )}
+      </div>
+    </Tooltip>
   );
 }

--- a/frontend/src/components/inputs/InputChipField.tsx
+++ b/frontend/src/components/inputs/InputChipField.tsx
@@ -71,7 +71,6 @@ export default function InputChipField({
       data-variant={disabled ? "disabled" : "primary"}
       className={cn(
         "opal-input min-h-9 cursor-text flex-wrap gap-1",
-        disabled && "pointer-events-none",
         className,
       )}
       onClick={() => inputRef.current?.focus()}

--- a/frontend/src/components/triggers/ActionEditor.tsx
+++ b/frontend/src/components/triggers/ActionEditor.tsx
@@ -19,6 +19,7 @@ import {
   SvgTrash,
   SvgUser,
 } from "@onyx-ai/opal/icons";
+import { ContentAction } from "@onyx-ai/opal/layouts";
 
 import InputChipField from "@/components/inputs/InputChipField";
 import InputTextArea from "@/components/inputs/InputTextArea";
@@ -141,27 +142,27 @@ function ActionGroupRow({
 
   return (
     <div className="group/action flex w-full flex-col gap-1">
-      <div className="flex w-full items-center px-[2px]">
-        <div className="flex-1">
-          <Text font="main-ui-action" color="text-04">
-            {label}
-          </Text>
-        </div>
-        {onRemove && (
-          /* Hidden at rest per the mock; hover over the action block reveals it. */
-          <span className="opacity-0 transition-opacity group-focus-within/action:opacity-100 group-hover/action:opacity-100">
-            <Button
-              type="button"
-              icon={SvgTrash}
-              size="sm"
-              prominence="tertiary"
-              tooltip="Remove this action"
-              onClick={onRemove}
-              disabled={disabled}
-            />
-          </span>
-        )}
-      </div>
+      <ContentAction
+        title={label}
+        sizePreset="main-ui"
+        variant="section"
+        rightChildren={
+          onRemove && (
+            /* Hidden at rest per the mock; hover over the action block reveals it. */
+            <span className="opacity-0 transition-opacity group-focus-within/action:opacity-100 group-hover/action:opacity-100">
+              <Button
+                type="button"
+                icon={SvgTrash}
+                size="sm"
+                prominence="tertiary"
+                tooltip="Remove this action"
+                onClick={onRemove}
+                disabled={disabled}
+              />
+            </span>
+          )
+        }
+      />
 
       <Popover open={typeOpen} onOpenChange={setTypeOpen}>
         {/* SelectButton draws no border of its own; the slot supplies the

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -523,10 +523,10 @@ function ScheduleFields({
 
   return (
     <div className="flex flex-col gap-3 rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-01) p-[14px]">
-      <label className="flex flex-col gap-1.5">
-        <Content title="Frequency" sizePreset="main-ui" variant="section" />
+      <LabeledField title="Frequency" htmlFor="schedule-frequency">
         {/* raw-ok: no Opal multiline input */}
         <select
+          id="schedule-frequency"
           value={parts.preset}
           onChange={(e) =>
             onPartsChange({
@@ -543,13 +543,13 @@ function ScheduleFields({
             </option>
           ))}
         </select>
-      </label>
+      </LabeledField>
 
       {showTimeOfDay && (
-        <label className="flex flex-col gap-1.5">
-          <Content title="Time of day" sizePreset="main-ui" variant="section" />
+        <LabeledField title="Time of day" htmlFor="schedule-time">
           {/* raw-ok: no Opal multiline input */}
           <input
+            id="schedule-time"
             type="time"
             value={timeValue}
             onChange={(e) => {
@@ -564,14 +564,14 @@ function ScheduleFields({
           <Text font="secondary-body" color="text-03">
             Interpreted in the timezone selected below.
           </Text>
-        </label>
+        </LabeledField>
       )}
 
       {showWeekday && (
-        <label className="flex flex-col gap-1.5">
-          <Content title="Day of week" sizePreset="main-ui" variant="section" />
+        <LabeledField title="Day of week" htmlFor="schedule-weekday">
           {/* raw-ok: no Opal multiline input */}
           <select
+            id="schedule-weekday"
             value={parts.dayOfWeek}
             onChange={(e) =>
               onPartsChange({ ...parts, dayOfWeek: Number(e.target.value) })
@@ -585,18 +585,14 @@ function ScheduleFields({
               </option>
             ))}
           </select>
-        </label>
+        </LabeledField>
       )}
 
       {showDayOfMonth && (
-        <label className="flex flex-col gap-1.5">
-          <Content
-            title="Day of month"
-            sizePreset="main-ui"
-            variant="section"
-          />
+        <LabeledField title="Day of month" htmlFor="schedule-monthday">
           {/* raw-ok: no Opal multiline input */}
           <input
+            id="schedule-monthday"
             type="number"
             min={1}
             max={31}
@@ -615,13 +611,13 @@ function ScheduleFields({
             entirely &mdash; the schedule does not roll over to the next valid
             day.
           </Text>
-        </label>
+        </LabeledField>
       )}
 
-      <label className="flex flex-col gap-1.5">
-        <Content title="Timezone" sizePreset="main-ui" variant="section" />
+      <LabeledField title="Timezone" htmlFor="schedule-timezone">
         {/* raw-ok: no Opal multiline input */}
         <select
+          id="schedule-timezone"
           value={tz}
           onChange={(e) => onTzChange(e.target.value)}
           disabled={disabled}
@@ -638,16 +634,15 @@ function ScheduleFields({
           The schedule runs in this timezone. Daylight-saving transitions are
           handled automatically.
         </Text>
-      </label>
+      </LabeledField>
 
-      <label className="flex flex-col gap-1.5">
-        <Content
-          title="Do not fire before (optional)"
-          sizePreset="main-ui"
-          variant="section"
-        />
+      <LabeledField
+        title="Do not fire before (optional)"
+        htmlFor="schedule-not-before"
+      >
         {/* raw-ok: no Opal multiline input */}
         <input
+          id="schedule-not-before"
           type="datetime-local"
           value={startAtLocal}
           onChange={(e) => onStartAtChange(e.target.value)}
@@ -659,7 +654,7 @@ function ScheduleFields({
           scheduled run. Useful for delaying a launch (e.g. &ldquo;don&rsquo;t
           start until next Monday&rdquo;).
         </Text>
-      </label>
+      </LabeledField>
 
       <details>
         <summary className="cursor-pointer text-xs font-semibold text-(--text-04) select-none">

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from "react";
 
 import useSWR from "swr";
 
@@ -521,12 +528,17 @@ function ScheduleFields({
 
   const timeValue = `${pad(parts.hour)}:${pad(parts.minute)}`;
 
+  // Unique per mounted panel so a second open panel can't duplicate ids or
+  // let a label focus another instance's control.
+  const uid = useId();
+  const id = (field: string) => `${uid}-${field}`;
+
   return (
     <div className="flex flex-col gap-3 rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-01) p-[14px]">
-      <LabeledField title="Frequency" htmlFor="schedule-frequency">
+      <LabeledField title="Frequency" htmlFor={id("frequency")}>
         {/* raw-ok: no Opal multiline input */}
         <select
-          id="schedule-frequency"
+          id={id("frequency")}
           value={parts.preset}
           onChange={(e) =>
             onPartsChange({
@@ -546,10 +558,10 @@ function ScheduleFields({
       </LabeledField>
 
       {showTimeOfDay && (
-        <LabeledField title="Time of day" htmlFor="schedule-time">
+        <LabeledField title="Time of day" htmlFor={id("time")}>
           {/* raw-ok: no Opal multiline input */}
           <input
-            id="schedule-time"
+            id={id("time")}
             type="time"
             value={timeValue}
             onChange={(e) => {
@@ -568,10 +580,10 @@ function ScheduleFields({
       )}
 
       {showWeekday && (
-        <LabeledField title="Day of week" htmlFor="schedule-weekday">
+        <LabeledField title="Day of week" htmlFor={id("weekday")}>
           {/* raw-ok: no Opal multiline input */}
           <select
-            id="schedule-weekday"
+            id={id("weekday")}
             value={parts.dayOfWeek}
             onChange={(e) =>
               onPartsChange({ ...parts, dayOfWeek: Number(e.target.value) })
@@ -589,10 +601,10 @@ function ScheduleFields({
       )}
 
       {showDayOfMonth && (
-        <LabeledField title="Day of month" htmlFor="schedule-monthday">
+        <LabeledField title="Day of month" htmlFor={id("monthday")}>
           {/* raw-ok: no Opal multiline input */}
           <input
-            id="schedule-monthday"
+            id={id("monthday")}
             type="number"
             min={1}
             max={31}
@@ -614,10 +626,10 @@ function ScheduleFields({
         </LabeledField>
       )}
 
-      <LabeledField title="Timezone" htmlFor="schedule-timezone">
+      <LabeledField title="Timezone" htmlFor={id("timezone")}>
         {/* raw-ok: no Opal multiline input */}
         <select
-          id="schedule-timezone"
+          id={id("timezone")}
           value={tz}
           onChange={(e) => onTzChange(e.target.value)}
           disabled={disabled}
@@ -638,11 +650,11 @@ function ScheduleFields({
 
       <LabeledField
         title="Do not fire before (optional)"
-        htmlFor="schedule-not-before"
+        htmlFor={id("not-before")}
       >
         {/* raw-ok: no Opal multiline input */}
         <input
-          id="schedule-not-before"
+          id={id("not-before")}
           type="datetime-local"
           value={startAtLocal}
           onChange={(e) => onStartAtChange(e.target.value)}

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -22,6 +22,7 @@ import {
   SvgWorkflow,
   SvgX,
 } from "@onyx-ai/opal/icons";
+import { Content } from "@onyx-ai/opal/layouts";
 import { markdown } from "@onyx-ai/opal/utils";
 import {
   PRESET_OPTIONS,
@@ -109,6 +110,39 @@ function groupsFromActions(
       message: "",
     });
   return out;
+}
+
+/** Vertical label + control + helper stack. Composes Opal's Content for the
+ * label row; InputVertical is unsuitable here (its root is h-full, sized for
+ * fixed-height rows, and collapses in a free-flow column). */
+function LabeledField({
+  title,
+  helper,
+  htmlFor,
+  children,
+}: {
+  title: string;
+  helper?: string;
+  /** id of the native control below, so the visible title is a real label. */
+  htmlFor?: string;
+  children: React.ReactNode;
+}) {
+  const heading = (
+    <Content title={title} sizePreset="main-ui" variant="section" />
+  );
+  return (
+    <div className="flex w-full flex-col gap-1">
+      {htmlFor ? <label htmlFor={htmlFor}>{heading}</label> : heading}
+      {children}
+      {helper && (
+        <div className="px-[2px]">
+          <Text font="secondary-body" color="text-03">
+            {helper}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
 }
 
 const EXAMPLE_IF = "the document is updated with a release version";
@@ -323,12 +357,10 @@ export function TriggerPanel({
             </Tabs.List>
           </Tabs>
 
-          <div className="flex w-full flex-col gap-1">
-            <div className="px-[2px]">
-              <Text font="main-ui-action" color="text-04">
-                Watch
-              </Text>
-            </div>
+          <LabeledField
+            title="Watch"
+            helper="Add specific sections or entire pages to watch."
+          >
             <WatchScopePicker
               scopePath={scopePath}
               onScopePath={(p) => {
@@ -337,12 +369,7 @@ export function TriggerPanel({
               disabled={busy || Boolean(lockScope)}
               locked={Boolean(lockScope)}
             />
-            <div className="px-[2px]">
-              <Text font="secondary-body" color="text-03">
-                Add specific sections or entire pages to watch.
-              </Text>
-            </div>
-          </div>
+          </LabeledField>
 
           <Divider />
 
@@ -363,12 +390,7 @@ export function TriggerPanel({
             />
           )}
 
-          <div className="flex w-full flex-col gap-1">
-            <div className="px-[2px]">
-              <Text font="main-ui-action" color="text-04">
-                Run if
-              </Text>
-            </div>
+          <LabeledField title="Run if">
             <InputTextArea
               value={ifText}
               onChange={(e) => setIfText(e.target.value)}
@@ -384,7 +406,7 @@ export function TriggerPanel({
                 </Text>
               </div>
             )}
-          </div>
+          </LabeledField>
 
           <ActionEditor
             groups={groups}
@@ -492,11 +514,9 @@ function ScheduleFields({
   const timeValue = `${pad(parts.hour)}:${pad(parts.minute)}`;
 
   return (
-    <div className="flex flex-col gap-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-01) p-[14px]">
+    <div className="flex flex-col gap-3 rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-01) p-[14px]">
       <label className="flex flex-col gap-1.5">
-        <Text font="main-ui-action" color="text-04">
-          Frequency
-        </Text>
+        <Content title="Frequency" sizePreset="main-ui" variant="section" />
         {/* raw-ok: no Opal multiline input */}
         <select
           value={parts.preset}
@@ -507,7 +527,7 @@ function ScheduleFields({
             })
           }
           disabled={disabled}
-          className="box-border w-full cursor-pointer rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+          className="box-border w-full cursor-pointer rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
         >
           {PRESET_OPTIONS.map((o) => (
             <option key={o.value} value={o.value}>
@@ -519,9 +539,7 @@ function ScheduleFields({
 
       {showTimeOfDay && (
         <label className="flex flex-col gap-1.5">
-          <Text font="main-ui-action" color="text-04">
-            Time of day
-          </Text>
+          <Content title="Time of day" sizePreset="main-ui" variant="section" />
           {/* raw-ok: no Opal multiline input */}
           <input
             type="time"
@@ -533,7 +551,7 @@ function ScheduleFields({
               }
             }}
             disabled={disabled}
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+            className="box-border w-full rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
           />
           <Text font="secondary-body" color="text-03">
             Interpreted in the timezone selected below.
@@ -543,9 +561,7 @@ function ScheduleFields({
 
       {showWeekday && (
         <label className="flex flex-col gap-1.5">
-          <Text font="main-ui-action" color="text-04">
-            Day of week
-          </Text>
+          <Content title="Day of week" sizePreset="main-ui" variant="section" />
           {/* raw-ok: no Opal multiline input */}
           <select
             value={parts.dayOfWeek}
@@ -553,7 +569,7 @@ function ScheduleFields({
               onPartsChange({ ...parts, dayOfWeek: Number(e.target.value) })
             }
             disabled={disabled}
-            className="box-border w-full cursor-pointer rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+            className="box-border w-full cursor-pointer rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
           >
             {WEEKDAY_NAMES.map((name, i) => (
               <option key={i} value={i}>
@@ -566,9 +582,11 @@ function ScheduleFields({
 
       {showDayOfMonth && (
         <label className="flex flex-col gap-1.5">
-          <Text font="main-ui-action" color="text-04">
-            Day of month
-          </Text>
+          <Content
+            title="Day of month"
+            sizePreset="main-ui"
+            variant="section"
+          />
           {/* raw-ok: no Opal multiline input */}
           <input
             type="number"
@@ -582,7 +600,7 @@ function ScheduleFields({
               }
             }}
             disabled={disabled}
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+            className="box-border w-full rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
           />
           <Text font="secondary-body" color="text-03">
             Months without this day (e.g. day 31 in February) skip that month
@@ -593,15 +611,13 @@ function ScheduleFields({
       )}
 
       <label className="flex flex-col gap-1.5">
-        <Text font="main-ui-action" color="text-04">
-          Timezone
-        </Text>
+        <Content title="Timezone" sizePreset="main-ui" variant="section" />
         {/* raw-ok: no Opal multiline input */}
         <select
           value={tz}
           onChange={(e) => onTzChange(e.target.value)}
           disabled={disabled}
-          className="box-border w-full cursor-pointer rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+          className="box-border w-full cursor-pointer rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
         >
           {tzOptions.includes(tz) ? null : <option value={tz}>{tz}</option>}
           {tzOptions.map((zone) => (
@@ -617,16 +633,18 @@ function ScheduleFields({
       </label>
 
       <label className="flex flex-col gap-1.5">
-        <Text font="main-ui-action" color="text-04">
-          Do not fire before (optional)
-        </Text>
+        <Content
+          title="Do not fire before (optional)"
+          sizePreset="main-ui"
+          variant="section"
+        />
         {/* raw-ok: no Opal multiline input */}
         <input
           type="datetime-local"
           value={startAtLocal}
           onChange={(e) => onStartAtChange(e.target.value)}
           disabled={disabled}
-          className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
+          className="box-border w-full rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 text-sm outline-none"
         />
         <Text font="secondary-body" color="text-03">
           Anchored to your local time. Leave empty to start at the next
@@ -661,7 +679,7 @@ function ScheduleFields({
             }}
             disabled={disabled}
             placeholder="*/15 * * * *"
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 font-mono text-sm outline-none"
+            className="box-border w-full rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-[10px] py-2 font-mono text-sm outline-none"
           />
           <Text font="secondary-body" color="text-03">
             Standard 5-field cron. Editing this switches the frequency to

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -23,7 +23,7 @@ import {
   SvgX,
 } from "@onyx-ai/opal/icons";
 import { Content } from "@onyx-ai/opal/layouts";
-import { markdown } from "@onyx-ai/opal/utils";
+import { cn, markdown } from "@onyx-ai/opal/utils";
 import {
   PRESET_OPTIONS,
   WEEKDAY_NAMES,
@@ -290,13 +290,16 @@ export function TriggerPanel({
     <div
       className={
         docked
-          ? "flex max-h-full w-full flex-col"
+          ? "flex w-full flex-col"
           : "fixed top-2 right-2 z-[100] flex max-h-[calc(100vh-16px)] w-[464px] max-w-[calc(100vw-16px)] flex-col"
       }
     >
       <form
         onSubmit={onSubmit}
-        className="flex max-h-full w-full flex-col overflow-hidden rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-00)"
+        className={cn(
+          "flex w-full flex-col overflow-hidden rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-00)",
+          !docked && "max-h-full",
+        )}
       >
         <div className="flex w-full items-start gap-2 p-2">
           <div className="flex min-w-0 flex-1 items-start gap-[2px] p-[2px]">
@@ -323,7 +326,12 @@ export function TriggerPanel({
           />
         </div>
 
-        <div className="flex w-full flex-1 flex-col gap-3 overflow-y-auto bg-(--background-tint-01) p-3">
+        <div
+          className={cn(
+            "flex w-full flex-1 flex-col gap-3 bg-(--background-tint-01) p-3",
+            !docked && "overflow-y-auto",
+          )}
+        >
           <Tabs
             value={kind}
             onValueChange={(v) => {


### PR DESCRIPTION
## Description

Compose the trigger panel and action editor from Opal layouts, plus chip UX fixes surfaced while testing.

**Layouts**
- Panel header and each Then/And Send row → `ContentAction`.
- The eight hand-rolled label stacks (panel + schedule fields) → one `LabeledField` on Opal `Content`; `InputVertical` rejected (its `h-full` root collapses in a free-flow column).
- Schedule fields use explicit `htmlFor` label bindings.
- Fixed undefined `--border-radius-04` tokens (rendered square) → real `--radius-04`.

**Chips**
- Long labels ellipsize instead of forcing a panel-wide horizontal scrollbar.
- Full label shown in a hover tooltip, wrapped so long paths aren't clipped.
- Locked/disabled chip field stays hoverable (the tooltip was blocked by `pointer-events-none`).
- Docked panel grows to content height; the panel column owns scrolling (no nested scrollbar).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check