### PR TITLE
feat(templates): ai_management_allowed default on templates

### DIFF
--- a/backend/app/api/templates.py
+++ b/backend/app/api/templates.py
@@ -37,6 +37,7 @@ def _view(row: dict[str, Any]) -> DocumentTemplateView:
         system_prompt=row["system_prompt"],
         ingestion_auto_update_disabled=row["ingestion_auto_update_disabled"],
         update_instruction=row["update_instruction"],
+        ai_management_allowed=row["ai_management_allowed"],
         sort_order=row["sort_order"],
         created_at=row["created_at"],
         updated_at=row["updated_at"],
@@ -110,6 +111,7 @@ def create_template(
             system_prompt=(req.system_prompt or None),
             ingestion_auto_update_disabled=req.ingestion_auto_update_disabled,
             update_instruction=(req.update_instruction or None),
+            ai_management_allowed=req.ai_management_allowed,
             created_by_user_id=actor.id,
         )
     except templates_repo.TemplateNameTaken as exc:
@@ -141,6 +143,8 @@ def update_template(
             policy["ingestion_auto_update_disabled"] = req.ingestion_auto_update_disabled
         if "update_instruction" in req.model_fields_set:
             policy["update_instruction"] = req.update_instruction or None
+        if "ai_management_allowed" in req.model_fields_set:
+            policy["ai_management_allowed"] = req.ai_management_allowed
         row = templates_repo.update(
             template_id,
             name=name,

--- a/backend/app/db/migrations/versions/e4b8c61d9a73_template_ai_management.py
+++ b/backend/app/db/migrations/versions/e4b8c61d9a73_template_ai_management.py
@@ -1,0 +1,42 @@
+"""template ai management
+
+Adds ``document_templates.ai_management_allowed`` — a template can opt pages
+created from it into AI auto-management from birth (applied to the page's
+update-policy row by ``apply_policy_to_page``). Starter templates ship with it
+unset; admins opt specific templates in. Guarded with the inspector because
+``0001_initial`` builds fresh databases from the current models.
+
+Revision ID: e4b8c61d9a73
+Revises: c7d3e85f1b02
+Create Date: 2026-07-10 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "e4b8c61d9a73"
+down_revision: str | None = "c7d3e85f1b02"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("document_templates")}
+    if "ai_management_allowed" not in cols:
+        op.add_column(
+            "document_templates",
+            sa.Column("ai_management_allowed", sa.Boolean(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("document_templates")}
+    if "ai_management_allowed" in cols:
+        op.drop_column("document_templates", "ai_management_allowed")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -652,9 +652,11 @@ class DocumentTemplate(Base):
     # Default update policy seeded onto a page created from this template
     # (applied to its update_policies row). NULL = leave to the inherited
     # default. Lets a template (e.g. "Meeting notes") start with auto-update
-    # off, or carry scope guidance for the updater.
+    # off, carry scope guidance for the updater, or opt the page into AI
+    # auto-management from birth.
     ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
     update_instruction: Mapped[str | None] = mapped_column(Text)
+    ai_management_allowed: Mapped[bool | None] = mapped_column(Boolean)
     # Admin-controlled ordering for the picker. Lower values render
     # first; ties fall back to ``name`` alphabetical. New rows land at
     # the end (max(sort_order) + 1) so admins decide where they live.

--- a/backend/app/llm/agents/tools/list_templates.py
+++ b/backend/app/llm/agents/tools/list_templates.py
@@ -20,6 +20,7 @@ def handle(args: dict[str, Any]) -> Any:
             "description": t["description"],
             "body": t["body"],
             "auto_update_disabled": t["ingestion_auto_update_disabled"],
+            "ai_management_allowed": t["ai_management_allowed"],
             "update_instruction": t["update_instruction"],
         }
         for t in templates_repo.list_all()

--- a/backend/app/models/template.py
+++ b/backend/app/models/template.py
@@ -15,6 +15,7 @@ class DocumentTemplateView(BaseModel):
     # Default update policy applied to a page created from this template.
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    ai_management_allowed: bool | None = None
     sort_order: int
     created_at: str
     updated_at: str
@@ -47,6 +48,7 @@ class CreateDocumentTemplateRequest(BaseModel):
     system_prompt: str | None = None
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    ai_management_allowed: bool | None = None
 
 
 class UpdateDocumentTemplateRequest(BaseModel):
@@ -56,6 +58,7 @@ class UpdateDocumentTemplateRequest(BaseModel):
     system_prompt: str | None = None
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
+    ai_management_allowed: bool | None = None
 
 
 class ReorderDocumentTemplatesRequest(BaseModel):

--- a/backend/app/wiki/templates.py
+++ b/backend/app/wiki/templates.py
@@ -69,6 +69,7 @@ def _to_dict(t: DocumentTemplate) -> dict[str, Any]:
         "description": t.description,
         "system_prompt": t.system_prompt,
         "ingestion_auto_update_disabled": t.ingestion_auto_update_disabled,
+        "ai_management_allowed": t.ai_management_allowed,
         "update_instruction": t.update_instruction,
         "sort_order": t.sort_order,
         "created_by_user_id": t.created_by_user_id,
@@ -101,6 +102,7 @@ def create(
     description: str | None,
     system_prompt: str | None,
     ingestion_auto_update_disabled: bool | None = None,
+    ai_management_allowed: bool | None = None,
     update_instruction: str | None = None,
     created_by_user_id: str | None,
 ) -> dict[str, Any]:
@@ -120,6 +122,7 @@ def create(
                 description=description,
                 system_prompt=system_prompt,
                 ingestion_auto_update_disabled=ingestion_auto_update_disabled,
+                ai_management_allowed=ai_management_allowed,
                 update_instruction=update_instruction,
                 sort_order=next_order,
                 created_by_user_id=created_by_user_id,
@@ -143,6 +146,7 @@ def update(
     description: str | None,
     system_prompt: str | None,
     ingestion_auto_update_disabled: bool | None | _UnsetType = _UNSET,
+    ai_management_allowed: bool | None | _UnsetType = _UNSET,
     update_instruction: str | None | _UnsetType = _UNSET,
 ) -> dict[str, Any] | None:
     with session() as s:
@@ -162,6 +166,8 @@ def update(
         # client that doesn't send them can't silently clear a template's policy.
         if not isinstance(ingestion_auto_update_disabled, _UnsetType):
             t.ingestion_auto_update_disabled = ingestion_auto_update_disabled
+        if not isinstance(ai_management_allowed, _UnsetType):
+            t.ai_management_allowed = ai_management_allowed
         if not isinstance(update_instruction, _UnsetType):
             t.update_instruction = update_instruction
         t.updated_at = _now_text(s)
@@ -216,6 +222,8 @@ def apply_policy_to_page(
         patch["ingestion_auto_update_disabled"] = tmpl["ingestion_auto_update_disabled"]
     if tmpl.get("update_instruction"):
         patch["update_instruction"] = tmpl["update_instruction"]
+    if tmpl.get("ai_management_allowed") is not None:
+        patch["ai_management_allowed"] = tmpl["ai_management_allowed"]
     if patch:
         update_policy.set_policy(path, actor_user_id=actor_user_id, **patch)
     return True

--- a/backend/tests/test_template_update_policy.py
+++ b/backend/tests/test_template_update_policy.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from app.auth import users as users_repo
 from app.main import create_app
+from app.wiki import git as wiki_git
 from app.wiki import templates as templates_repo
 from app.wiki import update_policy
 from tests._auth import login_fastapi
@@ -174,3 +175,40 @@ def test_blank_template_cannot_be_renamed_but_can_be_edited(client: TestClient) 
         f"/api/admin/templates/{t['id']}", json={"name": "Blank", "body": "# scaffold\n"}
     )
     assert edited.status_code == 200
+
+
+def test_template_seeds_ai_management_allowed(tmp_repo):
+    row = templates_repo.create(
+        name="Managed Space",
+        body="# {{title}}\n",
+        description=None,
+        system_prompt=None,
+        ai_management_allowed=True,
+        created_by_user_id=None,
+    )
+    assert row["ai_management_allowed"] is True
+
+    path = "spaces/managed-page.md"
+    wiki_git.commit_file(path, "# Managed page\n", "seed", author=None)
+    assert templates_repo.apply_policy_to_page(path, row["id"], None) is True
+    assert update_policy.is_ai_management_allowed(path) is True
+    # The other policy fields stay inherited — the template only set the flag.
+    assert update_policy.resolve_for_path(path).ingestion_auto_update_disabled is False
+
+
+def test_template_without_flag_leaves_policy_inherited(tmp_repo):
+    row = templates_repo.create(
+        name="Plain Notes",
+        body="# Notes\n",
+        description=None,
+        system_prompt=None,
+        created_by_user_id=None,
+    )
+    assert row["ai_management_allowed"] is None
+    path = "spaces/plain-page.md"
+    wiki_git.commit_file(path, "# Plain\n", "seed", author=None)
+    templates_repo.apply_policy_to_page(path, row["id"], None)
+    # No explicit row fields were written for the flag.
+    assert update_policy.is_ai_management_allowed(path) is False
+    explicit = update_policy.get(path)
+    assert explicit is None or explicit["ai_management_allowed"] is None

--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -258,6 +258,12 @@ function TemplateModal({
   const [updateInstruction, setUpdateInstruction] = useState(
     initial?.update_instruction ?? "",
   );
+  // Whether pages created from this template start opted into AI
+  // auto-management. Defaults to off; a template author enables it
+  // deliberately (e.g. team spaces the AI should keep organized).
+  const [aiManagedOn, setAiManagedOn] = useState<boolean>(
+    initial?.ai_management_allowed === true,
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -283,6 +289,9 @@ function TemplateModal({
         system_prompt: initial?.system_prompt ?? null,
         ingestion_auto_update_disabled: !autoUpdateOn,
         update_instruction: updateInstruction.trim() || null,
+        // Unset (inherit) unless deliberately enabled — starter templates
+        // ship without the flag.
+        ai_management_allowed: aiManagedOn ? true : null,
       };
       if (initial) {
         await updateTemplate(initial.id, payload);
@@ -350,6 +359,18 @@ function TemplateModal({
             Pages created from this template start with ingestion auto-update{" "}
             {autoUpdateOn ? "on" : "off"}. Leave it off for pages that shouldn't
             be rewritten by ingestion (e.g. meeting notes).
+          </div>
+        </div>
+
+        <div>
+          <div className="flex items-center justify-between gap-3">
+            <div className={lblClass}>AI management</div>
+            <Switch checked={aiManagedOn} onCheckedChange={setAiManagedOn} />
+          </div>
+          <div className="mt-1 text-xs text-(--text-02)">
+            Pages created from this template {aiManagedOn ? "are" : "are not"}{" "}
+            opted into AI auto-management (the AI may organize them — moves,
+            merges — without per-change approval).
           </div>
         </div>
 

--- a/frontend/src/lib/templates.ts
+++ b/frontend/src/lib/templates.ts
@@ -10,6 +10,7 @@ export interface DocumentTemplate {
   system_prompt: string | null;
   // Default update policy applied to a page created from this template.
   ingestion_auto_update_disabled: boolean | null;
+  ai_management_allowed: boolean | null;
   update_instruction: string | null;
   sort_order: number;
   created_at: string;
@@ -21,6 +22,7 @@ export interface DocumentTemplateSummary {
   name: string;
   description: string | null;
   ingestion_auto_update_disabled: boolean | null;
+  ai_management_allowed: boolean | null;
 }
 
 export interface CreateTemplateInput {
@@ -29,6 +31,7 @@ export interface CreateTemplateInput {
   description?: string | null;
   system_prompt?: string | null;
   ingestion_auto_update_disabled?: boolean | null;
+  ai_management_allowed?: boolean | null;
   update_instruction?: string | null;
 }
 


### PR DESCRIPTION
## What

The admin-curated adoption lever for AI management ([engineering page](https://dev-wiki.onyx.app/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/Wiki%20Auto%20Management%20%E2%80%94%20Engineering.md)): a template can opt pages created from it into `ai_management_allowed` from birth — e.g. a "Team Space" template whose pages the AI keeps organized, decided once by an admin instead of per-page toggling.

## How

Third policy field through the existing template seam, same shape as the other two:

- `document_templates.ai_management_allowed` (nullable) + guarded migration
- Repo: `create` / `update` (patch semantics) / `apply_policy_to_page` — the single application point, so the UI create path and `write_doc(template_id)` both inherit it
- Admin API: create/update/view wiring with `model_fields_set` PATCH semantics preserved
- `list_templates` agent tool exposes it (agents picking a template can see the default)
- Admin editor: an "AI management" toggle below Auto-update, default **off**; when off the payload sends `null` (inherit), so **starter templates ship unset** — admins opt specific templates in (per the org-default discussion staying open for Phase 2)

## Testing

New tests: template with the flag seeds the page's policy (other fields stay inherited); template without it writes nothing (page inherits default-off). Policy suites: 53 passed; ruff + basedpyright + tsc + prettier clean.
<img width="630" height="166" alt="Screenshot 2026-07-10 at 11 24 35 AM" src="https://github.com/user-attachments/assets/cc6ae701-8eb5-4e68-ad6c-12362fb30599" />

