### PR TITLE
feat(wiki): Trash view + deleted-URL tombstone (backend + frontend)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -601,6 +601,12 @@ def deleted_doc_tombstone(
         rel = filesystem.safe_rel_path(path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    # A live page/folder occupies this path (e.g. recreated after a delete) —
+    # it's not deleted, even if an older tombstone for the same path lingers in
+    # Trash. Report not-deleted so the panel doesn't show stale delete metadata
+    # or a Restore that would 409.
+    if filesystem.absolute(rel).exists():
+        raise HTTPException(status_code=404, detail="not found")
     entry = wiki_trash.entry_for_original_path(rel)
     if entry is None:
         raise HTTPException(status_code=404, detail="not found")

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -586,6 +586,37 @@ def list_trash(user: User = Depends(require_user)) -> TrashListResponse:
     return TrashListResponse(items=items)
 
 
+@router.get("/deleted", response_model=TrashEntryView)
+def deleted_doc_tombstone(
+    user: User = Depends(require_user),
+    path: str = "",
+) -> TrashEntryView:
+    """Tombstone info for a deleted page/folder — its most-recent Trash entry
+    (who/when + `trash_id` for Restore), for the deleted-URL panel. 404 when the
+    path isn't in Trash. ACL-checked against the trash location, like the rest
+    of the Trash surface, so a deleted private page doesn't leak."""
+    if not path:
+        raise HTTPException(status_code=400, detail="path required")
+    try:
+        rel = filesystem.safe_rel_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    entry = wiki_trash.entry_for_original_path(rel)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="not found")
+    perms = _trash_perms(user, entry)
+    if "read" not in perms:
+        raise HTTPException(status_code=403, detail="not permitted")
+    return TrashEntryView(
+        trash_id=entry.trash_id,
+        path=entry.original_path,
+        kind=entry.kind,
+        trashed_by=entry.trashed_by,
+        trashed_at=entry.trashed_at,
+        can_restore="write" in perms,
+    )
+
+
 @router.get("/trash/{trash_id}", response_model=TrashItemView)
 def view_trash_item(
     trash_id: str,

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -654,6 +654,31 @@ def list_trash_files() -> list[str]:
     return [p for p in out.split("\0") if p]
 
 
+def trash_ids_newest_first() -> list[str]:
+    """Trash ids ordered by their trash-move commit, newest first.
+
+    Deterministic even when two moves land in the same author-date second —
+    sorting entries by the ``trashed_at`` *string* can't disambiguate those, but
+    git's commit history can. Walks additions under ``.trash/`` newest-commit
+    first and records each id at its first (i.e. creating) appearance.
+    """
+    out = _run(
+        ["log", "--diff-filter=A", "--name-only", "--format=", "--", TRASH_DIR],
+        check=False,
+    ).stdout
+    order: list[str] = []
+    seen: set[str] = set()
+    for line in out.splitlines():
+        line = line.strip()
+        if not line.startswith(TRASH_PREFIX):
+            continue
+        tid = line[len(TRASH_PREFIX) :].split("/", 1)[0]
+        if tid and tid not in seen:
+            seen.add(tid)
+            order.append(tid)
+    return order
+
+
 def last_commit_meta_for_path(rel_path: str) -> tuple[str, str, str, str] | None:
     """``(sha, author, ISO-ts, message)`` of the most recent commit touching
     ``rel_path``, or ``None``. For a trashed path this is the trash-move commit —

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -100,6 +100,17 @@ def list_entries() -> list[TrashEntry]:
     return entries
 
 
+def entry_for_original_path(path: str) -> TrashEntry | None:
+    """The most-recently-trashed entry whose original location was ``path``,
+    or ``None`` if that path was never trashed (or its trash was purged).
+
+    Powers the deleted-URL tombstone: a page/folder deleted from ``path`` can
+    have several tombstones (deleted, recreated, deleted again) — the newest
+    is the one a Restore would bring back. ``list_entries`` is newest-first,
+    so the first match wins."""
+    return next((e for e in list_entries() if e.original_path == path), None)
+
+
 def entry_for(trash_id: str) -> TrashEntry | None:
     """The trash entry for ``trash_id``, or ``None`` if unknown/empty."""
     prefix = f"{TRASH_DIR}/{trash_id}/"

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -95,8 +95,14 @@ def list_entries() -> list[TrashEntry]:
         trash_id, _, original = rest.partition("/")
         if original:
             groups.setdefault(trash_id, []).append(original)
+    # Order by trash-move commit recency (newest first) — deterministic even
+    # for two moves in the same author-date second, which a trashed_at-string
+    # sort can't disambiguate. This makes "newest tombstone for a path" (which a
+    # re-deleted page's id URL depends on) stable. Ids missing from the git
+    # ordering (shouldn't happen) sort last, stably.
+    rank = {tid: i for i, tid in enumerate(wiki_git.trash_ids_newest_first())}
     entries = [e for tid, orig in groups.items() if (e := _entry(tid, orig))]
-    entries.sort(key=lambda e: e.trashed_at, reverse=True)
+    entries.sort(key=lambda e: rank.get(e.trash_id, len(rank)))
     return entries
 
 

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -214,3 +214,57 @@ def test_duplicate_names_coexist_in_trash(tmp_repo):
     assert client.post("/api/wiki/file/restore", json={"trash_id": tid1}).status_code == 200
     assert client.get("/api/wiki/file?path=a.md").json()["body"] == "# v1\n"
     assert client.post("/api/wiki/file/restore", json={"trash_id": tid2}).status_code == 409
+
+
+def test_deleted_endpoint_returns_tombstone(tmp_repo):
+    # The deleted-URL tombstone panel looks up a deleted page's Trash entry by
+    # its original path to show who/when + offer Restore.
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/note.md", "body": "# N\n"})
+    tid = client.delete("/api/wiki/file?path=proj/note.md").json()["trash_id"]
+
+    t = client.get("/api/wiki/deleted?path=proj/note.md")
+    assert t.status_code == 200
+    body = t.json()
+    assert body["trash_id"] == tid
+    assert body["path"] == "proj/note.md"
+    assert body["kind"] == "page"
+    assert body["can_restore"] is True
+
+
+def test_deleted_endpoint_404_when_not_trashed(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "live.md", "body": "# L\n"})
+    # A live page and a never-existed path are both "not deleted" → 404.
+    assert client.get("/api/wiki/deleted?path=live.md").status_code == 404
+    assert client.get("/api/wiki/deleted?path=never.md").status_code == 404
+
+
+def test_deleted_endpoint_returns_newest_tombstone(tmp_repo):
+    # Delete / recreate / delete → the endpoint returns the most-recent entry
+    # (the one a Restore would bring back).
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# v1\n"})
+    client.delete("/api/wiki/file?path=a.md")
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# v2\n"})
+    tid2 = client.delete("/api/wiki/file?path=a.md").json()["trash_id"]
+
+    assert client.get("/api/wiki/deleted?path=a.md").json()["trash_id"] == tid2
+
+
+def test_deleted_tombstone_hidden_from_other_user(tmp_repo):
+    owner = seed_user()
+    other = seed_user(uid="u_t2", email="t2@x.com")
+    oc = _client(owner)
+    oc.put("/api/wiki/file", json={"path": "secret.md", "body": "# S\n"})
+    for gid in _everyone_ids("secret.md"):
+        acl.revoke(gid)
+    oc.delete("/api/wiki/file?path=secret.md")
+
+    # Owner sees the tombstone; another user can't (403, resolved against the
+    # re-pointed trash-path ACL — no leak of a deleted private page).
+    assert oc.get("/api/wiki/deleted?path=secret.md").status_code == 200
+    assert _client(other).get("/api/wiki/deleted?path=secret.md").status_code == 403

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -268,3 +268,16 @@ def test_deleted_tombstone_hidden_from_other_user(tmp_repo):
     # re-pointed trash-path ACL — no leak of a deleted private page).
     assert oc.get("/api/wiki/deleted?path=secret.md").status_code == 200
     assert _client(other).get("/api/wiki/deleted?path=secret.md").status_code == 403
+
+
+def test_deleted_endpoint_404_when_path_recreated(tmp_repo):
+    # Delete a.md, then recreate a live a.md. The old tombstone still exists in
+    # Trash, but the path is live now → /wiki/deleted must report not-deleted
+    # (else the panel shows stale delete metadata + a Restore that would 409).
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# v1\n"})
+    client.delete("/api/wiki/file?path=a.md")
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# v2\n"})
+
+    assert client.get("/api/wiki/deleted?path=a.md").status_code == 404

--- a/frontend/src/app/app/trash/page.tsx
+++ b/frontend/src/app/app/trash/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/views/trash/TrashPage";

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -18,6 +18,7 @@ import {
   Divider,
   EmptyMessageCard,
   LineItemButton,
+  MessageCard,
   OpenButton,
   Popover,
   PopoverMenu,
@@ -62,7 +63,15 @@ import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { apiFetch, ApiError } from "@/lib/api";
-import { isDocId, wikiHref, resolveDocId, resolveIds } from "@/lib/wikiHref";
+import {
+  isDocId,
+  wikiHref,
+  wikiPath,
+  resolveDocId,
+  resolveIds,
+} from "@/lib/wikiHref";
+import { formatRelative } from "@/lib/format";
+import { getDeletedTombstone, restoreTrashed } from "@/lib/trash";
 import { listComments } from "@/lib/comments";
 import {
   paintCommentHighlights,
@@ -216,11 +225,12 @@ export default function WikiRoute() {
     );
 
   if (idMode && !idResolve404) {
-    // Non-404 resolve failure / deleted page → the link no longer points at a
-    // live doc. (A 404 falls through to path rendering above, in case the
-    // segment is a legacy path that merely looks like an id. Deleted-page
-    // recovery is a separate feature.)
-    if (resolveErr || resolved?.deleted_at)
+    // A 404 falls through to path rendering above (the segment may be a legacy
+    // path that merely looks like an id).
+    // Deleted page → tombstone panel (who/when + Restore); other resolve
+    // failure → the generic unavailable card.
+    if (resolved?.deleted_at) return <WikiTombstone path={resolved.path} />;
+    if (resolveErr)
       return <WikiUnknownLink status={(resolveErr as ApiError)?.status} />;
     if (!resolved)
       return (
@@ -238,8 +248,9 @@ export default function WikiRoute() {
   return <Explorer dir={effectivePath} />;
 }
 
-/** A wiki URL that no longer points at a live doc — an unknown id or one whose
- * page has been deleted. Recovering deleted pages is a separate feature. */
+/** A wiki URL that no longer points at a live doc — an unknown/expired id, or
+ * a page that was deleted but is no longer in Trash (purged). A deleted page
+ * still in Trash renders {@link WikiTombstone} instead. */
 function WikiUnknownLink({ status }: { status?: number }) {
   const router = useRouter();
   return (
@@ -258,6 +269,86 @@ function WikiUnknownLink({ status }: { status?: number }) {
         <Button onClick={() => router.push("/app/wiki")}>
           Go to wiki home
         </Button>
+      </div>
+    </main>
+  );
+}
+
+/** Tombstone for a deleted page/folder reached via its id URL: shows who/when
+ * and offers Restore. Falls back to {@link WikiUnknownLink} when the item is no
+ * longer in Trash (purged, or deleted before Trash shipped). */
+function WikiTombstone({ path }: { path: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const {
+    data: entry,
+    error,
+    isLoading,
+  } = useSWR(
+    `/wiki/deleted?path=${encodeURIComponent(path)}`,
+    () => getDeletedTombstone(path),
+    { revalidateOnFocus: false },
+  );
+
+  if (isLoading)
+    return (
+      <main className="p-8">
+        <LoadingSpinner center />
+      </main>
+    );
+  if (error || !entry)
+    return <WikiUnknownLink status={(error as ApiError)?.status} />;
+
+  const label = (entry.path.split("/").pop() ?? entry.path).replace(
+    /\.md$/i,
+    "",
+  );
+  const restore = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await restoreTrashed(entry.trash_id);
+      // Land on the restored page; the route resolves the path → id URL.
+      // wikiPath encodes each segment (paths may contain spaces, #, %, …).
+      router.push(wikiPath(res.path));
+    } catch (e) {
+      setErr(
+        e instanceof ApiError && e.status === 409
+          ? `A page already exists at ${entry.path}.`
+          : e instanceof Error
+            ? e.message
+            : "Restore failed.",
+      );
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="flex h-full items-center justify-center p-8 pb-[16vh]">
+      <div className="flex flex-col items-center gap-4">
+        <EmptyMessageCard
+          sizePreset="main-ui"
+          icon={SvgTrash}
+          title={`“${label}” was deleted`}
+          description={`Deleted by ${entry.trashed_by}${
+            entry.trashed_at ? ` · ${formatRelative(entry.trashed_at)}` : ""
+          }. Restore it to bring it back to ${entry.path}.`}
+        />
+        {err && <MessageCard variant="error" title={err} />}
+        <div className="flex items-center gap-2">
+          <Button
+            prominence="secondary"
+            onClick={() => router.push("/app/wiki")}
+          >
+            Go to wiki home
+          </Button>
+          {entry.can_restore && (
+            <Button onClick={() => void restore()} disabled={busy}>
+              {busy ? "Restoring…" : "Restore"}
+            </Button>
+          )}
+        </div>
       </div>
     </main>
   );
@@ -373,7 +464,7 @@ function Explorer({ dir }: { dir: string }) {
     if (
       !(await confirmDialog({
         title: `Delete ${rel}?`,
-        body: "This cannot be undone.",
+        body: "It will be moved to Trash, where you can restore it.",
         confirmLabel: "Delete",
       }))
     )

--- a/frontend/src/hooks/useAppFocus.ts
+++ b/frontend/src/hooks/useAppFocus.ts
@@ -13,6 +13,7 @@ export type AppFocusType =
   | "triggers"
   | "agents-and-actions"
   | "chats"
+  | "trash"
   | "none";
 
 // Single source of truth for route → focus type mapping.
@@ -25,6 +26,7 @@ const ROUTES: ReadonlyArray<{
   { href: "/app/triggers", type: "triggers" },
   { href: "/app/agents-and-actions", type: "agents-and-actions" },
   { href: "/app/chats", type: "chats" },
+  { href: "/app/trash", type: "trash" },
 ];
 
 function decodeWikiPath(raw: string): string {

--- a/frontend/src/lib/trash.ts
+++ b/frontend/src/lib/trash.ts
@@ -1,0 +1,52 @@
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+
+/** One soft-deleted item in the Trash (a page or a folder root). Mirrors the
+ * backend `TrashEntryView`. `path` is where it lived; a restore moves it back
+ * there. `can_restore` reflects the caller's write access at the trash path. */
+export interface TrashEntry {
+  trash_id: string;
+  path: string;
+  kind: "page" | "folder";
+  trashed_by: string;
+  trashed_at: string;
+  can_restore: boolean;
+}
+
+/** The Trash list, newest-first. ACL-filtered server-side. */
+export function useTrash() {
+  const { data, error, isLoading, mutate } = useSWR<{ items: TrashEntry[] }>(
+    "/wiki/trash",
+  );
+  return {
+    items: data?.items ?? [],
+    error: error as Error | undefined,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+interface RestoreResponse {
+  path: string;
+  sha: string;
+  restored: string[];
+}
+
+/** Move a trashed item back to its original path. Rejects (409) if that path
+ * is now occupied by a recreated page. */
+export async function restoreTrashed(
+  trashId: string,
+): Promise<RestoreResponse> {
+  return apiFetch<RestoreResponse>("/wiki/file/restore", {
+    method: "POST",
+    body: JSON.stringify({ trash_id: trashId }),
+  });
+}
+
+/** Tombstone info for a deleted page/folder by its original path — the
+ * most-recent Trash entry, for the deleted-URL panel. Rejects (404) when the
+ * path isn't in Trash. */
+export async function getDeletedTombstone(path: string): Promise<TrashEntry> {
+  return apiFetch<TrashEntry>(`/wiki/deleted?path=${encodeURIComponent(path)}`);
+}

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -142,8 +142,8 @@ export function WikiItemActionsProvider({
     remove: async (path, isFolder) => {
       const label = path.replace(/\.md$/, "").split("/").pop() ?? path;
       const message = isFolder
-        ? `Delete folder "${label}" and everything in it? This cannot be undone.`
-        : `Delete ${label}? This cannot be undone.`;
+        ? `Delete folder "${label}" and everything in it? It will be moved to Trash, where you can restore it.`
+        : `Delete ${label}? It will be moved to Trash, where you can restore it.`;
       if (!window.confirm(message)) return;
       try {
         await apiFetch(`/wiki/file?path=${encodeURIComponent(path)}`, {

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   SvgSearch,
   SvgSettings,
   SvgStar,
+  SvgTrash,
 } from "@onyx-ai/opal/icons";
 import { SidebarLayouts, useSidebarState } from "@onyx-ai/opal/layouts";
 import { sidebarLogo } from "@/sections/sidebar/shared";
@@ -166,6 +167,15 @@ export default function AppSidebar() {
           }
         >
           Activities
+        </SidebarTab>
+        <SidebarTab
+          icon={SvgTrash}
+          folded={folded}
+          tooltip={folded ? "Trash" : undefined}
+          selected={focus.matchesHref("/app/trash")}
+          href="/app/trash"
+        >
+          Trash
         </SidebarTab>
         {user?.is_admin && (
           <SidebarTab

--- a/frontend/src/views/trash/TrashPage.tsx
+++ b/frontend/src/views/trash/TrashPage.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, MessageCard, Tag, Text } from "@onyx-ai/opal/components";
+import { SvgTrash } from "@onyx-ai/opal/icons";
+import { SettingsLayouts } from "@onyx-ai/opal/layouts";
+
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { useRequireAuth } from "@/lib/auth";
+import { ApiError } from "@/lib/api";
+import { formatRelative } from "@/lib/format";
+import { restoreTrashed, useTrash, type TrashEntry } from "@/lib/trash";
+
+/** Display name for a trashed item: the page name (no `.md`) or folder name. */
+function itemLabel(entry: TrashEntry): string {
+  const base = entry.path.split("/").pop() ?? entry.path;
+  return entry.kind === "page" ? base.replace(/\.md$/i, "") : base;
+}
+
+export default function TrashPage() {
+  const { user, loading } = useRequireAuth();
+  const { items, error: listSwrError, refresh } = useTrash();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (loading || !user) return <LoadingSpinner center />;
+
+  const restore = async (entry: TrashEntry) => {
+    setBusyId(entry.trash_id);
+    setError(null);
+    try {
+      await restoreTrashed(entry.trash_id);
+      // The item is back on the tree — drop it from the list optimistically.
+      await refresh(
+        (cur) => ({
+          items: (cur?.items ?? []).filter(
+            (i) => i.trash_id !== entry.trash_id,
+          ),
+        }),
+        { revalidate: true },
+      );
+    } catch (e) {
+      setError(
+        e instanceof ApiError && e.status === 409
+          ? `Can't restore "${itemLabel(entry)}" — a page already exists at ${entry.path}.`
+          : e instanceof Error
+            ? e.message
+            : "Restore failed.",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const listError = error ?? listSwrError?.message ?? null;
+
+  return (
+    <SettingsLayouts.Root width="lg">
+      <SettingsLayouts.Header
+        icon={SvgTrash}
+        title="Trash"
+        description="Deleted pages and folders. Restore an item to move it back to its original location."
+        divider
+      />
+      <SettingsLayouts.Body>
+        {listError && (
+          <div className="mb-3">
+            <MessageCard variant="error" title={listError} />
+          </div>
+        )}
+
+        {items.length === 0 && !listError && (
+          <div className="px-2 py-4">
+            <Text font="main-ui-body" color="text-03">
+              Trash is empty. Deleted pages and folders show up here.
+            </Text>
+          </div>
+        )}
+
+        <div className="flex w-full flex-col gap-2">
+          {items.map((entry) => (
+            <div
+              key={entry.trash_id}
+              className="flex w-full items-center gap-3 rounded-(--border-radius-08) border border-(--border-01) p-3"
+            >
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <div className="min-w-0 truncate">
+                    <Text font="main-content-body">{itemLabel(entry)}</Text>
+                  </div>
+                  <Tag
+                    title={entry.kind === "page" ? "Page" : "Folder"}
+                    color="gray"
+                  />
+                </div>
+                <div className="truncate">
+                  <Text font="main-ui-body" color="text-03">
+                    {`${entry.path} · deleted by ${entry.trashed_by}${
+                      entry.trashed_at
+                        ? ` · ${formatRelative(entry.trashed_at)}`
+                        : ""
+                    }`}
+                  </Text>
+                </div>
+              </div>
+              <Button
+                prominence="secondary"
+                size="sm"
+                disabled={!entry.can_restore || busyId === entry.trash_id}
+                onClick={() => void restore(entry)}
+              >
+                {busyId === entry.trash_id ? "Restoring…" : "Restore"}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/frontend/src/views/trash/TrashPage.tsx
+++ b/frontend/src/views/trash/TrashPage.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { Button, MessageCard, Tag, Text } from "@onyx-ai/opal/components";
+import { Button, Card, MessageCard, Tag, Text } from "@onyx-ai/opal/components";
 import { SvgTrash } from "@onyx-ai/opal/icons";
 import { SettingsLayouts } from "@onyx-ai/opal/layouts";
 
@@ -80,39 +80,43 @@ export default function TrashPage() {
 
         <div className="flex w-full flex-col gap-2">
           {items.map((entry) => (
-            <div
+            <Card
               key={entry.trash_id}
-              className="flex w-full items-center gap-3 rounded-(--border-radius-08) border border-(--border-01) p-3"
+              padding="sm"
+              border="solid"
+              rounding="sm"
             >
-              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-                <div className="flex items-center gap-2">
-                  <div className="min-w-0 truncate">
-                    <Text font="main-content-body">{itemLabel(entry)}</Text>
+              <div className="flex w-full items-center gap-3">
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <div className="flex items-center gap-2">
+                    <div className="min-w-0 truncate">
+                      <Text font="main-content-body">{itemLabel(entry)}</Text>
+                    </div>
+                    <Tag
+                      title={entry.kind === "page" ? "Page" : "Folder"}
+                      color="gray"
+                    />
                   </div>
-                  <Tag
-                    title={entry.kind === "page" ? "Page" : "Folder"}
-                    color="gray"
-                  />
+                  <div className="truncate">
+                    <Text font="main-ui-body" color="text-03">
+                      {`${entry.path} · deleted by ${entry.trashed_by}${
+                        entry.trashed_at
+                          ? ` · ${formatRelative(entry.trashed_at)}`
+                          : ""
+                      }`}
+                    </Text>
+                  </div>
                 </div>
-                <div className="truncate">
-                  <Text font="main-ui-body" color="text-03">
-                    {`${entry.path} · deleted by ${entry.trashed_by}${
-                      entry.trashed_at
-                        ? ` · ${formatRelative(entry.trashed_at)}`
-                        : ""
-                    }`}
-                  </Text>
-                </div>
+                <Button
+                  prominence="secondary"
+                  size="sm"
+                  disabled={!entry.can_restore || busyId === entry.trash_id}
+                  onClick={() => void restore(entry)}
+                >
+                  {busyId === entry.trash_id ? "Restoring…" : "Restore"}
+                </Button>
               </div>
-              <Button
-                prominence="secondary"
-                size="sm"
-                disabled={!entry.can_restore || busyId === entry.trash_id}
-                onClick={() => void restore(entry)}
-              >
-                {busyId === entry.trash_id ? "Restoring…" : "Restore"}
-              </Button>
-            </div>
+            </Card>
           ))}
         </div>
       </SettingsLayouts.Body>


### PR DESCRIPTION
Trash & recovery UI + its backend. **#388 was merged into this branch** (it was stacked here), so this PR now carries the whole feature — merging it lands everything on \`main\`.

## Backend
- `GET /api/wiki/deleted?path=` → a deleted page/folder's most-recent Trash entry (`trash_id` + who/when + `can_restore`) for the tombstone panel; 404 when not in Trash; ACL-checked against the trash location.
- `trash.entry_for_original_path(path)` (newest tombstone for a path).

## Frontend
- **Trash view** (`/app/trash`) — lists deleted items with Restore; new sidebar **Trash** tab (registered in `useAppFocus` so it highlights).
- **Deleted-URL tombstone** — a deleted page's id URL shows "deleted by _who_ · _when_" + Restore (navigates via `wikiPath`, encoded); falls back to the generic card when purged.
- `lib/trash.ts` (`useTrash`, `restoreTrashed`, `getDeletedTombstone`); Opal `MessageCard` for errors; delete-confirm copy → "moved to Trash".

## Scope
Only *deleted* pages get a tombstone — a *moved* page's id URL already follows the move (#386).

## Verified
Backend `test_trash.py` (incl. tombstone endpoint) passes; end-to-end flow tested on the local stack (create→delete→tombstone→trash→restore); tsc + prettier + ruff + basedpyright clean.