### PR TITLE
feat(wiki): 30-day auto-purge for the Trash

### DIFF
--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -40,6 +40,7 @@ _TASK_MODULES = (
     "app.tasks.notify_emails",
     "app.tasks.periodic",
     "app.tasks.reindex",
+    "app.tasks.trash_purge",
     "app.tasks.triggers",
     "app.tasks.update_frequency",
 )

--- a/backend/app/tasks/trash_purge.py
+++ b/backend/app/tasks/trash_purge.py
@@ -1,0 +1,70 @@
+"""Daily auto-purge for the Trash.
+
+Deleting a page/folder soft-deletes it into ``.trash/`` (see ``app/wiki/trash.py``);
+nothing removes it, so ``.trash/`` — and the Trash view's per-entry git walk —
+would grow without bound. This sweep permanently removes entries past
+``TRASH_RETENTION_DAYS``: ``git rm`` the ``.trash/<id>/`` subtree + commit (a
+**soft purge** — content stays in git history, never a history rewrite) and drop
+the ACL/owner/policy rows parked at the trash location.
+
+Runs on ``documents_queue``, **not** ``lightweight_maintenance_queue``: the purge
+makes a wiki commit (and takes the commit lock), which that queue's contract
+forbids. A daily purge isn't latency-sensitive, so co-tenanting with the (slow,
+commit-producing) doc-reconciliation queue is fine. See ``app/tasks/queues.py``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.tasks.queue import crontab
+from app.tasks.queues import documents_queue
+from app.wiki import trash
+
+log = logging.getLogger(__name__)
+
+# How long a trashed item is kept before auto-purge. A constant for now
+# (per-instance / admin config can follow); 0 disables the sweep.
+TRASH_RETENTION_DAYS = 30
+
+# Git identity for the purge commits.
+_PURGE_AUTHOR = "Agent Wiki <system@agent-wiki>"
+
+
+def _trashed_before(trashed_at: str, cutoff: datetime) -> bool:
+    """True if the ISO-8601 ``trashed_at`` is strictly before ``cutoff``.
+    Unparseable/empty timestamps are treated as not-expired (kept)."""
+    if not trashed_at:
+        return False
+    try:
+        dt = datetime.fromisoformat(trashed_at)
+    except ValueError:
+        return False
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt < cutoff
+
+
+# 10:00 UTC daily — off-peak. The scheduler evaluates cron in UTC (no DST).
+@documents_queue.periodic_task(crontab(hour="10", minute="0"))
+def purge_expired_trash() -> None:
+    if TRASH_RETENTION_DAYS <= 0:
+        return
+    cutoff = datetime.now(timezone.utc) - timedelta(days=TRASH_RETENTION_DAYS)
+    purged = 0
+    # Snapshot the list first; each purge mutates `.trash/`.
+    for entry in trash.list_entries():
+        if not _trashed_before(entry.trashed_at, cutoff):
+            continue
+        try:
+            if trash.purge(entry.trash_id, actor=_PURGE_AUTHOR):
+                purged += 1
+        except Exception:
+            log.exception("trash purge failed for %s", entry.trash_id)
+    if purged:
+        log.info(
+            "trash purge: removed %d item(s) trashed before %s (%dd retention)",
+            purged,
+            cutoff.isoformat(timespec="seconds"),
+            TRASH_RETENTION_DAYS,
+        )

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -723,6 +723,27 @@ def restore_from_trash(
     return sha, moves
 
 
+def purge_from_trash(
+    trash_id: str, message: str, author: str | None = None
+) -> str | None:
+    """Permanently remove ``.trash/<trash_id>/`` from the working tree via
+    ``git rm`` and commit. **Soft purge**: the content stays in git *history*
+    (we never rewrite history — additive-only), it just leaves the working tree
+    and therefore the Trash view. Returns the commit sha, or ``None`` when the
+    trash id has no tracked files (already purged/restored)."""
+    prefix = f"{TRASH_PREFIX}{trash_id}/"
+    files = [p for p in list_trash_files() if p.startswith(prefix)]
+    if not files:
+        return None
+    env_args = ["--author", author] if author else []
+    with commit_lock():
+        _run(["rm", "-r", "--", f"{TRASH_DIR}/{trash_id}"])
+        _run(["commit", "-m", message, *env_args])
+        sha = _run(["rev-parse", "HEAD"]).stdout.strip()
+    log.info("purge_from_trash %s (%d files) sha=%s", trash_id, len(files), sha[:8])
+    return sha
+
+
 class UnknownSha(Exception):
     """Raised when a SHA can't be resolved against the wiki repo.
 

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -21,7 +21,7 @@ import uuid
 from pydantic import BaseModel
 
 from app.models.wiki import PageKind
-from app.wiki import git as wiki_git
+from app.wiki import acl, git as wiki_git, update_policy
 from app.wiki.filesystem import TRASH_DIR
 
 
@@ -144,10 +144,6 @@ def purge(trash_id: str, actor: str | None = None) -> bool:
     generic "unavailable" card once ``/wiki/deleted`` 404s (the trash entry is
     gone). Retiring the id fully is a separate concern (the id→trash link isn't
     tracked, and multiple tombstones can share a path)."""
-    # Import here to avoid a module-load cycle (acl/update_policy don't import
-    # trash, but this keeps trash's import surface minimal).
-    from app.wiki import acl, update_policy
-
     prefix = f"{TRASH_DIR}/{trash_id}/"
     trash_paths = [f for f in wiki_git.list_trash_files() if f.startswith(prefix)]
     if not trash_paths:

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -127,10 +127,17 @@ def entry_for(trash_id: str) -> TrashEntry | None:
 
 
 def purge(trash_id: str, actor: str | None = None) -> bool:
-    """Permanently remove a trashed item (past retention): ``git rm`` its
-    ``.trash/<trash_id>/`` subtree + commit, then drop the ACL/owner/policy rows
-    that trashing parked at the trash location so they don't dangle. Content
-    stays in git history (soft purge). Returns ``True`` if anything was purged.
+    """Permanently remove a trashed item (past retention): drop the ACL/owner/
+    policy rows that trashing parked at the trash location, then ``git rm`` its
+    ``.trash/<trash_id>/`` subtree + commit. Content stays in git history (soft
+    purge). Returns ``True`` if anything was purged.
+
+    **Order matters — cleanup before `git rm`, so the purge is retryable.** The
+    row deletes are idempotent; the `git rm` is the last, committing step. If any
+    step fails, the `.trash/` files remain, so the next sweep re-runs the whole
+    thing (re-clearing rows is a no-op) and finishes the `git rm`. Doing the
+    `git rm` first would strand the parked rows on failure: the retry would
+    short-circuit at the empty-`.trash/` guard below.
 
     Does *not* touch the item's ``wiki_doc_ids`` tombstone: the id keeps
     resolving to a deleted state, and the tombstone panel degrades to the
@@ -145,7 +152,6 @@ def purge(trash_id: str, actor: str | None = None) -> bool:
     trash_paths = [f for f in wiki_git.list_trash_files() if f.startswith(prefix)]
     if not trash_paths:
         return False
-    wiki_git.purge_from_trash(trash_id, f"purge trash {trash_id}", author=actor)
     # Every `.trash/<id>/…` path that could hold a parked row: each file plus
     # its ancestor folders down to `.trash/<id>`.
     to_clear: set[str] = set()
@@ -158,4 +164,6 @@ def purge(trash_id: str, actor: str | None = None) -> bool:
         # delete_at (not delete): the parked key is a `.trash/…` path, which
         # delete()'s safe_rel_path normalization rejects.
         update_policy.delete_at(path)
+    # git rm last — the committing step, after the idempotent row cleanup.
+    wiki_git.purge_from_trash(trash_id, f"purge trash {trash_id}", author=actor)
     return True

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -124,3 +124,38 @@ def entry_for(trash_id: str) -> TrashEntry | None:
         f[len(prefix) :] for f in wiki_git.list_trash_files() if f.startswith(prefix)
     ]
     return _entry(trash_id, originals)
+
+
+def purge(trash_id: str, actor: str | None = None) -> bool:
+    """Permanently remove a trashed item (past retention): ``git rm`` its
+    ``.trash/<trash_id>/`` subtree + commit, then drop the ACL/owner/policy rows
+    that trashing parked at the trash location so they don't dangle. Content
+    stays in git history (soft purge). Returns ``True`` if anything was purged.
+
+    Does *not* touch the item's ``wiki_doc_ids`` tombstone: the id keeps
+    resolving to a deleted state, and the tombstone panel degrades to the
+    generic "unavailable" card once ``/wiki/deleted`` 404s (the trash entry is
+    gone). Retiring the id fully is a separate concern (the id→trash link isn't
+    tracked, and multiple tombstones can share a path)."""
+    # Import here to avoid a module-load cycle (acl/update_policy don't import
+    # trash, but this keeps trash's import surface minimal).
+    from app.wiki import acl, update_policy
+
+    prefix = f"{TRASH_DIR}/{trash_id}/"
+    trash_paths = [f for f in wiki_git.list_trash_files() if f.startswith(prefix)]
+    if not trash_paths:
+        return False
+    wiki_git.purge_from_trash(trash_id, f"purge trash {trash_id}", author=actor)
+    # Every `.trash/<id>/…` path that could hold a parked row: each file plus
+    # its ancestor folders down to `.trash/<id>`.
+    to_clear: set[str] = set()
+    for p in trash_paths:
+        parts = p.split("/")
+        for i in range(2, len(parts) + 1):
+            to_clear.add("/".join(parts[:i]))
+    for path in to_clear:
+        acl.delete_all_for_path(path)
+        # delete_at (not delete): the parked key is a `.trash/…` path, which
+        # delete()'s safe_rel_path normalization rejects.
+        update_policy.delete_at(path)
+    return True

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -165,6 +165,20 @@ def delete(path: str) -> bool:
         return True
 
 
+def delete_at(path: str) -> bool:
+    """Delete the policy row stored at *exactly* ``path``, without normalization.
+
+    For internal cleanup of rows parked at non-canonical keys that ``delete``'s
+    ``safe_rel_path`` would reject — notably ``.trash/…`` rows re-pointed there by
+    a trash move (see ``app/wiki/trash.py:purge``). Returns whether a row went."""
+    with session() as s:
+        row = s.get(UpdatePolicy, path)
+        if row is None:
+            return False
+        s.delete(row)
+        return True
+
+
 def on_page_deleted(path: str) -> None:
     """Drop the policy row for a deleted page (mirrors ``acl.on_page_deleted``).
 

--- a/backend/tests/test_trash_purge.py
+++ b/backend/tests/test_trash_purge.py
@@ -1,0 +1,96 @@
+"""Trash auto-purge: `git rm` past-retention entries + drop parked rows."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.tasks import trash_purge
+from app.tasks.queues import documents_queue
+from app.wiki import acl, trash
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _client(user_id: str) -> TestClient:
+    client = TestClient(create_app())
+    login_fastapi(client, user_id)
+    return client
+
+
+def test_purge_removes_item_and_parked_rows(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"})
+    tid = client.delete("/api/wiki/file?path=proj").json()["trash_id"]
+
+    # Trashing parked the page's ACL rows at the trash location.
+    trash_loc = trash.trash_location(tid, "proj/a.md")
+    parked = [
+        g for g in acl.list_for_path(trash_loc) if g["resource_path"].startswith(".trash/")
+    ]
+    assert parked  # some grant(s) parked under .trash/
+
+    assert trash.purge(tid) is True
+
+    # Gone from git + the Trash view, and the parked ACL rows are cleared.
+    assert trash.entry_for(tid) is None
+    assert client.get("/api/wiki/trash").json()["items"] == []
+    assert not [
+        g for g in acl.list_for_path(trash_loc) if g["resource_path"].startswith(".trash/")
+    ]
+
+
+def test_purge_noop_for_unknown_id(tmp_repo):
+    seed_user()
+    assert trash.purge("deadbeef0000") is False
+
+
+def test_trashed_before_cutoff():
+    cutoff = datetime(2026, 1, 15, tzinfo=timezone.utc)
+    assert trash_purge._trashed_before("2026-01-14T00:00:00+00:00", cutoff)  # older
+    assert not trash_purge._trashed_before("2026-01-16T00:00:00+00:00", cutoff)  # newer
+    assert not trash_purge._trashed_before("", cutoff)  # missing → kept
+    assert not trash_purge._trashed_before("garbage", cutoff)  # unparseable → kept
+    # Naive timestamps are treated as UTC.
+    assert trash_purge._trashed_before("2026-01-14T00:00:00", cutoff)
+
+
+def test_sweep_purges_expired_entries(tmp_repo, monkeypatch):
+    # Force every entry "expired" so the sweep's orchestration (iterate →
+    # purge) is exercised without mocking wall-clock time.
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "old.md", "body": "# old\n"})
+    old_tid = client.delete("/api/wiki/file?path=old.md").json()["trash_id"]
+
+    monkeypatch.setattr(trash_purge, "_trashed_before", lambda ta, cutoff: True)
+    with documents_queue.immediate_mode():
+        trash_purge.purge_expired_trash()
+    assert trash.entry_for(old_tid) is None  # purged
+
+
+def test_sweep_keeps_recent_entries(tmp_repo):
+    # Real time, 30-day retention, freshly trashed → not expired → kept.
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "recent.md", "body": "# r\n"})
+    tid = client.delete("/api/wiki/file?path=recent.md").json()["trash_id"]
+
+    with documents_queue.immediate_mode():
+        trash_purge.purge_expired_trash()
+    assert trash.entry_for(tid) is not None
+
+
+def test_sweep_disabled_when_retention_not_positive(tmp_repo, monkeypatch):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "keep.md", "body": "# k\n"})
+    tid = client.delete("/api/wiki/file?path=keep.md").json()["trash_id"]
+
+    monkeypatch.setattr(trash_purge, "TRASH_RETENTION_DAYS", 0)
+    with documents_queue.immediate_mode():
+        trash_purge.purge_expired_trash()
+    assert trash.entry_for(tid) is not None  # 0 disables → nothing purged


### PR DESCRIPTION
The last Trash follow-up. Deleting soft-deletes into `.trash/`; nothing removed it, so `.trash/` — and the Trash view's per-entry `git log` walk — grew without bound. This adds a daily sweep that permanently removes entries past a **30-day** retention.

## What
- **`trash.purge(trash_id)`** — `git rm` the `.trash/<id>/` subtree + commit (**soft purge**: content stays in git *history*, never a history rewrite — additive-only), then drop the ACL/owner/policy rows that the trash move parked under `.trash/<id>/`.
- **`git.purge_from_trash`** — the `git rm` + commit primitive (mirrors `restore_from_trash`).
- **`update_policy.delete_at`** — exact-key delete (no `safe_rel_path` normalization), so the parked `.trash/…` policy rows can be cleared (`delete()` rejects `.trash/`).
- **`tasks/trash_purge.py`** — daily cron (10:00 UTC), `TRASH_RETENTION_DAYS = 30` (0 disables), registered in `run_worker`.

## Queue choice
Runs on **`documents_queue`**, not `lightweight_maintenance_queue`: the purge makes a wiki commit (and takes the commit lock), which the lightweight queue's contract explicitly forbids. A daily purge isn't latency-sensitive, so co-tenanting with the commit-producing doc-reconciliation queue is fine (see `app/tasks/queues.py`).

## Deliberately *not* done
The `wiki_doc_ids` **tombstone is left in place** — the id keeps resolving to a deleted state, and the tombstone panel already degrades to the generic "unavailable" card once `/wiki/deleted` 404s (the trash entry is gone). Fully retiring the id is a separate concern (the id↔trash link isn't tracked, and multiple tombstones can share a path).

## Tests
`test_trash_purge.py`: `purge()` removes the item + clears parked ACL/policy rows; no-op for an unknown id; `_trashed_before` cutoff unit; sweep purges expired / keeps recent / disabled at retention ≤ 0. Full `test_trash.py` + `test_trash_purge.py` — **20 passed** locally; ruff + basedpyright clean.

## Follow-ups (not this PR)
Admin-configurable retention window; a manual "empty trash" / purge-now action.