### PR TITLE
feat(wiki): expose stable doc id in listing/search responses

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -17,6 +17,7 @@ from app.models.file_system import (
     CreateFolderRequest,
     CreateFolderResponse,
     DeleteDocumentResponse,
+    DocRef,
     DocumentActivityResponse,
     DocumentDraftView,
     DocumentEntry,
@@ -153,7 +154,8 @@ def list_documents(
         # Keep non-md paths (folders, .gitkeep) so the explorer can render
         # the tree; permission checks happen on actual page access.
         raw = [(p, ts) for p, ts in raw if not p.endswith(".md") or p in visible]
-    entries = [DocumentEntry(path=p, updated_at=ts) for p, ts in raw]
+    ids = doc_ids.ids_for_paths([p for p, _ in raw])
+    entries = [DocumentEntry(path=p, updated_at=ts, id=ids.get(p)) for p, ts in raw]
     return ListDocumentsResponse(entries=entries)
 
 
@@ -177,8 +179,10 @@ def list_recent_pages(
         md = [(p, ts) for p, ts in md if p in visible]
     # Newest first; empty timestamps sink to the bottom.
     md.sort(key=lambda pt: pt[1], reverse=True)
+    top = md[:limit]
+    ids = doc_ids.ids_for_paths([p for p, _ in top])
     pages: list[RecentPageView] = []
-    for path, ts in md[:limit]:
+    for path, ts in top:
         abs_path = filesystem.absolute(path)
         if not abs_path.is_file():
             continue
@@ -187,7 +191,11 @@ def list_recent_pages(
         except OSError:
             continue
         title, preview = _title_and_preview(body, path)
-        pages.append(RecentPageView(path=path, title=title, updated_at=ts, preview=preview))
+        pages.append(
+            RecentPageView(
+                path=path, title=title, updated_at=ts, preview=preview, id=ids.get(path)
+            )
+        )
     return ListRecentPagesResponse(pages=pages)
 
 
@@ -710,6 +718,7 @@ def search_documents(
         user_id=user.id,
         is_admin=user.is_admin,
     )
+    ids = doc_ids.ids_for_paths([h.path for h in hits])
     return SearchResponse(
         query=query,
         hits=[
@@ -719,6 +728,7 @@ def search_documents(
                 title=h.title,
                 snippet=h.snippet,
                 score=h.score,
+                id=ids.get(h.path),
             )
             for h in hits
         ],
@@ -736,7 +746,9 @@ def list_recent_docs(user: User = Depends(require_user)) -> RecentDocsResponse:
         from app.wiki import acl as _acl
 
         paths = _acl.filter_paths_in_python(user.id, False, paths)
-    return RecentDocsResponse(paths=paths)
+    ids = doc_ids.ids_for_paths(paths)
+    items = [DocRef(path=p, id=ids.get(p)) for p in paths]
+    return RecentDocsResponse(paths=paths, items=items)
 
 
 @router.post("/recents", status_code=status.HTTP_204_NO_CONTENT)
@@ -762,7 +774,9 @@ def list_starred_docs(user: User = Depends(require_user)) -> StarredDocsResponse
         from app.wiki import acl as _acl
 
         paths = _acl.filter_paths_in_python(user.id, False, paths)
-    return StarredDocsResponse(paths=paths)
+    ids = doc_ids.ids_for_paths(paths)
+    items = [DocRef(path=p, id=ids.get(p)) for p in paths]
+    return StarredDocsResponse(paths=paths, items=items)
 
 
 @router.post("/starred", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -102,10 +102,18 @@ class IngestRequest(BaseModel):
 class DocumentEntry(BaseModel):
     path: str
     updated_at: str  # ISO-8601 author-time of the most recent commit touching the path
+    id: str | None = None  # stable wiki_doc_id; None for pre-id rows not yet backfilled
 
 
 class ListDocumentsResponse(BaseModel):
     entries: list[DocumentEntry]
+
+
+class DocRef(BaseModel):
+    """A path paired with its stable id, for id-based navigation links."""
+
+    path: str
+    id: str | None = None
 
 
 class RecordRecentDocRequest(BaseModel):
@@ -116,6 +124,9 @@ class RecentDocsResponse(BaseModel):
     # Newest-first paths of docs the user opened, already filtered to
     # ones that still exist and remain readable.
     paths: list[str]
+    # Same list paired with stable ids, for id-based links. Kept alongside
+    # ``paths`` (not replacing it) so the pre-migration frontend still works.
+    items: list[DocRef] = []
 
 
 class StarDocRequest(BaseModel):
@@ -131,6 +142,9 @@ class StarredDocsResponse(BaseModel):
     # User-ordered starred doc paths, already filtered to ones that
     # still exist and remain readable.
     paths: list[str]
+    # Same list paired with stable ids, for id-based links. Additive; see
+    # RecentDocsResponse.
+    items: list[DocRef] = []
 
 
 class RecentPageView(BaseModel):
@@ -145,6 +159,7 @@ class RecentPageView(BaseModel):
     title: str
     updated_at: str
     preview: str
+    id: str | None = None  # stable wiki_doc_id
 
 
 class ListRecentPagesResponse(BaseModel):
@@ -319,11 +334,12 @@ class FileDiffResponse(BaseModel):
 
 
 class SearchHitView(BaseModel):
-    doc_id: str
+    doc_id: str  # search-index key (currently the path); distinct from the stable id below
     path: str
     title: str | None
     snippet: str
     score: float
+    id: str | None = None  # stable wiki_doc_id, for id-based navigation
 
 
 class FolderHitView(BaseModel):

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -69,22 +69,35 @@ def id_for_path(path: str) -> str | None:
 
 
 def ids_for_paths(paths: list[str]) -> dict[str, str]:
-    """``{path: id}`` for the live rows among ``paths``, in one query.
+    """``{path: id}`` for the live rows among ``paths``.
 
     Paths without a live row are simply absent from the result — callers
     building navigation links tolerate a missing id (fall back to the path).
     Used by the listing/search endpoints to attach stable ids in bulk rather
     than resolving one path at a time.
+
+    The lookup is chunked so a whole-tree listing can't emit one ``IN (...)``
+    with an unbounded bind-parameter count (parse/plan cost grows with it);
+    every path is still returned, just across a bounded number of statements.
     """
     if not paths:
         return {}
+    out: dict[str, str] = {}
     with session() as s:
-        rows = s.execute(
-            select(WikiDocId.path, WikiDocId.id).where(
-                WikiDocId.path.in_(paths), WikiDocId.deleted_at.is_(None)
-            )
-        ).all()
-    return {path: doc_id for path, doc_id in rows}
+        for i in range(0, len(paths), _ID_LOOKUP_CHUNK):
+            chunk = paths[i : i + _ID_LOOKUP_CHUNK]
+            rows = s.execute(
+                select(WikiDocId.path, WikiDocId.id).where(
+                    WikiDocId.path.in_(chunk), WikiDocId.deleted_at.is_(None)
+                )
+            ).all()
+            out.update({path: doc_id for path, doc_id in rows})
+    return out
+
+
+# Max paths per ``IN (...)`` in ``ids_for_paths`` — bounds per-statement
+# parse/plan cost on a large tree without a round-trip per path.
+_ID_LOOKUP_CHUNK = 1000
 
 
 def get_or_mint(path: str) -> str:

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -68,6 +68,25 @@ def id_for_path(path: str) -> str | None:
         return row.id if row else None
 
 
+def ids_for_paths(paths: list[str]) -> dict[str, str]:
+    """``{path: id}`` for the live rows among ``paths``, in one query.
+
+    Paths without a live row are simply absent from the result — callers
+    building navigation links tolerate a missing id (fall back to the path).
+    Used by the listing/search endpoints to attach stable ids in bulk rather
+    than resolving one path at a time.
+    """
+    if not paths:
+        return {}
+    with session() as s:
+        rows = s.execute(
+            select(WikiDocId.path, WikiDocId.id).where(
+                WikiDocId.path.in_(paths), WikiDocId.deleted_at.is_(None)
+            )
+        ).all()
+    return {path: doc_id for path, doc_id in rows}
+
+
 def get_or_mint(path: str) -> str:
     """Id of the live row at ``path``, minting one if absent.
 

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -210,3 +210,13 @@ def test_listing_id_is_none_for_unbackfilled_page(tmp_repo):
     entries = {e["path"]: e["id"] for e in client.get("/api/wiki").json()["entries"]}
     assert "legacy.md" in entries
     assert entries["legacy.md"] is None
+
+
+def test_ids_for_paths_merges_across_chunks(tmp_repo, monkeypatch):
+    # Force multiple chunks so the merge path is exercised without 1000+ rows.
+    monkeypatch.setattr(doc_ids, "_ID_LOOKUP_CHUNK", 2)
+    paths = [f"p{i}.md" for i in range(5)]
+    want = {p: doc_ids.mint_for_page(p) for p in paths}
+    # An absent path is simply omitted, not an error.
+    got = doc_ids.ids_for_paths(paths + ["missing.md"])
+    assert got == want

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -176,3 +176,37 @@ def test_resolve_unknown_id_404(tmp_repo):
     client = _client(user)
     assert client.get("/api/wiki/id/deadbeefdeadbeef").status_code == 404
     assert client.get("/api/wiki/file?id=deadbeefdeadbeef").status_code == 404
+
+
+def test_listing_endpoints_carry_stable_id(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"}
+    ).json()["id"]
+
+    # The tree listing is file-based (git ls-files), so it carries page ids;
+    # implicit folders like ``proj`` aren't rows here (the frontend derives the
+    # folder tree from paths and resolves a folder's own id separately).
+    entries = {e["path"]: e["id"] for e in client.get("/api/wiki").json()["entries"]}
+    assert entries["proj/a.md"] == page_id
+
+    # Recents and starred expose the id alongside the legacy paths list.
+    client.post("/api/wiki/recents", json={"path": "proj/a.md"})
+    client.post("/api/wiki/starred", json={"path": "proj/a.md"})
+    recents = client.get("/api/wiki/recents").json()
+    starred = client.get("/api/wiki/starred").json()
+    assert recents["paths"] == ["proj/a.md"]
+    assert recents["items"] == [{"path": "proj/a.md", "id": page_id}]
+    assert starred["items"] == [{"path": "proj/a.md", "id": page_id}]
+
+
+def test_listing_id_is_none_for_unbackfilled_page(tmp_repo):
+    # A page seeded outside the API has no id row yet; the tree still lists it,
+    # with id=None, rather than failing.
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("legacy.md", "# L\n", "seed")
+    entries = {e["path"]: e["id"] for e in client.get("/api/wiki").json()["entries"]}
+    assert "legacy.md" in entries
+    assert entries["legacy.md"] is None

--- a/backend/tests/test_recents_api.py
+++ b/backend/tests/test_recents_api.py
@@ -41,11 +41,11 @@ def test_record_and_list_newest_first(client):
 
     _record(client, "a.md")
     _record(client, "b.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["b.md", "a.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["b.md", "a.md"]
 
     # Re-opening an older doc bumps it to the front, no duplicate row.
     _record(client, "a.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["a.md", "b.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["a.md", "b.md"]
 
 
 def test_doc_updates_do_not_affect_recents(client):
@@ -63,7 +63,7 @@ def test_doc_updates_do_not_affect_recents(client):
     wiki_git.commit_file("never-opened.md", "# n v2", "agent update")
     wiki_git.commit_file("a.md", "# a v2", "agent update")
 
-    assert client.get("/api/wiki/recents").json() == {"paths": ["b.md", "a.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["b.md", "a.md"]
 
 
 def test_recents_are_per_user(client):
@@ -77,7 +77,7 @@ def test_recents_are_per_user(client):
 
     login_fastapi(client, bob)
     _record(client, "b.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["b.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["b.md"]
 
 
 def test_deleted_docs_drop_out(client):
@@ -89,7 +89,7 @@ def test_deleted_docs_drop_out(client):
     _record(client, "keep.md")
 
     wiki_git.delete_path("gone.md", "remove")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["keep.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["keep.md"]
 
 
 def test_revoked_read_access_drops_out(client):
@@ -100,7 +100,7 @@ def test_revoked_read_access_drops_out(client):
 
     login_fastapi(client, bob)
     _record(client, "private.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["private.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["private.md"]
 
     # Make the doc owner-only after Bob's view.
     acl.set_owner("private.md", alice)
@@ -108,7 +108,7 @@ def test_revoked_read_access_drops_out(client):
         if grant["principal_kind"] == "everyone":
             acl.revoke(grant["id"])
 
-    assert client.get("/api/wiki/recents").json() == {"paths": []}
+    assert client.get("/api/wiki/recents").json()["paths"] == []
 
 
 def test_record_requires_read_access(client):
@@ -123,7 +123,7 @@ def test_record_requires_read_access(client):
     login_fastapi(client, bob)
     resp = client.post("/api/wiki/recents", json={"path": "private.md"})
     assert resp.status_code == 403
-    assert client.get("/api/wiki/recents").json() == {"paths": []}
+    assert client.get("/api/wiki/recents").json()["paths"] == []
 
 
 def test_record_rejects_traversal(client):


### PR DESCRIPTION
> Stacked on #374 (deleted-page-recovery, which now includes the merged #375 stable-doc-ids). First slice of **Goal 1 — id-based URLs**: the backend-only piece so the frontend can build `/app/wiki/<id>/<slug>` links without an N+1 of resolve calls.

## Why

Id-based URLs need the stable id for every navigable item, but the listing endpoints returned paths only. This adds the id to each, bulk-resolved in a single query.

## Changes

- `doc_ids.ids_for_paths(paths)` — one query returning `{path: id}` for live rows (avoids per-item lookups on a full-tree listing).
- `DocumentEntry.id` (tree), `SearchHitView.id` (distinct from the existing `doc_id` search key), `RecentPageView.id` (home grid).
- `RecentDocsResponse` / `StarredDocsResponse` gain `items: list[DocRef]` ({path, id}) **alongside** the legacy `paths` list.

All new fields are additive/optional, so the not-yet-migrated frontend keeps working. `id` is `None` for pre-id pages not yet backfilled.

## Scoping note

The tree listing is file-based (`git ls-files`), so it carries **page** ids; implicit folders aren't rows there. The frontend derives the folder tree from paths and will resolve a folder's own id separately (a small bulk path→id endpoint can follow if the per-folder resolve proves chatty).

## Testing

New tests: listing/recents/starred carry the id; id is `None` for an un-backfilled page. Updated the recents API tests (which asserted exact full-body equality) to assert on `paths`. Full backend suite passes; ruff + basedpyright clean.