### PR TITLE
feat(triggers): webhook destination UI (connectors card, manage modal, trigger picker)

### DIFF
--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -15,6 +15,7 @@ secret is never written to the wiki git repo. Repos return dicts, not ORM rows.
 from __future__ import annotations
 
 import logging
+import secrets
 import uuid
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -114,6 +115,10 @@ def create(
         routing_tag = cfg.get("routing_tag")
         if routing_tag is not None and not isinstance(routing_tag, str):
             raise ValueError("webhook routing_tag must be a string")
+        if secret is None:
+            # Sign every webhook. Mint a secret server-side when the caller
+            # did not supply one. Stored encrypted, never returned.
+            secret = secrets.token_hex(32)
 
     if type == destinations.EMAIL_ID:
         address = ((config or {}).get("address") or "")

--- a/backend/app/webhooks/client.py
+++ b/backend/app/webhooks/client.py
@@ -53,4 +53,8 @@ def deliver(
         # type only and drop the cause chain so responses and logs stay clean.
         raise WebhookError(f"webhook POST failed: {type(e).__name__}") from None
     if response.status_code >= 400:
-        raise WebhookError(f"webhook returned {response.status_code}")
+        # The body is how a 4xx says why (e.g. n8n: "workflow must be
+        # active"). Truncated, and never our secret.
+        raise WebhookError(
+            f"webhook returned {response.status_code}: {response.text[:500]}"
+        )

--- a/backend/tests/test_webhook_destination.py
+++ b/backend/tests/test_webhook_destination.py
@@ -92,11 +92,14 @@ def test_deliver_raises_on_non_2xx(monkeypatch: pytest.MonkeyPatch) -> None:
 
     class _Resp:
         status_code = 500
+        text = "workflow must be active"
 
     monkeypatch.setattr(
         "app.webhooks.client.requests.post", lambda *a, **k: _Resp()
     )
-    with pytest.raises(webhook_client.WebhookError):
+    with pytest.raises(
+        webhook_client.WebhookError, match="500.*workflow must be active"
+    ):
         webhook_client.deliver(url="https://example.com/hook", body=b"{}")
 
 

--- a/frontend/src/components/inputs/Chip.tsx
+++ b/frontend/src/components/inputs/Chip.tsx
@@ -12,6 +12,8 @@ export interface ChipProps {
   error?: boolean;
   /** Cap the label at 120px with an ellipsis (the mock's mini-tag form). */
   truncateLabel?: boolean;
+  /** Hover tooltip content. Defaults to the label. */
+  tooltip?: string;
 }
 
 /** Port of Onyx's refresh-components Chip (chip/tag with optional remove),
@@ -25,12 +27,14 @@ export default function Chip({
   smallLabel = false,
   error = false,
   truncateLabel = false,
+  tooltip,
 }: ChipProps) {
+  const tooltipText = tooltip ?? children;
   return (
     <Tooltip
       tooltip={
-        children ? (
-          <span className="font-secondary-body break-all">{children}</span>
+        tooltipText ? (
+          <span className="font-secondary-body break-all">{tooltipText}</span>
         ) : undefined
       }
       side="top"
@@ -45,12 +49,13 @@ export default function Chip({
       >
         {Icon && <Icon className="size-3 shrink-0 text-(--text-03)" />}
         {children && (
+          // leading-[0]: kill the wrapper's line-box strut so the inner Text's
+          // line-height sizes it and flex centers glyphs with the remove button.
           <span
-            className={
-              truncateLabel
-                ? "block max-w-[120px] min-w-0 truncate"
-                : "block min-w-0 truncate"
-            }
+            className={cn(
+              "block min-w-0 truncate leading-[0]",
+              truncateLabel && "max-w-[120px]",
+            )}
           >
             <Text
               font={smallLabel ? "figure-small-value" : "main-ui-body"}

--- a/frontend/src/components/inputs/ChipList.tsx
+++ b/frontend/src/components/inputs/ChipList.tsx
@@ -1,0 +1,51 @@
+import Chip from "@/components/inputs/Chip";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+
+export interface ChipListItem {
+  /** Stable React key and the value handed back to `onRemove`. */
+  id: string;
+  /** Text shown inside the chip. */
+  label: string;
+}
+
+/** A wrap-flowing row of removable {@link Chip}s (small, 120px truncation)
+ * for any labelled list. All items show by default. `maxVisible` collapses
+ * the rest into a "+N" chip (with `overflowIcon`) whose tooltip names the
+ * hidden entries. */
+export default function ChipList({
+  items,
+  onRemove,
+  maxVisible,
+  overflowIcon,
+}: {
+  items: ChipListItem[];
+  onRemove?: (id: string) => void;
+  maxVisible?: number;
+  overflowIcon?: IconFunctionComponent;
+}) {
+  const visible = maxVisible === undefined ? items : items.slice(0, maxVisible);
+  const hidden = items.slice(visible.length);
+  return (
+    <div className="flex w-full flex-wrap items-center gap-1">
+      {visible.map((item) => (
+        <Chip
+          key={item.id}
+          smallLabel
+          truncateLabel
+          onRemove={onRemove ? () => onRemove(item.id) : undefined}
+        >
+          {item.label}
+        </Chip>
+      ))}
+      {hidden.length > 0 && (
+        <Chip
+          smallLabel
+          icon={overflowIcon}
+          tooltip={hidden.map((item) => item.label).join(", ")}
+        >
+          {`+${hidden.length}`}
+        </Chip>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/inputs/InputChipField.tsx
+++ b/frontend/src/components/inputs/InputChipField.tsx
@@ -74,7 +74,7 @@ export default function InputChipField({
     <div
       data-variant={disabled ? "disabled" : "primary"}
       className={cn(
-        "opal-input min-h-9 cursor-text flex-wrap gap-1",
+        "opal-input min-h-9 cursor-text flex-wrap !justify-start gap-1",
         className,
       )}
       onClick={() => inputRef.current?.focus()}

--- a/frontend/src/components/settings/ConnectorModal.tsx
+++ b/frontend/src/components/settings/ConnectorModal.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Button, Text } from "@onyx-ai/opal/components";
+import { SvgX } from "@onyx-ai/opal/icons";
+import { Content, ContentAction } from "@onyx-ai/opal/layouts";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+
+/** Shared chrome for the Settings connector modals (Emails, Webhooks): the
+ * mock's 480px three-zone alert. Scrim, header with icon + close, a raised
+ * content panel the caller fills, and a Done footer. Opal ships no Modal
+ * primitive, so the shell lives here once. */
+export function ConnectorModalShell({
+  icon,
+  title,
+  description,
+  onClose,
+  banner,
+  children,
+}: {
+  icon: IconFunctionComponent;
+  title: string;
+  description: string;
+  onClose: () => void;
+  /** Rendered above the card, inside the scrim (e.g. a "check your inbox" toast). */
+  banner?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-(--mask-03) backdrop-blur-[2px]"
+      onClick={onClose}
+    >
+      {banner}
+      <div
+        className="flex max-h-[92vh] w-[min(480px,92vw)] flex-col overflow-y-auto rounded-(--radius-16) border border-(--border-01) bg-(--background-tint-01) shadow-(--shadow-modal)"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="relative w-full rounded-t-(--radius-16) bg-(--background-tint-00) p-4">
+          <Content
+            sizePreset="section"
+            variant="heading"
+            icon={icon}
+            title={title}
+            description={description}
+          />
+          <span className="absolute top-2 right-2">
+            <Button
+              type="button"
+              icon={SvgX}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Close"
+              onClick={onClose}
+            />
+          </span>
+        </div>
+
+        <div className="w-full flex-1 p-4">
+          <div className="flex w-full flex-col gap-2 rounded-(--radius-12) bg-(--background-tint-00) p-2">
+            {children}
+          </div>
+        </div>
+
+        <div className="flex h-[68px] w-full items-center justify-end rounded-b-(--radius-16) bg-(--background-tint-00) p-4">
+          <Button type="button" prominence="secondary" onClick={onClose}>
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** One registered destination inside a connector modal: raised row card with
+ * icon, name, status line, and right-side actions (children). */
+export function ConfigRowCard({
+  icon,
+  title,
+  description,
+  children,
+}: {
+  icon: IconFunctionComponent;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="w-full rounded-(--radius-08) bg-(--background-tint-01) p-[6px]">
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={icon}
+        title={title}
+        description={description}
+        rightChildren={
+          <span className="flex shrink-0 items-center gap-1">{children}</span>
+        }
+      />
+    </div>
+  );
+}
+
+/** The row cards' small inline action (Verify, Test). Slot overrides shrink
+ * Opal's Button below its xs metrics to fit the 6px row padding. */
+export function MiniActionButton({
+  icon,
+  disabled,
+  onClick,
+  children,
+}: {
+  icon: IconFunctionComponent;
+  disabled?: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <span className="flex items-center [&_button]:!h-6 [&_button]:!rounded-(--radius-08) [&_button]:!border-0 [&_button]:!bg-(--background-tint-00) [&_button_span]:!text-[12px] [&_button_span]:!leading-4">
+      <Button
+        type="button"
+        size="xs"
+        prominence="secondary"
+        icon={icon}
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {children}
+      </Button>
+    </span>
+  );
+}
+
+/** Centered "N Things" count between two rules, closing the config list. */
+export function CountDivider({ count, noun }: { count: number; noun: string }) {
+  return (
+    <div className="flex w-full items-center gap-2 px-4 py-2">
+      <span className="h-0 min-w-px flex-1 border-t border-(--border-01)" />
+      <Text font="secondary-body" color="text-03" nowrap>
+        {`${count} ${noun}${count === 1 ? "" : "s"}`}
+      </Text>
+      <span className="h-0 min-w-px flex-1 border-t border-(--border-01)" />
+    </div>
+  );
+}

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -7,6 +7,7 @@ import {
   SvgArrowExchange,
   SvgCheckCircle,
   SvgClock,
+  SvgLink,
   SvgMail,
   SvgSettings,
   SvgSlack,
@@ -14,11 +15,18 @@ import {
   SvgVolumeOff,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { Content, ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
+import { Content, InputErrorText } from "@onyx-ai/opal/layouts";
 import { cn, markdown } from "@onyx-ai/opal/utils";
 
 import { SvgSend } from "@/components/icons/SvgSend";
-import Chip from "@/components/inputs/Chip";
+import {
+  ConfigRowCard,
+  ConnectorModalShell,
+  CountDivider,
+  MiniActionButton,
+} from "@/components/settings/ConnectorModal";
+import { WebhookModal } from "@/components/settings/WebhookModal";
+import ChipList from "@/components/inputs/ChipList";
 import InputChipField, {
   type ChipItem,
 } from "@/components/inputs/InputChipField";
@@ -40,7 +48,7 @@ import {
 
 const MAX_EMAILS = 5;
 
-/** Status-coloured icons for ContentAction's icon slot. */
+/** Status-coloured icons for the config row's icon slot. */
 function VerifiedIcon(props: React.ComponentProps<typeof SvgCheckCircle>) {
   return (
     <SvgCheckCircle
@@ -68,10 +76,12 @@ export function ConnectorsTab() {
   const { status, refresh: refreshSlack, isLoading } = useSlackConnectStatus();
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
   const [emailsOpen, setEmailsOpen] = useState(false);
+  const [webhooksOpen, setWebhooksOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const confirmDialog = useConfirm();
 
   const emailConfigs = configs.filter((c) => c.type === "email");
+  const webhookConfigs = configs.filter((c) => c.type === "webhook");
 
   async function onDisconnect() {
     if (
@@ -102,10 +112,10 @@ export function ConnectorsTab() {
     }
   }
 
-  async function onRemoveAddress(c: DestinationConfig) {
+  async function onRemoveConfig(id: string) {
     setError(null);
     try {
-      await deleteDestinationConfig(c.id);
+      await deleteDestinationConfig(id);
       await refreshConfigs();
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to remove");
@@ -172,9 +182,11 @@ export function ConnectorsTab() {
         onConnect={() => setEmailsOpen(true)}
         detail={
           emailConfigs.length > 0 ? (
-            <AddressTags
-              configs={emailConfigs}
-              onRemove={(c) => void onRemoveAddress(c)}
+            <ChipList
+              items={emailConfigs.map((c) => ({ id: c.id, label: c.name }))}
+              onRemove={(id) => void onRemoveConfig(id)}
+              maxVisible={2}
+              overflowIcon={SvgMail}
             />
           ) : undefined
         }
@@ -192,6 +204,34 @@ export function ConnectorsTab() {
         }
       />
 
+      <ConnectorCard
+        icon={SvgLink}
+        title="Webhooks"
+        description="POST wiki updates to Zapier, n8n, Make, or any HTTP endpoint."
+        connected={webhookConfigs.length > 0}
+        onConnect={() => setWebhooksOpen(true)}
+        detail={
+          webhookConfigs.length > 0 ? (
+            <ChipList
+              items={webhookConfigs.map((c) => ({ id: c.id, label: c.name }))}
+              onRemove={(id) => void onRemoveConfig(id)}
+            />
+          ) : undefined
+        }
+        foldActions={
+          webhookConfigs.length > 0 ? (
+            <Button
+              type="button"
+              icon={SvgSettings}
+              size="md"
+              prominence="tertiary"
+              tooltip="Manage"
+              onClick={() => setWebhooksOpen(true)}
+            />
+          ) : undefined
+        }
+      />
+
       {error && <InputErrorText type="error">{error}</InputErrorText>}
 
       {emailsOpen && (
@@ -199,6 +239,14 @@ export function ConnectorsTab() {
           configs={emailConfigs}
           refresh={refreshConfigs}
           onClose={() => setEmailsOpen(false)}
+        />
+      )}
+
+      {webhooksOpen && (
+        <WebhookModal
+          configs={webhookConfigs}
+          refresh={refreshConfigs}
+          onClose={() => setWebhooksOpen(false)}
         />
       )}
     </div>
@@ -293,29 +341,6 @@ function ConnectorCard({
           </div>
         </div>
       </Card>
-    </div>
-  );
-}
-
-/** The mock's mini address tags: 10px labels on tint-02, truncated at
- * 120px, first two shown with an overflow "+N" tag carrying a mail glyph. */
-function AddressTags({
-  configs,
-  onRemove,
-}: {
-  configs: DestinationConfig[];
-  onRemove: (c: DestinationConfig) => void;
-}) {
-  const visible = configs.slice(0, 2);
-  const overflow = configs.length - visible.length;
-  return (
-    <div className="flex w-full flex-wrap items-center gap-1">
-      {visible.map((c) => (
-        <Chip key={c.id} smallLabel truncateLabel onRemove={() => onRemove(c)}>
-          {c.name}
-        </Chip>
-      ))}
-      {overflow > 0 && <Chip smallLabel icon={SvgMail}>{`+${overflow}`}</Chip>}
     </div>
   );
 }
@@ -445,155 +470,101 @@ function EmailsModal({
     }
   }
 
-  return (
+  const banner = sentBanner && (
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-(--mask-03) backdrop-blur-[2px]"
-      onClick={onClose}
+      className="fixed top-6 left-1/2 flex w-[min(480px,92vw)] -translate-x-1/2 items-start gap-2 rounded-(--radius-12) border border-(--status-info-03) bg-(--background-tint-00) p-3 shadow-(--shadow-modal)"
+      onClick={(e) => e.stopPropagation()}
     >
-      {sentBanner && (
-        <div
-          className="fixed top-6 left-1/2 flex w-[min(480px,92vw)] -translate-x-1/2 items-start gap-2 rounded-(--radius-12) border border-(--status-info-03) bg-(--background-tint-00) p-3 shadow-(--shadow-modal)"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <SvgSend className="mt-[2px] size-4 shrink-0 text-(--status-info-05)" />
-          <div className="flex min-w-0 flex-1 flex-col">
-            <Text font="main-ui-action" color="text-04">
-              Check your email inbox.
-            </Text>
-            <Text font="secondary-body" color="text-03">
-              We&apos;ve sent a verification link to your email address.
-            </Text>
-          </div>
+      <SvgSend className="mt-[2px] size-4 shrink-0 text-(--status-info-05)" />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Text font="main-ui-action" color="text-04">
+          Check your email inbox.
+        </Text>
+        <Text font="secondary-body" color="text-03">
+          We&apos;ve sent a verification link to your email address.
+        </Text>
+      </div>
+      <Button
+        type="button"
+        icon={SvgX}
+        size="sm"
+        prominence="tertiary"
+        tooltip="Dismiss"
+        onClick={() => setSentBanner(false)}
+      />
+    </div>
+  );
+
+  return (
+    <ConnectorModalShell
+      icon={SvgMail}
+      title="Emails"
+      description="Send wiki updates notifications to your email addresses."
+      onClose={onClose}
+      banner={banner}
+    >
+      <div className="flex w-full items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <InputChipField
+            chips={drafts}
+            onRemoveChip={(id: string) =>
+              setDrafts((cur) => cur.filter((d) => d.id !== id))
+            }
+            onAdd={addDraft}
+            value={draft}
+            onChange={setDraft}
+            placeholder="Add an email…"
+            disabled={busy}
+          />
+        </div>
+        {drafts.length > 0 && (
           <Button
             type="button"
-            icon={SvgX}
-            size="sm"
-            prominence="tertiary"
-            tooltip="Dismiss"
-            onClick={() => setSentBanner(false)}
-          />
-        </div>
-      )}
-      <div
-        className="flex max-h-[92vh] w-[min(480px,92vw)] flex-col overflow-y-auto rounded-(--radius-16) border border-(--border-01) bg-(--background-tint-01) shadow-(--shadow-modal)"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="relative w-full rounded-t-(--radius-16) bg-(--background-tint-00) p-4">
-          <Content
-            sizePreset="section"
-            variant="heading"
-            icon={SvgMail}
-            title="Emails"
-            description="Send wiki updates notifications to your email addresses."
-          />
-          <span className="absolute top-2 right-2">
-            <Button
-              type="button"
-              icon={SvgX}
-              size="sm"
-              prominence="tertiary"
-              tooltip="Close"
-              onClick={onClose}
-            />
-          </span>
-        </div>
-
-        <div className="w-full flex-1 p-4">
-          <div className="flex w-full flex-col gap-2 rounded-(--radius-12) bg-(--background-tint-00) p-2">
-            <div className="flex w-full items-center gap-1">
-              <div className="min-w-0 flex-1">
-                <InputChipField
-                  chips={drafts}
-                  onRemoveChip={(id: string) =>
-                    setDrafts((cur) => cur.filter((d) => d.id !== id))
-                  }
-                  onAdd={addDraft}
-                  value={draft}
-                  onChange={setDraft}
-                  placeholder="Add an email…"
-                  disabled={busy}
-                />
-              </div>
-              {drafts.length > 0 && (
-                <Button
-                  type="button"
-                  variant="action"
-                  icon={SvgSend}
-                  disabled={busy}
-                  onClick={() => void onSend()}
-                >
-                  Send
-                </Button>
-              )}
-            </div>
-
-            {error && <InputErrorText type="error">{error}</InputErrorText>}
-
-            <div className="flex w-full flex-col gap-1">
-              {configs.map((c) => {
-                const deadline = cooldowns.get(c.id) ?? 0;
-                const remaining = Math.max(
-                  0,
-                  Math.ceil((deadline - now) / 1000),
-                );
-                return (
-                  <div
-                    key={c.id}
-                    className="w-full rounded-(--radius-08) bg-(--background-tint-01) p-[6px]"
-                  >
-                    <ContentAction
-                      sizePreset="main-ui"
-                      variant="section"
-                      icon={c.verified_at ? VerifiedIcon : PendingIcon}
-                      title={c.name}
-                      description={c.verified_at ? "Verified" : "Not verified"}
-                      rightChildren={
-                        <span className="flex shrink-0 items-center gap-1">
-                          {!c.verified_at && (
-                            <span className="flex items-center [&_button]:!h-6 [&_button]:!rounded-(--radius-08) [&_button]:!border-0 [&_button]:!bg-(--background-tint-00) [&_button_span]:!text-[12px] [&_button_span]:!leading-4">
-                              <Button
-                                type="button"
-                                size="xs"
-                                prominence="secondary"
-                                icon={SvgSend}
-                                disabled={remaining > 0}
-                                onClick={() => void onResend(c)}
-                              >
-                                {remaining > 0 ? `${remaining}s` : "Verify"}
-                              </Button>
-                            </span>
-                          )}
-                          <Button
-                            type="button"
-                            icon={SvgX}
-                            size="sm"
-                            prominence="tertiary"
-                            tooltip="Remove address"
-                            onClick={() => void onDelete(c)}
-                          />
-                        </span>
-                      }
-                    />
-                  </div>
-                );
-              })}
-              <div className="flex w-full items-center gap-2 px-4 py-2">
-                <span className="h-0 min-w-px flex-1 border-t border-(--border-01)" />
-                <Text font="secondary-body" color="text-03" nowrap>
-                  {`${configs.length} ${configs.length === 1 ? "Email" : "Emails"}`}
-                </Text>
-                <span className="h-0 min-w-px flex-1 border-t border-(--border-01)" />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex h-[68px] w-full items-center justify-end rounded-b-(--radius-16) bg-(--background-tint-00) p-4">
-          <Button type="button" prominence="secondary" onClick={onClose}>
-            Done
+            variant="action"
+            icon={SvgSend}
+            disabled={busy}
+            onClick={() => void onSend()}
+          >
+            Send
           </Button>
-        </div>
+        )}
       </div>
-    </div>
+
+      {error && <InputErrorText type="error">{error}</InputErrorText>}
+
+      <div className="flex w-full flex-col gap-1">
+        {configs.map((c) => {
+          const deadline = cooldowns.get(c.id) ?? 0;
+          const remaining = Math.max(0, Math.ceil((deadline - now) / 1000));
+          return (
+            <ConfigRowCard
+              key={c.id}
+              icon={c.verified_at ? VerifiedIcon : PendingIcon}
+              title={c.name}
+              description={c.verified_at ? "Verified" : "Not verified"}
+            >
+              {!c.verified_at && (
+                <MiniActionButton
+                  icon={SvgSend}
+                  disabled={remaining > 0}
+                  onClick={() => void onResend(c)}
+                >
+                  {remaining > 0 ? `${remaining}s` : "Verify"}
+                </MiniActionButton>
+              )}
+              <Button
+                type="button"
+                icon={SvgX}
+                size="sm"
+                prominence="tertiary"
+                tooltip="Remove address"
+                onClick={() => void onDelete(c)}
+              />
+            </ConfigRowCard>
+          );
+        })}
+        <CountDivider count={configs.length} noun="Email" />
+      </div>
+    </ConnectorModalShell>
   );
 }

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -215,6 +215,8 @@ export function ConnectorsTab() {
             <ChipList
               items={webhookConfigs.map((c) => ({ id: c.id, label: c.name }))}
               onRemove={(id) => void onRemoveConfig(id)}
+              maxVisible={6}
+              overflowIcon={SvgLink}
             />
           ) : undefined
         }

--- a/frontend/src/components/settings/WebhookModal.tsx
+++ b/frontend/src/components/settings/WebhookModal.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, InputTypeIn } from "@onyx-ai/opal/components";
+import { SvgLink, SvgX } from "@onyx-ai/opal/icons";
+import { InputErrorText } from "@onyx-ai/opal/layouts";
+
+import { SvgSend } from "@/components/icons/SvgSend";
+import {
+  ConfigRowCard,
+  ConnectorModalShell,
+  CountDivider,
+  MiniActionButton,
+} from "@/components/settings/ConnectorModal";
+import {
+  createDestinationConfig,
+  deleteDestinationConfig,
+  sendTestEvent,
+  type DestinationConfig,
+} from "@/lib/triggers";
+
+/** Short label for a webhook endpoint: its host, falling back to the raw URL. */
+function hostLabel(url: string): string {
+  try {
+    return new URL(url).host || url;
+  } catch {
+    return url;
+  }
+}
+
+/** Register/manage webhook endpoints. Each is a `destination_configs` row of
+ * type webhook with a URL, an optional routing tag, and a signing secret
+ * (server-minted when the creator supplies none). "Test" POSTs a sample event
+ * so a receiver can learn the shape. */
+export function WebhookModal({
+  configs,
+  refresh,
+  onClose,
+}: {
+  configs: DestinationConfig[];
+  refresh: () => Promise<unknown>;
+  onClose: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [tag, setTag] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [testing, setTesting] = useState<string | null>(null);
+  const [tested, setTested] = useState<Set<string>>(new Set());
+
+  async function onAdd() {
+    const target = url.trim();
+    if (!target || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const routingTag = tag.trim();
+      await createDestinationConfig({
+        type: "webhook",
+        name: name.trim() || hostLabel(target),
+        config: routingTag
+          ? { url: target, routing_tag: routingTag }
+          : { url: target },
+      });
+      await refresh();
+      setName("");
+      setUrl("");
+      setTag("");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to add endpoint");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onTest(c: DestinationConfig) {
+    setError(null);
+    setTesting(c.id);
+    try {
+      await sendTestEvent(c.id);
+      setTested((cur) => new Set(cur).add(c.id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "test send failed");
+    } finally {
+      setTesting((cur) => (cur === c.id ? null : cur));
+    }
+  }
+
+  async function onDelete(c: DestinationConfig) {
+    setError(null);
+    try {
+      await deleteDestinationConfig(c.id);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to remove");
+    }
+  }
+
+  return (
+    <ConnectorModalShell
+      icon={SvgLink}
+      title="Webhooks"
+      description="POST wiki updates to Zapier, n8n, Make, or any HTTP endpoint."
+      onClose={onClose}
+    >
+      <InputTypeIn
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name (e.g. Slack #general)"
+      />
+      <InputTypeIn
+        value={url}
+        onChange={(e) => {
+          setUrl(e.target.value);
+          setError(null);
+        }}
+        placeholder="https://hooks.zapier.com/hooks/catch/…"
+      />
+      <div className="flex w-full items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <InputTypeIn
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+            placeholder="Routing tag (optional)"
+          />
+        </div>
+        <Button
+          type="button"
+          variant="action"
+          disabled={busy || !url.trim()}
+          onClick={() => void onAdd()}
+        >
+          Add
+        </Button>
+      </div>
+
+      {error && <InputErrorText type="error">{error}</InputErrorText>}
+
+      <div className="flex w-full flex-col gap-1">
+        {configs.map((c) => {
+          const endpoint = String(c.config.url ?? c.name);
+          const routingTag =
+            typeof c.config.routing_tag === "string"
+              ? c.config.routing_tag
+              : null;
+          return (
+            <ConfigRowCard
+              key={c.id}
+              icon={SvgLink}
+              title={c.name}
+              description={
+                routingTag ? `${endpoint} · ${routingTag}` : endpoint
+              }
+            >
+              <MiniActionButton
+                icon={SvgSend}
+                disabled={testing === c.id}
+                onClick={() => void onTest(c)}
+              >
+                {tested.has(c.id) ? "Sent" : "Test"}
+              </MiniActionButton>
+              <Button
+                type="button"
+                icon={SvgX}
+                size="sm"
+                prominence="tertiary"
+                tooltip="Remove endpoint"
+                onClick={() => void onDelete(c)}
+              />
+            </ConfigRowCard>
+          );
+        })}
+        <CountDivider count={configs.length} noun="Webhook" />
+      </div>
+    </ConnectorModalShell>
+  );
+}

--- a/frontend/src/components/triggers/ActionEditor.tsx
+++ b/frontend/src/components/triggers/ActionEditor.tsx
@@ -13,6 +13,7 @@ import {
 import {
   SvgActivity,
   SvgHash,
+  SvgLink,
   SvgMail,
   SvgSlack,
   SvgChevronDown,
@@ -31,7 +32,7 @@ import {
 } from "@/lib/slackConnect";
 import type { DestinationConfig } from "@/lib/triggers";
 
-export type ActionGroupType = "event_log" | "slack" | "email";
+export type ActionGroupType = "event_log" | "slack" | "email" | "webhook";
 
 export interface ActionGroup {
   key: number;
@@ -47,6 +48,7 @@ const TYPE_META: Record<
   event_log: { label: "Notification in Activity Center", icon: SvgActivity },
   slack: { label: "Slack", icon: SvgSlack },
   email: { label: "Email", icon: SvgMail },
+  webhook: { label: "Webhook", icon: SvgLink },
 };
 
 interface Props {
@@ -132,11 +134,15 @@ function ActionGroupRow({
   // connection exists (or this group already targets it, so an edit of an
   // existing Slack trigger stays visible).
   const typeOptions = (
-    ["event_log", "slack", "email"] as ActionGroupType[]
+    ["event_log", "slack", "email", "webhook"] as ActionGroupType[]
   ).filter((t) => {
     if (t === "event_log")
       return group.type === "event_log" || !usedTypes.includes("event_log");
     if (t === "slack") return slackConnected || group.type === "slack";
+    if (t === "webhook")
+      return (
+        group.type === "webhook" || configs.some((c) => c.type === "webhook")
+      );
     return true;
   });
 
@@ -223,6 +229,14 @@ function ActionGroupRow({
           onError={onError}
         />
       )}
+      {group.type === "webhook" && (
+        <WebhookToRow
+          configIds={group.configIds}
+          onConfigIds={(ids) => onPatch({ configIds: ids })}
+          configs={configs}
+          disabled={disabled}
+        />
+      )}
 
       <InputTextArea
         value={group.message}
@@ -232,6 +246,119 @@ function ActionGroupRow({
         rows={3}
       />
     </div>
+  );
+}
+
+function WebhookToRow({
+  configIds,
+  onConfigIds,
+  configs,
+  disabled,
+}: {
+  configIds: string[];
+  onConfigIds: (ids: string[]) => void;
+  configs: DestinationConfig[];
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const endpoints = configs.filter((c) => c.type === "webhook");
+  const selected = configIds
+    .map((id) => endpoints.find((c) => c.id === id))
+    .filter((c): c is DestinationConfig => Boolean(c));
+  const q = search.trim().toLowerCase();
+  const available = endpoints.filter(
+    (c) =>
+      !configIds.includes(c.id) && (!q || c.name.toLowerCase().includes(q)),
+  );
+
+  function add(id: string) {
+    onConfigIds([...configIds, id]);
+    setSearch("");
+  }
+
+  if (endpoints.length === 0) {
+    return (
+      <>
+        <ToLabel />
+        <div className="px-[2px]">
+          <Text font="secondary-body" color="text-03">
+            Add a webhook endpoint in Settings → Connectors to send here.
+          </Text>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ToLabel />
+      <Popover open={open} onOpenChange={setOpen}>
+        <Popover.Anchor asChild>
+          <div ref={anchorRef} className="w-full">
+            <InputChipField
+              chips={selected.map((c) => ({ id: c.id, label: c.name }))}
+              onRemoveChip={(id) =>
+                onConfigIds(configIds.filter((x) => x !== id))
+              }
+              onAdd={() => {
+                const first = available[0];
+                if (first) add(first.id);
+              }}
+              value={search}
+              onChange={(v) => {
+                setSearch(v);
+                if (!open) setOpen(true);
+              }}
+              onFocus={() => setOpen(true)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") setOpen(false);
+              }}
+              disabled={disabled}
+              placeholder={
+                selected.length ? "Add an endpoint" : "Pick an endpoint"
+              }
+            />
+          </div>
+        </Popover.Anchor>
+        <Popover.Content
+          width="trigger"
+          align="start"
+          sideOffset={4}
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onInteractOutside={(e) => {
+            if (anchorRef.current?.contains(e.target as Node))
+              e.preventDefault();
+          }}
+        >
+          {available.length === 0 ? (
+            <div className="px-3 py-2">
+              <Text font="secondary-body" color="text-03">
+                {q ? "No matching endpoints." : "All endpoints added."}
+              </Text>
+            </div>
+          ) : (
+            <PopoverMenu>
+              {available.map((c) => (
+                <LineItemButton
+                  key={c.id}
+                  icon={SvgLink}
+                  title={c.name}
+                  sizePreset="main-ui"
+                  variant="body"
+                  state="empty"
+                  onClick={() => {
+                    add(c.id);
+                    setOpen(false);
+                  }}
+                />
+              ))}
+            </PopoverMenu>
+          )}
+        </Popover.Content>
+      </Popover>
+    </>
   );
 }
 

--- a/frontend/src/components/triggers/TriggerCard.tsx
+++ b/frontend/src/components/triggers/TriggerCard.tsx
@@ -7,6 +7,7 @@ import { markdown } from "@onyx-ai/opal/utils";
 import {
   SvgChevronDown,
   SvgChevronUp,
+  SvgClock,
   SvgInfo,
   SvgSettings,
   SvgWorkflow,
@@ -64,9 +65,17 @@ export function TriggerCard({
   const isRowOpen = (f: TriggerFire) =>
     overrides.get(f.event_id) ?? (t.enabled && f === fires[0]);
 
+  // Drop actions whose destination config was deleted so they don't
+  // appear in the summary or the avatar cluster.
+  const liveActions = t.actions.filter(
+    (a) =>
+      !a.destination_config_id ||
+      configs.some((c) => c.id === a.destination_config_id),
+  );
+
   const destinationTypes = [
     ...new Set(
-      t.actions.map((a) => {
+      liveActions.map((a) => {
         if (!a.destination_config_id) return "event_log";
         const cfg = configs.find((c) => c.id === a.destination_config_id);
         return cfg?.type ?? "event_log";
@@ -97,9 +106,10 @@ export function TriggerCard({
               <Tag title={`+${t.scopes.length - 1}`} />
             </span>
           )}
-          <span className="flex size-4 items-center justify-center p-[2px]">
-            <SvgWorkflow className="size-3 text-(--text-03)" />
-          </span>
+          <Tag
+            icon={t.kind === "schedule" ? SvgClock : SvgWorkflow}
+            title={t.kind === "schedule" ? "Recurring" : "On updates"}
+          />
           <AvatarCluster
             ownerName={ownerName}
             destinationTypes={destinationTypes}
@@ -148,13 +158,11 @@ export function TriggerCard({
                   {markdown(`**IF** ${t.nl_description}`)}
                 </Text>
               </span>
-              {t.actions.map((a, i) => {
+              {liveActions.map((a, i) => {
                 const cfg = a.destination_config_id
                   ? configs.find((c) => c.id === a.destination_config_id)
                   : null;
-                const dest = a.destination_config_id
-                  ? (cfg?.name ?? "(destination removed)")
-                  : "Activity Center";
+                const dest = cfg?.name ?? "Activity Center";
                 return (
                   <span
                     key={`${a.destination_config_id ?? "event_log"}-${i}`}
@@ -166,10 +174,10 @@ export function TriggerCard({
                   </span>
                 );
               })}
-              {t.actions[0]?.message && (
+              {liveActions[0]?.message && (
                 <span className="px-[2px]">
                   <Text font="secondary-action" color="text-03">
-                    {t.actions[0].message}
+                    {liveActions[0].message}
                   </Text>
                 </span>
               )}

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -96,7 +96,9 @@ function groupsFromActions(
       ? configs.find((c) => c.id === a.destination_config_id)
       : undefined;
     const type: ActionGroup["type"] =
-      cfg?.type === "slack" || cfg?.type === "email" ? cfg.type : "event_log";
+      cfg?.type === "slack" || cfg?.type === "email" || cfg?.type === "webhook"
+        ? cfg.type
+        : "event_log";
     const existing = out.find((g) => g.type === type && g.message === message);
     if (existing) {
       if (cfg && !existing.configIds.includes(cfg.id))

--- a/frontend/src/components/triggers/fireParts.tsx
+++ b/frontend/src/components/triggers/fireParts.tsx
@@ -8,6 +8,7 @@ import {
   SvgBook,
   SvgFile,
   SvgFolder,
+  SvgLink,
   SvgMail,
   SvgSlack,
 } from "@onyx-ai/opal/icons";
@@ -22,6 +23,7 @@ export function scopeIcon(scope: string) {
 export function destinationIcon(type: string) {
   if (type === "slack") return SvgSlack;
   if (type === "email") return SvgMail;
+  if (type === "webhook") return SvgLink;
   return SvgActivity;
 }
 

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -220,6 +220,14 @@ export function deleteDestinationConfig(id: string): Promise<void> {
   });
 }
 
+/** POST a sample event to a webhook destination so a receiver (Zapier, n8n,
+ * ...) can learn the field shape before a real trigger points at it. */
+export function sendTestEvent(id: string): Promise<void> {
+  return apiFetch<void>(`/triggers/destination-configs/${id}/test`, {
+    method: "POST",
+  });
+}
+
 /** Resend the verification email. A 429 resolves with the server's
  * retry_after_seconds so callers can run a countdown instead of guessing. */
 export async function resendVerification(


### PR DESCRIPTION
## Description

Frontend for the #363 webhook destinations:

- Connectors tab gets a Webhooks card. Endpoints render as named chips through a new generic `ChipList` (same rendering as the email chips).
- `WebhookModal`: register endpoints with a name, URL, and optional routing tag. Per-endpoint Test button POSTs a sample event. Signing secret is minted server-side when the creator supplies none.
- Trigger editor: webhook destination type with an endpoint picker. Trigger cards now tag the kind (Recurring / On updates) and hide actions whose destination was deleted.
- Shared `ConnectorModal` chrome (shell, config row, mini action button, count divider) extracted and consumed by both the Emails and Webhooks modals.
- Backend: webhook delivery errors now include the receiver's response body (truncated) so a 4xx says why.

## How Has This Been Tested?