### PR TITLE
fix(dev): add `BACKEND_URL` to `.env.example` for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,7 @@ OIDC_REDIRECT_URI=
 
 # --- Frontend ---
 NEXT_PUBLIC_API_BASE=/api
+# Required for host-native dev (launch.json / bun run dev). Next.js proxies
+# /api/* here; without it the rewrite falls back to http://backend:8080 which
+# only resolves inside Docker and causes 500s on the frontend.
+BACKEND_URL=http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,8 @@ services:
     profiles: ["app"]
     build: ./frontend
     env_file: .env
+    environment:
+      - BACKEND_URL=http://backend:8080
     expose:
       - "3000"
     depends_on:


### PR DESCRIPTION
## Summary

- Adds `BACKEND_URL=http://localhost:8080` to `.env.example` with an explanatory comment
- Without this, `next.config.js` falls back to `http://backend:8080` (a Docker-internal hostname) when running the frontend natively, causing all `/api/*` requests to 500 before they reach the backend

## Test plan

- Copy `.env.example` → `.env`, start the backend and frontend natively (VS Code "Run All Services"), confirm `http://localhost:3000/api/auth/config` returns JSON instead of 500