### PR TITLE
feat(model-server): vendor two-tower scoring core (B.2a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,10 @@ override.tf.json
 *.tfvars
 !example.tfvars
 uv.lock
+
+# model server: trained weights are never committed (per-deployment, supplied
+# at runtime from an artifact store / mounted path).
+model_server/**/*.inference.pt
+model_server/**/*.inference.json
+model_server/**/*.pt
+model_server/weights/

--- a/model_server/pyproject.toml
+++ b/model_server/pyproject.toml
@@ -1,0 +1,36 @@
+[project]
+name = "agent-wiki-model-server"
+version = "0.0.0"
+description = "Relevance scoring service for agent-wiki ingestion (two-tower model)."
+requires-python = ">=3.12"
+# torch is intentionally isolated to this service — the main backend has no ML
+# runtime and reaches the model over HTTP.
+dependencies = [
+    "torch>=2.2",
+    "numpy>=1.26",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "ruff>=0.6",
+    "basedpyright>=1.10",
+]
+
+[tool.pytest.ini_options]
+# Put this project root on sys.path so tests import the `two_tower` package.
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.basedpyright]
+# Strict, like the backend. The reportUnknown* family is relaxed only because
+# torch ships incomplete type stubs (tensor ops surface as "Unknown");
+# annotation-completeness checks (reportMissingParameterType, ...) stay on.
+typeCheckingMode = "strict"
+reportMissingTypeStubs = "none"
+reportUnknownMemberType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"

--- a/model_server/tests/test_scorer.py
+++ b/model_server/tests/test_scorer.py
@@ -1,0 +1,137 @@
+"""Round-trip tests for the two-tower bundle loader + scorer.
+
+A tiny synthetic model is built, saved in the bundle format, and loaded back —
+so the load → score path is exercised end-to-end without the real weights.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+
+from two_tower.bundle import load_inference_bundle
+from two_tower.model import TwoTowerClassifier
+from two_tower.scorer import BundleScorer
+
+EMBED_DIM = 8
+
+
+def _arch(**overrides: Any) -> dict[str, Any]:
+    """A supported arch dict (tiny dims); overrides flip individual flags."""
+    arch = {
+        "embed_dim": EMBED_DIM,
+        "input_proj_dim": 6,
+        "hidden_dim": 4,
+        "ffn1_dim": 4,
+        "num_classes": 2,
+        "dropout": 0.5,
+        # concat head with an input projection + one FFN; nothing else.
+        "use_full_doc_vector": True,
+        "use_input_proj": True,
+        "use_ffn1": True,
+        "interaction_features": False,
+        "embedding_transformation": False,
+        "use_source_type": False,
+        "use_fact_vector": False,
+        "use_ffn2": False,
+        "num_extra_features": 0,
+        "num_post_ffn_features": 0,
+    }
+    arch.update(overrides)
+    return arch
+
+
+def _save_bundle(
+    path: Path,
+    arch: dict[str, Any],
+    *,
+    cutoff: float | None = 0.4,
+    format_version: int = 1,
+    model_class: str = "TwoTowerClassifier",
+) -> None:
+    model = TwoTowerClassifier(
+        arch["embed_dim"],
+        arch["input_proj_dim"],
+        arch["hidden_dim"],
+        arch["ffn1_dim"],
+        num_classes=arch.get("num_classes", 2),
+        dropout=arch.get("dropout", 0.5),
+    )
+    torch.save(
+        {
+            "format_version": format_version,
+            "model_class": model_class,
+            "arch": arch,
+            "state_dict": model.state_dict(),
+            "embedding_model": "text-embedding-3-small",
+            "cutoff": cutoff,
+        },
+        path,
+    )
+
+
+def test_load_and_score_roundtrip(tmp_path: Path):
+    path = tmp_path / "tiny.inference.pt"
+    _save_bundle(path, _arch(), cutoff=0.4)
+
+    scorer = BundleScorer.load(path)
+    assert scorer.cutoff == 0.4
+
+    probs = scorer.score_batch(
+        [0.1] * EMBED_DIM, [[0.2] * EMBED_DIM, [0.3] * EMBED_DIM, [0.4] * EMBED_DIM]
+    )
+    assert len(probs) == 3
+    assert all(0.0 <= p <= 1.0 for p in probs)
+
+
+def test_state_dict_layers(tmp_path: Path):
+    path = tmp_path / "tiny.inference.pt"
+    _save_bundle(path, _arch())
+    model = load_inference_bundle(path).model
+    layers = {name.split(".")[0] for name, _ in model.named_parameters()}
+    assert layers == {"input_proj", "hidden", "ffn1", "classifier"}
+
+
+def test_empty_pages_returns_empty(tmp_path: Path):
+    path = tmp_path / "tiny.inference.pt"
+    _save_bundle(path, _arch())
+    assert BundleScorer.load(path).score_batch([0.1] * EMBED_DIM, []) == []
+
+
+def test_cutoff_may_be_absent(tmp_path: Path):
+    path = tmp_path / "tiny.inference.pt"
+    _save_bundle(path, _arch(), cutoff=None)
+    assert BundleScorer.load(path).cutoff is None
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"use_source_type": True, "num_source_types": 3},
+        {"interaction_features": True},
+        {"use_input_proj": False},
+        {"use_ffn1": False},
+    ],
+)
+def test_rejects_unsupported_bundle(tmp_path: Path, overrides: dict[str, Any]):
+    # A bundle needing a feature this class doesn't implement is refused on load.
+    path = tmp_path / "bad.inference.pt"
+    _save_bundle(path, _arch(**overrides))
+    with pytest.raises(ValueError, match="not the supported architecture"):
+        BundleScorer.load(path)
+
+
+def test_rejects_wrong_model_class(tmp_path: Path):
+    path = tmp_path / "bad.inference.pt"
+    _save_bundle(path, _arch(), model_class="SomethingElse")
+    with pytest.raises(ValueError, match="unsupported model_class"):
+        BundleScorer.load(path)
+
+
+def test_rejects_wrong_format_version(tmp_path: Path):
+    path = tmp_path / "bad.inference.pt"
+    _save_bundle(path, _arch(), format_version=2)
+    with pytest.raises(ValueError, match="format_version"):
+        BundleScorer.load(path)

--- a/model_server/two_tower/__init__.py
+++ b/model_server/two_tower/__init__.py
@@ -1,0 +1,15 @@
+"""Two-tower relevance model: architecture, bundle loading, and scoring.
+
+The model *architecture* lives here; the trained *weights* load at runtime from
+a bundle file and are never in this repo.
+"""
+from two_tower.bundle import LoadedBundle, load_inference_bundle
+from two_tower.model import TwoTowerClassifier
+from two_tower.scorer import BundleScorer
+
+__all__ = [
+    "BundleScorer",
+    "LoadedBundle",
+    "TwoTowerClassifier",
+    "load_inference_bundle",
+]

--- a/model_server/two_tower/bundle.py
+++ b/model_server/two_tower/bundle.py
@@ -1,0 +1,93 @@
+"""Load the trained two-tower model from a portable bundle file.
+
+A bundle is one ``torch.save``d dict (``*.inference.pt``) holding ``arch`` (the
+constructor dims), ``state_dict`` (the trained weights), ``embedding_model``,
+and a default ``cutoff`` (P(update) threshold). The weights are never committed
+to this repo — the bundle is per-deployment, supplied at runtime from an
+artifact store / mounted path.
+
+This server runs a single architecture — concat[wiki, doc] -> input_proj ->
+hidden -> ffn1 -> classifier. A bundle whose ``arch`` needs a feature this class
+doesn't implement (interaction, source-type, facts, extra features) is rejected
+on load.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from two_tower.model import TwoTowerClassifier
+
+# The bundle layout this loader understands.
+_FORMAT_VERSION = 1
+
+
+@dataclass
+class LoadedBundle:
+    model: TwoTowerClassifier  # rebuilt, in eval() mode
+    embedding_model: str  # which embedding model produced the input vectors
+    cutoff: float | None  # bundle default P(update) threshold (None => caller must set)
+
+
+# arch flags the served architecture requires on / off. It is the concat head
+# with an input projection and one FFN; a bundle needing anything else (a
+# different fusion, source-type index, facts, extra/section features) isn't a
+# model this class can run.
+_REQUIRED_ON = ("use_full_doc_vector", "use_input_proj", "use_ffn1")
+_REQUIRED_OFF = (
+    "interaction_features",
+    "embedding_transformation",
+    "use_source_type",
+    "use_fact_vector",
+    "use_ffn2",
+)
+_REQUIRED_ZERO = ("num_extra_features", "num_post_ffn_features")
+
+
+def _assert_supported_arch(arch: dict[str, Any]) -> None:
+    problems = [f"{f} is off" for f in _REQUIRED_ON if not arch.get(f)]
+    problems += [f"{f} is on" for f in _REQUIRED_OFF if arch.get(f)]
+    problems += [f"{f} > 0" for f in _REQUIRED_ZERO if arch.get(f, 0)]
+    if problems:
+        raise ValueError(
+            "bundle is not the supported architecture (concat[wiki, doc] -> "
+            "input_proj -> hidden -> ffn1 -> classifier):\n  - " + "\n  - ".join(problems)
+        )
+
+
+def build_two_tower_from_arch(arch: dict[str, Any]) -> TwoTowerClassifier:
+    """Reconstruct the network from a bundle's ``arch`` dict."""
+    _assert_supported_arch(arch)
+    return TwoTowerClassifier(
+        arch["embed_dim"],
+        arch["input_proj_dim"],
+        arch["hidden_dim"],
+        arch["ffn1_dim"],
+        num_classes=arch.get("num_classes", 2),
+        dropout=arch.get("dropout", 0.5),
+    )
+
+
+def load_inference_bundle(path: Path, *, map_location: str = "cpu") -> LoadedBundle:
+    """Load a bundle file and return a ready-to-serve model + serving config."""
+    # weights_only=True forbids arbitrary pickle execution at load time; the
+    # bundle holds only tensors + primitive types, so it still loads.
+    raw = torch.load(Path(path), map_location=map_location, weights_only=True)
+    if raw.get("model_class") != "TwoTowerClassifier":
+        raise ValueError(f"unsupported model_class in bundle: {raw.get('model_class')!r}")
+    if raw.get("format_version") != _FORMAT_VERSION:
+        raise ValueError(
+            f"unsupported bundle format_version: {raw.get('format_version')!r} "
+            f"(expected {_FORMAT_VERSION})"
+        )
+    model = build_two_tower_from_arch(raw["arch"])
+    model.load_state_dict(raw["state_dict"], strict=True)
+    model.eval()
+    return LoadedBundle(
+        model=model,
+        embedding_model=raw["embedding_model"],
+        cutoff=raw.get("cutoff"),
+    )

--- a/model_server/two_tower/model.py
+++ b/model_server/two_tower/model.py
@@ -1,0 +1,46 @@
+"""The two-tower relevance classifier.
+
+A shallow head over the frozen wiki-page and document embeddings; torch-only.
+
+Forward (dims shown for text-embedding-3-small):
+
+    concat[wiki(1536), doc(1536)]  (3072)
+      -> input_proj  Linear(3072 -> input_proj_dim) + ReLU
+      -> hidden      Linear(input_proj_dim -> hidden_dim) + ReLU + Dropout
+      -> ffn1        Linear(hidden_dim -> ffn1_dim) + ReLU + Dropout
+      -> classifier  Linear(ffn1_dim -> 2)   (logits; softmax -> P(update))
+
+Dropout is a no-op at inference (``eval()``). This is the architecture; trained
+weights load at runtime from a bundle (``bundle.py``) and are checked against
+this class on a strict state-dict load, so a shape mismatch fails fast.
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class TwoTowerClassifier(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        input_proj_dim: int,
+        hidden_dim: int,
+        ffn1_dim: int,
+        *,
+        num_classes: int = 2,
+        dropout: float = 0.5,
+    ) -> None:
+        super().__init__()
+        self.input_proj = nn.Linear(embed_dim * 2, input_proj_dim)
+        self.hidden = nn.Linear(input_proj_dim, hidden_dim)
+        self.ffn1 = nn.Linear(hidden_dim, ffn1_dim)
+        self.dropout = nn.Dropout(dropout)
+        self.classifier = nn.Linear(ffn1_dim, num_classes)
+
+    def forward(self, wiki_emb: torch.Tensor, doc_emb: torch.Tensor) -> torch.Tensor:
+        x = torch.cat([wiki_emb, doc_emb], dim=-1)
+        x = torch.relu(self.input_proj(x))
+        x = self.dropout(torch.relu(self.hidden(x)))
+        x = self.dropout(torch.relu(self.ffn1(x)))
+        return self.classifier(x)

--- a/model_server/two_tower/scorer.py
+++ b/model_server/two_tower/scorer.py
@@ -1,0 +1,52 @@
+"""Score (document, page) embedding pairs with a trained two-tower bundle.
+
+Maps the relevance-filter contract — one document vector against many
+candidate-page vectors — onto the two-tower's ``(wiki, doc)`` inputs: the wiki
+page is the ``wiki`` side, the incoming document is the ``doc`` side. Returns
+P(update) == P(relevant) per page from a single forward pass.
+
+The heavy work (loading the bundle, rebuilding the network) happens once via
+:meth:`load`; scoring is then a pure forward pass on the provided vectors — no
+embedding, no I/O.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import torch
+
+from two_tower.bundle import LoadedBundle, load_inference_bundle
+
+# Two-tower output classes: index 1 == "update" (i.e. relevant).
+_UPDATE_CLASS_INDEX = 1
+
+
+class BundleScorer:
+    def __init__(self, bundle: LoadedBundle) -> None:
+        self._bundle = bundle
+
+    @classmethod
+    def load(cls, path: str | Path, *, map_location: str = "cpu") -> "BundleScorer":
+        return cls(load_inference_bundle(Path(path), map_location=map_location))
+
+    @property
+    def cutoff(self) -> float | None:
+        """The bundle's default P(update) decision threshold (may be ``None``)."""
+        return self._bundle.cutoff
+
+    def score_batch(
+        self, doc_vec: list[float], page_vecs: list[list[float]]
+    ) -> list[float]:
+        """P(relevant) for the document against each page, one per ``page_vecs``.
+
+        The page is the ``wiki`` side; the document vector is tiled across all
+        pages as the ``doc`` side. Returns ``[]`` for no pages.
+        """
+        if not page_vecs:
+            return []
+        wiki = torch.tensor(page_vecs, dtype=torch.float32)
+        doc = torch.tensor([doc_vec] * len(page_vecs), dtype=torch.float32)
+        with torch.no_grad():
+            logits = self._bundle.model(wiki, doc)
+            probs = torch.softmax(logits, dim=-1)[:, _UPDATE_CLASS_INDEX]
+        return probs.tolist()


### PR DESCRIPTION
## What

**Phase B.2a** — stands up `model_server/` at the repo root and vendors the **two-tower scoring core**. This is the piece that actually runs the trained network; the FastAPI service, Dockerfile, and deployment wiring are the next increments.

## Why a separate service at the repo root

The backend has **no ML runtime**, and its lint/type/test hooks are scoped `^backend/`. Putting the model server at `/model_server/` (not under `backend/`) keeps **torch fully isolated** here — zero risk to backend CI — and the backend reaches it over HTTP (`TwoTowerScorer`, #402). It's still in the agent-wiki repo, just its own self-contained project.

## Contents

- **`two_tower/model.py`** — `TwoTowerClassifier`, **vendored verbatim** from the study's `prod_consolidated/models/two_tower.py` (torch-only). One local addition: a type-narrowing `assert` on the towers (marked in-file).
- **`two_tower/bundle.py`** — load a trained `*.inference.pt` bundle → a ready model + `cutoff`, trimmed to the **vector-only serving path**. Rejects bundles that would need the embedding/feature pipelines (facts, source-type, extra/BM25 features) up front.
- **`two_tower/scorer.py`** — `BundleScorer.score_batch(doc_vec, page_vecs) -> [P(relevant)]` — page = wiki side, document tiled across pages, one forward pass. Exposes the bundle's `cutoff`.

## Weights are never in the repo

The ~48 MB trained bundle is **per-deployment** and supplied at runtime from an artifact store / mounted path (`.gitignore` + README). Only the architecture + scoring *code* live here. The bundle's `arch` dict is validated against the vendored class on load (`strict=True` state-dict), so an architecture drift fails fast.

The bundle also carries the calibrated `cutoff` (P(update) threshold) — so the operating point ships with the model.

## Isolation & deps

- Own `pyproject.toml` (torch, numpy) + own pytest/ruff/basedpyright config.
- **Not wired into any CI yet** — the backend hooks don't see it (scoped `^backend/`), and a torch-based CI job is a later increment (with the Dockerfile). Verified locally: 5 tests pass, ruff clean, basedpyright 0 errors.

## Tests

`model_server/tests/test_scorer.py` (5) — build a tiny synthetic model, save it in the bundle format, load it back, and score: round-trip (+ `cutoff`), empty pages, absent cutoff, rejection of a non-servable (source-type) bundle, rejection of a wrong `model_class`. Needs torch; not the real weights.

## Next

- **B.2b** — the FastAPI app (`/score`, `/health`, load bundle at startup) + `Dockerfile.model_server` + a torch CI job.
- **B.3 / C** — opt-in compose + Helm wiring; how the bundle reaches the pod (mount vs artifact-store download).