### PR TITLE
feat(wiki): deleted-page recovery + Trash (git-based)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -32,6 +32,7 @@ from app.models.file_system import (
     MovedFile,
     MovePathRequest,
     MovePathResponse,
+    PathTombstoneResponse,
     PutDocumentRequest,
     PutDocumentResponse,
     RecentDocsResponse,
@@ -39,6 +40,8 @@ from app.models.file_system import (
     ReindexRequest,
     ReindexResponse,
     ReorderStarredRequest,
+    RestorePathRequest,
+    RestorePathResponse,
     ReviseDraftRequest,
     ReviseDraftResponse,
     SearchHitView,
@@ -46,6 +49,9 @@ from app.models.file_system import (
     SetDocumentDraftRequest,
     StarDocRequest,
     StarredDocsResponse,
+    TombstoneCommit,
+    TrashItem,
+    TrashListResponse,
 )
 from app.tasks.reindex import index_path
 from app.triggers import repo as triggers_repo
@@ -459,6 +465,167 @@ def delete_document_by_path(
         wiki_notify.after_doc_delete(p, sha, author)
     log.info("doc deleted %s (%d pages) by %s sha=%s", rel, len(md_paths), author or "?", sha[:8])
     return DeleteDocumentResponse(sha=sha)
+
+
+def _restorable_paths(fate: wiki_git.PathFate) -> tuple[list[str], list[str]]:
+    """``(all files, .md pages)`` that a restore of ``fate`` would reintroduce."""
+    if fate.last_content_sha is None:
+        return [], []
+    prefix = fate.path + "/"
+    files = [
+        p
+        for p in wiki_git.tree_paths_at(fate.last_content_sha)
+        if p == fate.path or p.startswith(prefix)
+    ]
+    return files, [p for p in files if p.endswith(".md")]
+
+
+@router.get("/trash", response_model=TrashListResponse)
+def list_trash(
+    user: User = Depends(require_user),
+    limit: int = Query(100, ge=1, le=500),
+) -> TrashListResponse:
+    """Pages/folders deleted (and not since re-created or restored) — the Trash
+    view. Sourced from git: each delete is a commit, so we walk recent deletes
+    and keep those whose path has no live doc now. ACL-filtered: an item shows
+    only if the caller can read its closest surviving ancestor scope."""
+    items: list[TrashItem] = []
+    seen: set[str] = set()
+    for d in wiki_git.recent_deletions(limit=limit * 3):
+        if d.path in seen:
+            continue
+        seen.add(d.path)
+        # Skip anything live again at that path (re-created or already restored).
+        if filesystem.absolute(d.path).exists():
+            continue
+        if not acl.can(user.id, user.is_admin, "read", d.path):
+            continue
+        kind = "page" if d.path.endswith(".md") else "folder"
+        items.append(
+            TrashItem(
+                path=d.path,
+                kind=kind,
+                deleted_sha=d.sha,
+                deleted_by=d.author,
+                deleted_at=d.ts,
+                last_content_sha=wiki_git.parent_sha(d.sha),
+            )
+        )
+        if len(items) >= limit:
+            break
+    return TrashListResponse(items=items)
+
+
+@router.get("/file/tombstone", response_model=PathTombstoneResponse)
+def file_tombstone(
+    user: User = Depends(require_user),
+    path: str = "",
+) -> PathTombstoneResponse:
+    """Fate of a wiki path that no longer exists at HEAD: deleted (with the
+    ref where the content is still readable) or moved (with its current path,
+    rename chains followed). 404 when the path never existed."""
+    if not path:
+        raise HTTPException(status_code=400, detail="path required")
+    try:
+        rel = filesystem.safe_rel_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if filesystem.absolute(rel).exists():
+        raise HTTPException(status_code=409, detail="path exists")
+    fate = wiki_git.path_fate(rel)
+    if fate is None:
+        raise HTTPException(status_code=404, detail="not found")
+    commit = TombstoneCommit(sha=fate.sha, author=fate.author, ts=fate.ts, message=fate.message)
+    if fate.status == "moved" and fate.new_path is not None:
+        # The page's ACL rows moved with it — the target's rules decide who
+        # may learn where it went.
+        require_can("read", fate.new_path, user)
+        return PathTombstoneResponse(
+            path=rel, status="moved", commit=commit, moved_to=fate.new_path
+        )
+    # Deleted: the page's own ACL rows are gone, so this resolves through the
+    # closest surviving ancestor folder's ACLs (implicit-public if unmanaged).
+    require_can("read", fate.path, user)
+    _, md_paths = _restorable_paths(fate)
+    can_restore = bool(md_paths) and all(
+        acl.can(user.id, user.is_admin, "write", p) for p in md_paths
+    )
+    return PathTombstoneResponse(
+        path=rel,
+        status="deleted",
+        commit=commit,
+        last_content_sha=fate.last_content_sha,
+        can_restore=can_restore,
+    )
+
+
+@router.post("/file/restore", response_model=RestorePathResponse)
+def restore_deleted_path(
+    req: RestorePathRequest,
+    user: User = Depends(require_user),
+) -> RestorePathResponse:
+    """Reintroduce a deleted file or folder as of just before its delete
+    commit — a new additive commit, no history rewrite. Each restored page
+    runs the create lifecycle, so the restorer becomes its owner."""
+    try:
+        rel = filesystem.safe_rel_path(req.path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if filesystem.absolute(rel).exists():
+        raise HTTPException(status_code=409, detail="path already exists")
+    fate = wiki_git.path_fate(rel)
+    if fate is None:
+        raise HTTPException(status_code=404, detail="not found")
+    if fate.status == "moved":
+        raise HTTPException(
+            status_code=409, detail=f"not deleted — moved to '{fate.new_path}'"
+        )
+    if fate.last_content_sha is None:
+        raise HTTPException(status_code=404, detail="no restorable content")
+    # A moved-then-deleted page restores at its final (post-move) name, which
+    # may differ from the requested path — make sure that spot is free too.
+    if fate.path != rel and filesystem.absolute(fate.path).exists():
+        raise HTTPException(status_code=409, detail=f"'{fate.path}' already exists")
+    files, md_paths = _restorable_paths(fate)
+    if not files:
+        raise HTTPException(status_code=404, detail="no restorable content")
+    # Page-level ACL rows died with the pages; this resolves through the
+    # surviving ancestor folders' rules (implicit-public if unmanaged).
+    for p in md_paths:
+        require_can("write", p, user)
+    blocking = coedit.blocking_active_session_path(fate.path)
+    if blocking is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"someone is editing an unsaved draft at '{blocking}' — "
+            "wait for it to be saved",
+        )
+    author = _git_author(user)
+    try:
+        sha = wiki_git.restore_path(
+            fate.path, fate.last_content_sha, f"restore {fate.path}", author=author
+        )
+    except wiki_git.UnknownSha as exc:
+        raise HTTPException(status_code=404, detail="no restorable content") from exc
+    for p in md_paths:
+        # Create lifecycle: default-public ACLs + owner stamp, FTS reindex,
+        # trigger fan-out, MCP pub-sub.
+        wiki_notify.after_doc_write(
+            p, sha, ChangeKind.CREATE, author, owner_user_id=user.id
+        )
+    # Restoring a folder can reintroduce trigger YAMLs whose cache rows were
+    # dropped — reconverge the cache from disk so they fire again.
+    if any(p.rsplit("/", 1)[-1].startswith(".trigger_") for p in files):
+        triggers_repo.rebuild_from_filesystem()
+    log.info(
+        "restored %s (%d pages) from %s by %s sha=%s",
+        fate.path,
+        len(md_paths),
+        fate.last_content_sha[:8],
+        author or "?",
+        sha[:8],
+    )
+    return RestorePathResponse(path=fate.path, sha=sha, restored=files)
 
 
 @router.post("/reindex", response_model=ReindexResponse)

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -186,6 +186,60 @@ class DeleteDocumentResponse(BaseModel):
     sha: str
 
 
+class TombstoneCommit(BaseModel):
+    """The commit that removed or renamed the requested path."""
+
+    sha: str
+    author: str
+    ts: str
+    message: str
+
+
+class PathTombstoneResponse(BaseModel):
+    """Fate of a wiki path that no longer exists at HEAD.
+
+    ``status="deleted"``: ``last_content_sha`` is the ref where the content is
+    still readable (``GET /wiki/file?ref=``) and ``path`` is the name the page
+    had when deleted (differs from the requested path if it was moved first).
+    ``status="moved"``: ``moved_to`` is the path's current name at HEAD.
+    """
+
+    path: str
+    status: Literal["deleted", "moved"]
+    commit: TombstoneCommit
+    moved_to: str | None = None
+    last_content_sha: str | None = None
+    can_restore: bool = False
+
+
+class RestorePathRequest(BaseModel):
+    path: str = Field(min_length=1)
+
+
+class RestorePathResponse(BaseModel):
+    path: str
+    sha: str
+    restored: list[str]  # every file reintroduced (all of them for a folder)
+
+
+class TrashItem(BaseModel):
+    """One deleted page/folder in the Trash view.
+
+    ``path`` is where it lived when deleted; feed it to the restore endpoint.
+    """
+
+    path: str
+    kind: Literal["page", "folder"]
+    deleted_sha: str
+    deleted_by: str
+    deleted_at: str  # ISO-8601
+    last_content_sha: str | None = None  # ref to preview the pre-delete content
+
+
+class TrashListResponse(BaseModel):
+    items: list[TrashItem]
+
+
 class ReindexResponse(BaseModel):
     path: str
     queued: bool

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from collections.abc import Generator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -260,6 +261,182 @@ def delete_path(rel_path: str, message: str, author: str | None = None) -> str:
         sha = _run(["rev-parse", "HEAD"]).stdout.strip()
     log.debug("delete_path %s sha=%s author=%s", rel_path, sha[:8], author or "default")
     return sha
+
+
+class PathFate(BaseModel):
+    """Resolution of a path that is absent from HEAD's tree.
+
+    ``path`` is the name the file/folder had when the fate commit touched it
+    — for a moved-then-deleted page this is the post-move name, which is
+    where ``last_content_sha`` can read it and where a restore reintroduces it.
+    """
+
+    status: Literal["deleted", "moved"]
+    path: str
+    sha: str  # the commit that removed or renamed the path
+    author: str
+    ts: str  # ISO-8601 author date
+    message: str  # commit subject
+    new_path: str | None = None  # moved only: current path at HEAD
+    last_content_sha: str | None = None  # deleted only: parent of the delete commit
+
+
+def _commit_name_status(sha: str) -> list[tuple[str, str, str | None]]:
+    """``(status, path, rename_target)`` rows for one commit, with rename
+    detection on. No pathspec — filtering by path would hide the new side
+    of a rename and make git report it as a plain delete."""
+    out = _run(
+        ["diff-tree", "-M", "--name-status", "-r", "--root", "--no-commit-id", sha],
+        check=False,
+    ).stdout
+    rows: list[tuple[str, str, str | None]] = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0]
+        if status.startswith("R") and len(parts) == 3:
+            rows.append((status, parts[1], parts[2]))
+        else:
+            rows.append((status, parts[-1], None))
+    return rows
+
+
+def _fate_commit_meta(rel_path: str) -> tuple[str, str, str, str] | None:
+    """``(sha, author, ts, subject)`` of the last commit touching ``rel_path``."""
+    sep = "\x1f"
+    out = _run(
+        ["log", "-n1", f"--pretty=format:%H{sep}%an{sep}%aI{sep}%s", "--", rel_path],
+        check=False,
+    ).stdout.strip()
+    if not out:
+        return None
+    parts = out.split(sep)
+    return (parts[0], parts[1], parts[2], parts[3]) if len(parts) == 4 else None
+
+
+def path_fate(rel_path: str, *, max_hops: int = 10) -> PathFate | None:
+    """Resolve the fate of a path that no longer exists at HEAD.
+
+    Returns a ``PathFate`` with status ``"deleted"`` (plus the ref where the
+    content is still readable) or ``"moved"`` (plus the path's current name at
+    HEAD, following up to ``max_hops`` successive renames — a moved-then-moved
+    or moved-then-deleted chain resolves to its final fate). Works for files
+    and folders; a folder's fate is derived from the fate of its tracked
+    children. Returns ``None`` when the path never existed, still exists at
+    HEAD, or the rename chain can't be resolved.
+    """
+    current = rel_path
+    for _ in range(max_hops):
+        meta = _fate_commit_meta(current)
+        if meta is None:
+            return None
+        sha, author, ts, subject = meta
+        rows = _commit_name_status(sha)
+        prefix = current + "/"
+        moved_to: str | None = None
+        deleted = False
+        for status, old_p, new_p in rows:
+            if status.startswith("R") and new_p is not None:
+                if old_p == current:
+                    moved_to = new_p
+                    break
+                if old_p.startswith(prefix):
+                    # Folder rename: recover the folder's new name by
+                    # stripping this child's relative suffix off its new path.
+                    rest = old_p[len(prefix) :]
+                    if new_p.endswith("/" + rest):
+                        moved_to = new_p[: -len(rest) - 1]
+                        break
+            elif status == "D" and (old_p == current or old_p.startswith(prefix)):
+                deleted = True
+            elif old_p == current or old_p.startswith(prefix):
+                # The last commit touching this path added/modified it — the
+                # path (or part of the folder) still exists; not a tombstone.
+                return None
+        if moved_to is not None:
+            if (Path(CONFIG.wiki_dir) / moved_to).exists():
+                return PathFate(
+                    status="moved",
+                    path=current,
+                    sha=sha,
+                    author=author,
+                    ts=ts,
+                    message=subject,
+                    new_path=moved_to,
+                )
+            current = moved_to  # renamed again or deleted later — keep chasing
+            continue
+        if deleted:
+            return PathFate(
+                status="deleted",
+                path=current,
+                sha=sha,
+                author=author,
+                ts=ts,
+                message=subject,
+                last_content_sha=parent_sha(sha),
+            )
+        return None
+    return None
+
+
+def restore_path(rel_path: str, ref: str, message: str, author: str | None = None) -> str:
+    """Reintroduce ``rel_path`` (file or folder) as it existed at ``ref``,
+    as a new commit — additive history, no revert. Returns the commit SHA.
+
+    Raises ``UnknownSha`` when ``ref:rel_path`` can't be resolved.
+    """
+    env_args = ["--author", author] if author else []
+    with commit_lock():
+        try:
+            # checkout <ref> -- <path> updates the index and working tree.
+            _run(["checkout", ref, "--", rel_path])
+        except subprocess.CalledProcessError as e:
+            raise UnknownSha(ref) from e
+        _run(["commit", "-m", message, *env_args])
+        sha = _run(["rev-parse", "HEAD"]).stdout.strip()
+    log.info("restore_path %s from %s sha=%s", rel_path, ref[:8], sha[:8])
+    return sha
+
+
+class Deletion(BaseModel):
+    """A deleted ``.md`` page, from a delete commit (for the Trash view)."""
+
+    path: str
+    sha: str  # the commit that deleted it
+    author: str
+    ts: str  # ISO-8601 author date
+
+
+def recent_deletions(limit: int = 100) -> list[Deletion]:
+    """Deleted ``.md`` pages, newest-first, one entry per (path, delete commit).
+
+    Walks ``git log --diff-filter=D`` for delete events. A page later
+    re-created or restored still appears here (git can't know it's live again);
+    the caller filters those out by checking current existence. Folder deletes
+    surface as their individual nested pages.
+    """
+    sep = "\x1f"
+    out = _run(
+        [
+            "log",
+            f"-n{limit}",
+            "--diff-filter=D",
+            "--name-only",
+            f"--pretty=format:C{sep}%H{sep}%an{sep}%aI",
+        ],
+        check=False,
+    ).stdout
+    dels: list[Deletion] = []
+    cur: tuple[str, str, str] | None = None
+    for line in out.splitlines():
+        if line.startswith("C" + sep):
+            parts = line.split(sep)
+            cur = (parts[1], parts[2], parts[3]) if len(parts) == 4 else None
+        elif line.endswith(".md") and cur is not None:
+            dels.append(Deletion(path=line, sha=cur[0], author=cur[1], ts=cur[2]))
+    return dels
 
 
 def read_file(rel_path: str, ref: str = "HEAD") -> str:

--- a/backend/tests/test_tombstone_restore.py
+++ b/backend/tests/test_tombstone_restore.py
@@ -1,0 +1,274 @@
+"""Tombstone + restore for deleted/moved wiki paths.
+
+``path_fate`` resolves a HEAD-absent path to its fate from git history —
+deleted (with the ref where content is still readable) or moved (rename
+chains followed to the current name). The tombstone endpoint exposes that;
+the restore endpoint reintroduces a deleted file or folder as a new additive
+commit and runs the create lifecycle per page, so the restorer becomes the
+owner and search/triggers pick the pages back up.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import acl
+from app.wiki import git as wiki_git
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _client(user_id: str) -> TestClient:
+    client = TestClient(create_app())
+    login_fastapi(client, user_id)
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# path_fate (git seam)                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_path_fate_deleted_file(tmp_repo):
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    del_sha = wiki_git.delete_path("a.md", "delete a.md")
+
+    fate = wiki_git.path_fate("a.md")
+
+    assert fate is not None
+    assert fate.status == "deleted"
+    assert fate.sha == del_sha
+    assert fate.path == "a.md"
+    assert fate.last_content_sha == wiki_git.parent_sha(del_sha)
+    assert wiki_git.read_file("a.md", ref=fate.last_content_sha or "") == "# A\n"
+
+
+def test_path_fate_moved_file(tmp_repo):
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.move_path("a.md", "b.md", "move")
+
+    fate = wiki_git.path_fate("a.md")
+
+    assert fate is not None
+    assert fate.status == "moved"
+    assert fate.new_path == "b.md"
+
+
+def test_path_fate_follows_move_then_delete_chain(tmp_repo):
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.move_path("a.md", "b.md", "move")
+    del_sha = wiki_git.delete_path("b.md", "delete b.md")
+
+    fate = wiki_git.path_fate("a.md")
+
+    assert fate is not None
+    assert fate.status == "deleted"
+    assert fate.path == "b.md"  # restores at its final name
+    assert fate.sha == del_sha
+
+
+def test_path_fate_follows_move_chain_to_head_name(tmp_repo):
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.move_path("a.md", "b.md", "move 1")
+    wiki_git.move_path("b.md", "c.md", "move 2")
+
+    fate = wiki_git.path_fate("a.md")
+
+    assert fate is not None
+    assert fate.status == "moved"
+    assert fate.new_path == "c.md"
+
+
+def test_path_fate_folder_delete_and_move(tmp_repo):
+    wiki_git.commit_file("proj/a.md", "# A\n", "seed a")
+    wiki_git.commit_file("proj/sub/b.md", "# B\n", "seed b")
+    wiki_git.move_path("proj", "proj2", "move folder")
+
+    moved = wiki_git.path_fate("proj")
+    assert moved is not None
+    assert moved.status == "moved"
+    assert moved.new_path == "proj2"
+
+    del_sha = wiki_git.delete_path("proj2", "delete folder")
+    deleted = wiki_git.path_fate("proj")
+    assert deleted is not None
+    assert deleted.status == "deleted"
+    assert deleted.path == "proj2"
+    assert deleted.sha == del_sha
+
+
+def test_path_fate_none_for_unknown_or_existing(tmp_repo):
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    assert wiki_git.path_fate("never-existed.md") is None
+    assert wiki_git.path_fate("a.md") is None  # exists at HEAD — not a tombstone
+
+
+# --------------------------------------------------------------------------- #
+# Tombstone endpoint                                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_tombstone_deleted_page(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    del_sha = wiki_git.delete_path("a.md", "delete a.md")
+
+    resp = client.get("/api/wiki/file/tombstone?path=a.md")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "deleted"
+    assert data["commit"]["sha"] == del_sha
+    assert data["can_restore"] is True
+    # The advertised ref serves the pre-delete body through the read endpoint.
+    read = client.get(f"/api/wiki/file?path=a.md&ref={data['last_content_sha']}")
+    assert read.status_code == 200
+    assert read.json()["body"] == "# A\n"
+
+
+def test_tombstone_moved_page(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.move_path("a.md", "docs/b.md", "move")
+
+    resp = client.get("/api/wiki/file/tombstone?path=a.md")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "moved"
+    assert data["moved_to"] == "docs/b.md"
+
+
+def test_tombstone_unknown_and_existing_paths(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+
+    assert client.get("/api/wiki/file/tombstone?path=nope.md").status_code == 404
+    assert client.get("/api/wiki/file/tombstone?path=a.md").status_code == 409
+
+
+# --------------------------------------------------------------------------- #
+# Restore endpoint                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_restore_deleted_page_roundtrip(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.delete_path("a.md", "delete a.md")
+
+    resp = client.post("/api/wiki/file/restore", json={"path": "a.md"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["path"] == "a.md"
+    assert data["restored"] == ["a.md"]
+    read = client.get("/api/wiki/file?path=a.md")
+    assert read.status_code == 200
+    assert read.json()["body"] == "# A\n"
+    # Create lifecycle ran: the restorer owns the page now.
+    assert acl.get_owner("a.md") == user
+    # The delete stays in history — restore is additive, not a rewrite.
+    messages = [c.message for c in wiki_git.history("a.md")]
+    assert "delete a.md" in messages
+    # Nothing left to restore at this path.
+    assert client.post("/api/wiki/file/restore", json={"path": "a.md"}).status_code == 409
+
+
+def test_restore_folder_restores_nested_pages(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("proj/a.md", "# A\n", "seed a")
+    wiki_git.commit_file("proj/sub/b.md", "# B\n", "seed b")
+    wiki_git.delete_path("proj", "delete folder")
+
+    resp = client.post("/api/wiki/file/restore", json={"path": "proj"})
+
+    assert resp.status_code == 200
+    assert sorted(resp.json()["restored"]) == ["proj/a.md", "proj/sub/b.md"]
+    for p, body in (("proj/a.md", "# A\n"), ("proj/sub/b.md", "# B\n")):
+        read = client.get(f"/api/wiki/file?path={p}")
+        assert read.status_code == 200
+        assert read.json()["body"] == body
+        assert acl.get_owner(p) == user
+
+
+def test_restore_moved_page_refused_with_pointer(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.move_path("a.md", "b.md", "move")
+
+    resp = client.post("/api/wiki/file/restore", json={"path": "a.md"})
+
+    assert resp.status_code == 409
+    assert "b.md" in resp.json()["error"]
+
+
+def test_restore_moved_then_deleted_restores_at_final_name(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.move_path("a.md", "b.md", "move")
+    wiki_git.delete_path("b.md", "delete b.md")
+
+    resp = client.post("/api/wiki/file/restore", json={"path": "a.md"})
+
+    assert resp.status_code == 200
+    assert resp.json()["path"] == "b.md"
+    read = client.get("/api/wiki/file?path=b.md")
+    assert read.status_code == 200
+    assert read.json()["body"] == "# A\n"
+
+
+# --------------------------------------------------------------------------- #
+# Trash listing                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_trash_lists_deleted_pages(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("keep.md", "# Keep\n", "seed")
+    wiki_git.commit_file("gone.md", "# Gone\n", "seed")
+    wiki_git.delete_path("gone.md", "delete gone.md")
+
+    items = client.get("/api/wiki/trash").json()["items"]
+    paths = {i["path"]: i for i in items}
+    assert "gone.md" in paths
+    assert "keep.md" not in paths  # live pages aren't trash
+    assert paths["gone.md"]["kind"] == "page"
+    # The advertised ref serves the pre-delete body.
+    read = client.get(
+        f"/api/wiki/file?path=gone.md&ref={paths['gone.md']['last_content_sha']}"
+    )
+    assert read.status_code == 200
+    assert read.json()["body"] == "# Gone\n"
+
+
+def test_trash_drops_recreated_and_restored_paths(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    # Deleted then re-created at the same path → not in trash (live again).
+    wiki_git.commit_file("a.md", "# A\n", "seed")
+    wiki_git.delete_path("a.md", "delete a.md")
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# A2\n"})
+
+    # Deleted then restored → not in trash.
+    wiki_git.commit_file("b.md", "# B\n", "seed")
+    wiki_git.delete_path("b.md", "delete b.md")
+    client.post("/api/wiki/file/restore", json={"path": "b.md"})
+
+    # Deleted and still gone → in trash.
+    wiki_git.commit_file("c.md", "# C\n", "seed")
+    wiki_git.delete_path("c.md", "delete c.md")
+
+    paths = {i["path"] for i in client.get("/api/wiki/trash").json()["items"]}
+    assert "c.md" in paths
+    assert "a.md" not in paths
+    assert "b.md" not in paths


### PR DESCRIPTION
Re-lands the deleted-page **restore engine** (salvaged from the abandoned #374, stripped of the id-URL/doc_ids coupling that conflicted with main) as a clean, focused PR on `main`, plus a new **Trash** listing.

## Why git-based

Every wiki delete is an additive git commit, so deleted content is already recoverable from history — no soft-delete table needed. Restore re-commits the old content; nothing is ever force-removed.

## Backend

- **`git.py`**
  - `path_fate(path)` — for a path absent at HEAD, resolves `deleted` (with `last_content_sha`, the ref where the pre-delete body is readable) or `moved` (following rename chains forward). Files and folders.
  - `restore_path(path, ref)` — `git checkout <ref> -- <path>` + commit; additive, no revert.
  - `recent_deletions(limit)` — walks `git log --diff-filter=D` for delete events.
- **Endpoints**
  - `GET /api/wiki/file/tombstone?path=` — a missing path's fate (deleted vs moved).
  - `POST /api/wiki/file/restore` — restore a deleted file/folder; each restored `.md` runs the normal create lifecycle (`after_doc_write(create)` → default ACLs + owner stamp, FTS reindex, trigger fan-out), and restored trigger YAMLs reconverge the cache.
  - `GET /api/wiki/trash` — deleted pages not since re-created or restored, ACL-filtered (an item shows only if the caller can read its closest surviving ancestor scope).

## Scope / decisions

- **Restore is content-only** — permissions re-seed to defaults (lossless permission-restore would need soft-deleted ACL rows; deferred).
- **Trash lists pages**; a deleted folder surfaces as its nested pages for now (folder-level grouping is a follow-up).
- **Frontend Trash view** lands in a stacked PR.
- Deliberately **excludes** the stable-doc-id / id-URL feature (separate, de-prioritized).

## Testing

Ported #374's tombstone/restore tests (git-only, no doc_ids) + added Trash-list tests (deleted pages listed; re-created/restored paths excluded). ruff + basedpyright clean locally. **pytest runs in CI** (my local Docker Postgres is wedged this session, so CI is the authoritative test run).