### PR TITLE
feat(wiki-fe): id-based wiki URLs + durable share links

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -16,6 +16,7 @@ import useSWR from "swr";
 import {
   Button,
   Divider,
+  EmptyMessageCard,
   LineItemButton,
   OpenButton,
   Popover,
@@ -23,6 +24,7 @@ import {
   SelectButton,
 } from "@onyx-ai/opal/components";
 import {
+  SvgAlertTriangle,
   SvgBubbleText,
   SvgChevronLeft,
   SvgChevronRight,
@@ -59,7 +61,8 @@ import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, ApiError } from "@/lib/api";
+import { isDocId, wikiHref, resolveDocId, resolveIds } from "@/lib/wikiHref";
 import { listComments } from "@/lib/comments";
 import {
   paintCommentHighlights,
@@ -121,39 +124,80 @@ interface FileResponse {
 export default function WikiRoute() {
   const { user, loading } = useRequireAuth();
   const isMobile = useIsMobile();
+  const router = useRouter();
   const params = useParams<{ slug?: string[] }>();
   const searchParams = useSearchParams();
   const isNewMode = searchParams?.get("new") === "1";
   const rawSlugParts = (params?.slug ?? []) as string[];
+
+  // Every wiki URL is id-based: `/app/wiki/<id>` (Google-Docs style). The id is
+  // stable, so the URL survives rename/move. A legacy `/app/wiki/<path>` URL
+  // still resolves as input and is redirected to its id URL below.
+  const first = rawSlugParts[0];
+  const idMode = !!first && isDocId(first);
+  const commentId = searchParams?.get("comment") ?? null;
+
+  // id mode: resolve the id to its current path / kind / deleted state.
+  const { data: resolved, error: resolveErr } = useSWR(
+    idMode ? `/wiki/id/${first}` : null,
+    () => resolveDocId(first as string),
+    { revalidateOnFocus: false },
+  );
+
   // Next.js may hand back percent-encoded segments (e.g. "local%20testing").
   // Decode so labels and downstream API paths use literal characters.
-  const slugParts = rawSlugParts.map((s) => {
+  const decodedParts = rawSlugParts.map((s) => {
     try {
       return decodeURIComponent(s);
     } catch {
       return s;
     }
   });
-  const slugPath = slugParts.join("/");
-  const isFile = slugPath.endsWith(".md");
+  const pathModePath = decodedParts.join("/");
+  // The doc/folder path we're viewing: from the resolved id, or (legacy path
+  // URL) straight from the URL.
+  const effectivePath = idMode ? (resolved?.path ?? null) : pathModePath;
+  const isFile = !!effectivePath && effectivePath.endsWith(".md");
 
-  // Remember the most recent wiki path so the "Last viewed" landing
-  // setting has something to fall back to, and feed the sidebar
-  // "Recents" list when an actual doc (not a folder) is opened.
+  // Redirect a legacy path URL to its canonical id URL (`/app/wiki/<id>`).
+  // Skips the new-doc flow (no id yet) and paths with no live id (unsaved /
+  // not-yet-backfilled) — those keep rendering by path. Guarded so it can't
+  // loop.
   useEffect(() => {
-    rememberWikiPath("/app/wiki" + (slugPath ? "/" + slugPath : ""));
-    if (isFile) void recordRecentDoc(slugPath);
-  }, [slugPath, isFile]);
+    if (idMode || !pathModePath || isNewMode) return;
+    const suffix = commentId ? `?comment=${encodeURIComponent(commentId)}` : "";
+    let cancelled = false;
+    void resolveIds([pathModePath])
+      .then((map) => {
+        const id = map[pathModePath];
+        if (!cancelled && id) router.replace(wikiHref(id) + suffix);
+      })
+      .catch(() => {
+        /* no live id — render by path */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [idMode, pathModePath, isNewMode, commentId, router]);
+
+  // Remember the most recent wiki path (for the "Last viewed" landing) and
+  // feed the sidebar Recents when an actual doc is opened.
+  useEffect(() => {
+    if (effectivePath === null) return;
+    rememberWikiPath("/app/wiki" + (effectivePath ? "/" + effectivePath : ""));
+    if (isFile) void recordRecentDoc(effectivePath);
+  }, [effectivePath, isFile]);
 
   // Tab title tracks the open doc (or folder); falls back to the app name.
   useEffect(() => {
-    const last = slugPath.split("/").pop() ?? "";
+    if (effectivePath === null) return;
+    const last = effectivePath.split("/").pop() ?? "";
     const label = isFile ? last.replace(/\.md$/i, "") : last;
     document.title = label || "agent-wiki";
     return () => {
       document.title = "agent-wiki";
     };
-  }, [slugPath, isFile]);
+  }, [effectivePath, isFile]);
 
   if (loading || !user)
     return (
@@ -162,12 +206,50 @@ export default function WikiRoute() {
       </main>
     );
 
-  if (isFile) return <FileViewer path={slugPath} />;
-  if (isNewMode) return <NewDocView dir={slugPath} />;
+  if (idMode) {
+    // Unknown id / resolve failure / deleted page → the link no longer points
+    // at a live doc. (Deleted-page recovery is a separate feature.)
+    if (resolveErr || resolved?.deleted_at)
+      return <WikiUnknownLink status={(resolveErr as ApiError)?.status} />;
+    if (!resolved)
+      return (
+        <main className={isMobile ? "p-4" : "p-8"}>
+          <LoadingSpinner center />
+        </main>
+      );
+  }
+
+  if (isFile) return <FileViewer path={effectivePath as string} />;
+  if (isNewMode) return <NewDocView dir={pathModePath} />;
   // Wiki root with no doc open → the "Welcome to Onyx Wiki" landing.
   // Sub-folders still render the directory explorer.
-  if (slugPath === "") return <WikiHome />;
-  return <Explorer dir={slugPath} />;
+  if (!effectivePath) return <WikiHome />;
+  return <Explorer dir={effectivePath} />;
+}
+
+/** A wiki URL that no longer points at a live doc — an unknown id or one whose
+ * page has been deleted. Recovering deleted pages is a separate feature. */
+function WikiUnknownLink({ status }: { status?: number }) {
+  const router = useRouter();
+  return (
+    <main className="flex h-full items-center justify-center p-8 pb-[16vh]">
+      <div className="flex flex-col items-center gap-4">
+        <EmptyMessageCard
+          sizePreset="main-ui"
+          icon={SvgAlertTriangle}
+          title="This page isn’t available"
+          description={
+            status === 404
+              ? "The link may be broken, or the page was removed."
+              : "The page it pointed to may have been moved or removed."
+          }
+        />
+        <Button onClick={() => router.push("/app/wiki")}>
+          Go to wiki home
+        </Button>
+      </div>
+    </main>
+  );
 }
 
 function Explorer({ dir }: { dir: string }) {
@@ -729,7 +811,7 @@ function NewDocView({ dir }: { dir: string }) {
     try {
       const name = filenameNoExt + ".md";
       const fullPath = (destDir ? destDir + "/" : "") + name;
-      await apiFetch("/wiki/file", {
+      const created = await apiFetch<{ id?: string | null }>("/wiki/file", {
         method: "PUT",
         body: JSON.stringify({
           path: fullPath,
@@ -747,7 +829,12 @@ function NewDocView({ dir }: { dir: string }) {
       // Hand-off: keep the drafting state (and the chat's drafting
       // session) alive across the navigation — see the unmount cleanup.
       createHandoffRef.current = true;
-      router.push(`/app/wiki/${fullPath}?new=1`);
+      // Land on the new page's id URL directly (the create response carries
+      // the minted id), so it's a clean /app/wiki/<id> like every other page.
+      // Keep ?new=1 — FileViewer reads it to auto-open the assistant on a
+      // freshly-created doc.
+      const base = created.id ? wikiHref(created.id) : `/app/wiki/${fullPath}`;
+      router.push(`${base}?new=1`);
     } catch (e) {
       setError(e instanceof Error ? e.message : "create failed");
       setSaving(false);

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
+import { shareableWikiUrl } from "@/lib/wikiHref";
 import {
   createComment,
   deleteComment,
@@ -71,15 +72,10 @@ function toIso(ts: string): string {
 }
 
 /** Deep-link to a specific thread: the page route reads `?comment=<id>`, opens
- * the panel, and scrolls to the thread's anchored span. Each path segment is
- * encoded since wiki paths contain spaces. */
-function commentLink(path: string, rootId: string): string {
-  const encoded = path
-    .split("/")
-    .filter(Boolean)
-    .map((s) => encodeURIComponent(s))
-    .join("/");
-  return `${window.location.origin}/app/wiki/${encoded}?comment=${rootId}`;
+ * the panel, and scrolls to the thread's anchored span. Uses the durable
+ * id-based URL so the link survives a page rename/move. */
+function commentLink(path: string, rootId: string): Promise<string> {
+  return shareableWikiUrl(path, `comment=${rootId}`);
 }
 
 export function CommentsPanel({
@@ -464,9 +460,12 @@ function Comment({
   // Copy a deep-link to this comment's thread (anchors live on the root, so all
   // comments in a thread share its link). Doesn't close the menu — the swapped
   // title/icon is the "done" feedback.
-  const copyLink = () => {
+  const copyLink = async () => {
+    // Durable id-based deep-link (survives rename/move); the ?comment= anchor
+    // rides along.
+    const url = await commentLink(path, comment.thread_root_id);
     void navigator.clipboard
-      .writeText(commentLink(path, comment.thread_root_id))
+      .writeText(url)
       .then(() => {
         setCopied(true);
         window.setTimeout(() => setCopied(false), 1500);

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -47,6 +47,7 @@ import {
   type UserLite,
 } from "@/lib/users";
 import { lastSegment } from "@/lib/wiki";
+import { shareableWikiUrl } from "@/lib/wikiHref";
 import { markdown } from "@onyx-ai/opal/utils";
 
 import { TransferModal } from "./TransferModal";
@@ -286,14 +287,8 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
 
   const copyLink = async () => {
     try {
-      const trimmed = path.replace(/\/+$/, "");
-      const encodedPath = trimmed
-        .split("/")
-        .filter(Boolean)
-        .map((segment) => encodeURIComponent(segment))
-        .join("/");
-      const targetPath = encodedPath ? `/app/wiki/${encodedPath}` : "/app/wiki";
-      const shareUrl = `${window.location.origin}${targetPath}`;
+      // Durable id-based URL so a shared link survives a later rename/move.
+      const shareUrl = await shareableWikiUrl(path.replace(/\/+$/, ""));
       await navigator.clipboard.writeText(shareUrl);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);

--- a/frontend/src/hooks/useAppFocus.ts
+++ b/frontend/src/hooks/useAppFocus.ts
@@ -2,6 +2,11 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
+import useSWR from "swr";
+
+import { isDocId, resolveDocId } from "@/lib/wikiHref";
+
+const WIKI_PREFIX = "/app/wiki/";
 
 export type AppFocusType =
   | "wiki"
@@ -73,16 +78,33 @@ export class AppFocus {
 
 export function useAppFocus(): AppFocus {
   const pathname = usePathname();
+
+  // Wiki URLs are id-based (`/app/wiki/<id>`). To report the real doc path
+  // (breadcrumbs, recents highlighting) we resolve the id to its path. This
+  // shares SWR's cache with the wiki route's own resolve, so it's not an extra
+  // request. Legacy path URLs (during the redirect to the id URL) parse inline.
+  const firstSeg = pathname.startsWith(WIKI_PREFIX)
+    ? pathname.slice(WIKI_PREFIX.length).split("/")[0]
+    : "";
+  const idInUrl = isDocId(firstSeg) ? firstSeg : null;
+  const { data: resolved } = useSWR(
+    idInUrl ? `/wiki/id/${idInUrl}` : null,
+    () => resolveDocId(idInUrl as string),
+    { revalidateOnFocus: false },
+  );
+
   return useMemo(() => {
     for (const { href, type } of ROUTES) {
       if (pathname.startsWith(href)) {
-        const wikiPath =
-          type === "wiki" && pathname.length > href.length
-            ? decodeWikiPath(pathname.slice(href.length + 1))
-            : null;
+        let wikiPath: string | null = null;
+        if (type === "wiki" && pathname.length > href.length) {
+          wikiPath = idInUrl
+            ? (resolved?.path ?? null)
+            : decodeWikiPath(pathname.slice(href.length + 1));
+        }
         return new AppFocus(type, href, wikiPath);
       }
     }
     return new AppFocus("none", null);
-  }, [pathname]);
+  }, [pathname, idInUrl, resolved]);
 }

--- a/frontend/src/lib/wikiHref.ts
+++ b/frontend/src/lib/wikiHref.ts
@@ -1,0 +1,82 @@
+// Wiki URL construction.
+//
+// Every wiki URL is id-based: `/app/wiki/<wiki_doc_id>`. The id is stable, so
+// the URL survives a rename/move. A legacy path URL (`/app/wiki/<path>`) still
+// resolves as input — the route looks up its id and redirects to the id URL.
+// `wikiPath()` is kept only for fallbacks (an unsaved doc, or a page with no
+// id row yet) and for the new-document flow, which is inherently path-based.
+
+import { apiFetch } from "@/lib/api";
+
+// A wiki_doc_id is 16 lowercase hex chars (see backend doc_ids._mint_id).
+const DOC_ID_RE = /^[0-9a-f]{16}$/;
+
+/** True if a URL segment is a wiki_doc_id (vs a legacy path segment). */
+export function isDocId(segment: string): boolean {
+  return DOC_ID_RE.test(segment);
+}
+
+/** The id-based wiki URL for a doc: `/app/wiki/<id>`. */
+export function wikiHref(id: string): string {
+  return `/app/wiki/${id}`;
+}
+
+/** Clean path-based wiki URL — fallback for docs without an id (unsaved / not
+ * yet backfilled) and the new-document flow. */
+export function wikiPath(path: string): string {
+  const slug = path
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+  return slug ? `/app/wiki/${slug}` : "/app/wiki";
+}
+
+export interface ResolvedDocId {
+  id: string;
+  path: string;
+  kind: "page" | "folder";
+  deleted_at: string | null;
+}
+
+/** Resolve a doc id to its current binding (path, kind, deleted state). */
+export function resolveDocId(id: string): Promise<ResolvedDocId> {
+  return apiFetch<ResolvedDocId>(`/wiki/id/${id}`);
+}
+
+interface ResolveIdsResponse {
+  items: { path: string; id: string | null }[];
+}
+
+/** Bulk path→id. Paths without a live id row are omitted from the map. */
+export async function resolveIds(
+  paths: string[],
+): Promise<Record<string, string>> {
+  if (paths.length === 0) return {};
+  const res = await apiFetch<ResolveIdsResponse>("/wiki/resolve-ids", {
+    method: "POST",
+    body: JSON.stringify({ paths }),
+  });
+  const out: Record<string, string> = {};
+  for (const it of res.items) if (it.id) out[it.path] = it.id;
+  return out;
+}
+
+/** Absolute, shareable wiki URL — the id URL (`/app/wiki/<id>`), so a shared
+ * link survives a later rename/move. Falls back to a path URL if the id can't
+ * be resolved. `extraParams` (e.g. `"comment=abc"`, no leading `?`/`&`) is
+ * appended as a query string. */
+export async function shareableWikiUrl(
+  path: string,
+  extraParams = "",
+): Promise<string> {
+  let id: string | undefined;
+  try {
+    id = (await resolveIds([path]))[path];
+  } catch {
+    /* no live id — fall back to the plain path URL */
+  }
+  const base = `${window.location.origin}${id ? wikiHref(id) : wikiPath(path)}`;
+  const q = extraParams.replace(/^[?&]/, "");
+  return q ? `${base}?${q}` : base;
+}

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import useSWR, { useSWRConfig } from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { shareableWikiUrl } from "@/lib/wikiHref";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { MoveModal, RenameModal } from "@/components/wiki/WikiItemModals";
@@ -121,9 +122,10 @@ export function WikiItemActionsProvider({
     rename: setRenamePath,
     move: setMovePath,
     launchAgent: setAgentPath,
-    copyLink: (path) => {
-      const encoded = path.split("/").map(encodeURIComponent).join("/");
-      const url = `${window.location.origin}/app/wiki/${encoded}`;
+    copyLink: async (path) => {
+      // Share the durable id-based URL so the link survives a later
+      // rename/move (falls back to a path URL if the id can't be resolved).
+      const url = await shareableWikiUrl(path);
       navigator.clipboard
         .writeText(url)
         .then(() => setToast("Link copied"))


### PR DESCRIPTION
> Stacked on #374 (deleted-page-recovery, which carries merged #375/#377/#378). **Goal 1 frontend**, scoped to id-based URLs and sharing.

## What it does

- **Route** `/app/wiki/<id>/<slug>` — id-first (`<id>` = stable `wiki_doc_id`, detected by 16-hex shape; slug cosmetic). Legacy `/app/wiki/<path>` still works and the route **canonicalizes the address bar to the id URL** (preserving query like `?comment=`), so the visible/copied URL survives a later rename/move. An unknown or deleted id shows a plain "page isn't available" (no recovery UI).
- **Durable share links** — Copy Link (tree/explorer rows), comment deep-links, and the Share dialog all emit the id URL, resolved at share time via `shareableWikiUrl()` (falls back to a path URL if no live id).
- New `src/lib/wikiHref.ts`: `wikiHref`, `isDocId`, `resolveDocId`, `resolveIds`, `shareableWikiUrl`.

## Explicitly out of scope

Deleted-page **tombstone view + Restore** and **moved-link redirects** were removed from this PR — they belong with the Trash/restore feature, not the URL work. A deleted/moved URL here falls back to the plain unavailable/error state.

## Verified

- `bun run typecheck` + prettier clean.
- Local run (Next dev → local backend): id URL, legacy path URL, bad id, missing path, and home all SSR-render 200; `resolve-ids` returns the ids the share helper uses.
- Not interactively click-tested in a browser (no headless browser here) — a manual pass of the canonicalization redirect + Copy Link is worth doing before merge.

## Deferred polish

In-app nav links (tree/breadcrumb/search/recents/starred) still emit path URLs — they resolve + canonicalize fine, so it's a redirect-round-trip nicety, not correctness.
<img width="1084" height="477" alt="Screenshot 2026-07-13 at 12 49 29 PM" src="https://github.com/user-attachments/assets/04563160-82c7-4fe4-9944-77659e3a77bd" />
<img width="1755" height="839" alt="Screenshot 2026-07-13 at 1 09 28 PM" src="https://github.com/user-attachments/assets/2494b582-0530-4ada-b9c5-7b8ed7e8dee2" />



