### PR TITLE
fix(wiki-fe): reactive sidebar/viewer on create + inline rename (follow-ups to #391)

### DIFF
--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -978,6 +978,9 @@ function NewDocView({ dir }: { dir: string }) {
       if (appliedTemplateId) {
         await setDraftTemplate(fullPath, appliedTemplateId);
       }
+      // Revalidate every wiki cache so the persistent Directory sidebar (and
+      // any open folder listing) shows the new page without a full reload.
+      void revalidateWiki();
       // Hand-off: keep the drafting state (and the chat's drafting
       // session) alive across the navigation — see the unmount cleanup.
       createHandoffRef.current = true;

--- a/frontend/src/app/app/wiki/[[...slug]]/page.tsx
+++ b/frontend/src/app/app/wiki/[[...slug]]/page.tsx
@@ -2125,7 +2125,14 @@ function FileViewer({ path }: { path: string }) {
           method: "POST",
           body: JSON.stringify({ old_path: path, new_path: newRel }),
         });
-        router.push(`/app/wiki/${newRel}`);
+        // The id URL survives a rename, so the open page's id→path resolve now
+        // points at the old path. Revalidate every wiki cache (including that
+        // resolve and the content read) so the page follows to its new path,
+        // then route to the renamed doc's durable id URL — falling back to the
+        // path URL only for an id-less page.
+        await revalidateWiki();
+        const id = (await resolveIds([newRel]))[newRel];
+        router.replace(id ? wikiHref(id) : `/app/wiki/${newRel}`);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "save failed");

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useState, type FormEvent } from "react";
-import useSWR, { useSWRConfig } from "swr";
+import useSWR from "swr";
 
 import {
   Button,
@@ -20,6 +20,7 @@ import {
 } from "@onyx-ai/opal/icons";
 
 import { apiFetch } from "@/lib/api";
+import { revalidateWiki } from "@/lib/wikiHref";
 import { useActiveFolder } from "@/providers/WikiItemActionsProvider";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import styles from "@/components/wiki/WikiTree.module.css";
@@ -189,7 +190,6 @@ function FolderNode({
  */
 export function WikiTree() {
   const router = useRouter();
-  const { mutate } = useSWRConfig();
   const { data } = useSWR<{ entries: Entry[] }>("/wiki");
   const entries = data?.entries ?? [];
   const { folders, files } = childrenOf(entries, "");
@@ -247,7 +247,7 @@ export function WikiTree() {
     });
   };
 
-  const refresh = () => void mutate("/wiki");
+  const refresh = () => void revalidateWiki();
 
   // New pages route to NewDocView for the active folder; new folders create
   // inside it. Both fall back to the wiki root when nothing is active.


### PR DESCRIPTION
Two reactivity gaps left after #391 (which is merged). Both are cases where a write didn't invalidate the right SWR caches, so the UI showed stale state until a full page reload.

## 1. "Not found" after inline rename in the open page

FileViewer's edit→rename→**Done** committed the `/wiki/move` then pushed the *path* URL, but never revalidated the open doc's `/wiki/id/<id>` resolve. That resolve is `revalidateOnFocus:false` and still cached the pre-rename path, so once the path URL round-tripped back to the durable id URL the viewer loaded the old (now-missing) path and showed a red **"not found"** until a manual refresh dropped the cache.

Fix: revalidate every wiki cache after the move, then route to the renamed doc's id URL. Matches the Explorer / sidebar-menu refresh, which already go through `revalidateWiki`.

## 2. Directory sidebar doesn't show a newly-created page/folder

`NewDocView.onCreate` committed the new file then navigated straight to it with no cache invalidation, so the persistent Directory sidebar kept its stale `/wiki` listing — the new page didn't appear until a full reload.

Fix: `revalidateWiki()` after the create. Also routed `WikiTree`'s own create refresh through `revalidateWiki` (was a bare `mutate("/wiki")`) so the sidebar, recents, and id resolves all refresh in one place.

Frontend-only. Typecheck clean; verified locally (create / rename now reflect immediately, no manual refresh).