### PR TITLE
feat(model-server): FastAPI /score service + Dockerfile + CI (B.2b)

### DIFF
--- a/.github/workflows/model-server.yml
+++ b/.github/workflows/model-server.yml
@@ -1,0 +1,37 @@
+name: Model server checks
+
+concurrency:
+  group: model-server-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    # Self-contained project with its own (torch) deps — only run when it changes.
+    paths:
+      - "model_server/**"
+  workflow_dispatch:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: model_server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install deps
+        run: uv sync --group dev
+
+      - name: ruff
+        run: uv run --group dev ruff check two_tower tests server.py
+
+      - name: basedpyright
+        run: uv run --group dev basedpyright two_tower tests server.py
+
+      - name: pytest
+        run: uv run --group dev pytest -q

--- a/model_server/Dockerfile
+++ b/model_server/Dockerfile
@@ -1,0 +1,25 @@
+# Two-tower relevance model server. PyTorch lives only in this image; the main
+# backend has no ML runtime and calls this over HTTP.
+FROM python:3.12-slim
+
+# uv for dependency install.
+COPY --from=ghcr.io/astral-sh/uv:0.5 /uv /usr/local/bin/uv
+
+WORKDIR /app
+
+# Install runtime deps first so this layer caches unless pyproject changes.
+COPY pyproject.toml ./
+RUN uv sync --no-dev --no-install-project
+
+# App code.
+COPY two_tower ./two_tower
+COPY server.py ./
+
+# The trained bundle is NOT baked into the image — it is per-deployment and
+# supplied at runtime (mounted, or downloaded from an artifact store) at this
+# path. Nothing here reads it until the service starts.
+ENV MODEL_BUNDLE_PATH=/models/model.inference.pt
+ENV PYTHONPATH=/app
+EXPOSE 9100
+
+CMD ["uv", "run", "--no-dev", "--no-sync", "uvicorn", "server:app", "--host", "0.0.0.0", "--port", "9100"]

--- a/model_server/pyproject.toml
+++ b/model_server/pyproject.toml
@@ -8,6 +8,8 @@ requires-python = ">=3.12"
 dependencies = [
     "torch>=2.2",
     "numpy>=1.26",
+    "fastapi>=0.115",
+    "uvicorn>=0.30",
 ]
 
 [dependency-groups]
@@ -15,6 +17,7 @@ dev = [
     "pytest>=8",
     "ruff>=0.6",
     "basedpyright>=1.10",
+    "httpx>=0.27",  # fastapi.testclient transport
 ]
 
 [tool.pytest.ini_options]

--- a/model_server/server.py
+++ b/model_server/server.py
@@ -1,0 +1,66 @@
+"""FastAPI model server for two-tower relevance scoring.
+
+Loads the trained bundle once at startup from ``MODEL_BUNDLE_PATH`` and serves:
+
+  POST /score   ScoreRequest (embedding vectors) -> ScoreResponse (probabilities)
+  GET  /health  readiness
+
+Vectors in, probabilities out — the server does not embed. It runs one model,
+loaded from the path the deployment points it at (the backend reaches this over
+HTTP; see ``app/ingest/relevance/two_tower_scorer.py``).
+
+``ScoreRequest`` / ``ScoreResponse`` mirror the backend's wire contract; the two
+sides own their own copies of these DTOs and agree on the JSON shape.
+"""
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from two_tower.scorer import BundleScorer
+
+MODEL_BUNDLE_PATH_ENV = "MODEL_BUNDLE_PATH"
+
+
+class ScoreRequest(BaseModel):
+    doc_vec: list[float]
+    page_vecs: list[list[float]]
+
+
+class ScoreResponse(BaseModel):
+    probs: list[float]
+
+
+# The loaded model, set once at startup. Module-level so the request handlers
+# reach it without threading it through every call.
+_scorer: BundleScorer | None = None
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
+    global _scorer
+    path = os.environ.get(MODEL_BUNDLE_PATH_ENV)
+    if not path:
+        raise RuntimeError(f"{MODEL_BUNDLE_PATH_ENV} is not set")
+    _scorer = BundleScorer.load(path)
+    yield
+    _scorer = None
+
+
+app = FastAPI(title="agent-wiki model server", lifespan=lifespan)
+
+
+@app.get("/health")
+def health() -> dict[str, bool]:
+    return {"ready": _scorer is not None}
+
+
+@app.post("/score")
+def score(request: ScoreRequest) -> ScoreResponse:
+    if _scorer is None:
+        raise HTTPException(status_code=503, detail="model not loaded")
+    return ScoreResponse(probs=_scorer.score_batch(request.doc_vec, request.page_vecs))

--- a/model_server/tests/conftest.py
+++ b/model_server/tests/conftest.py
@@ -1,0 +1,89 @@
+"""Shared test fixtures: build synthetic bundles in the on-disk format.
+
+A tiny model is constructed and ``torch.save``d in the bundle layout, so the
+load → score path is exercised end-to-end without the real weights.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+import torch
+
+from two_tower.model import TwoTowerClassifier
+
+EMBED_DIM = 8
+
+
+def _arch(**overrides: Any) -> dict[str, Any]:
+    """A supported arch dict (tiny dims); overrides flip individual flags."""
+    arch = {
+        "embed_dim": EMBED_DIM,
+        "input_proj_dim": 6,
+        "hidden_dim": 4,
+        "ffn1_dim": 4,
+        "num_classes": 2,
+        "dropout": 0.5,
+        # concat head with an input projection + one FFN; nothing else.
+        "use_full_doc_vector": True,
+        "use_input_proj": True,
+        "use_ffn1": True,
+        "interaction_features": False,
+        "embedding_transformation": False,
+        "use_source_type": False,
+        "use_fact_vector": False,
+        "use_ffn2": False,
+        "num_extra_features": 0,
+        "num_post_ffn_features": 0,
+    }
+    arch.update(overrides)
+    return arch
+
+
+@pytest.fixture
+def embed_dim() -> int:
+    return EMBED_DIM
+
+
+@pytest.fixture
+def make_bundle(tmp_path: Path) -> Callable[..., Path]:
+    """Write a bundle file and return its path.
+
+    Keyword args ``cutoff`` / ``format_version`` / ``model_class`` set the
+    bundle envelope; any other kwargs flip ``arch`` flags (e.g.
+    ``make_bundle(use_source_type=True)`` for a non-servable bundle).
+    """
+
+    def _make(
+        *,
+        cutoff: float | None = 0.4,
+        format_version: int = 1,
+        model_class: str = "TwoTowerClassifier",
+        name: str = "model.inference.pt",
+        **arch_overrides: Any,
+    ) -> Path:
+        arch = _arch(**arch_overrides)
+        model = TwoTowerClassifier(
+            arch["embed_dim"],
+            arch["input_proj_dim"],
+            arch["hidden_dim"],
+            arch["ffn1_dim"],
+            num_classes=arch["num_classes"],
+            dropout=arch["dropout"],
+        )
+        path = tmp_path / name
+        torch.save(
+            {
+                "format_version": format_version,
+                "model_class": model_class,
+                "arch": arch,
+                "state_dict": model.state_dict(),
+                "embedding_model": "text-embedding-3-small",
+                "cutoff": cutoff,
+            },
+            path,
+        )
+        return path
+
+    return _make

--- a/model_server/tests/test_scorer.py
+++ b/model_server/tests/test_scorer.py
@@ -1,109 +1,38 @@
-"""Round-trip tests for the two-tower bundle loader + scorer.
-
-A tiny synthetic model is built, saved in the bundle format, and loaded back —
-so the load → score path is exercised end-to-end without the real weights.
-"""
+"""Tests for the bundle loader + scorer, over synthetic bundles (see conftest)."""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import pytest
-import torch
 
 from two_tower.bundle import load_inference_bundle
-from two_tower.model import TwoTowerClassifier
 from two_tower.scorer import BundleScorer
 
-EMBED_DIM = 8
 
-
-def _arch(**overrides: Any) -> dict[str, Any]:
-    """A supported arch dict (tiny dims); overrides flip individual flags."""
-    arch = {
-        "embed_dim": EMBED_DIM,
-        "input_proj_dim": 6,
-        "hidden_dim": 4,
-        "ffn1_dim": 4,
-        "num_classes": 2,
-        "dropout": 0.5,
-        # concat head with an input projection + one FFN; nothing else.
-        "use_full_doc_vector": True,
-        "use_input_proj": True,
-        "use_ffn1": True,
-        "interaction_features": False,
-        "embedding_transformation": False,
-        "use_source_type": False,
-        "use_fact_vector": False,
-        "use_ffn2": False,
-        "num_extra_features": 0,
-        "num_post_ffn_features": 0,
-    }
-    arch.update(overrides)
-    return arch
-
-
-def _save_bundle(
-    path: Path,
-    arch: dict[str, Any],
-    *,
-    cutoff: float | None = 0.4,
-    format_version: int = 1,
-    model_class: str = "TwoTowerClassifier",
-) -> None:
-    model = TwoTowerClassifier(
-        arch["embed_dim"],
-        arch["input_proj_dim"],
-        arch["hidden_dim"],
-        arch["ffn1_dim"],
-        num_classes=arch.get("num_classes", 2),
-        dropout=arch.get("dropout", 0.5),
-    )
-    torch.save(
-        {
-            "format_version": format_version,
-            "model_class": model_class,
-            "arch": arch,
-            "state_dict": model.state_dict(),
-            "embedding_model": "text-embedding-3-small",
-            "cutoff": cutoff,
-        },
-        path,
-    )
-
-
-def test_load_and_score_roundtrip(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch(), cutoff=0.4)
-
-    scorer = BundleScorer.load(path)
+def test_load_and_score_roundtrip(make_bundle: Callable[..., Path], embed_dim: int):
+    scorer = BundleScorer.load(make_bundle(cutoff=0.4))
     assert scorer.cutoff == 0.4
 
     probs = scorer.score_batch(
-        [0.1] * EMBED_DIM, [[0.2] * EMBED_DIM, [0.3] * EMBED_DIM, [0.4] * EMBED_DIM]
+        [0.1] * embed_dim, [[0.2] * embed_dim, [0.3] * embed_dim, [0.4] * embed_dim]
     )
     assert len(probs) == 3
     assert all(0.0 <= p <= 1.0 for p in probs)
 
 
-def test_state_dict_layers(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch())
-    model = load_inference_bundle(path).model
+def test_state_dict_layers(make_bundle: Callable[..., Path]):
+    model = load_inference_bundle(make_bundle()).model
     layers = {name.split(".")[0] for name, _ in model.named_parameters()}
     assert layers == {"input_proj", "hidden", "ffn1", "classifier"}
 
 
-def test_empty_pages_returns_empty(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch())
-    assert BundleScorer.load(path).score_batch([0.1] * EMBED_DIM, []) == []
+def test_empty_pages_returns_empty(make_bundle: Callable[..., Path], embed_dim: int):
+    assert BundleScorer.load(make_bundle()).score_batch([0.1] * embed_dim, []) == []
 
 
-def test_cutoff_may_be_absent(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch(), cutoff=None)
-    assert BundleScorer.load(path).cutoff is None
+def test_cutoff_may_be_absent(make_bundle: Callable[..., Path]):
+    assert BundleScorer.load(make_bundle(cutoff=None)).cutoff is None
 
 
 @pytest.mark.parametrize(
@@ -115,23 +44,16 @@ def test_cutoff_may_be_absent(tmp_path: Path):
         {"use_ffn1": False},
     ],
 )
-def test_rejects_unsupported_bundle(tmp_path: Path, overrides: dict[str, Any]):
-    # A bundle needing a feature this class doesn't implement is refused on load.
-    path = tmp_path / "bad.inference.pt"
-    _save_bundle(path, _arch(**overrides))
+def test_rejects_unsupported_bundle(make_bundle: Callable[..., Path], overrides: dict[str, Any]):
     with pytest.raises(ValueError, match="not the supported architecture"):
-        BundleScorer.load(path)
+        BundleScorer.load(make_bundle(**overrides))
 
 
-def test_rejects_wrong_model_class(tmp_path: Path):
-    path = tmp_path / "bad.inference.pt"
-    _save_bundle(path, _arch(), model_class="SomethingElse")
+def test_rejects_wrong_model_class(make_bundle: Callable[..., Path]):
     with pytest.raises(ValueError, match="unsupported model_class"):
-        BundleScorer.load(path)
+        BundleScorer.load(make_bundle(model_class="SomethingElse"))
 
 
-def test_rejects_wrong_format_version(tmp_path: Path):
-    path = tmp_path / "bad.inference.pt"
-    _save_bundle(path, _arch(), format_version=2)
+def test_rejects_wrong_format_version(make_bundle: Callable[..., Path]):
     with pytest.raises(ValueError, match="format_version"):
-        BundleScorer.load(path)
+        BundleScorer.load(make_bundle(format_version=2))

--- a/model_server/tests/test_server.py
+++ b/model_server/tests/test_server.py
@@ -1,0 +1,36 @@
+"""Tests for the FastAPI model server (endpoints + startup)."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server
+
+
+def test_health_and_score(
+    make_bundle: Callable[..., Path], embed_dim: int, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv(server.MODEL_BUNDLE_PATH_ENV, str(make_bundle()))
+    with TestClient(server.app) as client:  # enter -> lifespan loads the bundle
+        health = client.get("/health")
+        assert health.status_code == 200
+        assert health.json() == {"ready": True}
+
+        resp = client.post(
+            "/score",
+            json={"doc_vec": [0.1] * embed_dim, "page_vecs": [[0.2] * embed_dim, [0.3] * embed_dim]},
+        )
+        assert resp.status_code == 200
+        probs = resp.json()["probs"]
+        assert len(probs) == 2
+        assert all(0.0 <= p <= 1.0 for p in probs)
+
+
+def test_startup_fails_without_bundle_path(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv(server.MODEL_BUNDLE_PATH_ENV, raising=False)
+    with pytest.raises(RuntimeError, match=server.MODEL_BUNDLE_PATH_ENV):
+        with TestClient(server.app):
+            pass


### PR DESCRIPTION
## What

**Phase B.2b** — turns the scoring core (#403) into a **running service**. Builds on the `TwoTowerScorer` HTTP client (#402): this is the server that client talks to.

## Pieces

- **`server.py`** — FastAPI app. Loads the bundle **once at startup** from `MODEL_BUNDLE_PATH` into a `BundleScorer` (lifespan), then:
  - `POST /score` — `{doc_vec, page_vecs}` → `{probs}` (mirrors the backend's wire contract)
  - `GET /health` — `{ready: bool}`
  - Startup **fails fast** if `MODEL_BUNDLE_PATH` is unset; `/score` returns 503 if the model isn't loaded.
- **`Dockerfile`** — torch (PyTorch) lives *only* in this image; deps installed from `pyproject.toml` via `uv`, uvicorn CMD on port 9100. The trained bundle is **not baked in** — supplied at runtime at `MODEL_BUNDLE_PATH` (mount / artifact download; B.3).
- **`.github/workflows/model-server.yml`** — dedicated CI (ruff + basedpyright + pytest, **with torch**) gated on `model_server/**`. The model server had *no* CI before, since the backend hooks are scoped `^backend/`.
- **Tests** — `conftest.py` builds synthetic bundles (shared by scorer + server tests). `test_server.py` exercises `/score` + `/health` via `TestClient`, and the missing-`MODEL_BUNDLE_PATH` startup failure. `test_scorer.py` refactored onto the shared fixtures (removes the duplicated builders).

## Contract note

`ScoreRequest`/`ScoreResponse` are defined here *and* in the backend (`two_tower_scorer.py`) — each side owns its DTO across the service boundary; they agree on the JSON shape. That's normal for a microservice seam (the backend can't import this torch project, and vice-versa).

## Not in scope

- **B.3** — weights delivery (S3/mount + init container) + Helm opt-in wiring + `RELEVANCE_MODEL_SERVER_URL` config on the backend. A real Docker image build also lands there.
- Wiring the filter into the reconcile flow.

## Verification

Local: **12 tests pass** (10 scorer + 2 server), ruff + strict basedpyright clean, real bundle loads + scores. The **Dockerfile is inspection-verified only** — a torch image build is heavy and there's no daemon here; the actual build gets validated with the deployment wiring (B.3). The uv flags used (`--no-install-project`, `--no-sync`) were confirmed valid.