### PR TITLE
fix(wiki-fe): emit id URLs from search, recents, starred, home, breadcrumbs

### DIFF
--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -25,7 +25,9 @@ export function WikiHeader() {
   // Ancestor + self segment paths, resolved to ids so each crumb links to the
   // stable `/app/wiki/<id>` URL. Folder segments (no id) and paths that haven't
   // resolved yet fall back to a path URL, which the route canonicalizes.
-  const segmentPaths = segments.map((_, i) => segments.slice(0, i + 1).join("/"));
+  const segmentPaths = segments.map((_, i) =>
+    segments.slice(0, i + 1).join("/"),
+  );
   const { data: crumbIds } = useSWR(
     segmentPaths.length ? ["wiki-crumb-ids", segmentPaths.join("\n")] : null,
     () => resolveIds(segmentPaths),

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import useSWR from "swr";
 import { Button } from "@onyx-ai/opal/components";
 import { SvgFolder } from "@onyx-ai/opal/icons";
 import { NotificationBell } from "@/components/common/NotificationBell";
@@ -8,6 +9,7 @@ import { CraftNotifier } from "@/components/wiki/CraftNotifier";
 import { useAppFocus } from "@/hooks/useAppFocus";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 import { useHeaderActionsHost } from "@/providers/WikiHeaderActionsProvider";
+import { resolveIds, wikiHref } from "@/lib/wikiHref";
 
 function segmentLabel(segment: string): string {
   return segment.replace(/\.md$/, "").replace(/_/g, " ");
@@ -20,12 +22,24 @@ export function WikiHeader() {
   const host = useHeaderActionsHost();
 
   const segments = wikiPath ? wikiPath.split("/") : [];
+  // Ancestor + self segment paths, resolved to ids so each crumb links to the
+  // stable `/app/wiki/<id>` URL. Folder segments (no id) and paths that haven't
+  // resolved yet fall back to a path URL, which the route canonicalizes.
+  const segmentPaths = segments.map((_, i) => segments.slice(0, i + 1).join("/"));
+  const { data: crumbIds } = useSWR(
+    segmentPaths.length ? ["wiki-crumb-ids", segmentPaths.join("\n")] : null,
+    () => resolveIds(segmentPaths),
+  );
   const crumbs: Array<{ label: string; href: string }> = [
     { label: "Wiki", href: "/app/wiki" },
   ];
   segments.forEach((seg, i) => {
-    const path = segments.slice(0, i + 1).join("/");
-    crumbs.push({ label: segmentLabel(seg), href: `/app/wiki/${path}` });
+    const path = segmentPaths[i];
+    const id = crumbIds?.[path];
+    crumbs.push({
+      label: segmentLabel(seg),
+      href: id ? wikiHref(id) : `/app/wiki/${path}`,
+    });
   });
 
   return (

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -28,6 +28,7 @@ import { relativeTime } from "@/lib/time";
 import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
 import { AI_DRAFT_KEY, generateDraft, type RecentPage } from "@/lib/wiki";
+import { wikiHref, wikiPath } from "@/lib/wikiHref";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import styles from "@/components/wiki/WikiHome.module.css";
 
@@ -192,7 +193,9 @@ export function WikiHome() {
               <div key={p.path} className={styles.recentCell}>
                 <RecentCard
                   page={p}
-                  onClick={() => router.push(`/app/wiki/${p.path}`)}
+                  onClick={() =>
+                    router.push(p.id ? wikiHref(p.id) : wikiPath(p.path))
+                  }
                 />
               </div>
             ))}

--- a/frontend/src/components/wiki/WikiSearch.tsx
+++ b/frontend/src/components/wiki/WikiSearch.tsx
@@ -17,6 +17,7 @@ import {
 import { createPortal } from "react-dom";
 
 import { apiFetch, ApiError } from "@/lib/api";
+import { wikiHref, wikiPath } from "@/lib/wikiHref";
 
 // Imperative handle so the sidebar can focus the search input after
 // expanding from a collapsed state (the input only mounts when the
@@ -189,9 +190,11 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
           router.push(
             `/app/wiki/${row.hit.doc_path}?comment=${row.hit.thread_root_id}`,
           );
+        } else if (row.kind === "folder") {
+          // no id in payload — folder hits stay path-based.
+          router.push(wikiPath(row.folder.path));
         } else {
-          const path = row.kind === "folder" ? row.folder.path : row.hit.path;
-          router.push(`/app/wiki/${path}`);
+          router.push(wikiHref(row.hit.doc_id));
         }
         onNavigate?.();
       },

--- a/frontend/src/lib/recents.ts
+++ b/frontend/src/lib/recents.ts
@@ -11,6 +11,7 @@ export const RECENTS_KEY = "/wiki/recents";
 
 export interface RecentDocsResponse {
   paths: string[];
+  items?: { path: string; id: string | null }[];
 }
 
 /** Record that the user opened a wiki doc, then refresh any mounted

--- a/frontend/src/lib/starred.ts
+++ b/frontend/src/lib/starred.ts
@@ -12,6 +12,7 @@ export const STARRED_KEY = "/wiki/starred";
 
 export interface StarredDocsResponse {
   paths: string[];
+  items?: { path: string; id: string | null }[];
 }
 
 export async function starDoc(path: string): Promise<void> {

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -17,6 +17,7 @@ export interface RecentPage {
   title: string;
   updated_at: string;
   preview: string;
+  id?: string | null;
 }
 
 export interface WordDiff {

--- a/frontend/src/lib/wikiHref.ts
+++ b/frontend/src/lib/wikiHref.ts
@@ -20,7 +20,10 @@ export function revalidateWiki(): Promise<unknown> {
     const k = Array.isArray(key) ? key[0] : key;
     return (
       typeof k === "string" &&
-      (k.startsWith("/wiki") || k === "id-fallback" || k === "wiki-path-id")
+      (k.startsWith("/wiki") ||
+        k === "id-fallback" ||
+        k === "wiki-path-id" ||
+        k === "wiki-crumb-ids")
     );
   });
 }

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -22,6 +22,7 @@ import { apiFetch } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { RECENTS_KEY, type RecentDocsResponse } from "@/lib/recents";
 import { STARRED_KEY, starDoc, type StarredDocsResponse } from "@/lib/starred";
+import { wikiHref } from "@/lib/wikiHref";
 import { docLabel } from "@/sections/sidebar/docLabel";
 import StarredList from "@/sections/sidebar/StarredList";
 import UserMenu from "@/sections/sidebar/UserMenu";
@@ -31,22 +32,32 @@ import { useAppFocus } from "@/hooks/useAppFocus";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 import { isNewActivity, useEvents } from "@/lib/activities";
 
-function useRecentPages() {
+type DocRef = { path: string; id: string | null };
+
+/** path→id map from a `{paths, items}` response — items is additive, so fall
+ * back to no ids when it's absent (links then use a path URL). */
+function idMap(items: DocRef[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const it of items ?? []) if (it.id) out[it.path] = it.id;
+  return out;
+}
+
+function useRecentPages(): DocRef[] {
   const { data } = useSWR(
     RECENTS_KEY,
     (key: string) => apiFetch<RecentDocsResponse>(key),
     { revalidateOnFocus: false },
   );
-  return data?.paths ?? [];
+  return data?.items ?? (data?.paths ?? []).map((path) => ({ path, id: null }));
 }
 
-function useStarredPages() {
+function useStarredPages(): { paths: string[]; ids: Record<string, string> } {
   const { data } = useSWR(
     STARRED_KEY,
     (key: string) => apiFetch<StarredDocsResponse>(key),
     { revalidateOnFocus: false },
   );
-  return data?.paths ?? [];
+  return { paths: data?.paths ?? [], ids: idMap(data?.items) };
 }
 
 export default function AppSidebar() {
@@ -59,10 +70,10 @@ export default function AppSidebar() {
     { refreshInterval: 30_000 },
   );
   const hasNewActivities = activityEvents.some((ev) => isNewActivity(ev.ts));
-  const starred = useStarredPages();
+  const { paths: starred, ids: starredIds } = useStarredPages();
   const starredSet = new Set(starred);
   const recents = useRecentPages();
-  const pages = recents.filter((p) => !starredSet.has(p));
+  const pages = recents.filter((p) => !starredSet.has(p.path));
   const searchRef = useRef<WikiSearchHandle>(null);
   const { folded, setFolded } = useSidebarState();
 
@@ -107,7 +118,11 @@ export default function AppSidebar() {
       <SidebarLayouts.Body scrollKey="app-sidebar">
         {starred.length > 0 && (
           <SidebarLayouts.Section title="Starred">
-            <StarredList paths={starred} onNavigate={closeMobile} />
+            <StarredList
+              paths={starred}
+              ids={starredIds}
+              onNavigate={closeMobile}
+            />
           </SidebarLayouts.Section>
         )}
 
@@ -119,8 +134,8 @@ export default function AppSidebar() {
               </Text>
             </div>
           )}
-          {pages.map((path) => {
-            const href = `/app/wiki/${path}`;
+          {pages.map(({ path, id }) => {
+            const href = id ? wikiHref(id) : `/app/wiki/${path}`;
             return (
               <div key={path} className="group/recent">
                 <SidebarTab

--- a/frontend/src/sections/sidebar/StarredList.tsx
+++ b/frontend/src/sections/sidebar/StarredList.tsx
@@ -22,16 +22,18 @@ import { CSS } from "@dnd-kit/utilities";
 import { Button, SidebarTab } from "@onyx-ai/opal/components";
 import { SvgDocFile, SvgStarOff } from "@onyx-ai/opal/icons";
 import { reorderStarred, unstarDoc } from "@/lib/starred";
+import { wikiHref } from "@/lib/wikiHref";
 import { docLabel } from "@/sections/sidebar/docLabel";
 import { useAppFocus } from "@/hooks/useAppFocus";
 
 interface StarredRowProps {
   path: string;
+  id: string | null;
   selected: boolean;
   onNavigate: () => void;
 }
 
-function StarredRow({ path, selected, onNavigate }: StarredRowProps) {
+function StarredRow({ path, id, selected, onNavigate }: StarredRowProps) {
   const {
     attributes,
     listeners,
@@ -50,7 +52,7 @@ function StarredRow({ path, selected, onNavigate }: StarredRowProps) {
       {...listeners}
     >
       <SidebarTab
-        href={`/app/wiki/${path}`}
+        href={id ? wikiHref(id) : `/app/wiki/${path}`}
         selected={selected}
         icon={SvgDocFile}
         nested
@@ -79,12 +81,18 @@ function StarredRow({ path, selected, onNavigate }: StarredRowProps) {
 
 interface StarredListProps {
   paths: string[];
+  // path→id for id-based hrefs; drag-reorder still keys on `paths`.
+  ids: Record<string, string>;
   onNavigate: () => void;
 }
 
 /** The draggable "Starred" rows. Reordering is optimistic — the SWR
  * cache is updated immediately and rolled back if the PUT fails. */
-export default function StarredList({ paths, onNavigate }: StarredListProps) {
+export default function StarredList({
+  paths,
+  ids,
+  onNavigate,
+}: StarredListProps) {
   const focus = useAppFocus();
   // Require a little movement before a drag starts so plain clicks
   // still navigate to the doc.
@@ -114,6 +122,7 @@ export default function StarredList({ paths, onNavigate }: StarredListProps) {
             <StarredRow
               key={path}
               path={path}
+              id={ids[path] ?? null}
               selected={focus.matchesWikiPath(path)}
               onNavigate={onNavigate}
             />


### PR DESCRIPTION
Closes the PARTIAL from release QA item 12 (*id urls emitted everywhere*).

## Before
Search results, sidebar Recents/Starred, the home recent-pages grid, and breadcrumbs all navigated via raw `/app/wiki/<path>` and leaned on the route's path→id redirect to canonicalize the address bar. Links worked, but didn't literally emit the durable id URL — and the backend was already returning the ids on every one of these payloads, just being dropped by the frontend.

## After — each surface links by id, with a path fallback
| Surface | Source of id |
|---|---|
| Search doc hits | `SearchHit.doc_id` |
| Home recent-pages grid | `RecentPageView.id` |
| Sidebar Recents | `/wiki/recents` `items: [{path,id}]` |
| Sidebar Starred | `/wiki/starred` `items` (drag-reorder still keys on `paths`) |
| Breadcrumbs | one bulk `resolveIds()` over ancestor + self segment paths |

Left path-based (no id in payload, by design): search **folder** hits and **comment** hits. Every surface falls back to a path URL when the id is absent or still resolving, so navigation never breaks.

Frontend-only; backend already emits the ids. `bun run typecheck` clean.