### PR TITLE
fix(wiki): cross-folder single-page move 500s + corrupts folder rows

### DIFF
--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -736,11 +736,18 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                     update(WikiOwner).where(WikiOwner.path == old_p).values(path=new_p)
                 )
 
-        # The folder-level prefix swap. Prefer the caller's explicit root_move
-        # (the actual folder rename); otherwise infer it from the shared prefix
-        # of the file moves — which can under-reach (see docstring).
-        if root_move is not None and not _is_md_page(root_move.old):
-            old_prefix, new_prefix = root_move.old, root_move.new
+        # The folder-level prefix swap. A `.md`-page root is a single page
+        # move: the per-file loop above re-keys it and there is no folder to
+        # prefix-rewrite. Only a folder root drives the swap. Legacy callers
+        # without a root_move fall back to inferring the prefix from the shared
+        # prefix of the file moves — which can under-reach (see docstring) and
+        # can't tell a single cross-folder file move from a folder rename.
+        if root_move is not None:
+            old_prefix, new_prefix = (
+                (None, None)
+                if _is_md_page(root_move.old)
+                else (root_move.old, root_move.new)
+            )
         else:
             old_prefix, new_prefix = common_folder_rename(moves)
         if old_prefix is not None and new_prefix is not None:

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -207,8 +207,18 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                     .where(WikiDocId.path == mv.old, WikiDocId.deleted_at.is_(None))
                     .values(deleted_at=_now_text())
                 )
-        if root_move is not None and not root_move.old.endswith(".md"):
-            old_prefix, new_prefix = root_move.old, root_move.new
+        if root_move is not None:
+            # A `.md`-page root is a single page move: the per-file loop above
+            # re-keys it and there is no folder-prefix rewrite. Only a folder
+            # root drives the prefix swap. (Inferring the prefix from the file
+            # moves alone can't tell a single cross-folder file move from a
+            # folder rename, and would rewrite the source folder's row onto the
+            # destination's.)
+            old_prefix, new_prefix = (
+                (None, None)
+                if root_move.old.endswith(".md")
+                else (root_move.old, root_move.new)
+            )
         else:
             old_prefix, new_prefix = filesystem.common_folder_rename(moves)
         if old_prefix is not None and new_prefix is not None:

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -211,8 +211,18 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                 .where(UpdatePolicy.path == mv.old)
                 .values(path=mv.new)
             )
-        if root_move is not None and not root_move.old.endswith(".md"):
-            old_prefix, new_prefix = root_move.old, root_move.new
+        if root_move is not None:
+            # A `.md`-page root is a single page move: the per-file loop above
+            # re-keys it and there is no folder-prefix rewrite. Only a folder
+            # root drives the prefix swap. (Inferring the prefix from the file
+            # moves alone can't tell a single cross-folder file move from a
+            # folder rename, and would rewrite the source folder's row onto the
+            # destination's.)
+            old_prefix, new_prefix = (
+                (None, None)
+                if root_move.old.endswith(".md")
+                else (root_move.old, root_move.new)
+            )
         else:
             old_prefix, new_prefix = filesystem.common_folder_rename(moves)
         if old_prefix is not None and new_prefix is not None:

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -64,6 +64,37 @@ def test_id_follows_file_move(tmp_repo):
     assert resolved["deleted_at"] is None
 
 
+def test_page_move_between_existing_folders_keeps_folder_ids(tmp_repo):
+    """Moving a single page between two existing folders re-keys only the page
+    id, never the source folder's row. A lone cross-folder file move looks like
+    a folder rename to prefix inference; the page ``root_move`` tells
+    ``on_path_moved`` it isn't, so the source folder's row is left alone.
+    Rewriting it onto the existing destination folder row hit the live-path
+    unique index and 500'd the move."""
+    user = seed_user()
+    client = _client(user)
+    # Two sibling folders, each with a page, so both folder id rows exist.
+    src_page = client.put(
+        "/api/wiki/file", json={"path": "scratch/xrep.md", "body": "# X\n"}
+    ).json()["id"]
+    client.put("/api/wiki/file", json={"path": "dest/keep.md", "body": "# K\n"})
+    scratch_id = doc_ids.id_for_path("scratch")
+    dest_id = doc_ids.id_for_path("dest")
+
+    resp = client.post(
+        "/api/wiki/move", json={"old_path": "scratch/xrep.md", "new_path": "dest/xrep.md"}
+    )
+    assert resp.status_code == 200
+
+    # The page id followed the move; the source page path is now unbound.
+    assert doc_ids.id_for_path("dest/xrep.md") == src_page
+    assert doc_ids.id_for_path("scratch/xrep.md") is None
+    # Both folder id rows are intact — the source folder was not rewritten onto
+    # the destination.
+    assert doc_ids.id_for_path("scratch") == scratch_id
+    assert doc_ids.id_for_path("dest") == dest_id
+
+
 def test_ids_follow_folder_move(tmp_repo):
     user = seed_user()
     client = _client(user)

--- a/backend/tests/test_folder_acl_repoint.py
+++ b/backend/tests/test_folder_acl_repoint.py
@@ -1,9 +1,15 @@
-"""Folder-level ACL/policy re-point on move, including the deep-only case.
+"""Folder-level ACL/policy re-point on move.
 
-`acl.on_path_moved` / `update_policy.on_path_moved` infer the folder-prefix
-swap from the file moves, but that finds the *deepest* shared prefix — so a
-folder whose files all sit in one subdirectory would leave the folder's own
-row stranded. The move callers pass the real rename as `root_move` to fix it.
+The move callers pass the real rename as `root_move`. A folder `root_move`
+drives the folder-prefix swap; a `.md`-page `root_move` is a single page move,
+so no folder row is touched. This matters both ways:
+
+- Deep-only folder: a folder whose files all sit in one subdirectory. Inference
+  from the file moves finds only the *deepest* shared prefix and would strand
+  the folder's own row; `root_move` re-points it correctly.
+- Single cross-folder file move: inference can't tell it from a folder rename
+  and would rewrite the source folder's row onto the destination; the page
+  `root_move` suppresses the folder-prefix swap entirely.
 """
 from __future__ import annotations
 
@@ -52,6 +58,38 @@ def test_without_root_move_the_deep_prefix_is_missed(tmp_db):
     )
     acl.on_path_moved([PathMove(old="proj/sub/a.md", new="proj2/sub/a.md")])
     assert "proj" in _folder_paths("proj/sub/a.md")  # stranded without root_move
+
+
+def test_page_move_between_folders_leaves_folder_acl_untouched(tmp_db):
+    # A folder grant on each of two sibling folders. Moving a single page from
+    # one to the other must not rewrite the source folder's grant onto the
+    # destination — the page root_move suppresses the folder-prefix swap.
+    for folder in ("scratch", "dest"):
+        acl.grant(
+            resource_kind="folder",
+            resource_path=folder,
+            principal_kind="everyone",
+            principal_id=None,
+            permission="read",
+            granted_by_user_id=None,
+        )
+    acl.on_path_moved(
+        [PathMove(old="scratch/xrep.md", new="dest/xrep.md")],
+        root_move=PathMove(old="scratch/xrep.md", new="dest/xrep.md"),
+    )
+    assert "scratch" in _folder_paths("scratch/other.md")
+    assert "dest" in _folder_paths("dest/xrep.md")
+
+
+def test_page_move_between_folders_leaves_policy_rows_untouched(tmp_db):
+    update_policy.set_policy("scratch", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("dest", ingestion_auto_update_disabled=True)
+    update_policy.on_path_moved(
+        [PathMove(old="scratch/xrep.md", new="dest/xrep.md")],
+        root_move=PathMove(old="scratch/xrep.md", new="dest/xrep.md"),
+    )
+    assert update_policy.get("scratch") is not None
+    assert update_policy.get("dest") is not None
 
 
 def test_update_policy_folder_repoints_with_root_move(tmp_db):


### PR DESCRIPTION
## Problem

Moving a single page between two folders — e.g. `scratch/xrep.md → trashtest-area/xrep.md` — returns **500 Internal Server Error**, and afterward the page reads "This page isn't available" until a manual refresh.

Root cause: a one-element move list is fed to `common_folder_rename`, which cannot tell a single cross-folder file move from a folder rename and returns the folder-prefix swap `(scratch, trashtest-area)`. All three path-keyed re-keyers then try to rewrite the **source folder's** row onto the destination:

- `doc_ids` — hits the `uq_wiki_doc_ids_live_path` unique index → **500**, and the id re-key aborts half-applied, so the id resolves to a broken state (the "unavailable" card).
- `acl` / `update_policy` — no unique constraint, so this **silently moves** the source folder's ACL grant / update policy onto the destination folder. This also fires on delete-to-trash of a single page (`scratch/x.md → .trash/<id>/scratch/x.md` infers `scratch → .trash/<id>/scratch`), quietly parking the whole `scratch` folder's row in trash.

## Fix

The move callers already pass the caller's actual rename as `root_move`. Use it authoritatively in all three `on_path_moved`:

- a `.md`-page `root_move` is a single page move → the per-file loop re-keys it; **no** folder-prefix swap.
- a folder `root_move` → drives the swap (unchanged).
- no `root_move` (legacy callers only) → fall back to `common_folder_rename` inference.

## Tests

Added regression tests in `test_doc_ids.py` and `test_folder_acl_repoint.py` covering a page move between two existing folders — they 500 / corrupt on `main` and pass with the fix. Full move/id/acl/policy suites green.

Backend-only. The "unavailable until refresh" reactivity piece after rename/move is separate (#391).