### PR TITLE
feat(model-server): torch→ONNX export tool + CI

### DIFF
--- a/.github/workflows/model-server.yml
+++ b/.github/workflows/model-server.yml
@@ -1,0 +1,37 @@
+name: Model server checks
+
+concurrency:
+  group: model-server-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    # Self-contained project with its own (torch) deps — only run when it changes.
+    paths:
+      - "model_server/**"
+  workflow_dispatch:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: model_server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Install deps
+        run: uv sync --group dev
+
+      - name: ruff
+        run: uv run --group dev ruff check two_tower tests export.py
+
+      - name: basedpyright
+        run: uv run --group dev basedpyright two_tower tests export.py
+
+      - name: pytest
+        run: uv run --group dev pytest -q

--- a/model_server/export.py
+++ b/model_server/export.py
@@ -1,0 +1,93 @@
+"""Export a trained two-tower bundle to ONNX for in-process serving.
+
+The backend scores relevance in-process with onnxruntime — no torch, no separate
+model-server pod. This tool is the torch → ONNX bridge: load a bundle, export
+the network to a graph whose output is P(update) per (doc, page) pair, and
+verify the ONNX output matches torch before writing it.
+
+    python export.py model.inference.pt model.onnx
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import onnxruntime as ort
+import torch
+from torch import nn
+
+from two_tower.bundle import load_inference_bundle
+
+# Two-tower output classes: index 1 == "update" (i.e. relevant).
+_UPDATE_CLASS_INDEX = 1
+
+# Inputs match what the backend's OnnxScorer feeds: the page (wiki) side and the
+# document side, one row per candidate pair.
+_INPUT_NAMES = ["wiki", "doc"]
+_OUTPUT_NAME = "prob"
+
+_PARITY_ATOL = 1e-5
+
+
+class _ProbHead(nn.Module):
+    """Wrap the classifier so the graph outputs P(update) directly, not logits."""
+
+    def __init__(self, model: nn.Module) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(self, wiki_emb: torch.Tensor, doc_emb: torch.Tensor) -> torch.Tensor:
+        logits = self.model(wiki_emb, doc_emb)
+        return torch.softmax(logits, dim=-1)[:, _UPDATE_CLASS_INDEX]
+
+
+def export_onnx(bundle_path: Path, out_path: Path) -> None:
+    """Export ``bundle_path`` (a .inference.pt) to an ONNX graph at ``out_path``.
+
+    Raises if the ONNX output doesn't match torch within tolerance.
+    """
+    bundle = load_inference_bundle(bundle_path)
+    head = _ProbHead(bundle.model).eval()
+    embed_dim = bundle.model.input_proj.in_features // 2  # concat[wiki, doc]
+
+    example = (torch.randn(3, embed_dim), torch.randn(3, embed_dim))
+    torch.onnx.export(
+        head,
+        example,
+        str(out_path),
+        input_names=_INPUT_NAMES,
+        output_names=[_OUTPUT_NAME],
+        # Batch (number of candidate pages) varies per request.
+        dynamic_axes={name: {0: "batch"} for name in [*_INPUT_NAMES, _OUTPUT_NAME]},
+        # Classic TorchScript exporter — the dynamo path pulls in onnxscript and
+        # is overkill for this plain MLP.
+        dynamo=False,
+    )
+    _assert_parity(head, out_path, example)
+
+
+def _assert_parity(
+    head: nn.Module, onnx_path: Path, example: tuple[torch.Tensor, torch.Tensor]
+) -> None:
+    wiki, doc = example
+    with torch.no_grad():
+        torch_out = head(wiki, doc).numpy()
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    onnx_out = session.run(None, {"wiki": wiki.numpy(), "doc": doc.numpy()})[0]
+    max_diff = float(np.abs(torch_out - onnx_out).max())
+    if max_diff > _PARITY_ATOL:
+        raise RuntimeError(f"ONNX/torch parity failed: max diff {max_diff} > {_PARITY_ATOL}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", type=Path, help="path to a *.inference.pt bundle")
+    parser.add_argument("out", type=Path, help="destination *.onnx path")
+    args = parser.parse_args()
+    export_onnx(args.bundle, args.out)
+    print(f"exported {args.out} (parity within {_PARITY_ATOL})")
+
+
+if __name__ == "__main__":
+    main()

--- a/model_server/export.py
+++ b/model_server/export.py
@@ -13,11 +13,12 @@ import argparse
 from pathlib import Path
 
 import numpy as np
+import onnx
 import onnxruntime as ort
 import torch
 from torch import nn
 
-from two_tower.bundle import load_inference_bundle
+from two_tower.bundle import LoadedBundle, load_inference_bundle
 
 # Two-tower output classes: index 1 == "update" (i.e. relevant).
 _UPDATE_CLASS_INDEX = 1
@@ -64,7 +65,25 @@ def export_onnx(bundle_path: Path, out_path: Path) -> None:
         # is overkill for this plain MLP.
         dynamo=False,
     )
+    _embed_metadata(out_path, bundle)
     _assert_parity(head, out_path, example)
+
+
+def _embed_metadata(out_path: Path, bundle: LoadedBundle) -> None:
+    """Carry the model's serving config in the ONNX graph itself, so the served
+    artifact is self-describing: the calibrated ``cutoff`` (the backend reads it
+    as the two-tower threshold) and the ``embedding_model`` its vectors must
+    come from. Keeps the threshold with the model instead of hand-configured.
+    """
+    model = onnx.load(str(out_path))
+    props = {"embedding_model": bundle.embedding_model}
+    if bundle.cutoff is not None:
+        props["cutoff"] = str(bundle.cutoff)
+    for key, value in props.items():
+        entry = model.metadata_props.add()
+        entry.key = key
+        entry.value = value
+    onnx.save(model, str(out_path))
 
 
 def _assert_parity(

--- a/model_server/export.py
+++ b/model_server/export.py
@@ -10,6 +10,7 @@ verify the ONNX output matches torch before writing it.
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +20,8 @@ import torch
 from torch import nn
 
 from two_tower.bundle import LoadedBundle, load_inference_bundle
+
+log = logging.getLogger(__name__)
 
 # Two-tower output classes: index 1 == "update" (i.e. relevant).
 _UPDATE_CLASS_INDEX = 1
@@ -46,27 +49,36 @@ class _ProbHead(nn.Module):
 def export_onnx(bundle_path: Path, out_path: Path) -> None:
     """Export ``bundle_path`` (a .inference.pt) to an ONNX graph at ``out_path``.
 
-    Raises if the ONNX output doesn't match torch within tolerance.
+    Raises if the ONNX output doesn't match torch within tolerance. The graph
+    is written to a temp sibling and renamed into ``out_path`` only after the
+    parity check passes, so a failed export never leaves an unverified file at
+    the destination (deploy scripts key off the file's existence).
     """
     bundle = load_inference_bundle(bundle_path)
     head = _ProbHead(bundle.model).eval()
     embed_dim = bundle.model.input_proj.in_features // 2  # concat[wiki, doc]
 
     example = (torch.randn(3, embed_dim), torch.randn(3, embed_dim))
-    torch.onnx.export(
-        head,
-        example,
-        str(out_path),
-        input_names=_INPUT_NAMES,
-        output_names=[_OUTPUT_NAME],
-        # Batch (number of candidate pages) varies per request.
-        dynamic_axes={name: {0: "batch"} for name in [*_INPUT_NAMES, _OUTPUT_NAME]},
-        # Classic TorchScript exporter — the dynamo path pulls in onnxscript and
-        # is overkill for this plain MLP.
-        dynamo=False,
-    )
-    _embed_metadata(out_path, bundle)
-    _assert_parity(head, out_path, example)
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    try:
+        torch.onnx.export(
+            head,
+            example,
+            str(tmp_path),
+            input_names=_INPUT_NAMES,
+            output_names=[_OUTPUT_NAME],
+            # Batch (number of candidate pages) varies per request.
+            dynamic_axes={name: {0: "batch"} for name in [*_INPUT_NAMES, _OUTPUT_NAME]},
+            # Classic TorchScript exporter — the dynamo path pulls in onnxscript and
+            # is overkill for this plain MLP.
+            dynamo=False,
+        )
+        _embed_metadata(tmp_path, bundle)
+        _assert_parity(head, tmp_path, example)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise
+    tmp_path.replace(out_path)
 
 
 def _embed_metadata(out_path: Path, bundle: LoadedBundle) -> None:
@@ -104,8 +116,9 @@ def main() -> None:
     parser.add_argument("bundle", type=Path, help="path to a *.inference.pt bundle")
     parser.add_argument("out", type=Path, help="destination *.onnx path")
     args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO)
     export_onnx(args.bundle, args.out)
-    print(f"exported {args.out} (parity within {_PARITY_ATOL})")
+    log.info("exported %s (parity within %s)", args.out, _PARITY_ATOL)
 
 
 if __name__ == "__main__":

--- a/model_server/pyproject.toml
+++ b/model_server/pyproject.toml
@@ -8,6 +8,8 @@ requires-python = ">=3.12"
 dependencies = [
     "torch>=2.2",
     "numpy>=1.26",
+    "onnx>=1.16",  # torch's ONNX exporter serializes through it
+    "onnxruntime>=1.17",  # parity-check the exported graph against torch
 ]
 
 [dependency-groups]

--- a/model_server/tests/conftest.py
+++ b/model_server/tests/conftest.py
@@ -1,0 +1,89 @@
+"""Shared test fixtures: build synthetic bundles in the on-disk format.
+
+A tiny model is constructed and ``torch.save``d in the bundle layout, so the
+load → score / export paths are exercised end-to-end without the real weights.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+import torch
+
+from two_tower.model import TwoTowerClassifier
+
+EMBED_DIM = 8
+
+
+def _arch(**overrides: Any) -> dict[str, Any]:
+    """A supported arch dict (tiny dims); overrides flip individual flags."""
+    arch = {
+        "embed_dim": EMBED_DIM,
+        "input_proj_dim": 6,
+        "hidden_dim": 4,
+        "ffn1_dim": 4,
+        "num_classes": 2,
+        "dropout": 0.5,
+        # concat head with an input projection + one FFN; nothing else.
+        "use_full_doc_vector": True,
+        "use_input_proj": True,
+        "use_ffn1": True,
+        "interaction_features": False,
+        "embedding_transformation": False,
+        "use_source_type": False,
+        "use_fact_vector": False,
+        "use_ffn2": False,
+        "num_extra_features": 0,
+        "num_post_ffn_features": 0,
+    }
+    arch.update(overrides)
+    return arch
+
+
+@pytest.fixture
+def embed_dim() -> int:
+    return EMBED_DIM
+
+
+@pytest.fixture
+def make_bundle(tmp_path: Path) -> Callable[..., Path]:
+    """Write a bundle file and return its path.
+
+    Keyword args ``cutoff`` / ``format_version`` / ``model_class`` set the
+    bundle envelope; any other kwargs flip ``arch`` flags (e.g.
+    ``make_bundle(use_source_type=True)`` for an unsupported bundle).
+    """
+
+    def _make(
+        *,
+        cutoff: float | None = 0.4,
+        format_version: int = 1,
+        model_class: str = "TwoTowerClassifier",
+        name: str = "model.inference.pt",
+        **arch_overrides: Any,
+    ) -> Path:
+        arch = _arch(**arch_overrides)
+        model = TwoTowerClassifier(
+            arch["embed_dim"],
+            arch["input_proj_dim"],
+            arch["hidden_dim"],
+            arch["ffn1_dim"],
+            num_classes=arch["num_classes"],
+            dropout=arch["dropout"],
+        )
+        path = tmp_path / name
+        torch.save(
+            {
+                "format_version": format_version,
+                "model_class": model_class,
+                "arch": arch,
+                "state_dict": model.state_dict(),
+                "embedding_model": "text-embedding-3-small",
+                "cutoff": cutoff,
+            },
+            path,
+        )
+        return path
+
+    return _make

--- a/model_server/tests/test_export.py
+++ b/model_server/tests/test_export.py
@@ -1,0 +1,41 @@
+"""Test the torch → ONNX export: the exported graph must match the torch scorer."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+import onnxruntime as ort
+
+from export import export_onnx
+from two_tower.scorer import BundleScorer
+
+
+def test_export_matches_torch(make_bundle: Callable[..., Path], embed_dim: int, tmp_path: Path):
+    bundle_path = make_bundle()
+    onnx_path = tmp_path / "model.onnx"
+
+    export_onnx(bundle_path, onnx_path)  # raises if parity fails
+    assert onnx_path.exists()
+
+    doc = [0.1] * embed_dim
+    pages = [[0.2] * embed_dim, [0.5] * embed_dim, [-0.3] * embed_dim]
+
+    # torch reference
+    torch_probs = BundleScorer.load(bundle_path).score_batch(doc, pages)
+
+    # onnxruntime: wiki = pages, doc tiled across them
+    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    onnx_out = np.asarray(
+        session.run(
+            None,
+            {
+                "wiki": np.asarray(pages, dtype=np.float32),
+                "doc": np.asarray([doc] * len(pages), dtype=np.float32),
+            },
+        )[0]
+    ).ravel()
+
+    assert onnx_out.shape == (len(pages),)
+    for t, o in zip(torch_probs, onnx_out):
+        assert abs(t - float(o)) < 1e-5

--- a/model_server/tests/test_export.py
+++ b/model_server/tests/test_export.py
@@ -47,3 +47,20 @@ def test_export_matches_torch(make_bundle: Callable[..., Path], embed_dim: int, 
     assert onnx_out.shape == (len(pages),)
     for t, o in zip(torch_probs, onnx_out):
         assert abs(t - float(o)) < 1e-5
+
+
+def test_failed_parity_leaves_no_file(make_bundle: Callable[..., Path], tmp_path: Path, monkeypatch):
+    # A parity failure must not leave an unverified .onnx at the destination
+    # (deploy scripts key off the file's existence) — nor a stray temp file.
+    import export as export_mod
+
+    def boom(head, path, example):
+        raise RuntimeError("parity failed")
+
+    monkeypatch.setattr(export_mod, "_assert_parity", boom)
+    onnx_path = tmp_path / "model.onnx"
+    import pytest
+    with pytest.raises(RuntimeError):
+        export_mod.export_onnx(make_bundle(), onnx_path)
+    assert not onnx_path.exists()
+    assert not onnx_path.with_suffix(".onnx.tmp").exists()

--- a/model_server/tests/test_export.py
+++ b/model_server/tests/test_export.py
@@ -18,6 +18,14 @@ def test_export_matches_torch(make_bundle: Callable[..., Path], embed_dim: int, 
     export_onnx(bundle_path, onnx_path)  # raises if parity fails
     assert onnx_path.exists()
 
+    # The calibrated cutoff and embedding model ride in the graph so the served
+    # artifact is self-describing — the backend reads cutoff as its threshold.
+    meta = ort.InferenceSession(
+        str(onnx_path), providers=["CPUExecutionProvider"]
+    ).get_modelmeta().custom_metadata_map
+    assert meta["cutoff"] == str(0.4)  # make_bundle's default cutoff
+    assert meta["embedding_model"] == "text-embedding-3-small"
+
     doc = [0.1] * embed_dim
     pages = [[0.2] * embed_dim, [0.5] * embed_dim, [-0.3] * embed_dim]
 

--- a/model_server/tests/test_scorer.py
+++ b/model_server/tests/test_scorer.py
@@ -1,109 +1,38 @@
-"""Round-trip tests for the two-tower bundle loader + scorer.
-
-A tiny synthetic model is built, saved in the bundle format, and loaded back —
-so the load → score path is exercised end-to-end without the real weights.
-"""
+"""Tests for the bundle loader + scorer, over synthetic bundles (see conftest)."""
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import pytest
-import torch
 
 from two_tower.bundle import load_inference_bundle
-from two_tower.model import TwoTowerClassifier
 from two_tower.scorer import BundleScorer
 
-EMBED_DIM = 8
 
-
-def _arch(**overrides: Any) -> dict[str, Any]:
-    """A supported arch dict (tiny dims); overrides flip individual flags."""
-    arch = {
-        "embed_dim": EMBED_DIM,
-        "input_proj_dim": 6,
-        "hidden_dim": 4,
-        "ffn1_dim": 4,
-        "num_classes": 2,
-        "dropout": 0.5,
-        # concat head with an input projection + one FFN; nothing else.
-        "use_full_doc_vector": True,
-        "use_input_proj": True,
-        "use_ffn1": True,
-        "interaction_features": False,
-        "embedding_transformation": False,
-        "use_source_type": False,
-        "use_fact_vector": False,
-        "use_ffn2": False,
-        "num_extra_features": 0,
-        "num_post_ffn_features": 0,
-    }
-    arch.update(overrides)
-    return arch
-
-
-def _save_bundle(
-    path: Path,
-    arch: dict[str, Any],
-    *,
-    cutoff: float | None = 0.4,
-    format_version: int = 1,
-    model_class: str = "TwoTowerClassifier",
-) -> None:
-    model = TwoTowerClassifier(
-        arch["embed_dim"],
-        arch["input_proj_dim"],
-        arch["hidden_dim"],
-        arch["ffn1_dim"],
-        num_classes=arch.get("num_classes", 2),
-        dropout=arch.get("dropout", 0.5),
-    )
-    torch.save(
-        {
-            "format_version": format_version,
-            "model_class": model_class,
-            "arch": arch,
-            "state_dict": model.state_dict(),
-            "embedding_model": "text-embedding-3-small",
-            "cutoff": cutoff,
-        },
-        path,
-    )
-
-
-def test_load_and_score_roundtrip(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch(), cutoff=0.4)
-
-    scorer = BundleScorer.load(path)
+def test_load_and_score_roundtrip(make_bundle: Callable[..., Path], embed_dim: int):
+    scorer = BundleScorer.load(make_bundle(cutoff=0.4))
     assert scorer.cutoff == 0.4
 
     probs = scorer.score_batch(
-        [0.1] * EMBED_DIM, [[0.2] * EMBED_DIM, [0.3] * EMBED_DIM, [0.4] * EMBED_DIM]
+        [0.1] * embed_dim, [[0.2] * embed_dim, [0.3] * embed_dim, [0.4] * embed_dim]
     )
     assert len(probs) == 3
     assert all(0.0 <= p <= 1.0 for p in probs)
 
 
-def test_state_dict_layers(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch())
-    model = load_inference_bundle(path).model
+def test_state_dict_layers(make_bundle: Callable[..., Path]):
+    model = load_inference_bundle(make_bundle()).model
     layers = {name.split(".")[0] for name, _ in model.named_parameters()}
     assert layers == {"input_proj", "hidden", "ffn1", "classifier"}
 
 
-def test_empty_pages_returns_empty(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch())
-    assert BundleScorer.load(path).score_batch([0.1] * EMBED_DIM, []) == []
+def test_empty_pages_returns_empty(make_bundle: Callable[..., Path], embed_dim: int):
+    assert BundleScorer.load(make_bundle()).score_batch([0.1] * embed_dim, []) == []
 
 
-def test_cutoff_may_be_absent(tmp_path: Path):
-    path = tmp_path / "tiny.inference.pt"
-    _save_bundle(path, _arch(), cutoff=None)
-    assert BundleScorer.load(path).cutoff is None
+def test_cutoff_may_be_absent(make_bundle: Callable[..., Path]):
+    assert BundleScorer.load(make_bundle(cutoff=None)).cutoff is None
 
 
 @pytest.mark.parametrize(
@@ -115,23 +44,16 @@ def test_cutoff_may_be_absent(tmp_path: Path):
         {"use_ffn1": False},
     ],
 )
-def test_rejects_unsupported_bundle(tmp_path: Path, overrides: dict[str, Any]):
-    # A bundle needing a feature this class doesn't implement is refused on load.
-    path = tmp_path / "bad.inference.pt"
-    _save_bundle(path, _arch(**overrides))
+def test_rejects_unsupported_bundle(make_bundle: Callable[..., Path], overrides: dict[str, Any]):
     with pytest.raises(ValueError, match="not the supported architecture"):
-        BundleScorer.load(path)
+        BundleScorer.load(make_bundle(**overrides))
 
 
-def test_rejects_wrong_model_class(tmp_path: Path):
-    path = tmp_path / "bad.inference.pt"
-    _save_bundle(path, _arch(), model_class="SomethingElse")
+def test_rejects_wrong_model_class(make_bundle: Callable[..., Path]):
     with pytest.raises(ValueError, match="unsupported model_class"):
-        BundleScorer.load(path)
+        BundleScorer.load(make_bundle(model_class="SomethingElse"))
 
 
-def test_rejects_wrong_format_version(tmp_path: Path):
-    path = tmp_path / "bad.inference.pt"
-    _save_bundle(path, _arch(), format_version=2)
+def test_rejects_wrong_format_version(make_bundle: Callable[..., Path]):
     with pytest.raises(ValueError, match="format_version"):
-        BundleScorer.load(path)
+        BundleScorer.load(make_bundle(format_version=2))


### PR DESCRIPTION
## What

Pivots the two-tower to **in-process ONNX serving** instead of a separate PyTorch model-server pod. This PR is the **torch → ONNX bridge** (`model_server` becomes an offline export tool); the in-process `OnnxScorer` lands in the backend next.

## Why the pivot

The model is a **~6M-param CPU MLP**, internal and opt-in. A dedicated PyTorch service pod (image + weights-delivery + Deployment/Service) is disproportionate — Onyx separates its model server only because *its* models are GB-scale / GPU / shared, none of which applies here. Instead the backend scores **in-process with `onnxruntime` (~40 MB)** inside the `documents` worker — no new pod, no HTTP hop, same scores, equal-or-better latency. The `Scorer` boundary (#397) makes this a clean swap; **#405 (the FastAPI service) is closed.**

## This PR

- **`export.py`** — load a trained `*.inference.pt` bundle, export the network to an ONNX graph whose output is **P(update) per (doc, page) pair**, and **assert the ONNX output matches torch** (within 1e-5) before writing. Uses the classic exporter (`dynamo=False`) to avoid the `onnxscript` dep.
- **deps** — `onnx` (exporter serialization) + `onnxruntime` (parity check).
- **`tests/conftest.py`** — shared synthetic-bundle fixtures; `test_scorer.py` refactored onto them; **`test_export.py`** round-trips a bundle through ONNX and checks the graph matches the torch `BundleScorer`.
- **`.github/workflows/model-server.yml`** — CI for `model_server` (ruff + basedpyright + pytest, **with torch**), gated on `model_server/**`. (The model server had no CI; the backend hooks are `^backend/`-scoped.)

## Verification

- **Exported the real A4 bundle** → 24 MB `.onnx`, **parity within 1e-5** vs torch.
- 11 tests pass, ruff + strict basedpyright clean.
- Output/perf: ONNX runs the same float32 math (probabilities identical to ~1e-6); `onnxruntime` is as-fast-or-faster than torch for a small MLP, and in-process removes the network hop. So no regression — a strict simplification.

## Not in scope (next)

- **`OnnxScorer(Scorer)`** in the backend — runs the exported graph in-process via `onnxruntime` (adds `onnxruntime` as a backend dep), plugging into the existing filter.
- Weights delivery of the `.onnx` (mount / artifact download) + wiring the filter into the reconcile flow.

## Note

`torch.onnx.export(dynamo=False)` emits a deprecation warning (the dynamo exporter is becoming the default). Kept the classic path to avoid the `onnxscript` dependency for a trivially-exportable MLP; can revisit if it's removed upstream.