### PR TITLE
feat(ingest): TwoTowerScorer HTTP client + score wire contract

### DIFF
--- a/backend/app/ingest/relevance/__init__.py
+++ b/backend/app/ingest/relevance/__init__.py
@@ -11,5 +11,18 @@ pluggable :class:`Scorer`). Filters operate on the pipeline carriers
 from app.ingest.relevance.cosine_filter import CosineSimilarityFilter
 from app.ingest.relevance.filter import RelevanceFilter
 from app.ingest.relevance.two_tower_filter import Scorer, TwoTowerFilter
+from app.ingest.relevance.two_tower_scorer import (
+    ScoreRequest,
+    ScoreResponse,
+    TwoTowerScorer,
+)
 
-__all__ = ["CosineSimilarityFilter", "RelevanceFilter", "Scorer", "TwoTowerFilter"]
+__all__ = [
+    "CosineSimilarityFilter",
+    "RelevanceFilter",
+    "Scorer",
+    "ScoreRequest",
+    "ScoreResponse",
+    "TwoTowerFilter",
+    "TwoTowerScorer",
+]

--- a/backend/app/ingest/relevance/two_tower_scorer.py
+++ b/backend/app/ingest/relevance/two_tower_scorer.py
@@ -1,0 +1,71 @@
+"""HTTP :class:`~app.ingest.relevance.two_tower_filter.Scorer` client for the
+relevance model server.
+
+Scores embedding pairs by POSTing them to a separate model-server service (the
+Onyx ``model_server`` pattern) that hosts the trained two-tower network. Keeping
+the model in its own service means the backend carries no ML runtime — only
+this thin HTTP client and the shared request/response schema.
+
+Raises on any transport or protocol failure; ``TwoTowerFilter`` catches it and
+fails open (keeps the candidates), so a slow or down model server degrades to
+"keep everything" rather than blocking ingestion.
+
+The ``ScoreRequest`` / ``ScoreResponse`` schema is the wire contract the model
+server must implement; both sides share it.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import requests
+from pydantic import BaseModel
+
+# Path on the model server that scores a batch of (doc, page) embedding pairs.
+SCORE_PATH = "/score"
+
+# Conservative default: the filter only saves reconcile cost, so a scorer that
+# can't answer quickly should fail open fast rather than stall the pipeline.
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+class ScoreRequest(BaseModel):
+    """One document vector scored against many candidate-page vectors."""
+
+    doc_vec: list[float]
+    page_vecs: list[list[float]]
+
+
+class ScoreResponse(BaseModel):
+    """P(relevant) per page, aligned to ``ScoreRequest.page_vecs``."""
+
+    probs: list[float]
+
+
+class TwoTowerScorer:
+    """The two-tower :class:`Scorer`, backed by an HTTP call to the model server.
+
+    Named for the model it serves, though the wire contract itself is a plain
+    vectors-in/probs-out call — the two-tower is what the server hosts.
+    """
+
+    def __init__(
+        self, base_url: str, *, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
+    ) -> None:
+        self._url = base_url.rstrip("/") + SCORE_PATH
+        self._timeout = timeout_seconds
+        # One persistent session: the scorer is hit once per document during an
+        # ingestion run, so reusing the connection avoids a per-call TCP/TLS
+        # handshake to the same host.
+        self._session = requests.Session()
+
+    def score_batch(
+        self, doc_vec: Sequence[float], page_vecs: list[Sequence[float]]
+    ) -> list[float]:
+        payload = ScoreRequest(
+            doc_vec=list(doc_vec), page_vecs=[list(v) for v in page_vecs]
+        )
+        resp = self._session.post(
+            self._url, json=payload.model_dump(), timeout=self._timeout
+        )
+        resp.raise_for_status()
+        return ScoreResponse.model_validate(resp.json()).probs

--- a/backend/tests/test_two_tower_scorer.py
+++ b/backend/tests/test_two_tower_scorer.py
@@ -1,0 +1,74 @@
+"""Tests for the two-tower HTTP scorer client.
+
+The network is mocked (patching ``Session.post``) — we assert the wire contract
+(URL, payload, parse) and that failures propagate as exceptions so
+``TwoTowerFilter`` fails open.
+"""
+from __future__ import annotations
+
+import pytest
+import requests
+
+from app.ingest.relevance import TwoTowerFilter, TwoTowerScorer, two_tower_scorer
+from app.ingest.types import CandidatePage, IngestionDocument
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict | None, *, ok: bool = True) -> None:
+        self._payload = payload
+        self._ok = ok
+
+    def raise_for_status(self) -> None:
+        if not self._ok:
+            raise requests.HTTPError("model server 500")
+
+    def json(self) -> dict:
+        assert self._payload is not None
+        return self._payload
+
+
+def test_score_batch_posts_contract_and_parses(monkeypatch):
+    captured: dict = {}
+
+    def fake_post(self, url, json=None, timeout=None):
+        captured.update(url=url, json=json, timeout=timeout)
+        return _FakeResponse({"probs": [0.9, 0.1]})
+
+    monkeypatch.setattr(two_tower_scorer.requests.Session, "post", fake_post)
+
+    scorer = TwoTowerScorer("http://model-server:9100/")
+    probs = scorer.score_batch([1.0, 0.0], [[0.1, 0.2], [0.3, 0.4]])
+
+    assert probs == [0.9, 0.1]
+    assert captured["url"] == "http://model-server:9100/score"  # trailing slash trimmed
+    assert captured["json"] == {
+        "doc_vec": [1.0, 0.0],
+        "page_vecs": [[0.1, 0.2], [0.3, 0.4]],
+    }
+    assert captured["timeout"] == two_tower_scorer.DEFAULT_TIMEOUT_SECONDS
+
+
+def test_score_batch_raises_on_http_error(monkeypatch):
+    monkeypatch.setattr(
+        two_tower_scorer.requests.Session,
+        "post",
+        lambda self, url, json=None, timeout=None: _FakeResponse(None, ok=False),
+    )
+    with pytest.raises(requests.HTTPError):
+        TwoTowerScorer("http://model-server:9100").score_batch([1.0], [[1.0]])
+
+
+def test_filter_fails_open_when_model_server_errors(monkeypatch):
+    # End-to-end: TwoTowerScorer raises → TwoTowerFilter keeps all candidates.
+    def boom(self, url, json=None, timeout=None):
+        raise requests.ConnectionError("model server unreachable")
+
+    monkeypatch.setattr(two_tower_scorer.requests.Session, "post", boom)
+
+    f = TwoTowerFilter(TwoTowerScorer("http://model-server:9100"), threshold=0.99)
+    doc = IngestionDocument(content="d", embedding=[1.0, 0.0])
+    pages = [
+        CandidatePage(path="a.md", body="b", embedding=[0.1, 0.2]),
+        CandidatePage(path="b.md", body="b", embedding=[0.3, 0.4]),
+    ]
+    assert f.keep_relevant(doc, pages) == pages


### PR DESCRIPTION
## What

**Phase B.1** of the two-tower serving path, following the **Onyx `model_server` pattern**: the two-tower model runs in its own service, and the backend reaches it through a thin HTTP client — so the **backend carries no ML runtime** (no torch, no ONNX), only `requests` + the shared schema.

Builds on the `Scorer` boundary from #397. Nothing is wired in yet.

## Pieces

- **`ScoreRequest` / `ScoreResponse`** — the wire contract: one `doc_vec` scored against many `page_vecs` → `probs` (P(relevant) per page, aligned). The model server takes **vectors, not text** — it's a pure scorer, not an embedder (embeddings are produced upstream by `enrich`). Shared by both sides.
- **`TwoTowerScorer(Scorer)`** — POSTs to the model server's `/score` and parses the probabilities. Named for the two-tower specifically (the only model the serving stack hosts), though the wire contract is a plain vectors-in/probs-out call. Satisfies the `Scorer` protocol structurally.

## Persistent connection

Scoring goes through a per-instance `requests.Session`, so repeated calls to the same model server reuse the connection instead of doing a fresh TCP/TLS handshake each time — the scorer is hit once per document during an ingestion run, so it adds up.

## Fail-open

`TwoTowerScorer` **raises** on any transport/protocol failure (connection error, timeout, non-200, malformed body). `TwoTowerFilter` catches it and keeps all candidates — so a slow or down model server degrades to "keep everything," never blocks ingestion. End-to-end test covers this.

## Notes

- Uses `requests` — matches `app/onyx/client.py`, `web/serper.py`, and Onyx's own model-server client.
- `base_url` is a constructor arg (no Config field yet) — config wiring comes with deployment. Default timeout 5s (fail open fast rather than stall).

## Next increments

- **B.2** — the model-server service: FastAPI + lifespan loading the trained bundle via the scoring slice of Joachim's `TwoTowerPredictor` (just the network + `score_batch`, **no** embedding code — it takes vectors), `POST /score` + `/health`, its own Dockerfile.
- **B.3 / C** — opt-in compose + Helm wiring (`enabled: false` default), config for the URL, threshold calibration.

## Tests

`backend/tests/test_two_tower_scorer.py` (3) — posts the exact URL/payload and parses probs; raises on HTTP error; end-to-end fail-open when the server is unreachable (via `TwoTowerFilter`). Network mocked (`Session.post`). Ruff + basedpyright clean.