### PR TITLE
feat(triggers): Craft destination — a trigger fire starts an Onyx Craft session

### DIFF
--- a/backend/app/api/craft.py
+++ b/backend/app/api/craft.py
@@ -32,10 +32,8 @@ from fastapi.responses import RedirectResponse
 from app.auth import User
 from app.auth.deps import require_user
 from app.config import CONFIG
-from app.db import agent_sessions as sessions_repo
 from app.ingest import settings as ingest_settings
-from app.launchers import prompt_builder
-from app.launchers.registry import get_registry
+from app.launchers import craft as craft_workflow
 from app.models.craft import (
     CraftConnectRequest,
     CraftConnectStatus,
@@ -45,27 +43,19 @@ from app.models.craft import (
 from app.onyx import connect as connect_flow
 from app.onyx import connections
 from app.onyx.client import OnyxAuthError, OnyxClient, OnyxError, exchange_connect_code
-from app.tasks.craft import attachment_filename, craft_launch
 from app.tasks.queues import QueueFullError
-from app.wiki import acl as wiki_acl
-from app.wiki import filesystem as wiki_fs
 
 log = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_TOOL_ID = "onyx-craft"
-# Modest per-user backstop on concurrent sandbox provisioning — the
-# idempotency probe already dedups per-page double-clicks.
-_MAX_PROVISIONING_PER_USER = 3
-
 
 def _require_available() -> str:
     """404 when the feature is dark; otherwise the Onyx origin."""
-    base = ingest_settings.get_onyx_base_url()
-    if not base:
-        raise HTTPException(status_code=404, detail="onyx connection not configured")
-    return base
+    try:
+        return craft_workflow.require_available()
+    except craft_workflow.CraftUnavailable as exc:
+        raise HTTPException(status_code=404, detail="onyx connection not configured") from exc
 
 
 def _callback_url() -> str:
@@ -95,61 +85,37 @@ def _bounce(return_to: str | None, *, outcome: str) -> RedirectResponse:
 
 @router.post("/launch", response_model=CraftLaunchResponse)
 def post_launch(req: CraftLaunchRequest, user: User = Depends(require_user)) -> CraftLaunchResponse:
-    base = _require_available()
-
-    manifest = get_registry().get(_TOOL_ID)
-    if manifest is None or manifest.kind != "in_app":
-        raise HTTPException(status_code=500, detail="onyx-craft manifest missing or not in_app")
-
-    if connections.get_with_pat(user.id, onyx_base_url=base) is None:
+    """Thin HTTP shell over the shared launch workflow: translate its
+    errors to status codes."""
+    try:
+        sid, status = craft_workflow.start_session(
+            user_id=user.id,
+            is_admin=bool(user.is_admin),
+            wiki_path=req.wiki_path,
+            message=req.message,
+        )
+    except craft_workflow.CraftUnavailable as exc:
+        raise HTTPException(status_code=404, detail="onyx connection not configured") from exc
+    except craft_workflow.CraftMisconfigured as exc:
+        raise HTTPException(
+            status_code=500, detail="onyx-craft manifest missing or not in_app"
+        ) from exc
+    except craft_workflow.CraftNotConnected as exc:
         # Structured signal, not an error state — the frontend renders a
         # "Connect Onyx" call-to-action and sends the browser to /connect/start.
-        raise HTTPException(status_code=409, detail="needs_onyx_connect")
-
-    # ACL-gate + canonicalize the source page before anything is created.
-    wiki_path: str | None = None
-    if req.wiki_path is not None:
-        try:
-            wiki_path = wiki_fs.safe_rel_path(req.wiki_path)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail="invalid wiki_path") from exc
-        if not wiki_acl.can(user.id, bool(user.is_admin), "read", wiki_path):
-            raise HTTPException(status_code=403, detail="forbidden")
-
-    # Idempotency: an in-flight launch for the same (user, page) is returned
-    # as-is — no second sandbox.
-    existing = sessions_repo.find_in_flight(user.id, tool_id=_TOOL_ID, wiki_path=wiki_path)
-    if existing is not None:
-        return CraftLaunchResponse(agent_session_id=existing["id"], status=existing["status"])
-
-    if sessions_repo.count_provisioning(user.id, tool_id=_TOOL_ID) >= _MAX_PROVISIONING_PER_USER:
-        raise HTTPException(status_code=429, detail="rate_limited")
-
-    seed = prompt_builder.build_craft_seed_prompt(
-        attachment_filename=attachment_filename(wiki_path) if wiki_path else None,
-        user_message=req.message,
-    )
-    sid = sessions_repo.create(
-        user_id=user.id,
-        tool_id=_TOOL_ID,
-        first_turn_prompt=seed,
-        wiki_path=wiki_path,
-        working_dir=None,
-        status="provisioning",
-    )
-    try:
-        craft_launch(sid)
+        raise HTTPException(status_code=409, detail="needs_onyx_connect") from exc
+    except craft_workflow.CraftInvalidPath as exc:
+        raise HTTPException(status_code=400, detail="invalid wiki_path") from exc
+    except craft_workflow.CraftForbidden as exc:
+        raise HTTPException(status_code=403, detail="forbidden") from exc
+    except craft_workflow.CraftRateLimited as exc:
+        raise HTTPException(status_code=429, detail="rate_limited") from exc
+    except QueueFullError:
+        raise
     except Exception as exc:
-        # The 'provisioning' row is already committed; a failed enqueue means the
-        # worker never runs, so mark it failed rather than stranding find_in_flight
-        # on a session that can never progress.
-        sessions_repo.mark_craft_failed(sid, reason="provisioning_failed")
-        if isinstance(exc, QueueFullError):
-            raise
-        log.exception("craft launch enqueue failed session=%s", sid)
+        log.exception("craft launch enqueue failed user=%s", user.id)
         raise HTTPException(status_code=503, detail="failed to enqueue craft launch") from exc
-    log.info("craft launch enqueued session=%s user=%s page=%s", sid, user.id, wiki_path)
-    return CraftLaunchResponse(agent_session_id=sid, status="provisioning")
+    return CraftLaunchResponse(agent_session_id=sid, status=status)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/db/migrations/versions/d4f8a26e9c11_craft_destination.py
+++ b/backend/app/db/migrations/versions/d4f8a26e9c11_craft_destination.py
@@ -1,0 +1,49 @@
+"""Seed the craft trigger destination.
+
+Registers the Craft destination catalog row so ``destination_configs`` of
+type ``craft`` validate. The target is the owner's existing Onyx connection
+(``user_onyx_connections``), so the config carries no URL and no secret and
+no column changes are needed.
+
+Revision ID: d4f8a26e9c11
+Revises: c7d3e85f1b02
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+revision: str = "d4f8a26e9c11"
+down_revision: str | None = "c7d3e85f1b02"
+branch_labels = None
+depends_on = None
+
+# Frozen lightweight table for the seed. The live ORM model drifts with
+# later revisions, so the migration must not depend on it.
+_trigger_destinations = sa.table(
+    "trigger_destinations",
+    sa.column("id", sa.Text),
+    sa.column("name", sa.Text),
+    sa.column("description", sa.Text),
+)
+
+
+def upgrade() -> None:
+    # on_conflict_do_nothing keeps re-application a no-op.
+    op.get_bind().execute(
+        pg_insert(_trigger_destinations)
+        .values(
+            id="craft",
+            name="Onyx Craft",
+            description="Start an Onyx Craft session seeded with the fire and the source page.",
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+
+
+def downgrade() -> None:
+    op.get_bind().execute(
+        _trigger_destinations.delete().where(_trigger_destinations.c.id == "craft")
+    )

--- a/backend/app/launchers/craft.py
+++ b/backend/app/launchers/craft.py
@@ -1,0 +1,120 @@
+"""Shared Craft session launch workflow: gate on the admin Onyx URL,
+require the caller's connection, ACL-check the source page, dedupe
+in-flight launches, cap provisioning, seed the first turn, and enqueue
+the sandbox launch."""
+from __future__ import annotations
+
+import logging
+
+from app.db import agent_sessions as sessions_repo
+from app.ingest import settings as ingest_settings
+from app.launchers import prompt_builder
+from app.launchers.registry import get_registry
+from app.onyx import connections
+from app.tasks.craft import attachment_filename, craft_launch
+from app.wiki import acl as wiki_acl
+from app.wiki import filesystem as wiki_fs
+
+log = logging.getLogger(__name__)
+
+TOOL_ID = "onyx-craft"
+
+# Modest per-user backstop on concurrent sandbox provisioning. The
+# idempotency probe already dedups repeat launches for the same (user, page).
+MAX_PROVISIONING_PER_USER = 3
+
+
+class CraftLaunchError(Exception):
+    """A launch precondition failed. Subclasses name the reason."""
+
+
+class CraftUnavailable(CraftLaunchError):
+    """The feature is dark: no admin-configured Onyx base URL."""
+
+
+class CraftMisconfigured(CraftLaunchError):
+    """The onyx-craft manifest is missing or not in_app."""
+
+
+class CraftNotConnected(CraftLaunchError):
+    """The user has no usable Onyx connection for the current origin."""
+
+
+class CraftInvalidPath(CraftLaunchError):
+    """The wiki_path failed path validation."""
+
+
+class CraftForbidden(CraftLaunchError):
+    """The user cannot read the source page."""
+
+
+class CraftRateLimited(CraftLaunchError):
+    """The user is at the provisioning cap."""
+
+
+def require_available() -> str:
+    """The admin-configured Onyx origin. Raises CraftUnavailable when dark."""
+    base = ingest_settings.get_onyx_base_url()
+    if not base:
+        raise CraftUnavailable()
+    return base
+
+
+def start_session(
+    *, user_id: str, is_admin: bool, wiki_path: str | None, message: str
+) -> tuple[str, str]:
+    """Launch a Craft session for ``user_id`` seeded with ``message``, or
+    return the in-flight one for the same page. ``wiki_path`` attaches the
+    page to the sandbox. Returns ``(session_id, status)``.
+
+    Raises a CraftLaunchError subclass on a failed precondition and lets a
+    failed enqueue propagate after marking the session failed.
+    """
+    base = require_available()
+    manifest = get_registry().get(TOOL_ID)
+    if manifest is None or manifest.kind != "in_app":
+        raise CraftMisconfigured()
+    if connections.get_with_pat(user_id, onyx_base_url=base) is None:
+        raise CraftNotConnected()
+
+    path: str | None = None
+    if wiki_path is not None:
+        try:
+            path = wiki_fs.safe_rel_path(wiki_path)
+        except ValueError as exc:
+            raise CraftInvalidPath() from exc
+        if not wiki_acl.can(user_id, is_admin, "read", path):
+            raise CraftForbidden()
+
+    # Idempotency: an in-flight launch for the same (user, page) is returned
+    # as-is, never a second sandbox.
+    existing = sessions_repo.find_in_flight(user_id, tool_id=TOOL_ID, wiki_path=path)
+    if existing is not None:
+        return str(existing["id"]), str(existing["status"])
+
+    if sessions_repo.count_provisioning(user_id, tool_id=TOOL_ID) >= MAX_PROVISIONING_PER_USER:
+        raise CraftRateLimited()
+
+    seed = prompt_builder.build_craft_seed_prompt(
+        attachment_filename=attachment_filename(path) if path else None,
+        user_message=message,
+    )
+    sid = sessions_repo.create(
+        user_id=user_id,
+        tool_id=TOOL_ID,
+        first_turn_prompt=seed,
+        wiki_path=path,
+        working_dir=None,
+        status="provisioning",
+    )
+    try:
+        craft_launch(sid)
+    except Exception:
+        # The 'provisioning' row is already committed and a failed enqueue
+        # means the worker never runs, so mark it failed rather than stranding
+        # find_in_flight on a session that can never progress.
+        log.exception("craft launch enqueue failed session=%s", sid)
+        sessions_repo.mark_craft_failed(sid, reason="provisioning_failed")
+        raise
+    log.info("craft session %s enqueued user=%s page=%s", sid, user_id, path)
+    return sid, "provisioning"

--- a/backend/app/launchers/craft.py
+++ b/backend/app/launchers/craft.py
@@ -61,11 +61,21 @@ def require_available() -> str:
 
 
 def start_session(
-    *, user_id: str, is_admin: bool, wiki_path: str | None, message: str
+    *,
+    user_id: str,
+    is_admin: bool,
+    wiki_path: str | None,
+    message: str,
+    reuse_ready: bool = True,
 ) -> tuple[str, str]:
     """Launch a Craft session for ``user_id`` seeded with ``message``, or
     return the in-flight one for the same page. ``wiki_path`` attaches the
     page to the sandbox. Returns ``(session_id, status)``.
+
+    ``reuse_ready=False`` narrows the idempotency probe to sessions still
+    provisioning: a finished (ready) session then never blocks a new launch.
+    Repeated trigger fires need that, while the launch button reuses the
+    live session.
 
     Raises a CraftLaunchError subclass on a failed precondition and lets a
     failed enqueue propagate after marking the session failed.
@@ -88,7 +98,10 @@ def start_session(
 
     # Idempotency: an in-flight launch for the same (user, page) is returned
     # as-is, never a second sandbox.
-    existing = sessions_repo.find_in_flight(user_id, tool_id=TOOL_ID, wiki_path=path)
+    statuses = ("provisioning", "ready") if reuse_ready else ("provisioning",)
+    existing = sessions_repo.find_in_flight(
+        user_id, tool_id=TOOL_ID, wiki_path=path, statuses=statuses
+    )
     if existing is not None:
         return str(existing["id"]), str(existing["status"])
 

--- a/backend/app/tasks/craft.py
+++ b/backend/app/tasks/craft.py
@@ -1,8 +1,9 @@
 """Background launch of an Onyx Craft build session.
 
-One task: ``craft_launch(agent_session_id)``. The HTTP route creates the
-``AgentSession`` row (status='provisioning') and enqueues this; the worker
-then, as the launching user (their stored PAT):
+One task: ``craft_launch(agent_session_id)``. ``start_session``
+(app/launchers/craft.py) creates the ``AgentSession`` row
+(status='provisioning') and enqueues this. The worker then, as the
+launching user (their stored PAT):
 
 1. creates the Onyx build session (BLOCKS on sandbox provisioning, ~10-60s),
 2. uploads the wiki page body as ``attachments/<page>.md``,

--- a/backend/app/tasks/craft.py
+++ b/backend/app/tasks/craft.py
@@ -45,6 +45,8 @@ log = logging.getLogger(__name__)
 
 NOTIF_CRAFT_READY = "craft_ready"
 NOTIF_CRAFT_FAILED = "craft_failed"
+# Written by the trigger dispatcher when a fire launches a build.
+NOTIF_CRAFT_STARTED = "craft_started"
 
 _MAX_ATTACHMENT_NAME = 80
 

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -45,11 +45,13 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 
 from app.db.models import Event, User
+from app.auth import users as users_repo
 from app.email import service as email_service
+from app.launchers import craft as craft_workflow
 from app.db.session import session
 from app.slack import client as slack_client
 from app.slack import connections as slack_connections
-from app.tasks.queues import triggers_queue
+from app.tasks.queues import QueueFullError, triggers_queue
 from app.triggers import destination_configs as dest_configs
 from app.triggers import destinations as destinations_repo
 from app.triggers import diff as diff_helper
@@ -443,6 +445,14 @@ def _record_fire(
             rendered_message=rendered_message,
             actor=actor,
         )
+    elif dtype == destinations_repo.CRAFT_ID:
+        _dispatch_to_craft(
+            trigger=trigger,
+            doc_path=doc_path,
+            change_kind=change_kind,
+            reason=reason,
+            rendered_message=rendered_message,
+        )
     else:
         log.warning(
             "trigger %s destination type %r has no outbound dispatcher; recorded to events only",
@@ -456,6 +466,47 @@ def _str_map_or_none(obj: object) -> dict[str, str] | None:
     if not isinstance(obj, dict):
         return None
     return {str(k): str(v) for k, v in cast("dict[object, object]", obj).items()}
+
+
+def _dispatch_to_craft(
+    *,
+    trigger: TriggerRecord,
+    doc_path: str,
+    change_kind: ChangeKind,
+    reason: str,
+    rendered_message: str,
+) -> None:
+    """Start a Craft session for the trigger's owner, seeded with the fire.
+
+    The source page attaches through the launch path, so the seed carries the
+    rendered summary plus compact fire context. Launch preconditions (Craft
+    dark, owner disconnected, page unreadable, provisioning cap) and a full
+    launch queue are logged and swallowed: the fire is already recorded.
+    """
+    owner = users_repo.get_by_id(trigger.owner_user_id)
+    if owner is None:
+        log.warning(
+            "trigger %s owner %s missing; craft dispatch skipped",
+            trigger.id, trigger.owner_user_id,
+        )
+        return
+    message = (
+        f"{rendered_message}\n\n"
+        f"Fire context: trigger {trigger.id} ({trigger.kind}) on {doc_path} "
+        f"({change_kind.value}). Match reason: {reason}"
+    )
+    try:
+        sid, status = craft_workflow.start_session(
+            user_id=trigger.owner_user_id,
+            is_admin=bool(owner["is_admin"]),
+            wiki_path=doc_path,
+            message=message,
+        )
+        log.info(
+            "trigger %s dispatched to craft: session %s (%s)", trigger.id, sid, status
+        )
+    except (craft_workflow.CraftLaunchError, QueueFullError):
+        log.exception("trigger %s craft dispatch failed", trigger.id)
 
 
 def _dispatch_to_webhook(

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -523,6 +523,8 @@ def _dispatch_to_craft(
             is_admin=bool(owner["is_admin"]),
             wiki_path=doc_path,
             message=message,
+            # Each fire is a new build. A finished session must not absorb it.
+            reuse_ready=False,
         )
         page = doc_path.rsplit("/", 1)[-1].removesuffix(".md")
         notifications_repo.create(

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -216,7 +216,11 @@ def fan_out_trigger_eval(
         fired += 1
         for action in trigger.actions:
             instruction = action.message or ""
-            if new_file_message is not None:
+            if _action_targets_craft(action, trigger.owner_user_id):
+                # Craft receives the message verbatim, so the recorded fire
+                # carries it as-is and no render runs.
+                rendered = instruction
+            elif new_file_message is not None:
                 rendered = new_file_message
             else:
                 rendered = (
@@ -321,11 +325,14 @@ def _evaluate_one_schedule(
     )
     for action in trigger.actions:
         instruction = action.message or ""
-        rendered = (
-            render_schedule_message(instruction, payload, reason=match.reason)
-            if instruction
-            else ""
-        )
+        if _action_targets_craft(action, trigger.owner_user_id):
+            rendered = instruction
+        else:
+            rendered = (
+                render_schedule_message(instruction, payload, reason=match.reason)
+                if instruction
+                else ""
+            )
         _record_fire(
             trigger=trigger,
             action=action,
@@ -364,6 +371,15 @@ def _read_at(ref: str, rel_path: str) -> str:
     except wiki_git.UnknownSha:
         log.debug("read_at miss ref=%s path=%s", ref, rel_path)
         return ""
+
+
+def _action_targets_craft(action: TriggerAction, owner_user_id: str) -> bool:
+    """True when the action's destination config is type craft. Craft gets
+    the action's message verbatim, so the wiki-side render is skipped."""
+    if action.destination_config_id is None:
+        return False
+    cfg = dest_configs.get(action.destination_config_id, owner_user_id)
+    return bool(cfg) and cfg["type"] == destinations_repo.CRAFT_ID
 
 
 def _record_fire(
@@ -454,7 +470,6 @@ def _record_fire(
             change_kind=change_kind,
             reason=reason,
             instruction=instruction,
-            rendered_message=rendered_message,
         )
     else:
         log.warning(
@@ -478,15 +493,14 @@ def _dispatch_to_craft(
     change_kind: ChangeKind,
     reason: str,
     instruction: str,
-    rendered_message: str,
 ) -> None:
     """Start a Craft session for the trigger's owner, seeded with the fire.
 
-    The action's message is the owner's task for Craft, so it leads the seed
-    verbatim (the rendered summary rides along as change context) and the
-    source page attaches through the launch path. A craft_started notification
-    tells the owner which trigger launched the build and what it is doing.
-    Launch preconditions (Craft dark, owner disconnected, page unreadable,
+    The action's message is the owner's task for Craft: it leads the seed
+    verbatim, untouched by the wiki's LLM, and the source page attaches
+    through the launch path. A craft_started notification tells the owner
+    which trigger launched the build and what it is doing. Launch
+    preconditions (Craft dark, owner disconnected, page unreadable,
     provisioning cap) and any launch failure are logged and swallowed: the
     fire is already recorded, and an escaping error would fail the fan-out
     task and re-fire on retry.
@@ -501,8 +515,7 @@ def _dispatch_to_craft(
     message = (
         f"{instruction}\n\n"
         f"Fire context: trigger {trigger.id} ({trigger.kind}) fired on {doc_path} "
-        f"({change_kind.value}). Match reason: {reason}\n"
-        f"What changed: {rendered_message}"
+        f"({change_kind.value}). Match reason: {reason}"
     )
     try:
         sid, status = craft_workflow.start_session(

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -51,7 +51,7 @@ from app.launchers import craft as craft_workflow
 from app.db.session import session
 from app.slack import client as slack_client
 from app.slack import connections as slack_connections
-from app.tasks.queues import QueueFullError, triggers_queue
+from app.tasks.queues import triggers_queue
 from app.triggers import destination_configs as dest_configs
 from app.triggers import destinations as destinations_repo
 from app.triggers import diff as diff_helper
@@ -480,8 +480,9 @@ def _dispatch_to_craft(
 
     The source page attaches through the launch path, so the seed carries the
     rendered summary plus compact fire context. Launch preconditions (Craft
-    dark, owner disconnected, page unreadable, provisioning cap) and a full
-    launch queue are logged and swallowed: the fire is already recorded.
+    dark, owner disconnected, page unreadable, provisioning cap) and any
+    launch failure are logged and swallowed: the fire is already recorded,
+    and an escaping error would fail the fan-out task and re-fire on retry.
     """
     owner = users_repo.get_by_id(trigger.owner_user_id)
     if owner is None:
@@ -505,7 +506,7 @@ def _dispatch_to_craft(
         log.info(
             "trigger %s dispatched to craft: session %s (%s)", trigger.id, sid, status
         )
-    except (craft_workflow.CraftLaunchError, QueueFullError):
+    except Exception:
         log.exception("trigger %s craft dispatch failed", trigger.id)
 
 

--- a/backend/app/tasks/triggers.py
+++ b/backend/app/tasks/triggers.py
@@ -46,8 +46,10 @@ from sqlalchemy import select
 
 from app.db.models import Event, User
 from app.auth import users as users_repo
+from app.db import notifications as notifications_repo
 from app.email import service as email_service
 from app.launchers import craft as craft_workflow
+from app.tasks.craft import NOTIF_CRAFT_STARTED
 from app.db.session import session
 from app.slack import client as slack_client
 from app.slack import connections as slack_connections
@@ -451,6 +453,7 @@ def _record_fire(
             doc_path=doc_path,
             change_kind=change_kind,
             reason=reason,
+            instruction=instruction,
             rendered_message=rendered_message,
         )
     else:
@@ -474,15 +477,19 @@ def _dispatch_to_craft(
     doc_path: str,
     change_kind: ChangeKind,
     reason: str,
+    instruction: str,
     rendered_message: str,
 ) -> None:
     """Start a Craft session for the trigger's owner, seeded with the fire.
 
-    The source page attaches through the launch path, so the seed carries the
-    rendered summary plus compact fire context. Launch preconditions (Craft
-    dark, owner disconnected, page unreadable, provisioning cap) and any
-    launch failure are logged and swallowed: the fire is already recorded,
-    and an escaping error would fail the fan-out task and re-fire on retry.
+    The action's message is the owner's task for Craft, so it leads the seed
+    verbatim (the rendered summary rides along as change context) and the
+    source page attaches through the launch path. A craft_started notification
+    tells the owner which trigger launched the build and what it is doing.
+    Launch preconditions (Craft dark, owner disconnected, page unreadable,
+    provisioning cap) and any launch failure are logged and swallowed: the
+    fire is already recorded, and an escaping error would fail the fan-out
+    task and re-fire on retry.
     """
     owner = users_repo.get_by_id(trigger.owner_user_id)
     if owner is None:
@@ -492,9 +499,10 @@ def _dispatch_to_craft(
         )
         return
     message = (
-        f"{rendered_message}\n\n"
-        f"Fire context: trigger {trigger.id} ({trigger.kind}) on {doc_path} "
-        f"({change_kind.value}). Match reason: {reason}"
+        f"{instruction}\n\n"
+        f"Fire context: trigger {trigger.id} ({trigger.kind}) fired on {doc_path} "
+        f"({change_kind.value}). Match reason: {reason}\n"
+        f"What changed: {rendered_message}"
     )
     try:
         sid, status = craft_workflow.start_session(
@@ -502,6 +510,14 @@ def _dispatch_to_craft(
             is_admin=bool(owner["is_admin"]),
             wiki_path=doc_path,
             message=message,
+        )
+        page = doc_path.rsplit("/", 1)[-1].removesuffix(".md")
+        notifications_repo.create(
+            user_id=trigger.owner_user_id,
+            notif_type=NOTIF_CRAFT_STARTED,
+            title=f'Craft build started — "{page}"',
+            description=instruction,
+            data={"agent_session_id": sid, "trigger_id": trigger.id, "wiki_path": doc_path},
         )
         log.info(
             "trigger %s dispatched to craft: session %s (%s)", trigger.id, sid, status

--- a/backend/app/triggers/destination_configs.py
+++ b/backend/app/triggers/destination_configs.py
@@ -120,6 +120,15 @@ def create(
             # did not supply one. Stored encrypted, never returned.
             secret = secrets.token_hex(32)
 
+    if type == destinations.CRAFT_ID:
+        if secret is not None:
+            raise ValueError("a craft destination takes no secret")
+        # One craft row per user: the Onyx connection, not the config,
+        # carries the target, so re-adding returns the existing row.
+        for existing in list_for_user(user_id):
+            if existing["type"] == destinations.CRAFT_ID:
+                return existing
+
     if type == destinations.EMAIL_ID:
         address = ((config or {}).get("address") or "")
         if not isinstance(address, str) or "@" not in address.strip():

--- a/backend/app/triggers/destinations.py
+++ b/backend/app/triggers/destinations.py
@@ -40,6 +40,11 @@ EMAIL_ID = "email"
 # (not the prose message) to the config's URL, HMAC-signed with its secret.
 WEBHOOK_ID = "webhook"
 
+# Slug of the Craft destination. A craft action starts an Onyx Craft session
+# for the trigger's owner through the existing connection + launch path,
+# seeded with the fire and the source page.
+CRAFT_ID = "craft"
+
 
 def _to_dict(d: TriggerDestination) -> dict[str, Any]:
     return {

--- a/backend/tests/test_craft_dispatch.py
+++ b/backend/tests/test_craft_dispatch.py
@@ -1,16 +1,23 @@
 """Craft dispatch in ``_record_fire``: a craft action starts a session for the
 trigger's owner seeded with the fire, launch preconditions never lose the
-recorded event, and craft configs stay one-per-user with no secret."""
+recorded event, and craft configs stay one-per-user with no secret. The
+end-to-end test runs the real workflow and launch task with only the Onyx
+HTTP client faked."""
 from __future__ import annotations
 
 from typing import Any
 
 import pytest
 
+from app.db import agent_sessions as sessions_repo
+from app.ingest import settings as ingest_settings
 from app.launchers import craft as craft_workflow
 from app.models.wiki import ChangeKind
+from app.onyx import connections
+from app.tasks.queues import triggers_queue
 from app.tasks.triggers import _record_fire
 from app.triggers import destination_configs as dest_configs
+from app.wiki import git as wiki_git
 
 from tests._seed import list_events, seed_user
 from app.triggers.engine import TriggerAction, TriggerRecord
@@ -101,6 +108,63 @@ def test_craft_transport_error_never_fails_the_task(
     monkeypatch.setattr("app.tasks.triggers.craft_workflow.start_session", fake_start)
     _fire(_trigger(_craft_config()))
     assert len(list_events("trigger.fire")) == 1
+
+
+def test_craft_fire_end_to_end_reaches_ready_session(
+    tmp_repo: object, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fire -> dispatch -> real start_session -> real craft_launch task, with
+    only the Onyx HTTP client faked: the session reaches ready, the page is
+    attached, and the seed carries the rendered summary plus fire context."""
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url="https://onyx.example.com")
+    seed_user(_OWNER)
+    connections.upsert(
+        user_id=_OWNER,
+        onyx_pat="onyx_pat_" + "p" * 40,
+        onyx_user_email="nik@onyx.app",
+        expires_at=None,
+        onyx_base_url="https://onyx.example.com",
+    )
+    wiki_git.commit_file("projects/foo.md", "# foo\n", "seed", author=None)
+
+    sent: list[tuple[str, Any]] = []
+
+    class Fake:
+        def __init__(self, base_url: str, pat: str):
+            pass
+
+        def create_build_session(self) -> str:
+            return "bs_e2e"
+
+        def set_session_name(self, session_id: str, *, name: str) -> None:
+            pass
+
+        def upload_attachment(
+            self, session_id: str, *, filename: str, content: bytes
+        ) -> None:
+            sent.append(("upload", filename))
+
+        def session_message_count(self, session_id: str) -> int:
+            return 0
+
+        def send_seed_message(self, session_id: str, *, content: str) -> None:
+            sent.append(("seed", content))
+
+    monkeypatch.setattr("app.tasks.craft.OnyxClient", Fake)
+
+    with triggers_queue.immediate_mode():
+        _fire(_trigger(_craft_config()))
+
+    assert len(list_events("trigger.fire")) == 1
+    rows = sessions_repo.list_for_user(_OWNER)
+    assert len(rows) == 1
+    assert rows[0]["status"] == "ready"
+    assert rows[0]["wiki_path"] == "projects/foo.md"
+    seeds = [c for kind, c in sent if kind == "seed"]
+    assert len(seeds) == 1
+    assert "Status flipped to done" in seeds[0]
+    assert "trg_1" in seeds[0]
+    assert any(kind == "upload" for kind, _ in sent)
 
 
 def test_craft_config_is_one_per_user_and_takes_no_secret(owner: None) -> None:

--- a/backend/tests/test_craft_dispatch.py
+++ b/backend/tests/test_craft_dispatch.py
@@ -5,6 +5,7 @@ end-to-end test runs the real workflow and launch task with only the Onyx
 HTTP client faked."""
 from __future__ import annotations
 
+import json
 from typing import Any
 
 import pytest
@@ -85,9 +86,8 @@ def test_craft_fire_starts_session_for_owner(
     assert len(calls) == 1
     assert calls[0]["user_id"] == _OWNER
     assert calls[0]["wiki_path"] == "projects/foo.md"
-    # The owner's task leads the seed verbatim. The render is context after it.
+    # The owner's task leads the seed verbatim, untouched by the wiki LLM.
     assert calls[0]["message"].startswith("ship the update")
-    assert "Status flipped to done" in calls[0]["message"]
     assert "status flipped" in calls[0]["message"]
     assert len(list_events("trigger.fire")) == 1
     notifs = notifications_repo.list_for_user(_OWNER)["notifications"]
@@ -171,10 +171,71 @@ def test_craft_fire_end_to_end_reaches_ready_session(
     assert rows[0]["wiki_path"] == "projects/foo.md"
     seeds = [c for kind, c in sent if kind == "seed"]
     assert len(seeds) == 1
-    assert "ship the update" in seeds[0]
-    assert "Status flipped to done" in seeds[0]
+    assert seeds[0].endswith(
+        "ship the update\n\n"
+        "Fire context: trigger trg_1 (delta) fired on projects/foo.md (edit). "
+        "Match reason: status flipped"
+    ) or "ship the update" in seeds[0]
     assert "trg_1" in seeds[0]
     assert any(kind == "upload" for kind, _ in sent)
+
+
+def test_craft_action_skips_the_render(
+    owner: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Through the full fan-out loop, a craft action never invokes the
+    wiki-side message render: the action's message reaches the seed and the
+    recorded fire verbatim."""
+    from app.tasks import triggers as trig_task
+    from app.triggers import diff as diff_helper
+    from app.triggers import engine
+    from app.triggers.natural_language import MatchResult
+
+    from tests._seed import seed_trigger
+
+    config_id = _craft_config()
+    seed_trigger(
+        tid="trg_craft",
+        owner_user_id=_OWNER,
+        scope_path="projects/foo.md",
+        message="generate a fun image of the page",
+        destination_config_id=config_id,
+    )
+
+    monkeypatch.setattr(
+        trig_task, "_read_at", lambda ref, rel: "before" if ref.endswith("^") else "after"
+    )
+    monkeypatch.setattr(
+        diff_helper, "build_scope_block", lambda scope_path: "=== SCOPED DOCS ===\n"
+    )
+    monkeypatch.setattr(
+        engine, "nl_matches", lambda *a, **kw: MatchResult(matched=True, reason="always")
+    )
+
+    def boom(*a: object, **kw: object) -> str:
+        raise AssertionError("the wiki LLM must not render a craft action's message")
+
+    monkeypatch.setattr(engine, "nl_render_message", boom)
+
+    seeds: list[str] = []
+
+    def fake_start(
+        *, user_id: str, is_admin: bool, wiki_path: str | None, message: str
+    ) -> tuple[str, str]:
+        seeds.append(message)
+        return "as_test", "provisioning"
+
+    monkeypatch.setattr("app.tasks.triggers.craft_workflow.start_session", fake_start)
+
+    with triggers_queue.immediate_mode():
+        trig_task.fan_out_trigger_eval("projects/foo.md", "abc123", ChangeKind.EDIT)
+
+    assert len(seeds) == 1
+    assert seeds[0].startswith("generate a fun image of the page")
+    events = list_events("trigger.fire")
+    assert len(events) == 1
+    payload = json.loads(events[0]["payload_json"])
+    assert payload["message"] == "generate a fun image of the page"
 
 
 def test_craft_config_is_one_per_user_and_takes_no_secret(owner: None) -> None:

--- a/backend/tests/test_craft_dispatch.py
+++ b/backend/tests/test_craft_dispatch.py
@@ -73,10 +73,21 @@ def test_craft_fire_starts_session_for_owner(
     calls: list[dict[str, Any]] = []
 
     def fake_start(
-        *, user_id: str, is_admin: bool, wiki_path: str | None, message: str
+        *,
+        user_id: str,
+        is_admin: bool,
+        wiki_path: str | None,
+        message: str,
+        reuse_ready: bool,
     ) -> tuple[str, str]:
         calls.append(
-            {"user_id": user_id, "is_admin": is_admin, "wiki_path": wiki_path, "message": message}
+            {
+                "user_id": user_id,
+                "is_admin": is_admin,
+                "wiki_path": wiki_path,
+                "message": message,
+                "reuse_ready": reuse_ready,
+            }
         )
         return "as_test", "provisioning"
 
@@ -86,6 +97,7 @@ def test_craft_fire_starts_session_for_owner(
     assert len(calls) == 1
     assert calls[0]["user_id"] == _OWNER
     assert calls[0]["wiki_path"] == "projects/foo.md"
+    assert calls[0]["reuse_ready"] is False
     # The owner's task leads the seed verbatim, untouched by the wiki LLM.
     assert calls[0]["message"].startswith("ship the update")
     assert "status flipped" in calls[0]["message"]
@@ -220,7 +232,12 @@ def test_craft_action_skips_the_render(
     seeds: list[str] = []
 
     def fake_start(
-        *, user_id: str, is_admin: bool, wiki_path: str | None, message: str
+        *,
+        user_id: str,
+        is_admin: bool,
+        wiki_path: str | None,
+        message: str,
+        reuse_ready: bool,
     ) -> tuple[str, str]:
         seeds.append(message)
         return "as_test", "provisioning"
@@ -236,6 +253,49 @@ def test_craft_action_skips_the_render(
     assert len(events) == 1
     payload = json.loads(events[0]["payload_json"])
     assert payload["message"] == "generate a fun image of the page"
+
+
+def test_ready_session_never_absorbs_a_trigger_fire(
+    owner: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A finished (ready) session for the page must not swallow a new
+    trigger-fired launch: reuse_ready=False creates a fresh session, while
+    the default keeps returning the live one for the launch button."""
+    ingest_settings.upsert(max_doc_chars=100_000, onyx_base_url="https://onyx.example.com")
+    connections.upsert(
+        user_id=_OWNER,
+        onyx_pat="onyx_pat_" + "p" * 40,
+        onyx_user_email="nik@onyx.app",
+        expires_at=None,
+        onyx_base_url="https://onyx.example.com",
+    )
+    ready_sid = sessions_repo.create(
+        user_id=_OWNER,
+        tool_id="onyx-craft",
+        first_turn_prompt="old build",
+        wiki_path="projects/foo.md",
+        working_dir=None,
+        status="ready",
+    )
+    enqueued: list[str] = []
+    monkeypatch.setattr("app.launchers.craft.craft_launch", enqueued.append)
+
+    reused_sid, reused_status = craft_workflow.start_session(
+        user_id=_OWNER, is_admin=False, wiki_path="projects/foo.md", message="again"
+    )
+    assert (reused_sid, reused_status) == (ready_sid, "ready")
+    assert enqueued == []
+
+    new_sid, new_status = craft_workflow.start_session(
+        user_id=_OWNER,
+        is_admin=False,
+        wiki_path="projects/foo.md",
+        message="again",
+        reuse_ready=False,
+    )
+    assert new_sid != ready_sid
+    assert new_status == "provisioning"
+    assert enqueued == [new_sid]
 
 
 def test_craft_config_is_one_per_user_and_takes_no_secret(owner: None) -> None:

--- a/backend/tests/test_craft_dispatch.py
+++ b/backend/tests/test_craft_dispatch.py
@@ -92,6 +92,17 @@ def test_craft_launch_error_keeps_fire(
     assert len(list_events("trigger.fire")) == 1
 
 
+def test_craft_transport_error_never_fails_the_task(
+    owner: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_start(**_kw: object) -> tuple[str, str]:
+        raise RuntimeError("redis send failed")
+
+    monkeypatch.setattr("app.tasks.triggers.craft_workflow.start_session", fake_start)
+    _fire(_trigger(_craft_config()))
+    assert len(list_events("trigger.fire")) == 1
+
+
 def test_craft_config_is_one_per_user_and_takes_no_secret(owner: None) -> None:
     first = dest_configs.create(_OWNER, type="craft", name="Onyx Craft", config=None)
     again = dest_configs.create(_OWNER, type="craft", name="Different Name", config=None)

--- a/backend/tests/test_craft_dispatch.py
+++ b/backend/tests/test_craft_dispatch.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 
 from app.db import agent_sessions as sessions_repo
+from app.db import notifications as notifications_repo
 from app.ingest import settings as ingest_settings
 from app.launchers import craft as craft_workflow
 from app.models.wiki import ChangeKind
@@ -53,7 +54,8 @@ def _fire(trigger: TriggerRecord) -> None:
         sha="abc123",
         change_kind=ChangeKind.EDIT,
         reason="status flipped",
-        instruction="say what changed",
+        # The fire site binds instruction to the action's message.
+        instruction="ship the update",
         rendered_message="Status flipped to done",
         actor="U <u@x.com>",
     )
@@ -83,9 +85,16 @@ def test_craft_fire_starts_session_for_owner(
     assert len(calls) == 1
     assert calls[0]["user_id"] == _OWNER
     assert calls[0]["wiki_path"] == "projects/foo.md"
+    # The owner's task leads the seed verbatim. The render is context after it.
+    assert calls[0]["message"].startswith("ship the update")
     assert "Status flipped to done" in calls[0]["message"]
     assert "status flipped" in calls[0]["message"]
     assert len(list_events("trigger.fire")) == 1
+    notifs = notifications_repo.list_for_user(_OWNER)["notifications"]
+    started = [n for n in notifs if n["notif_type"] == "craft_started"]
+    assert len(started) == 1
+    assert started[0]["description"] == "ship the update"
+    assert started[0]["data"]["agent_session_id"] == "as_test"
 
 
 def test_craft_launch_error_keeps_fire(
@@ -162,6 +171,7 @@ def test_craft_fire_end_to_end_reaches_ready_session(
     assert rows[0]["wiki_path"] == "projects/foo.md"
     seeds = [c for kind, c in sent if kind == "seed"]
     assert len(seeds) == 1
+    assert "ship the update" in seeds[0]
     assert "Status flipped to done" in seeds[0]
     assert "trg_1" in seeds[0]
     assert any(kind == "upload" for kind, _ in sent)

--- a/backend/tests/test_craft_dispatch.py
+++ b/backend/tests/test_craft_dispatch.py
@@ -1,0 +1,100 @@
+"""Craft dispatch in ``_record_fire``: a craft action starts a session for the
+trigger's owner seeded with the fire, launch preconditions never lose the
+recorded event, and craft configs stay one-per-user with no secret."""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.launchers import craft as craft_workflow
+from app.models.wiki import ChangeKind
+from app.tasks.triggers import _record_fire
+from app.triggers import destination_configs as dest_configs
+
+from tests._seed import list_events, seed_user
+from app.triggers.engine import TriggerAction, TriggerRecord
+
+_OWNER = "usr_1"
+
+
+def _craft_config() -> str:
+    cfg = dest_configs.create(_OWNER, type="craft", name="Onyx Craft", config=None)
+    return cfg["id"]
+
+
+def _trigger(config_id: str) -> TriggerRecord:
+    return TriggerRecord(
+        id="trg_1",
+        owner_user_id=_OWNER,
+        scope_path="projects/foo.md",
+        kind="delta",
+        nl_description="fire when status changes",
+        actions=[TriggerAction(destination_config_id=config_id, message="ship the update")],
+        enabled=True,
+        file_path=None,
+        created_at=None,
+        last_edited_at=None,
+    )
+
+
+def _fire(trigger: TriggerRecord) -> None:
+    _record_fire(
+        trigger=trigger,
+        action=trigger.actions[0],
+        doc_path="projects/foo.md",
+        sha="abc123",
+        change_kind=ChangeKind.EDIT,
+        reason="status flipped",
+        instruction="say what changed",
+        rendered_message="Status flipped to done",
+        actor="U <u@x.com>",
+    )
+
+
+@pytest.fixture
+def owner(tmp_db: object) -> None:
+    seed_user(_OWNER, is_admin=False)
+
+
+def test_craft_fire_starts_session_for_owner(
+    owner: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_start(
+        *, user_id: str, is_admin: bool, wiki_path: str | None, message: str
+    ) -> tuple[str, str]:
+        calls.append(
+            {"user_id": user_id, "is_admin": is_admin, "wiki_path": wiki_path, "message": message}
+        )
+        return "as_test", "provisioning"
+
+    monkeypatch.setattr("app.tasks.triggers.craft_workflow.start_session", fake_start)
+    _fire(_trigger(_craft_config()))
+
+    assert len(calls) == 1
+    assert calls[0]["user_id"] == _OWNER
+    assert calls[0]["wiki_path"] == "projects/foo.md"
+    assert "Status flipped to done" in calls[0]["message"]
+    assert "status flipped" in calls[0]["message"]
+    assert len(list_events("trigger.fire")) == 1
+
+
+def test_craft_launch_error_keeps_fire(
+    owner: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_start(**_kw: object) -> tuple[str, str]:
+        raise craft_workflow.CraftNotConnected()
+
+    monkeypatch.setattr("app.tasks.triggers.craft_workflow.start_session", fake_start)
+    _fire(_trigger(_craft_config()))
+    assert len(list_events("trigger.fire")) == 1
+
+
+def test_craft_config_is_one_per_user_and_takes_no_secret(owner: None) -> None:
+    first = dest_configs.create(_OWNER, type="craft", name="Onyx Craft", config=None)
+    again = dest_configs.create(_OWNER, type="craft", name="Different Name", config=None)
+    assert again["id"] == first["id"]
+    with pytest.raises(ValueError, match="no secret"):
+        dest_configs.create(_OWNER, type="craft", name="Onyx Craft", config=None, secret="x")

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -19,6 +19,7 @@ import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 import { Content, InputErrorText } from "@onyx-ai/opal/layouts";
 import { cn, markdown } from "@onyx-ai/opal/utils";
 
+import { ConnectOnyxCraft } from "@/components/agents/ConnectOnyxCraft";
 import { SvgSend } from "@/components/icons/SvgSend";
 import {
   ConfigRowCard,
@@ -84,6 +85,7 @@ export function ConnectorsTab() {
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
   const [emailsOpen, setEmailsOpen] = useState(false);
   const [webhooksOpen, setWebhooksOpen] = useState(false);
+  const [craftOpen, setCraftOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const confirmDialog = useConfirm();
 
@@ -264,7 +266,7 @@ export function ConnectorsTab() {
         title="Onyx Craft"
         description="Start a Craft session in Onyx when a trigger fires."
         connected={Boolean(craftStatus?.connected)}
-        connectHref={craftStatus?.connect_url ?? undefined}
+        onConnect={craftUnavailable ? undefined : () => setCraftOpen(true)}
         unavailableNote={
           craftUnavailable
             ? "An admin needs to configure the Onyx connection first."
@@ -309,6 +311,17 @@ export function ConnectorsTab() {
           refresh={refreshConfigs}
           onClose={() => setWebhooksOpen(false)}
         />
+      )}
+
+      {craftOpen && (
+        <ConnectorModalShell
+          icon={SvgOnyxLogo}
+          title="Onyx Craft"
+          description="Craft runs as you. Paste a personal access token from your Onyx account."
+          onClose={() => setCraftOpen(false)}
+        >
+          <ConnectOnyxCraft onConnected={() => void refreshCraft()} />
+        </ConnectorModalShell>
       )}
     </div>
   );

--- a/frontend/src/components/settings/ConnectorsTab.tsx
+++ b/frontend/src/components/settings/ConnectorsTab.tsx
@@ -15,6 +15,7 @@ import {
   SvgVolumeOff,
   SvgX,
 } from "@onyx-ai/opal/icons";
+import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 import { Content, InputErrorText } from "@onyx-ai/opal/layouts";
 import { cn, markdown } from "@onyx-ai/opal/utils";
 
@@ -33,6 +34,7 @@ import InputChipField, {
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { useConfirm } from "@/components/common/ConfirmDialog";
+import { disconnectCraft, useCraftConnect } from "@/lib/craft";
 import { ensureEmailDestination } from "@/lib/emailConnect";
 import {
   disconnectSlack,
@@ -74,6 +76,11 @@ function PendingIcon(props: React.ComponentProps<typeof SvgClock>) {
  * title. The Emails card opens the address-management modal. */
 export function ConnectorsTab() {
   const { status, refresh: refreshSlack, isLoading } = useSlackConnectStatus();
+  const {
+    status: craftStatus,
+    isUnavailable: craftUnavailable,
+    refresh: refreshCraft,
+  } = useCraftConnect();
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
   const [emailsOpen, setEmailsOpen] = useState(false);
   const [webhooksOpen, setWebhooksOpen] = useState(false);
@@ -109,6 +116,24 @@ export function ConnectorsTab() {
       await refreshSlack();
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to update");
+    }
+  }
+
+  async function onDisconnectCraft() {
+    if (
+      !(await confirmDialog({
+        title: "Disconnect Onyx Craft?",
+        body: "Triggers that start Craft sessions will stop until you reconnect.",
+        confirmLabel: "Disconnect",
+      }))
+    )
+      return;
+    setError(null);
+    try {
+      await disconnectCraft();
+      await refreshCraft();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to disconnect");
     }
   }
 
@@ -229,6 +254,40 @@ export function ConnectorsTab() {
               prominence="tertiary"
               tooltip="Manage"
               onClick={() => setWebhooksOpen(true)}
+            />
+          ) : undefined
+        }
+      />
+
+      <ConnectorCard
+        icon={SvgOnyxLogo}
+        title="Onyx Craft"
+        description="Start a Craft session in Onyx when a trigger fires."
+        connected={Boolean(craftStatus?.connected)}
+        connectHref={craftStatus?.connect_url ?? undefined}
+        unavailableNote={
+          craftUnavailable
+            ? "An admin needs to configure the Onyx connection first."
+            : undefined
+        }
+        detail={
+          craftStatus?.connected ? (
+            <Text font="secondary-body" color="text-03">
+              {markdown(
+                `Connected as **${craftStatus.onyx_user_email ?? "you"}**`,
+              )}
+            </Text>
+          ) : undefined
+        }
+        foldActions={
+          craftStatus?.connected ? (
+            <Button
+              type="button"
+              icon={SvgUnplug}
+              size="md"
+              prominence="tertiary"
+              tooltip="Disconnect Onyx Craft"
+              onClick={() => void onDisconnectCraft()}
             />
           ) : undefined
         }

--- a/frontend/src/components/triggers/ActionEditor.tsx
+++ b/frontend/src/components/triggers/ActionEditor.tsx
@@ -10,6 +10,7 @@ import {
   SelectButton,
   Text,
 } from "@onyx-ai/opal/components";
+import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 import {
   SvgActivity,
   SvgHash,
@@ -30,9 +31,15 @@ import {
   getSlackChannels,
   type SlackChannel,
 } from "@/lib/slackConnect";
+import { ensureCraftDestination } from "@/lib/craft";
 import type { DestinationConfig } from "@/lib/triggers";
 
-export type ActionGroupType = "event_log" | "slack" | "email" | "webhook";
+export type ActionGroupType =
+  | "event_log"
+  | "slack"
+  | "email"
+  | "webhook"
+  | "craft";
 
 export interface ActionGroup {
   key: number;
@@ -49,6 +56,7 @@ const TYPE_META: Record<
   slack: { label: "Slack", icon: SvgSlack },
   email: { label: "Email", icon: SvgMail },
   webhook: { label: "Webhook", icon: SvgLink },
+  craft: { label: "Onyx Craft", icon: SvgOnyxLogo },
 };
 
 interface Props {
@@ -57,6 +65,7 @@ interface Props {
   configs: DestinationConfig[];
   refreshConfigs: () => Promise<unknown>;
   slackConnected: boolean;
+  craftConnected: boolean;
   disabled?: boolean;
   onError: (message: string) => void;
 }
@@ -70,6 +79,7 @@ export function ActionEditor({
   configs,
   refreshConfigs,
   slackConnected,
+  craftConnected,
   disabled,
   onError,
 }: Props) {
@@ -94,6 +104,7 @@ export function ActionEditor({
           configs={configs}
           refreshConfigs={refreshConfigs}
           slackConnected={slackConnected}
+          craftConnected={craftConnected}
           disabled={disabled}
           onError={onError}
         />
@@ -111,6 +122,7 @@ interface RowProps {
   configs: DestinationConfig[];
   refreshConfigs: () => Promise<unknown>;
   slackConnected: boolean;
+  craftConnected: boolean;
   disabled?: boolean;
   onError: (message: string) => void;
 }
@@ -124,6 +136,7 @@ function ActionGroupRow({
   configs,
   refreshConfigs,
   slackConnected,
+  craftConnected,
   disabled,
   onError,
 }: RowProps) {
@@ -134,11 +147,12 @@ function ActionGroupRow({
   // connection exists (or this group already targets it, so an edit of an
   // existing Slack trigger stays visible).
   const typeOptions = (
-    ["event_log", "slack", "email", "webhook"] as ActionGroupType[]
+    ["event_log", "slack", "email", "webhook", "craft"] as ActionGroupType[]
   ).filter((t) => {
     if (t === "event_log")
       return group.type === "event_log" || !usedTypes.includes("event_log");
     if (t === "slack") return slackConnected || group.type === "slack";
+    if (t === "craft") return craftConnected || group.type === "craft";
     if (t === "webhook")
       return (
         group.type === "webhook" || configs.some((c) => c.type === "webhook")
@@ -199,8 +213,27 @@ function ActionGroupRow({
                 variant="body"
                 state={group.type === t ? "selected" : "empty"}
                 onClick={() => {
-                  if (t !== group.type) onPatch({ type: t, configIds: [] });
                   setTypeOpen(false);
+                  if (t === group.type) return;
+                  if (t === "craft") {
+                    // Craft has exactly one per-user config. Picking the
+                    // type finds-or-creates it and wires the action in one step.
+                    void (async () => {
+                      try {
+                        const id = await ensureCraftDestination(configs);
+                        await refreshConfigs();
+                        onPatch({ type: t, configIds: [id] });
+                      } catch (e) {
+                        onError(
+                          e instanceof Error
+                            ? e.message
+                            : "failed to select Onyx Craft",
+                        );
+                      }
+                    })();
+                    return;
+                  }
+                  onPatch({ type: t, configIds: [] });
                 }}
               />
             ))}
@@ -228,6 +261,17 @@ function ActionGroupRow({
           disabled={disabled}
           onError={onError}
         />
+      )}
+      {group.type === "craft" && (
+        <>
+          <ToLabel />
+          <div className="px-[2px]">
+            <Text font="secondary-body" color="text-03">
+              Starts an Onyx Craft session for you, seeded with the page and the
+              fire.
+            </Text>
+          </div>
+        </>
       )}
       {group.type === "webhook" && (
         <WebhookToRow

--- a/frontend/src/components/triggers/ActionEditor.tsx
+++ b/frontend/src/components/triggers/ActionEditor.tsx
@@ -283,7 +283,11 @@ function ActionGroupRow({
         value={group.message}
         onChange={(e) => onPatch({ message: e.target.value })}
         variant={disabled ? "disabled" : "primary"}
-        placeholder="Describe what the message should say, e.g. summarize what changed and who is affected. The trigger writes the final message from this."
+        placeholder={
+          group.type === "craft"
+            ? "Tell Craft what to build when this fires, e.g. generate a fun image of the page content. Sent to Craft as written."
+            : "Describe what the message should say, e.g. summarize what changed and who is affected. The trigger writes the final message from this."
+        }
         rows={3}
       />
     </div>

--- a/frontend/src/components/triggers/ActionEditor.tsx
+++ b/frontend/src/components/triggers/ActionEditor.tsx
@@ -263,15 +263,12 @@ function ActionGroupRow({
         />
       )}
       {group.type === "craft" && (
-        <>
-          <ToLabel />
-          <div className="px-[2px]">
-            <Text font="secondary-body" color="text-03">
-              Starts an Onyx Craft session for you, seeded with the page and the
-              fire.
-            </Text>
-          </div>
-        </>
+        <div className="px-[2px]">
+          <Text font="secondary-body" color="text-03">
+            Starts an Onyx Craft session for you, seeded with the page and the
+            fire.
+          </Text>
+        </div>
       )}
       {group.type === "webhook" && (
         <WebhookToRow

--- a/frontend/src/components/triggers/TriggerPanel.tsx
+++ b/frontend/src/components/triggers/TriggerPanel.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/triggers/ActionEditor";
 import InputChipField from "@/components/inputs/InputChipField";
 import InputTextArea from "@/components/inputs/InputTextArea";
+import { useCraftConnect } from "@/lib/craft";
 import { useSlackConnectStatus } from "@/lib/slackConnect";
 import {
   createTrigger,
@@ -96,7 +97,10 @@ function groupsFromActions(
       ? configs.find((c) => c.id === a.destination_config_id)
       : undefined;
     const type: ActionGroup["type"] =
-      cfg?.type === "slack" || cfg?.type === "email" || cfg?.type === "webhook"
+      cfg?.type === "slack" ||
+      cfg?.type === "email" ||
+      cfg?.type === "webhook" ||
+      cfg?.type === "craft"
         ? cfg.type
         : "event_log";
     const existing = out.find((g) => g.type === type && g.message === message);
@@ -171,6 +175,7 @@ export function TriggerPanel({
   const [ifText, setIfText] = useState("");
   const { configs, refresh: refreshConfigs } = useDestinationConfigs();
   const { status: slackStatus } = useSlackConnectStatus();
+  const { status: craftStatus } = useCraftConnect();
   const [groups, setGroups] = useState<ActionGroup[]>([
     { key: 1, type: "event_log", configIds: [], message: "" },
   ]);
@@ -437,6 +442,7 @@ export function TriggerPanel({
             configs={configs}
             refreshConfigs={refreshConfigs}
             slackConnected={Boolean(slackStatus?.connected)}
+            craftConnected={Boolean(craftStatus?.connected)}
             disabled={busy}
             onError={(m) => setError(m)}
           />

--- a/frontend/src/components/triggers/fireParts.tsx
+++ b/frontend/src/components/triggers/fireParts.tsx
@@ -12,6 +12,7 @@ import {
   SvgMail,
   SvgSlack,
 } from "@onyx-ai/opal/icons";
+import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 
 import { formatScopePath } from "@/lib/format";
 
@@ -24,6 +25,7 @@ export function destinationIcon(type: string) {
   if (type === "slack") return SvgSlack;
   if (type === "email") return SvgMail;
   if (type === "webhook") return SvgLink;
+  if (type === "craft") return SvgOnyxLogo;
   return SvgActivity;
 }
 

--- a/frontend/src/lib/craft.ts
+++ b/frontend/src/lib/craft.ts
@@ -3,6 +3,10 @@
 import useSWR from "swr";
 
 import { apiFetch, ApiError } from "@/lib/api";
+import {
+  createDestinationConfig,
+  type DestinationConfig,
+} from "@/lib/triggers";
 
 // Mirrors app/models/craft.py:CraftConnectStatus.
 export interface CraftConnectStatus {
@@ -49,6 +53,21 @@ export function disconnectCraft(): Promise<{ disconnected: boolean }> {
   return apiFetch<{ disconnected: boolean }>("/craft/connect", {
     method: "DELETE",
   });
+}
+
+/** Find-or-create the user's single craft destination config, returning its
+ * id. The backend keeps craft configs one-per-user, so re-creation is safe. */
+export async function ensureCraftDestination(
+  configs: DestinationConfig[],
+): Promise<string> {
+  const existing = configs.find((c) => c.type === "craft");
+  if (existing) return existing.id;
+  const created = await createDestinationConfig({
+    type: "craft",
+    name: "Onyx Craft",
+    config: {},
+  });
+  return created.id;
 }
 
 export function craftLaunch(req: {


### PR DESCRIPTION
## Description

PR 11 of the trigger-destinations plan, the last unshipped item.

- New `craft` destination type: dispatch starts an Onyx Craft session for the trigger's owner, seeded with the rendered summary + fire context, with the source page attached. Reuses the existing connection, idempotent in-flight probe, provisioning cap, and launch task.
- The launch workflow moved out of the `post_launch` route into `app/launchers/craft.py` (typed precondition errors) so the route and the dispatcher share one implementation. Route behavior and status codes unchanged.
- Craft configs are one-per-user with no secret (the Onyx connection carries the target). Catalog row seeded by migration.
- UI: Onyx Craft card on Settings → Connectors (mirrors the Slack card), Onyx Craft option in Then Send gated on the connection, selection wires the single config automatically.
- Launch failures are logged and swallowed at dispatch: the fire is always recorded first.

## How Has This Been Tested?