### PR TITLE
feat(ingest): relevance-filter interface + pipeline carrier types

### DIFF
--- a/backend/app/ingest/relevance/__init__.py
+++ b/backend/app/ingest/relevance/__init__.py
@@ -1,0 +1,11 @@
+"""Relevance filtering for document ingestion.
+
+Public interface: the :class:`RelevanceFilter` contract. It operates on the
+pipeline carriers :class:`app.ingest.types.IngestionDocument` and
+:class:`app.ingest.types.CandidatePage`. Concrete models (cosine, two-tower,
+...) live in their own modules and subclass ``RelevanceFilter``; the pipeline
+depends only on this interface.
+"""
+from app.ingest.relevance.filter import RelevanceFilter
+
+__all__ = ["RelevanceFilter"]

--- a/backend/app/ingest/relevance/filter.py
+++ b/backend/app/ingest/relevance/filter.py
@@ -1,0 +1,39 @@
+"""The relevance-filter contract."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from app.ingest.types import CandidatePage, IngestionDocument
+
+
+class RelevanceFilter(ABC):
+    """Decides whether a pushed document is relevant to a wiki page, so the
+    expensive LLM reconcile only runs on plausible pairs.
+
+    The contract is intentionally minimal — domain objects in, boolean out — so
+    any kind of model fits: cosine similarity or a trained two-tower over
+    embeddings, an LLM yes/no, or a metadata rule. How a verdict is reached
+    (embedding, scoring, thresholding, prompting) is entirely a subclass
+    concern; nothing here assumes a numeric score exists or that the inputs are
+    vectors.
+
+    Inputs are the pipeline carriers :class:`IngestionDocument` and
+    :class:`CandidatePage`. A filter reads only what it needs — an embedding
+    model reads their ``embedding`` slots (filled by an earlier enrichment
+    stage), a rule reads ``metadata``, an LLM reads the text — so no field is
+    required by the contract.
+    """
+
+    @abstractmethod
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        """Whether ``doc`` is relevant to ``page``."""
+
+    def keep_relevant(
+        self, doc: IngestionDocument, pages: list[CandidatePage]
+    ) -> list[CandidatePage]:
+        """Return the subset of ``pages`` the document is relevant to.
+
+        Defaults to a per-page loop. A model may override to batch — e.g. score
+        the document's embedding against all candidate embeddings in one pass.
+        """
+        return [page for page in pages if self.is_relevant(doc, page)]

--- a/backend/app/ingest/types.py
+++ b/backend/app/ingest/types.py
@@ -1,0 +1,57 @@
+"""Domain types that flow through the ingestion pipeline.
+
+A document pushed from an external system is normalized into an
+:class:`IngestionDocument` at the API boundary (mapped from
+``app.models.file_system.IngestRequest``) and then flows through the pipeline.
+Stages *enrich* it — e.g. an embedding stage attaches ``embedding`` — and
+downstream filters read whichever fields they need. :class:`CandidatePage` is
+the wiki-side counterpart: a page the document might be relevant to.
+
+Both are frozen. Enrichment produces a new copy via ``dataclasses.replace`` so
+data flow through the pipeline stays explicit and stage order can't silently
+mutate a shared object:
+
+    doc = dataclasses.replace(doc, embedding=vec)
+
+Derived fields default to ``None`` and mean "not computed yet"; readers treat
+``None`` as "unavailable" and fall back (a relevance filter, for instance,
+stays fail-open). Keep this carrier disciplined — raw inputs plus a few
+well-defined derived slots, not a dumping ground.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class IngestionDocument:
+    """A document being ingested, as it flows through the pipeline.
+
+    Raw fields come from the inbound push; ``id`` is the source system's
+    ``source_document_id``. ``embedding`` is a derived slot filled by an
+    enrichment stage — ``None`` until then.
+    """
+
+    content: str
+    id: str | None = None
+    title: str | None = None
+    source_type: str | None = None
+    url: str | None = None
+    metadata: dict[str, Any] | None = None
+    embedding: list[float] | None = None
+
+
+@dataclass(frozen=True)
+class CandidatePage:
+    """A wiki page the document might be relevant to.
+
+    ``path`` is the wiki-relative path — also the key into the stored page
+    embeddings. ``embedding`` is the page's vector, filled from that store by a
+    pre-load stage; ``None`` until then.
+    """
+
+    path: str
+    body: str
+    title: str | None = None
+    embedding: list[float] | None = None

--- a/backend/tests/test_relevance.py
+++ b/backend/tests/test_relevance.py
@@ -1,0 +1,46 @@
+"""Contract tests for the relevance-filter interface.
+
+No model here — a stub subclass returns a fixed verdict so we can assert the
+shared batch/abstract behavior in isolation.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.ingest.relevance import RelevanceFilter
+from app.ingest.types import CandidatePage, IngestionDocument
+
+
+class _StubFilter(RelevanceFilter):
+    """Returns a preset verdict regardless of inputs."""
+
+    def __init__(self, verdict: bool) -> None:
+        self._verdict = verdict
+
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        return self._verdict
+
+
+_DOC = IngestionDocument(content="release notes", source_type="github")
+_PAGES = [
+    CandidatePage(path="a.md", body="alpha"),
+    CandidatePage(path="b.md", body="beta"),
+]
+
+
+def test_cannot_instantiate_abstract_base():
+    with pytest.raises(TypeError):
+        RelevanceFilter()  # type: ignore[abstract]
+
+
+def test_keep_relevant_returns_all_when_relevant():
+    assert _StubFilter(True).keep_relevant(_DOC, _PAGES) == _PAGES
+
+
+def test_keep_relevant_returns_none_when_irrelevant():
+    assert _StubFilter(False).keep_relevant(_DOC, _PAGES) == []
+
+
+def test_is_relevant_verdict_is_used():
+    assert _StubFilter(True).is_relevant(_DOC, _PAGES[0]) is True
+    assert _StubFilter(False).is_relevant(_DOC, _PAGES[0]) is False


### PR DESCRIPTION
## What

The relevance filter's **interface** plus the **domain carrier types** it operates on. Interface only — no concrete model, no pipeline wiring. First increment of the relevance-filter integration.

## `app/ingest/types.py` — pipeline carriers

`IngestionDocument` and `CandidatePage` — frozen dataclasses that flow through the ingestion pipeline. Raw fields come from the inbound push (mapped from `IngestRequest` at the API boundary) and the wiki page; **derived slots (`embedding`) are filled by enrichment stages** and default to `None`.

```python
@dataclass(frozen=True)
class IngestionDocument:
    content: str
    id: str | None = None            # source_document_id
    title: str | None = None
    source_type: str | None = None
    url: str | None = None
    metadata: dict[str, Any] | None = None
    embedding: list[float] | None = None   # filled by an enrichment stage

@dataclass(frozen=True)
class CandidatePage:
    path: str
    body: str
    title: str | None = None
    embedding: list[float] | None = None   # filled from the page-embedding store
```

- **Enrichment via `dataclasses.replace`** (`doc = replace(doc, embedding=vec)`) — data flow stays explicit; stage order can't silently mutate shared state.
- **Shared, not filter-local** — so the pipeline and multiple filters converge on one carrier and the embedding is computed once, not per filter.
- **Disciplined** — raw inputs + a few well-defined derived slots, not a god-object.

## `app/ingest/relevance/` — the filter contract

```python
class RelevanceFilter(ABC):
    @abstractmethod
    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool: ...
    def keep_relevant(self, doc, pages):          # batch default
        return [p for p in pages if self.is_relevant(doc, p)]
```

Domain objects in, boolean out. Nothing assumes a numeric **score** exists or that inputs are **vectors** — an embedding model reads the `embedding` slots, a rule reads `metadata`, an LLM reads the text; every field is optional to the contract and filters stay **fail-open** on a missing slot. So cosine / two-tower / LLM / rule all fit. Score, threshold, and embedding *computation* are subclass / enrichment-stage concerns added later.

## Next increments

- Enrichment stage that fills `IngestionDocument.embedding` once, and pre-loads `CandidatePage.embedding` from Phase 0's `page_embeddings`.
- `CosineModel` + a `ScoreThresholdFilter` base (score = cosine, config threshold), reading the pre-filled embeddings.
- Pipeline maps `IngestRequest → IngestionDocument` at the boundary and calls `keep_relevant` where it currently decides which candidates survive.

## Tests

`backend/tests/test_relevance.py` — ABC can't be instantiated; `keep_relevant` keeps all / none per verdict; `is_relevant` verdict is used. Ruff + basedpyright clean; no import cycle.