### PR TITLE
feat(wiki): bulk path→id resolve endpoint + folder-hit id

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -172,7 +172,7 @@ def resolve_ids(
     dropped; folder paths pass through (folder existence is already visible in
     the tree, and page-level permission is enforced on actual access)."""
     try:
-        rels = [filesystem.safe_rel_path(p) for p in req.paths if p.strip()]
+        rels = [filesystem.safe_rel_path(p.strip()) for p in req.paths if p.strip()]
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     if not user.is_admin:

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -44,6 +44,8 @@ from app.models.file_system import (
     ReindexRequest,
     ReindexResponse,
     ResolveDocIdResponse,
+    ResolveIdsRequest,
+    ResolveIdsResponse,
     ReorderStarredRequest,
     ReviseDraftRequest,
     ReviseDraftResponse,
@@ -157,6 +159,28 @@ def list_documents(
     ids = doc_ids.ids_for_paths([p for p, _ in raw])
     entries = [DocumentEntry(path=p, updated_at=ts, id=ids.get(p)) for p, ts in raw]
     return ListDocumentsResponse(entries=entries)
+
+
+@router.post("/resolve-ids", response_model=ResolveIdsResponse)
+def resolve_ids(
+    req: ResolveIdsRequest,
+    user: User = Depends(require_user),
+) -> ResolveIdsResponse:
+    """Bulk path→id for building id-based hrefs (folders, breadcrumb ancestors).
+
+    ACL-filtered like the tree listing: a `.md` path the caller can't read is
+    dropped; folder paths pass through (folder existence is already visible in
+    the tree, and page-level permission is enforced on actual access)."""
+    try:
+        rels = [filesystem.safe_rel_path(p) for p in req.paths if p.strip()]
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if not user.is_admin:
+        md = [p for p in rels if p.endswith(".md")]
+        visible = set(acl.filter_paths_in_python(user.id, False, md))
+        rels = [p for p in rels if not p.endswith(".md") or p in visible]
+    ids = doc_ids.ids_for_paths(rels)
+    return ResolveIdsResponse(items=[DocRef(path=p, id=i) for p, i in ids.items()])
 
 
 @router.get("/recent", response_model=ListRecentPagesResponse)
@@ -718,7 +742,7 @@ def search_documents(
         user_id=user.id,
         is_admin=user.is_admin,
     )
-    ids = doc_ids.ids_for_paths([h.path for h in hits])
+    ids = doc_ids.ids_for_paths([h.path for h in hits] + [f.path for f in folders])
     return SearchResponse(
         query=query,
         hits=[
@@ -732,7 +756,7 @@ def search_documents(
             )
             for h in hits
         ],
-        folders=[FolderHitView(path=f.path) for f in folders],
+        folders=[FolderHitView(path=f.path, id=ids.get(f.path)) for f in folders],
     )
 
 

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -121,7 +121,9 @@ class ResolveIdsRequest(BaseModel):
     paths it holds but has no id for yet — folder paths (not carried by the
     file-based tree listing) and synthesized breadcrumb ancestors."""
 
-    paths: list[str]
+    # Bounded like the other parameterised endpoints; a single view resolves at
+    # most a handful (visible folders + breadcrumb ancestors), so 1000 is ample.
+    paths: list[str] = Field(max_length=1000)
 
 
 class ResolveIdsResponse(BaseModel):

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -116,6 +116,20 @@ class DocRef(BaseModel):
     id: str | None = None
 
 
+class ResolveIdsRequest(BaseModel):
+    """Bulk path→id lookup. The frontend uses this to build id-based hrefs for
+    paths it holds but has no id for yet — folder paths (not carried by the
+    file-based tree listing) and synthesized breadcrumb ancestors."""
+
+    paths: list[str]
+
+
+class ResolveIdsResponse(BaseModel):
+    # One entry per input path that has a live id row; paths without one are
+    # simply omitted (the caller falls back to a path URL).
+    items: list[DocRef]
+
+
 class RecordRecentDocRequest(BaseModel):
     path: str
 
@@ -344,6 +358,7 @@ class SearchHitView(BaseModel):
 
 class FolderHitView(BaseModel):
     path: str
+    id: str | None = None  # stable wiki_doc_id of the folder, for id-based navigation
 
 
 class SearchResponse(BaseModel):

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -220,3 +220,40 @@ def test_ids_for_paths_merges_across_chunks(tmp_repo, monkeypatch):
     # An absent path is simply omitted, not an error.
     got = doc_ids.ids_for_paths(paths + ["missing.md"])
     assert got == want
+
+
+def test_resolve_ids_endpoint_returns_folder_and_page_ids(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"}
+    ).json()["id"]
+    proj_id = doc_ids.id_for_path("proj")
+    sub_id = doc_ids.id_for_path("proj/sub")
+
+    resp = client.post(
+        "/api/wiki/resolve-ids",
+        json={"paths": ["proj", "proj/sub", "proj/sub/a.md", "nope.md", ""]},
+    )
+    assert resp.status_code == 200
+    got = {it["path"]: it["id"] for it in resp.json()["items"]}
+    # Folder paths (absent from the file-based tree listing) resolve here.
+    assert got == {"proj": proj_id, "proj/sub": sub_id, "proj/sub/a.md": page_id}
+
+
+def test_resolve_ids_acl_filters_pages_for_non_admin(tmp_repo):
+    from app.wiki import acl
+
+    owner = seed_user()
+    other = seed_user(uid="u_other", email="other@x.com")
+    owner_client = _client(owner)
+    owner_client.put("/api/wiki/file", json={"path": "secret.md", "body": "# S\n"})
+    # Strip the default everyone-read grant → owner-only.
+    for g in acl.list_for_path("secret.md"):
+        if g["principal_kind"] == "everyone":
+            acl.revoke(g["id"])
+
+    resp = _client(other).post("/api/wiki/resolve-ids", json={"paths": ["secret.md"]})
+    assert resp.status_code == 200
+    # The page the caller can't read is omitted rather than leaked.
+    assert resp.json()["items"] == []

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -257,3 +257,25 @@ def test_resolve_ids_acl_filters_pages_for_non_admin(tmp_repo):
     assert resp.status_code == 200
     # The page the caller can't read is omitted rather than leaked.
     assert resp.json()["items"] == []
+
+
+def test_resolve_ids_trims_whitespace_padded_paths(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"}
+    ).json()["id"]
+    # A padded path must still resolve — the strip guard used to only gate
+    # blankness while passing the unstripped path to safe_rel_path.
+    resp = client.post("/api/wiki/resolve-ids", json={"paths": ["  proj/a.md  "]})
+    assert resp.status_code == 200
+    assert resp.json()["items"] == [{"path": "proj/a.md", "id": page_id}]
+
+
+def test_resolve_ids_rejects_oversized_batch(tmp_repo):
+    client = _client(seed_user())
+    resp = client.post(
+        "/api/wiki/resolve-ids", json={"paths": [f"p{i}.md" for i in range(1001)]}
+    )
+    # The app maps request-validation errors to 400 (see _on_validation_error).
+    assert resp.status_code == 400


### PR DESCRIPTION
> Stacked on #374. Second backend slice of **Goal 1 — id-based URLs**, needed before the frontend PR.

## Why

A URL only survives a rename if it's **id-based at construction time** — a copied *path* URL still breaks after the page/folder moves, because the old path no longer resolves to a live id. So the frontend must build links with ids. Pages already carry ids in the listing/search responses (#377), but **folders don't** (they aren't rows in the file-based tree listing), and neither do synthesized breadcrumb ancestors.

## Changes

- **`POST /api/wiki/resolve-ids`** `{paths: string[]}` → `{items: [{path, id}]}`. Bulk path→id via `doc_ids.ids_for_paths` (chunked). ACL-filtered exactly like the tree listing: a `.md` path the caller can't read is dropped (no existence leak); folder paths pass through (folder existence is already visible in the tree, page-level permission is enforced on access). Paths without a live id row are omitted → caller falls back to a path URL.
- **`FolderHitView.id`** — search folder hits now carry the folder's id, so folder search results link durably too.

## Testing

- resolve-ids returns folder + page ids, omits unknown/blank paths;
- resolve-ids ACL-filters a private page for a non-admin (omitted, not leaked).

Full `test_doc_ids.py` passes (15); ruff + basedpyright clean.

## Next

Frontend PR (`/app/wiki/<id>/<slug>` route + `wikiHref` link sweep + tombstone view) stacks on this.