### PR TITLE
feat(chat-fe): send the open wiki page with each chat message

### DIFF
--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -39,6 +39,7 @@ import {
   type PersistedChatMessage,
 } from "@/lib/chat";
 import { useDrafting, type DraftingState } from "@/lib/drafting";
+import { useAppFocus } from "@/hooks/useAppFocus";
 import { ChatHistoryPanel } from "@/components/chat/ChatHistoryPanel";
 import { presentTool } from "@/lib/tools";
 import { reviseDraft } from "@/lib/wiki";
@@ -79,6 +80,9 @@ const MIN_EXPANDED_WIDTH = 280;
 export function ChatWidget() {
   const { user } = useAuth();
   const { drafting, expandTick, getDraftBody, applyDraftBody } = useDrafting();
+  // The wiki page the user currently has open (null off the wiki), sent with
+  // each message so the chat agent knows what they're looking at.
+  const currentWikiPath = useAppFocus().wikiPath;
   const [mode, setMode] = useState<Mode>("closed");
   const [expandedWidth, setExpandedWidth] = useState<number>(
     DEFAULT_EXPANDED_WIDTH,
@@ -442,16 +446,21 @@ export function ChatWidget() {
 
       let streamFailed = false;
       try {
-        await streamMessage(activeId, text, (raw) => {
-          const ev = raw as StreamEvent;
-          if (ev.type === "error") {
-            streamFailed = true;
-            setError(ev.message);
-            setItems((prev) => markRunningToolsAsError(prev));
-            return;
-          }
-          setItems((prev) => reduceEvent(prev, ev));
-        });
+        await streamMessage(
+          activeId,
+          text,
+          (raw) => {
+            const ev = raw as StreamEvent;
+            if (ev.type === "error") {
+              streamFailed = true;
+              setError(ev.message);
+              setItems((prev) => markRunningToolsAsError(prev));
+              return;
+            }
+            setItems((prev) => reduceEvent(prev, ev));
+          },
+          { currentPath: currentWikiPath },
+        );
       } catch (err) {
         streamFailed = true;
         setError(formatError(err));
@@ -475,7 +484,7 @@ export function ChatWidget() {
         }
       }
     },
-    [sessionId, drafting, getDraftBody, applyDraftBody],
+    [sessionId, drafting, getDraftBody, applyDraftBody, currentWikiPath],
   );
 
   const onSend = useCallback(

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -48,13 +48,19 @@ export function streamMessage(
   sessionId: string,
   content: string,
   onEvent: (data: unknown) => void,
-  options?: { signal?: AbortSignal },
+  options?: { signal?: AbortSignal; currentPath?: string | null },
 ): Promise<void> {
   return apiStream(
     "/chat/messages",
     {
       method: "POST",
-      body: JSON.stringify({ session_id: sessionId, content }),
+      // current_path: the wiki page the user has open, so the agent knows
+      // what they're looking at (null when not on a page).
+      body: JSON.stringify({
+        session_id: sessionId,
+        content,
+        current_path: options?.currentPath ?? null,
+      }),
     },
     onEvent,
     options?.signal,


### PR DESCRIPTION
Frontend for chat page-awareness. **Stacked on #406** (the backend that consumes `current_path`).

⚠️ **Merge order:** merge **#406 first**, then this. GitHub will retarget this PR to `main` once #406 lands. (Merging this one first would fold it into the #406 branch, not `main` — the trap we hit with #398/#399.)

## What
- `ChatWidget` reads the current open wiki page via `useAppFocus().wikiPath` (null off the wiki) and passes it as `currentPath` to `streamMessage` on every send.
- `streamMessage` gained an optional `currentPath`, sent as `current_path` in the POST body.

Combined with #406, the agent now gets a per-turn context reminder naming the user and the page they have open. `bun run typecheck` + prettier clean.