### PR TITLE
feat(auth): AI system user — seeded identity principal

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -121,6 +121,9 @@ def update_user(
     if req.is_active is False and user_id == actor.id:
         raise HTTPException(status_code=400, detail="cannot deactivate yourself")
 
+    if target["kind"] != "human":
+        raise HTTPException(status_code=400, detail="cannot modify a system user")
+
     # An active admin being demoted and/or deactivated must not be the last one.
     if (was_admin and was_active) and not (final_admin and final_active):
         if users_repo.admin_count() <= 1:
@@ -197,6 +200,8 @@ def delete_user(user_id: str, actor: User = Depends(require_admin)) -> OkRespons
     target = users_repo.get_by_id(user_id)
     if target is None:
         raise HTTPException(status_code=404, detail="not found")
+    if target["kind"] != "human":
+        raise HTTPException(status_code=400, detail="cannot delete a system user")
     if bool(target["is_admin"]) and users_repo.admin_count() <= 1:
         raise HTTPException(status_code=400, detail="cannot delete the last admin")
     users_repo.delete(user_id)

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -121,7 +121,7 @@ def update_user(
     if req.is_active is False and user_id == actor.id:
         raise HTTPException(status_code=400, detail="cannot deactivate yourself")
 
-    if target["kind"] != "human":
+    if target["kind"] != users_repo.UserKind.HUMAN.value:
         raise HTTPException(status_code=400, detail="cannot modify a system user")
 
     # An active admin being demoted and/or deactivated must not be the last one.
@@ -200,7 +200,7 @@ def delete_user(user_id: str, actor: User = Depends(require_admin)) -> OkRespons
     target = users_repo.get_by_id(user_id)
     if target is None:
         raise HTTPException(status_code=404, detail="not found")
-    if target["kind"] != "human":
+    if target["kind"] != users_repo.UserKind.HUMAN.value:
         raise HTTPException(status_code=400, detail="cannot delete a system user")
     if bool(target["is_admin"]) and users_repo.admin_count() <= 1:
         raise HTTPException(status_code=400, detail="cannot delete the last admin")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from app.auth import User, users as users_repo
 from app.auth.basic import authenticate
 from app.auth.deps import require_user, user_epoch
-from app.auth.oidc import client as oidc_client, upsert_oidc_user
+from app.auth.oidc import client as oidc_client, upsert_oidc_user, SystemUserSignInError
 from app.auth import invites
 from app.auth.whitelist import is_allowed, is_open
 from app.config import CONFIG
@@ -162,7 +162,11 @@ async def oidc_callback(request: Request) -> Response:
 
     name_raw = userinfo.get("name")
     name = name_raw if isinstance(name_raw, str) else None
-    user_id = upsert_oidc_user(email=email, name=name)
+    try:
+        user_id = upsert_oidc_user(email=email, name=name)
+    except SystemUserSignInError:
+        log.warning("oidc: refused sign-in as system user %s", email)
+        return RedirectResponse(url="/login?error=oidc_email_not_allowed")
     invites.remove(email)
     row = users_repo.get_by_id(user_id)
     assert row is not None

--- a/backend/app/auth/basic.py
+++ b/backend/app/auth/basic.py
@@ -9,6 +9,10 @@ def authenticate(email: str, password: str) -> User | None:
     row = users_repo.get_by_email(email)
     if row is None or not row["password_hash"]:
         return None
+    if row["kind"] != "human":
+        # System principals (the AI user) can never authenticate, even if a
+        # password hash were ever set on the row.
+        return None
     if not verify_password(password, row["password_hash"]):
         return None
     if not row["is_active"]:

--- a/backend/app/auth/basic.py
+++ b/backend/app/auth/basic.py
@@ -9,7 +9,7 @@ def authenticate(email: str, password: str) -> User | None:
     row = users_repo.get_by_email(email)
     if row is None or not row["password_hash"]:
         return None
-    if row["kind"] != "human":
+    if row["kind"] != users_repo.UserKind.HUMAN.value:
         # System principals (the AI user) can never authenticate, even if a
         # password hash were ever set on the row.
         return None

--- a/backend/app/auth/oidc.py
+++ b/backend/app/auth/oidc.py
@@ -73,6 +73,14 @@ def client() -> StarletteOAuth2App | None:
     )
 
 
+class SystemUserSignInError(Exception):
+    """An OIDC sign-in resolved to a system principal — always refused."""
+
+    def __init__(self, email: str) -> None:
+        self.email = email
+        super().__init__(f"refusing OIDC sign-in as system user {email!r}")
+
+
 def upsert_oidc_user(email: str, name: str | None) -> str:
     """Find or create a user by email for an OIDC sign-in.
 
@@ -83,6 +91,10 @@ def upsert_oidc_user(email: str, name: str | None) -> str:
     """
     existing = users_repo.get_by_email(email)
     if existing is not None:
+        if existing["kind"] != users_repo.UserKind.HUMAN.value:
+            # A system principal (the AI user) can never be signed into, even
+            # if an IdP asserts its (placeholder, non-routable) email.
+            raise SystemUserSignInError(email)
         return existing["id"]
     # Random password the user can never use; OIDC sign-in bypasses
     # ``authenticate``. Schema requires password_hash; storing a hash

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import uuid
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Any, Iterable
 
 from sqlalchemy import func, or_, select, update
@@ -16,6 +17,17 @@ from app.db.session import session
 from app.models.user_settings import UserSettings
 
 log = logging.getLogger(__name__)
+
+
+class UserKind(str, Enum):
+    """Single source of truth for the valid ``users.kind`` values; the DB
+    CHECK constraint in ``app/db/models.py`` mirrors these (`str, Enum` so
+    members serialize as their string value, matching ``SessionStatus`` in
+    ``app/wiki/coedit.py``)."""
+
+    HUMAN = "human"  # every signup
+    SYSTEM = "system"  # seeded non-person principals (the AI user)
+
 
 # The seeded AI system user (see migration b5e2d19c7a44). A real, grantable,
 # attributable principal for autonomous wiki work — but kind="system": it can
@@ -72,7 +84,7 @@ def list_all(include_system: bool = False) -> list[dict[str, Any]]:
     with session() as s:
         stmt = select(User).order_by(User.created_at.asc())
         if not include_system:
-            stmt = stmt.where(User.kind == "human")
+            stmt = stmt.where(User.kind == UserKind.HUMAN.value)
         return [_to_dict(u) for u in s.scalars(stmt).all()]
 
 
@@ -100,7 +112,7 @@ def search(query: str, limit: int = 20) -> list[dict[str, Any]]:
         # System principals (the AI user) don't belong in people typeaheads;
         # surfaces that want them (e.g. the share picker, later) opt in
         # explicitly rather than every picker filtering them out.
-        stmt = select(User).where(User.kind == "human")
+        stmt = select(User).where(User.kind == UserKind.HUMAN.value)
         if q:
             like = "%" + q + "%"
             stmt = stmt.where(
@@ -124,7 +136,7 @@ def create(email: str, password: str, name: str | None = None) -> str:
         # first-signup auto-admin promotion.
         existing_count = (
             s.scalar(
-                select(func.count()).select_from(User).where(User.kind == "human")
+                select(func.count()).select_from(User).where(User.kind == UserKind.HUMAN.value)
             )
             or 0
         )
@@ -177,13 +189,13 @@ def status_counts() -> dict[str, int]:
             s.scalar(
                 select(func.count())
                 .select_from(User)
-                .where(User.is_active.is_(True), User.kind == "human")
+                .where(User.is_active.is_(True), User.kind == UserKind.HUMAN.value)
             )
             or 0
         )
         total = (
             s.scalar(
-                select(func.count()).select_from(User).where(User.kind == "human")
+                select(func.count()).select_from(User).where(User.kind == UserKind.HUMAN.value)
             )
             or 0
         )

--- a/backend/app/auth/users.py
+++ b/backend/app/auth/users.py
@@ -17,6 +17,12 @@ from app.models.user_settings import UserSettings
 
 log = logging.getLogger(__name__)
 
+# The seeded AI system user (see migration b5e2d19c7a44). A real, grantable,
+# attributable principal for autonomous wiki work — but kind="system": it can
+# never log in, never counts toward first-user-auto-admin or last-admin
+# guards, and is excluded from listings/search by default.
+AI_USER_ID = "system-wiki-ai"
+
 
 def _now() -> str:
     """UTC timestamp matching the ``YYYY-MM-DD HH:MM:SS`` column format."""
@@ -32,6 +38,7 @@ def _to_dict(u: User) -> dict[str, Any]:
         "session_epoch": u.session_epoch,
         "is_admin": u.is_admin,
         "is_active": u.is_active,
+        "kind": u.kind,
         "created_at": u.created_at,
         "updated_at": u.updated_at,
         "settings": _settings_with_defaults(u.settings),
@@ -61,10 +68,12 @@ def count() -> int:
         return s.scalar(select(func.count()).select_from(User)) or 0
 
 
-def list_all() -> list[dict[str, Any]]:
+def list_all(include_system: bool = False) -> list[dict[str, Any]]:
     with session() as s:
-        users = s.scalars(select(User).order_by(User.created_at.asc())).all()
-        return [_to_dict(u) for u in users]
+        stmt = select(User).order_by(User.created_at.asc())
+        if not include_system:
+            stmt = stmt.where(User.kind == "human")
+        return [_to_dict(u) for u in s.scalars(stmt).all()]
 
 
 def get_many(user_ids: Iterable[str]) -> dict[str, dict[str, Any]]:
@@ -88,7 +97,10 @@ def search(query: str, limit: int = 20) -> list[dict[str, Any]]:
     """
     q = (query or "").strip().lower()
     with session() as s:
-        stmt = select(User)
+        # System principals (the AI user) don't belong in people typeaheads;
+        # surfaces that want them (e.g. the share picker, later) opt in
+        # explicitly rather than every picker filtering them out.
+        stmt = select(User).where(User.kind == "human")
         if q:
             like = "%" + q + "%"
             stmt = stmt.where(
@@ -108,7 +120,14 @@ def create(email: str, password: str, name: str | None = None) -> str:
     """Create a user. The very first user is auto-promoted to admin."""
     user_id = str(uuid.uuid4())
     with session() as s:
-        existing_count = s.scalar(select(func.count()).select_from(User)) or 0
+        # Count humans only: the seeded AI system user must not steal the
+        # first-signup auto-admin promotion.
+        existing_count = (
+            s.scalar(
+                select(func.count()).select_from(User).where(User.kind == "human")
+            )
+            or 0
+        )
         is_admin = existing_count == 0
         s.add(
             User(
@@ -123,6 +142,14 @@ def create(email: str, password: str, name: str | None = None) -> str:
         "user created id=%s email=%s is_admin=%s", user_id, email.lower(), is_admin
     )
     return user_id
+
+
+def get_ai_user() -> dict[str, Any]:
+    """The seeded AI system user. Raises if the seed migration hasn't run."""
+    row = get_by_id(AI_USER_ID)
+    if row is None:
+        raise RuntimeError("AI system user missing — did migrations run?")
+    return row
 
 
 def set_admin(user_id: str, is_admin: bool) -> None:
@@ -142,16 +169,24 @@ def set_active(user_id: str, is_active: bool) -> None:
 
 
 def status_counts() -> dict[str, int]:
-    """``{active, inactive}`` counts over real accounts (invited emails are
-    counted separately, in ``app.auth.invites``)."""
+    """``{active, inactive}`` counts over real human accounts (invited emails
+    are counted separately, in ``app.auth.invites``; system principals like
+    the AI user are not people and are excluded)."""
     with session() as s:
         active = (
             s.scalar(
-                select(func.count()).select_from(User).where(User.is_active.is_(True))
+                select(func.count())
+                .select_from(User)
+                .where(User.is_active.is_(True), User.kind == "human")
             )
             or 0
         )
-        total = s.scalar(select(func.count()).select_from(User)) or 0
+        total = (
+            s.scalar(
+                select(func.count()).select_from(User).where(User.kind == "human")
+            )
+            or 0
+        )
     return {"active": active, "inactive": total - active}
 
 

--- a/backend/app/db/migrations/versions/b5e2d19c7a44_ai_system_user.py
+++ b/backend/app/db/migrations/versions/b5e2d19c7a44_ai_system_user.py
@@ -37,6 +37,11 @@ def upgrade() -> None:
                 "kind", sa.Text(), nullable=False, server_default=sa.text("'human'")
             ),
         )
+    constraints = {c["name"] for c in inspector.get_check_constraints("users")}
+    if "users_kind_check" not in constraints:
+        op.create_check_constraint(
+            "users_kind_check", "users", "kind IN ('human', 'system')"
+        )
     # Seed the AI user. No password hash (can never log in), not admin, active.
     bind.execute(
         sa.text(

--- a/backend/app/db/migrations/versions/b5e2d19c7a44_ai_system_user.py
+++ b/backend/app/db/migrations/versions/b5e2d19c7a44_ai_system_user.py
@@ -1,0 +1,63 @@
+"""ai system user
+
+Adds ``users.kind`` (``human`` | ``system``) and seeds the AI system user —
+the principal that attributes autonomous wiki work (commit authorship, ACL
+grants, page ownership) for Wiki Auto Management. Guarded with the inspector
+because ``0001_initial`` builds fresh databases from the current models.
+
+Revision ID: b5e2d19c7a44
+Revises: a1b7c93e4f20
+Create Date: 2026-07-09 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b5e2d19c7a44"
+down_revision: str | None = "a1b7c93e4f20"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Fixed, well-known id — code references the AI user by this constant
+# (app/auth/users.py:AI_USER_ID), never by email lookup.
+AI_USER_ID = "system-wiki-ai"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("users")}
+    if "kind" not in cols:
+        op.add_column(
+            "users",
+            sa.Column(
+                "kind", sa.Text(), nullable=False, server_default=sa.text("'human'")
+            ),
+        )
+    # Seed the AI user. No password hash (can never log in), not admin, active.
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO users (id, email, name, password_hash, is_admin, is_active, kind)
+            VALUES (:id, :email, :name, NULL, FALSE, TRUE, 'system')
+            ON CONFLICT (id) DO NOTHING
+            """
+        ),
+        {
+            "id": AI_USER_ID,
+            "email": "wiki-ai@system.local",
+            "name": "Agent Wiki AI",
+        },
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(sa.text("DELETE FROM users WHERE id = :id"), {"id": AI_USER_ID})
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("users")}
+    if "kind" in cols:
+        op.drop_column("users", "kind")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -61,6 +61,14 @@ class User(Base):
     name: Mapped[str | None] = mapped_column(Text)
     # Null when AUTH_MODE=oidc.
     password_hash: Mapped[str | None] = mapped_column(Text)
+    # "human" for every signup; "system" for seeded non-person principals (the
+    # AI user). System users can never log in, never count toward the
+    # first-user-auto-admin or last-admin guards, and are excluded from user
+    # listings/search by default — but they are real, grantable, attributable
+    # principals everywhere else (ACL grants, page ownership, commit authorship).
+    kind: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'human'")
+    )
     is_admin: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("FALSE")
     )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -66,6 +66,7 @@ class User(Base):
     # first-user-auto-admin or last-admin guards, and are excluded from user
     # listings/search by default — but they are real, grantable, attributable
     # principals everywhere else (ACL grants, page ownership, commit authorship).
+    # Valid values mirror ``app.auth.users.UserKind``.
     kind: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=text("'human'")
     )
@@ -93,6 +94,13 @@ class User(Base):
     # field defaults from the pydantic model on read.
     settings: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('human', 'system')",
+            name="users_kind_check",
+        ),
     )
 
 

--- a/backend/tests/test_system_user.py
+++ b/backend/tests/test_system_user.py
@@ -103,3 +103,12 @@ def test_kind_check_constraint_rejects_unknown_values(tmp_db):
                     kind="robot",
                 )
             )
+
+
+def test_oidc_upsert_refuses_system_user_email(tmp_db):
+    import pytest
+
+    from app.auth.oidc import SystemUserSignInError, upsert_oidc_user
+
+    with pytest.raises(SystemUserSignInError):
+        upsert_oidc_user(email="wiki-ai@system.local", name="Impostor")

--- a/backend/tests/test_system_user.py
+++ b/backend/tests/test_system_user.py
@@ -1,0 +1,86 @@
+"""The seeded AI system user (users.kind='system') and its guards.
+
+Real DB per test; the seed migration runs via init_db's `alembic upgrade head`,
+so the AI user row exists in every schema without test-side seeding.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.auth.basic import authenticate
+from app.main import create_app
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def test_ai_user_is_seeded_by_migrations(tmp_db):
+    row = users_repo.get_ai_user()
+    assert row["id"] == users_repo.AI_USER_ID
+    assert row["kind"] == "system"
+    assert row["is_admin"] is False
+    assert row["is_active"] is True
+    assert row["password_hash"] is None
+
+
+def test_first_human_signup_still_auto_admin(tmp_db):
+    # The seeded AI user must not steal the first-signup promotion.
+    uid = users_repo.create(email="first@x.com", password="hunter2-x")
+    row = users_repo.get_by_id(uid)
+    assert row is not None and row["is_admin"] is True
+    # And only the first human — the second signup stays basic.
+    uid2 = users_repo.create(email="second@x.com", password="hunter2-x")
+    row2 = users_repo.get_by_id(uid2)
+    assert row2 is not None and row2["is_admin"] is False
+
+
+def test_system_user_cannot_authenticate(tmp_db):
+    # No password hash: authenticate fails on the hash check.
+    assert authenticate("wiki-ai@system.local", "anything") is None
+    # Even with a hash forced onto the row, the kind guard refuses.
+    from app.auth.passwords import hash_password
+    from app.db.models import User
+    from app.db.session import session
+
+    with session() as s:
+        u = s.get(User, users_repo.AI_USER_ID)
+        assert u is not None
+        u.password_hash = hash_password("anything")
+    assert authenticate("wiki-ai@system.local", "anything") is None
+
+
+def test_listings_exclude_system_by_default(tmp_db):
+    seed_user(uid="u_h", email="human@x.com")
+    all_default = users_repo.list_all()
+    assert all(r["kind"] == "human" for r in all_default)
+    all_with_system = users_repo.list_all(include_system=True)
+    assert any(r["id"] == users_repo.AI_USER_ID for r in all_with_system)
+    # Typeahead search never returns the AI user.
+    assert all(r["id"] != users_repo.AI_USER_ID for r in users_repo.search("agent"))
+    assert all(r["id"] != users_repo.AI_USER_ID for r in users_repo.search(""))
+
+
+def test_get_many_includes_system_for_attribution(tmp_db):
+    got = users_repo.get_many([users_repo.AI_USER_ID])
+    assert users_repo.AI_USER_ID in got
+    assert got[users_repo.AI_USER_ID]["name"] == "Agent Wiki AI"
+
+
+def test_admin_cannot_modify_or_delete_system_user(tmp_db, tmp_repo):
+    seed_user(uid="u_admin", email="admin@x.com", is_admin=True)
+    client = TestClient(create_app())
+    login_fastapi(client, "u_admin")
+
+    r = client.patch(
+        f"/api/admin/users/{users_repo.AI_USER_ID}", json={"is_admin": True}
+    )
+    assert r.status_code == 400
+    assert "system user" in r.json()["error"]
+
+    r = client.delete(f"/api/admin/users/{users_repo.AI_USER_ID}")
+    assert r.status_code == 400
+    assert "system user" in r.json()["error"]
+
+    # Untouched.
+    row = users_repo.get_ai_user()
+    assert row["is_admin"] is False and row["is_active"] is True

--- a/backend/tests/test_system_user.py
+++ b/backend/tests/test_system_user.py
@@ -84,3 +84,22 @@ def test_admin_cannot_modify_or_delete_system_user(tmp_db, tmp_repo):
     # Untouched.
     row = users_repo.get_ai_user()
     assert row["is_admin"] is False and row["is_active"] is True
+
+
+def test_kind_check_constraint_rejects_unknown_values(tmp_db):
+    import pytest
+    from sqlalchemy.exc import IntegrityError
+
+    from app.db.models import User
+    from app.db.session import session
+
+    with pytest.raises(IntegrityError):
+        with session() as s:
+            s.add(
+                User(
+                    id="u_bad_kind",
+                    email="bad@x.com",
+                    password_hash="x",
+                    kind="robot",
+                )
+            )


### PR DESCRIPTION
## What

The identity half of Wiki Auto Management's concept stack ([PRD — Identity and authorization](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/PRD:%20Wiki%20Auto%20Management.md)): a seeded, first-class **AI system user** the engine will attribute commits to, receive ACL grants as, and own pages as. Identity only — nothing acts as this user yet.

- `users.kind` — `'human'` (default, all signups) | `'system'`
- Seed migration: fixed id `system-wiki-ai`, name "Agent Wiki AI", no password hash, not admin, active (`ON CONFLICT DO NOTHING`)
- Code references it via `users_repo.AI_USER_ID` / `get_ai_user()`, never email lookup

## Guards

- **Login**: cannot authenticate — no hash, plus an explicit `kind` guard in `authenticate` so even a force-set hash wouldn't help
- **First-signup auto-admin**: counts humans only, so the seeded row can't steal the promotion on a fresh install
- **Listings**: excluded from `list_all` / `search` (typeaheads) / `status_counts` (admin dashboard) by default; `list_all(include_system=True)` opts in; `get_many` still resolves it so attribution surfaces (comments, history) render the name
- **Admin API**: `PATCH`/`DELETE /admin/users/{id}` refuse system users (400), so it can't be promoted, deactivated, or deleted

## Testing

New `tests/test_system_user.py` (6 tests): seed exists post-migrations, first human still auto-admin, authenticate refused even with a forced hash, listings exclude / `include_system` opts in / `get_many` resolves, admin modify+delete refused. Full backend suite: 1436 passed (one existing test caught `status_counts` counting the AI user — fixed to count humans). ruff + basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)