### PR TITLE
refactor(wiki): unify page/folder kind onto a shared PageKind enum

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -73,7 +73,7 @@ from app.wiki import (
 )
 from app.ingest import settings as ingest_settings
 from app.models.update_policy import UpdateHealthResponse
-from app.models.wiki import ChangeKind, CommitMaxRetriesError, PathMove
+from app.models.wiki import ChangeKind, CommitMaxRetriesError, PageKind, PathMove
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -523,7 +523,7 @@ def view_trash_item(
     if "read" not in perms:
         raise HTTPException(status_code=403, detail="not permitted")
     body: str | None = None
-    if entry.kind == "page":
+    if entry.kind == PageKind.PAGE:
         body = wiki_git.read_file_opt(
             wiki_trash.trash_location(trash_id, entry.original_path)
         )

--- a/backend/app/llm/agents/tools/set_update_policy.py
+++ b/backend/app/llm/agents/tools/set_update_policy.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.auth import PermissionDenied, current_user, require_can
+from app.models.wiki import PageKind
 from app.wiki import update_policy, utils as wiki_utils
 
 
@@ -41,7 +42,7 @@ def handle(args: dict[str, Any]) -> Any:
 
     # A page policy must target an existing page; folder/root policies may be set
     # ahead of their children (future pages inherit them).
-    if kind == "page" and not wiki_utils.file_exists(norm):
+    if kind == PageKind.PAGE and not wiki_utils.file_exists(norm):
         return {"error": f"file not found: {norm}"}
 
     # PATCH: only change settings the caller actually provided. Key present =
@@ -86,7 +87,7 @@ def handle(args: dict[str, Any]) -> Any:
     effective = update_policy.resolve_for_path(norm)
     return {
         "path": norm,
-        "kind": kind,
+        "kind": kind.value,
         # This scope's own row (None once it carries no settings and inherits fully).
         "explicit": explicit,
         # What actually applies here after folder→page inheritance.

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from app.models.wiki import PageKind
+
 
 # --------------------------------------------------------------------------- #
 # Existing schemas (kept for forward compatibility)                           #
@@ -193,7 +195,7 @@ class TrashEntryView(BaseModel):
 
     trash_id: str
     path: str  # original location; restore moves it back here
-    kind: Literal["page", "folder"]
+    kind: PageKind
     trashed_by: str
     trashed_at: str  # ISO-8601
     can_restore: bool = False

--- a/backend/app/models/permissions.py
+++ b/backend/app/models/permissions.py
@@ -11,6 +11,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.models.wiki import PageKind
+
 
 # --------------------------------------------------------------------------- #
 # Groups                                                                      #
@@ -80,12 +82,11 @@ class GroupSharesResponse(BaseModel):
 
 
 PrincipalKind = Literal["user", "group", "everyone"]
-ResourceKind = Literal["page", "folder"]
 Permission = Literal["read", "write"]
 
 
 class AclGrantRequest(BaseModel):
-    resource_kind: ResourceKind
+    resource_kind: PageKind
     resource_path: str
     principal_kind: PrincipalKind
     principal_id: str | None = None
@@ -94,7 +95,7 @@ class AclGrantRequest(BaseModel):
 
 class AclEntryOut(BaseModel):
     id: str
-    resource_kind: str
+    resource_kind: PageKind
     resource_path: str
     principal_kind: str
     principal_id: str | None

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -1,9 +1,9 @@
 """HTTP shapes for /api/update-policy."""
 from __future__ import annotations
 
-from typing import Literal
-
 from pydantic import BaseModel, Field
+
+from app.models.wiki import PageKind
 
 
 class EffectivePolicy(BaseModel):
@@ -18,7 +18,7 @@ class ExplicitPolicy(BaseModel):
     """The policy row set on exactly this path (no cascade)."""
 
     path: str
-    kind: Literal["page", "folder"]
+    kind: PageKind
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
     ai_management_allowed: bool | None = None

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -14,6 +14,26 @@ class ChangeKind(str, Enum):
     SCHEDULE = "schedule"
 
 
+class PageKind(str, Enum):
+    """Whether a wiki path names a page (a ``.md`` file) or a folder.
+
+    The single representation of this distinction across the wiki layer —
+    ACLs (``resource_kind``), update policies, and the Trash view all classify
+    paths this way. ``str``-valued so it compares/serializes as ``"page"`` /
+    ``"folder"`` (matching the stored column values and the DB CHECK
+    constraints) with no ``.value`` juggling at call sites.
+    """
+
+    PAGE = "page"
+    FOLDER = "folder"
+
+    @classmethod
+    def of(cls, path: str) -> "PageKind":
+        """Classify ``path`` by extension: a ``.md`` file is a page, anything
+        else (including the root ``""``) is a folder."""
+        return cls.PAGE if path.endswith(".md") else cls.FOLDER
+
+
 class PathMove(BaseModel):
     """One tracked file relocated by a move/rename commit: ``old`` → ``new``.
 

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -44,7 +44,7 @@ from sqlalchemy import (
 from app.auth import groups as groups_repo
 from app.db.models import AclEntry, WikiOwner
 from app.db.session import session
-from app.models.wiki import PathMove
+from app.models.wiki import PageKind, PathMove
 from app.wiki.filesystem import common_folder_rename
 
 log = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ def _is_md_page(path: str) -> bool:
 def _owner_key(path: str) -> str:
     """WikiOwner rows are keyed by the same canonical path as AclEntry rows,
     so owner lookups and grants on the same resource always agree."""
-    return _canonicalize("page" if _is_md_page(path) else "folder", path)
+    return _canonicalize(PageKind.of(path), path)
 
 
 def get_owner(path: str) -> str | None:
@@ -123,7 +123,7 @@ def transfer_owner(path: str, new_owner_id: str | None) -> None:
     convention). Clearing the owner (``new_owner_id is None``) still
     leaves the prior owner an editor. The grant is idempotent.
     """
-    resource_kind = "page" if _is_md_page(path) else "folder"
+    resource_kind = PageKind.of(path)
     canon = _canonicalize(resource_kind, path)
     # Single session so the owner move and the editor grant commit (or roll
     # back) together — otherwise a failed grant after a committed owner move
@@ -183,9 +183,9 @@ def group_grant_counts() -> dict[str, dict[str, int]]:
             if gid is None:
                 continue
             row = out.setdefault(gid, {"pages": 0, "folders": 0})
-            if kind == "page":
+            if kind == PageKind.PAGE:
                 row["pages"] = int(n)
-            elif kind == "folder":
+            elif kind == PageKind.FOLDER:
                 row["folders"] = int(n)
     return out
 
@@ -195,7 +195,7 @@ def group_grant_counts() -> dict[str, dict[str, int]]:
 # --------------------------------------------------------------------------- #
 
 
-_VALID_RESOURCE_KINDS = {"page", "folder"}
+_VALID_RESOURCE_KINDS = {k.value for k in PageKind}
 _VALID_PRINCIPAL_KINDS = {"user", "group", "everyone"}
 _VALID_PERMISSIONS = {"read", "write"}
 
@@ -210,7 +210,7 @@ def _canonicalize(resource_kind: str, resource_path: str) -> str:
     p = os.path.normpath(p) if p else ""
     if p == ".":
         p = ""
-    if resource_kind == "page" and not _is_md_page(p):
+    if resource_kind == PageKind.PAGE and not _is_md_page(p):
         raise ValueError(f"page resource_path must end in .md: {resource_path!r}")
     return p
 
@@ -305,7 +305,7 @@ def list_for_path(path: str) -> list[dict[str, Any]]:
     is it inherited from."
     """
     is_page = _is_md_page(path)
-    canon = _canonicalize("page" if is_page else "folder", path)
+    canon = _canonicalize(PageKind.PAGE if is_page else PageKind.FOLDER, path)
     if is_page:
         ancestors = _ancestors(canon)
     else:
@@ -322,7 +322,7 @@ def list_for_path(path: str) -> list[dict[str, Any]]:
                 s.scalars(
                     select(AclEntry)
                     .where(
-                        AclEntry.resource_kind == "page",
+                        AclEntry.resource_kind == PageKind.PAGE,
                         AclEntry.resource_path == canon,
                     )
                     .order_by(AclEntry.created_at.asc())
@@ -334,7 +334,7 @@ def list_for_path(path: str) -> list[dict[str, Any]]:
                 s.scalars(
                     select(AclEntry)
                     .where(
-                        AclEntry.resource_kind == "folder",
+                        AclEntry.resource_kind == PageKind.FOLDER,
                         AclEntry.resource_path == f,
                     )
                     .order_by(AclEntry.created_at.asc())
@@ -375,7 +375,7 @@ def delete_all_for_path(path: str) -> None:
     with session() as s:
         s.execute(
             delete(AclEntry).where(
-                AclEntry.resource_kind == "page",
+                AclEntry.resource_kind == PageKind.PAGE,
                 AclEntry.resource_path == path,
             )
         )
@@ -421,11 +421,7 @@ def effective(
 
     raw_path = path.strip().strip("/")
     is_page = _is_md_page(raw_path)
-    canon_path = (
-        _canonicalize("page", raw_path)
-        if is_page
-        else _canonicalize("folder", raw_path)
-    )
+    canon_path = _canonicalize(PageKind.of(raw_path), raw_path)
     folder_paths = (
         _ancestors(canon_path) if is_page else _folder_self_and_ancestors(canon_path)
     )
@@ -466,14 +462,14 @@ def _path_is_managed(s: Any, page_path: str, folder_paths: list[str]) -> bool:
     if page_path and _is_md_page(page_path):
         conditions.append(
             and_(
-                AclEntry.resource_kind == "page",
+                AclEntry.resource_kind == PageKind.PAGE,
                 AclEntry.resource_path == page_path,
             )
         )
     if folder_paths:
         conditions.append(
             and_(
-                AclEntry.resource_kind == "folder",
+                AclEntry.resource_kind == PageKind.FOLDER,
                 AclEntry.resource_path.in_(folder_paths),
             )
         )
@@ -506,12 +502,12 @@ def _grants_for_principal(
     resource_clauses: list[ColumnElement[bool]] = []
     if page_path and _is_md_page(page_path):
         resource_clauses.append(
-            and_(AclEntry.resource_kind == "page", AclEntry.resource_path == page_path)
+            and_(AclEntry.resource_kind == PageKind.PAGE, AclEntry.resource_path == page_path)
         )
     if folder_paths:
         resource_clauses.append(
             and_(
-                AclEntry.resource_kind == "folder",
+                AclEntry.resource_kind == PageKind.FOLDER,
                 AclEntry.resource_path.in_(folder_paths),
             )
         )
@@ -583,12 +579,12 @@ def visible_paths_filter(
     principal_predicate = or_(*principal_clauses)
 
     page_match = and_(
-        AclEntry.resource_kind == "page",
+        AclEntry.resource_kind == PageKind.PAGE,
         AclEntry.resource_path == path_column,
         principal_predicate,
     )
     folder_match = and_(
-        AclEntry.resource_kind == "folder",
+        AclEntry.resource_kind == PageKind.FOLDER,
         principal_predicate,
         or_(
             AclEntry.resource_path == "",
@@ -603,11 +599,11 @@ def visible_paths_filter(
     any_acl_match = and_(
         or_(
             and_(
-                AclEntry.resource_kind == "page",
+                AclEntry.resource_kind == PageKind.PAGE,
                 AclEntry.resource_path == path_column,
             ),
             and_(
-                AclEntry.resource_kind == "folder",
+                AclEntry.resource_kind == PageKind.FOLDER,
                 or_(
                     AclEntry.resource_path == "",
                     path_column.like(AclEntry.resource_path + "/%"),
@@ -666,7 +662,7 @@ def on_page_created(path: str, owner_user_id: str | None) -> None:
     """
     if not _is_md_page(path):
         return
-    canon = _canonicalize("page", path)
+    canon = _canonicalize(PageKind.PAGE, path)
     with session() as s:
         if s.get(WikiOwner, canon) is None:
             s.add(WikiOwner(path=canon, owner_user_id=owner_user_id))
@@ -675,7 +671,7 @@ def on_page_created(path: str, owner_user_id: str | None) -> None:
                 select(func.count())
                 .select_from(AclEntry)
                 .where(
-                    AclEntry.resource_kind == "page",
+                    AclEntry.resource_kind == PageKind.PAGE,
                     AclEntry.resource_path == canon,
                     AclEntry.principal_kind == "everyone",
                 )
@@ -687,7 +683,7 @@ def on_page_created(path: str, owner_user_id: str | None) -> None:
                 s.add(
                     AclEntry(
                         id=f"acl_{uuid.uuid4().hex[:12]}",
-                        resource_kind="page",
+                        resource_kind=PageKind.PAGE,
                         resource_path=canon,
                         principal_kind="everyone",
                         principal_id=None,
@@ -701,7 +697,7 @@ def on_page_deleted(path: str) -> None:
     """Remove owner + all page-level ACL rows for ``path``."""
     if not _is_md_page(path):
         return
-    canon = _canonicalize("page", path)
+    canon = _canonicalize(PageKind.PAGE, path)
     delete_all_for_path(canon)
 
 
@@ -731,7 +727,7 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                 s.execute(
                     update(AclEntry)
                     .where(
-                        AclEntry.resource_kind == "page",
+                        AclEntry.resource_kind == PageKind.PAGE,
                         AclEntry.resource_path == old_p,
                     )
                     .values(resource_path=new_p)
@@ -752,7 +748,7 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
             s.execute(
                 update(AclEntry)
                 .where(
-                    AclEntry.resource_kind == "folder",
+                    AclEntry.resource_kind == PageKind.FOLDER,
                     AclEntry.resource_path == old_prefix,
                 )
                 .values(resource_path=new_prefix)
@@ -761,7 +757,7 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
             s.execute(
                 update(AclEntry)
                 .where(
-                    AclEntry.resource_kind == "folder",
+                    AclEntry.resource_kind == PageKind.FOLDER,
                     AclEntry.resource_path.like(old_prefix + "/%"),
                 )
                 .values(

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 
 import os
 import uuid
-from typing import Literal
 
 from pydantic import BaseModel
 
+from app.models.wiki import PageKind
 from app.wiki import git as wiki_git
 from app.wiki.filesystem import TRASH_DIR
 
@@ -30,7 +30,7 @@ class TrashEntry(BaseModel):
 
     trash_id: str
     original_path: str  # where it lived; restore moves it back here
-    kind: Literal["page", "folder"]
+    kind: PageKind
     trashed_by: str  # git author of the trash-move commit
     trashed_at: str  # ISO-8601
 
@@ -76,7 +76,7 @@ def _entry(trash_id: str, originals: list[str]) -> TrashEntry | None:
         # No trailer (trash predating trash_commit_message) — infer from the file
         # list. Ambiguous for a single-file folder, hence the trailer above.
         root = originals[0] if len(originals) == 1 else os.path.commonpath(originals)
-    kind: Literal["page", "folder"] = "page" if root.endswith(".md") else "folder"
+    kind = PageKind.of(root)
     return TrashEntry(
         trash_id=trash_id,
         original_path=root,

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import func, select, update
 
 from app.db.models import UpdatePolicy
-from app.models.wiki import PathMove
+from app.models.wiki import PageKind, PathMove
 from app.db.session import session
 from app.ingest import settings as ingest_settings
 from app.wiki import filesystem
@@ -56,9 +56,9 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
-def kind_for_path(path: str) -> str:
+def kind_for_path(path: str) -> PageKind:
     """A ``.md`` path is a ``page``; everything else (incl. root) is a ``folder``."""
-    return "page" if path.endswith(".md") else "folder"
+    return PageKind.of(path)
 
 
 def normalize_path(raw: str) -> str:
@@ -341,7 +341,7 @@ def count_ingest_enabled_pages(
         return total_pages
     candidates: set[str] = set()
     for scope in scopes:
-        if kind_for_path(scope) == "page":
+        if kind_for_path(scope) == PageKind.PAGE:
             candidates.add(scope)
         else:
             candidates.update(list_pages_under(f"{scope}/" if scope else ""))

--- a/backend/tests/test_page_kind.py
+++ b/backend/tests/test_page_kind.py
@@ -1,0 +1,31 @@
+"""Contract for the shared PageKind enum.
+
+PageKind is the single page-vs-folder representation across ACLs, update
+policies, and Trash. These lock the two properties the refactor relies on:
+`.of()` classification, and `str`-compatibility (equality + JSON value) so it
+drops into str-typed columns/params and serializes as `"page"`/`"folder"`.
+"""
+from __future__ import annotations
+
+import json
+
+from app.models.wiki import PageKind
+
+
+def test_of_classifies_by_extension():
+    assert PageKind.of("notes/a.md") is PageKind.PAGE
+    assert PageKind.of("notes") is PageKind.FOLDER
+    assert PageKind.of("") is PageKind.FOLDER  # wiki root is a folder
+
+
+def test_str_compatibility():
+    # Equal to and interchangeable with the bare strings the DB stores.
+    assert PageKind.PAGE == "page"
+    assert PageKind.FOLDER == "folder"
+    assert PageKind.PAGE in {"page", "folder"}
+    assert PageKind("folder") is PageKind.FOLDER
+
+
+def test_json_serializes_to_value():
+    # Not "PageKind.PAGE" — API responses stay "page"/"folder".
+    assert json.dumps(PageKind.PAGE) == '"page"'


### PR DESCRIPTION
## What

Collapses the three separate representations of the page-vs-folder distinction onto one `PageKind(str, Enum)` in `app/models/wiki.py` (next to `ChangeKind`):

| Was | Now |
|-----|-----|
| `acl.py` — bare `"page"`/`"folder"` + private `_VALID_RESOURCE_KINDS` set | `PageKind.PAGE`/`.FOLDER`; `_VALID_RESOURCE_KINDS` derived from the enum |
| `update_policy.kind_for_path()` → bare `str` | returns `PageKind` (via `PageKind.of`) |
| `Literal["page","folder"]` on permissions / update-policy / trash Pydantic models | `PageKind` |

`PageKind.of(path)` centralizes the `.endswith(".md")` classification that was duplicated across `acl._is_md_page`, `update_policy.kind_for_path`, and `trash._entry`.

## Design notes

- **`str`-valued enum** (like the existing `ChangeKind`): compares equal to `"page"`/`"folder"`, stores as those in the DB (matching the `resource_kind IN ('page','folder')` CHECK constraints), and `json.dumps`/pydantic serialize to the plain value — so **API shapes and response assertions are unchanged**.
- **`acl.grant` keeps a `str` param on purpose.** `PageKind` is `str`-compatible, so the ~60 existing `resource_kind="page"` call sites (all in tests) and the boundary `AclGrantRequest` (which now parses incoming JSON straight to `PageKind`) flow through with **zero churn**. Narrowing the param would have forced ~60 edits for no safety gain, since the column is `str`.

## Follow-up context

Falls out of the #382 review discussion (should `TrashEntry.kind` be an enum?). Rather than bolt a lone enum onto one model, this unifies all three sites.

## Tests

`tests/test_page_kind.py` locks the contract: `.of()` classification, `str`-equality/membership, and JSON-serializes-to-value. Existing ACL/trash/update-policy suites exercise it end-to-end (incl. the DB CHECK-constraint backstop). ruff + basedpyright clean across `app` and `tests`.