### PR TITLE
fix(wiki): don't leak deleted private page metadata via id resolve

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -209,13 +209,23 @@ def resolve_doc_id(
         # -public). Gate on that trash location like the rest of the Trash
         # surface (`/deleted`, `/trash`) so a formerly-private page's path,
         # kind, and deletion time don't leak to a user who never had access.
-        # Resolve against the path's *own* trash location (not the entry root)
+        # Authorize against the path's own trash location (not the entry root)
         # so a page nested under a trashed folder inherits the folder's grants.
-        # A purged entry (its `.trash/` tree gone) can't be authorized, so it
-        # reads as unknown — matching the "purged → unavailable" tombstone.
-        entry = wiki_trash.entry_containing_path(path)
-        loc = wiki_trash.trash_location(entry.trash_id, path) if entry else None
-        if loc is None or "read" not in acl.effective(user.id, user.is_admin, loc):
+        # A path can map to several trash entries (deleted, recreated, folder
+        # deleted) and the tombstone doesn't say which is ours, so require read
+        # on *every* matching entry: an unauthorized user is always blocked by
+        # the truly-private one, and we never authorize against an unrelated
+        # page's ACL. No entries (its `.trash/` tree was purged) → unknown,
+        # matching the "purged → unavailable" tombstone.
+        entries = wiki_trash.entries_containing_path(path)
+        readable = entries and all(
+            "read"
+            in acl.effective(
+                user.id, user.is_admin, wiki_trash.trash_location(e.trash_id, path)
+            )
+            for e in entries
+        )
+        if not readable:
             raise HTTPException(status_code=404, detail="unknown id")
     else:
         require_can("read", path, user)

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -203,7 +203,22 @@ def resolve_doc_id(
         path = filesystem.safe_rel_path(str(row["path"]))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    require_can("read", path, user)
+    if row["deleted_at"] is not None:
+        # Deleted: the trashing move re-pointed the item's ACL rows to its
+        # `.trash/` location, leaving the original path unmanaged (implicit
+        # -public). Gate on that trash location like the rest of the Trash
+        # surface (`/deleted`, `/trash`) so a formerly-private page's path,
+        # kind, and deletion time don't leak to a user who never had access.
+        # Resolve against the path's *own* trash location (not the entry root)
+        # so a page nested under a trashed folder inherits the folder's grants.
+        # A purged entry (its `.trash/` tree gone) can't be authorized, so it
+        # reads as unknown — matching the "purged → unavailable" tombstone.
+        entry = wiki_trash.entry_containing_path(path)
+        loc = wiki_trash.trash_location(entry.trash_id, path) if entry else None
+        if loc is None or "read" not in acl.effective(user.id, user.is_admin, loc):
+            raise HTTPException(status_code=404, detail="unknown id")
+    else:
+        require_can("read", path, user)
     return ResolveDocIdResponse(
         id=doc_id, path=path, kind=PageKind.of(path), deleted_at=row["deleted_at"]
     )

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -117,23 +117,24 @@ def entry_for_original_path(path: str) -> TrashEntry | None:
     return next((e for e in list_entries() if e.original_path == path), None)
 
 
-def entry_containing_path(path: str) -> TrashEntry | None:
-    """The newest trash entry whose trashed subtree contains ``path`` — either
-    ``path`` itself (a directly-trashed page/folder) or a page nested under a
-    trashed folder (``path`` = ``proj/a.md``, entry root = ``proj``).
+def entries_containing_path(path: str) -> list[TrashEntry]:
+    """Every trash entry whose trashed subtree contains ``path`` — ``path``
+    itself (a directly-trashed page/folder) or a page nested under a trashed
+    folder (``path`` = ``proj/a.md``, entry root = ``proj``).
 
-    Unlike ``entry_for_original_path`` (exact-root match, for the tombstone
-    panel), this finds the entry that parked ``path``'s ACL at its trash
-    location, so a deleted id's resolve can authorize against it — including a
-    nested page whose own root was never a separate trash entry."""
-    return next(
-        (
-            e
-            for e in list_entries()
-            if path == e.original_path or path.startswith(e.original_path + "/")
-        ),
-        None,
-    )
+    A path can be covered by more than one entry (deleted, recreated, then its
+    enclosing folder deleted), and the ``wiki_doc_ids`` tombstone doesn't record
+    which trash entry it belongs to. Rather than guess — picking the wrong one
+    would authorize a deleted id against an unrelated page's ACL — the caller
+    checks access against *all* of them, so it can fail safe when ambiguous.
+    Each entry parked ``path``'s ACL at its own ``.trash/<id>/<path>`` location
+    (see ``trash_location``); authorize against that, not the entry root, so a
+    nested page inherits its trashed folder's grants."""
+    return [
+        e
+        for e in list_entries()
+        if path == e.original_path or path.startswith(e.original_path + "/")
+    ]
 
 
 def entry_for(trash_id: str) -> TrashEntry | None:

--- a/backend/app/wiki/trash.py
+++ b/backend/app/wiki/trash.py
@@ -117,6 +117,25 @@ def entry_for_original_path(path: str) -> TrashEntry | None:
     return next((e for e in list_entries() if e.original_path == path), None)
 
 
+def entry_containing_path(path: str) -> TrashEntry | None:
+    """The newest trash entry whose trashed subtree contains ``path`` — either
+    ``path`` itself (a directly-trashed page/folder) or a page nested under a
+    trashed folder (``path`` = ``proj/a.md``, entry root = ``proj``).
+
+    Unlike ``entry_for_original_path`` (exact-root match, for the tombstone
+    panel), this finds the entry that parked ``path``'s ACL at its trash
+    location, so a deleted id's resolve can authorize against it — including a
+    nested page whose own root was never a separate trash entry."""
+    return next(
+        (
+            e
+            for e in list_entries()
+            if path == e.original_path or path.startswith(e.original_path + "/")
+        ),
+        None,
+    )
+
+
 def entry_for(trash_id: str) -> TrashEntry | None:
     """The trash entry for ``trash_id``, or ``None`` if unknown/empty."""
     prefix = f"{TRASH_DIR}/{trash_id}/"

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -270,6 +270,30 @@ def test_deleted_tombstone_hidden_from_other_user(tmp_repo):
     assert _client(other).get("/api/wiki/deleted?path=secret.md").status_code == 403
 
 
+def test_deleted_id_resolve_hidden_from_other_user(tmp_repo):
+    # The id-URL resolve endpoint must not leak a deleted private page. Deleting
+    # re-points the page's ACL to its trash location, leaving the original path
+    # unmanaged (implicit-public) — so resolve must gate on the trash location,
+    # not the bare path, or path/kind/deleted_at leak to anyone.
+    owner = seed_user()
+    other = seed_user(uid="u_t2", email="t2@x.com")
+    oc = _client(owner)
+    doc_id = oc.put("/api/wiki/file", json={"path": "secret.md", "body": "# S\n"}).json()[
+        "id"
+    ]
+    for gid in _everyone_ids("secret.md"):
+        acl.revoke(gid)
+    oc.delete("/api/wiki/file?path=secret.md")
+
+    # Owner still resolves the id to its tombstone; another user gets a 404 that
+    # reveals nothing (no path, kind, or deletion time).
+    owner_view = oc.get(f"/api/wiki/id/{doc_id}")
+    assert owner_view.status_code == 200
+    assert owner_view.json()["deleted_at"] is not None
+    assert owner_view.json()["path"] == "secret.md"
+    assert _client(other).get(f"/api/wiki/id/{doc_id}").status_code == 404
+
+
 def test_deleted_endpoint_404_when_path_recreated(tmp_repo):
     # Delete a.md, then recreate a live a.md. The old tombstone still exists in
     # Trash, but the path is live now → /wiki/deleted must report not-deleted

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -294,6 +294,32 @@ def test_deleted_id_resolve_hidden_from_other_user(tmp_repo):
     assert _client(other).get(f"/api/wiki/id/{doc_id}").status_code == 404
 
 
+def test_deleted_id_resolve_denies_when_ambiguous_tombstones(tmp_repo):
+    # A path can carry several tombstones (delete → recreate → delete the
+    # enclosing folder), and the tombstone doesn't record which trash entry it
+    # belongs to. The old id must stay hidden from a user who lacked access to
+    # *its* delete, even when a newer same-path tombstone is public.
+    owner = seed_user()
+    other = seed_user(uid="u_amb", email="amb@x.com")
+    oc = _client(owner)
+    # Private page, deleted → tombstone #1 (private).
+    old_id = oc.put(
+        "/api/wiki/file", json={"path": "proj/secret.md", "body": "# S\n"}
+    ).json()["id"]
+    for gid in _everyone_ids("proj/secret.md"):
+        acl.revoke(gid)
+    oc.delete("/api/wiki/file?path=proj/secret.md")
+    # Recreate at the same path (public), then trash the whole folder → a second,
+    # public tombstone whose subtree also covers proj/secret.md.
+    oc.put("/api/wiki/file", json={"path": "proj/secret.md", "body": "# new\n"})
+    oc.delete("/api/wiki/file?path=proj")
+
+    # The other user is blocked by the private entry even though the folder
+    # tombstone covering the same path is public; the owner still resolves it.
+    assert _client(other).get(f"/api/wiki/id/{old_id}").status_code == 404
+    assert oc.get(f"/api/wiki/id/{old_id}").status_code == 200
+
+
 def test_deleted_endpoint_404_when_path_recreated(tmp_repo):
     # Delete a.md, then recreate a live a.md. The old tombstone still exists in
     # Trash, but the path is live now → /wiki/deleted must report not-deleted


### PR DESCRIPTION
Found during release QA of the "Unique id for each path" checklist (item 11: *private page id url must not leak content or who/when*).

## The leak

`GET /api/wiki/id/{doc_id}` on a **trashed** page/folder returned `200 {path, kind, deleted_at}` to *any* authenticated user — including one who never had read access.

Probe against a formerly-private page:
```
LIVE resolve by unauthorized:      403   (correct)
TOMBSTONE resolve by unauthorized: 200 {path: "secret.md", kind: "page", deleted_at: ...}   ← leak
DELETED endpoint by unauthorized:  403   (correct)
```

**Root cause:** deleting is a `git mv` into `.trash/`; the trashing move re-points the item's ACL/owner rows to the trash location, so the *original* path becomes unmanaged → implicit-public → `require_can("read", path)` passes for everyone.

**Leaked:** the id's existence, original path/filename + location, kind, deletion timestamp. **Not leaked:** content, who deleted it, the full tombstone (`/deleted` and `/trash/{id}` already gate on the trash location).

## Fix

When the resolved row is deleted, authorize against the path's own `.trash/` location — mirroring the rest of the Trash surface — instead of the unmanaged original path:

- New `trash.entry_containing_path(path)` finds the trash entry whose subtree contains the path (the path itself, or a page nested under a trashed folder).
- Authorize against `trash_location(entry.trash_id, path)` so a nested page inherits the folder's re-pointed grants (fixes the folder-delete tombstone case).
- A purged entry can't be authorized → reads as unknown (404), matching the existing "purged → unavailable" tombstone behavior.

Unauthorized users now get a 404 that reveals nothing; the owner still resolves the tombstone.

## Tests

New `test_deleted_id_resolve_hidden_from_other_user`. Full `test_trash.py` + `test_doc_ids.py` + `test_trash_purge.py` = 39 passed; ruff + basedpyright clean.

Backend-only, off `main`.