### PR TITLE
feat(triggers): multi-file watch lists with optional line ranges

### DIFF
--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -309,7 +309,10 @@ def update_trigger(
     sent_fields = req.model_fields_set
     kwargs: dict[str, Any] = {}
 
-    if "scopes" in sent_fields and req.scopes:
+    if "scopes" in sent_fields:
+        # An explicit empty list must not silently keep the old watch list.
+        if not req.scopes:
+            raise HTTPException(status_code=400, detail="scopes cannot be empty")
         try:
             kwargs["scopes"] = [s.model_dump() for s in req.scopes]
             kwargs["scope_path"] = _normalize_scope_path(req.scopes[0].path)

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -323,9 +323,10 @@ def update_trigger(
             kwargs["scope_path"] = _normalize_scope_path(req.scope_path or "")
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        # Rebinding the primary without a watch list resets to single-scope.
-        if existing.get("scopes") and len(existing["scopes"]) > 1:
-            kwargs["scopes"] = [{"path": kwargs["scope_path"]}]
+        # Rebinding the primary without a watch list resets to single-scope —
+        # unconditionally, or a cached secondary path or line range would keep
+        # the trigger watching the old target until a rebuild.
+        kwargs["scopes"] = [{"path": kwargs["scope_path"]}]
 
     # Require read access against whichever scope ends up sticking — the
     # new one if rebinding, otherwise the existing one (in case ACLs

--- a/backend/app/api/triggers.py
+++ b/backend/app/api/triggers.py
@@ -249,13 +249,19 @@ def create_trigger(
     req: CreateTriggerRequest, user: User = Depends(require_user),
 ) -> TriggerView:
     try:
-        scope_path = _normalize_scope_path(req.scope_path)
+        scopes = [s.model_dump() for s in req.scopes] if req.scopes else None
+        scope_path = _normalize_scope_path(
+            req.scopes[0].path if req.scopes else req.scope_path
+        )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    # A trigger reads the scope at fire-time to render its message; require
-    # the same up-front so users can't watch paths they can't see.
+    # A trigger reads its scopes at fire-time to render its message; require
+    # the same up-front on every watched path so users can't watch paths
+    # they can't see.
     require_can("read", scope_path, user)
+    for entry in scopes or []:
+        require_can("read", triggers_storage.normalize_scope_path(entry["path"]), user)
 
     if req.kind not in triggers_repo.ALLOWED_KINDS:
         raise HTTPException(status_code=400, detail=f"unsupported kind: {req.kind!r}")
@@ -264,6 +270,7 @@ def create_trigger(
         trigger = triggers_repo.create(
             owner_user_id=user.id,
             scope_path=scope_path,
+            scopes=scopes,
             nl_description=req.nl_description.strip(),
             actions=[a.model_dump() for a in req.actions],
             kind=req.kind,
@@ -302,17 +309,31 @@ def update_trigger(
     sent_fields = req.model_fields_set
     kwargs: dict[str, Any] = {}
 
-    if "scope_path" in sent_fields:
+    if "scopes" in sent_fields and req.scopes:
+        try:
+            kwargs["scopes"] = [s.model_dump() for s in req.scopes]
+            kwargs["scope_path"] = _normalize_scope_path(req.scopes[0].path)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    elif "scope_path" in sent_fields:
         try:
             kwargs["scope_path"] = _normalize_scope_path(req.scope_path or "")
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        # Rebinding the primary without a watch list resets to single-scope.
+        if existing.get("scopes") and len(existing["scopes"]) > 1:
+            kwargs["scopes"] = [{"path": kwargs["scope_path"]}]
 
     # Require read access against whichever scope ends up sticking — the
     # new one if rebinding, otherwise the existing one (in case ACLs
     # were revoked after the trigger was created).
     final_scope = kwargs.get("scope_path", existing["scope_path"])
     require_can("read", final_scope, user)
+    sent_scopes = cast("list[dict[str, Any]]", kwargs.get("scopes") or [])
+    for entry in sent_scopes:
+        require_can(
+            "read", triggers_storage.normalize_scope_path(str(entry["path"])), user
+        )
 
     if "nl_description" in sent_fields:
         nl = (req.nl_description or "").strip()

--- a/backend/app/db/migrations/versions/8c3fa27d9e42_trigger_scopes_json.py
+++ b/backend/app/db/migrations/versions/8c3fa27d9e42_trigger_scopes_json.py
@@ -6,7 +6,7 @@ inspector because ``0001_initial`` builds fresh databases from the current
 models.
 
 Revision ID: 8c3fa27d9e42
-Revises: 0075dcbb622e
+Revises: 7f2a91c04b11
 Create Date: 2026-07-07 07:05:00.000000+00:00
 """
 from __future__ import annotations
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 
 revision: str = "8c3fa27d9e42"
-down_revision: str | None = "0075dcbb622e"
+down_revision: str | None = "7f2a91c04b11"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/app/db/migrations/versions/8c3fa27d9e42_trigger_scopes_json.py
+++ b/backend/app/db/migrations/versions/8c3fa27d9e42_trigger_scopes_json.py
@@ -1,0 +1,36 @@
+"""trigger multi-scope watch list
+
+Adds ``triggers.scopes_json`` — the full watch list with optional line
+ranges; ``scope_path`` keeps mirroring the first entry. Guarded with the
+inspector because ``0001_initial`` builds fresh databases from the current
+models.
+
+Revision ID: 8c3fa27d9e42
+Revises: 0075dcbb622e
+Create Date: 2026-07-07 07:05:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "8c3fa27d9e42"
+down_revision: str | None = "0075dcbb622e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("triggers")}
+    if "scopes_json" not in cols:
+        op.add_column("triggers", sa.Column("scopes_json", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("triggers", "scopes_json")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -443,6 +443,10 @@ class Trigger(Base):
         Text, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
     scope_path: Mapped[str] = mapped_column(Text, nullable=False)
+    # Full watch list [{path, start_line?, end_line?}, ...]; scope_path
+    # mirrors the first entry's path (file placement + fast primary lookup).
+    # NULL = legacy single scope derived from scope_path.
+    scopes_json: Mapped[list[dict[str, Any]] | None] = mapped_column(JSONB)
     kind: Mapped[str] = mapped_column(Text, nullable=False)  # "delta" | "schedule"
     nl_description: Mapped[str] = mapped_column(Text, nullable=False)
     # ``{"actions": [{"destination_config_id", "message"}, ...]}``. Each action

--- a/backend/app/models/trigger.py
+++ b/backend/app/models/trigger.py
@@ -25,6 +25,15 @@ class TriggerActionView(BaseModel):
 # --------------------------------------------------------------------------- #
 
 
+class TriggerScopeShape(BaseModel):
+    """One watch entry: a page or folder path, optionally narrowed to a
+    1-based inclusive line range (pages only)."""
+
+    path: str = Field(min_length=1)
+    start_line: int | None = Field(default=None, ge=1)
+    end_line: int | None = Field(default=None, ge=1)
+
+
 class CreateTriggerRequest(BaseModel):
     """``actions`` is the delivery list; each entry's ``destination_config_id``
     must reference a destination config the caller owns (GET
@@ -37,6 +46,9 @@ class CreateTriggerRequest(BaseModel):
     """
 
     scope_path: str = Field(min_length=1)
+    # Full watch list; when present, scopes[0].path governs and scope_path
+    # may be omitted from consideration (kept for older clients).
+    scopes: list[TriggerScopeShape] | None = None
     nl_description: str = Field(min_length=1)
     actions: list[TriggerActionShape] = Field(min_length=1)
     kind: str = "delta"
@@ -50,6 +62,7 @@ class UpdateTriggerRequest(BaseModel):
     """All fields optional — the route only updates the ones that were sent."""
 
     scope_path: str | None = None
+    scopes: list[TriggerScopeShape] | None = None
     nl_description: str | None = None
     actions: list[TriggerActionShape] | None = None
     enabled: bool | None = None
@@ -73,6 +86,7 @@ class TriggerView(BaseModel):
     id: str
     owner_user_id: str
     scope_path: str
+    scopes: list[TriggerScopeShape] = Field(default_factory=list)
     kind: str
     nl_description: str
     actions: list[TriggerActionView]

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -62,6 +62,7 @@ from app.triggers.engine import (
     evaluate_schedule,
     find_due_schedule_triggers,
     find_matching_triggers,
+    matched_scope,
     render_delta_message,
     render_schedule_message,
     schedule_window_start,
@@ -108,22 +109,28 @@ def fan_out_trigger_eval(
             scope_blocks[scope_path] = block
         return block
 
-    def _delta_payload(scope_path: str) -> str:
+    def _lead_block(trigger: TriggerRecord) -> str:
+        """The payload's scoped-docs lead covering the trigger's whole watch
+        list; per-path blocks are shared across triggers on this commit."""
+        paths = list(dict.fromkeys(s.path for s in trigger.scopes))
+        return "\n\n".join(_scope_block(p) for p in paths)
+
+    def _delta_payload(trigger: TriggerRecord) -> str:
         return diff_helper.build_payload(
             doc_path=doc_path,
             change_kind=change_kind,
             before=before,
             after=after,
-            scope_path=scope_path,
-            scope_block=_scope_block(scope_path),
+            scope_path=trigger.scope_path,
+            scope_block=_lead_block(trigger),
         )
 
-    def _new_file_payload(scope_path: str) -> str:
+    def _new_file_payload(trigger: TriggerRecord) -> str:
         return diff_helper.build_new_file_payload(
             doc_path=doc_path,
             body=after,
-            scope_path=scope_path,
-            scope_block=_scope_block(scope_path),
+            scope_path=trigger.scope_path,
+            scope_block=_lead_block(trigger),
         )
 
     # Cache owner ACL flags by user id — most fan-outs touch a handful of
@@ -163,13 +170,28 @@ def fan_out_trigger_eval(
             )
             continue
 
+        # A line-ranged watch entry only fires when the edit touches those
+        # lines of the changed doc; checked cheaply before any LLM eval.
+        matched = matched_scope(trigger, doc_path)
+        if matched is not None and matched.start_line is not None:
+            end = matched.end_line or matched.start_line
+            if not diff_helper.change_touches_lines(
+                before, after, matched.start_line, end
+            ):
+                log.debug(
+                    "trigger %s skipped: change outside lines %d-%d of %s",
+                    trigger.id, matched.start_line, end, doc_path,
+                )
+                continue
+
         # Evaluate the firing condition once per trigger, then deliver each
         # action. Delta renders per action; the new-file eval renders in its
         # single combined call.
-        if change_kind == ChangeKind.CREATE and trigger.scope_path != doc_path:
+        matched_path = matched.path if matched is not None else trigger.scope_path
+        if change_kind == ChangeKind.CREATE and matched_path != doc_path:
             primary = (trigger.actions[0].message or "") if trigger.actions else ""
             new_file_result = evaluate_new_file_in_dir(
-                trigger, primary, _new_file_payload(trigger.scope_path)
+                trigger, primary, _new_file_payload(trigger)
             )
             if not new_file_result.triggered:
                 continue
@@ -177,7 +199,7 @@ def fan_out_trigger_eval(
             reason = "new file under directory scope"
             log.info("trigger fired (new-file-in-dir) id=%s doc=%s", trigger.id, doc_path)
         else:
-            match = evaluate_delta(trigger, _delta_payload(trigger.scope_path))
+            match = evaluate_delta(trigger, _delta_payload(trigger))
             if not match.matched:
                 continue
             new_file_message = None
@@ -192,7 +214,7 @@ def fan_out_trigger_eval(
             else:
                 rendered = (
                     render_delta_message(
-                        instruction, _delta_payload(trigger.scope_path), reason=reason
+                        instruction, _delta_payload(trigger), reason=reason
                     )
                     if instruction
                     else ""

--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -264,6 +264,38 @@ def build_changes_since(*, scope_path: str, since_iso: str) -> str:
     return "\n".join(chunks)
 
 
+def change_touches_lines(
+    before: str, after: str, start_line: int, end_line: int
+) -> bool:
+    """Does the edit touch the 1-based inclusive ``[start_line, end_line]``
+    of the *current* body? Insertions and replacements count where they land
+    in the new file; a pure deletion counts at the line it collapses onto.
+    New files count if the range exists in the body; deletions of the whole
+    file always count (the watched lines are gone)."""
+    if before == after:
+        return False
+    if not after:
+        return True
+    after_lines = after.splitlines()
+    if not before:
+        return start_line <= len(after_lines)
+    matcher = difflib.SequenceMatcher(
+        a=before.splitlines(keepends=True), b=after.splitlines(keepends=True)
+    )
+    for tag, _i1, _i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        # New-file line span of this edit; a deletion (j1 == j2) collapses
+        # onto line j1, so treat it as touching that single position.
+        lo = j1 + 1
+        hi = j2 if j2 > j1 else min(j1 + 1, len(after_lines))
+        if lo > hi:
+            lo = hi
+        if hi >= start_line and lo <= end_line:
+            return True
+    return False
+
+
 def _unified_diff(before: str, after: str) -> str:
     return "".join(
         difflib.unified_diff(

--- a/backend/app/triggers/engine.py
+++ b/backend/app/triggers/engine.py
@@ -23,7 +23,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from croniter import croniter
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import select
 
 from app.db.models import Trigger
@@ -40,7 +40,6 @@ from app.triggers.natural_language import (
     render_snapshot_message as nl_render_snapshot_message,
 )
 from app.triggers.repo import _parse_actions  # pyright: ignore[reportPrivateUsage]
-from app.wiki.filesystem import parent_dirs
 
 log = logging.getLogger(__name__)
 
@@ -53,13 +52,25 @@ class TriggerAction(BaseModel):
     message: str | None = None
 
 
+class TriggerScope(BaseModel):
+    """One watched path, optionally narrowed to a 1-based inclusive line
+    range (line ranges only make sense on ``.md`` page scopes)."""
+
+    path: str
+    start_line: int | None = None
+    end_line: int | None = None
+
+
 class TriggerRecord(BaseModel):
     """Eval-side view of a trigger row. ``actions`` is parsed from
-    ``Trigger.action_json``. The raw column shape is hidden."""
+    ``Trigger.action_json``; ``scopes`` is the full watch list (the legacy
+    single scope when the row predates multi-scope). The raw column shape
+    is hidden."""
 
     id: str
     owner_user_id: str
     scope_path: str
+    scopes: list[TriggerScope] = Field(default_factory=list)
     kind: str
     nl_description: str
     actions: list[TriggerAction]
@@ -72,12 +83,19 @@ class TriggerRecord(BaseModel):
     schedule_start_at: str | None = None
     schedule_last_fired_at: str | None = None
 
+    @model_validator(mode="after")
+    def _default_scopes(self) -> "TriggerRecord":
+        if not self.scopes:
+            self.scopes = [TriggerScope(path=self.scope_path)]
+        return self
+
 
 def _to_record(t: Trigger) -> TriggerRecord:
     return TriggerRecord(
         id=t.id,
         owner_user_id=t.owner_user_id,
         scope_path=t.scope_path,
+        scopes=_parse_scopes(t),
         kind=t.kind,
         nl_description=t.nl_description,
         actions=[TriggerAction(**a) for a in _parse_actions(t.action_json)],
@@ -92,18 +110,55 @@ def _to_record(t: Trigger) -> TriggerRecord:
     )
 
 
+def _parse_scopes(t: Trigger) -> list[TriggerScope]:
+    if not t.scopes_json:
+        return [TriggerScope(path=t.scope_path)]
+    out: list[TriggerScope] = []
+    for entry in t.scopes_json:
+        try:
+            out.append(TriggerScope(**entry))
+        except Exception:
+            log.warning("trigger %s: skipping malformed scope entry %r", t.id, entry)
+    return out or [TriggerScope(path=t.scope_path)]
+
+
+def scope_covers(scope_path: str, doc_path: str) -> bool:
+    """Exact page, ancestor folder, or whole wiki (empty scope)."""
+    if not scope_path:
+        return True
+    if doc_path == scope_path:
+        return True
+    return doc_path.startswith(scope_path.rstrip("/") + "/")
+
+
+def matched_scope(record: TriggerRecord, doc_path: str) -> TriggerScope | None:
+    """The most specific watch entry covering ``doc_path`` — an exact page
+    match wins over a folder, a folder over the whole wiki — so a line range
+    on the page entry governs even when a broader scope also matches."""
+    best: TriggerScope | None = None
+    for scope in record.scopes:
+        if not scope_covers(scope.path, doc_path):
+            continue
+        if best is None or len(scope.path) > len(best.path):
+            best = scope
+    return best
+
+
 def find_matching_triggers(doc_path: str) -> list[TriggerRecord]:
-    """Return enabled delta triggers attached to ``doc_path`` or any parent dir."""
-    candidates = [doc_path, *parent_dirs(doc_path)]
+    """Return enabled delta triggers whose watch list covers ``doc_path``.
+
+    Filters in Python over the enabled delta rows: the watch list lives in
+    JSON, and per-wiki trigger counts are small enough that a SQL pushdown
+    would buy nothing."""
     with session() as s:
         rows = s.scalars(
             select(Trigger).where(
                 Trigger.kind == "delta",
                 Trigger.enabled.is_(True),
-                Trigger.scope_path.in_(candidates),
             )
         ).all()
-        return [_to_record(t) for t in rows]
+        records = [_to_record(t) for t in rows]
+    return [r for r in records if matched_scope(r, doc_path) is not None]
 
 
 def find_due_schedule_triggers(now: datetime) -> list[TriggerRecord]:

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -610,6 +610,19 @@ def rebuild_from_filesystem() -> int:
             )
             skipped += 1
             continue
+        # Hand-edited files may carry unnormalized primaries (e.g. "/" for the
+        # whole wiki); the engine and the scopes validator both expect the
+        # stored form, so normalize before anything downstream sees it.
+        try:
+            data["scope_path"] = storage.normalize_scope_path(
+                str(data.get("scope_path", ""))
+            )
+        except ValueError:
+            log.warning(
+                "rebuild_from_filesystem: skip %s (invalid scope_path)", file_path
+            )
+            skipped += 1
+            continue
         parsed.append((file_path, data))
 
     fallback_now = _now_iso()

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -698,7 +698,7 @@ def rebuild_from_filesystem() -> int:
                     id=data["id"],
                     owner_user_id=owner_id,
                     scope_path=data["scope_path"],
-                    scopes_json=data.get("scopes"),
+                    scopes_json=_scopes_for_rebuild(data),
                     kind=data["kind"],
                     nl_description=data["nl_description"],
                     action_json=_actions_json(actions_payload),
@@ -715,6 +715,26 @@ def rebuild_from_filesystem() -> int:
             loaded += 1
     log.info("rebuild_from_filesystem loaded=%d skipped=%d", loaded, skipped)
     return loaded
+
+
+def _scopes_for_rebuild(data: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Run a YAML watch list through the same validator as the API; a
+    hand-edited file that fails validation degrades to the single primary
+    scope instead of caching an unvalidated list (or dropping the trigger)."""
+    scopes = data.get("scopes")
+    if not scopes:
+        return None
+    try:
+        return _validate_scopes(
+            cast("list[dict[str, Any]]", scopes), data["scope_path"]
+        )
+    except ValueError:
+        log.warning(
+            "rebuild_from_filesystem: trigger %s has an invalid scopes list; "
+            "falling back to its primary scope",
+            data.get("id"),
+        )
+        return None
 
 
 def fire_counts_by_sha(shas: set[str]) -> dict[str, int]:

--- a/backend/app/triggers/repo.py
+++ b/backend/app/triggers/repo.py
@@ -175,6 +175,7 @@ def _to_dict(t: Trigger) -> dict[str, Any]:
         "id": t.id,
         "owner_user_id": t.owner_user_id,
         "scope_path": t.scope_path,
+        "scopes": t.scopes_json or [{"path": t.scope_path}],
         "kind": t.kind,
         "nl_description": t.nl_description,
         "actions": _parse_actions(t.action_json),
@@ -189,6 +190,46 @@ def _to_dict(t: Trigger) -> dict[str, Any]:
     }
 
 
+def _validate_scopes(
+    scopes: list[dict[str, Any]] | None, scope_path: str
+) -> list[dict[str, Any]] | None:
+    """Validate the watch list: first entry must mirror ``scope_path``, paths
+    are normalized and deduped, line ranges are 1-based ordered ints allowed
+    on ``.md`` entries only. ``None`` stays ``None`` (single-scope row)."""
+    if scopes is None:
+        return None
+    if not scopes:
+        raise ValueError("scopes must be a non-empty list when provided")
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in scopes:
+        path = storage.normalize_scope_path(str(entry.get("path", "")))
+        start = entry.get("start_line")
+        end = entry.get("end_line")
+        if (start is not None or end is not None) and not path.endswith(".md"):
+            raise ValueError("line ranges are only valid on page (.md) scopes")
+        if start is not None:
+            if not isinstance(start, int) or start < 1:
+                raise ValueError("start_line must be a positive integer")
+            if end is not None and (not isinstance(end, int) or end < start):
+                raise ValueError("end_line must be an integer >= start_line")
+        elif end is not None:
+            raise ValueError("end_line requires start_line")
+        key = f"{path}#{start}-{end}"
+        if key in seen:
+            continue
+        seen.add(key)
+        scope: dict[str, Any] = {"path": path}
+        if start is not None:
+            scope["start_line"] = start
+            if end is not None:
+                scope["end_line"] = end
+        out.append(scope)
+    if out[0]["path"] != scope_path:
+        raise ValueError("scopes[0].path must match scope_path")
+    return out
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -197,6 +238,7 @@ def create(
     *,
     owner_user_id: str,
     scope_path: str,
+    scopes: list[dict[str, Any]] | None = None,
     nl_description: str,
     actions: object,
     kind: str = "delta",
@@ -220,6 +262,7 @@ def create(
         schedule_start_at=schedule_start_at,
     )
 
+    scopes_value = _validate_scopes(scopes, scope_path)
     trigger_id = "trg_" + uuid.uuid4().hex[:12]
     created_at = _now_iso()
     file_path = storage.compute_path(scope_path=scope_path, trigger_id=trigger_id)
@@ -227,6 +270,7 @@ def create(
         "id": trigger_id,
         "owner_user_id": owner_user_id,
         "scope_path": scope_path,
+        "scopes": scopes_value or [{"path": scope_path}],
         "kind": kind,
         "nl_description": nl_description,
         "actions": validated_actions,
@@ -244,6 +288,7 @@ def create(
                 id=trigger_id,
                 owner_user_id=owner_user_id,
                 scope_path=scope_path,
+                scopes_json=scopes_value,
                 kind=kind,
                 nl_description=nl_description,
                 action_json=_actions_json(validated_actions),
@@ -288,6 +333,7 @@ def update(
     trigger_id: str,
     *,
     scope_path: str | None = None,
+    scopes: list[dict[str, Any]] | None = None,
     nl_description: str | None = None,
     actions: object = _UNSET,
     enabled: bool | None = None,
@@ -303,6 +349,8 @@ def update(
     new = dict(existing)
     if scope_path is not None:
         new["scope_path"] = scope_path
+    if scopes is not None:
+        new["scopes"] = _validate_scopes(scopes, new.get("scope_path") or existing["scope_path"])
     if nl_description is not None:
         if not nl_description.strip():
             raise ValueError("nl_description must be a non-empty string")
@@ -338,6 +386,7 @@ def update(
 
     if (
         new["scope_path"] == existing["scope_path"]
+        and new.get("scopes") == existing.get("scopes")
         and new["nl_description"] == existing["nl_description"]
         and new["actions"] == existing["actions"]
         and new["enabled"] == existing["enabled"]
@@ -364,6 +413,8 @@ def update(
         if t is None:
             return None
         t.scope_path = new["scope_path"]
+        if scopes is not None:
+            t.scopes_json = new["scopes"]
         t.nl_description = new["nl_description"]
         t.action_json = _actions_json(new["actions"])
         t.enabled = new["enabled"]
@@ -647,6 +698,7 @@ def rebuild_from_filesystem() -> int:
                     id=data["id"],
                     owner_user_id=owner_id,
                     scope_path=data["scope_path"],
+                    scopes_json=data.get("scopes"),
                     kind=data["kind"],
                     nl_description=data["nl_description"],
                     action_json=_actions_json(actions_payload),

--- a/backend/app/triggers/storage.py
+++ b/backend/app/triggers/storage.py
@@ -130,6 +130,17 @@ def serialize(trigger: dict[str, Any]) -> str:
         value = trigger.get(key)
         if value is not None:
             payload[key] = value
+    # The full watch list is emitted only when it says more than scope_path
+    # alone (extra paths or a line range), so single-scope YAMLs stay clean.
+    scopes = cast("list[dict[str, Any]] | None", trigger.get("scopes"))
+    if scopes and (
+        len(scopes) > 1
+        or scopes[0].get("start_line") is not None
+        or scopes[0].get("path") != trigger["scope_path"]
+    ):
+        payload["scopes"] = [
+            {k: v for k, v in entry.items() if v is not None} for entry in scopes
+        ]
     return yaml.safe_dump(payload, sort_keys=False)
 
 
@@ -164,7 +175,29 @@ def parse(yaml_text: str) -> dict[str, Any]:
     typed.setdefault("schedule_cron", None)
     typed.setdefault("schedule_timezone", None)
     typed.setdefault("schedule_start_at", None)
+    typed["scopes"] = _parse_scopes(typed)
     return typed
+
+
+def _parse_scopes(data: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """Read the ``scopes`` watch list, dropping malformed entries. ``None``
+    when the file predates multi-scope (scope_path alone describes it)."""
+    raw = data.pop("scopes", None)
+    if not isinstance(raw, list):
+        return None
+    out: list[dict[str, Any]] = []
+    for entry in cast(list[Any], raw):
+        if not isinstance(entry, dict):
+            continue
+        e = cast(dict[str, Any], entry)
+        if not isinstance(e.get("path"), str):
+            continue
+        scope: dict[str, Any] = {"path": e["path"]}
+        for key in ("start_line", "end_line"):
+            if isinstance(e.get(key), int):
+                scope[key] = e[key]
+        out.append(scope)
+    return out or None
 
 
 def _parse_actions(data: dict[str, Any]) -> list[dict[str, Any]]:

--- a/backend/tests/_seed.py
+++ b/backend/tests/_seed.py
@@ -64,6 +64,7 @@ def seed_trigger(
     schedule_timezone: str | None = None,
     schedule_start_at: str | None = None,
     schedule_last_fired_at: str | None = None,
+    scopes: list[dict[str, Any]] | None = None,
 ) -> str:
     action_json = {
         "actions": [{"destination_config_id": destination_config_id, "message": message}]
@@ -74,6 +75,7 @@ def seed_trigger(
                 id=tid,
                 owner_user_id=owner_user_id,
                 scope_path=scope_path,
+                scopes_json=scopes,
                 kind=kind,
                 nl_description=nl_description,
                 action_json=action_json,

--- a/backend/tests/test_trigger_multi_scope.py
+++ b/backend/tests/test_trigger_multi_scope.py
@@ -271,3 +271,25 @@ def test_scope_path_rebind_resets_ranged_single_scope(client):
     assert r.json()["scopes"] == [{"path": "b.md", "start_line": None, "end_line": None}]
     assert [t.id for t in find_matching_triggers("b.md")] == [created["id"]]
     assert find_matching_triggers("a.md") == []
+
+
+def test_rebuild_normalizes_slash_whole_wiki(tmp_repo):
+    uid = seed_user(email="u@x.com")
+    created = triggers_repo.create(
+        owner_user_id=uid,
+        scope_path="",
+        nl_description="always",
+        actions=[{"destination_config_id": None, "message": "m"}],
+    )
+    # Hand-edit the YAML to the "/" spelling of the whole wiki.
+    from app.wiki import git as wiki_git
+
+    file_path = created["file_path"]
+    body = wiki_git.read_file(file_path)
+    body = body.replace("scope_path: ''", "scope_path: /")
+    wiki_git.commit_file(file_path, body, message="hand edit", author="t <t@x>")
+    triggers_repo.rebuild_from_filesystem()
+    row = triggers_repo.get(created["id"])
+    assert row is not None
+    assert row["scope_path"] == ""
+    assert [t.id for t in find_matching_triggers("anything/x.md")] == [created["id"]]

--- a/backend/tests/test_trigger_multi_scope.py
+++ b/backend/tests/test_trigger_multi_scope.py
@@ -211,3 +211,44 @@ def test_rebuild_restores_scopes(tmp_db):
         {"path": "a.md", "start_line": 2},
         {"path": "notes"},
     ]
+
+
+def test_update_rejects_empty_scopes(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    created = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "a.md",
+            "scopes": [{"path": "a.md"}, {"path": "notes"}],
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "m"}],
+        },
+    ).json()
+    r = client.put(f"/api/triggers/{created['id']}", json={"scopes": []})
+    assert r.status_code == 400
+    # The old watch list is untouched.
+    row = triggers_repo.get(created["id"])
+    assert row is not None and len(row["scopes"]) == 2
+
+
+def test_rebuild_drops_invalid_scope_lists(tmp_db):
+    uid = seed_user(email="u@x.com")
+    created = triggers_repo.create(
+        owner_user_id=uid,
+        scope_path="a.md",
+        scopes=[{"path": "a.md"}, {"path": "notes"}],
+        nl_description="always",
+        actions=[{"destination_config_id": None, "message": "m"}],
+    )
+    # Hand-corrupt the YAML: a range on a folder entry fails validation.
+    from app.wiki import git as wiki_git
+
+    file_path = created["file_path"]
+    body = wiki_git.read_file(file_path)
+    body = body.replace("- path: notes", "- path: notes\n  start_line: 3")
+    wiki_git.commit_file(file_path, body, message="corrupt", author="t <t@x>")
+    triggers_repo.rebuild_from_filesystem()
+    row = triggers_repo.get(created["id"])
+    assert row is not None
+    assert row["scopes"] == [{"path": "a.md"}]

--- a/backend/tests/test_trigger_multi_scope.py
+++ b/backend/tests/test_trigger_multi_scope.py
@@ -252,3 +252,22 @@ def test_rebuild_drops_invalid_scope_lists(tmp_db):
     row = triggers_repo.get(created["id"])
     assert row is not None
     assert row["scopes"] == [{"path": "a.md"}]
+
+
+def test_scope_path_rebind_resets_ranged_single_scope(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    created = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "a.md",
+            "scopes": [{"path": "a.md", "start_line": 6, "end_line": 9}],
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "m"}],
+        },
+    ).json()
+    r = client.put(f"/api/triggers/{created['id']}", json={"scope_path": "b.md"})
+    assert r.status_code == 200, r.text
+    assert r.json()["scopes"] == [{"path": "b.md", "start_line": None, "end_line": None}]
+    assert [t.id for t in find_matching_triggers("b.md")] == [created["id"]]
+    assert find_matching_triggers("a.md") == []

--- a/backend/tests/test_trigger_multi_scope.py
+++ b/backend/tests/test_trigger_multi_scope.py
@@ -22,7 +22,7 @@ from tests._seed import seed_trigger, seed_user
 
 
 @pytest.fixture
-def client(tmp_db):
+def client(tmp_repo):
     return TestClient(create_app())
 
 
@@ -195,7 +195,7 @@ def test_update_replaces_watch_list(client):
     assert find_matching_triggers("notes/x.md") == []
 
 
-def test_rebuild_restores_scopes(tmp_db):
+def test_rebuild_restores_scopes(tmp_repo):
     uid = seed_user(email="u@x.com")
     created = triggers_repo.create(
         owner_user_id=uid,
@@ -232,7 +232,7 @@ def test_update_rejects_empty_scopes(client):
     assert row is not None and len(row["scopes"]) == 2
 
 
-def test_rebuild_drops_invalid_scope_lists(tmp_db):
+def test_rebuild_drops_invalid_scope_lists(tmp_repo):
     uid = seed_user(email="u@x.com")
     created = triggers_repo.create(
         owner_user_id=uid,

--- a/backend/tests/test_trigger_multi_scope.py
+++ b/backend/tests/test_trigger_multi_scope.py
@@ -1,0 +1,213 @@
+"""Multi-scope watch lists and line-range gating: matching covers every
+entry, the most specific entry's line range governs, YAML round-trips the
+list, and the API validates and mirrors it."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.triggers import repo as triggers_repo
+from app.triggers import storage
+from app.triggers.diff import change_touches_lines
+from app.triggers.engine import (
+    TriggerRecord,
+    TriggerScope,
+    find_matching_triggers,
+    matched_scope,
+)
+
+from tests._auth import login_fastapi
+from tests._seed import seed_trigger, seed_user
+
+
+@pytest.fixture
+def client(tmp_db):
+    return TestClient(create_app())
+
+
+def _record(scopes: list[TriggerScope]) -> TriggerRecord:
+    return TriggerRecord(
+        id="trg_x",
+        owner_user_id="u1",
+        scope_path=scopes[0].path,
+        scopes=scopes,
+        kind="delta",
+        nl_description="always",
+        actions=[],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+
+def test_find_matching_covers_extra_scopes(tmp_db):
+    uid = seed_user(email="u@x.com")
+    seed_trigger(
+        tid="trg_multi",
+        owner_user_id=uid,
+        scope_path="a.md",
+        scopes=[{"path": "a.md"}, {"path": "notes"}],
+    )
+    assert [t.id for t in find_matching_triggers("a.md")] == ["trg_multi"]
+    assert [t.id for t in find_matching_triggers("notes/deep/b.md")] == ["trg_multi"]
+    assert find_matching_triggers("other.md") == []
+
+
+def test_legacy_row_without_scopes_json_still_matches(tmp_db):
+    uid = seed_user(email="u@x.com")
+    seed_trigger(tid="trg_legacy", owner_user_id=uid, scope_path="a.md")
+    assert [t.id for t in find_matching_triggers("a.md")] == ["trg_legacy"]
+
+
+def test_matched_scope_prefers_most_specific():
+    rec = _record(
+        [
+            TriggerScope(path=""),
+            TriggerScope(path="notes"),
+            TriggerScope(path="notes/a.md", start_line=6, end_line=9),
+        ]
+    )
+    match = matched_scope(rec, "notes/a.md")
+    assert match is not None and match.path == "notes/a.md"
+    assert match.start_line == 6
+    folder = matched_scope(rec, "notes/other.md")
+    assert folder is not None and folder.path == "notes"
+
+
+def test_change_touches_lines_gates_correctly():
+    before = "\n".join(f"line {i}" for i in range(1, 11)) + "\n"
+    inside = before.replace("line 7", "line 7 CHANGED")
+    outside = before.replace("line 2", "line 2 CHANGED")
+    assert change_touches_lines(before, inside, 6, 9)
+    assert not change_touches_lines(before, outside, 6, 9)
+    assert not change_touches_lines(before, before, 6, 9)
+    # New file: fires only when the range exists in the body.
+    assert change_touches_lines("", before, 6, 9)
+    assert not change_touches_lines("", "one line\n", 6, 9)
+    # Whole-file deletion always fires.
+    assert change_touches_lines(before, "", 6, 9)
+
+
+def test_yaml_round_trip_preserves_scopes(tmp_db):
+    trigger = {
+        "id": "trg_yaml",
+        "owner_user_id": "u1",
+        "scope_path": "a.md",
+        "scopes": [
+            {"path": "a.md", "start_line": 6, "end_line": 9},
+            {"path": "notes"},
+        ],
+        "kind": "delta",
+        "nl_description": "always",
+        "actions": [{"destination_config_id": None, "message": "m"}],
+        "enabled": True,
+        "created_at": None,
+    }
+    parsed = storage.parse(storage.serialize(trigger))
+    assert parsed["scopes"] == trigger["scopes"]
+
+
+def test_yaml_single_scope_stays_clean(tmp_db):
+    trigger = {
+        "id": "trg_single",
+        "owner_user_id": "u1",
+        "scope_path": "a.md",
+        "scopes": [{"path": "a.md"}],
+        "kind": "delta",
+        "nl_description": "always",
+        "actions": [{"destination_config_id": None, "message": "m"}],
+        "enabled": True,
+        "created_at": None,
+    }
+    text = storage.serialize(trigger)
+    assert "scopes:" not in text
+    assert storage.parse(text)["scopes"] is None
+
+
+def test_api_create_with_scopes_and_view(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    r = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "a.md",
+            "scopes": [
+                {"path": "a.md", "start_line": 6, "end_line": 9},
+                {"path": "notes"},
+            ],
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "m"}],
+        },
+    )
+    assert r.status_code == 201, r.text
+    view = r.json()
+    assert view["scope_path"] == "a.md"
+    assert view["scopes"] == [
+        {"path": "a.md", "start_line": 6, "end_line": 9},
+        {"path": "notes", "start_line": None, "end_line": None},
+    ]
+    # The cache row matches both watched paths.
+    assert [t.id for t in find_matching_triggers("notes/x.md")] == [view["id"]]
+
+
+def test_api_rejects_bad_ranges(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    base = {
+        "scope_path": "a.md",
+        "nl_description": "always",
+        "actions": [{"destination_config_id": None, "message": "m"}],
+    }
+    r = client.post(
+        "/api/triggers",
+        json={**base, "scopes": [{"path": "a.md", "start_line": 9, "end_line": 6}]},
+    )
+    assert r.status_code == 400
+    r = client.post(
+        "/api/triggers",
+        json={**base, "scopes": [{"path": "notes", "start_line": 1, "end_line": 2}]},
+    )
+    assert r.status_code == 400
+
+
+def test_update_replaces_watch_list(client):
+    uid = seed_user(email="u@x.com")
+    login_fastapi(client, uid)
+    created = client.post(
+        "/api/triggers",
+        json={
+            "scope_path": "a.md",
+            "scopes": [{"path": "a.md"}, {"path": "notes"}],
+            "nl_description": "always",
+            "actions": [{"destination_config_id": None, "message": "m"}],
+        },
+    ).json()
+    r = client.put(
+        f"/api/triggers/{created['id']}",
+        json={"scopes": [{"path": "a.md", "start_line": 1, "end_line": 3}]},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["scopes"] == [
+        {"path": "a.md", "start_line": 1, "end_line": 3}
+    ]
+    assert find_matching_triggers("notes/x.md") == []
+
+
+def test_rebuild_restores_scopes(tmp_db):
+    uid = seed_user(email="u@x.com")
+    created = triggers_repo.create(
+        owner_user_id=uid,
+        scope_path="a.md",
+        scopes=[{"path": "a.md", "start_line": 2}, {"path": "notes"}],
+        nl_description="always",
+        actions=[{"destination_config_id": None, "message": "m"}],
+    )
+    triggers_repo.rebuild_from_filesystem()
+    row = triggers_repo.get(created["id"])
+    assert row is not None
+    assert row["scopes"] == [
+        {"path": "a.md", "start_line": 2},
+        {"path": "notes"},
+    ]

--- a/frontend/src/components/inputs/InputChipField.tsx
+++ b/frontend/src/components/inputs/InputChipField.tsx
@@ -26,6 +26,9 @@ export interface InputChipFieldProps {
   disabled?: boolean;
   icon?: IconFunctionComponent;
   className?: string;
+  /** Put the text input on its own full-width line below the chips instead
+   * of inline, so a long placeholder is never clipped in the leftover gap. */
+  inputBelow?: boolean;
   onFocus?: () => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 }
@@ -45,6 +48,7 @@ export default function InputChipField({
   disabled = false,
   icon: Icon,
   className,
+  inputBelow = false,
   onFocus,
   onKeyDown,
 }: InputChipFieldProps) {
@@ -90,7 +94,10 @@ export default function InputChipField({
       <input
         ref={inputRef}
         type="text"
-        className="opal-input-field min-w-[80px] flex-1"
+        className={cn(
+          "opal-input-field",
+          inputBelow ? "basis-full" : "min-w-[80px] flex-1",
+        )}
         disabled={disabled}
         value={value}
         onChange={(e) => onChange(e.target.value)}

--- a/frontend/src/components/triggers/TriggerCard.tsx
+++ b/frontend/src/components/triggers/TriggerCard.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { Button, Switch, Text } from "@onyx-ai/opal/components";
+import { Button, Switch, Tag, Text } from "@onyx-ai/opal/components";
 import { markdown } from "@onyx-ai/opal/utils";
 import {
   SvgChevronDown,
@@ -87,6 +87,16 @@ export function TriggerCard({
       <div className="flex w-full items-center p-[2px]">
         <div className="flex min-w-0 flex-1 items-center gap-1 p-[2px]">
           <ScopeChip scope={t.scope_path} />
+          {(t.scopes?.length ?? 0) > 1 && (
+            <span
+              title={t.scopes
+                .slice(1)
+                .map((sc) => sc.path || "Whole wiki")
+                .join(", ")}
+            >
+              <Tag title={`+${t.scopes.length - 1}`} />
+            </span>
+          )}
           <span className="flex size-4 items-center justify-center p-[2px]">
             <SvgWorkflow className="size-3 text-(--text-03)" />
           </span>

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -807,6 +807,7 @@ function WatchScopePicker({
       <Popover.Anchor asChild>
         <div ref={anchorRef} className="w-full">
           <InputChipField
+            inputBelow
             chips={scopes.map((scope, i) => ({
               id: `${scope.path}#${scope.start_line ?? ""}#${i}`,
               label: scopeLabel(scope),

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -54,6 +54,7 @@ import InputTextArea from "@/components/inputs/InputTextArea";
 import { useSlackConnectStatus } from "@/lib/slackConnect";
 import {
   createTrigger,
+  type TriggerScope,
   updateTrigger,
   useDestinationConfigs,
   type Trigger,
@@ -164,7 +165,7 @@ export function TriggerPanel({
   docked,
 }: Props) {
   const isEdit = Boolean(initial?.id);
-  const [scopePath, setScopePath] = useState("");
+  const [scopes, setScopes] = useState<TriggerScope[]>([]);
   const [ifText, setIfText] = useState("");
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
   const { status: slackStatus } = useSlackConnectStatus();
@@ -187,7 +188,13 @@ export function TriggerPanel({
 
   useEffect(() => {
     if (!open) return;
-    setScopePath(initial?.scope_path ?? "");
+    setScopes(
+      initial?.scopes?.length
+        ? initial.scopes
+        : initial?.scope_path
+          ? [{ path: initial.scope_path }]
+          : [],
+    );
     setIfText(initial?.nl_description ?? "");
     setGroups(groupsFromActions(initial?.actions, configsRef.current));
     setKind((initial?.kind as TriggerKind) ?? "delta");
@@ -232,7 +239,8 @@ export function TriggerPanel({
               })),
       );
       const baseInput: TriggerCreateInput = {
-        scope_path: scopePath.trim(),
+        scope_path: scopes[0]?.path ?? "",
+        scopes,
         nl_description: nl,
         actions,
         kind,
@@ -252,7 +260,7 @@ export function TriggerPanel({
         // delta we explicitly null them so a kind-flip in the DB stays
         // consistent (the API already enforces the invariant).
         saved = await updateTrigger(initial.id, {
-          scope_path: scopePath.trim(),
+          scopes,
           nl_description: nl,
           actions,
           schedule_cron: kind === "schedule" ? computedCron : null,
@@ -277,7 +285,7 @@ export function TriggerPanel({
       g.message.trim() && (g.type === "event_log" || g.configIds.length > 0),
   );
   const canSave =
-    scopePath.trim() &&
+    scopes.length > 0 &&
     ifText.trim() &&
     groupsValid &&
     (kind === "delta" || (computedCron && tz));
@@ -377,10 +385,8 @@ export function TriggerPanel({
             helper="Add specific sections or entire pages to watch."
           >
             <WatchScopePicker
-              scopePath={scopePath}
-              onScopePath={(p) => {
-                setScopePath(p);
-              }}
+              scopes={scopes}
+              onScopes={setScopes}
               disabled={busy || Boolean(lockScope)}
               locked={Boolean(lockScope)}
             />
@@ -727,14 +733,25 @@ function pad(n: number): string {
 /** Search-and-pick for the trigger's watched scope: a dropdown over the
  * ACL-filtered wiki path list (files and their folders), selection only —
  * free-typed paths can't be committed, so a scope always exists. */
+function scopeLabel(scope: TriggerScope): string {
+  const base =
+    scope.path === "" || scope.path === "/" ? "Whole wiki" : scope.path;
+  if (scope.start_line == null) return base;
+  const range =
+    scope.end_line != null && scope.end_line !== scope.start_line
+      ? `line ${scope.start_line}\u2013${scope.end_line}`
+      : `line ${scope.start_line}`;
+  return `${base} \u00b7 ${range}`;
+}
+
 function WatchScopePicker({
-  scopePath,
-  onScopePath,
+  scopes,
+  onScopes,
   disabled,
   locked,
 }: {
-  scopePath: string;
-  onScopePath: (path: string) => void;
+  scopes: TriggerScope[];
+  onScopes: (scopes: TriggerScope[]) => void;
   disabled?: boolean;
   locked?: boolean;
 }) {
@@ -771,30 +788,36 @@ function WatchScopePicker({
     .slice(0, 20);
 
   function pick(path: string) {
-    onScopePath(path);
+    // Whole wiki subsumes everything; otherwise append if not already watched.
+    if (path === "/" || path === "") {
+      onScopes([{ path: "/" }]);
+    } else if (!scopes.some((s) => s.path === path)) {
+      onScopes([...scopes.filter((s) => s.path !== "/"), { path }]);
+    }
     setQuery("");
     setOpen(false);
   }
 
-  const committed = scopePath.trim();
+  function remove(index: number) {
+    onScopes(scopes.filter((_, i) => i !== index));
+  }
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <Popover.Anchor asChild>
         <div ref={anchorRef} className="w-full">
           <InputChipField
-            chips={
-              committed
-                ? [
-                    {
-                      id: committed,
-                      label: committed === "/" ? "Whole wiki" : committed,
-                    },
-                  ]
-                : []
-            }
-            onRemoveChip={() => {
-              if (!locked) onScopePath("");
+            chips={scopes.map((scope, i) => ({
+              id: `${scope.path}#${scope.start_line ?? ""}#${i}`,
+              label: scopeLabel(scope),
+            }))}
+            onRemoveChip={(id) => {
+              if (disabled || locked) return;
+              const i = scopes.findIndex(
+                (scope, idx) =>
+                  `${scope.path}#${scope.start_line ?? ""}#${idx}` === id,
+              );
+              if (i >= 0) remove(i);
             }}
             onAdd={() => {
               // Enter commits the visually top row: Whole wiki leads an
@@ -811,8 +834,14 @@ function WatchScopePicker({
             onKeyDown={(e) => {
               if (e.key === "Escape") setOpen(false);
             }}
-            disabled={disabled || (Boolean(committed) && Boolean(locked))}
-            placeholder={committed ? "" : "Search pages and folders to watch"}
+            disabled={disabled || Boolean(locked)}
+            placeholder={
+              scopes.length
+                ? locked
+                  ? ""
+                  : "Add another page or folder"
+                : "Search pages and folders to watch"
+            }
           />
         </div>
       </Popover.Anchor>

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -14,10 +14,17 @@ export interface TriggerActionInput {
   message: string;
 }
 
+export interface TriggerScope {
+  path: string;
+  start_line?: number | null;
+  end_line?: number | null;
+}
+
 export interface Trigger {
   id: string;
   owner_user_id: string;
   scope_path: string;
+  scopes: TriggerScope[];
   kind: TriggerKind;
   nl_description: string;
   actions: TriggerAction[];
@@ -41,6 +48,7 @@ export interface TriggerCommit {
 
 export interface TriggerCreateInput {
   scope_path: string;
+  scopes?: TriggerScope[];
   nl_description: string;
   actions: TriggerActionInput[];
   enabled?: boolean;
@@ -52,6 +60,7 @@ export interface TriggerCreateInput {
 
 export interface TriggerUpdateInput {
   scope_path?: string;
+  scopes?: TriggerScope[];
   nl_description?: string;
   actions?: TriggerActionInput[];
   enabled?: boolean;


### PR DESCRIPTION
## Description

A trigger watches a list of scopes instead of one path: pages, folders, or whole-wiki, each page entry optionally narrowed to a 1-based inclusive line range. The list lives in the trigger YAML and a `scopes_json` cache column; `scope_path` still mirrors the first entry, so file placement, older clients, and existing rows keep working.

- Matching covers every entry, most-specific wins (a line range beats a folder entry).
- The range gates the fire before any LLM eval (SequenceMatcher intersection; new files and whole-file deletions always count).
- Create/update require read access on every watched path.
- Panel Watch bar takes multiple chips (whole-wiki subsumes the rest) via the shared `InputChipField`; chips show line-range labels; cards show a `+N` badge for extra scopes.

## How Has This Been Tested?

14 backend tests (multi-scope + legacy matching, most-specific-wins, the line gate's edge cases, YAML round-trip, API create/reject/replace, filesystem rebuild); full trigger suite green. Frontend not yet re-verified live after the rebase onto `InputChipField`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check