### PR TITLE
fix(wiki): reject moving a folder into its own descendant with 400

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -474,6 +474,14 @@ def move_document_or_folder(
         raise HTTPException(status_code=400, detail=str(e)) from e
     if old_rel == new_rel:
         raise HTTPException(status_code=400, detail="old_path and new_path are identical")
+    # A folder can't move inside itself — git refuses `mv proj proj/sub` and
+    # would surface as a bare 500. The UI already blocks this; guard the API/MCP
+    # path too. (Unreachable for a page target — a valid path can't nest under a
+    # `.md` file — but the string check is harmless there.)
+    if new_rel.startswith(old_rel + "/"):
+        raise HTTPException(
+            status_code=400, detail="cannot move a folder into itself"
+        )
     old_abs = filesystem.absolute(old_rel)
     new_abs = filesystem.absolute(new_rel)
     if not old_abs.exists():

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -474,18 +474,19 @@ def move_document_or_folder(
         raise HTTPException(status_code=400, detail=str(e)) from e
     if old_rel == new_rel:
         raise HTTPException(status_code=400, detail="old_path and new_path are identical")
-    # A folder can't move inside itself — git refuses `mv proj proj/sub` and
-    # would surface as a bare 500. The UI already blocks this; guard the API/MCP
-    # path too. (Unreachable for a page target — a valid path can't nest under a
-    # `.md` file — but the string check is harmless there.)
-    if new_rel.startswith(old_rel + "/"):
-        raise HTTPException(
-            status_code=400, detail="cannot move a folder into itself"
-        )
     old_abs = filesystem.absolute(old_rel)
     new_abs = filesystem.absolute(new_rel)
     if not old_abs.exists():
         raise HTTPException(status_code=404, detail="not found")
+    # A folder can't move inside itself — git refuses `mv proj proj/sub` and
+    # would surface as a bare 500. The UI already blocks this; guard the API/MCP
+    # path too. After the existence check so a missing source still 404s.
+    # (Unreachable for a page target — a valid path can't nest under a `.md`
+    # file — but the string check is harmless there.)
+    if new_rel.startswith(old_rel + "/"):
+        raise HTTPException(
+            status_code=400, detail="cannot move a folder into itself"
+        )
     if new_abs.exists():
         raise HTTPException(
             status_code=409,

--- a/backend/app/llm/agents/tools/move_path.py
+++ b/backend/app/llm/agents/tools/move_path.py
@@ -34,6 +34,9 @@ def handle(args: dict[str, Any]) -> Any:
             raise ToolError("paths must be non-empty")
         if old_rel == new_rel:
             raise ToolError("old_path and new_path are identical")
+        # A folder can't move inside itself — `git mv proj proj/sub` fails.
+        if new_rel.startswith(old_rel + "/"):
+            raise ToolError("cannot move a folder into itself")
 
         old_abs = filesystem.absolute(old_rel)
         new_abs = filesystem.absolute(new_rel)

--- a/backend/app/llm/agents/tools/move_path.py
+++ b/backend/app/llm/agents/tools/move_path.py
@@ -34,14 +34,15 @@ def handle(args: dict[str, Any]) -> Any:
             raise ToolError("paths must be non-empty")
         if old_rel == new_rel:
             raise ToolError("old_path and new_path are identical")
-        # A folder can't move inside itself — `git mv proj proj/sub` fails.
-        if new_rel.startswith(old_rel + "/"):
-            raise ToolError("cannot move a folder into itself")
 
         old_abs = filesystem.absolute(old_rel)
         new_abs = filesystem.absolute(new_rel)
         if not old_abs.exists():
             raise ToolError(f"old_path not found: {old_rel}")
+        # A folder can't move inside itself — `git mv proj proj/sub` fails.
+        # After the existence check so a missing source still reports not-found.
+        if new_rel.startswith(old_rel + "/"):
+            raise ToolError("cannot move a folder into itself")
         if new_abs.exists():
             raise ToolError(f"new_path already exists: {new_rel}")
         blocking = coedit.blocking_active_session_path(new_rel)

--- a/backend/tests/test_dir_tools.py
+++ b/backend/tests/test_dir_tools.py
@@ -179,6 +179,17 @@ def test_move_path_rejects_dir_to_md(repo):
     assert ".md" in out["error"]
 
 
+def test_move_path_rejects_move_into_own_subtree(repo):
+    # `auth` is a seeded folder; moving it under itself would make git fatal.
+    from app.llm.agents.tools.move_path import handle
+
+    out = handle(
+        {"old_path": "auth", "new_path": "auth/nested", "commit_message": "x"}
+    )
+    assert "error" in out
+    assert "into itself" in out["error"]
+
+
 def test_move_path_rejects_traversal(repo):
     from app.llm.agents.tools.move_path import handle
 

--- a/backend/tests/test_dir_tools.py
+++ b/backend/tests/test_dir_tools.py
@@ -189,6 +189,13 @@ def test_move_path_rejects_move_into_own_subtree(repo):
     assert "error" in out
     assert "into itself" in out["error"]
 
+    # A missing source reports not-found, not "into itself" — the self-nesting
+    # guard runs after the existence check.
+    ghost = handle(
+        {"old_path": "ghost", "new_path": "ghost/sub", "commit_message": "x"}
+    )
+    assert "not found" in ghost["error"]
+
 
 def test_move_path_rejects_traversal(repo):
     from app.llm.agents.tools.move_path import handle

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -108,6 +108,13 @@ def test_move_folder_into_own_descendant_is_400(tmp_repo):
     assert resp.status_code == 400
     assert "into itself" in resp.json()["error"]
 
+    # A missing source still reports 404 — the self-nesting guard defers to the
+    # existence check rather than shadowing it with a 400.
+    ghost = client.post(
+        "/api/wiki/move", json={"old_path": "ghost", "new_path": "ghost/sub"}
+    )
+    assert ghost.status_code == 404
+
 
 def test_ids_follow_folder_move(tmp_repo):
     user = seed_user()

--- a/backend/tests/test_doc_ids.py
+++ b/backend/tests/test_doc_ids.py
@@ -95,6 +95,20 @@ def test_page_move_between_existing_folders_keeps_folder_ids(tmp_repo):
     assert doc_ids.id_for_path("dest") == dest_id
 
 
+def test_move_folder_into_own_descendant_is_400(tmp_repo):
+    # Moving a folder inside itself makes `git mv` fatal; the endpoint must
+    # reject it with a clean 400, not surface the git failure as a 500.
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "proj/a.md", "body": "# A\n"})
+
+    resp = client.post(
+        "/api/wiki/move", json={"old_path": "proj", "new_path": "proj/sub"}
+    )
+    assert resp.status_code == 400
+    assert "into itself" in resp.json()["error"]
+
+
 def test_ids_follow_folder_move(tmp_repo):
     user = seed_user()
     client = _client(user)


### PR DESCRIPTION
Found in the release-QA sweep of the moved/deleted-page feature set.

## Problem
Moving a folder into its own descendant (`proj` → `proj/sub`) made `git mv` fatal, surfacing as a bare **500 `git move failed`**:
```
POST /api/wiki/move {old:"proj", new:"proj/sub"}  →  500 {'error': 'git move failed'}
```
The Move modal already blocks this (`canSelect` excludes the folder itself and its descendants), so it was only reachable via the **HTTP API** or the **`move_path` MCP tool**. No data was ever at risk — git refuses the move, so nothing commits — but the status code was wrong.

## Fix
Reject `new_rel.startswith(old_rel + "/")` with a clean **400** (HTTP route) / **ToolError** (MCP tool), alongside the existing identical / already-exists / not-found checks. Both entry points now fail gracefully.

## Tests
- `test_move_folder_into_own_descendant_is_400` (route, TestClient)
- `test_move_path_rejects_move_into_own_subtree` (MCP tool)

33 tests pass across `test_dir_tools.py` + `test_doc_ids.py`; ruff + basedpyright clean. Backend-only, off `main`.