### PR TITLE
fix(wiki-fe): reactive UI after rename/move/delete/create

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -69,6 +69,7 @@ import {
   wikiPath,
   resolveDocId,
   resolveIds,
+  revalidateWiki,
 } from "@/lib/wikiHref";
 import { formatRelative } from "@/lib/format";
 import { getDeletedTombstone, restoreTrashed } from "@/lib/trash";
@@ -415,10 +416,13 @@ function Explorer({ dir }: { dir: string }) {
   const error =
     mutationError ?? (listError instanceof Error ? listError.message : null);
   const setError = setMutationError;
-  // Force the cache to revalidate from the server. Used after writes
-  // (create / delete / move) to pull in the new tree.
+  // Force the cache to revalidate from the server after writes (create /
+  // delete / move). Refreshes this listing *and* every wiki cache — including
+  // the open doc's id→path resolve and content — so a rename/move is reflected
+  // on screen instead of leaving the view on the old path.
   const refresh = useCallback(() => {
     void mutatePaths();
+    void revalidateWiki();
   }, [mutatePaths]);
   const [busyPath, setBusyPath] = useState<string | null>(null);
   // Folders still use an inline filename form; new docs route to

--- a/frontend/src/lib/wikiHref.ts
+++ b/frontend/src/lib/wikiHref.ts
@@ -6,7 +6,25 @@
 // `wikiPath()` is kept only for fallbacks (an unsaved doc, or a page with no
 // id row yet) and for the new-document flow, which is inherently path-based.
 
+import { mutate } from "swr";
+
 import { apiFetch } from "@/lib/api";
+
+/** Revalidate every wiki-related SWR cache after a create / rename / move /
+ * delete / restore, so the UI reacts: the tree listing, the open doc's id→path
+ * resolve (`/wiki/id/<id>` — the key that makes a rename/move survive on screen),
+ * its content (`/wiki/file…`), recents, starred, trash, and the path→id lookups.
+ * Without this a rename leaves the open page resolving to its old (now gone)
+ * path. Matches both string keys under `/wiki` and the path-id array keys. */
+export function revalidateWiki(): Promise<unknown> {
+  return mutate((key) => {
+    const k = Array.isArray(key) ? key[0] : key;
+    return (
+      typeof k === "string" &&
+      (k.startsWith("/wiki") || k === "id-fallback" || k === "wiki-path-id")
+    );
+  });
+}
 
 // A wiki_doc_id is 16 lowercase hex chars (see backend doc_ids._mint_id).
 const DOC_ID_RE = /^[0-9a-f]{16}$/;

--- a/frontend/src/lib/wikiHref.ts
+++ b/frontend/src/lib/wikiHref.ts
@@ -11,11 +11,10 @@ import { mutate } from "swr";
 import { apiFetch } from "@/lib/api";
 
 /** Revalidate every wiki-related SWR cache after a create / rename / move /
- * delete / restore, so the UI reacts: the tree listing, the open doc's id→path
- * resolve (`/wiki/id/<id>` — the key that makes a rename/move survive on screen),
- * its content (`/wiki/file…`), recents, starred, trash, and the path→id lookups.
- * Without this a rename leaves the open page resolving to its old (now gone)
- * path. Matches both string keys under `/wiki` and the path-id array keys. */
+ * delete / restore: the tree listing, the open doc's id→path resolve
+ * (`/wiki/id/<id>`), its content (`/wiki/file…`), recents, starred, trash, and
+ * the path→id lookups. Matches both string keys under `/wiki` and the path-id
+ * array keys. */
 export function revalidateWiki(): Promise<unknown> {
   return mutate((key) => {
     const k = Array.isArray(key) ? key[0] : key;

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -8,10 +8,10 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import useSWR, { useSWRConfig } from "swr";
+import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
-import { shareableWikiUrl } from "@/lib/wikiHref";
+import { revalidateWiki, shareableWikiUrl } from "@/lib/wikiHref";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { MoveModal, RenameModal } from "@/components/wiki/WikiItemModals";
@@ -84,7 +84,6 @@ export function WikiItemActionsProvider({
   children,
   active = true,
 }: WikiItemActionsProviderProps) {
-  const { mutate } = useSWRConfig();
   const { data } = useSWR<{ entries: Entry[] }>(active ? "/wiki" : null);
   const entries = data?.entries ?? [];
 
@@ -101,12 +100,10 @@ export function WikiItemActionsProvider({
     return () => clearTimeout(t);
   }, [toast]);
 
-  const refresh = () => {
-    void mutate("/wiki");
-    void mutate(
-      (key) => typeof key === "string" && key.startsWith("/wiki/recent"),
-    );
-  };
+  // Revalidate every wiki cache (tree, open doc's id→path resolve + content,
+  // recents, starred, trash) so a rename/move/delete is reflected immediately —
+  // otherwise the open page keeps resolving to its old, now-gone path.
+  const refresh = () => void revalidateWiki();
 
   const remapActiveFolder = (oldPath: string, newPath: string) =>
     setActiveFolder((prev) =>

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -100,9 +100,8 @@ export function WikiItemActionsProvider({
     return () => clearTimeout(t);
   }, [toast]);
 
-  // Revalidate every wiki cache (tree, open doc's id→path resolve + content,
-  // recents, starred, trash) so a rename/move/delete is reflected immediately —
-  // otherwise the open page keeps resolving to its old, now-gone path.
+  // Revalidate every wiki cache the tree and open document read, after a
+  // rename / move / delete.
   const refresh = () => void revalidateWiki();
 
   const remapActiveFolder = (oldPath: string, newPath: string) =>


### PR DESCRIPTION
## Bug
After a rename/move (or delete/create) the UI didn't update — most visibly, **move/rename "lost" the open page**: the id survives the move (backend re-keys it), but the open doc's `resolveDocId` SWR (`/wiki/id/<id>`, `revalidateOnFocus: false`) stayed cached on the *old* path, so the view kept loading a path that no longer exists.

## Cause
Wiki mutations only revalidated the tree listing (`/wiki`) and recents — not `/wiki/id/*` (id→path resolve) or `/wiki/file*` (open-doc content).

## Fix
New `revalidateWiki()` (in `lib/wikiHref`) revalidates **every** wiki SWR cache — tree, `/wiki/id/*`, `/wiki/file*`, recents, starred, trash, and the `wiki-path-id` / `id-fallback` array keys — and it's called from both refresh paths: the Explorer/FileViewer `refresh` (`page.tsx`) and the context-menu provider `refresh`. So a rename/move now re-resolves the open page to its new path and re-renders in place; deletes/creates update the tree immediately.

tsc + prettier clean.