### PR TITLE
fix(wiki): re-point folder ACL/policy on move when files are all nested

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -67,7 +67,7 @@ from app.wiki import (
 )
 from app.ingest import settings as ingest_settings
 from app.models.update_policy import UpdateHealthResponse
-from app.models.wiki import ChangeKind, CommitMaxRetriesError
+from app.models.wiki import ChangeKind, CommitMaxRetriesError, PathMove
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -412,7 +412,11 @@ def move_document_or_folder(
 
     # after_path_move re-points every live path-keyed cache (ACL, comments,
     # activity, drafts, working-dirs) and reconverges the trigger cache.
-    wiki_notify.after_path_move(moves, sha, author)
+    # root_move is the actual rename so folder-level grants re-point correctly
+    # even when all of a folder's files sit in one subdirectory.
+    wiki_notify.after_path_move(
+        moves, sha, author, root_move=PathMove(old=old_rel, new=new_rel)
+    )
 
     log.info(
         "move %s -> %s by %s sha=%s files=%d", old_rel, new_rel, author or "?", sha[:8], len(moves)

--- a/backend/app/llm/agents/tools/move_path.py
+++ b/backend/app/llm/agents/tools/move_path.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.models.wiki import PathMove
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
 from app.wiki import coedit, filesystem, git as wiki_git, notify as wiki_notify
@@ -55,7 +56,9 @@ def handle(args: dict[str, Any]) -> Any:
         sha, moves = wiki_git.move_path(
             old_rel, new_rel, commit_message.strip(), author=author
         )
-        wiki_notify.after_path_move(moves, sha, author)
+        wiki_notify.after_path_move(
+            moves, sha, author, root_move=PathMove(old=old_rel, new=new_rel)
+        )
 
         return {
             "old_path": old_rel,

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -705,7 +705,7 @@ def on_page_deleted(path: str) -> None:
     delete_all_for_path(canon)
 
 
-def on_path_moved(moves: list[PathMove]) -> None:
+def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> None:
     """Rewrite ``acl_entries.resource_path`` and ``wiki_owners.path`` for
     every ``(old, new)`` pair from one ``git mv`` commit.
 
@@ -713,6 +713,13 @@ def on_path_moved(moves: list[PathMove]) -> None:
     a directory ``a/`` is renamed to ``b/``, an existing folder grant
     at ``a/sub`` becomes ``b/sub``. We do this with a row-by-row
     rewrite per move; the volume is tiny in practice.
+
+    ``root_move`` is the rename as the caller issued it (the folder itself for
+    a directory move). Prefer it for the folder-prefix rewrite: inferring the
+    prefix from the file moves via ``common_folder_rename`` finds the *deepest*
+    shared prefix, which misses the renamed folder's own grant when all its
+    files sit in one subdirectory (e.g. moving ``a`` whose only file is
+    ``a/sub/x.md``). Falls back to inference when not supplied.
     """
     if not moves:
         return
@@ -733,12 +740,13 @@ def on_path_moved(moves: list[PathMove]) -> None:
                     update(WikiOwner).where(WikiOwner.path == old_p).values(path=new_p)
                 )
 
-        # Detect a folder-level rename by looking for a common (old, new)
-        # prefix shared across every moved file. ``move_path`` of a
-        # directory yields one tuple per nested file all sharing the
-        # same prefix swap, so this catches it without the caller having
-        # to tell us.
-        old_prefix, new_prefix = common_folder_rename(moves)
+        # The folder-level prefix swap. Prefer the caller's explicit root_move
+        # (the actual folder rename); otherwise infer it from the shared prefix
+        # of the file moves — which can under-reach (see docstring).
+        if root_move is not None and not _is_md_page(root_move.old):
+            old_prefix, new_prefix = root_move.old, root_move.new
+        else:
+            old_prefix, new_prefix = common_folder_rename(moves)
         if old_prefix is not None and new_prefix is not None:
             # Folder ACL at the renamed folder itself.
             s.execute(

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -153,7 +153,11 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
 
 
 def after_path_move(
-    moves: list[PathMove], sha: str, actor: str | None
+    moves: list[PathMove],
+    sha: str,
+    actor: str | None,
+    *,
+    root_move: PathMove | None = None,
 ) -> None:
     """Post-move side effects for every ``(old, new)`` pair from a single
     ``git mv`` commit.
@@ -185,8 +189,8 @@ def after_path_move(
     delete, and a single ``list_changed`` is fired at the end (the
     tree shape changed once, even if many paths moved).
     """
-    acl.on_path_moved(moves)
-    update_policy.on_path_moved(moves)
+    acl.on_path_moved(moves, root_move=root_move)
+    update_policy.on_path_moved(moves, root_move=root_move)
     coedit.on_path_moved(moves)
     list_changed = False
     for mv in moves:

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -175,7 +175,7 @@ def on_page_deleted(path: str) -> None:
     delete(path)
 
 
-def on_path_moved(moves: list[PathMove]) -> None:
+def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> None:
     """Re-key policy rows so a page/folder policy follows a move/rename.
 
     For each ``(old, new)`` pair the exact row at ``old`` is repointed to
@@ -183,6 +183,10 @@ def on_path_moved(moves: list[PathMove]) -> None:
     folder's own row and every row nested under it are repointed too — so
     renaming ``a`` to ``b`` carries ``a`` and ``a/sub`` along. Mirrors
     ``acl.on_path_moved``; the row volume is tiny in practice.
+
+    ``root_move`` is the caller's actual folder rename; prefer it over inferring
+    the prefix from the file moves (which finds the deepest shared prefix and
+    can miss the folder's own row). See ``acl.on_path_moved``.
     """
     if not moves:
         return
@@ -193,7 +197,10 @@ def on_path_moved(moves: list[PathMove]) -> None:
                 .where(UpdatePolicy.path == mv.old)
                 .values(path=mv.new)
             )
-        old_prefix, new_prefix = filesystem.common_folder_rename(moves)
+        if root_move is not None and not root_move.old.endswith(".md"):
+            old_prefix, new_prefix = root_move.old, root_move.new
+        else:
+            old_prefix, new_prefix = filesystem.common_folder_rename(moves)
         if old_prefix is not None and new_prefix is not None:
             # The renamed folder's own policy row.
             s.execute(

--- a/backend/tests/test_folder_acl_repoint.py
+++ b/backend/tests/test_folder_acl_repoint.py
@@ -1,0 +1,64 @@
+"""Folder-level ACL/policy re-point on move, including the deep-only case.
+
+`acl.on_path_moved` / `update_policy.on_path_moved` infer the folder-prefix
+swap from the file moves, but that finds the *deepest* shared prefix — so a
+folder whose files all sit in one subdirectory would leave the folder's own
+row stranded. The move callers pass the real rename as `root_move` to fix it.
+"""
+from __future__ import annotations
+
+from app.models.wiki import PathMove
+from app.wiki import acl, update_policy
+
+
+def _folder_paths(path: str) -> set[str]:
+    """resource_paths of folder ACL rows that apply to ``path``."""
+    return {
+        g["resource_path"]
+        for g in acl.list_for_path(path)
+        if g["resource_kind"] == "folder"
+    }
+
+
+def test_folder_acl_repoints_with_root_move_deep_only(tmp_db):
+    # Folder grant on `proj`; its only file lives under `proj/sub/`.
+    acl.grant(
+        resource_kind="folder",
+        resource_path="proj",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
+        granted_by_user_id=None,
+    )
+    moves = [PathMove(old="proj/sub/a.md", new="proj2/sub/a.md")]
+
+    acl.on_path_moved(moves, root_move=PathMove(old="proj", new="proj2"))
+
+    # The folder grant followed to proj2 — not stranded at the old `proj`.
+    assert "proj2" in _folder_paths("proj2/sub/a.md")
+    assert "proj" not in _folder_paths("proj/sub/a.md")
+
+
+def test_without_root_move_the_deep_prefix_is_missed(tmp_db):
+    # Control: inference alone (no root_move) can't see the `proj` root, so the
+    # folder grant is NOT re-pointed — this is the bug root_move fixes.
+    acl.grant(
+        resource_kind="folder",
+        resource_path="proj",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
+        granted_by_user_id=None,
+    )
+    acl.on_path_moved([PathMove(old="proj/sub/a.md", new="proj2/sub/a.md")])
+    assert "proj" in _folder_paths("proj/sub/a.md")  # stranded without root_move
+
+
+def test_update_policy_folder_repoints_with_root_move(tmp_db):
+    update_policy.set_policy("proj", ingestion_auto_update_disabled=True)
+    update_policy.on_path_moved(
+        [PathMove(old="proj/sub/a.md", new="proj2/sub/a.md")],
+        root_move=PathMove(old="proj", new="proj2"),
+    )
+    assert update_policy.get("proj2") is not None
+    assert update_policy.get("proj") is None

--- a/backend/tests/test_folder_acl_repoint.py
+++ b/backend/tests/test_folder_acl_repoint.py
@@ -56,9 +56,13 @@ def test_without_root_move_the_deep_prefix_is_missed(tmp_db):
 
 def test_update_policy_folder_repoints_with_root_move(tmp_db):
     update_policy.set_policy("proj", ingestion_auto_update_disabled=True)
+    # A nested-folder row exercises the LIKE "proj/%" branch of the rewrite.
+    update_policy.set_policy("proj/sub", ingestion_auto_update_disabled=True)
     update_policy.on_path_moved(
         [PathMove(old="proj/sub/a.md", new="proj2/sub/a.md")],
         root_move=PathMove(old="proj", new="proj2"),
     )
     assert update_policy.get("proj2") is not None
     assert update_policy.get("proj") is None
+    assert update_policy.get("proj2/sub") is not None
+    assert update_policy.get("proj/sub") is None


### PR DESCRIPTION
## Problem

`acl.on_path_moved` and `update_policy.on_path_moved` re-point path-keyed rows after a `git mv`. For the folder-level prefix rewrite they inferred the swap from the file moves via `common_folder_rename`, which returns the **deepest** shared `(old, new)` prefix.

When a moved folder's files all live in one subdirectory — e.g. moving `a` whose only file is `a/sub/x.md` — the inferred prefix is `a/sub → b/sub`, so the folder's **own** grant/policy row keyed at `a` is never rewritten and is stranded on a path that no longer exists. A folder-level ACL grant (or update policy) silently stops applying after the move.

## Fix

Thread the caller's actual rename through as an explicit `root_move` and prefer it for the folder-prefix rewrite, falling back to prefix inference when it isn't supplied. Both callers pass it:

- `app/api/wiki.py` move route
- `app/llm/agents/tools/move_path.py` agent tool

`notify.after_path_move` gained a keyword-only `root_move` param that it forwards to both `on_path_moved` functions.

## Tests

`tests/test_folder_acl_repoint.py` covers the deep-only case for both ACL and update-policy, plus a control asserting the pre-fix inference misses it.