### PR TITLE
feat(wiki-fe): Trash view + deleted-URL tombstone

### DIFF
--- a/frontend/src/app/app/trash/page.tsx
+++ b/frontend/src/app/app/trash/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/views/trash/TrashPage";

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -63,7 +63,13 @@ import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { apiFetch, ApiError } from "@/lib/api";
-import { isDocId, wikiHref, resolveDocId, resolveIds } from "@/lib/wikiHref";
+import {
+  isDocId,
+  wikiHref,
+  wikiPath,
+  resolveDocId,
+  resolveIds,
+} from "@/lib/wikiHref";
 import { formatRelative } from "@/lib/format";
 import { getDeletedTombstone, restoreTrashed } from "@/lib/trash";
 import { listComments } from "@/lib/comments";
@@ -304,7 +310,8 @@ function WikiTombstone({ path }: { path: string }) {
     try {
       const res = await restoreTrashed(entry.trash_id);
       // Land on the restored page; the route resolves the path → id URL.
-      router.push("/app/wiki/" + res.path);
+      // wikiPath encodes each segment (paths may contain spaces, #, %, …).
+      router.push(wikiPath(res.path));
     } catch (e) {
       setErr(
         e instanceof ApiError && e.status === 409

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -18,6 +18,7 @@ import {
   Divider,
   EmptyMessageCard,
   LineItemButton,
+  MessageCard,
   OpenButton,
   Popover,
   PopoverMenu,
@@ -327,11 +328,7 @@ function WikiTombstone({ path }: { path: string }) {
             entry.trashed_at ? ` · ${formatRelative(entry.trashed_at)}` : ""
           }. Restore it to bring it back to ${entry.path}.`}
         />
-        {err && (
-          <div className="rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
-            {err}
-          </div>
-        )}
+        {err && <MessageCard variant="error" title={err} />}
         <div className="flex items-center gap-2">
           <Button
             prominence="secondary"

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -63,6 +63,8 @@ import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { apiFetch, ApiError } from "@/lib/api";
 import { isDocId, wikiHref, resolveDocId, resolveIds } from "@/lib/wikiHref";
+import { formatRelative } from "@/lib/format";
+import { getDeletedTombstone, restoreTrashed } from "@/lib/trash";
 import { listComments } from "@/lib/comments";
 import {
   paintCommentHighlights,
@@ -216,11 +218,12 @@ export default function WikiRoute() {
     );
 
   if (idMode && !idResolve404) {
-    // Non-404 resolve failure / deleted page → the link no longer points at a
-    // live doc. (A 404 falls through to path rendering above, in case the
-    // segment is a legacy path that merely looks like an id. Deleted-page
-    // recovery is a separate feature.)
-    if (resolveErr || resolved?.deleted_at)
+    // A 404 falls through to path rendering above (the segment may be a legacy
+    // path that merely looks like an id).
+    // Deleted page → tombstone panel (who/when + Restore); other resolve
+    // failure → the generic unavailable card.
+    if (resolved?.deleted_at) return <WikiTombstone path={resolved.path} />;
+    if (resolveErr)
       return <WikiUnknownLink status={(resolveErr as ApiError)?.status} />;
     if (!resolved)
       return (
@@ -238,8 +241,9 @@ export default function WikiRoute() {
   return <Explorer dir={effectivePath} />;
 }
 
-/** A wiki URL that no longer points at a live doc — an unknown id or one whose
- * page has been deleted. Recovering deleted pages is a separate feature. */
+/** A wiki URL that no longer points at a live doc — an unknown/expired id, or
+ * a page that was deleted but is no longer in Trash (purged). A deleted page
+ * still in Trash renders {@link WikiTombstone} instead. */
 function WikiUnknownLink({ status }: { status?: number }) {
   const router = useRouter();
   return (
@@ -258,6 +262,89 @@ function WikiUnknownLink({ status }: { status?: number }) {
         <Button onClick={() => router.push("/app/wiki")}>
           Go to wiki home
         </Button>
+      </div>
+    </main>
+  );
+}
+
+/** Tombstone for a deleted page/folder reached via its id URL: shows who/when
+ * and offers Restore. Falls back to {@link WikiUnknownLink} when the item is no
+ * longer in Trash (purged, or deleted before Trash shipped). */
+function WikiTombstone({ path }: { path: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const {
+    data: entry,
+    error,
+    isLoading,
+  } = useSWR(
+    `/wiki/deleted?path=${encodeURIComponent(path)}`,
+    () => getDeletedTombstone(path),
+    { revalidateOnFocus: false },
+  );
+
+  if (isLoading)
+    return (
+      <main className="p-8">
+        <LoadingSpinner center />
+      </main>
+    );
+  if (error || !entry)
+    return <WikiUnknownLink status={(error as ApiError)?.status} />;
+
+  const label = (entry.path.split("/").pop() ?? entry.path).replace(
+    /\.md$/i,
+    "",
+  );
+  const restore = async () => {
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await restoreTrashed(entry.trash_id);
+      // Land on the restored page; the route resolves the path → id URL.
+      router.push("/app/wiki/" + res.path);
+    } catch (e) {
+      setErr(
+        e instanceof ApiError && e.status === 409
+          ? `A page already exists at ${entry.path}.`
+          : e instanceof Error
+            ? e.message
+            : "Restore failed.",
+      );
+      setBusy(false);
+    }
+  };
+
+  return (
+    <main className="flex h-full items-center justify-center p-8 pb-[16vh]">
+      <div className="flex flex-col items-center gap-4">
+        <EmptyMessageCard
+          sizePreset="main-ui"
+          icon={SvgTrash}
+          title={`“${label}” was deleted`}
+          description={`Deleted by ${entry.trashed_by}${
+            entry.trashed_at ? ` · ${formatRelative(entry.trashed_at)}` : ""
+          }. Restore it to bring it back to ${entry.path}.`}
+        />
+        {err && (
+          <div className="rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+            {err}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <Button
+            prominence="secondary"
+            onClick={() => router.push("/app/wiki")}
+          >
+            Go to wiki home
+          </Button>
+          {entry.can_restore && (
+            <Button onClick={() => void restore()} disabled={busy}>
+              {busy ? "Restoring…" : "Restore"}
+            </Button>
+          )}
+        </div>
       </div>
     </main>
   );
@@ -373,7 +460,7 @@ function Explorer({ dir }: { dir: string }) {
     if (
       !(await confirmDialog({
         title: `Delete ${rel}?`,
-        body: "This cannot be undone.",
+        body: "It will be moved to Trash, where you can restore it.",
         confirmLabel: "Delete",
       }))
     )

--- a/frontend/src/hooks/useAppFocus.ts
+++ b/frontend/src/hooks/useAppFocus.ts
@@ -13,6 +13,7 @@ export type AppFocusType =
   | "triggers"
   | "agents-and-actions"
   | "chats"
+  | "trash"
   | "none";
 
 // Single source of truth for route → focus type mapping.
@@ -25,6 +26,7 @@ const ROUTES: ReadonlyArray<{
   { href: "/app/triggers", type: "triggers" },
   { href: "/app/agents-and-actions", type: "agents-and-actions" },
   { href: "/app/chats", type: "chats" },
+  { href: "/app/trash", type: "trash" },
 ];
 
 function decodeWikiPath(raw: string): string {

--- a/frontend/src/lib/trash.ts
+++ b/frontend/src/lib/trash.ts
@@ -1,0 +1,52 @@
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api";
+
+/** One soft-deleted item in the Trash (a page or a folder root). Mirrors the
+ * backend `TrashEntryView`. `path` is where it lived; a restore moves it back
+ * there. `can_restore` reflects the caller's write access at the trash path. */
+export interface TrashEntry {
+  trash_id: string;
+  path: string;
+  kind: "page" | "folder";
+  trashed_by: string;
+  trashed_at: string;
+  can_restore: boolean;
+}
+
+/** The Trash list, newest-first. ACL-filtered server-side. */
+export function useTrash() {
+  const { data, error, isLoading, mutate } = useSWR<{ items: TrashEntry[] }>(
+    "/wiki/trash",
+  );
+  return {
+    items: data?.items ?? [],
+    error: error as Error | undefined,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+interface RestoreResponse {
+  path: string;
+  sha: string;
+  restored: string[];
+}
+
+/** Move a trashed item back to its original path. Rejects (409) if that path
+ * is now occupied by a recreated page. */
+export async function restoreTrashed(
+  trashId: string,
+): Promise<RestoreResponse> {
+  return apiFetch<RestoreResponse>("/wiki/file/restore", {
+    method: "POST",
+    body: JSON.stringify({ trash_id: trashId }),
+  });
+}
+
+/** Tombstone info for a deleted page/folder by its original path — the
+ * most-recent Trash entry, for the deleted-URL panel. Rejects (404) when the
+ * path isn't in Trash. */
+export async function getDeletedTombstone(path: string): Promise<TrashEntry> {
+  return apiFetch<TrashEntry>(`/wiki/deleted?path=${encodeURIComponent(path)}`);
+}

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -142,8 +142,8 @@ export function WikiItemActionsProvider({
     remove: async (path, isFolder) => {
       const label = path.replace(/\.md$/, "").split("/").pop() ?? path;
       const message = isFolder
-        ? `Delete folder "${label}" and everything in it? This cannot be undone.`
-        : `Delete ${label}? This cannot be undone.`;
+        ? `Delete folder "${label}" and everything in it? It will be moved to Trash, where you can restore it.`
+        : `Delete ${label}? It will be moved to Trash, where you can restore it.`;
       if (!window.confirm(message)) return;
       try {
         await apiFetch(`/wiki/file?path=${encodeURIComponent(path)}`, {

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -8,6 +8,7 @@ import {
   SvgSearch,
   SvgSettings,
   SvgStar,
+  SvgTrash,
 } from "@onyx-ai/opal/icons";
 import { SidebarLayouts, useSidebarState } from "@onyx-ai/opal/layouts";
 import { sidebarLogo } from "@/sections/sidebar/shared";
@@ -166,6 +167,15 @@ export default function AppSidebar() {
           }
         >
           Activities
+        </SidebarTab>
+        <SidebarTab
+          icon={SvgTrash}
+          folded={folded}
+          tooltip={folded ? "Trash" : undefined}
+          selected={focus.matchesHref("/app/trash")}
+          href="/app/trash"
+        >
+          Trash
         </SidebarTab>
         {user?.is_admin && (
           <SidebarTab

--- a/frontend/src/views/trash/TrashPage.tsx
+++ b/frontend/src/views/trash/TrashPage.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import { Button, Tag, Text } from "@onyx-ai/opal/components";
+import { Button, MessageCard, Tag, Text } from "@onyx-ai/opal/components";
 import { SvgTrash } from "@onyx-ai/opal/icons";
 import { SettingsLayouts } from "@onyx-ai/opal/layouts";
 
@@ -65,8 +65,8 @@ export default function TrashPage() {
       />
       <SettingsLayouts.Body>
         {listError && (
-          <div className="mb-3 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
-            {listError}
+          <div className="mb-3">
+            <MessageCard variant="error" title={listError} />
           </div>
         )}
 

--- a/frontend/src/views/trash/TrashPage.tsx
+++ b/frontend/src/views/trash/TrashPage.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button, Tag, Text } from "@onyx-ai/opal/components";
+import { SvgTrash } from "@onyx-ai/opal/icons";
+import { SettingsLayouts } from "@onyx-ai/opal/layouts";
+
+import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { useRequireAuth } from "@/lib/auth";
+import { ApiError } from "@/lib/api";
+import { formatRelative } from "@/lib/format";
+import { restoreTrashed, useTrash, type TrashEntry } from "@/lib/trash";
+
+/** Display name for a trashed item: the page name (no `.md`) or folder name. */
+function itemLabel(entry: TrashEntry): string {
+  const base = entry.path.split("/").pop() ?? entry.path;
+  return entry.kind === "page" ? base.replace(/\.md$/i, "") : base;
+}
+
+export default function TrashPage() {
+  const { user, loading } = useRequireAuth();
+  const { items, error: listSwrError, refresh } = useTrash();
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (loading || !user) return <LoadingSpinner center />;
+
+  const restore = async (entry: TrashEntry) => {
+    setBusyId(entry.trash_id);
+    setError(null);
+    try {
+      await restoreTrashed(entry.trash_id);
+      // The item is back on the tree — drop it from the list optimistically.
+      await refresh(
+        (cur) => ({
+          items: (cur?.items ?? []).filter(
+            (i) => i.trash_id !== entry.trash_id,
+          ),
+        }),
+        { revalidate: true },
+      );
+    } catch (e) {
+      setError(
+        e instanceof ApiError && e.status === 409
+          ? `Can't restore "${itemLabel(entry)}" — a page already exists at ${entry.path}.`
+          : e instanceof Error
+            ? e.message
+            : "Restore failed.",
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const listError = error ?? listSwrError?.message ?? null;
+
+  return (
+    <SettingsLayouts.Root width="lg">
+      <SettingsLayouts.Header
+        icon={SvgTrash}
+        title="Trash"
+        description="Deleted pages and folders. Restore an item to move it back to its original location."
+        divider
+      />
+      <SettingsLayouts.Body>
+        {listError && (
+          <div className="mb-3 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+            {listError}
+          </div>
+        )}
+
+        {items.length === 0 && !listError && (
+          <div className="px-2 py-4">
+            <Text font="main-ui-body" color="text-03">
+              Trash is empty. Deleted pages and folders show up here.
+            </Text>
+          </div>
+        )}
+
+        <div className="flex w-full flex-col gap-2">
+          {items.map((entry) => (
+            <div
+              key={entry.trash_id}
+              className="flex w-full items-center gap-3 rounded-(--border-radius-08) border border-(--border-01) p-3"
+            >
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                  <div className="min-w-0 truncate">
+                    <Text font="main-content-body">{itemLabel(entry)}</Text>
+                  </div>
+                  <Tag
+                    title={entry.kind === "page" ? "Page" : "Folder"}
+                    color="gray"
+                  />
+                </div>
+                <div className="truncate">
+                  <Text font="main-ui-body" color="text-03">
+                    {`${entry.path} · deleted by ${entry.trashed_by}${
+                      entry.trashed_at
+                        ? ` · ${formatRelative(entry.trashed_at)}`
+                        : ""
+                    }`}
+                  </Text>
+                </div>
+              </div>
+              <Button
+                prominence="secondary"
+                size="sm"
+                disabled={!entry.can_restore || busyId === entry.trash_id}
+                onClick={() => void restore(entry)}
+              >
+                {busyId === entry.trash_id ? "Restoring…" : "Restore"}
+              </Button>
+            </div>
+          ))}
+        </div>
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}


### PR DESCRIPTION
Frontend for Trash & recovery. **Stacked on #387** (the `GET /wiki/deleted` backend) — base retargets to `main` once #387 merges; merge #387 first.

## What
- **Trash view** (`/app/trash`, `src/views/trash/TrashPage.tsx`, mirrors the Triggers page) — lists deleted pages/folders (name · kind · previous path · who · when) with a **Restore** action. Optimistic removal on success; a 409 (path recreated) is surfaced. Reachable from a new **Trash** tab in the sidebar footer.
- **Deleted-URL tombstone** — a deleted page's id URL (`resolveDocId` → `deleted_at`) now renders `WikiTombstone`: "deleted by _who_ · _when_" + **Restore** (lands on the restored page, which resolves back to its id URL). Falls back to the generic "unavailable" card when the item is no longer in Trash (purged).
- `lib/trash.ts`: `useTrash()` SWR hook, `restoreTrashed()`, `getDeletedTombstone()`.
- Delete-confirm copy: "moved to Trash, where you can restore it" (was "cannot be undone"), in both the tree row action and the file-viewer delete.

## Scope
Only the **deleted** case gets a tombstone — a *moved* page's id URL already follows the move (#386), so no moved-redirect needed.

## Checks
tsc + prettier clean. (Backend `test_trash.py`, incl. the tombstone endpoint, passes locally — 13/13.)
<img width="207" height="167" alt="Screenshot 2026-07-14 at 11 38 48 AM" src="https://github.com/user-attachments/assets/618c0773-8a51-456f-b10d-52a405cbced6" />
<img width="1143" height="349" alt="Screenshot 2026-07-14 at 11 39 12 AM" src="https://github.com/user-attachments/assets/838a7af9-422b-4be5-973b-be95afa3248f" />
<img width="665" height="256" alt="Screenshot 2026-07-14 at 11 39 02 AM" src="https://github.com/user-attachments/assets/c2ad3c6c-eac3-48cd-8020-1019dca6fa2c" />
<img width="592" height="241" alt="Screenshot 2026-07-14 at 11 46 05 AM" src="https://github.com/user-attachments/assets/e81ffca2-c08e-4020-9311-121218a77d3c" />



