### PR TITLE
feat(ingest): two-tower relevance filter interface (Scorer boundary)

### DIFF
--- a/backend/app/ingest/relevance/__init__.py
+++ b/backend/app/ingest/relevance/__init__.py
@@ -1,12 +1,15 @@
 """Relevance filtering for document ingestion.
 
-Public interface: the :class:`RelevanceFilter` contract, plus the concrete
-:class:`CosineSimilarityFilter` (the cold-start model). Filters operate on the
-pipeline carriers :class:`app.ingest.types.IngestionDocument` and
+Public interface: the :class:`RelevanceFilter` contract and the concrete
+filters — :class:`CosineSimilarityFilter` (the cold-start model) and
+:class:`TwoTowerFilter` (the warm, per-deployment model, which scores through a
+pluggable :class:`Scorer`). Filters operate on the pipeline carriers
+:class:`app.ingest.types.IngestionDocument` and
 :class:`app.ingest.types.CandidatePage`, whose embeddings are filled by
 ``app.ingest.enrich``.
 """
 from app.ingest.relevance.cosine_filter import CosineSimilarityFilter
 from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.relevance.two_tower_filter import Scorer, TwoTowerFilter
 
-__all__ = ["CosineSimilarityFilter", "RelevanceFilter"]
+__all__ = ["CosineSimilarityFilter", "RelevanceFilter", "Scorer", "TwoTowerFilter"]

--- a/backend/app/ingest/relevance/two_tower_filter.py
+++ b/backend/app/ingest/relevance/two_tower_filter.py
@@ -1,0 +1,101 @@
+"""Two-tower relevance filter — the warm, per-deployment model.
+
+Unlike the cosine filter (parameter-free, cold-start), this scores each
+(document, page) pair with a trained two-tower network that outputs
+P(relevant), then thresholds it. The network is **not** run here: scoring is
+delegated to a :class:`Scorer`, so the filter is agnostic to *how* and *where*
+the model executes — a remote model-server call, an in-process runtime, etc.
+
+A deployment plugs in a Scorer only after training a model on its own data;
+until then it runs the cosine filter. Trained weights are per-deployment and
+are never shipped to other deployments.
+
+Fail-open throughout: a missing embedding, a scorer error, or a malformed score
+list keeps the affected candidates, so the filter only ever *saves* reconcile
+cost and never *costs* recall on an infra miss.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import Protocol
+
+from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.types import CandidatePage, IngestionDocument
+
+log = logging.getLogger(__name__)
+
+
+class Scorer(Protocol):
+    """Turns embedding pairs into relevance probabilities — the execution
+    boundary for the two-tower model.
+
+    Implementations run the trained network however they choose (a remote
+    model server, an in-process runtime, ...). :class:`TwoTowerFilter` depends
+    only on this one call, so the serving strategy can change without touching
+    the filter.
+    """
+
+    def score_batch(
+        self, doc_vec: Sequence[float], page_vecs: list[Sequence[float]]
+    ) -> list[float]:
+        """P(relevant) for each ``(doc_vec, page_vec)`` pair — one score per
+        entry in ``page_vecs``, in the same order."""
+        ...
+
+
+class TwoTowerFilter(RelevanceFilter):
+    """Relevant when the trained two-tower's P(relevant) >= ``threshold``.
+
+    Owns only batching, thresholding, and the fail-open policy; the forward
+    pass lives behind :class:`Scorer`. ``threshold`` is a probability in [0, 1]
+    and is deployment-specific (calibrated per trained model), so there is no
+    default — a caller must choose one.
+    """
+
+    def __init__(self, scorer: Scorer, threshold: float) -> None:
+        self._scorer = scorer
+        self._threshold = threshold
+
+    @property
+    def threshold(self) -> float:
+        return self._threshold
+
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        return bool(self.keep_relevant(doc, [page]))
+
+    def keep_relevant(
+        self, doc: IngestionDocument, pages: list[CandidatePage]
+    ) -> list[CandidatePage]:
+        if not pages:
+            return []
+        doc_vec = doc.embedding
+        if doc_vec is None:
+            return list(pages)  # no document vector to score against → keep all
+
+        # Score only the pages that have an embedding; the rest are kept as-is.
+        idx: list[int] = []
+        page_vecs: list[Sequence[float]] = []
+        for i, page in enumerate(pages):
+            vec = page.embedding
+            if vec is not None:
+                idx.append(i)
+                page_vecs.append(vec)
+        if not page_vecs:
+            return list(pages)  # nothing embedded to score → keep all
+
+        try:
+            probs = self._scorer.score_batch(doc_vec, page_vecs)
+            if len(probs) != len(page_vecs):
+                raise ValueError(
+                    f"scorer returned {len(probs)} scores for {len(page_vecs)} pairs"
+                )
+        except Exception:
+            log.warning(
+                "two-tower scoring failed or returned malformed scores; keeping all candidates",
+                exc_info=True,
+            )
+            return list(pages)
+
+        keep = {idx[k] for k, prob in enumerate(probs) if prob >= self._threshold}
+        return [page for i, page in enumerate(pages) if page.embedding is None or i in keep]

--- a/backend/tests/test_two_tower_filter.py
+++ b/backend/tests/test_two_tower_filter.py
@@ -1,0 +1,96 @@
+"""Tests for the two-tower relevance filter.
+
+No model here — a stub Scorer returns preset probabilities so we can assert the
+filter's thresholding and fail-open policy in isolation. The concrete scorer
+(which runs the trained network) is a later phase.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from app.ingest.relevance import TwoTowerFilter
+from app.ingest.types import CandidatePage, IngestionDocument
+
+
+class _StubScorer:
+    """Returns a preset list of probabilities regardless of inputs."""
+
+    def __init__(self, probs: list[float]) -> None:
+        self._probs = probs
+        self.calls = 0
+
+    def score_batch(
+        self, doc_vec: Sequence[float], page_vecs: list[Sequence[float]]
+    ) -> list[float]:
+        self.calls += 1
+        return list(self._probs)
+
+
+class _RaisingScorer:
+    def score_batch(
+        self, doc_vec: Sequence[float], page_vecs: list[Sequence[float]]
+    ) -> list[float]:
+        raise RuntimeError("boom")
+
+
+_DOC = IngestionDocument(content="doc", embedding=[1.0, 0.0])
+
+
+def _page(path: str, emb: list[float] | None) -> CandidatePage:
+    return CandidatePage(path=path, body="b", embedding=emb)
+
+
+def test_keeps_pairs_at_or_above_threshold():
+    f = TwoTowerFilter(_StubScorer([0.9, 0.2]), threshold=0.5)
+    pages = [_page("a.md", [0.1, 0.2]), _page("b.md", [0.3, 0.4])]
+    assert [p.path for p in f.keep_relevant(_DOC, pages)] == ["a.md"]
+
+
+def test_threshold_boundary_is_inclusive():
+    f = TwoTowerFilter(_StubScorer([0.5]), threshold=0.5)
+    assert [p.path for p in f.keep_relevant(_DOC, [_page("a.md", [0.1])])] == ["a.md"]
+
+
+def test_empty_pages_returns_empty():
+    f = TwoTowerFilter(_StubScorer([]), threshold=0.5)
+    assert f.keep_relevant(_DOC, []) == []
+
+
+def test_fail_open_on_scorer_error():
+    pages = [_page("a.md", [0.1]), _page("b.md", [0.2])]
+    kept = TwoTowerFilter(_RaisingScorer(), threshold=0.99).keep_relevant(_DOC, pages)
+    assert kept == pages
+
+
+def test_fail_open_when_doc_embedding_missing():
+    scorer = _StubScorer([0.0])  # would drop everything if consulted
+    doc = IngestionDocument(content="doc", embedding=None)
+    pages = [_page("a.md", [0.1])]
+    kept = TwoTowerFilter(scorer, threshold=0.99).keep_relevant(doc, pages)
+    assert kept == pages
+    assert scorer.calls == 0  # never scored — no doc vector
+
+
+def test_fail_open_on_score_count_mismatch():
+    # scorer returns 1 prob for 2 scorable pages → malformed → keep all
+    pages = [_page("a.md", [0.1]), _page("b.md", [0.2])]
+    kept = TwoTowerFilter(_StubScorer([0.9]), threshold=0.5).keep_relevant(_DOC, pages)
+    assert kept == pages
+
+
+def test_pages_without_embedding_are_kept_and_not_scored():
+    scorer = _StubScorer([0.1])  # the one embedded page scores below threshold
+    no_emb = _page("keep.md", None)
+    low = _page("drop.md", [0.3, 0.4])
+    kept = TwoTowerFilter(scorer, threshold=0.5).keep_relevant(_DOC, [no_emb, low])
+    # unembedded page kept (fail-open); embedded-but-low page dropped
+    assert [p.path for p in kept] == ["keep.md"]
+
+
+def test_is_relevant_single_pair():
+    assert TwoTowerFilter(_StubScorer([0.8]), threshold=0.5).is_relevant(
+        _DOC, _page("a.md", [0.1])
+    ) is True
+    assert TwoTowerFilter(_StubScorer([0.3]), threshold=0.5).is_relevant(
+        _DOC, _page("a.md", [0.1])
+    ) is False


### PR DESCRIPTION
## What

**Phase A** of the warm relevance model: the `TwoTowerFilter` and the **execution boundary** above it — with *no model attached yet*. Builds on the `RelevanceFilter` interface (#380) and sits alongside `CosineSimilarityFilter` (#383).

**Interface only** — no torch, no ONNX, no service, no weights, no pipeline wiring. Ships **default-off** (nothing constructs it yet).

## Shape

```python
class Scorer(Protocol):
    def score_batch(self, doc_vec, page_vecs) -> list[float]: ...   # P(relevant) per pair

class TwoTowerFilter(RelevanceFilter):
    def __init__(self, scorer: Scorer, threshold: float): ...
    # is_relevant / keep_relevant: batch → score → threshold, fail-open
```

`TwoTowerFilter` owns only **batching, thresholding, and fail-open**; the forward pass lives behind the `Scorer` protocol. So the serving strategy (remote model-server pod vs. in-process runtime) is a **later phase** decided without touching the filter — the same way the `RelevanceFilter` interface landed before the concrete cosine model.

## Fail-open policy

The filter only ever *saves* reconcile cost — it must never *cost* recall on an infra miss. So it keeps the affected candidates when:
- the document has no embedding,
- a page has no embedding (kept, not scored),
- the scorer raises, or
- the scorer returns a score count that doesn't match the pairs.

## Design notes

- **`threshold` has no default** — it's a P(relevant) cutoff in [0, 1], per-deployment and calibrated per trained model, so a caller must choose one (unlike cosine's study-derived default).
- **Warm, per-deployment model**: a deployment plugs in a `Scorer` only after training on its own data; until then it runs cosine. Trained weights are per-deployment and never shipped across deployments.

## Not in scope (later phases)

- **Phase B** — the concrete `Scorer`: the serving code (model-server pod *or* in-process ONNX), loading the trained bundle, running the network. This is where the torch/ONNX + model-packaging decisions get made.
- **Phase C** — threshold calibration + deployment wiring (Helm opt-in).
- **Phase D** — wire into the reconcile flow; the per-deployment training pipeline.

## Tests

`backend/tests/test_two_tower_filter.py` (8) — threshold filtering + inclusive boundary, empty input, and every fail-open path (scorer error, missing doc embedding [scorer not consulted], score-count mismatch, unembedded pages kept), plus `is_relevant`. Stub scorer, no model. Ruff + basedpyright clean.