### PR TITLE
feat(trash): permanently delete a trashed item on demand

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -33,6 +33,7 @@ from app.models.file_system import (
     MovedFile,
     MovePathRequest,
     MovePathResponse,
+    PurgeTrashResponse,
     PutDocumentRequest,
     PutDocumentResponse,
     RecentDocsResponse,
@@ -684,6 +685,26 @@ def view_trash_item(
         can_restore="write" in perms,
         body=body,
     )
+
+
+@router.delete("/trash/{trash_id}", response_model=PurgeTrashResponse)
+def purge_trash_item(
+    trash_id: str,
+    user: User = Depends(require_user),
+) -> PurgeTrashResponse:
+    """Permanently remove a trashed item now, ahead of the 30-day auto-purge:
+    `git rm` its `.trash/` subtree + drop the parked ACL/owner/policy rows.
+    Content stays in git history (soft purge). Requires the same permission as
+    restore (write on the trashed item) — if you can bring it back, you can
+    delete it for good. The item's ``wiki_doc_ids`` tombstone is left as-is, so
+    its id URL degrades to the generic "unavailable" card (like auto-purge)."""
+    entry = wiki_trash.entry_for(trash_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="not found")
+    if "write" not in _trash_perms(user, entry):
+        raise HTTPException(status_code=403, detail="not permitted")
+    wiki_trash.purge(trash_id, actor=_git_author(user))
+    return PurgeTrashResponse(trash_id=trash_id, path=entry.original_path)
 
 
 @router.post("/file/restore", response_model=RestorePathResponse)

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -703,7 +703,15 @@ def purge_trash_item(
         raise HTTPException(status_code=404, detail="not found")
     if "write" not in _trash_perms(user, entry):
         raise HTTPException(status_code=403, detail="not permitted")
-    wiki_trash.purge(trash_id, actor=_git_author(user))
+    if not wiki_trash.purge(trash_id, actor=_git_author(user)):
+        # entry_for found it a moment ago, so a False return means the `.trash/`
+        # subtree was gone by the time purge ran — a concurrent purge (e.g. the
+        # daily sweep) beat us. The end state is the same (item is gone), but
+        # the race is unexpected, so surface it.
+        log.warning(
+            "purge_trash_item: %s vanished before purge (concurrent sweep?)",
+            trash_id,
+        )
     return PurgeTrashResponse(trash_id=trash_id, path=entry.original_path)
 
 

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -267,6 +267,11 @@ class RestorePathResponse(BaseModel):
     restored: list[str]  # every file reintroduced
 
 
+class PurgeTrashResponse(BaseModel):
+    trash_id: str
+    path: str  # the original path that was permanently removed
+
+
 class ReindexResponse(BaseModel):
     path: str
     queued: bool

--- a/backend/tests/test_trash.py
+++ b/backend/tests/test_trash.py
@@ -54,6 +54,42 @@ def test_delete_moves_to_trash_and_hides_everywhere(tmp_repo):
     assert items["proj/a.md"]["kind"] == "page"
 
 
+def test_purge_trash_item_removes_it_immediately(tmp_repo):
+    # Permanent delete from Trash, ahead of the 30-day auto-purge.
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "note.md", "body": "# N\n"})
+    tid = client.delete("/api/wiki/file?path=note.md").json()["trash_id"]
+    assert any(
+        i["trash_id"] == tid for i in client.get("/api/wiki/trash").json()["items"]
+    )
+
+    resp = client.delete(f"/api/wiki/trash/{tid}")
+    assert resp.status_code == 200
+    assert resp.json()["path"] == "note.md"
+
+    # Gone from Trash and no longer viewable.
+    assert not any(
+        i["trash_id"] == tid for i in client.get("/api/wiki/trash").json()["items"]
+    )
+    assert client.get(f"/api/wiki/trash/{tid}").status_code == 404
+
+
+def test_purge_trash_item_requires_write(tmp_repo):
+    # Mirrors restore: a user without write on the trashed item can't purge it.
+    owner = seed_user()
+    other = seed_user(uid="u_pp", email="pp@x.com")
+    oc = _client(owner)
+    oc.put("/api/wiki/file", json={"path": "secret.md", "body": "# S\n"})
+    for gid in _everyone_ids("secret.md"):
+        acl.revoke(gid)
+    tid = oc.delete("/api/wiki/file?path=secret.md").json()["trash_id"]
+
+    assert _client(other).delete(f"/api/wiki/trash/{tid}").status_code == 403
+    # Still there for the owner.
+    assert oc.get(f"/api/wiki/trash/{tid}").status_code == 200
+
+
 def test_view_trashed_page_returns_content(tmp_repo):
     user = seed_user()
     client = _client(user)

--- a/frontend/src/lib/trash.ts
+++ b/frontend/src/lib/trash.ts
@@ -44,6 +44,15 @@ export async function restoreTrashed(
   });
 }
 
+/** Permanently remove a trashed item now, ahead of the 30-day auto-purge.
+ * Irreversible from the app (content remains in git history). Requires the
+ * same write access as restore; 403 otherwise. */
+export async function purgeTrashed(trashId: string): Promise<void> {
+  await apiFetch<void>(`/wiki/trash/${encodeURIComponent(trashId)}`, {
+    method: "DELETE",
+  });
+}
+
 /** Tombstone info for a deleted page/folder by its original path — the
  * most-recent Trash entry, for the deleted-URL panel. Rejects (404) when the
  * path isn't in Trash. */

--- a/frontend/src/views/trash/TrashPage.tsx
+++ b/frontend/src/views/trash/TrashPage.tsx
@@ -7,10 +7,16 @@ import { SvgTrash } from "@onyx-ai/opal/icons";
 import { SettingsLayouts } from "@onyx-ai/opal/layouts";
 
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { useConfirm } from "@/components/common/ConfirmDialog";
 import { useRequireAuth } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
 import { formatRelative } from "@/lib/format";
-import { restoreTrashed, useTrash, type TrashEntry } from "@/lib/trash";
+import {
+  purgeTrashed,
+  restoreTrashed,
+  useTrash,
+  type TrashEntry,
+} from "@/lib/trash";
 
 /** Display name for a trashed item: the page name (no `.md`) or folder name. */
 function itemLabel(entry: TrashEntry): string {
@@ -21,25 +27,30 @@ function itemLabel(entry: TrashEntry): string {
 export default function TrashPage() {
   const { user, loading } = useRequireAuth();
   const { items, error: listSwrError, refresh } = useTrash();
-  const [busyId, setBusyId] = useState<string | null>(null);
+  const [busy, setBusy] = useState<{
+    id: string;
+    kind: "restore" | "purge";
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const confirmDialog = useConfirm();
 
   if (loading || !user) return <LoadingSpinner center />;
 
+  // Drop an item from the list once it leaves Trash (restored or purged).
+  const dropFromList = (trashId: string) =>
+    refresh(
+      (cur) => ({
+        items: (cur?.items ?? []).filter((i) => i.trash_id !== trashId),
+      }),
+      { revalidate: true },
+    );
+
   const restore = async (entry: TrashEntry) => {
-    setBusyId(entry.trash_id);
+    setBusy({ id: entry.trash_id, kind: "restore" });
     setError(null);
     try {
       await restoreTrashed(entry.trash_id);
-      // The item is back on the tree — drop it from the list optimistically.
-      await refresh(
-        (cur) => ({
-          items: (cur?.items ?? []).filter(
-            (i) => i.trash_id !== entry.trash_id,
-          ),
-        }),
-        { revalidate: true },
-      );
+      await dropFromList(entry.trash_id);
     } catch (e) {
       setError(
         e instanceof ApiError && e.status === 409
@@ -49,7 +60,28 @@ export default function TrashPage() {
             : "Restore failed.",
       );
     } finally {
-      setBusyId(null);
+      setBusy(null);
+    }
+  };
+
+  const purge = async (entry: TrashEntry) => {
+    if (
+      !(await confirmDialog({
+        title: `Permanently delete "${itemLabel(entry)}"?`,
+        body: "It will be removed from Trash and can no longer be restored.",
+        confirmLabel: "Delete permanently",
+      }))
+    )
+      return;
+    setBusy({ id: entry.trash_id, kind: "purge" });
+    setError(null);
+    try {
+      await purgeTrashed(entry.trash_id);
+      await dropFromList(entry.trash_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed.");
+    } finally {
+      setBusy(null);
     }
   };
 
@@ -60,7 +92,7 @@ export default function TrashPage() {
       <SettingsLayouts.Header
         icon={SvgTrash}
         title="Trash"
-        description="Deleted pages and folders. Restore an item to move it back to its original location."
+        description="Deleted pages and folders. Restore an item to move it back to its original location, or delete it permanently. Items are auto-removed after 30 days."
         divider
       />
       <SettingsLayouts.Body>
@@ -107,14 +139,28 @@ export default function TrashPage() {
                     </Text>
                   </div>
                 </div>
-                <Button
-                  prominence="secondary"
-                  size="sm"
-                  disabled={!entry.can_restore || busyId === entry.trash_id}
-                  onClick={() => void restore(entry)}
-                >
-                  {busyId === entry.trash_id ? "Restoring…" : "Restore"}
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    prominence="secondary"
+                    size="sm"
+                    disabled={!entry.can_restore || busy?.id === entry.trash_id}
+                    onClick={() => void restore(entry)}
+                  >
+                    {busy?.id === entry.trash_id && busy.kind === "restore"
+                      ? "Restoring…"
+                      : "Restore"}
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={!entry.can_restore || busy?.id === entry.trash_id}
+                    onClick={() => void purge(entry)}
+                  >
+                    {busy?.id === entry.trash_id && busy.kind === "purge"
+                      ? "Deleting…"
+                      : "Delete"}
+                  </Button>
+                </div>
               </div>
             </Card>
           ))}


### PR DESCRIPTION
Requested: let users empty items from Trash immediately instead of waiting for the 30-day auto-purge.

## What
`DELETE /api/wiki/trash/{trash_id}` — permanently removes a trashed page/folder now. Reuses the existing `trash.purge` machinery that the 30-day sweep already uses:
- `git rm` the `.trash/<id>/` subtree + commit (soft purge — content stays in git history)
- drops the parked ACL / owner / update-policy rows

**Permission:** same as restore — write on the trashed item (if you can bring it back, you can delete it for good). Returns 403 otherwise, 404 for an unknown id.

The item's `wiki_doc_ids` tombstone is intentionally left as-is (identical to auto-purge), so its id URL degrades to the generic "unavailable" card.

## Tests
- `test_purge_trash_item_removes_it_immediately` — gone from Trash + view 404s after
- `test_purge_trash_item_requires_write` — no-write user gets 403

24 tests pass across `test_trash.py` + `test_trash_purge.py`; ruff + basedpyright clean. Backend only — frontend "Delete permanently" action stacks on this.