### PR TITLE
feat(wiki): Trash — soft delete as a move to hidden .trash/

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -470,7 +470,9 @@ def delete_document_by_path(
     dest = wiki_trash.trash_location(trash_id, rel)
     msg = wiki_trash.trash_commit_message(rel)
     sha, moves = wiki_git.move_path(rel, dest, msg, author=author)
-    wiki_notify.after_doc_trashed(moves, sha, author)
+    wiki_notify.after_doc_trashed(
+        moves, sha, author, root_move=PathMove(old=rel, new=dest)
+    )
     log.info("doc trashed %s (%d pages) trash_id=%s by %s", rel, len(md_paths), trash_id, author or "?")
     return DeleteDocumentResponse(sha=sha, trash_id=trash_id)
 
@@ -556,7 +558,12 @@ def restore_trashed(
         req.trash_id, f"restore {entry.original_path}", author=author
     )
     # Moving out of .trash/ is a normal move: re-index + re-point everything back.
-    wiki_notify.after_path_move(moves, sha, author)
+    # root_move is the trash root → original, so a folder's own ACL/policy row
+    # follows even when its files are all nested (mirrors the trash direction).
+    trash_root = wiki_trash.trash_location(req.trash_id, entry.original_path)
+    wiki_notify.after_path_move(
+        moves, sha, author, root_move=PathMove(old=trash_root, new=entry.original_path)
+    )
     log.info(
         "restored trash_id=%s to %s (%d files) by %s",
         req.trash_id,

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -477,31 +477,35 @@ def delete_document_by_path(
     return DeleteDocumentResponse(sha=sha, trash_id=trash_id)
 
 
-def _trash_perm(user: User, action: str, entry: "wiki_trash.TrashEntry") -> bool:
-    """Can ``user`` read/restore this trashed item? Checked against the *trash*
-    path — the item's own ACL grants were re-pointed there by the trashing move,
-    so this reflects who could access the page, not who can see its (possibly
-    unrelated) original folder now."""
+def _trash_perms(user: User, entry: "wiki_trash.TrashEntry") -> set[str]:
+    """The user's permissions on a trashed item, resolved once against the
+    *trash* path — the item's own ACL grants were re-pointed there by the
+    trashing move, so this reflects who could access the page, not who can see
+    its (possibly unrelated) original folder now. Callers derive read-visibility
+    and restore (write) from the returned set to avoid a second DB round-trip."""
     loc = wiki_trash.trash_location(entry.trash_id, entry.original_path)
-    return acl.can(user.id, user.is_admin, action, loc)
+    return acl.effective(user.id, user.is_admin, loc)
 
 
 @router.get("/trash", response_model=TrashListResponse)
 def list_trash(user: User = Depends(require_user)) -> TrashListResponse:
     """Trashed pages/folders, newest-first — the Trash view. Derived from the
     `.trash/` git tree; shown only to callers who could access the item."""
-    items = [
-        TrashEntryView(
-            trash_id=e.trash_id,
-            path=e.original_path,
-            kind="page" if e.kind == "page" else "folder",
-            trashed_by=e.trashed_by,
-            trashed_at=e.trashed_at,
-            can_restore=_trash_perm(user, "write", e),
+    items: list[TrashEntryView] = []
+    for e in wiki_trash.list_entries():
+        perms = _trash_perms(user, e)
+        if "read" not in perms:
+            continue
+        items.append(
+            TrashEntryView(
+                trash_id=e.trash_id,
+                path=e.original_path,
+                kind="page" if e.kind == "page" else "folder",
+                trashed_by=e.trashed_by,
+                trashed_at=e.trashed_at,
+                can_restore="write" in perms,
+            )
         )
-        for e in wiki_trash.list_entries()
-        if _trash_perm(user, "read", e)
-    ]
     return TrashListResponse(items=items)
 
 
@@ -515,7 +519,8 @@ def view_trash_item(
     entry = wiki_trash.entry_for(trash_id)
     if entry is None:
         raise HTTPException(status_code=404, detail="not found")
-    if not _trash_perm(user, "read", entry):
+    perms = _trash_perms(user, entry)
+    if "read" not in perms:
         raise HTTPException(status_code=403, detail="not permitted")
     body: str | None = None
     if entry.kind == "page":
@@ -528,7 +533,7 @@ def view_trash_item(
         kind="page" if entry.kind == "page" else "folder",
         trashed_by=entry.trashed_by,
         trashed_at=entry.trashed_at,
-        can_restore=_trash_perm(user, "write", entry),
+        can_restore="write" in perms,
         body=body,
     )
 
@@ -544,7 +549,7 @@ def restore_trashed(
     entry = wiki_trash.entry_for(req.trash_id)
     if entry is None:
         raise HTTPException(status_code=404, detail="not found")
-    if not _trash_perm(user, "write", entry):
+    if "write" not in _trash_perms(user, entry):
         raise HTTPException(status_code=403, detail="not permitted")
     # Refuse if any original path is now occupied (re-created since deletion).
     prefix = f"{wiki_trash.TRASH_DIR}/{req.trash_id}/"

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -500,7 +500,7 @@ def list_trash(user: User = Depends(require_user)) -> TrashListResponse:
             TrashEntryView(
                 trash_id=e.trash_id,
                 path=e.original_path,
-                kind="page" if e.kind == "page" else "folder",
+                kind=e.kind,
                 trashed_by=e.trashed_by,
                 trashed_at=e.trashed_at,
                 can_restore="write" in perms,
@@ -530,7 +530,7 @@ def view_trash_item(
     return TrashItemView(
         trash_id=entry.trash_id,
         path=entry.original_path,
-        kind="page" if entry.kind == "page" else "folder",
+        kind=entry.kind,
         trashed_by=entry.trashed_by,
         trashed_at=entry.trashed_at,
         can_restore="write" in perms,

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -39,6 +39,8 @@ from app.models.file_system import (
     ReindexRequest,
     ReindexResponse,
     ReorderStarredRequest,
+    RestorePathResponse,
+    RestoreTrashRequest,
     ReviseDraftRequest,
     ReviseDraftResponse,
     SearchHitView,
@@ -46,6 +48,9 @@ from app.models.file_system import (
     SetDocumentDraftRequest,
     StarDocRequest,
     StarredDocsResponse,
+    TrashEntryView,
+    TrashItemView,
+    TrashListResponse,
 )
 from app.tasks.reindex import index_path
 from app.triggers import repo as triggers_repo
@@ -62,6 +67,7 @@ from app.wiki import (
     search as wiki_search,
     starred as wiki_starred,
     templates as templates_repo,
+    trash as wiki_trash,
     update_policy as update_policy_repo,
     utils as wiki_utils,
 )
@@ -456,13 +462,110 @@ def delete_document_by_path(
     for p in md_paths:
         require_can("write", p, user)
     author = _git_author(user)
-    sha = wiki_git.delete_path(rel, f"delete {rel}", author=author)
-    for p in md_paths:
-        # Drops FTS / ACL / comments / activity / working-dir state for each
-        # removed page.
-        wiki_notify.after_doc_delete(p, sha, author)
-    log.info("doc deleted %s (%d pages) by %s sha=%s", rel, len(md_paths), author or "?", sha[:8])
-    return DeleteDocumentResponse(sha=sha)
+    # Soft delete = move into the hidden .trash/<trash_id>/<path>. Because it's
+    # a move, after_doc_trashed re-points ACL/comments/policy to the trash
+    # location, so restore is lossless; the item is dropped from search and
+    # hidden everywhere (see filesystem.TRASH_DIR + the enumerator exclusions).
+    trash_id = wiki_trash.new_trash_id()
+    dest = wiki_trash.trash_location(trash_id, rel)
+    sha, moves = wiki_git.move_path(rel, dest, f"trash {rel}", author=author)
+    wiki_notify.after_doc_trashed(moves, sha, author)
+    log.info("doc trashed %s (%d pages) trash_id=%s by %s", rel, len(md_paths), trash_id, author or "?")
+    return DeleteDocumentResponse(sha=sha, trash_id=trash_id)
+
+
+def _trash_perm(user: User, action: str, entry: "wiki_trash.TrashEntry") -> bool:
+    """Can ``user`` read/restore this trashed item? Checked against the *trash*
+    path — the item's own ACL grants were re-pointed there by the trashing move,
+    so this reflects who could access the page, not who can see its (possibly
+    unrelated) original folder now."""
+    loc = wiki_trash.trash_location(entry.trash_id, entry.original_path)
+    return acl.can(user.id, user.is_admin, action, loc)
+
+
+@router.get("/trash", response_model=TrashListResponse)
+def list_trash(user: User = Depends(require_user)) -> TrashListResponse:
+    """Trashed pages/folders, newest-first — the Trash view. Derived from the
+    `.trash/` git tree; shown only to callers who could access the item."""
+    items = [
+        TrashEntryView(
+            trash_id=e.trash_id,
+            path=e.original_path,
+            kind="page" if e.kind == "page" else "folder",
+            trashed_by=e.trashed_by,
+            trashed_at=e.trashed_at,
+            can_restore=_trash_perm(user, "write", e),
+        )
+        for e in wiki_trash.list_entries()
+        if _trash_perm(user, "read", e)
+    ]
+    return TrashListResponse(items=items)
+
+
+@router.get("/trash/{trash_id}", response_model=TrashItemView)
+def view_trash_item(
+    trash_id: str,
+    user: User = Depends(require_user),
+) -> TrashItemView:
+    """A trashed item's details + (for a page) its content, for preview before
+    restore. Reads the `.trash/` copy directly — the only read path into it."""
+    entry = wiki_trash.entry_for(trash_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="not found")
+    if not _trash_perm(user, "read", entry):
+        raise HTTPException(status_code=403, detail="not permitted")
+    body: str | None = None
+    if entry.kind == "page":
+        body = wiki_git.read_file_opt(
+            wiki_trash.trash_location(trash_id, entry.original_path)
+        )
+    return TrashItemView(
+        trash_id=entry.trash_id,
+        path=entry.original_path,
+        kind="page" if entry.kind == "page" else "folder",
+        trashed_by=entry.trashed_by,
+        trashed_at=entry.trashed_at,
+        can_restore=_trash_perm(user, "write", entry),
+        body=body,
+    )
+
+
+@router.post("/file/restore", response_model=RestorePathResponse)
+def restore_trashed(
+    req: RestoreTrashRequest,
+    user: User = Depends(require_user),
+) -> RestorePathResponse:
+    """Restore a trashed item: move it back out of `.trash/` to its original
+    path. Lossless — `after_path_move` re-points the metadata that trashing
+    parked at the trash location."""
+    entry = wiki_trash.entry_for(req.trash_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="not found")
+    if not _trash_perm(user, "write", entry):
+        raise HTTPException(status_code=403, detail="not permitted")
+    # Refuse if any original path is now occupied (re-created since deletion).
+    prefix = f"{wiki_trash.TRASH_DIR}/{req.trash_id}/"
+    for f in wiki_git.list_trash_files():
+        if f.startswith(prefix) and filesystem.absolute(f[len(prefix) :]).exists():
+            raise HTTPException(
+                status_code=409, detail=f"'{f[len(prefix):]}' already exists"
+            )
+    author = _git_author(user)
+    sha, moves = wiki_git.restore_from_trash(
+        req.trash_id, f"restore {entry.original_path}", author=author
+    )
+    # Moving out of .trash/ is a normal move: re-index + re-point everything back.
+    wiki_notify.after_path_move(moves, sha, author)
+    log.info(
+        "restored trash_id=%s to %s (%d files) by %s",
+        req.trash_id,
+        entry.original_path,
+        len(moves),
+        author or "?",
+    )
+    return RestorePathResponse(
+        path=entry.original_path, sha=sha, restored=[m.new for m in moves]
+    )
 
 
 @router.post("/reindex", response_model=ReindexResponse)

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -468,7 +468,8 @@ def delete_document_by_path(
     # hidden everywhere (see filesystem.TRASH_DIR + the enumerator exclusions).
     trash_id = wiki_trash.new_trash_id()
     dest = wiki_trash.trash_location(trash_id, rel)
-    sha, moves = wiki_git.move_path(rel, dest, f"trash {rel}", author=author)
+    msg = wiki_trash.trash_commit_message(rel)
+    sha, moves = wiki_git.move_path(rel, dest, msg, author=author)
     wiki_notify.after_doc_trashed(moves, sha, author)
     log.info("doc trashed %s (%d pages) trash_id=%s by %s", rel, len(md_paths), trash_id, author or "?")
     return DeleteDocumentResponse(sha=sha, trash_id=trash_id)

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -184,6 +184,39 @@ class MovePathResponse(BaseModel):
 
 class DeleteDocumentResponse(BaseModel):
     sha: str
+    # Deleting moves the item to Trash; this is its handle for restore/undo.
+    trash_id: str | None = None
+
+
+class TrashEntryView(BaseModel):
+    """One item in the Trash list."""
+
+    trash_id: str
+    path: str  # original location; restore moves it back here
+    kind: Literal["page", "folder"]
+    trashed_by: str
+    trashed_at: str  # ISO-8601
+    can_restore: bool = False
+
+
+class TrashListResponse(BaseModel):
+    items: list[TrashEntryView]
+
+
+class TrashItemView(TrashEntryView):
+    """A single trashed item plus (for a page) its content, for preview."""
+
+    body: str | None = None
+
+
+class RestoreTrashRequest(BaseModel):
+    trash_id: str = Field(min_length=1)
+
+
+class RestorePathResponse(BaseModel):
+    path: str  # where it was restored to
+    sha: str
+    restored: list[str]  # every file reintroduced
 
 
 class ReindexResponse(BaseModel):

--- a/backend/app/wiki/filesystem.py
+++ b/backend/app/wiki/filesystem.py
@@ -10,13 +10,25 @@ from app.models.wiki import PathMove
 
 log = logging.getLogger(__name__)
 
+# Reserved top-level directory holding trashed items (`.trash/<id>/<path>`).
+# It is internal: no user-facing path may live in or resolve into it, so the
+# whole feature's isolation hinges on rejecting it here — every read/write/list
+# normalizes through safe_rel_path. Trash internals build `.trash/…` paths
+# directly (bypassing this guard) via the trash repo.
+TRASH_DIR = ".trash"
+
 
 def safe_rel_path(rel_path: str) -> str:
-    """Reject path traversal. Returns a normalized path or raises ValueError."""
+    """Reject path traversal and the reserved ``.trash/`` area. Returns a
+    normalized path or raises ValueError."""
     if rel_path.startswith("/") or ".." in Path(rel_path).parts:
         log.warning("rejected unsafe wiki path: %r", rel_path)
         raise ValueError(f"unsafe path: {rel_path!r}")
-    return os.path.normpath(rel_path)
+    normalized = os.path.normpath(rel_path)
+    if normalized == TRASH_DIR or normalized.startswith(TRASH_DIR + "/"):
+        log.warning("rejected access to trash path: %r", rel_path)
+        raise ValueError(f"path is in trash and not directly accessible: {rel_path!r}")
+    return normalized
 
 
 def absolute(rel_path: str) -> Path:

--- a/backend/app/wiki/filesystem.py
+++ b/backend/app/wiki/filesystem.py
@@ -14,8 +14,10 @@ log = logging.getLogger(__name__)
 # It is internal: no user-facing path may live in or resolve into it, so the
 # whole feature's isolation hinges on rejecting it here — every read/write/list
 # normalizes through safe_rel_path. Trash internals build `.trash/…` paths
-# directly (bypassing this guard) via the trash repo.
+# directly (bypassing this guard) via the trash repo. This is the single
+# definition; git.py and trash.py import it.
 TRASH_DIR = ".trash"
+TRASH_PREFIX = TRASH_DIR + "/"
 
 
 def safe_rel_path(rel_path: str) -> str:
@@ -25,7 +27,7 @@ def safe_rel_path(rel_path: str) -> str:
         log.warning("rejected unsafe wiki path: %r", rel_path)
         raise ValueError(f"unsafe path: {rel_path!r}")
     normalized = os.path.normpath(rel_path)
-    if normalized == TRASH_DIR or normalized.startswith(TRASH_DIR + "/"):
+    if normalized == TRASH_DIR or normalized.startswith(TRASH_PREFIX):
         log.warning("rejected access to trash path: %r", rel_path)
         raise ValueError(f"path is in trash and not directly accessible: {rel_path!r}")
     return normalized

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -654,18 +654,21 @@ def list_trash_files() -> list[str]:
     return [p for p in out.split("\0") if p]
 
 
-def last_commit_meta_for_path(rel_path: str) -> tuple[str, str, str] | None:
-    """``(sha, author, ISO-ts)`` of the most recent commit touching ``rel_path``,
-    or ``None``. For a trashed path this is the trash-move commit (who/when)."""
+def last_commit_meta_for_path(rel_path: str) -> tuple[str, str, str, str] | None:
+    """``(sha, author, ISO-ts, message)`` of the most recent commit touching
+    ``rel_path``, or ``None``. For a trashed path this is the trash-move commit —
+    who/when plus the full message, whose ``Trash-Original`` trailer records the
+    root that was trashed (see ``app/wiki/trash.py``). ``message`` is placed last
+    so its embedded newlines can't be confused with a field separator."""
     sep = "\x1f"
     out = _run(
-        ["log", "-n1", f"--pretty=format:%H{sep}%an{sep}%aI", "--", rel_path],
+        ["log", "-n1", f"--pretty=format:%H{sep}%an{sep}%aI{sep}%B", "--", rel_path],
         check=False,
     ).stdout.strip()
     if not out:
         return None
-    parts = out.split(sep)
-    return (parts[0], parts[1], parts[2]) if len(parts) == 3 else None
+    parts = out.split(sep, 3)
+    return (parts[0], parts[1], parts[2], parts[3]) if len(parts) == 4 else None
 
 
 def restore_from_trash(

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -29,6 +29,12 @@ log = logging.getLogger(__name__)
 
 _SHA_LINE_RE = re.compile(r"^[0-9a-f]{40}$")
 
+# Trashed items live under `.trash/` (see app/wiki/trash.py). Every path
+# enumerator excludes it so trashed content never surfaces in the tree,
+# search, recents, or the reconcile sweep — the isolation the Trash feature
+# depends on. Trash internals address `.trash/` paths directly.
+_TRASH_PREFIX = ".trash/"
+
 
 class CommitInfo(BaseModel):
     """One commit in a path's history (newest first)."""
@@ -479,9 +485,9 @@ def ingest_update_times_24h(rel_path: str) -> list[int]:
 
 
 def list_paths(prefix: str = "") -> list[str]:
-    """List tracked files under a path prefix."""
+    """List tracked files under a path prefix (excluding the hidden ``.trash/``)."""
     out = _run(["ls-files", "-z", prefix or "."]).stdout
-    return [p for p in out.split("\0") if p]
+    return [p for p in out.split("\0") if p and not p.startswith(_TRASH_PREFIX)]
 
 
 def bundle(dest_path: str) -> None:
@@ -515,7 +521,11 @@ def paths_touched_since(since_iso: str) -> set[str]:
         ],
         check=False,
     ).stdout
-    return {line for line in out.splitlines() if line.strip()}
+    return {
+        line
+        for line in out.splitlines()
+        if line.strip() and not line.startswith(_TRASH_PREFIX)
+    }
 
 
 def rev_before(iso: str) -> str | None:
@@ -613,7 +623,11 @@ def paths_authored_by(author_email: str, limit: int = 50) -> list[tuple[str, str
             continue
         if not line or current_ts is None:
             continue
-        if line.endswith(".md") and line not in seen:
+        if (
+            line.endswith(".md")
+            and not line.startswith(_TRASH_PREFIX)
+            and line not in seen
+        ):
             seen[line] = current_ts
     return list(seen.items())[:limit]
 
@@ -628,6 +642,57 @@ def tree_paths_at(sha: str) -> list[str]:
     """All tracked file paths in the tree at ``sha``."""
     out = _run(["ls-tree", "-r", "--name-only", sha], check=False).stdout
     return [line for line in out.splitlines() if line]
+
+
+def list_trash_files() -> list[str]:
+    """Tracked files currently under ``.trash/`` — the raw trash contents.
+
+    Deliberately bypasses the ``.trash/`` exclusion the other enumerators apply;
+    only the trash repo (``app/wiki/trash.py``) should call it.
+    """
+    out = _run(["ls-files", "-z", "--", _TRASH_PREFIX.rstrip("/")]).stdout
+    return [p for p in out.split("\0") if p]
+
+
+def last_commit_meta_for_path(rel_path: str) -> tuple[str, str, str] | None:
+    """``(sha, author, ISO-ts)`` of the most recent commit touching ``rel_path``,
+    or ``None``. For a trashed path this is the trash-move commit (who/when)."""
+    sep = "\x1f"
+    out = _run(
+        ["log", "-n1", f"--pretty=format:%H{sep}%an{sep}%aI", "--", rel_path],
+        check=False,
+    ).stdout.strip()
+    if not out:
+        return None
+    parts = out.split(sep)
+    return (parts[0], parts[1], parts[2]) if len(parts) == 3 else None
+
+
+def restore_from_trash(
+    trash_id: str, message: str, author: str | None = None
+) -> tuple[str, list[PathMove]]:
+    """Move every file under ``.trash/<trash_id>/`` back to its original path
+    (the path with the ``.trash/<trash_id>/`` prefix stripped), one commit.
+
+    File-granular so restoring a single page doesn't collide with a still-live
+    sibling in the same folder. Returns ``(sha, moves)`` for the caller to
+    re-point path-keyed metadata via ``after_path_move``. Raises
+    ``GitNothingToCommitError`` if the trash id has no files.
+    """
+    prefix = f"{_TRASH_PREFIX}{trash_id}/"
+    trashed = [p for p in list_trash_files() if p.startswith(prefix)]
+    if not trashed:
+        raise GitNothingToCommitError(prefix)
+    moves = [PathMove(old=p, new=p[len(prefix) :]) for p in trashed]
+    env_args = ["--author", author] if author else []
+    with commit_lock():
+        for mv in moves:
+            (Path(CONFIG.wiki_dir) / mv.new).parent.mkdir(parents=True, exist_ok=True)
+            _run(["mv", mv.old, mv.new])
+        _run(["commit", "-m", message, *env_args])
+        sha = _run(["rev-parse", "HEAD"]).stdout.strip()
+    log.info("restore_from_trash %s (%d files) sha=%s", trash_id, len(moves), sha[:8])
+    return sha, moves
 
 
 class UnknownSha(Exception):

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -24,16 +24,16 @@ from pydantic import BaseModel
 from app.config import CONFIG
 from app.models.wiki import PathMove
 from app.wiki import constants
+from app.wiki.filesystem import TRASH_DIR, TRASH_PREFIX
 
 log = logging.getLogger(__name__)
 
 _SHA_LINE_RE = re.compile(r"^[0-9a-f]{40}$")
 
-# Trashed items live under `.trash/` (see app/wiki/trash.py). Every path
-# enumerator excludes it so trashed content never surfaces in the tree,
-# search, recents, or the reconcile sweep — the isolation the Trash feature
-# depends on. Trash internals address `.trash/` paths directly.
-_TRASH_PREFIX = ".trash/"
+# Trashed items live under `.trash/` (TRASH_PREFIX, defined in filesystem.py).
+# Every path enumerator excludes it so trashed content never surfaces in the
+# tree, search, recents, or the reconcile sweep — the isolation the Trash
+# feature depends on. Trash internals address `.trash/` paths directly.
 
 
 class CommitInfo(BaseModel):
@@ -487,7 +487,7 @@ def ingest_update_times_24h(rel_path: str) -> list[int]:
 def list_paths(prefix: str = "") -> list[str]:
     """List tracked files under a path prefix (excluding the hidden ``.trash/``)."""
     out = _run(["ls-files", "-z", prefix or "."]).stdout
-    return [p for p in out.split("\0") if p and not p.startswith(_TRASH_PREFIX)]
+    return [p for p in out.split("\0") if p and not p.startswith(TRASH_PREFIX)]
 
 
 def bundle(dest_path: str) -> None:
@@ -524,7 +524,7 @@ def paths_touched_since(since_iso: str) -> set[str]:
     return {
         line
         for line in out.splitlines()
-        if line.strip() and not line.startswith(_TRASH_PREFIX)
+        if line.strip() and not line.startswith(TRASH_PREFIX)
     }
 
 
@@ -625,7 +625,7 @@ def paths_authored_by(author_email: str, limit: int = 50) -> list[tuple[str, str
             continue
         if (
             line.endswith(".md")
-            and not line.startswith(_TRASH_PREFIX)
+            and not line.startswith(TRASH_PREFIX)
             and line not in seen
         ):
             seen[line] = current_ts
@@ -650,7 +650,7 @@ def list_trash_files() -> list[str]:
     Deliberately bypasses the ``.trash/`` exclusion the other enumerators apply;
     only the trash repo (``app/wiki/trash.py``) should call it.
     """
-    out = _run(["ls-files", "-z", "--", _TRASH_PREFIX.rstrip("/")]).stdout
+    out = _run(["ls-files", "-z", "--", TRASH_DIR]).stdout
     return [p for p in out.split("\0") if p]
 
 
@@ -679,7 +679,7 @@ def restore_from_trash(
     re-point path-keyed metadata via ``after_path_move``. Raises
     ``GitNothingToCommitError`` if the trash id has no files.
     """
-    prefix = f"{_TRASH_PREFIX}{trash_id}/"
+    prefix = f"{TRASH_PREFIX}{trash_id}/"
     trashed = [p for p in list_trash_files() if p.startswith(prefix)]
     if not trashed:
         raise GitNothingToCommitError(prefix)

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -152,7 +152,13 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     mcp_pubsub.publish_list_changed()
 
 
-def after_doc_trashed(moves: list[PathMove], sha: str, actor: str | None) -> None:
+def after_doc_trashed(
+    moves: list[PathMove],
+    sha: str,
+    actor: str | None,
+    *,
+    root_move: PathMove | None = None,
+) -> None:
     """Side effects when items are moved into ``.trash/`` (soft delete).
 
     Trashing is a move, so this **re-points** the path-keyed metadata (ACL,
@@ -164,9 +170,16 @@ def after_doc_trashed(moves: list[PathMove], sha: str, actor: str | None) -> Non
     so it disappears from search / triggers / live views. Restore reuses the
     normal ``after_path_move`` (moving out of ``.trash/`` re-indexes at the
     original path).
+
+    ``root_move`` is the folder/page root that was trashed (``rel`` →
+    ``.trash/<id>/rel``). Like ``after_path_move``, it's needed so a folder's
+    own ACL/policy row re-points to the trash location even when all its files
+    sit in a subdirectory — otherwise it strands at the (now gone) original
+    path and ``_trash_perm`` mis-authorizes the trashed folder. See
+    ``acl.on_path_moved``.
     """
-    acl.on_path_moved(moves)
-    update_policy.on_path_moved(moves)
+    acl.on_path_moved(moves, root_move=root_move)
+    update_policy.on_path_moved(moves, root_move=root_move)
     coedit.on_path_moved(moves)
     for mv in moves:
         if not mv.old.endswith(".md"):

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -175,7 +175,7 @@ def after_doc_trashed(
     ``.trash/<id>/rel``). Like ``after_path_move``, it's needed so a folder's
     own ACL/policy row re-points to the trash location even when all its files
     sit in a subdirectory — otherwise it strands at the (now gone) original
-    path and ``_trash_perm`` mis-authorizes the trashed folder. See
+    path and ``_trash_perms`` mis-authorizes the trashed folder. See
     ``acl.on_path_moved``.
     """
     acl.on_path_moved(moves, root_move=root_move)

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -152,6 +152,45 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     mcp_pubsub.publish_list_changed()
 
 
+def after_doc_trashed(moves: list[PathMove], sha: str, actor: str | None) -> None:
+    """Side effects when items are moved into ``.trash/`` (soft delete).
+
+    Trashing is a move, so this **re-points** the path-keyed metadata (ACL,
+    owner, policy, comments, activity, drafts, working-dirs) to the trash
+    location — that's what makes restore lossless: moving back re-points it
+    all to the original path. But unlike a normal move, the destination is
+    hidden, so we do **not** index or announce the ``.trash/`` copy; instead
+    we drop the item from search and fire a ``delete`` event on the old path,
+    so it disappears from search / triggers / live views. Restore reuses the
+    normal ``after_path_move`` (moving out of ``.trash/`` re-indexes at the
+    original path).
+    """
+    acl.on_path_moved(moves)
+    update_policy.on_path_moved(moves)
+    coedit.on_path_moved(moves)
+    for mv in moves:
+        if not mv.old.endswith(".md"):
+            continue
+        # Leave search/live: drop the index + embedding, fire delete, notify.
+        fts.delete_document(mv.old)
+        drop_page_embedding(mv.old)
+        fan_out_trigger_eval(mv.old, sha, ChangeKind.DELETE, actor)
+        mcp_pubsub.publish_doc_delete(mv.old, sha)
+        # Carry the durable metadata to the trash path so restore recovers it
+        # (do NOT re-anchor/re-index it — the .trash/ copy stays hidden).
+        comments.reassign_doc_path(mv.old, mv.new)
+        agent_activity.rename_doc(mv.old, mv.new)
+        drafts.rename(mv.old, mv.new)
+        page_dirs.rename_page(old_wiki_path=mv.old, new_wiki_path=mv.new)
+    # Trigger YAMLs moved into .trash are excluded from loading, so reconverging
+    # the cache from disk drops the trashed triggers (they stop firing).
+    try:
+        triggers_repo.rebuild_from_filesystem()
+    except Exception:
+        log.exception("trigger cache rebuild after trash failed")
+    mcp_pubsub.publish_list_changed()
+
+
 def after_path_move(
     moves: list[PathMove],
     sha: str,

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -1,0 +1,82 @@
+"""The Trash — soft-deleted wiki items, derived entirely from git.
+
+Deleting a page/folder is a **move** into a hidden ``.trash/<trash_id>/<path>``
+(see ``app/api/wiki.py`` delete + ``git.restore_from_trash``), not a ``git rm``.
+Because it's a move, ``notify.after_path_move`` re-points every path-keyed row
+(ACL, owner, policy, comments, …) to the trash location — so restore is
+lossless. Nothing about the trash is stored in Postgres: the ``.trash/`` tree is
+the source of truth, and the original path is encoded in the trash location
+(strip the ``.trash/<trash_id>/`` prefix). Who/when come from the move commit.
+
+``.trash/`` is excluded from every path enumerator and rejected by
+``filesystem.safe_rel_path``, so trashed content is unreachable except through
+this module and the Trash/restore endpoints.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from pydantic import BaseModel
+
+from app.wiki import git as wiki_git
+from app.wiki.filesystem import TRASH_DIR
+
+
+class TrashEntry(BaseModel):
+    """One trashed item (a page, or a folder root) for the Trash view."""
+
+    trash_id: str
+    original_path: str  # where it lived; restore moves it back here
+    kind: str  # "page" | "folder"
+    trashed_by: str  # git author of the trash-move commit
+    trashed_at: str  # ISO-8601
+
+
+def new_trash_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def trash_location(trash_id: str, original_path: str) -> str:
+    """The ``.trash/`` path an item at ``original_path`` moves to when trashed."""
+    return f"{TRASH_DIR}/{trash_id}/{original_path}"
+
+
+def _entry(trash_id: str, originals: list[str]) -> TrashEntry | None:
+    if not originals:
+        return None
+    root = originals[0] if len(originals) == 1 else os.path.commonpath(originals)
+    kind = "page" if (len(originals) == 1 and root.endswith(".md")) else "folder"
+    meta = wiki_git.last_commit_meta_for_path(f"{TRASH_DIR}/{trash_id}")
+    _sha, author, ts = meta if meta else ("", "", "")
+    return TrashEntry(
+        trash_id=trash_id,
+        original_path=root,
+        kind=kind,
+        trashed_by=author,
+        trashed_at=ts,
+    )
+
+
+def list_entries() -> list[TrashEntry]:
+    """All trashed items, newest-first. Derived from the ``.trash/`` tree."""
+    prefix = f"{TRASH_DIR}/"
+    groups: dict[str, list[str]] = {}
+    for f in wiki_git.list_trash_files():
+        rest = f[len(prefix) :]  # "<trash_id>/<original/path>"
+        trash_id, _, original = rest.partition("/")
+        if original:
+            groups.setdefault(trash_id, []).append(original)
+    entries = [e for tid, orig in groups.items() if (e := _entry(tid, orig))]
+    entries.sort(key=lambda e: e.trashed_at, reverse=True)
+    return entries
+
+
+def entry_for(trash_id: str) -> TrashEntry | None:
+    """The trash entry for ``trash_id``, or ``None`` if unknown/empty."""
+    prefix = f"{TRASH_DIR}/{trash_id}/"
+    originals = [
+        f[len(prefix) :] for f in wiki_git.list_trash_files() if f.startswith(prefix)
+    ]
+    return _entry(trash_id, originals)

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -43,13 +43,39 @@ def trash_location(trash_id: str, original_path: str) -> str:
     return f"{TRASH_DIR}/{trash_id}/{original_path}"
 
 
+_ORIGINAL_TRAILER = "Trash-Original:"
+
+
+def trash_commit_message(original_path: str) -> str:
+    """Commit message for a trash-move.
+
+    The subject (``trash <path>``) is for humans; the ``Trash-Original`` trailer
+    records the *root* that was trashed so the Trash view can classify it. The
+    ``.trash/`` tree alone can't: trashing a page ``p/a.md`` and trashing a
+    folder ``p/`` whose only file is ``a.md`` both land as ``.trash/<id>/p/a.md``
+    — byte-identical trees. Only the deleter knows which it was, so we record it.
+    """
+    return f"trash {original_path}\n\n{_ORIGINAL_TRAILER} {original_path}"
+
+
+def _original_from_message(message: str) -> str | None:
+    for line in message.splitlines():
+        if line.startswith(_ORIGINAL_TRAILER):
+            return line[len(_ORIGINAL_TRAILER) :].strip() or None
+    return None
+
+
 def _entry(trash_id: str, originals: list[str]) -> TrashEntry | None:
     if not originals:
         return None
-    root = originals[0] if len(originals) == 1 else os.path.commonpath(originals)
-    kind = "page" if (len(originals) == 1 and root.endswith(".md")) else "folder"
     meta = wiki_git.last_commit_meta_for_path(f"{TRASH_DIR}/{trash_id}")
-    _sha, author, ts = meta if meta else ("", "", "")
+    _sha, author, ts, message = meta if meta else ("", "", "", "")
+    root = _original_from_message(message)
+    if root is None:
+        # No trailer (trash predating trash_commit_message) — infer from the file
+        # list. Ambiguous for a single-file folder, hence the trailer above.
+        root = originals[0] if len(originals) == 1 else os.path.commonpath(originals)
+    kind = "page" if root.endswith(".md") else "folder"
     return TrashEntry(
         trash_id=trash_id,
         original_path=root,

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from typing import Literal
 
 from pydantic import BaseModel
 
@@ -29,7 +30,7 @@ class TrashEntry(BaseModel):
 
     trash_id: str
     original_path: str  # where it lived; restore moves it back here
-    kind: str  # "page" | "folder"
+    kind: Literal["page", "folder"]
     trashed_by: str  # git author of the trash-move commit
     trashed_at: str  # ISO-8601
 
@@ -75,7 +76,7 @@ def _entry(trash_id: str, originals: list[str]) -> TrashEntry | None:
         # No trailer (trash predating trash_commit_message) — infer from the file
         # list. Ambiguous for a single-file folder, hence the trailer above.
         root = originals[0] if len(originals) == 1 else os.path.commonpath(originals)
-    kind = "page" if root.endswith(".md") else "folder"
+    kind: Literal["page", "folder"] = "page" if root.endswith(".md") else "folder"
     return TrashEntry(
         trash_id=trash_id,
         original_path=root,

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -1,0 +1,144 @@
+"""Trash = soft delete via move into hidden `.trash/`.
+
+Deleting a page/folder moves it to `.trash/<trash_id>/<original>` instead of
+`git rm`. Because it's a move, path-keyed metadata (ACL, comments, …) is
+re-pointed there and comes back on restore — so restore is lossless. The
+`.trash/` area is hidden: excluded from listing/search and unreachable by
+URL/API; the only ways in are the Trash view and restore.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import acl, trash
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _client(user_id: str) -> TestClient:
+    client = TestClient(create_app())
+    login_fastapi(client, user_id)
+    return client
+
+
+def _everyone_ids(path: str) -> list[str]:
+    return [
+        g["id"] for g in acl.list_for_path(path) if g["principal_kind"] == "everyone"
+    ]
+
+
+def test_delete_moves_to_trash_and_hides_everywhere(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"})
+
+    resp = client.delete("/api/wiki/file?path=proj/a.md")
+    assert resp.status_code == 200
+    trash_id = resp.json()["trash_id"]
+    assert trash_id
+
+    # Gone from the live tree listing…
+    tree = {e["path"] for e in client.get("/api/wiki").json()["entries"]}
+    assert "proj/a.md" not in tree
+    assert not any(p.startswith(".trash/") for p in tree)  # .trash never surfaces
+    # …and unreachable by URL/API (hard-blocked regardless of ACL).
+    assert client.get("/api/wiki/file?path=proj/a.md").status_code == 404
+    trash_loc = trash.trash_location(trash_id, "proj/a.md")
+    assert client.get(f"/api/wiki/file?path={trash_loc}").status_code == 400
+    # …but present in Trash, at its original path.
+    items = {i["path"]: i for i in client.get("/api/wiki/trash").json()["items"]}
+    assert "proj/a.md" in items
+    assert items["proj/a.md"]["trash_id"] == trash_id
+    assert items["proj/a.md"]["kind"] == "page"
+
+
+def test_view_trashed_page_returns_content(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "note.md", "body": "# Note\nhi"})
+    tid = client.delete("/api/wiki/file?path=note.md").json()["trash_id"]
+
+    view = client.get(f"/api/wiki/trash/{tid}").json()
+    assert view["path"] == "note.md"
+    assert view["body"] == "# Note\nhi"
+
+
+def test_restore_moves_back_losslessly(tmp_repo):
+    owner = seed_user()
+    other = seed_user(uid="u_other", email="other@x.com")
+    client = _client(owner)
+    client.put("/api/wiki/file", json={"path": "doc.md", "body": "# Doc\n"})
+    # A specific grant that must survive the delete/restore round-trip.
+    acl.grant(
+        resource_kind="page",
+        resource_path="doc.md",
+        principal_kind="user",
+        principal_id=other,
+        permission="write",
+        granted_by_user_id=owner,
+    )
+
+    tid = client.delete("/api/wiki/file?path=doc.md").json()["trash_id"]
+    assert client.post("/api/wiki/file/restore", json={"trash_id": tid}).status_code == 200
+
+    # Content back…
+    read = client.get("/api/wiki/file?path=doc.md")
+    assert read.status_code == 200
+    assert read.json()["body"] == "# Doc\n"
+    # …and the grant came back with it (lossless — the move re-pointed it).
+    grants = [
+        (g["principal_kind"], g["principal_id"], g["permission"])
+        for g in acl.list_for_path("doc.md")
+    ]
+    assert ("user", other, "write") in grants
+
+
+def test_restore_refused_when_path_recreated(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"})
+    tid = client.delete("/api/wiki/file?path=a.md").json()["trash_id"]
+    # Re-create a live page at the same path.
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# new\n"})
+
+    resp = client.post("/api/wiki/file/restore", json={"trash_id": tid})
+    assert resp.status_code == 409
+
+
+def test_folder_trash_and_restore(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"})
+    client.put("/api/wiki/file", json={"path": "proj/sub/b.md", "body": "# B\n"})
+
+    tid = client.delete("/api/wiki/file?path=proj").json()["trash_id"]
+    items = {i["path"]: i for i in client.get("/api/wiki/trash").json()["items"]}
+    assert items["proj"]["kind"] == "folder"
+    assert client.get("/api/wiki/file?path=proj/a.md").status_code == 404
+
+    assert client.post("/api/wiki/file/restore", json={"trash_id": tid}).status_code == 200
+    assert client.get("/api/wiki/file?path=proj/a.md").json()["body"] == "# A\n"
+    assert client.get("/api/wiki/file?path=proj/sub/b.md").json()["body"] == "# B\n"
+
+
+def test_trashed_private_page_hidden_from_other_user(tmp_repo):
+    owner = seed_user()
+    other = seed_user(uid="u_other", email="other@x.com")
+    owner_client = _client(owner)
+    owner_client.put("/api/wiki/file", json={"path": "secret.md", "body": "# S\n"})
+    # Make it owner-only, then trash it — the grants re-point into .trash.
+    for gid in _everyone_ids("secret.md"):
+        acl.revoke(gid)
+    tid = owner_client.delete("/api/wiki/file?path=secret.md").json()["trash_id"]
+
+    other_client = _client(other)
+    # The other user can't see it in Trash, view it, or restore it.
+    assert other_client.get("/api/wiki/trash").json()["items"] == []
+    assert other_client.get(f"/api/wiki/trash/{tid}").status_code == 403
+    assert other_client.post("/api/wiki/file/restore", json={"trash_id": tid}).status_code == 403
+    # The owner still can.
+    assert any(
+        i["trash_id"] == tid for i in owner_client.get("/api/wiki/trash").json()["items"]
+    )

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -142,6 +142,35 @@ def test_single_file_folder_classified_as_folder(tmp_repo):
     assert client.get("/api/wiki/file?path=only/a.md").json()["body"] == "# A\n"
 
 
+def test_trashed_folder_grant_repoints_when_files_nested(tmp_repo):
+    # A folder visible only via a *folder-level* grant, whose only file sits in
+    # a subdirectory. Trashing must re-point the folder's own grant to the trash
+    # location (root_move) — otherwise it strands at the now-gone path and the
+    # item is mis-authorized in Trash. Without the fix `other` sees nothing.
+    owner = seed_user()
+    other = seed_user(uid="u_o2", email="o2@x.com")
+    oc = _client(owner)
+    oc.put("/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"})
+    # Drop the page's own public grant so visibility hinges on the folder grant.
+    for gid in _everyone_ids("proj/sub/a.md"):
+        acl.revoke(gid)
+    acl.grant(
+        resource_kind="folder",
+        resource_path="proj",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
+        granted_by_user_id=None,
+    )
+
+    tid = oc.delete("/api/wiki/file?path=proj").json()["trash_id"]
+
+    other_c = _client(other)
+    items = {i["path"]: i for i in other_c.get("/api/wiki/trash").json()["items"]}
+    assert "proj" in items and items["proj"]["kind"] == "folder"
+    assert other_c.get(f"/api/wiki/trash/{tid}").status_code == 200
+
+
 def test_trashed_private_page_hidden_from_other_user(tmp_repo):
     owner = seed_user()
     other = seed_user(uid="u_other", email="other@x.com")

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -142,3 +142,27 @@ def test_trashed_private_page_hidden_from_other_user(tmp_repo):
     assert any(
         i["trash_id"] == tid for i in owner_client.get("/api/wiki/trash").json()["items"]
     )
+
+
+def test_duplicate_names_coexist_in_trash(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    # Trash a.md, re-create a.md, trash again → two trashed "a.md" items.
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# v1\n"})
+    tid1 = client.delete("/api/wiki/file?path=a.md").json()["trash_id"]
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# v2\n"})
+    tid2 = client.delete("/api/wiki/file?path=a.md").json()["trash_id"]
+
+    assert tid1 != tid2
+    items = client.get("/api/wiki/trash").json()["items"]
+    a_items = [i for i in items if i["path"] == "a.md"]
+    assert len(a_items) == 2  # both coexist, distinct trash_ids
+    # Each keeps its own content.
+    assert client.get(f"/api/wiki/trash/{tid1}").json()["body"] == "# v1\n"
+    assert client.get(f"/api/wiki/trash/{tid2}").json()["body"] == "# v2\n"
+
+    # Path is free → restore one succeeds; then the path is occupied → the
+    # other 409s (can't restore two items onto the same live path).
+    assert client.post("/api/wiki/file/restore", json={"trash_id": tid1}).status_code == 200
+    assert client.get("/api/wiki/file?path=a.md").json()["body"] == "# v1\n"
+    assert client.post("/api/wiki/file/restore", json={"trash_id": tid2}).status_code == 409

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -123,6 +123,25 @@ def test_folder_trash_and_restore(tmp_repo):
     assert client.get("/api/wiki/file?path=proj/sub/b.md").json()["body"] == "# B\n"
 
 
+def test_single_file_folder_classified_as_folder(tmp_repo):
+    # A folder with exactly one .md file trashes to the same tree as trashing
+    # that page directly (.trash/<id>/only/a.md). The recorded root — not the
+    # file list — must decide: this is a folder, restore must recreate `only/`.
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "only/a.md", "body": "# A\n"})
+
+    tid = client.delete("/api/wiki/file?path=only").json()["trash_id"]
+    items = {i["path"]: i for i in client.get("/api/wiki/trash").json()["items"]}
+    assert items["only"]["kind"] == "folder"  # not "only/a.md" / "page"
+
+    view = client.get(f"/api/wiki/trash/{tid}").json()
+    assert view["path"] == "only" and view["kind"] == "folder"
+
+    assert client.post("/api/wiki/file/restore", json={"trash_id": tid}).status_code == 200
+    assert client.get("/api/wiki/file?path=only/a.md").json()["body"] == "# A\n"
+
+
 def test_trashed_private_page_hidden_from_other_user(tmp_repo):
     owner = seed_user()
     other = seed_user(uid="u_other", email="other@x.com")


### PR DESCRIPTION
Implements **Trash + lossless restore** by reframing delete as a *move*, per the design in `design/Deleted Page Recovery.md`. Supersedes the git-log/content-only #381 (which I'll close).

## The idea

**Soft delete = `git mv` into a hidden `.trash/<trash_id>/<original>`, not `git rm`.** Because it's a move, the existing `after_path_move` machinery re-points *every* path-keyed row — ACL grants, owner, update policy, comments, activity, drafts — to the trash location. So **restore is lossless**: moving it back re-points all of it to the original path. Permissions and everything come back.

**No new table.** The `.trash/` tree is the source of truth: the original path is encoded in the location (strip `.trash/<trash_id>/`), and who/when come from the move commit. Trash is *derived* from git, not stored in Postgres.

## Hidden — reachable only via Trash view + restore

- `filesystem.safe_rel_path` **hard-rejects** any `.trash/` path → direct URL (`/app/wiki/.trash/…`) and API (`?path=.trash/…`) access is denied **regardless of ACL**.
- The git path enumerators (`list_paths` + the two that filter through it, `paths_touched_since`, `paths_authored_by`) **exclude `.trash/`** → trashed content never appears in the tree, search, recents, or the hourly reconcile.
- Trashing drops the FTS row and does **not** index the `.trash/` copy (`after_doc_trashed`), so search can't return it.

## Endpoints

- `DELETE /wiki/file` → moves to Trash, returns `trash_id` (for undo).
- `GET /wiki/trash` → the Trash list (git-derived), ACL-filtered.
- `GET /wiki/trash/{trash_id}` → item details + page content (the only read path into `.trash/`).
- `POST /wiki/file/restore {trash_id}` → move back to the original path (409 if now occupied).

**Permission subtlety:** view/restore is authorized against the **trash path**, where the item's own ACL grants were re-pointed by the move — so a trashed *private* page can't leak even if its original folder is public. Test covers this.

## Scope

- **Retention / auto-purge** (delete from `.trash/` after N days) → separate PR.
- **Frontend Trash view** → separate PR.
- **True content erasure** (git-history scrub) explicitly out — purge will be a soft purge (leaves the product; stays in git history).

## Testing

New `test_trash.py`: delete→trash + hidden from tree/URL/API; view content; **lossless restore incl. an ACL grant surviving the round-trip**; restore refused when path re-created; folder trash+restore; trashed private page invisible/unrestorable to another user. ruff + basedpyright clean. **pytest runs in CI** (local Docker wedged this session).