### PR TITLE
feat(wiki): id-only wiki URLs (stable doc ids, backend + frontend)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -17,6 +17,7 @@ from app.models.file_system import (
     CreateFolderRequest,
     CreateFolderResponse,
     DeleteDocumentResponse,
+    DocRef,
     DocumentActivityResponse,
     DocumentDraftView,
     DocumentEntry,
@@ -38,6 +39,9 @@ from app.models.file_system import (
     RecordRecentDocRequest,
     ReindexRequest,
     ReindexResponse,
+    ResolveDocIdResponse,
+    ResolveIdsRequest,
+    ResolveIdsResponse,
     ReorderStarredRequest,
     RestorePathResponse,
     RestoreTrashRequest,
@@ -59,6 +63,7 @@ from app.wiki import (
     agent_activity,
     coedit,
     diff as wiki_diff,
+    doc_ids,
     drafts as wiki_drafts,
     filesystem,
     git as wiki_git,
@@ -153,8 +158,55 @@ def list_documents(
         # Keep non-md paths (folders, .gitkeep) so the explorer can render
         # the tree; permission checks happen on actual page access.
         raw = [(p, ts) for p, ts in raw if not p.endswith(".md") or p in visible]
-    entries = [DocumentEntry(path=p, updated_at=ts) for p, ts in raw]
+    ids = doc_ids.ids_for_paths([p for p, _ in raw])
+    entries = [DocumentEntry(path=p, updated_at=ts, id=ids.get(p)) for p, ts in raw]
     return ListDocumentsResponse(entries=entries)
+
+
+@router.post("/resolve-ids", response_model=ResolveIdsResponse)
+def resolve_ids(
+    req: ResolveIdsRequest,
+    user: User = Depends(require_user),
+) -> ResolveIdsResponse:
+    """Bulk path→id for building id-based hrefs (folders, breadcrumb ancestors).
+
+    ACL-filtered like the tree listing: a `.md` path the caller can't read is
+    dropped; folder paths pass through (folder existence is already visible in
+    the tree, and page-level permission is enforced on actual access)."""
+    try:
+        rels = [filesystem.safe_rel_path(p.strip()) for p in req.paths if p.strip()]
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if not user.is_admin:
+        md = [p for p in rels if p.endswith(".md")]
+        visible = set(acl.filter_paths_in_python(user.id, False, md))
+        rels = [p for p in rels if not p.endswith(".md") or p in visible]
+    ids = doc_ids.ids_for_paths(rels)
+    return ResolveIdsResponse(items=[DocRef(path=p, id=i) for p, i in ids.items()])
+
+
+@router.get("/id/{doc_id}", response_model=ResolveDocIdResponse)
+def resolve_doc_id(
+    doc_id: str,
+    user: User = Depends(require_user),
+) -> ResolveDocIdResponse:
+    """Resolve a stable doc id to its current binding — the id-URL entry point.
+
+    ``deleted_at`` set means the page/folder was trashed; ``path`` is where it
+    lived, for the tombstone/restore surfaces. 404 for an unknown id."""
+    row = doc_ids.get(doc_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="unknown id")
+    # Stored paths are app-generated from validated values, but re-validate
+    # before the ACL check so this endpoint matches every other read path.
+    try:
+        path = filesystem.safe_rel_path(str(row["path"]))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    require_can("read", path, user)
+    return ResolveDocIdResponse(
+        id=doc_id, path=path, kind=PageKind.of(path), deleted_at=row["deleted_at"]
+    )
 
 
 @router.get("/recent", response_model=ListRecentPagesResponse)
@@ -177,8 +229,10 @@ def list_recent_pages(
         md = [(p, ts) for p, ts in md if p in visible]
     # Newest first; empty timestamps sink to the bottom.
     md.sort(key=lambda pt: pt[1], reverse=True)
+    top = md[:limit]
+    ids = doc_ids.ids_for_paths([p for p, _ in top])
     pages: list[RecentPageView] = []
-    for path, ts in md[:limit]:
+    for path, ts in top:
         abs_path = filesystem.absolute(path)
         if not abs_path.is_file():
             continue
@@ -187,7 +241,11 @@ def list_recent_pages(
         except OSError:
             continue
         title, preview = _title_and_preview(body, path)
-        pages.append(RecentPageView(path=path, title=title, updated_at=ts, preview=preview))
+        pages.append(
+            RecentPageView(
+                path=path, title=title, updated_at=ts, preview=preview, id=ids.get(path)
+            )
+        )
     return ListRecentPagesResponse(pages=pages)
 
 
@@ -196,15 +254,28 @@ def get_document_by_path(
     user: User = Depends(require_user),
     path: str = "",
     ref: str | None = None,
+    doc_id: str | None = Query(None, alias="id"),
 ) -> GetDocumentResponse:
+    if doc_id and not path:
+        row = doc_ids.get(doc_id)
+        if row is None:
+            raise HTTPException(status_code=404, detail="unknown id")
+        path = str(row["path"])
     if not path:
-        raise HTTPException(status_code=400, detail="path required")
+        raise HTTPException(status_code=400, detail="path or id required")
     try:
         rel = filesystem.safe_rel_path(path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     require_can("read", rel, user)
     head_sha = wiki_git.head_sha_for_path(rel)
+    # Stable id: reading a live page lazily backfills its row (pre-id pages);
+    # historical/deleted reads only report an id if a live row exists.
+    page_id = (
+        doc_ids.get_or_mint(rel)
+        if filesystem.absolute(rel).is_file()
+        else doc_ids.id_for_path(rel)
+    )
     if ref:
         # The path may have been different at this ref (rename). Resolve
         # via --follow so old commits don't 404 on the current name.
@@ -213,7 +284,7 @@ def get_document_by_path(
             body = wiki_git.read_file(historical, ref=ref)
         except wiki_git.UnknownSha as exc:
             raise HTTPException(status_code=404, detail="not found at ref") from exc
-        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref)
+        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref, id=page_id)
     # Session-aware live read: when a co-edit session is open on this page, its
     # Postgres buffer holds the freshest edits. The checkpoint that commits the
     # buffer to git runs asynchronously, so HEAD lags — reading it would show
@@ -250,11 +321,13 @@ def get_document_by_path(
                     exc_info=True,
                 )
                 body = current
-        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha)
+        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, id=page_id)
     abs_path = filesystem.absolute(rel)
     if not abs_path.is_file():
         raise HTTPException(status_code=404, detail="not found")
-    return GetDocumentResponse(path=rel, body=abs_path.read_text(), head_sha=head_sha)
+    return GetDocumentResponse(
+        path=rel, body=abs_path.read_text(), head_sha=head_sha, id=page_id
+    )
 
 
 @router.put("/file", response_model=PutDocumentResponse)
@@ -322,6 +395,9 @@ def put_document_by_path(
         sha=sha,
         created=not existed,
         deprecated=[],
+        # The create lifecycle minted on first save; edits of pre-id pages
+        # backfill here.
+        id=doc_ids.get_or_mint(rel),
     )
 
 
@@ -351,6 +427,7 @@ def create_folder(
         raise HTTPException(status_code=409, detail="folder already exists")
     author = _git_author(user)
     sha = wiki_git.commit_file(f"{rel}/.gitkeep", "", f"create folder {rel}", author=author)
+    doc_ids.get_or_mint(rel)
     log.info("folder created %s by %s sha=%s", rel, author or "?", sha[:8])
     return CreateFolderResponse(path=rel, sha=sha)
 
@@ -569,6 +646,9 @@ def restore_trashed(
     wiki_notify.after_path_move(
         moves, sha, author, root_move=PathMove(old=trash_root, new=entry.original_path)
     )
+    # Re-bind the tombstoned ids to their original paths (after_path_move's
+    # doc_ids hook is a no-op here — nothing live sits at the .trash/ source).
+    doc_ids.on_restored([mv.new for mv in moves])
     log.info(
         "restored trash_id=%s to %s (%d files) by %s",
         req.trash_id,
@@ -640,6 +720,7 @@ def search_documents(
         user_id=user.id,
         is_admin=user.is_admin,
     )
+    ids = doc_ids.ids_for_paths([h.path for h in hits] + [f.path for f in folders])
     return SearchResponse(
         query=query,
         hits=[
@@ -649,10 +730,11 @@ def search_documents(
                 title=h.title,
                 snippet=h.snippet,
                 score=h.score,
+                id=ids.get(h.path),
             )
             for h in hits
         ],
-        folders=[FolderHitView(path=f.path) for f in folders],
+        folders=[FolderHitView(path=f.path, id=ids.get(f.path)) for f in folders],
     )
 
 
@@ -666,7 +748,9 @@ def list_recent_docs(user: User = Depends(require_user)) -> RecentDocsResponse:
         from app.wiki import acl as _acl
 
         paths = _acl.filter_paths_in_python(user.id, False, paths)
-    return RecentDocsResponse(paths=paths)
+    ids = doc_ids.ids_for_paths(paths)
+    items = [DocRef(path=p, id=ids.get(p)) for p in paths]
+    return RecentDocsResponse(paths=paths, items=items)
 
 
 @router.post("/recents", status_code=status.HTTP_204_NO_CONTENT)
@@ -692,7 +776,9 @@ def list_starred_docs(user: User = Depends(require_user)) -> StarredDocsResponse
         from app.wiki import acl as _acl
 
         paths = _acl.filter_paths_in_python(user.id, False, paths)
-    return StarredDocsResponse(paths=paths)
+    ids = doc_ids.ids_for_paths(paths)
+    items = [DocRef(path=p, id=ids.get(p)) for p in paths]
+    return StarredDocsResponse(paths=paths, items=items)
 
 
 @router.post("/starred", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/db/migrations/versions/76caae98c2b2_wiki_doc_ids.py
+++ b/backend/app/db/migrations/versions/76caae98c2b2_wiki_doc_ids.py
@@ -1,0 +1,62 @@
+"""wiki doc ids
+
+Adds ``wiki_doc_ids`` — the stable path↔id mapping for wiki pages and
+folders. Guarded with the inspector because ``0001_initial`` builds fresh
+databases from the current models.
+
+Revision ID: 76caae98c2b2
+Revises: b7f3c1a9d2e4
+Create Date: 2026-07-10 20:56:21.462534+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = '76caae98c2b2'
+down_revision: str | None = 'b7f3c1a9d2e4'
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("wiki_doc_ids"):
+        return
+    op.create_table(
+        'wiki_doc_ids',
+        sa.Column('id', sa.Text(), nullable=False),
+        sa.Column('path', sa.Text(), nullable=False),
+        sa.Column('kind', sa.Text(), nullable=False),
+        sa.Column(
+            'created_at',
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.Column('deleted_at', sa.Text(), nullable=True),
+        sa.CheckConstraint("kind IN ('page', 'folder')", name='wiki_doc_ids_kind_check'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    # Unique among live rows only: tombstone rows (deleted_at set) may share
+    # a path with each other and with a later live row at the same path.
+    op.create_index(
+        'uq_wiki_doc_ids_live_path',
+        'wiki_doc_ids',
+        ['path'],
+        unique=True,
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'uq_wiki_doc_ids_live_path',
+        table_name='wiki_doc_ids',
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+    op.drop_table('wiki_doc_ids')

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1268,6 +1268,46 @@ class UpdatePolicy(Base):
     )
 
 
+class WikiDocId(Base):
+    """Stable identity for a wiki page or folder — the path↔id mapping.
+
+    **Postgres-only** metadata like ``acl_entries``: git has no native file
+    identity (renames are heuristic inference), so IDs are minted here and
+    maintained at the wiki lifecycle seams (``app/wiki/notify.py``). ``path``
+    is the page's/folder's *live* location; moves re-key it in place so the
+    id survives any reorganization.
+
+    Deletes stamp ``deleted_at`` instead of dropping the row — an id keeps
+    resolving after deletion (to the tombstone view) and a restore re-binds
+    it. A page recreated at the same path is a *new* document and gets a
+    fresh id, hence the partial unique index: ``path`` is unique among live
+    rows only, while any number of tombstone rows may share it.
+    """
+
+    __tablename__ = "wiki_doc_ids"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    path: Mapped[str] = mapped_column(Text, nullable=False)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)  # "page" | "folder"
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    deleted_at: Mapped[str | None] = mapped_column(Text)
+
+    __table_args__ = (
+        CheckConstraint(
+            "kind IN ('page', 'folder')",
+            name="wiki_doc_ids_kind_check",
+        ),
+        Index(
+            "uq_wiki_doc_ids_live_path",
+            "path",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Wiki auto-management — change proposals (Postgres-only)                     #
 # --------------------------------------------------------------------------- #

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,6 +57,7 @@ from app.auth.deps import CurrentUserMiddleware
 import app.config as _app_config
 from app.db import comment_fts
 from app.wiki import comments as _comments_repo
+from app.wiki import doc_ids
 from app.metrics import setup_prometheus
 from app.realtime import bus
 from app.llm.errors import LLMError
@@ -176,6 +177,10 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # The index persists across reboots, so steady-state boots skip this.
     if comment_fts.count() == 0:
         _comments_repo.reindex_all_inline()
+    # Stable doc ids: mint for every existing page + folder that lacks one, so
+    # a pre-ids wiki gets full id coverage. Self-gates (cheap count) so a
+    # fully-minted wiki skips the work on later boots.
+    doc_ids.backfill_all()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_reconcile.reconcile_legacy_slack_triggers()
     triggers_repo.rebuild_from_filesystem()

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -104,10 +104,18 @@ class IngestRequest(BaseModel):
 class DocumentEntry(BaseModel):
     path: str
     updated_at: str  # ISO-8601 author-time of the most recent commit touching the path
+    id: str | None = None  # stable wiki_doc_id; None for pre-id rows not yet backfilled
 
 
 class ListDocumentsResponse(BaseModel):
     entries: list[DocumentEntry]
+
+
+class DocRef(BaseModel):
+    """A path paired with its stable id, for id-based navigation links."""
+
+    path: str
+    id: str | None = None
 
 
 class RecordRecentDocRequest(BaseModel):
@@ -118,6 +126,9 @@ class RecentDocsResponse(BaseModel):
     # Newest-first paths of docs the user opened, already filtered to
     # ones that still exist and remain readable.
     paths: list[str]
+    # Same list paired with stable ids, for id-based links. Kept alongside
+    # ``paths`` (not replacing it) so the pre-migration frontend still works.
+    items: list[DocRef] = []
 
 
 class StarDocRequest(BaseModel):
@@ -133,6 +144,9 @@ class StarredDocsResponse(BaseModel):
     # User-ordered starred doc paths, already filtered to ones that
     # still exist and remain readable.
     paths: list[str]
+    # Same list paired with stable ids, for id-based links. Additive; see
+    # RecentDocsResponse.
+    items: list[DocRef] = []
 
 
 class RecentPageView(BaseModel):
@@ -147,6 +161,7 @@ class RecentPageView(BaseModel):
     title: str
     updated_at: str
     preview: str
+    id: str | None = None  # stable wiki_doc_id
 
 
 class ListRecentPagesResponse(BaseModel):
@@ -158,6 +173,7 @@ class GetDocumentResponse(BaseModel):
     body: str
     head_sha: str | None
     ref: str | None = None  # only set when reading at a specific ref
+    id: str | None = None  # stable wiki_doc_id; None for historical/deleted reads
 
 
 class PutDocumentResponse(BaseModel):
@@ -165,6 +181,36 @@ class PutDocumentResponse(BaseModel):
     sha: str
     created: bool
     deprecated: list[str]
+    id: str | None = None  # stable wiki_doc_id (minted on create, backfilled on edit)
+
+
+class ResolveDocIdResponse(BaseModel):
+    """A stable doc id resolved to its current binding.
+
+    ``deleted_at`` set means the page/folder was deleted — the path is where
+    it lived at delete time (feed it to the tombstone/restore endpoints).
+    """
+
+    id: str
+    path: str
+    kind: PageKind
+    deleted_at: str | None = None
+
+
+class ResolveIdsRequest(BaseModel):
+    """Bulk path→id lookup. The frontend uses this to build id-based hrefs for
+    paths it holds but has no id for yet — folder paths (not carried by the
+    file-based tree listing) and synthesized breadcrumb ancestors."""
+
+    # Bounded like the other parameterised endpoints; a single view resolves at
+    # most a handful (visible folders + breadcrumb ancestors), so 1000 is ample.
+    paths: list[str] = Field(max_length=1000)
+
+
+class ResolveIdsResponse(BaseModel):
+    # One entry per input path that has a live id row; paths without one are
+    # simply omitted (the caller falls back to a path URL).
+    items: list[DocRef]
 
 
 class CreateFolderResponse(BaseModel):
@@ -303,15 +349,17 @@ class FileDiffResponse(BaseModel):
 
 
 class SearchHitView(BaseModel):
-    doc_id: str
+    doc_id: str  # search-index key (currently the path); distinct from the stable id below
     path: str
     title: str | None
     snippet: str
     score: float
+    id: str | None = None  # stable wiki_doc_id, for id-based navigation
 
 
 class FolderHitView(BaseModel):
     path: str
+    id: str | None = None  # stable wiki_doc_id of the folder, for id-based navigation
 
 
 class SearchResponse(BaseModel):

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -1,0 +1,280 @@
+"""Stable ids for wiki pages and folders — the ``wiki_doc_ids`` repo.
+
+Git has no native file identity, so ids are minted here (Postgres-only,
+like the ACL tables) and maintained at the wiki lifecycle seams: create
+mints, move re-keys the path in place, delete stamps ``deleted_at`` (the
+row is kept so the id still resolves — to a tombstone — and a restore
+re-binds it). A page recreated at a previously-deleted path is a new
+document with a fresh id; the partial unique index on live ``path`` rows
+enforces that at most one live row occupies a path.
+
+Backfill for pre-existing content is lazy: reads mint missing rows via
+:func:`get_or_mint`, and the hourly BM25 reconcile sweep calls
+:func:`ensure_for_paths` for recently-touched pages.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select, update
+from sqlalchemy.exc import IntegrityError
+
+from app.db.models import WikiDocId
+from app.db.session import session
+from app.models.wiki import PathMove
+from app.wiki import filesystem, git as wiki_git
+
+log = logging.getLogger(__name__)
+
+
+def _mint_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _now_text() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _kind_for(path: str) -> str:
+    return "page" if path.endswith(".md") else "folder"
+
+
+def _row_dict(row: WikiDocId) -> dict[str, str | None]:
+    return {
+        "id": row.id,
+        "path": row.path,
+        "kind": row.kind,
+        "created_at": row.created_at,
+        "deleted_at": row.deleted_at,
+    }
+
+
+def get(doc_id: str) -> dict[str, str | None] | None:
+    """The row for ``doc_id`` (live or tombstone), or ``None``."""
+    with session() as s:
+        row = s.get(WikiDocId, doc_id)
+        return _row_dict(row) if row else None
+
+
+def id_for_path(path: str) -> str | None:
+    """Id of the live row at ``path``, or ``None``."""
+    with session() as s:
+        row = s.execute(
+            select(WikiDocId).where(WikiDocId.path == path, WikiDocId.deleted_at.is_(None))
+        ).scalar_one_or_none()
+        return row.id if row else None
+
+
+def ids_for_paths(paths: list[str]) -> dict[str, str]:
+    """``{path: id}`` for the live rows among ``paths``.
+
+    Paths without a live row are simply absent from the result — callers
+    building navigation links tolerate a missing id (fall back to the path).
+    Used by the listing/search endpoints to attach stable ids in bulk rather
+    than resolving one path at a time.
+
+    The lookup is chunked so a whole-tree listing can't emit one ``IN (...)``
+    with an unbounded bind-parameter count (parse/plan cost grows with it);
+    every path is still returned, just across a bounded number of statements.
+    """
+    if not paths:
+        return {}
+    out: dict[str, str] = {}
+    with session() as s:
+        for i in range(0, len(paths), _ID_LOOKUP_CHUNK):
+            chunk = paths[i : i + _ID_LOOKUP_CHUNK]
+            rows = s.execute(
+                select(WikiDocId.path, WikiDocId.id).where(
+                    WikiDocId.path.in_(chunk), WikiDocId.deleted_at.is_(None)
+                )
+            ).all()
+            out.update({path: doc_id for path, doc_id in rows})
+    return out
+
+
+# Max paths per ``IN (...)`` in ``ids_for_paths`` — bounds per-statement
+# parse/plan cost on a large tree without a round-trip per path.
+_ID_LOOKUP_CHUNK = 1000
+
+
+def get_or_mint(path: str) -> str:
+    """Id of the live row at ``path``, minting one if absent.
+
+    Kind is derived from the path (``.md`` → page, else folder). Safe under
+    concurrency: a losing racer re-reads the winner's row.
+    """
+    existing = id_for_path(path)
+    if existing is not None:
+        return existing
+    new_id = _mint_id()
+    try:
+        with session() as s:
+            s.add(WikiDocId(id=new_id, path=path, kind=_kind_for(path)))
+    except IntegrityError:
+        # A concurrent writer minted first — theirs wins.
+        winner = id_for_path(path)
+        if winner is not None:
+            return winner
+        raise
+    return new_id
+
+
+def mint_for_page(path: str) -> str:
+    """Mint (or fetch) the page's id, plus rows for its ancestor folders.
+
+    Folder rows have no create hook of their own when a folder springs into
+    existence implicitly with its first page, so page creation seeds them.
+    """
+    parts = path.split("/")[:-1]
+    for i in range(1, len(parts) + 1):
+        get_or_mint("/".join(parts[:i]))
+    return get_or_mint(path)
+
+
+def ensure_for_paths(paths: list[str]) -> None:
+    """Backfill: mint live rows for any of ``paths`` that lack one. Pages
+    also seed their ancestor folders. Never raises — backfill must not
+    abort its caller (the startup reindex sweep)."""
+    for p in paths:
+        try:
+            if p.endswith(".md"):
+                mint_for_page(p)
+            else:
+                get_or_mint(p)
+        except Exception:
+            log.exception("doc_ids backfill failed for %s", p)
+
+
+def backfill_all() -> None:
+    """Mint ids for every tracked page and folder that lacks a live row.
+
+    Run once at boot so an existing wiki (created before stable ids) gets ids
+    for all its pages *and folders* — not just the pages someone happens to
+    open. Gated on a cheap count so a fully-minted wiki does almost no work;
+    otherwise mints the missing rows (``get_or_mint`` skips those that exist).
+
+    Folders are enumerated from the tracked-file prefixes so empty folders
+    (only a ``.gitkeep``) get ids too, which page-ancestor seeding misses.
+    """
+    files = wiki_git.list_paths()
+    md = [p for p in files if p.endswith(".md")]
+    folders: set[str] = set()
+    for f in files:
+        parts = f.split("/")[:-1]
+        for i in range(1, len(parts) + 1):
+            folders.add("/".join(parts[:i]))
+    want = len(folders | set(md))
+    with session() as s:
+        have = s.execute(
+            select(func.count())
+            .select_from(WikiDocId)
+            .where(WikiDocId.deleted_at.is_(None))
+        ).scalar_one()
+    if have >= want:
+        return
+    log.info("doc_ids backfill: %d live rows < %d tracked paths; minting missing", have, want)
+    ensure_for_paths([*sorted(folders), *md])
+
+
+def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> None:
+    """Re-key live rows so ids follow a move/rename.
+
+    Page rows are re-pointed pair-by-pair; a directory rename additionally
+    re-points the folder's own row and every nested row via prefix rewrite.
+    ``root_move`` is the rename as the caller issued it (the folder itself
+    for a directory move) — without it the folder prefix is inferred via
+    ``common_folder_rename``, which resolves to the *deepest* consistent
+    prefix and so can miss the renamed folder's own row when its files all
+    sit in one subdirectory. A page renamed *out of* ``.md``-space stops
+    being a document — its row is stamped deleted.
+    """
+    if not moves and root_move is None:
+        return
+    with session() as s:
+        for mv in moves:
+            if mv.old.endswith(".md") and mv.new.endswith(".md"):
+                s.execute(
+                    update(WikiDocId)
+                    .where(WikiDocId.path == mv.old, WikiDocId.deleted_at.is_(None))
+                    .values(path=mv.new)
+                )
+            elif mv.old.endswith(".md"):
+                s.execute(
+                    update(WikiDocId)
+                    .where(WikiDocId.path == mv.old, WikiDocId.deleted_at.is_(None))
+                    .values(deleted_at=_now_text())
+                )
+        if root_move is not None and not root_move.old.endswith(".md"):
+            old_prefix, new_prefix = root_move.old, root_move.new
+        else:
+            old_prefix, new_prefix = filesystem.common_folder_rename(moves)
+        if old_prefix is not None and new_prefix is not None:
+            s.execute(
+                update(WikiDocId)
+                .where(WikiDocId.path == old_prefix, WikiDocId.deleted_at.is_(None))
+                .values(path=new_prefix)
+            )
+            s.execute(
+                update(WikiDocId)
+                .where(
+                    WikiDocId.path.like(old_prefix + "/%"),
+                    WikiDocId.deleted_at.is_(None),
+                )
+                .values(
+                    path=func.concat(
+                        new_prefix,
+                        func.substr(WikiDocId.path, len(old_prefix) + 1),
+                    )
+                )
+            )
+
+
+def on_deleted(path: str) -> None:
+    """Stamp ``deleted_at`` on the live row at ``path`` and, for a folder,
+    every live row nested under it. Rows are kept — the id still resolves."""
+    with session() as s:
+        s.execute(
+            update(WikiDocId)
+            .where(
+                WikiDocId.deleted_at.is_(None),
+                (WikiDocId.path == path) | WikiDocId.path.like(path + "/%"),
+            )
+            .values(deleted_at=_now_text())
+        )
+
+
+def on_restored(paths: list[str]) -> None:
+    """Re-bind ids after a restore: for each path, resurrect the most
+    recently deleted tombstone row (clear ``deleted_at``) unless a live row
+    already occupies the path.
+
+    Each path is expanded to include its ancestor folders, so restoring a
+    page (or a folder's files) also resurrects the folder ids that were
+    tombstoned alongside it — callers can pass just the restored file paths.
+    """
+    targets: set[str] = set()
+    for p in paths:
+        targets.add(p)
+        parts = p.split("/")
+        for i in range(1, len(parts)):
+            targets.add("/".join(parts[:i]))
+    with session() as s:
+        for p in sorted(targets):
+            live = s.execute(
+                select(WikiDocId.id).where(
+                    WikiDocId.path == p, WikiDocId.deleted_at.is_(None)
+                )
+            ).scalar_one_or_none()
+            if live is not None:
+                continue
+            row = s.execute(
+                select(WikiDocId)
+                .where(WikiDocId.path == p, WikiDocId.deleted_at.is_not(None))
+                .order_by(WikiDocId.deleted_at.desc())
+                .limit(1)
+            ).scalar_one_or_none()
+            if row is not None:
+                row.deleted_at = None

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -38,7 +38,7 @@ from app.tasks.reindex import drop_page_embedding, index_path
 from app.tasks.triggers import fan_out_trigger_eval
 from app.tasks.update_frequency import check_update_frequency
 from app.triggers import repo as triggers_repo
-from app.wiki import acl, agent_activity, coedit, comments, constants as wiki_constants, drafts, update_policy
+from app.wiki import acl, agent_activity, coedit, comments, constants as wiki_constants, doc_ids, drafts, update_policy
 from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind, PathMove
 
@@ -88,6 +88,8 @@ def after_doc_write(
         return
     if change_kind == ChangeKind.CREATE:
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
+        # Mint a stable id for the page (and seed rows for its ancestor folders).
+        doc_ids.mint_for_page(rel_path)
     index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
     # Ingestion churn → check the page's 24h update frequency against the
@@ -138,6 +140,9 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     drop_page_embedding(rel_path)
     acl.on_page_deleted(rel_path)
     update_policy.on_page_deleted(rel_path)
+    # Tombstone the id (kept, not dropped) so it still resolves — to a deleted
+    # state — and a later restore can re-bind it.
+    doc_ids.on_deleted(rel_path)
     # The body is gone, so there's nothing to re-anchor against — orphan the
     # page's comments (keeps them as tombstones) rather than dropping them.
     comments.orphan_all_for_doc(rel_path)
@@ -181,6 +186,12 @@ def after_doc_trashed(
     acl.on_path_moved(moves, root_move=root_move)
     update_policy.on_path_moved(moves, root_move=root_move)
     coedit.on_path_moved(moves)
+    # Tombstone the id(s) at the *original* root rather than following the move
+    # into `.trash/` — the id keeps resolving (to a deleted state), and restore
+    # re-binds it. ACL/policy above deliberately follow into `.trash/` (so the
+    # Trash view can authorize); ids deliberately don't.
+    if root_move is not None:
+        doc_ids.on_deleted(root_move.old)
     for mv in moves:
         if not mv.old.endswith(".md"):
             continue
@@ -243,6 +254,7 @@ def after_path_move(
     """
     acl.on_path_moved(moves, root_move=root_move)
     update_policy.on_path_moved(moves, root_move=root_move)
+    doc_ids.on_path_moved(moves, root_move=root_move)
     coedit.on_path_moved(moves)
     list_changed = False
     for mv in moves:

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -1,0 +1,283 @@
+"""Stable doc ids: minted on create, follow moves, survive delete/restore.
+
+The ``wiki_doc_ids`` mapping is maintained at the lifecycle seams
+(``notify.after_doc_write/after_path_move/after_doc_delete`` + the folder
+routes). A delete stamps ``deleted_at`` instead of dropping the row, so the
+id still resolves and a restore re-binds it; a page recreated at the same
+path is a new document with a fresh id.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import doc_ids
+from app.wiki import git as wiki_git
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _client(user_id: str) -> TestClient:
+    client = TestClient(create_app())
+    login_fastapi(client, user_id)
+    return client
+
+
+def test_id_minted_on_create_and_stable_across_edits(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+
+    created = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"})
+    assert created.status_code == 200
+    doc_id = created.json()["id"]
+    assert doc_id
+
+    edited = client.put(
+        "/api/wiki/file", json={"path": "a.md", "body": "# A2\n"}
+    )
+    assert edited.json()["id"] == doc_id
+    assert client.get("/api/wiki/file?path=a.md").json()["id"] == doc_id
+
+
+def test_page_create_seeds_ancestor_folder_ids(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"})
+
+    assert doc_ids.id_for_path("proj") is not None
+    assert doc_ids.id_for_path("proj/sub") is not None
+
+
+def test_id_follows_file_move(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    doc_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"}).json()["id"]
+
+    resp = client.post("/api/wiki/move", json={"old_path": "a.md", "new_path": "docs/b.md"})
+    assert resp.status_code == 200
+
+    assert doc_ids.id_for_path("docs/b.md") == doc_id
+    assert doc_ids.id_for_path("a.md") is None
+    resolved = client.get(f"/api/wiki/id/{doc_id}").json()
+    assert resolved["path"] == "docs/b.md"
+    assert resolved["deleted_at"] is None
+
+
+def test_ids_follow_folder_move(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"}
+    ).json()["id"]
+    folder_id = doc_ids.id_for_path("proj")
+    sub_id = doc_ids.id_for_path("proj/sub")
+
+    resp = client.post("/api/wiki/move", json={"old_path": "proj", "new_path": "proj2"})
+    assert resp.status_code == 200
+
+    assert doc_ids.id_for_path("proj2") == folder_id
+    assert doc_ids.id_for_path("proj2/sub") == sub_id
+    assert doc_ids.id_for_path("proj2/sub/a.md") == page_id
+
+
+def test_delete_keeps_id_as_tombstone_and_restore_rebinds(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    doc_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"}).json()["id"]
+
+    # Delete = soft delete to Trash; the id tombstones (still resolves).
+    tid = client.delete("/api/wiki/file?path=a.md").json()["trash_id"]
+
+    resolved = client.get(f"/api/wiki/id/{doc_id}").json()
+    assert resolved["path"] == "a.md"
+    assert resolved["deleted_at"] is not None
+    assert doc_ids.id_for_path("a.md") is None
+
+    # Restore from Trash re-binds the same id to its original path.
+    assert client.post("/api/wiki/file/restore", json={"trash_id": tid}).status_code == 200
+    assert doc_ids.id_for_path("a.md") == doc_id
+    assert client.get(f"/api/wiki/id/{doc_id}").json()["deleted_at"] is None
+
+
+def test_recreate_at_deleted_path_gets_fresh_id(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    old_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"}).json()["id"]
+    client.delete("/api/wiki/file?path=a.md")
+
+    new_id = client.put("/api/wiki/file", json={"path": "a.md", "body": "# fresh\n"}).json()["id"]
+
+    assert new_id != old_id
+    # The old id still resolves — to its tombstone, not the new page.
+    old = client.get(f"/api/wiki/id/{old_id}").json()
+    assert old["deleted_at"] is not None
+    assert client.get(f"/api/wiki/id/{new_id}").json()["deleted_at"] is None
+
+
+def test_folder_delete_tombstones_folder_and_nested_ids(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"}
+    ).json()["id"]
+    folder_id = doc_ids.id_for_path("proj")
+    assert folder_id is not None
+
+    tid = client.delete("/api/wiki/file?path=proj").json()["trash_id"]
+
+    assert doc_ids.id_for_path("proj") is None
+    assert client.get(f"/api/wiki/id/{folder_id}").json()["deleted_at"] is not None
+    assert client.get(f"/api/wiki/id/{page_id}").json()["deleted_at"] is not None
+
+    # Folder restore re-binds the folder and page ids alike.
+    client.post("/api/wiki/file/restore", json={"trash_id": tid})
+    assert doc_ids.id_for_path("proj") == folder_id
+    assert doc_ids.id_for_path("proj/a.md") == page_id
+
+
+def test_nested_folder_ids_survive_delete_restore(tmp_repo):
+    # Two-level layout: the intermediate folder proj/sub has its own id row,
+    # which restore must resurrect rather than let mint_for_page mint fresh.
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"}
+    ).json()["id"]
+    proj_id = doc_ids.id_for_path("proj")
+    sub_id = doc_ids.id_for_path("proj/sub")
+    assert proj_id is not None and sub_id is not None
+
+    tid = client.delete("/api/wiki/file?path=proj").json()["trash_id"]
+    client.post("/api/wiki/file/restore", json={"trash_id": tid})
+
+    assert doc_ids.id_for_path("proj") == proj_id
+    assert doc_ids.id_for_path("proj/sub") == sub_id
+    assert doc_ids.id_for_path("proj/sub/a.md") == page_id
+
+
+def test_read_by_id_and_lazy_backfill(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    # Seed outside the API — no lifecycle hook, so no id row yet (pre-id page).
+    wiki_git.commit_file("legacy.md", "# Legacy\n", "seed")
+    assert doc_ids.id_for_path("legacy.md") is None
+
+    read = client.get("/api/wiki/file?path=legacy.md")
+    doc_id = read.json()["id"]
+    assert doc_id  # reading minted the row
+
+    by_id = client.get(f"/api/wiki/file?id={doc_id}")
+    assert by_id.status_code == 200
+    assert by_id.json()["path"] == "legacy.md"
+    assert by_id.json()["body"] == "# Legacy\n"
+
+
+def test_resolve_unknown_id_404(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    assert client.get("/api/wiki/id/deadbeefdeadbeef").status_code == 404
+    assert client.get("/api/wiki/file?id=deadbeefdeadbeef").status_code == 404
+
+
+def test_listing_endpoints_carry_stable_id(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"}
+    ).json()["id"]
+
+    # The tree listing is file-based (git ls-files), so it carries page ids;
+    # implicit folders like ``proj`` aren't rows here (the frontend derives the
+    # folder tree from paths and resolves a folder's own id separately).
+    entries = {e["path"]: e["id"] for e in client.get("/api/wiki").json()["entries"]}
+    assert entries["proj/a.md"] == page_id
+
+    # Recents and starred expose the id alongside the legacy paths list.
+    client.post("/api/wiki/recents", json={"path": "proj/a.md"})
+    client.post("/api/wiki/starred", json={"path": "proj/a.md"})
+    recents = client.get("/api/wiki/recents").json()
+    starred = client.get("/api/wiki/starred").json()
+    assert recents["paths"] == ["proj/a.md"]
+    assert recents["items"] == [{"path": "proj/a.md", "id": page_id}]
+    assert starred["items"] == [{"path": "proj/a.md", "id": page_id}]
+
+
+def test_listing_id_is_none_for_unbackfilled_page(tmp_repo):
+    # A page seeded outside the API has no id row yet; the tree still lists it,
+    # with id=None, rather than failing.
+    user = seed_user()
+    client = _client(user)
+    wiki_git.commit_file("legacy.md", "# L\n", "seed")
+    entries = {e["path"]: e["id"] for e in client.get("/api/wiki").json()["entries"]}
+    assert "legacy.md" in entries
+    assert entries["legacy.md"] is None
+
+
+def test_ids_for_paths_merges_across_chunks(tmp_repo, monkeypatch):
+    # Force multiple chunks so the merge path is exercised without 1000+ rows.
+    monkeypatch.setattr(doc_ids, "_ID_LOOKUP_CHUNK", 2)
+    paths = [f"p{i}.md" for i in range(5)]
+    want = {p: doc_ids.mint_for_page(p) for p in paths}
+    # An absent path is simply omitted, not an error.
+    got = doc_ids.ids_for_paths(paths + ["missing.md"])
+    assert got == want
+
+
+def test_resolve_ids_endpoint_returns_folder_and_page_ids(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/sub/a.md", "body": "# A\n"}
+    ).json()["id"]
+    proj_id = doc_ids.id_for_path("proj")
+    sub_id = doc_ids.id_for_path("proj/sub")
+
+    resp = client.post(
+        "/api/wiki/resolve-ids",
+        json={"paths": ["proj", "proj/sub", "proj/sub/a.md", "nope.md", ""]},
+    )
+    assert resp.status_code == 200
+    got = {it["path"]: it["id"] for it in resp.json()["items"]}
+    # Folder paths (absent from the file-based tree listing) resolve here.
+    assert got == {"proj": proj_id, "proj/sub": sub_id, "proj/sub/a.md": page_id}
+
+
+def test_resolve_ids_acl_filters_pages_for_non_admin(tmp_repo):
+    from app.wiki import acl
+
+    owner = seed_user()
+    other = seed_user(uid="u_other", email="other@x.com")
+    owner_client = _client(owner)
+    owner_client.put("/api/wiki/file", json={"path": "secret.md", "body": "# S\n"})
+    # Strip the default everyone-read grant → owner-only.
+    for g in acl.list_for_path("secret.md"):
+        if g["principal_kind"] == "everyone":
+            acl.revoke(g["id"])
+
+    resp = _client(other).post("/api/wiki/resolve-ids", json={"paths": ["secret.md"]})
+    assert resp.status_code == 200
+    # The page the caller can't read is omitted rather than leaked.
+    assert resp.json()["items"] == []
+
+
+def test_resolve_ids_trims_whitespace_padded_paths(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    page_id = client.put(
+        "/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"}
+    ).json()["id"]
+    # A padded path must still resolve — the strip guard used to only gate
+    # blankness while passing the unstripped path to safe_rel_path.
+    resp = client.post("/api/wiki/resolve-ids", json={"paths": ["  proj/a.md  "]})
+    assert resp.status_code == 200
+    assert resp.json()["items"] == [{"path": "proj/a.md", "id": page_id}]
+
+
+def test_resolve_ids_rejects_oversized_batch(tmp_repo):
+    client = _client(seed_user())
+    resp = client.post(
+        "/api/wiki/resolve-ids", json={"paths": [f"p{i}.md" for i in range(1001)]}
+    )
+    # The app maps request-validation errors to 400 (see _on_validation_error).
+    assert resp.status_code == 400

--- a/backend/tests/test_recents_api.py
+++ b/backend/tests/test_recents_api.py
@@ -41,11 +41,11 @@ def test_record_and_list_newest_first(client):
 
     _record(client, "a.md")
     _record(client, "b.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["b.md", "a.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["b.md", "a.md"]
 
     # Re-opening an older doc bumps it to the front, no duplicate row.
     _record(client, "a.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["a.md", "b.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["a.md", "b.md"]
 
 
 def test_doc_updates_do_not_affect_recents(client):
@@ -63,7 +63,7 @@ def test_doc_updates_do_not_affect_recents(client):
     wiki_git.commit_file("never-opened.md", "# n v2", "agent update")
     wiki_git.commit_file("a.md", "# a v2", "agent update")
 
-    assert client.get("/api/wiki/recents").json() == {"paths": ["b.md", "a.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["b.md", "a.md"]
 
 
 def test_recents_are_per_user(client):
@@ -77,7 +77,7 @@ def test_recents_are_per_user(client):
 
     login_fastapi(client, bob)
     _record(client, "b.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["b.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["b.md"]
 
 
 def test_deleted_docs_drop_out(client):
@@ -89,7 +89,7 @@ def test_deleted_docs_drop_out(client):
     _record(client, "keep.md")
 
     wiki_git.delete_path("gone.md", "remove")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["keep.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["keep.md"]
 
 
 def test_revoked_read_access_drops_out(client):
@@ -100,7 +100,7 @@ def test_revoked_read_access_drops_out(client):
 
     login_fastapi(client, bob)
     _record(client, "private.md")
-    assert client.get("/api/wiki/recents").json() == {"paths": ["private.md"]}
+    assert client.get("/api/wiki/recents").json()["paths"] == ["private.md"]
 
     # Make the doc owner-only after Bob's view.
     acl.set_owner("private.md", alice)
@@ -108,7 +108,7 @@ def test_revoked_read_access_drops_out(client):
         if grant["principal_kind"] == "everyone":
             acl.revoke(grant["id"])
 
-    assert client.get("/api/wiki/recents").json() == {"paths": []}
+    assert client.get("/api/wiki/recents").json()["paths"] == []
 
 
 def test_record_requires_read_access(client):
@@ -123,7 +123,7 @@ def test_record_requires_read_access(client):
     login_fastapi(client, bob)
     resp = client.post("/api/wiki/recents", json={"path": "private.md"})
     assert resp.status_code == 403
-    assert client.get("/api/wiki/recents").json() == {"paths": []}
+    assert client.get("/api/wiki/recents").json()["paths"] == []
 
 
 def test_record_rejects_traversal(client):

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -16,6 +16,7 @@ import useSWR from "swr";
 import {
   Button,
   Divider,
+  EmptyMessageCard,
   LineItemButton,
   OpenButton,
   Popover,
@@ -23,6 +24,7 @@ import {
   SelectButton,
 } from "@onyx-ai/opal/components";
 import {
+  SvgAlertTriangle,
   SvgBubbleText,
   SvgChevronLeft,
   SvgChevronRight,
@@ -59,7 +61,8 @@ import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
-import { apiFetch } from "@/lib/api";
+import { apiFetch, ApiError } from "@/lib/api";
+import { isDocId, wikiHref, resolveDocId, resolveIds } from "@/lib/wikiHref";
 import { listComments } from "@/lib/comments";
 import {
   paintCommentHighlights,
@@ -121,39 +124,80 @@ interface FileResponse {
 export default function WikiRoute() {
   const { user, loading } = useRequireAuth();
   const isMobile = useIsMobile();
+  const router = useRouter();
   const params = useParams<{ slug?: string[] }>();
   const searchParams = useSearchParams();
   const isNewMode = searchParams?.get("new") === "1";
   const rawSlugParts = (params?.slug ?? []) as string[];
+
+  // Every wiki URL is id-based: `/app/wiki/<id>` (Google-Docs style). The id is
+  // stable, so the URL survives rename/move. A legacy `/app/wiki/<path>` URL
+  // still resolves as input and is redirected to its id URL below.
+  const first = rawSlugParts[0];
+  const idMode = !!first && isDocId(first);
+  const commentId = searchParams?.get("comment") ?? null;
+
+  // id mode: resolve the id to its current path / kind / deleted state.
+  const { data: resolved, error: resolveErr } = useSWR(
+    idMode ? `/wiki/id/${first}` : null,
+    () => resolveDocId(first as string),
+    { revalidateOnFocus: false },
+  );
+
   // Next.js may hand back percent-encoded segments (e.g. "local%20testing").
   // Decode so labels and downstream API paths use literal characters.
-  const slugParts = rawSlugParts.map((s) => {
+  const decodedParts = rawSlugParts.map((s) => {
     try {
       return decodeURIComponent(s);
     } catch {
       return s;
     }
   });
-  const slugPath = slugParts.join("/");
-  const isFile = slugPath.endsWith(".md");
+  const pathModePath = decodedParts.join("/");
+  // The doc/folder path we're viewing: from the resolved id, or (legacy path
+  // URL) straight from the URL.
+  const effectivePath = idMode ? (resolved?.path ?? null) : pathModePath;
+  const isFile = !!effectivePath && effectivePath.endsWith(".md");
 
-  // Remember the most recent wiki path so the "Last viewed" landing
-  // setting has something to fall back to, and feed the sidebar
-  // "Recents" list when an actual doc (not a folder) is opened.
+  // Redirect a legacy path URL to its canonical id URL (`/app/wiki/<id>`).
+  // Skips the new-doc flow (no id yet) and paths with no live id (unsaved /
+  // not-yet-backfilled) — those keep rendering by path. Guarded so it can't
+  // loop.
   useEffect(() => {
-    rememberWikiPath("/app/wiki" + (slugPath ? "/" + slugPath : ""));
-    if (isFile) void recordRecentDoc(slugPath);
-  }, [slugPath, isFile]);
+    if (idMode || !pathModePath || isNewMode) return;
+    const suffix = commentId ? `?comment=${encodeURIComponent(commentId)}` : "";
+    let cancelled = false;
+    void resolveIds([pathModePath])
+      .then((map) => {
+        const id = map[pathModePath];
+        if (!cancelled && id) router.replace(wikiHref(id) + suffix);
+      })
+      .catch(() => {
+        /* no live id — render by path */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [idMode, pathModePath, isNewMode, commentId, router]);
+
+  // Remember the most recent wiki path (for the "Last viewed" landing) and
+  // feed the sidebar Recents when an actual doc is opened.
+  useEffect(() => {
+    if (effectivePath === null) return;
+    rememberWikiPath("/app/wiki" + (effectivePath ? "/" + effectivePath : ""));
+    if (isFile) void recordRecentDoc(effectivePath);
+  }, [effectivePath, isFile]);
 
   // Tab title tracks the open doc (or folder); falls back to the app name.
   useEffect(() => {
-    const last = slugPath.split("/").pop() ?? "";
+    if (effectivePath === null) return;
+    const last = effectivePath.split("/").pop() ?? "";
     const label = isFile ? last.replace(/\.md$/i, "") : last;
     document.title = label || "agent-wiki";
     return () => {
       document.title = "agent-wiki";
     };
-  }, [slugPath, isFile]);
+  }, [effectivePath, isFile]);
 
   if (loading || !user)
     return (
@@ -162,12 +206,50 @@ export default function WikiRoute() {
       </main>
     );
 
-  if (isFile) return <FileViewer path={slugPath} />;
-  if (isNewMode) return <NewDocView dir={slugPath} />;
+  if (idMode) {
+    // Unknown id / resolve failure / deleted page → the link no longer points
+    // at a live doc. (Deleted-page recovery is a separate feature.)
+    if (resolveErr || resolved?.deleted_at)
+      return <WikiUnknownLink status={(resolveErr as ApiError)?.status} />;
+    if (!resolved)
+      return (
+        <main className={isMobile ? "p-4" : "p-8"}>
+          <LoadingSpinner center />
+        </main>
+      );
+  }
+
+  if (isFile) return <FileViewer path={effectivePath as string} />;
+  if (isNewMode) return <NewDocView dir={pathModePath} />;
   // Wiki root with no doc open → the "Welcome to Onyx Wiki" landing.
   // Sub-folders still render the directory explorer.
-  if (slugPath === "") return <WikiHome />;
-  return <Explorer dir={slugPath} />;
+  if (!effectivePath) return <WikiHome />;
+  return <Explorer dir={effectivePath} />;
+}
+
+/** A wiki URL that no longer points at a live doc — an unknown id or one whose
+ * page has been deleted. Recovering deleted pages is a separate feature. */
+function WikiUnknownLink({ status }: { status?: number }) {
+  const router = useRouter();
+  return (
+    <main className="flex h-full items-center justify-center p-8 pb-[16vh]">
+      <div className="flex flex-col items-center gap-4">
+        <EmptyMessageCard
+          sizePreset="main-ui"
+          icon={SvgAlertTriangle}
+          title="This page isn’t available"
+          description={
+            status === 404
+              ? "The link may be broken, or the page was removed."
+              : "The page it pointed to may have been moved or removed."
+          }
+        />
+        <Button onClick={() => router.push("/app/wiki")}>
+          Go to wiki home
+        </Button>
+      </div>
+    </main>
+  );
 }
 
 function Explorer({ dir }: { dir: string }) {
@@ -729,7 +811,7 @@ function NewDocView({ dir }: { dir: string }) {
     try {
       const name = filenameNoExt + ".md";
       const fullPath = (destDir ? destDir + "/" : "") + name;
-      await apiFetch("/wiki/file", {
+      const created = await apiFetch<{ id?: string | null }>("/wiki/file", {
         method: "PUT",
         body: JSON.stringify({
           path: fullPath,
@@ -747,7 +829,12 @@ function NewDocView({ dir }: { dir: string }) {
       // Hand-off: keep the drafting state (and the chat's drafting
       // session) alive across the navigation — see the unmount cleanup.
       createHandoffRef.current = true;
-      router.push(`/app/wiki/${fullPath}?new=1`);
+      // Land on the new page's id URL directly (the create response carries
+      // the minted id), so it's a clean /app/wiki/<id> like every other page.
+      // Keep ?new=1 — FileViewer reads it to auto-open the assistant on a
+      // freshly-created doc.
+      const base = created.id ? wikiHref(created.id) : `/app/wiki/${fullPath}`;
+      router.push(`${base}?new=1`);
     } catch (e) {
       setError(e instanceof Error ? e.message : "create failed");
       setSaving(false);

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -134,7 +134,9 @@ export default function WikiRoute() {
   // stable, so the URL survives rename/move. A legacy `/app/wiki/<path>` URL
   // still resolves as input and is redirected to its id URL below.
   const first = rawSlugParts[0];
-  const idMode = !!first && isDocId(first);
+  // An id URL is always a single segment (`/app/wiki/<id>`); a multi-segment
+  // slug is a legacy path even if its first segment looks like an id.
+  const idMode = rawSlugParts.length === 1 && !!first && isDocId(first);
   const commentId = searchParams?.get("comment") ?? null;
 
   // id mode: resolve the id to its current path / kind / deleted state.
@@ -156,7 +158,14 @@ export default function WikiRoute() {
   const pathModePath = decodedParts.join("/");
   // The doc/folder path we're viewing: from the resolved id, or (legacy path
   // URL) straight from the URL.
-  const effectivePath = idMode ? (resolved?.path ?? null) : pathModePath;
+  // A 16-hex single segment can also be a legacy page/folder literally named
+  // like an id. If the id lookup 404s, fall back to treating the segment as a
+  // path so the real page/folder still loads.
+  const idResolve404 =
+    idMode && (resolveErr as ApiError | undefined)?.status === 404;
+  const effectivePath = idMode
+    ? (resolved?.path ?? (idResolve404 ? pathModePath : null))
+    : pathModePath;
   const isFile = !!effectivePath && effectivePath.endsWith(".md");
 
   // Redirect a legacy path URL to its canonical id URL (`/app/wiki/<id>`).
@@ -206,9 +215,11 @@ export default function WikiRoute() {
       </main>
     );
 
-  if (idMode) {
-    // Unknown id / resolve failure / deleted page → the link no longer points
-    // at a live doc. (Deleted-page recovery is a separate feature.)
+  if (idMode && !idResolve404) {
+    // Non-404 resolve failure / deleted page → the link no longer points at a
+    // live doc. (A 404 falls through to path rendering above, in case the
+    // segment is a legacy path that merely looks like an id. Deleted-page
+    // recovery is a separate feature.)
     if (resolveErr || resolved?.deleted_at)
       return <WikiUnknownLink status={(resolveErr as ApiError)?.status} />;
     if (!resolved)

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useAuth } from "@/lib/auth";
+import { shareableWikiUrl } from "@/lib/wikiHref";
 import {
   createComment,
   deleteComment,
@@ -71,15 +72,10 @@ function toIso(ts: string): string {
 }
 
 /** Deep-link to a specific thread: the page route reads `?comment=<id>`, opens
- * the panel, and scrolls to the thread's anchored span. Each path segment is
- * encoded since wiki paths contain spaces. */
-function commentLink(path: string, rootId: string): string {
-  const encoded = path
-    .split("/")
-    .filter(Boolean)
-    .map((s) => encodeURIComponent(s))
-    .join("/");
-  return `${window.location.origin}/app/wiki/${encoded}?comment=${rootId}`;
+ * the panel, and scrolls to the thread's anchored span. Uses the durable
+ * id-based URL so the link survives a page rename/move. */
+function commentLink(path: string, rootId: string): Promise<string> {
+  return shareableWikiUrl(path, `comment=${rootId}`);
 }
 
 export function CommentsPanel({
@@ -464,9 +460,12 @@ function Comment({
   // Copy a deep-link to this comment's thread (anchors live on the root, so all
   // comments in a thread share its link). Doesn't close the menu — the swapped
   // title/icon is the "done" feedback.
-  const copyLink = () => {
+  const copyLink = async () => {
+    // Durable id-based deep-link (survives rename/move); the ?comment= anchor
+    // rides along.
+    const url = await commentLink(path, comment.thread_root_id);
     void navigator.clipboard
-      .writeText(commentLink(path, comment.thread_root_id))
+      .writeText(url)
       .then(() => {
         setCopied(true);
         window.setTimeout(() => setCopied(false), 1500);

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -462,8 +462,14 @@ function Comment({
   // title/icon is the "done" feedback.
   const copyLink = async () => {
     // Durable id-based deep-link (survives rename/move); the ?comment= anchor
-    // rides along.
-    const url = await commentLink(path, comment.thread_root_id);
+    // rides along. A transient id-resolve failure skips the copy rather than
+    // handing over a fragile path link.
+    let url: string;
+    try {
+      url = await commentLink(path, comment.thread_root_id);
+    } catch {
+      return;
+    }
     void navigator.clipboard
       .writeText(url)
       .then(() => {

--- a/frontend/src/components/wiki/ShareDialog.tsx
+++ b/frontend/src/components/wiki/ShareDialog.tsx
@@ -47,6 +47,7 @@ import {
   type UserLite,
 } from "@/lib/users";
 import { lastSegment } from "@/lib/wiki";
+import { shareableWikiUrl } from "@/lib/wikiHref";
 import { markdown } from "@onyx-ai/opal/utils";
 
 import { TransferModal } from "./TransferModal";
@@ -286,14 +287,8 @@ export function ShareDialog({ path, open, onClose }: ShareDialogProps) {
 
   const copyLink = async () => {
     try {
-      const trimmed = path.replace(/\/+$/, "");
-      const encodedPath = trimmed
-        .split("/")
-        .filter(Boolean)
-        .map((segment) => encodeURIComponent(segment))
-        .join("/");
-      const targetPath = encodedPath ? `/app/wiki/${encodedPath}` : "/app/wiki";
-      const shareUrl = `${window.location.origin}${targetPath}`;
+      // Durable id-based URL so a shared link survives a later rename/move.
+      const shareUrl = await shareableWikiUrl(path.replace(/\/+$/, ""));
       await navigator.clipboard.writeText(shareUrl);
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1500);

--- a/frontend/src/hooks/useAppFocus.ts
+++ b/frontend/src/hooks/useAppFocus.ts
@@ -2,6 +2,11 @@
 
 import { useMemo } from "react";
 import { usePathname } from "next/navigation";
+import useSWR from "swr";
+
+import { isDocId, resolveDocId } from "@/lib/wikiHref";
+
+const WIKI_PREFIX = "/app/wiki/";
 
 export type AppFocusType =
   | "wiki"
@@ -73,16 +78,33 @@ export class AppFocus {
 
 export function useAppFocus(): AppFocus {
   const pathname = usePathname();
+
+  // Wiki URLs are id-based (`/app/wiki/<id>`). To report the real doc path
+  // (breadcrumbs, recents highlighting) we resolve the id to its path. This
+  // shares SWR's cache with the wiki route's own resolve, so it's not an extra
+  // request. Legacy path URLs (during the redirect to the id URL) parse inline.
+  const firstSeg = pathname.startsWith(WIKI_PREFIX)
+    ? pathname.slice(WIKI_PREFIX.length).split("/")[0]
+    : "";
+  const idInUrl = isDocId(firstSeg) ? firstSeg : null;
+  const { data: resolved } = useSWR(
+    idInUrl ? `/wiki/id/${idInUrl}` : null,
+    () => resolveDocId(idInUrl as string),
+    { revalidateOnFocus: false },
+  );
+
   return useMemo(() => {
     for (const { href, type } of ROUTES) {
       if (pathname.startsWith(href)) {
-        const wikiPath =
-          type === "wiki" && pathname.length > href.length
-            ? decodeWikiPath(pathname.slice(href.length + 1))
-            : null;
+        let wikiPath: string | null = null;
+        if (type === "wiki" && pathname.length > href.length) {
+          wikiPath = idInUrl
+            ? (resolved?.path ?? null)
+            : decodeWikiPath(pathname.slice(href.length + 1));
+        }
         return new AppFocus(type, href, wikiPath);
       }
     }
     return new AppFocus("none", null);
-  }, [pathname]);
+  }, [pathname, idInUrl, resolved]);
 }

--- a/frontend/src/lib/wikiHref.ts
+++ b/frontend/src/lib/wikiHref.ts
@@ -63,19 +63,19 @@ export async function resolveIds(
 }
 
 /** Absolute, shareable wiki URL — the id URL (`/app/wiki/<id>`), so a shared
- * link survives a later rename/move. Falls back to a path URL if the id can't
- * be resolved. `extraParams` (e.g. `"comment=abc"`, no leading `?`/`&`) is
- * appended as a query string. */
+ * link survives a later rename/move. `extraParams` (e.g. `"comment=abc"`, no
+ * leading `?`/`&`) is appended as a query string.
+ *
+ * A path with no live id row is simply absent from the resolve result — that's
+ * a legitimate fallback to a plain path URL. A transient lookup failure, by
+ * contrast, *rejects*: we must not hand back a fragile path URL as if it were
+ * the durable link, so the caller can surface the failure instead of silently
+ * copying a link that may break on the next rename. */
 export async function shareableWikiUrl(
   path: string,
   extraParams = "",
 ): Promise<string> {
-  let id: string | undefined;
-  try {
-    id = (await resolveIds([path]))[path];
-  } catch {
-    /* no live id — fall back to the plain path URL */
-  }
+  const id = (await resolveIds([path]))[path];
   const base = `${window.location.origin}${id ? wikiHref(id) : wikiPath(path)}`;
   const q = extraParams.replace(/^[?&]/, "");
   return q ? `${base}?${q}` : base;

--- a/frontend/src/lib/wikiHref.ts
+++ b/frontend/src/lib/wikiHref.ts
@@ -1,0 +1,82 @@
+// Wiki URL construction.
+//
+// Every wiki URL is id-based: `/app/wiki/<wiki_doc_id>`. The id is stable, so
+// the URL survives a rename/move. A legacy path URL (`/app/wiki/<path>`) still
+// resolves as input — the route looks up its id and redirects to the id URL.
+// `wikiPath()` is kept only for fallbacks (an unsaved doc, or a page with no
+// id row yet) and for the new-document flow, which is inherently path-based.
+
+import { apiFetch } from "@/lib/api";
+
+// A wiki_doc_id is 16 lowercase hex chars (see backend doc_ids._mint_id).
+const DOC_ID_RE = /^[0-9a-f]{16}$/;
+
+/** True if a URL segment is a wiki_doc_id (vs a legacy path segment). */
+export function isDocId(segment: string): boolean {
+  return DOC_ID_RE.test(segment);
+}
+
+/** The id-based wiki URL for a doc: `/app/wiki/<id>`. */
+export function wikiHref(id: string): string {
+  return `/app/wiki/${id}`;
+}
+
+/** Clean path-based wiki URL — fallback for docs without an id (unsaved / not
+ * yet backfilled) and the new-document flow. */
+export function wikiPath(path: string): string {
+  const slug = path
+    .split("/")
+    .filter(Boolean)
+    .map(encodeURIComponent)
+    .join("/");
+  return slug ? `/app/wiki/${slug}` : "/app/wiki";
+}
+
+export interface ResolvedDocId {
+  id: string;
+  path: string;
+  kind: "page" | "folder";
+  deleted_at: string | null;
+}
+
+/** Resolve a doc id to its current binding (path, kind, deleted state). */
+export function resolveDocId(id: string): Promise<ResolvedDocId> {
+  return apiFetch<ResolvedDocId>(`/wiki/id/${id}`);
+}
+
+interface ResolveIdsResponse {
+  items: { path: string; id: string | null }[];
+}
+
+/** Bulk path→id. Paths without a live id row are omitted from the map. */
+export async function resolveIds(
+  paths: string[],
+): Promise<Record<string, string>> {
+  if (paths.length === 0) return {};
+  const res = await apiFetch<ResolveIdsResponse>("/wiki/resolve-ids", {
+    method: "POST",
+    body: JSON.stringify({ paths }),
+  });
+  const out: Record<string, string> = {};
+  for (const it of res.items) if (it.id) out[it.path] = it.id;
+  return out;
+}
+
+/** Absolute, shareable wiki URL — the id URL (`/app/wiki/<id>`), so a shared
+ * link survives a later rename/move. Falls back to a path URL if the id can't
+ * be resolved. `extraParams` (e.g. `"comment=abc"`, no leading `?`/`&`) is
+ * appended as a query string. */
+export async function shareableWikiUrl(
+  path: string,
+  extraParams = "",
+): Promise<string> {
+  let id: string | undefined;
+  try {
+    id = (await resolveIds([path]))[path];
+  } catch {
+    /* no live id — fall back to the plain path URL */
+  }
+  const base = `${window.location.origin}${id ? wikiHref(id) : wikiPath(path)}`;
+  const q = extraParams.replace(/^[?&]/, "");
+  return q ? `${base}?${q}` : base;
+}

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -124,8 +124,16 @@ export function WikiItemActionsProvider({
     launchAgent: setAgentPath,
     copyLink: async (path) => {
       // Share the durable id-based URL so the link survives a later
-      // rename/move (falls back to a path URL if the id can't be resolved).
-      const url = await shareableWikiUrl(path);
+      // rename/move (falls back to a path URL only when the page genuinely
+      // has no live id). A transient resolve failure rejects rather than
+      // copying a fragile link, so report it instead of a false success.
+      let url: string;
+      try {
+        url = await shareableWikiUrl(path);
+      } catch {
+        setToast("Couldn't copy link");
+        return;
+      }
       navigator.clipboard
         .writeText(url)
         .then(() => setToast("Link copied"))

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -11,6 +11,7 @@ import { createPortal } from "react-dom";
 import useSWR, { useSWRConfig } from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { shareableWikiUrl } from "@/lib/wikiHref";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { MoveModal, RenameModal } from "@/components/wiki/WikiItemModals";
@@ -121,9 +122,10 @@ export function WikiItemActionsProvider({
     rename: setRenamePath,
     move: setMovePath,
     launchAgent: setAgentPath,
-    copyLink: (path) => {
-      const encoded = path.split("/").map(encodeURIComponent).join("/");
-      const url = `${window.location.origin}/app/wiki/${encoded}`;
+    copyLink: async (path) => {
+      // Share the durable id-based URL so the link survives a later
+      // rename/move (falls back to a path URL if the id can't be resolved).
+      const url = await shareableWikiUrl(path);
       navigator.clipboard
         .writeText(url)
         .then(() => setToast("Link copied"))


### PR DESCRIPTION
## What & why

Wiki URLs currently embed the full path (`/app/wiki/Engineering%20Projects/…/Plan.md`), so they rot on rename/move and aren't stable. This makes every wiki URL a **stable id** — `/app/wiki/<wiki_doc_id>` (Google-Docs style) — that survives renames and moves.

This is the revival of the abandoned **#374 stack** (#375/#377/#378 backend + #379 frontend), which got orphaned when #374 was closed (it never merged to `main`, so it's not on dev-wiki). Rebuilt cleanly onto current `main` and reconciled with everything that landed since — **trash (#382)**, **root_move (#384)**, and **PageKind (#385)**. Single PR (backend + frontend) so id-URLs go live in one merge.

## Backend

- **`wiki_doc_ids` table** (Postgres-only, like ACLs): `path ↔ id`, `deleted_at` tombstone, partial unique index on live `path` (a page recreated at a deleted path gets a fresh id; tombstones keep resolving). Migration re-parented onto current head `b7f3c1a9d2e4`.
- **`doc_ids` repo**: mint / resolve / `ids_for_paths` (chunked) / `on_path_moved(root_move)` / `on_deleted` / `on_restored` (resurrects ancestor folder ids) / `backfill_all`.
- **Lifecycle wired into `notify.py`**: mint on create; `on_path_moved(root_move=…)` on move; **trash → tombstone at the original root** (deliberately *not* following the id into `.trash/`, unlike ACL); **restore → `on_restored`** re-binds. Hard-delete path also tombstones.
- **API**: `GET /wiki/id/{id}` resolve; `GET /wiki/file?id=` (+ returns `id`, lazy backfill); `PUT` returns `id`; `POST /wiki/resolve-ids` (bulk, ACL-filtered); `id` added to listing / recent / search / recents / starred responses.
- **Startup `backfill_all()`** mints ids for every existing page + folder (self-gated), so a pre-ids wiki gets full coverage on deploy.
- `ResolveDocIdResponse.kind` uses the `PageKind` enum.

## Frontend

- Route resolves the id → current path and renders; a legacy `/app/wiki/<path>` URL still resolves and **redirects to its id URL**. Unknown/deleted id → "page unavailable".
- Share (Copy Link, Share dialog, comment deep-links) emits `/app/wiki/<id>`.
- `useAppFocus` resolves id → path via the route's SWR cache (no extra fetch), so breadcrumbs/recents show the real location.
- `lib/wikiHref.ts`: `wikiHref(id)`, `wikiPath` fallback, `resolveDocId`, `resolveIds`, `shareableWikiUrl`.

## Notes

- Deleted-page recovery / Trash is a separate, already-merged feature (#382); the id tombstone/restore here integrates with it (trash tombstones the id, restore re-binds).
- ruff + basedpyright clean (app + tests); frontend tsc + prettier clean. Local pytest is blocked by an unrelated pgmq test-harness quirk, so the `doc_ids` suite validates in CI.