### PR TITLE
feat(ingest): page-embedding foundation for the relevance filter (Phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 .venv/
+.venv
 venv/
 .pytest_cache/
 .mypy_cache/

--- a/backend/.venv
+++ b/backend/.venv
@@ -1,0 +1,1 @@
+/Users/boyang/Projects/agent-wiki/backend/.venv

--- a/backend/.venv
+++ b/backend/.venv
@@ -1,1 +1,0 @@
-/Users/boyang/Projects/agent-wiki/backend/.venv

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,6 +64,13 @@ class Config(BaseModel):
     ingest_bm25_limit: int
     ingest_irrelevant_stop_n: int
 
+    # Relevance-filter embeddings (Phase 0). Off by default: when enabled, the
+    # reindex path embeds page bodies into ``page_embeddings`` (adds OpenAI cost
+    # on commits). No ingestion behavior change — the store is populated for the
+    # cosine cold-start / two-tower warm filter that lands in later phases.
+    ingest_embeddings_enabled: bool
+    ingest_embed_model: str
+
     # Opt-in eval logging — captures reconciler inputs/outputs to ingest_eval_samples
     ingest_eval_logging: bool
     # Retention for ingest_eval_samples, in days; rows older than this are pruned
@@ -170,6 +177,9 @@ def load_config() -> Config:
         ingest_bm25_title_boost=_positive_float("INGEST_BM25_TITLE_BOOST", 2.0),
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),
         ingest_irrelevant_stop_n=_positive_int("INGEST_IRRELEVANT_STOP_N", 2),
+        ingest_embeddings_enabled=os.environ.get("INGEST_EMBEDDINGS_ENABLED", "false").lower()
+        in {"1", "true", "yes"},
+        ingest_embed_model=os.environ.get("INGEST_EMBED_MODEL", "text-embedding-3-small"),
         auth_mode=os.environ.get("AUTH_MODE", "basic"),
         oidc_issuer=os.environ.get("OIDC_ISSUER", ""),
         oidc_client_id=os.environ.get("OIDC_CLIENT_ID", ""),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,11 +64,11 @@ class Config(BaseModel):
     ingest_bm25_limit: int
     ingest_irrelevant_stop_n: int
 
-    # Relevance-filter embeddings (Phase 0). Off by default: when enabled, the
-    # reindex path embeds page bodies into ``page_embeddings`` (adds OpenAI cost
-    # on commits). No ingestion behavior change — the store is populated for the
-    # cosine cold-start / two-tower warm filter that lands in later phases.
-    ingest_embeddings_enabled: bool
+    # Relevance-filter embeddings (Phase 0): the model used to embed page/doc
+    # bodies into ``page_embeddings``. Active whenever an OpenAI key is
+    # configured (no separate enable flag) — a deployment without one is a
+    # no-op. Populates the store for the cosine cold-start / two-tower warm
+    # filter that lands in later phases.
     ingest_embed_model: str
 
     # Opt-in eval logging — captures reconciler inputs/outputs to ingest_eval_samples
@@ -177,8 +177,6 @@ def load_config() -> Config:
         ingest_bm25_title_boost=_positive_float("INGEST_BM25_TITLE_BOOST", 2.0),
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),
         ingest_irrelevant_stop_n=_positive_int("INGEST_IRRELEVANT_STOP_N", 2),
-        ingest_embeddings_enabled=os.environ.get("INGEST_EMBEDDINGS_ENABLED", "false").lower()
-        in {"1", "true", "yes"},
         ingest_embed_model=os.environ.get("INGEST_EMBED_MODEL", "text-embedding-3-small"),
         auth_mode=os.environ.get("AUTH_MODE", "basic"),
         oidc_issuer=os.environ.get("OIDC_ISSUER", ""),

--- a/backend/app/db/migrations/versions/b7f3c1a9d2e4_page_embeddings.py
+++ b/backend/app/db/migrations/versions/b7f3c1a9d2e4_page_embeddings.py
@@ -1,9 +1,9 @@
 """page embeddings
 
 Adds ``page_embeddings`` — the per-page embedding-vector store for the
-ingestion relevance filter (Phase 0). Durable storage only; scoring runs
-against an in-worker matrix built from these rows. Guarded with the inspector
-because ``0001_initial`` builds fresh databases from the current models.
+ingestion relevance filter. Durable storage only; scoring runs against an
+in-worker matrix built from these rows. Guarded with the inspector because
+``0001_initial`` builds fresh databases from the current models.
 
 Revision ID: b7f3c1a9d2e4
 Revises: e4b8c61d9a73

--- a/backend/app/db/migrations/versions/b7f3c1a9d2e4_page_embeddings.py
+++ b/backend/app/db/migrations/versions/b7f3c1a9d2e4_page_embeddings.py
@@ -1,0 +1,50 @@
+"""page embeddings
+
+Adds ``page_embeddings`` — the per-page embedding-vector store for the
+ingestion relevance filter (Phase 0). Durable storage only; scoring runs
+against an in-worker matrix built from these rows. Guarded with the inspector
+because ``0001_initial`` builds fresh databases from the current models.
+
+Revision ID: b7f3c1a9d2e4
+Revises: e4b8c61d9a73
+Create Date: 2026-07-13 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'b7f3c1a9d2e4'
+down_revision: str | None = 'e4b8c61d9a73'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("page_embeddings"):
+        return
+    op.create_table(
+        'page_embeddings',
+        sa.Column('path', sa.Text(), nullable=False),
+        sa.Column('content_sha256', sa.Text(), nullable=False),
+        sa.Column('model', sa.Text(), nullable=False),
+        sa.Column('vector', sa.LargeBinary(), nullable=False),
+        sa.Column(
+            'updated_at',
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint('path'),
+    )
+    op.create_index('ix_page_embeddings_updated_at', 'page_embeddings', ['updated_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_page_embeddings_updated_at', table_name='page_embeddings')
+    op.drop_table('page_embeddings')

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -824,6 +824,36 @@ class IngestSettings(Base):
     __table_args__ = (CheckConstraint("id = 1", name="ingest_settings_singleton"),)
 
 
+class PageEmbedding(Base):
+    """Per-page embedding vector for the ingestion relevance filter (Phase 0).
+
+    Durable store for the raw embedding of each ``.md`` page body. Postgres
+    never computes similarity — scoring runs against an in-worker matrix loaded
+    from these rows; the DB only stores/loads. Path-keyed so it follows page
+    moves/deletes like other live rows. Written best-effort from the reindex
+    path (``app.tasks.reindex``); read by ``app.db.page_embeddings``.
+    """
+
+    __tablename__ = "page_embeddings"
+
+    # Wiki-relative page path; also the OpenSearch ``_id`` and the natural key.
+    path: Mapped[str] = mapped_column(Text, primary_key=True)
+    # sha256 of the (capped) page body — re-embed guard for unchanged bodies.
+    content_sha256: Mapped[str] = mapped_column(Text, nullable=False)
+    # Embedding model id (e.g. "text-embedding-3-small"); vectors are
+    # model-specific, so a model change is a full re-embed backfill.
+    model: Mapped[str] = mapped_column(Text, nullable=False)
+    # Raw vector, packed float32 (app.llm.embeddings.pack/unpack).
+    vector: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    # ISO timestamp; indexed so the in-worker cache can refresh incrementally
+    # (rows with updated_at > cursor) instead of reloading everything.
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (Index("ix_page_embeddings_updated_at", "updated_at"),)
+
+
 class BraintrustSettings(Base):
     __tablename__ = "braintrust_settings"
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -825,7 +825,7 @@ class IngestSettings(Base):
 
 
 class PageEmbedding(Base):
-    """Per-page embedding vector for the ingestion relevance filter (Phase 0).
+    """Per-page embedding vector for the ingestion relevance filter.
 
     Durable store for the raw embedding of each ``.md`` page body. Postgres
     never computes similarity — scoring runs against an in-worker matrix loaded

--- a/backend/app/db/page_embeddings.py
+++ b/backend/app/db/page_embeddings.py
@@ -1,4 +1,4 @@
-"""Postgres store for wiki page embeddings (Phase 0 relevance-filter foundation).
+"""Postgres store for wiki page embeddings (ingestion relevance filter).
 
 Durable storage only — Postgres never computes similarity (no pgvector). The
 filter scores an incoming doc against *every* page, so scoring runs against an

--- a/backend/app/db/page_embeddings.py
+++ b/backend/app/db/page_embeddings.py
@@ -11,11 +11,21 @@ is swallowed there so it never aborts a doc commit.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import NamedTuple
 
 from sqlalchemy import delete as sa_delete, select
 
 from app.db.models import PageEmbedding
 from app.db.session import session
+
+
+class PageVector(NamedTuple):
+    """A page's stored embedding: its wiki path and the packed float32 vector
+    (unpack with ``app.llm.embeddings.unpack``). The unit :func:`load_all`
+    returns to build the in-worker scoring matrix."""
+
+    path: str
+    vector: bytes
 
 
 def _now() -> str:
@@ -59,12 +69,12 @@ def delete(path: str) -> None:
         s.execute(sa_delete(PageEmbedding).where(PageEmbedding.path == path))
 
 
-def load_all(model: str | None = None) -> list[tuple[str, bytes]]:
-    """``(path, packed-vector)`` for all rows, optionally filtered to a
-    single embedding ``model``. Builds the in-worker scoring matrix — a cold
-    load / periodic refresh, never the per-document hot path."""
+def load_all(model: str | None = None) -> list[PageVector]:
+    """All stored page vectors, optionally filtered to a single embedding
+    ``model``. Builds the in-worker scoring matrix — a cold load / periodic
+    refresh, never the per-document hot path."""
     with session() as s:
         stmt = select(PageEmbedding.path, PageEmbedding.vector)
         if model:
             stmt = stmt.where(PageEmbedding.model == model)
-        return [(path, bytes(vec)) for path, vec in s.execute(stmt)]
+        return [PageVector(path, bytes(vec)) for path, vec in s.execute(stmt)]

--- a/backend/app/db/page_embeddings.py
+++ b/backend/app/db/page_embeddings.py
@@ -1,0 +1,70 @@
+"""Postgres store for wiki page embeddings (Phase 0 relevance-filter foundation).
+
+Durable storage only — Postgres never computes similarity (no pgvector). The
+filter scores an incoming doc against *every* page, so scoring runs against an
+in-worker matrix built from :func:`load_all`; this module just persists and
+loads the raw vectors (packed float32 via ``app.llm.embeddings.pack``).
+
+Callers (the reindex path) invoke these best-effort — a store glitch logs and
+is swallowed there so it never aborts a doc commit.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import delete as sa_delete, select
+
+from app.db.models import PageEmbedding
+from app.db.session import session
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def get_sha(path: str) -> str | None:
+    """Stored content hash for ``path`` (or ``None`` if not stored) — the
+    re-embed guard: skip re-embedding a page whose body is unchanged."""
+    with session() as s:
+        row = s.get(PageEmbedding, path)
+        return row.content_sha256 if row else None
+
+
+def all_shas() -> dict[str, str]:
+    """``path -> content_sha256`` for every stored page. Cheap (no vectors);
+    used by backfill / reconcile to find missing or stale pages."""
+    with session() as s:
+        return {
+            path: sha
+            for path, sha in s.execute(
+                select(PageEmbedding.path, PageEmbedding.content_sha256)
+            )
+        }
+
+
+def upsert(path: str, content_sha256: str, model: str, vector: bytes) -> None:
+    with session() as s:
+        row = s.get(PageEmbedding, path)
+        if row is None:
+            row = PageEmbedding(path=path)
+            s.add(row)
+        row.content_sha256 = content_sha256
+        row.model = model
+        row.vector = vector
+        row.updated_at = _now()
+
+
+def delete(path: str) -> None:
+    with session() as s:
+        s.execute(sa_delete(PageEmbedding).where(PageEmbedding.path == path))
+
+
+def load_all(model: str | None = None) -> list[tuple[str, bytes]]:
+    """``(path, packed-vector)`` for all rows, optionally filtered to a
+    single embedding ``model``. Builds the in-worker scoring matrix — a cold
+    load / periodic refresh, never the per-document hot path."""
+    with session() as s:
+        stmt = select(PageEmbedding.path, PageEmbedding.vector)
+        if model:
+            stmt = stmt.where(PageEmbedding.model == model)
+        return [(path, bytes(vec)) for path, vec in s.execute(stmt)]

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -1,4 +1,4 @@
-"""OpenAI embeddings for the ingestion relevance filter (Phase 0).
+"""OpenAI embeddings for the ingestion relevance filter.
 
 Best-effort, like ``app.db.fts``: any failure logs at WARNING and returns
 ``None`` so an embedding glitch never aborts a doc commit or the reindex
@@ -8,8 +8,7 @@ fallback), matching the chat providers.
 Vectors are ``text-embedding-3-small`` (1536-d), content-capped to match the
 offline model-selection study so production vectors are distributed like the
 vectors the cosine / model thresholds were calibrated on. Gated on the OpenAI
-key alone (:func:`available`): a deployment without one is a no-op, so this
-module changes no behavior until an OpenAI provider is configured.
+key alone (:func:`available`): a deployment without one is a no-op.
 """
 from __future__ import annotations
 

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -7,9 +7,9 @@ fallback), matching the chat providers.
 
 Vectors are ``text-embedding-3-small`` (1536-d), content-capped to match the
 offline model-selection study so production vectors are distributed like the
-vectors the cosine / model thresholds were calibrated on. Everything here is
-gated behind ``CONFIG.ingest_embeddings_enabled`` (default off), so importing
-or shipping this module changes no behavior until an operator opts in.
+vectors the cosine / model thresholds were calibrated on. Gated on the OpenAI
+key alone (:func:`available`): a deployment without one is a no-op, so this
+module changes no behavior until an OpenAI provider is configured.
 """
 from __future__ import annotations
 
@@ -71,18 +71,21 @@ def _api_key() -> str:
 
 
 def available() -> bool:
-    """True when embeddings are enabled *and* an OpenAI key is configured."""
-    return bool(CONFIG.ingest_embeddings_enabled) and bool(_api_key())
+    """True when an OpenAI key is configured. Embeddings are gated on the key
+    alone — there's no separate enable flag; a deployment with an OpenAI key
+    (the same one the chat providers use) gets page/doc embeddings, one without
+    is a no-op."""
+    return bool(_api_key())
 
 
 def embed_texts(texts: list[str]) -> list[list[float]] | None:
     """Embed a batch of texts.
 
     Returns one vector per input (same order), or ``None`` on any failure and
-    when embeddings are disabled / unconfigured. Never raises — callers treat
-    ``None`` as "no vector this time" and fall back (stale vector / skip).
+    when no OpenAI key is configured. Never raises — callers treat ``None`` as
+    "no vector this time" and fall back (stale vector / skip).
     """
-    if not CONFIG.ingest_embeddings_enabled or not texts:
+    if not texts:
         return None
     key = _api_key()
     if not key:

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -98,7 +98,11 @@ def embed_texts(texts: list[str]) -> list[list[float]] | None:
             # OpenAI rejects empty strings; substitute a space.
             chunk = [t if t else " " for t in texts[i : i + _BATCH]]
             resp = client.embeddings.create(model=model, input=chunk)
-            out.extend(list(d.embedding) for d in resp.data)
+            # The API does not guarantee resp.data is in input order; each item
+            # carries its input position in ``.index``. Order by it so vector[i]
+            # aligns to texts[i] — otherwise a batch could silently mis-assign a
+            # page's vector to another page.
+            out.extend(list(d.embedding) for d in sorted(resp.data, key=lambda d: d.index))
         return out
     except Exception:
         log.warning("embeddings: embed_texts failed for %d text(s)", len(texts), exc_info=True)

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -16,12 +16,10 @@ from __future__ import annotations
 import hashlib
 import logging
 from array import array
-from functools import lru_cache
-
-from openai import OpenAI
 
 from app.config import CONFIG
 from app.llm import settings as llm_settings
+from app.llm.providers import openai as openai_provider
 
 log = logging.getLogger(__name__)
 
@@ -57,11 +55,6 @@ def unpack(blob: bytes) -> list[float]:
     return a.tolist()
 
 
-@lru_cache(maxsize=4)
-def _client(api_key: str) -> OpenAI:
-    return OpenAI(api_key=api_key)
-
-
 def _api_key() -> str:
     try:
         return llm_settings.get().openai_api_key or ""
@@ -90,19 +83,11 @@ def embed_texts(texts: list[str]) -> list[list[float]] | None:
     key = _api_key()
     if not key:
         return None
-    client = _client(key)
     model = model_name()
     out: list[list[float]] = []
     try:
         for i in range(0, len(texts), _BATCH):
-            # OpenAI rejects empty strings; substitute a space.
-            chunk = [t if t else " " for t in texts[i : i + _BATCH]]
-            resp = client.embeddings.create(model=model, input=chunk)
-            # The API does not guarantee resp.data is in input order; each item
-            # carries its input position in ``.index``. Order by it so vector[i]
-            # aligns to texts[i] — otherwise a batch could silently mis-assign a
-            # page's vector to another page.
-            out.extend(list(d.embedding) for d in sorted(resp.data, key=lambda d: d.index))
+            out.extend(openai_provider.embed(key, model, texts[i : i + _BATCH]))
         return out
     except Exception:
         log.warning("embeddings: embed_texts failed for %d text(s)", len(texts), exc_info=True)

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -1,0 +1,108 @@
+"""OpenAI embeddings for the ingestion relevance filter (Phase 0).
+
+Best-effort, like ``app.db.fts``: any failure logs at WARNING and returns
+``None`` so an embedding glitch never aborts a doc commit or the reindex
+sweep. The OpenAI key is the admin-configured one in ``llm_settings`` (no env
+fallback), matching the chat providers.
+
+Vectors are ``text-embedding-3-small`` (1536-d), content-capped to match the
+offline model-selection study so production vectors are distributed like the
+vectors the cosine / model thresholds were calibrated on. Everything here is
+gated behind ``CONFIG.ingest_embeddings_enabled`` (default off), so importing
+or shipping this module changes no behavior until an operator opts in.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from array import array
+from functools import lru_cache
+
+from openai import OpenAI
+
+from app.config import CONFIG
+from app.llm import settings as llm_settings
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "text-embedding-3-small"
+EMBED_DIM = 1536
+
+# Char caps mirror the eval so production vectors match the calibrated
+# thresholds: incoming doc content ~8k, wiki page body ~24k.
+DOC_CHAR_CAP = 8_000
+PAGE_CHAR_CAP = 24_000
+
+_BATCH = 128
+
+
+def model_name() -> str:
+    return CONFIG.ingest_embed_model or DEFAULT_MODEL
+
+
+def content_sha256(text: str) -> str:
+    """Stable content hash — the re-embed guard (skip unchanged bodies)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def pack(vec: list[float]) -> bytes:
+    """Pack a float vector to bytes for the ``bytea`` column (float32)."""
+    return array("f", vec).tobytes()
+
+
+def unpack(blob: bytes) -> list[float]:
+    """Inverse of :func:`pack`."""
+    a = array("f")
+    a.frombytes(blob)
+    return a.tolist()
+
+
+@lru_cache(maxsize=4)
+def _client(api_key: str) -> OpenAI:
+    return OpenAI(api_key=api_key)
+
+
+def _api_key() -> str:
+    try:
+        return llm_settings.get().openai_api_key or ""
+    except Exception:
+        log.warning("embeddings: could not read llm_settings", exc_info=True)
+        return ""
+
+
+def available() -> bool:
+    """True when embeddings are enabled *and* an OpenAI key is configured."""
+    return bool(CONFIG.ingest_embeddings_enabled) and bool(_api_key())
+
+
+def embed_texts(texts: list[str]) -> list[list[float]] | None:
+    """Embed a batch of texts.
+
+    Returns one vector per input (same order), or ``None`` on any failure and
+    when embeddings are disabled / unconfigured. Never raises — callers treat
+    ``None`` as "no vector this time" and fall back (stale vector / skip).
+    """
+    if not CONFIG.ingest_embeddings_enabled or not texts:
+        return None
+    key = _api_key()
+    if not key:
+        return None
+    client = _client(key)
+    model = model_name()
+    out: list[list[float]] = []
+    try:
+        for i in range(0, len(texts), _BATCH):
+            # OpenAI rejects empty strings; substitute a space.
+            chunk = [t if t else " " for t in texts[i : i + _BATCH]]
+            resp = client.embeddings.create(model=model, input=chunk)
+            out.extend(list(d.embedding) for d in resp.data)
+        return out
+    except Exception:
+        log.warning("embeddings: embed_texts failed for %d text(s)", len(texts), exc_info=True)
+        return None
+
+
+def embed_text(text: str) -> list[float] | None:
+    """Embed a single text. ``None`` on failure / disabled / unconfigured."""
+    res = embed_texts([text])
+    return res[0] if res else None

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -30,6 +30,22 @@ def _client(api_key: str) -> OpenAI:
     return OpenAI(api_key=api_key)
 
 
+def embed(api_key: str, model: str, inputs: list[str]) -> list[list[float]]:
+    """One embedding vector per input, ordered to match ``inputs``.
+
+    The SDK call surface for embeddings lives here (with the rest of the OpenAI
+    provider) so no module above ``providers/`` imports the SDK. Reuses the same
+    cached ``_client`` as chat, so there's a single client-construction path.
+
+    OpenAI rejects empty strings, so blanks are sent as a space. The API may
+    return items out of order; each carries its input position in ``.index``,
+    so results are sorted by it before extraction.
+    """
+    payload = [t if t else " " for t in inputs]
+    resp = cast(Any, _client(api_key)).embeddings.create(model=model, input=payload)
+    return [list(d.embedding) for d in sorted(resp.data, key=lambda d: d.index)]
+
+
 class OpenAIProvider:
     name = "openai"
 

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import logging
 import re
 
-from app.config import CONFIG
 from app.db import fts, page_embeddings
 from app.llm import embeddings
 from app.tasks.queue import crontab
@@ -42,14 +41,14 @@ def _extract_title(body: str) -> str:
 # Page embeddings (Phase 0 relevance-filter foundation)                       #
 #                                                                             #
 # Ride the reindex path: the same walk that keeps OpenSearch fresh keeps the  #
-# per-page embedding store fresh. All best-effort and gated behind            #
-# CONFIG.ingest_embeddings_enabled — a failure (or the feature being off)     #
-# never affects BM25 indexing or a doc commit.                                #
+# per-page embedding store fresh. All best-effort and gated on an OpenAI key  #
+# (embeddings.available()) — a failure (or no key configured) never affects   #
+# BM25 indexing or a doc commit.                                              #
 # --------------------------------------------------------------------------- #
 
 
 def _embed_page(path: str, body: str) -> None:
-    """Embed a page body into ``page_embeddings`` when enabled + configured.
+    """Embed a page body into ``page_embeddings`` when an OpenAI key is configured.
 
     Skips re-embedding when the (capped) body hash is unchanged, so ordinary
     commits and the hourly sweep don't re-hit the embedding API for pages that
@@ -70,9 +69,9 @@ def _embed_page(path: str, body: str) -> None:
 
 
 def drop_page_embedding(path: str) -> None:
-    """Remove a page's stored embedding (page delete / move-away). Best-effort
-    and gated; a no-op when the feature was never enabled."""
-    if not CONFIG.ingest_embeddings_enabled:
+    """Remove a page's stored embedding (page delete / move-away). Best-effort;
+    a no-op when no OpenAI key is configured (nothing was ever stored)."""
+    if not embeddings.available():
         return
     try:
         page_embeddings.delete(path)

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import logging
 import re
 
-from app.db import fts
+from app.config import CONFIG
+from app.db import fts, page_embeddings
+from app.llm import embeddings
 from app.tasks.queue import crontab
 from app.tasks.queues import lightweight_maintenance_queue
 from app.wiki import git as wiki_git
@@ -34,6 +36,48 @@ def _extract_title(body: str) -> str:
     """Return the first # or ## heading, or empty string."""
     m = _H1_RE.search(body)
     return m.group(1).strip() if m else ""
+
+
+# --------------------------------------------------------------------------- #
+# Page embeddings (Phase 0 relevance-filter foundation)                       #
+#                                                                             #
+# Ride the reindex path: the same walk that keeps OpenSearch fresh keeps the  #
+# per-page embedding store fresh. All best-effort and gated behind            #
+# CONFIG.ingest_embeddings_enabled — a failure (or the feature being off)     #
+# never affects BM25 indexing or a doc commit.                                #
+# --------------------------------------------------------------------------- #
+
+
+def _embed_page(path: str, body: str) -> None:
+    """Embed a page body into ``page_embeddings`` when enabled + configured.
+
+    Skips re-embedding when the (capped) body hash is unchanged, so ordinary
+    commits and the hourly sweep don't re-hit the embedding API for pages that
+    didn't change. Swallows all errors."""
+    if not embeddings.available():
+        return
+    try:
+        capped = body[: embeddings.PAGE_CHAR_CAP]
+        sha = embeddings.content_sha256(capped)
+        if page_embeddings.get_sha(path) == sha:
+            return  # unchanged — skip re-embed
+        vec = embeddings.embed_text(capped)
+        if vec is None:
+            return
+        page_embeddings.upsert(path, sha, embeddings.model_name(), embeddings.pack(vec))
+    except Exception:
+        log.warning("reindex: embedding page %s failed", path, exc_info=True)
+
+
+def drop_page_embedding(path: str) -> None:
+    """Remove a page's stored embedding (page delete / move-away). Best-effort
+    and gated; a no-op when the feature was never enabled."""
+    if not CONFIG.ingest_embeddings_enabled:
+        return
+    try:
+        page_embeddings.delete(path)
+    except Exception:
+        log.warning("reindex: dropping embedding for %s failed", path, exc_info=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -55,9 +99,11 @@ def index_path_inline(path: str) -> None:
     except Exception:
         log.warning("index_path_inline: could not read %s, removing from index", path)
         fts.delete_document(path)
+        drop_page_embedding(path)
         return
 
     fts.upsert_document(path, path, _extract_title(body), body)
+    _embed_page(path, body)
 
 
 # --------------------------------------------------------------------------- #
@@ -93,5 +139,6 @@ def reconcile_bm25_index() -> None:
         try:
             body = wiki_git.read_file(path)
             fts.upsert_document(path, path, _extract_title(body), body)
+            _embed_page(path, body)
         except Exception:
             log.warning("reconcile_bm25_index: failed to reindex %s", path, exc_info=True)

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -38,7 +38,7 @@ def _extract_title(body: str) -> str:
 
 
 # --------------------------------------------------------------------------- #
-# Page embeddings (Phase 0 relevance-filter foundation)                       #
+# Page embeddings (ingestion relevance filter)                                #
 #                                                                             #
 # Ride the reindex path: the same walk that keeps OpenSearch fresh keeps the  #
 # per-page embedding store fresh. All best-effort and gated on an OpenAI key  #

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -34,7 +34,7 @@ import logging
 from app.db import fts, page_dirs
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks import coedit_rebase as coedit_rebase_trigger
-from app.tasks.reindex import index_path
+from app.tasks.reindex import drop_page_embedding, index_path
 from app.tasks.triggers import fan_out_trigger_eval
 from app.tasks.update_frequency import check_update_frequency
 from app.triggers import repo as triggers_repo
@@ -135,6 +135,7 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     if not rel_path.endswith(".md"):
         return
     fts.delete_document(rel_path)
+    drop_page_embedding(rel_path)
     acl.on_page_deleted(rel_path)
     update_policy.on_page_deleted(rel_path)
     # The body is gone, so there's nothing to re-anchor against — orphan the
@@ -194,6 +195,7 @@ def after_path_move(
         new_is_md = new_p.endswith(".md")
         if old_is_md:
             fts.delete_document(old_p)
+            drop_page_embedding(old_p)
             fan_out_trigger_eval(old_p, sha, ChangeKind.DELETE, actor)
             mcp_pubsub.publish_doc_delete(old_p, sha)
             list_changed = True

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,7 +119,6 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_title_boost=2.0,
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
-        ingest_embeddings_enabled=False,
         ingest_embed_model="text-embedding-3-small",
         ingest_eval_logging=False,
         ingest_eval_retention_days=90,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -119,6 +119,8 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_title_boost=2.0,
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
+        ingest_embeddings_enabled=False,
+        ingest_embed_model="text-embedding-3-small",
         ingest_eval_logging=False,
         ingest_eval_retention_days=90,
         launchers_enabled=True,

--- a/backend/tests/test_page_embeddings.py
+++ b/backend/tests/test_page_embeddings.py
@@ -1,0 +1,34 @@
+"""Unit tests for the Phase-0 embedding foundation (pure — no DB / network).
+
+Covers the vector pack/unpack round-trip, the content-hash guard, and that the
+feature is a safe no-op when disabled (the default), so shipping it changes no
+behavior until an operator opts in.
+"""
+from __future__ import annotations
+
+from app.llm import embeddings
+
+
+def test_pack_unpack_roundtrip() -> None:
+    vec = [0.125, -0.5, 0.0, 1.5, -2.25]
+    out = embeddings.unpack(embeddings.pack(vec))
+    assert len(out) == len(vec)
+    for a, b in zip(out, vec):
+        assert abs(a - b) < 1e-6  # float32 exact for these values
+
+
+def test_content_sha256_is_stable_and_distinct() -> None:
+    assert embeddings.content_sha256("hello") == embeddings.content_sha256("hello")
+    assert embeddings.content_sha256("a") != embeddings.content_sha256("b")
+
+
+def test_disabled_by_default_is_a_noop() -> None:
+    # Default config has ingest embeddings off (and test env has no OpenAI key),
+    # so the client is never called and every entry point is best-effort None.
+    assert embeddings.available() is False
+    assert embeddings.embed_texts(["anything"]) is None
+    assert embeddings.embed_text("anything") is None
+
+
+def test_model_name_has_a_default() -> None:
+    assert embeddings.model_name()  # non-empty; defaults to text-embedding-3-small

--- a/backend/tests/test_page_embeddings.py
+++ b/backend/tests/test_page_embeddings.py
@@ -1,8 +1,8 @@
 """Unit tests for the Phase-0 embedding foundation (pure — no DB / network).
 
 Covers the vector pack/unpack round-trip, the content-hash guard, and that the
-feature is a safe no-op when disabled (the default), so shipping it changes no
-behavior until an operator opts in.
+feature is a safe no-op without an OpenAI key, so shipping it changes no
+behavior until an OpenAI provider is configured.
 """
 from __future__ import annotations
 
@@ -22,9 +22,10 @@ def test_content_sha256_is_stable_and_distinct() -> None:
     assert embeddings.content_sha256("a") != embeddings.content_sha256("b")
 
 
-def test_disabled_by_default_is_a_noop() -> None:
-    # Default config has ingest embeddings off (and test env has no OpenAI key),
-    # so the client is never called and every entry point is best-effort None.
+def test_noop_without_openai_key(monkeypatch) -> None:
+    # Embeddings are gated on an OpenAI key; with none configured the client is
+    # never called and every entry point is a best-effort no-op.
+    monkeypatch.setattr(embeddings, "_api_key", lambda: "")
     assert embeddings.available() is False
     assert embeddings.embed_texts(["anything"]) is None
     assert embeddings.embed_text("anything") is None


### PR DESCRIPTION
Phase 0 of the relevance-filter integration ([design](https://github.com/onyx-dot-app/agent-wiki) — *Relevance Filter Integration* wiki page): add **embedding capability end to end** so later phases can score incoming docs against pages. **No ingestion behavior change** — everything is gated behind `INGEST_EMBEDDINGS_ENABLED` (default **off**).

## What this adds
- **`app/llm/embeddings.py`** — best-effort OpenAI `text-embedding-3-small` (1536-d) client. Reuses the admin-configured `llm_settings` OpenAI key (no env fallback, like the chat providers). Content-capped (doc 8k / page 24k chars) to match the offline model-selection study so production vectors match the calibrated thresholds. `pack`/`unpack` (float32) + `content_sha256` helpers. Never raises — returns `None` on failure/disabled/unconfigured.
- **`page_embeddings` table + `app/db/page_embeddings.py`** — durable per-page vector store, keyed by page path (float32 `bytea`). **No pgvector**: Postgres only stores/loads; scoring will run against an in-worker matrix (later phase). `updated_at` indexed for incremental cache refresh.
- **Freshness rides the reindex path** (`app/tasks/reindex.py`) — page bodies are embedded alongside the OpenSearch upsert on every commit, at startup backfill (`reindex_all_inline`), and in the hourly `reconcile_bm25_index` sweep. A **content-hash guard** skips re-embedding unchanged bodies. Page delete/move (`app/wiki/notify.py`) drops the vector so the store stays in lockstep with the index.
- **Migration** `b7f3c1a9d2e4` (chains off `e4b8c61d9a73`), inspector-guarded like the others.

## Safety / rollout
- **Default off** → merging changes nothing in production. Turning it on adds OpenAI embedding cost on commits and populates `page_embeddings`; it does **not** alter which candidates the pipeline selects.
- All embedding work is **best-effort** (mirrors `fts`'s "never abort a commit"): a failure logs at WARNING and is swallowed.

## Not in this PR (later phases)
- Incoming-doc embedding + in-worker scoring matrix + `embed_cosine` shadow logging on `ingest_eval_samples` (Phase 0b).
- Cosine cold-start threshold replacing the BM25 gate (Phase 1).
- Two-tower warm model, weights loaded from a private artifact store (Phase 2).

## Testing
- New unit tests (`tests/test_page_embeddings.py`): pack/unpack round-trip, content-hash stability, and that the feature is a no-op when disabled (default).
- `py_compile` + import-cycle check pass; alembic has a single head after the migration. (Integration tests requiring live Postgres not run in this environment.)