### PR TITLE
feat(wiki): stable doc ids (wiki_doc_ids path↔id mapping)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -482,8 +482,9 @@ def delete_document_by_path(
         # Drops FTS / ACL / comments / activity / working-dir state for each
         # removed page.
         wiki_notify.after_doc_delete(p, sha, author)
-    # Per-page fan-out stamped each page's id row; a folder delete also
-    # tombstones the folder rows themselves (the fan-out only sees .md paths).
+    # Stamps the folder's own id rows, which the per-page fan-out above never
+    # sees (it only gets .md paths). For a single-page delete rel == the page
+    # already stamped, so this is a no-op (deleted_at IS NULL no longer matches).
     doc_ids.on_deleted(rel)
     log.info("doc deleted %s (%d pages) by %s sha=%s", rel, len(md_paths), author or "?", sha[:8])
     return DeleteDocumentResponse(sha=sha)
@@ -500,7 +501,12 @@ def resolve_doc_id(
     row = doc_ids.get(doc_id)
     if row is None:
         raise HTTPException(status_code=404, detail="unknown id")
-    path = str(row["path"])
+    # Stored paths are always app-generated from validated values, but
+    # re-validate before the ACL check so this endpoint matches every other.
+    try:
+        path = filesystem.safe_rel_path(str(row["path"]))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     require_can("read", path, user)
     kind = "page" if row["kind"] == "page" else "folder"
     return ResolveDocIdResponse(
@@ -616,7 +622,14 @@ def restore_deleted_path(
         raise HTTPException(status_code=404, detail="no restorable content") from exc
     # Re-bind stable ids before the create lifecycle runs, so the fan-out's
     # mint step finds the resurrected rows instead of minting fresh ids.
-    doc_ids.on_restored([fate.path, *files])
+    # ``files`` are blobs only, so add every intermediate folder path too —
+    # otherwise nested folders (e.g. proj/sub) get fresh ids on restore.
+    restore_paths: set[str] = {fate.path, *files}
+    for f in files:
+        parts = f.split("/")[:-1]
+        for i in range(1, len(parts) + 1):
+            restore_paths.add("/".join(parts[:i]))
+    doc_ids.on_restored(sorted(restore_paths))
     for p in md_paths:
         # Create lifecycle: default-public ACLs + owner stamp, FTS reindex,
         # trigger fan-out, MCP pub-sub.

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -42,6 +42,7 @@ from app.models.file_system import (
     RecordRecentDocRequest,
     ReindexRequest,
     ReindexResponse,
+    ResolveDocIdResponse,
     ReorderStarredRequest,
     ReviseDraftRequest,
     ReviseDraftResponse,
@@ -58,6 +59,7 @@ from app.wiki import (
     agent_activity,
     coedit,
     diff as wiki_diff,
+    doc_ids,
     drafts as wiki_drafts,
     filesystem,
     git as wiki_git,
@@ -71,7 +73,7 @@ from app.wiki import (
 )
 from app.ingest import settings as ingest_settings
 from app.models.update_policy import UpdateHealthResponse
-from app.models.wiki import ChangeKind, CommitMaxRetriesError
+from app.models.wiki import ChangeKind, CommitMaxRetriesError, PathMove
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -194,15 +196,28 @@ def get_document_by_path(
     user: User = Depends(require_user),
     path: str = "",
     ref: str | None = None,
+    doc_id: str | None = Query(None, alias="id"),
 ) -> GetDocumentResponse:
+    if doc_id and not path:
+        row = doc_ids.get(doc_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="unknown id")
+        path = str(row["path"])
     if not path:
-        raise HTTPException(status_code=400, detail="path required")
+        raise HTTPException(status_code=400, detail="path or id required")
     try:
         rel = filesystem.safe_rel_path(path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     require_can("read", rel, user)
     head_sha = wiki_git.head_sha_for_path(rel)
+    # Stable id: reading a live page lazily backfills its row (pre-id pages);
+    # historical/deleted reads only report an id if a live row exists.
+    page_id = (
+        doc_ids.get_or_mint(rel)
+        if filesystem.absolute(rel).is_file()
+        else doc_ids.id_for_path(rel)
+    )
     if ref:
         # The path may have been different at this ref (rename). Resolve
         # via --follow so old commits don't 404 on the current name.
@@ -211,7 +226,7 @@ def get_document_by_path(
             body = wiki_git.read_file(historical, ref=ref)
         except wiki_git.UnknownSha as exc:
             raise HTTPException(status_code=404, detail="not found at ref") from exc
-        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref)
+        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref, id=page_id)
     # Session-aware live read: when a co-edit session is open on this page, its
     # Postgres buffer holds the freshest edits. The checkpoint that commits the
     # buffer to git runs asynchronously, so HEAD lags — reading it would show
@@ -248,11 +263,11 @@ def get_document_by_path(
                     exc_info=True,
                 )
                 body = current
-        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha)
+        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, id=page_id)
     abs_path = filesystem.absolute(rel)
     if not abs_path.is_file():
         raise HTTPException(status_code=404, detail="not found")
-    return GetDocumentResponse(path=rel, body=abs_path.read_text(), head_sha=head_sha)
+    return GetDocumentResponse(path=rel, body=abs_path.read_text(), head_sha=head_sha, id=page_id)
 
 
 @router.put("/file", response_model=PutDocumentResponse)
@@ -320,6 +335,9 @@ def put_document_by_path(
         sha=sha,
         created=not existed,
         deprecated=[],
+        # The create lifecycle minted on first save; edits of pre-id pages
+        # backfill here.
+        id=doc_ids.get_or_mint(rel),
     )
 
 
@@ -349,6 +367,7 @@ def create_folder(
         raise HTTPException(status_code=409, detail="folder already exists")
     author = _git_author(user)
     sha = wiki_git.commit_file(f"{rel}/.gitkeep", "", f"create folder {rel}", author=author)
+    doc_ids.get_or_mint(rel)
     log.info("folder created %s by %s sha=%s", rel, author or "?", sha[:8])
     return CreateFolderResponse(path=rel, sha=sha)
 
@@ -416,7 +435,9 @@ def move_document_or_folder(
 
     # after_path_move re-points every live path-keyed cache (ACL, comments,
     # activity, drafts, working-dirs) and reconverges the trigger cache.
-    wiki_notify.after_path_move(moves, sha, author)
+    wiki_notify.after_path_move(
+        moves, sha, author, root_move=PathMove(old=old_rel, new=new_rel)
+    )
 
     log.info(
         "move %s -> %s by %s sha=%s files=%d", old_rel, new_rel, author or "?", sha[:8], len(moves)
@@ -461,8 +482,30 @@ def delete_document_by_path(
         # Drops FTS / ACL / comments / activity / working-dir state for each
         # removed page.
         wiki_notify.after_doc_delete(p, sha, author)
+    # Per-page fan-out stamped each page's id row; a folder delete also
+    # tombstones the folder rows themselves (the fan-out only sees .md paths).
+    doc_ids.on_deleted(rel)
     log.info("doc deleted %s (%d pages) by %s sha=%s", rel, len(md_paths), author or "?", sha[:8])
     return DeleteDocumentResponse(sha=sha)
+
+
+@router.get("/id/{doc_id}", response_model=ResolveDocIdResponse)
+def resolve_doc_id(
+    doc_id: str,
+    user: User = Depends(require_user),
+) -> ResolveDocIdResponse:
+    """Resolve a stable doc id to its current binding. ``deleted_at`` set
+    means the page/folder was deleted; ``path`` is where it lived at delete
+    time — feed it to the tombstone/restore endpoints."""
+    row = doc_ids.get(doc_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="unknown id")
+    path = str(row["path"])
+    require_can("read", path, user)
+    kind = "page" if row["kind"] == "page" else "folder"
+    return ResolveDocIdResponse(
+        id=doc_id, path=path, kind=kind, deleted_at=row["deleted_at"]
+    )
 
 
 def _restorable_paths(fate: wiki_git.PathFate) -> tuple[list[str], list[str]]:
@@ -571,6 +614,9 @@ def restore_deleted_path(
         )
     except wiki_git.UnknownSha as exc:
         raise HTTPException(status_code=404, detail="no restorable content") from exc
+    # Re-bind stable ids before the create lifecycle runs, so the fan-out's
+    # mint step finds the resurrected rows instead of minting fresh ids.
+    doc_ids.on_restored([fate.path, *files])
     for p in md_paths:
         # Create lifecycle: default-public ACLs + owner stamp, FTS reindex,
         # trigger fan-out, MCP pub-sub.

--- a/backend/app/db/migrations/versions/76caae98c2b2_wiki_doc_ids.py
+++ b/backend/app/db/migrations/versions/76caae98c2b2_wiki_doc_ids.py
@@ -1,0 +1,62 @@
+"""wiki doc ids
+
+Adds ``wiki_doc_ids`` — the stable path↔id mapping for wiki pages and
+folders. Guarded with the inspector because ``0001_initial`` builds fresh
+databases from the current models.
+
+Revision ID: 76caae98c2b2
+Revises: e4b8c61d9a73
+Create Date: 2026-07-10 20:56:21.462534+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '76caae98c2b2'
+down_revision: str | None = 'e4b8c61d9a73'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("wiki_doc_ids"):
+        return
+    op.create_table(
+        'wiki_doc_ids',
+        sa.Column('id', sa.Text(), nullable=False),
+        sa.Column('path', sa.Text(), nullable=False),
+        sa.Column('kind', sa.Text(), nullable=False),
+        sa.Column(
+            'created_at',
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.Column('deleted_at', sa.Text(), nullable=True),
+        sa.CheckConstraint("kind IN ('page', 'folder')", name='wiki_doc_ids_kind_check'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    # Unique among live rows only: tombstone rows (deleted_at set) may share
+    # a path with each other and with a later live row at the same path.
+    op.create_index(
+        'uq_wiki_doc_ids_live_path',
+        'wiki_doc_ids',
+        ['path'],
+        unique=True,
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'uq_wiki_doc_ids_live_path',
+        table_name='wiki_doc_ids',
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+    op.drop_table('wiki_doc_ids')

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1238,6 +1238,46 @@ class UpdatePolicy(Base):
     )
 
 
+class WikiDocId(Base):
+    """Stable identity for a wiki page or folder — the path↔id mapping.
+
+    **Postgres-only** metadata like ``acl_entries``: git has no native file
+    identity (renames are heuristic inference), so IDs are minted here and
+    maintained at the wiki lifecycle seams (``app/wiki/notify.py``). ``path``
+    is the page's/folder's *live* location; moves re-key it in place so the
+    id survives any reorganization.
+
+    Deletes stamp ``deleted_at`` instead of dropping the row — an id keeps
+    resolving after deletion (to the tombstone view) and a restore re-binds
+    it. A page recreated at the same path is a *new* document and gets a
+    fresh id, hence the partial unique index: ``path`` is unique among live
+    rows only, while any number of tombstone rows may share it.
+    """
+
+    __tablename__ = "wiki_doc_ids"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # "page" | "folder"
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    deleted_at: Mapped[str | None] = mapped_column(Text)
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('page', 'folder')",
+            name="wiki_doc_ids_kind_check",
+        ),
+        Index(
+            "uq_wiki_doc_ids_live_path",
+            "path",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Wiki auto-management — change proposals (Postgres-only)                     #
 # --------------------------------------------------------------------------- #

--- a/backend/app/llm/agents/tools/move_path.py
+++ b/backend/app/llm/agents/tools/move_path.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.models.wiki import PathMove
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
 from app.wiki import coedit, filesystem, git as wiki_git, notify as wiki_notify
@@ -55,7 +56,9 @@ def handle(args: dict[str, Any]) -> Any:
         sha, moves = wiki_git.move_path(
             old_rel, new_rel, commit_message.strip(), author=author
         )
-        wiki_notify.after_path_move(moves, sha, author)
+        wiki_notify.after_path_move(
+            moves, sha, author, root_move=PathMove(old=old_rel, new=new_rel)
+        )
 
         return {
             "old_path": old_rel,

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -156,6 +156,7 @@ class GetDocumentResponse(BaseModel):
     body: str
     head_sha: str | None
     ref: str | None = None  # only set when reading at a specific ref
+    id: str | None = None  # stable doc id; None on historical/deleted reads
 
 
 class PutDocumentResponse(BaseModel):
@@ -163,6 +164,20 @@ class PutDocumentResponse(BaseModel):
     sha: str
     created: bool
     deprecated: list[str]
+    id: str | None = None  # stable doc id
+
+
+class ResolveDocIdResponse(BaseModel):
+    """A stable doc id resolved to its current binding.
+
+    ``deleted_at`` set means the page/folder was deleted — the path is where
+    it lived at delete time (feed it to the tombstone/restore endpoints).
+    """
+
+    id: str
+    path: str
+    kind: Literal["page", "folder"]
+    deleted_at: str | None = None
 
 
 class CreateFolderResponse(BaseModel):

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -12,8 +12,9 @@ Three entry points:
 All three swallow exceptions so a broken OpenSearch never aborts a doc
 write or hourly sweep.  Errors are logged at WARNING level.
 
-Neither function depends on the ``documents`` table — only the git
-working tree is consulted for content and path existence.
+Content and path existence come from the git working tree only. The
+startup sweep additionally backfills ``wiki_doc_ids`` rows for pages
+that predate stable ids.
 """
 from __future__ import annotations
 
@@ -23,7 +24,7 @@ import re
 from app.db import fts
 from app.tasks.queue import crontab
 from app.tasks.queues import lightweight_maintenance_queue
-from app.wiki import git as wiki_git
+from app.wiki import doc_ids, git as wiki_git
 
 log = logging.getLogger(__name__)
 
@@ -78,6 +79,8 @@ def reindex_all_inline() -> None:
     if not paths:
         return
     log.info("reindex: indexing %d wiki page(s) at startup", len(paths))
+    # Same walk doubles as the stable-id backfill for pre-id content.
+    doc_ids.ensure_for_paths(paths)
     for path in paths:
         index_path_inline(path)
 

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -1,0 +1,206 @@
+"""Stable ids for wiki pages and folders — the ``wiki_doc_ids`` repo.
+
+Git has no native file identity, so ids are minted here (Postgres-only,
+like the ACL tables) and maintained at the wiki lifecycle seams: create
+mints, move re-keys the path in place, delete stamps ``deleted_at`` (the
+row is kept so the id still resolves — to a tombstone — and a restore
+re-binds it). A page recreated at a previously-deleted path is a new
+document with a fresh id; the partial unique index on live ``path`` rows
+enforces that at most one live row occupies a path.
+
+Backfill for pre-existing content is lazy: reads mint missing rows via
+:func:`get_or_mint`, and the hourly BM25 reconcile sweep calls
+:func:`ensure_for_paths` for recently-touched pages.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select, update
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import WikiDocId
+from app.db.session import session
+from app.models.wiki import PathMove
+from app.wiki import filesystem
+
+log = logging.getLogger(__name__)
+
+
+def _mint_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _kind_for(path: str) -> str:
+    return "page" if path.endswith(".md") else "folder"
+
+
+def _row_dict(row: WikiDocId) -> dict[str, str | None]:
+    return {
+        "id": row.id,
+        "path": row.path,
+        "kind": row.kind,
+        "created_at": row.created_at,
+        "deleted_at": row.deleted_at,
+    }
+
+
+def get(doc_id: str) -> dict[str, str | None] | None:
+    """The row for ``doc_id`` (live or tombstone), or ``None``."""
+    with session() as s:
+        row = s.get(WikiDocId, doc_id)
+        return _row_dict(row) if row else None
+
+
+def id_for_path(path: str) -> str | None:
+    """Id of the live row at ``path``, or ``None``."""
+    with session() as s:
+        row = s.execute(
+            select(WikiDocId).where(WikiDocId.path == path, WikiDocId.deleted_at.is_(None))
+        ).scalar_one_or_none()
+        return row.id if row else None
+
+
+def get_or_mint(path: str) -> str:
+    """Id of the live row at ``path``, minting one if absent.
+
+    Kind is derived from the path (``.md`` → page, else folder). Safe under
+    concurrency: a losing racer re-reads the winner's row.
+    """
+    existing = id_for_path(path)
+    if existing is not None:
+        return existing
+    new_id = _mint_id()
+    try:
+        with session() as s:
+            s.add(WikiDocId(id=new_id, path=path, kind=_kind_for(path)))
+    except IntegrityError:
+        # A concurrent writer minted first — theirs wins.
+        winner = id_for_path(path)
+        if winner is not None:
+            return winner
+        raise
+    return new_id
+
+
+def mint_for_page(path: str) -> str:
+    """Mint (or fetch) the page's id, plus rows for its ancestor folders.
+
+    Folder rows have no create hook of their own when a folder springs into
+    existence implicitly with its first page, so page creation seeds them.
+    """
+    parts = path.split("/")[:-1]
+    for i in range(1, len(parts) + 1):
+        get_or_mint("/".join(parts[:i]))
+    return get_or_mint(path)
+
+
+def ensure_for_paths(paths: list[str]) -> None:
+    """Backfill: mint live rows for any of ``paths`` that lack one. Pages
+    also seed their ancestor folders. Never raises — backfill must not
+    abort its caller (the startup reindex sweep)."""
+    for p in paths:
+        try:
+            if p.endswith(".md"):
+                mint_for_page(p)
+            else:
+                get_or_mint(p)
+        except Exception:
+            log.exception("doc_ids backfill failed for %s", p)
+
+
+def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> None:
+    """Re-key live rows so ids follow a move/rename.
+
+    Page rows are re-pointed pair-by-pair; a directory rename additionally
+    re-points the folder's own row and every nested row via prefix rewrite.
+    ``root_move`` is the rename as the caller issued it (the folder itself
+    for a directory move) — without it the folder prefix is inferred via
+    ``common_folder_rename``, which resolves to the *deepest* consistent
+    prefix and so can miss the renamed folder's own row when its files all
+    sit in one subdirectory. A page renamed *out of* ``.md``-space stops
+    being a document — its row is stamped deleted.
+    """
+    if not moves and root_move is None:
+        return
+    with session() as s:
+        for mv in moves:
+            if mv.old.endswith(".md") and mv.new.endswith(".md"):
+                s.execute(
+                    update(WikiDocId)
+                    .where(WikiDocId.path == mv.old, WikiDocId.deleted_at.is_(None))
+                    .values(path=mv.new)
+                )
+            elif mv.old.endswith(".md"):
+                s.execute(
+                    update(WikiDocId)
+                    .where(WikiDocId.path == mv.old, WikiDocId.deleted_at.is_(None))
+                    .values(deleted_at=_now_text())
+                )
+        if root_move is not None and not root_move.old.endswith(".md"):
+            old_prefix, new_prefix = root_move.old, root_move.new
+        else:
+            old_prefix, new_prefix = filesystem.common_folder_rename(moves)
+        if old_prefix is not None and new_prefix is not None:
+            s.execute(
+                update(WikiDocId)
+                .where(WikiDocId.path == old_prefix, WikiDocId.deleted_at.is_(None))
+                .values(path=new_prefix)
+            )
+            s.execute(
+                update(WikiDocId)
+                .where(
+                    WikiDocId.path.like(old_prefix + "/%"),
+                    WikiDocId.deleted_at.is_(None),
+                )
+                .values(
+                    path=func.concat(
+                        new_prefix,
+                        func.substr(WikiDocId.path, len(old_prefix) + 1),
+                    )
+                )
+            )
+
+
+def on_deleted(path: str) -> None:
+    """Stamp ``deleted_at`` on the live row at ``path`` and, for a folder,
+    every live row nested under it. Rows are kept — the id still resolves."""
+    with session() as s:
+        s.execute(
+            update(WikiDocId)
+            .where(
+                WikiDocId.deleted_at.is_(None),
+                (WikiDocId.path == path) | WikiDocId.path.like(path + "/%"),
+            )
+            .values(deleted_at=_now_text())
+        )
+
+
+def on_restored(paths: list[str]) -> None:
+    """Re-bind ids after a restore: for each path, resurrect the most
+    recently deleted tombstone row (clear ``deleted_at``) unless a live row
+    already occupies the path."""
+    with session() as s:
+        for p in paths:
+            live = s.execute(
+                select(WikiDocId.id).where(
+                    WikiDocId.path == p, WikiDocId.deleted_at.is_(None)
+                )
+            ).scalar_one_or_none()
+            if live is not None:
+                continue
+            row = s.execute(
+                select(WikiDocId)
+                .where(WikiDocId.path == p, WikiDocId.deleted_at.is_not(None))
+                .order_by(WikiDocId.deleted_at.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+            if row is not None:
+                row.deleted_at = None

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -38,7 +38,7 @@ from app.tasks.reindex import index_path
 from app.tasks.triggers import fan_out_trigger_eval
 from app.tasks.update_frequency import check_update_frequency
 from app.triggers import repo as triggers_repo
-from app.wiki import acl, agent_activity, coedit, comments, constants as wiki_constants, drafts, update_policy
+from app.wiki import acl, agent_activity, coedit, comments, constants as wiki_constants, doc_ids, drafts, update_policy
 from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind, PathMove
 
@@ -88,6 +88,8 @@ def after_doc_write(
         return
     if change_kind == ChangeKind.CREATE:
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
+        # Stable id for the new page (+ any implicitly-created ancestor folders).
+        doc_ids.mint_for_page(rel_path)
     index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
     # Ingestion churn → check the page's 24h update frequency against the
@@ -137,6 +139,9 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     fts.delete_document(rel_path)
     acl.on_page_deleted(rel_path)
     update_policy.on_page_deleted(rel_path)
+    # Stable id survives as a tombstone row (delete stamps, never drops) so
+    # id URLs keep resolving and a restore re-binds the same id.
+    doc_ids.on_deleted(rel_path)
     # The body is gone, so there's nothing to re-anchor against — orphan the
     # page's comments (keeps them as tombstones) rather than dropping them.
     comments.orphan_all_for_doc(rel_path)
@@ -152,7 +157,11 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
 
 
 def after_path_move(
-    moves: list[PathMove], sha: str, actor: str | None
+    moves: list[PathMove],
+    sha: str,
+    actor: str | None,
+    *,
+    root_move: PathMove | None = None,
 ) -> None:
     """Post-move side effects for every ``(old, new)`` pair from a single
     ``git mv`` commit.
@@ -186,6 +195,10 @@ def after_path_move(
     """
     acl.on_path_moved(moves)
     update_policy.on_path_moved(moves)
+    # root_move (the rename as issued — the folder itself for a directory
+    # move) lets doc_ids re-key the renamed folder's own row even when
+    # common_folder_rename can't see it from the file moves alone.
+    doc_ids.on_path_moved(moves, root_move=root_move)
     coedit.on_path_moved(moves)
     list_changed = False
     for mv in moves:

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -134,6 +134,26 @@ def test_folder_delete_tombstones_folder_and_nested_ids(tmp_repo):
     assert doc_ids.id_for_path("proj/a.md") == page_id
 
 
+def test_nested_folder_ids_survive_delete_restore(tmp_repo):
+    # Two-level layout: the intermediate folder proj/sub has its own id row,
+    # which restore must resurrect rather than let mint_for_page mint fresh.
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"}
+    ).json()["id"]
+    proj_id = doc_ids.id_for_path("proj")
+    sub_id = doc_ids.id_for_path("proj/sub")
+    assert proj_id is not None and sub_id is not None
+
+    client.delete("/api/wiki/file?path=proj")
+    client.post("/api/wiki/file/restore", json={"path": "proj"})
+
+    assert doc_ids.id_for_path("proj") == proj_id
+    assert doc_ids.id_for_path("proj/sub") == sub_id
+    assert doc_ids.id_for_path("proj/sub/a.md") == page_id
+
+
 def test_read_by_id_and_lazy_backfill(tmp_repo):
     user = seed_user()
     client = _client(user)

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -1,0 +1,158 @@
+"""Stable doc ids: minted on create, follow moves, survive delete/restore.
+
+The ``wiki_doc_ids`` mapping is maintained at the lifecycle seams
+(``notify.after_doc_write/after_path_move/after_doc_delete`` + the folder
+routes). A delete stamps ``deleted_at`` instead of dropping the row, so the
+id still resolves and a restore re-binds it; a page recreated at the same
+path is a new document with a fresh id.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import doc_ids
+from app.wiki import git as wiki_git
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _client(user_id: str) -> TestClient:
+    client = TestClient(create_app())
+    login_fastapi(client, user_id)
+    return client
+
+
+def test_id_minted_on_create_and_stable_across_edits(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+
+    created = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"})
+    assert created.status_code == 200
+    doc_id = created.json()["id"]
+    assert doc_id
+
+    edited = client.put(
+        "/api/wiki/file", json={"path": "a.md", "body": "# A2\n"}
+    )
+    assert edited.json()["id"] == doc_id
+    assert client.get("/api/wiki/file?path=a.md").json()["id"] == doc_id
+
+
+def test_page_create_seeds_ancestor_folder_ids(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"})
+
+    assert doc_ids.id_for_path("proj") is not None
+    assert doc_ids.id_for_path("proj/sub") is not None
+
+
+def test_id_follows_file_move(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    doc_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"}).json()["id"]
+
+    resp = client.post("/api/wiki/move", json={"old_path": "a.md", "new_path": "docs/b.md"})
+    assert resp.status_code == 200
+
+    assert doc_ids.id_for_path("docs/b.md") == doc_id
+    assert doc_ids.id_for_path("a.md") is None
+    resolved = client.get(f"/api/wiki/id/{doc_id}").json()
+    assert resolved["path"] == "docs/b.md"
+    assert resolved["deleted_at"] is None
+
+
+def test_ids_follow_folder_move(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"}
+    ).json()["id"]
+    folder_id = doc_ids.id_for_path("proj")
+    sub_id = doc_ids.id_for_path("proj/sub")
+
+    resp = client.post("/api/wiki/move", json={"old_path": "proj", "new_path": "proj2"})
+    assert resp.status_code == 200
+
+    assert doc_ids.id_for_path("proj2") == folder_id
+    assert doc_ids.id_for_path("proj2/sub") == sub_id
+    assert doc_ids.id_for_path("proj2/sub/a.md") == page_id
+
+
+def test_delete_keeps_id_as_tombstone_and_restore_rebinds(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    doc_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"}).json()["id"]
+
+    assert client.delete("/api/wiki/file?path=a.md").status_code == 200
+
+    resolved = client.get(f"/api/wiki/id/{doc_id}").json()
+    assert resolved["path"] == "a.md"
+    assert resolved["deleted_at"] is not None
+    assert doc_ids.id_for_path("a.md") is None
+
+    assert client.post("/api/wiki/file/restore", json={"path": "a.md"}).status_code == 200
+    assert doc_ids.id_for_path("a.md") == doc_id
+    assert client.get(f"/api/wiki/id/{doc_id}").json()["deleted_at"] is None
+
+
+def test_recreate_at_deleted_path_gets_fresh_id(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    old_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"}).json()["id"]
+    client.delete("/api/wiki/file?path=a.md")
+
+    new_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# fresh\n"}).json()["id"]
+
+    assert new_id != old_id
+    # The old id still resolves — to its tombstone, not the new page.
+    old = client.get(f"/api/wiki/id/{old_id}").json()
+    assert old["deleted_at"] is not None
+    assert client.get(f"/api/wiki/id/{new_id}").json()["deleted_at"] is None
+
+
+def test_folder_delete_tombstones_folder_and_nested_ids(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"}
+    ).json()["id"]
+    folder_id = doc_ids.id_for_path("proj")
+    assert folder_id is not None
+
+    client.delete("/api/wiki/file?path=proj")
+
+    assert doc_ids.id_for_path("proj") is None
+    assert client.get(f"/api/wiki/id/{folder_id}").json()["deleted_at"] is not None
+    assert client.get(f"/api/wiki/id/{page_id}").json()["deleted_at"] is not None
+
+    # Folder restore re-binds the folder and page ids alike.
+    client.post("/api/wiki/file/restore", json={"path": "proj"})
+    assert doc_ids.id_for_path("proj") == folder_id
+    assert doc_ids.id_for_path("proj/a.md") == page_id
+
+
+def test_read_by_id_and_lazy_backfill(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    # Seed outside the API — no lifecycle hook, so no id row yet (pre-id page).
+    wiki_git.commit_file("legacy.md", "# Legacy\n", "seed")
+    assert doc_ids.id_for_path("legacy.md") is None
+
+    read = client.get("/api/wiki/file?path=legacy.md")
+    doc_id = read.json()["id"]
+    assert doc_id  # reading minted the row
+
+    by_id = client.get(f"/api/wiki/file?id={doc_id}")
+    assert by_id.status_code == 200
+    assert by_id.json()["path"] == "legacy.md"
+    assert by_id.json()["body"] == "# Legacy\n"
+
+
+def test_resolve_unknown_id_404(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    assert client.get("/api/wiki/id/deadbeefdeadbeef").status_code == 404
+    assert client.get("/api/wiki/file?id=deadbeefdeadbeef").status_code == 404


### PR DESCRIPTION
> Stacked on #374 (deleted-page tombstone + restore) — review that first; this PR's restore integration builds on it.

## Problem

Every wiki URL, ACL row, comment anchor, and trigger scope is keyed by *path*, so every move/rename rots links (other wiki pages, Slack, agent memory). Git has no native file identity — renames are heuristic inference at diff time — so a stable identity has to be minted and maintained by the app.

## What this adds (backend only)

**`wiki_doc_ids` table** — `id` (16-hex random), `path`, `kind` (page/folder), `created_at`, `deleted_at`. Unique index on `path` **among live rows only**: deletes stamp `deleted_at` instead of dropping, so an id keeps resolving after deletion (to the tombstone) and a restore re-binds it, while a page recreated at the same path is a new document with a fresh id.

**Lifecycle wiring** (`app/wiki/doc_ids.py`, called from the seams that already exist):
- create (`after_doc_write`) mints the page's id + rows for implicitly-created ancestor folders; `POST /folder` mints for explicit folders
- move (`after_path_move`) re-keys rows in place. The move callers now pass an explicit `root_move` — `common_folder_rename` resolves to the *deepest* consistent prefix and can miss the renamed folder's own row when its files all sit in one subdirectory
- delete stamps `deleted_at` (folder deletes tombstone the folder rows too); a page renamed out of `.md`-space is stamped deleted
- restore (#374) re-binds the resurrected paths' most recent tombstone rows before the create lifecycle runs

**API**: `GET /api/wiki/id/{id}` resolves `{id, path, kind, deleted_at}` (deleted ids resolve — feed the path to the tombstone/restore endpoints); `GET /wiki/file` accepts `?id=` and returns `id`; `PUT /wiki/file` returns `id`.

**Backfill**: lazy — reads mint missing rows on the fly, and the startup `reindex_all_inline` sweep mints for every existing page (+ ancestors). No alembic backfill (migrations don't touch the wiki volume). Migration is inspector-guarded like `change_proposals` since `0001_initial` builds fresh DBs from current models.

## Non-goals (tracked in the design doc)

Re-keying the existing path-keyed tables (ACL/comments/policies/triggers) by id — that's the DB-primary-store discussion in the enterprise-scale track. IDs land as an alias first. Frontend id-first URLs (`/app/wiki/<id>/<slug>`) come in a stacked PR.

Design doc: wiki page `Engineering Projects/Agent Wiki Project/design/Stable Doc IDs.md` (covers why Postgres mapping over frontmatter ids).

## Testing

9 new tests in `tests/test_doc_ids.py`: mint-on-create + stability across edits, ancestor-folder seeding, id follows file and folder moves (including the folder-own-row case), delete→tombstone→restore re-bind, fresh id on recreate-at-deleted-path, folder delete/restore, read-by-id + lazy backfill, unknown-id 404s. Full backend suite passes; ruff + basedpyright clean.