### PR TITLE
feat(ingest): cosine relevance filter + embedding enrichment

### DIFF
--- a/backend/app/db/page_embeddings.py
+++ b/backend/app/db/page_embeddings.py
@@ -40,6 +40,31 @@ def get_sha(path: str) -> str | None:
         return row.content_sha256 if row else None
 
 
+def get_vector(path: str) -> bytes | None:
+    """Stored packed vector for ``path`` (unpack with
+    ``app.llm.embeddings.unpack``), or ``None`` if the page has no embedding."""
+    with session() as s:
+        row = s.get(PageEmbedding, path)
+        return bytes(row.vector) if row else None
+
+
+def load_paths(paths: list[str]) -> dict[str, bytes]:
+    """``path -> packed vector`` for the given paths that have a stored
+    embedding (missing paths are simply absent). One query — used to attach
+    candidate-page vectors before relevance filtering."""
+    if not paths:
+        return {}
+    with session() as s:
+        return {
+            path: bytes(vec)
+            for path, vec in s.execute(
+                select(PageEmbedding.path, PageEmbedding.vector).where(
+                    PageEmbedding.path.in_(paths)
+                )
+            )
+        }
+
+
 def all_shas() -> dict[str, str]:
     """``path -> content_sha256`` for every stored page. Cheap (no vectors);
     used by backfill / reconcile to find missing or stale pages."""

--- a/backend/app/ingest/enrich.py
+++ b/backend/app/ingest/enrich.py
@@ -1,0 +1,52 @@
+"""Enrichment stages: attach derived data to the ingestion carriers.
+
+The relevance filter compares embeddings, but the raw carriers arrive without
+them — an :class:`IngestionDocument` from the inbound push, a
+:class:`CandidatePage` from search. These helpers fill the ``embedding`` slots:
+the document is embedded once; each page's vector is read from the stored
+page-embedding table by path.
+
+Best-effort, like the rest of the embedding path: if a vector can't be produced
+(no OpenAI key, an embed error, or a page not yet embedded) the carrier is
+returned with its ``embedding`` left ``None``. Downstream filters treat ``None``
+as "unavailable" and stay fail-open.
+"""
+from __future__ import annotations
+
+from dataclasses import replace
+
+from app.db import page_embeddings
+from app.ingest.types import CandidatePage, IngestionDocument
+from app.llm import embeddings
+
+
+def with_document_embedding(doc: IngestionDocument) -> IngestionDocument:
+    """Return ``doc`` with its ``embedding`` filled (best-effort).
+
+    Embeds the capped content once. A no-op if already embedded, or if embedding
+    is unavailable (returns the document with ``embedding`` still ``None``).
+    """
+    if doc.embedding is not None:
+        return doc
+    vec = embeddings.embed_text(doc.content[: embeddings.DOC_CHAR_CAP])
+    return doc if vec is None else replace(doc, embedding=vec)
+
+
+def with_page_embeddings(pages: list[CandidatePage]) -> list[CandidatePage]:
+    """Return ``pages`` with each ``embedding`` filled from the store by path.
+
+    One batched load. A page whose vector isn't already set and isn't stored
+    keeps ``embedding=None``.
+    """
+    if not pages:
+        return []
+    to_load = [p.path for p in pages if p.embedding is None]
+    blobs = page_embeddings.load_paths(to_load) if to_load else {}
+    out: list[CandidatePage] = []
+    for page in pages:
+        if page.embedding is not None:
+            out.append(page)
+            continue
+        blob = blobs.get(page.path)
+        out.append(page if blob is None else replace(page, embedding=embeddings.unpack(blob)))
+    return out

--- a/backend/app/ingest/relevance/__init__.py
+++ b/backend/app/ingest/relevance/__init__.py
@@ -1,11 +1,12 @@
 """Relevance filtering for document ingestion.
 
-Public interface: the :class:`RelevanceFilter` contract. It operates on the
+Public interface: the :class:`RelevanceFilter` contract, plus the concrete
+:class:`CosineSimilarityFilter` (the cold-start model). Filters operate on the
 pipeline carriers :class:`app.ingest.types.IngestionDocument` and
-:class:`app.ingest.types.CandidatePage`. Concrete models (cosine, two-tower,
-...) live in their own modules and subclass ``RelevanceFilter``; the pipeline
-depends only on this interface.
+:class:`app.ingest.types.CandidatePage`, whose embeddings are filled by
+``app.ingest.enrich``.
 """
+from app.ingest.relevance.cosine_filter import CosineSimilarityFilter
 from app.ingest.relevance.filter import RelevanceFilter
 
-__all__ = ["RelevanceFilter"]
+__all__ = ["CosineSimilarityFilter", "RelevanceFilter"]

--- a/backend/app/ingest/relevance/cosine_filter.py
+++ b/backend/app/ingest/relevance/cosine_filter.py
@@ -1,0 +1,72 @@
+"""Cosine-similarity relevance filter — the cold-start model.
+
+No training, no labels, no weights: relevance is the cosine similarity of the
+document and page embeddings, thresholded. The embeddings come from the
+carriers' ``embedding`` slots (filled by ``app.ingest.enrich``); this filter
+only compares them.
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.types import CandidatePage, IngestionDocument
+
+# Cosine cutoff at the study's 85%-filter operating point (keep the top 15% of
+# candidate pairs) — the 85th percentile of embed_cosine on the offline
+# model-selection dataset. Fit on that dataset's candidate population;
+# recalibrate against the production score distribution before it gates.
+DEFAULT_THRESHOLD = 0.4334
+
+
+def cosine_similarity_score(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity of two equal-length vectors, in [-1, 1].
+
+    Returns 0.0 if either vector is all-zeros (undefined direction). ``strict``
+    zip raises on a length mismatch rather than silently truncating the dot
+    product (which the norms wouldn't match) — callers must pass equal-length
+    vectors; the filter guards for that before calling here."""
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+class CosineSimilarityFilter(RelevanceFilter):
+    """Relevant when ``cosine_similarity_score(doc.embedding, page.embedding) >= threshold``.
+
+    Fail-open: if either embedding is missing (``None`` — no key, embed failure,
+    or a page not yet embedded), the pair is kept. The filter only ever saves
+    reconcile cost; it must never cost recall because of an infra miss.
+    """
+
+    def __init__(self, threshold: float = DEFAULT_THRESHOLD) -> None:
+        self._threshold = threshold
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    def similarity(
+        self, doc: IngestionDocument, page: CandidatePage
+    ) -> float | None:
+        """Cosine of the two embeddings, or ``None`` if either is unavailable.
+
+        Exposed (not just the boolean) so callers can shadow-log scores and
+        calibrate the threshold against real traffic.
+
+        A length mismatch (e.g. vectors from different embedding models during a
+        migration) is treated like a missing embedding — ``None``, so the pair
+        is kept — rather than scored over a truncated dimension count or raised
+        (a raise would abort the whole filter, dropping every candidate)."""
+        doc_vec, page_vec = doc.embedding, page.embedding
+        if doc_vec is None or page_vec is None or len(doc_vec) != len(page_vec):
+            return None
+        return cosine_similarity_score(doc_vec, page_vec)
+
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        sim = self.similarity(doc, page)
+        return True if sim is None else sim >= self._threshold

--- a/backend/tests/test_cosine_filter.py
+++ b/backend/tests/test_cosine_filter.py
@@ -1,0 +1,143 @@
+"""Tests for the cosine relevance filter and the embedding enrichment stage.
+
+Pure unit tests — the enrichment helpers are exercised with the embedding
+client and the page-embedding store monkeypatched, so nothing here touches
+OpenAI or the database.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.ingest import enrich
+from app.ingest.relevance import CosineSimilarityFilter
+from app.ingest.relevance.cosine_filter import cosine_similarity_score
+from app.ingest.types import CandidatePage, IngestionDocument
+
+
+# --------------------------------------------------------------------------- #
+# cosine_similarity_score()                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_cosine_identical_is_one():
+    assert cosine_similarity_score([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == pytest.approx(1.0)
+
+
+def test_cosine_orthogonal_is_zero():
+    assert cosine_similarity_score([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+
+def test_cosine_opposite_is_minus_one():
+    assert cosine_similarity_score([1.0, 1.0], [-1.0, -1.0]) == pytest.approx(-1.0)
+
+
+def test_cosine_zero_vector_is_zero():
+    assert cosine_similarity_score([0.0, 0.0], [1.0, 2.0]) == 0.0
+
+
+def test_cosine_raises_on_length_mismatch():
+    # The pure helper is strict — a length mismatch is a loud error, never a
+    # silently-truncated (wrong) similarity.
+    with pytest.raises(ValueError):
+        cosine_similarity_score([1.0, 2.0], [1.0, 2.0, 3.0])
+
+
+# --------------------------------------------------------------------------- #
+# CosineSimilarityFilter                                                      #
+# --------------------------------------------------------------------------- #
+
+_UNIT = [1.0, 0.0]
+
+
+def _doc(vec):
+    return IngestionDocument(content="x", embedding=vec)
+
+
+def _page(vec):
+    return CandidatePage(path="p.md", body="b", embedding=vec)
+
+
+def test_relevant_at_and_above_threshold():
+    f = CosineSimilarityFilter(threshold=0.5)
+    # identical vectors → cosine 1.0 ≥ 0.5
+    assert f.is_relevant(_doc(_UNIT), _page(_UNIT)) is True
+
+
+def test_not_relevant_below_threshold():
+    f = CosineSimilarityFilter(threshold=0.5)
+    # orthogonal → cosine 0.0 < 0.5
+    assert f.is_relevant(_doc([1.0, 0.0]), _page([0.0, 1.0])) is False
+
+
+def test_threshold_boundary_is_inclusive():
+    # cosine of these is exactly cos(45°) ≈ 0.7071; set threshold to match.
+    sim = cosine_similarity_score([1.0, 0.0], [1.0, 1.0])
+    f = CosineSimilarityFilter(threshold=sim)
+    assert f.is_relevant(_doc([1.0, 0.0]), _page([1.0, 1.0])) is True
+
+
+def test_fail_open_when_doc_embedding_missing():
+    f = CosineSimilarityFilter(threshold=0.99)
+    assert f.is_relevant(_doc(None), _page(_UNIT)) is True
+    assert f.similarity(_doc(None), _page(_UNIT)) is None
+
+
+def test_fail_open_when_page_embedding_missing():
+    f = CosineSimilarityFilter(threshold=0.99)
+    assert f.is_relevant(_doc(_UNIT), _page(None)) is True
+
+
+def test_fail_open_on_length_mismatch():
+    # Mismatched dims (e.g. a partially-migrated store) → can't compare → keep.
+    f = CosineSimilarityFilter(threshold=0.99)
+    doc = _doc([1.0, 0.0, 0.0])
+    page = _page([1.0, 0.0])
+    assert f.similarity(doc, page) is None
+    assert f.is_relevant(doc, page) is True
+
+
+def test_keep_relevant_filters_the_batch():
+    f = CosineSimilarityFilter(threshold=0.5)
+    doc = _doc([1.0, 0.0])
+    close = CandidatePage(path="close.md", body="b", embedding=[1.0, 0.0])   # cos 1.0
+    far = CandidatePage(path="far.md", body="b", embedding=[0.0, 1.0])       # cos 0.0
+    kept = f.keep_relevant(doc, [close, far])
+    assert [p.path for p in kept] == ["close.md"]
+
+
+# --------------------------------------------------------------------------- #
+# enrichment                                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_with_document_embedding_fills_slot(monkeypatch):
+    monkeypatch.setattr(enrich.embeddings, "embed_text", lambda text: [0.1, 0.2])
+    out = enrich.with_document_embedding(IngestionDocument(content="hello"))
+    assert out.embedding == [0.1, 0.2]
+
+
+def test_with_document_embedding_noop_when_unavailable(monkeypatch):
+    monkeypatch.setattr(enrich.embeddings, "embed_text", lambda text: None)
+    out = enrich.with_document_embedding(IngestionDocument(content="hello"))
+    assert out.embedding is None
+
+
+def test_with_document_embedding_skips_when_already_set(monkeypatch):
+    def _boom(text):
+        raise AssertionError("should not re-embed")
+
+    monkeypatch.setattr(enrich.embeddings, "embed_text", _boom)
+    doc = IngestionDocument(content="hello", embedding=[9.0])
+    assert enrich.with_document_embedding(doc).embedding == [9.0]
+
+
+def test_with_page_embeddings_fills_from_store(monkeypatch):
+    # store returns a packed vector for "a.md" only; "b.md" stays None.
+    packed = enrich.embeddings.pack([0.3, 0.4])
+    monkeypatch.setattr(
+        enrich.page_embeddings, "load_paths", lambda paths: {"a.md": packed}
+    )
+    pages = [CandidatePage(path="a.md", body="x"), CandidatePage(path="b.md", body="y")]
+    out = {p.path: p.embedding for p in enrich.with_page_embeddings(pages)}
+    assert out["a.md"] == pytest.approx([0.3, 0.4])
+    assert out["b.md"] is None


### PR DESCRIPTION
## What

The **cold-start relevance model** (`CosineSimilarityFilter`) and the **enrichment** that feeds it. Builds on #380's interface + carriers. **Standalone** — not yet wired into the reconcile flow (that waits for the pipeline rework).

## `CosineSimilarityFilter` (`app/ingest/relevance/cosine_filter.py`)

Relevant when `cosine(doc.embedding, page.embedding) >= threshold`. No training, no labels, no weights — pure arithmetic on the two embeddings.

- **Fail-open**: if either embedding is `None` (no key, embed failure, or a page not yet embedded), the pair is kept. The filter only ever *saves* reconcile cost; it must never *cost recall* on an infra miss.
- **Default threshold `0.4334`** — the study's 85%-filter operating point (keep the top 15% of candidate pairs), i.e. the 85th percentile of `embed_cosine` on the offline dataset. Fit on that dataset's candidate population; **recalibrate against the production score distribution before it gates.**
- **`similarity()` exposed** (not just the bool) so scores can be shadow-logged and the threshold tuned against real traffic — that's calibrating one scalar, not training.

## `app/ingest/enrich.py` — fill the carriers' embedding slots

- `with_document_embedding(doc)` — embeds the capped content once (`DOC_CHAR_CAP`).
- `with_page_embeddings(pages)` — fills candidate vectors from the page-embedding store in one batched load.
- Best-effort: a missing vector leaves the slot `None` (filter stays fail-open). Enrichment is `dataclasses.replace`, per the carrier design.

## `app/db/page_embeddings.py` — point readers

`get_vector(path)` and `load_paths(paths)` — read stored vectors by path for enrichment (mirrors the existing `get_sha`/`all_shas`).

## Not in scope

No pipeline wiring, no config field (threshold is a constructor arg for now), no two-tower / training / labels.

## Next

Wire `IngestRequest → IngestionDocument` at the boundary, enrich, and call `keep_relevant` where the pipeline currently picks surviving candidates — when you're ready to touch the pipeline.

## Tests

`backend/tests/test_cosine_filter.py` (14) — cosine math (identical/orthogonal/opposite/zero), threshold boundary (inclusive), fail-open on missing doc/page embedding, `keep_relevant` batch filtering, and enrichment (fills / no-op unavailable / skip-if-set / store fill) with the embedding client + store monkeypatched (no OpenAI, no DB). Ruff + basedpyright clean; no import cycle.