### PR TITLE
refactor(wiki): drop the boot-time doc-id backfill

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,6 @@ from app.auth.deps import CurrentUserMiddleware
 import app.config as _app_config
 from app.db import comment_fts
 from app.wiki import comments as _comments_repo
-from app.wiki import doc_ids
 from app.metrics import setup_prometheus
 from app.realtime import bus
 from app.llm.errors import LLMError
@@ -177,10 +176,6 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # The index persists across reboots, so steady-state boots skip this.
     if comment_fts.count() == 0:
         _comments_repo.reindex_all_inline()
-    # Stable doc ids: mint for every existing page + folder that lacks one, so
-    # a pre-ids wiki gets full id coverage. Self-gates (cheap count) so a
-    # fully-minted wiki skips the work on later boots.
-    doc_ids.backfill_all()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_reconcile.reconcile_legacy_slack_triggers()
     triggers_repo.rebuild_from_filesystem()

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -8,9 +8,9 @@ re-binds it). A page recreated at a previously-deleted path is a new
 document with a fresh id; the partial unique index on live ``path`` rows
 enforces that at most one live row occupies a path.
 
-Backfill for pre-existing content is lazy: reads mint missing rows via
-:func:`get_or_mint`, and the hourly BM25 reconcile sweep calls
-:func:`ensure_for_paths` for recently-touched pages.
+Backfill for pre-existing content is lazy: a read of a page with no row mints
+one via :func:`get_or_mint`. Ancestor-folder rows are seeded when a page is
+created under them (:func:`mint_for_page`), not on a lazy read.
 """
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ from sqlalchemy.exc import IntegrityError
 from app.db.models import WikiDocId
 from app.db.session import session
 from app.models.wiki import PathMove
-from app.wiki import filesystem, git as wiki_git
+from app.wiki import filesystem
 
 log = logging.getLogger(__name__)
 
@@ -132,51 +132,6 @@ def mint_for_page(path: str) -> str:
     for i in range(1, len(parts) + 1):
         get_or_mint("/".join(parts[:i]))
     return get_or_mint(path)
-
-
-def ensure_for_paths(paths: list[str]) -> None:
-    """Backfill: mint live rows for any of ``paths`` that lack one. Pages
-    also seed their ancestor folders. Never raises — backfill must not
-    abort its caller (the startup reindex sweep)."""
-    for p in paths:
-        try:
-            if p.endswith(".md"):
-                mint_for_page(p)
-            else:
-                get_or_mint(p)
-        except Exception:
-            log.exception("doc_ids backfill failed for %s", p)
-
-
-def backfill_all() -> None:
-    """Mint ids for every tracked page and folder that lacks a live row.
-
-    Run once at boot so an existing wiki (created before stable ids) gets ids
-    for all its pages *and folders* — not just the pages someone happens to
-    open. Gated on a cheap count so a fully-minted wiki does almost no work;
-    otherwise mints the missing rows (``get_or_mint`` skips those that exist).
-
-    Folders are enumerated from the tracked-file prefixes so empty folders
-    (only a ``.gitkeep``) get ids too, which page-ancestor seeding misses.
-    """
-    files = wiki_git.list_paths()
-    md = [p for p in files if p.endswith(".md")]
-    folders: set[str] = set()
-    for f in files:
-        parts = f.split("/")[:-1]
-        for i in range(1, len(parts) + 1):
-            folders.add("/".join(parts[:i]))
-    want = len(folders | set(md))
-    with session() as s:
-        have = s.execute(
-            select(func.count())
-            .select_from(WikiDocId)
-            .where(WikiDocId.deleted_at.is_(None))
-        ).scalar_one()
-    if have >= want:
-        return
-    log.info("doc_ids backfill: %d live rows < %d tracked paths; minting missing", have, want)
-    ensure_for_paths([*sorted(folders), *md])
 
 
 def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> None:


### PR DESCRIPTION
Verified in production: every tracked path already has a `wiki_doc_ids` row (186 paths, 0 missing), so the startup `backfill_all()` is a no-op. Since the product is internal-only right now, we're removing it.

## What
- Remove `doc_ids.backfill_all()` from the boot sequence (`main.py`) and delete it + its only-caller helper `ensure_for_paths` from `doc_ids.py`.
- Trim the now-unused `git as wiki_git` import; fix the module docstring.

## What still covers id coverage
- **Create / move**: lifecycle hooks mint (`mint_for_page` also seeds ancestor folders).
- **Pre-id page read**: `/wiki/file` still lazily mints a missing row via `get_or_mint`.

## Trade-off (accepted for internal-only)
The boot backfill was the only thing that minted ids from an existing git tree when the DB lacked them — i.e. a **fresh instance's seed content** (seed is git-committed before the mint hook) and a **git-into-empty-DB** repair. Without it, a brand-new instance's seed folders / unopened seed pages fall back to path URLs (which still redirect) until opened. Normal backup/restore restores the DB *with* its ids, so those paths are unaffected. Easy to reinstate before we onboard external installs.

ruff + basedpyright clean; `test_doc_ids.py` + `test_trash.py` = 35 pass (incl. lazy-mint-on-read).