### PR TITLE
feat(trash-fe): "Delete permanently" action in the Trash view

### DIFF
--- a/frontend/src/lib/trash.ts
+++ b/frontend/src/lib/trash.ts
@@ -44,6 +44,15 @@ export async function restoreTrashed(
   });
 }
 
+/** Permanently remove a trashed item now, ahead of the 30-day auto-purge.
+ * Irreversible from the app (content remains in git history). Requires the
+ * same write access as restore; 403 otherwise. */
+export async function purgeTrashed(trashId: string): Promise<void> {
+  await apiFetch<void>(`/wiki/trash/${encodeURIComponent(trashId)}`, {
+    method: "DELETE",
+  });
+}
+
 /** Tombstone info for a deleted page/folder by its original path — the
  * most-recent Trash entry, for the deleted-URL panel. Rejects (404) when the
  * path isn't in Trash. */

--- a/frontend/src/views/trash/TrashPage.tsx
+++ b/frontend/src/views/trash/TrashPage.tsx
@@ -7,10 +7,16 @@ import { SvgTrash } from "@onyx-ai/opal/icons";
 import { SettingsLayouts } from "@onyx-ai/opal/layouts";
 
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
+import { useConfirm } from "@/components/common/ConfirmDialog";
 import { useRequireAuth } from "@/lib/auth";
 import { ApiError } from "@/lib/api";
 import { formatRelative } from "@/lib/format";
-import { restoreTrashed, useTrash, type TrashEntry } from "@/lib/trash";
+import {
+  purgeTrashed,
+  restoreTrashed,
+  useTrash,
+  type TrashEntry,
+} from "@/lib/trash";
 
 /** Display name for a trashed item: the page name (no `.md`) or folder name. */
 function itemLabel(entry: TrashEntry): string {
@@ -21,25 +27,30 @@ function itemLabel(entry: TrashEntry): string {
 export default function TrashPage() {
   const { user, loading } = useRequireAuth();
   const { items, error: listSwrError, refresh } = useTrash();
-  const [busyId, setBusyId] = useState<string | null>(null);
+  const [busy, setBusy] = useState<{
+    id: string;
+    kind: "restore" | "purge";
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const confirmDialog = useConfirm();
 
   if (loading || !user) return <LoadingSpinner center />;
 
+  // Drop an item from the list once it leaves Trash (restored or purged).
+  const dropFromList = (trashId: string) =>
+    refresh(
+      (cur) => ({
+        items: (cur?.items ?? []).filter((i) => i.trash_id !== trashId),
+      }),
+      { revalidate: true },
+    );
+
   const restore = async (entry: TrashEntry) => {
-    setBusyId(entry.trash_id);
+    setBusy({ id: entry.trash_id, kind: "restore" });
     setError(null);
     try {
       await restoreTrashed(entry.trash_id);
-      // The item is back on the tree — drop it from the list optimistically.
-      await refresh(
-        (cur) => ({
-          items: (cur?.items ?? []).filter(
-            (i) => i.trash_id !== entry.trash_id,
-          ),
-        }),
-        { revalidate: true },
-      );
+      await dropFromList(entry.trash_id);
     } catch (e) {
       setError(
         e instanceof ApiError && e.status === 409
@@ -49,7 +60,28 @@ export default function TrashPage() {
             : "Restore failed.",
       );
     } finally {
-      setBusyId(null);
+      setBusy(null);
+    }
+  };
+
+  const purge = async (entry: TrashEntry) => {
+    if (
+      !(await confirmDialog({
+        title: `Permanently delete "${itemLabel(entry)}"?`,
+        body: "It will be removed from Trash and can no longer be restored.",
+        confirmLabel: "Delete permanently",
+      }))
+    )
+      return;
+    setBusy({ id: entry.trash_id, kind: "purge" });
+    setError(null);
+    try {
+      await purgeTrashed(entry.trash_id);
+      await dropFromList(entry.trash_id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed.");
+    } finally {
+      setBusy(null);
     }
   };
 
@@ -60,7 +92,7 @@ export default function TrashPage() {
       <SettingsLayouts.Header
         icon={SvgTrash}
         title="Trash"
-        description="Deleted pages and folders. Restore an item to move it back to its original location."
+        description="Deleted pages and folders. Restore an item to move it back to its original location, or delete it permanently. Items are auto-removed after 30 days."
         divider
       />
       <SettingsLayouts.Body>
@@ -107,14 +139,28 @@ export default function TrashPage() {
                     </Text>
                   </div>
                 </div>
-                <Button
-                  prominence="secondary"
-                  size="sm"
-                  disabled={!entry.can_restore || busyId === entry.trash_id}
-                  onClick={() => void restore(entry)}
-                >
-                  {busyId === entry.trash_id ? "Restoring…" : "Restore"}
-                </Button>
+                <div className="flex items-center gap-2">
+                  <Button
+                    prominence="secondary"
+                    size="sm"
+                    disabled={!entry.can_restore || busy?.id === entry.trash_id}
+                    onClick={() => void restore(entry)}
+                  >
+                    {busy?.id === entry.trash_id && busy.kind === "restore"
+                      ? "Restoring…"
+                      : "Restore"}
+                  </Button>
+                  <Button
+                    variant="danger"
+                    size="sm"
+                    disabled={!entry.can_restore || busy?.id === entry.trash_id}
+                    onClick={() => void purge(entry)}
+                  >
+                    {busy?.id === entry.trash_id && busy.kind === "purge"
+                      ? "Deleting…"
+                      : "Delete"}
+                  </Button>
+                </div>
               </div>
             </Card>
           ))}


### PR DESCRIPTION
Frontend for permanent Trash deletion. **Stacked on #398** (the backend endpoint) — merge #398 first; GitHub will retarget this to `main`.

## What
- Each Trash row gets a danger **Delete** button beside Restore.
- Clicking it opens a confirm dialog ("It will be removed from Trash and can no longer be restored."), then calls `DELETE /api/wiki/trash/{id}` (new `purgeTrashed` in `lib/trash.ts`).
- Gated on the same `can_restore` (write) flag as Restore; the row drops from the list on success.
- A single `busy` state disambiguates the Restore vs Delete spinners.
- Header copy updated: restore **or delete permanently**, and notes the 30-day auto-removal.
<img width="1205" height="538" alt="Screenshot 2026-07-14 at 4 21 52 PM" src="https://github.com/user-attachments/assets/03c451b3-85f4-4bea-9bb5-23b8153a51f0" />

`bun run typecheck` + prettier clean.