### PR TITLE
feat(ingest): in-process two-tower ONNX scorer

### DIFF
--- a/backend/app/ingest/relevance/__init__.py
+++ b/backend/app/ingest/relevance/__init__.py
@@ -7,22 +7,20 @@ pluggable :class:`Scorer`). Filters operate on the pipeline carriers
 :class:`app.ingest.types.IngestionDocument` and
 :class:`app.ingest.types.CandidatePage`, whose embeddings are filled by
 ``app.ingest.enrich``.
+
+``TwoTowerScorer`` is intentionally NOT re-exported here — it pulls in
+``onnxruntime`` (via ``onnx_model``), and importing this package shouldn't cost
+that shared-library load for callers that only want the filter contract or the
+cosine filter. Import it directly from ``app.ingest.relevance.two_tower_scorer``
+where the warm model is actually constructed (the ingest worker).
 """
 from app.ingest.relevance.cosine_filter import CosineSimilarityFilter
 from app.ingest.relevance.filter import RelevanceFilter
 from app.ingest.relevance.two_tower_filter import Scorer, TwoTowerFilter
-from app.ingest.relevance.two_tower_scorer import (
-    ScoreRequest,
-    ScoreResponse,
-    TwoTowerScorer,
-)
 
 __all__ = [
     "CosineSimilarityFilter",
     "RelevanceFilter",
     "Scorer",
-    "ScoreRequest",
-    "ScoreResponse",
     "TwoTowerFilter",
-    "TwoTowerScorer",
 ]

--- a/backend/app/ingest/relevance/onnx_model.py
+++ b/backend/app/ingest/relevance/onnx_model.py
@@ -1,0 +1,26 @@
+"""Thin ONNX-runtime wrapper: load a graph, run a feed.
+
+Model-agnostic — it runs whatever ONNX graph it's given. It also isolates
+onnxruntime's untyped surface in one place, so callers (e.g. the two-tower
+scorer) stay strict-clean.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import onnxruntime
+
+
+class OnnxModel:
+    """A loaded ONNX graph, run on CPU."""
+
+    def __init__(self, model_path: str) -> None:
+        # onnxruntime is thinly typed; confine the untyped surface to this class.
+        self._session: Any = onnxruntime.InferenceSession(  # pyright: ignore[reportUnknownMemberType]
+            model_path, providers=["CPUExecutionProvider"]
+        )
+
+    def run(self, feed: dict[str, np.ndarray], output: str) -> np.ndarray:
+        """Run the graph on ``feed`` and return the named ``output`` tensor."""
+        return np.asarray(self._session.run([output], feed)[0])

--- a/backend/app/ingest/relevance/two_tower_scorer.py
+++ b/backend/app/ingest/relevance/two_tower_scorer.py
@@ -1,71 +1,42 @@
-"""HTTP :class:`~app.ingest.relevance.two_tower_filter.Scorer` client for the
-relevance model server.
+"""The two-tower :class:`Scorer` — runs the exported two-tower ONNX graph.
 
-Scores embedding pairs by POSTing them to a separate model-server service (the
-Onyx ``model_server`` pattern) that hosts the trained two-tower network. Keeping
-the model in its own service means the backend carries no ML runtime — only
-this thin HTTP client and the shared request/response schema.
+Maps the filter's one-document-against-many-pages call onto the graph's
+``(wiki, doc) -> prob`` contract: the page is the wiki side, the document is
+tiled across the candidate pages, one forward pass returns P(update) per page.
+Execution is delegated to :class:`OnnxModel`; this class owns only the
+two-tower-specific I/O — the parallel to ``cosine_similarity_score`` for the
+cosine filter.
 
-Raises on any transport or protocol failure; ``TwoTowerFilter`` catches it and
-fails open (keeps the candidates), so a slow or down model server degrades to
-"keep everything" rather than blocking ingestion.
-
-The ``ScoreRequest`` / ``ScoreResponse`` schema is the wire contract the model
-server must implement; both sides share it.
+The trained model is exported to ONNX offline (torch lives only in that export
+step); the backend only ever loads and runs the resulting graph, in-process.
 """
 from __future__ import annotations
 
 from collections.abc import Sequence
 
-import requests
-from pydantic import BaseModel
+import numpy as np
 
-# Path on the model server that scores a batch of (doc, page) embedding pairs.
-SCORE_PATH = "/score"
+from app.ingest.relevance.onnx_model import OnnxModel
 
-# Conservative default: the filter only saves reconcile cost, so a scorer that
-# can't answer quickly should fail open fast rather than stall the pipeline.
-DEFAULT_TIMEOUT_SECONDS = 5.0
-
-
-class ScoreRequest(BaseModel):
-    """One document vector scored against many candidate-page vectors."""
-
-    doc_vec: list[float]
-    page_vecs: list[list[float]]
-
-
-class ScoreResponse(BaseModel):
-    """P(relevant) per page, aligned to ``ScoreRequest.page_vecs``."""
-
-    probs: list[float]
+# Graph input/output names — must match what the ONNX export writes.
+_WIKI_INPUT = "wiki"
+_DOC_INPUT = "doc"
+_PROB_OUTPUT = "prob"
 
 
 class TwoTowerScorer:
-    """The two-tower :class:`Scorer`, backed by an HTTP call to the model server.
+    """A :class:`Scorer` backed by the two-tower ONNX graph, run in-process."""
 
-    Named for the model it serves, though the wire contract itself is a plain
-    vectors-in/probs-out call — the two-tower is what the server hosts.
-    """
-
-    def __init__(
-        self, base_url: str, *, timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS
-    ) -> None:
-        self._url = base_url.rstrip("/") + SCORE_PATH
-        self._timeout = timeout_seconds
-        # One persistent session: the scorer is hit once per document during an
-        # ingestion run, so reusing the connection avoids a per-call TCP/TLS
-        # handshake to the same host.
-        self._session = requests.Session()
+    def __init__(self, model_path: str) -> None:
+        self._model = OnnxModel(model_path)
 
     def score_batch(
         self, doc_vec: Sequence[float], page_vecs: list[Sequence[float]]
     ) -> list[float]:
-        payload = ScoreRequest(
-            doc_vec=list(doc_vec), page_vecs=[list(v) for v in page_vecs]
-        )
-        resp = self._session.post(
-            self._url, json=payload.model_dump(), timeout=self._timeout
-        )
-        resp.raise_for_status()
-        return ScoreResponse.model_validate(resp.json()).probs
+        if not page_vecs:
+            return []
+        wiki = np.asarray(page_vecs, dtype=np.float32)
+        # The document is scored against every page, so tile it across the batch.
+        doc = np.asarray([list(doc_vec)] * len(page_vecs), dtype=np.float32)
+        probs = self._model.run({_WIKI_INPUT: wiki, _DOC_INPUT: doc}, _PROB_OUTPUT)
+        return probs.astype(np.float64).ravel().tolist()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "fastapi>=0.110,<0.137",
     "uvicorn[standard]>=0.27",  # ASGI server — production entry via Dockerfile CMD
     "itsdangerous>=2.1", # Starlette SessionMiddleware signs the session cookie
+    "onnxruntime>=1.17", # in-process relevance scoring (two-tower ONNX); no torch
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_two_tower_scorer.py
+++ b/backend/tests/test_two_tower_scorer.py
@@ -1,74 +1,66 @@
-"""Tests for the two-tower HTTP scorer client.
+"""Tests for the two-tower ONNX scorer.
 
-The network is mocked (patching ``Session.post``) — we assert the wire contract
-(URL, payload, parse) and that failures propagate as exceptions so
-``TwoTowerFilter`` fails open.
+onnxruntime is mocked with a fake session (patched in ``onnx_model``) — we
+assert the scorer's own logic: tile the doc across pages, stack pages, read the
+``prob`` output. That the exported graph itself is numerically correct is
+covered by the export tool's torch-vs-ONNX parity test, not here.
 """
 from __future__ import annotations
 
+from typing import Any
+
+import numpy as np
 import pytest
-import requests
 
-from app.ingest.relevance import TwoTowerFilter, TwoTowerScorer, two_tower_scorer
-from app.ingest.types import CandidatePage, IngestionDocument
-
-
-class _FakeResponse:
-    def __init__(self, payload: dict | None, *, ok: bool = True) -> None:
-        self._payload = payload
-        self._ok = ok
-
-    def raise_for_status(self) -> None:
-        if not self._ok:
-            raise requests.HTTPError("model server 500")
-
-    def json(self) -> dict:
-        assert self._payload is not None
-        return self._payload
+from app.ingest.relevance import Scorer
+from app.ingest.relevance import onnx_model
+from app.ingest.relevance.two_tower_scorer import TwoTowerScorer
 
 
-def test_score_batch_posts_contract_and_parses(monkeypatch):
-    captured: dict = {}
+class _FakeSession:
+    """Captures the feed and returns a preset ``prob`` array."""
 
-    def fake_post(self, url, json=None, timeout=None):
-        captured.update(url=url, json=json, timeout=timeout)
-        return _FakeResponse({"probs": [0.9, 0.1]})
+    def __init__(self, probs: list[float]) -> None:
+        self._probs = probs
+        self.feed: dict[str, Any] | None = None
 
-    monkeypatch.setattr(two_tower_scorer.requests.Session, "post", fake_post)
-
-    scorer = TwoTowerScorer("http://model-server:9100/")
-    probs = scorer.score_batch([1.0, 0.0], [[0.1, 0.2], [0.3, 0.4]])
-
-    assert probs == [0.9, 0.1]
-    assert captured["url"] == "http://model-server:9100/score"  # trailing slash trimmed
-    assert captured["json"] == {
-        "doc_vec": [1.0, 0.0],
-        "page_vecs": [[0.1, 0.2], [0.3, 0.4]],
-    }
-    assert captured["timeout"] == two_tower_scorer.DEFAULT_TIMEOUT_SECONDS
+    def run(self, output_names: list[str], feed: dict[str, Any]) -> list[Any]:
+        self.feed = feed
+        return [np.asarray(self._probs, dtype=np.float32)]
 
 
-def test_score_batch_raises_on_http_error(monkeypatch):
-    monkeypatch.setattr(
-        two_tower_scorer.requests.Session,
-        "post",
-        lambda self, url, json=None, timeout=None: _FakeResponse(None, ok=False),
-    )
-    with pytest.raises(requests.HTTPError):
-        TwoTowerScorer("http://model-server:9100").score_batch([1.0], [[1.0]])
+def _scorer(
+    monkeypatch: pytest.MonkeyPatch, probs: list[float]
+) -> tuple[TwoTowerScorer, _FakeSession]:
+    fake = _FakeSession(probs)
+    monkeypatch.setattr(onnx_model.onnxruntime, "InferenceSession", lambda *a, **k: fake)
+    return TwoTowerScorer("unused.onnx"), fake
 
 
-def test_filter_fails_open_when_model_server_errors(monkeypatch):
-    # End-to-end: TwoTowerScorer raises → TwoTowerFilter keeps all candidates.
-    def boom(self, url, json=None, timeout=None):
-        raise requests.ConnectionError("model server unreachable")
+def test_score_batch_returns_probs(monkeypatch: pytest.MonkeyPatch):
+    scorer, _ = _scorer(monkeypatch, [0.9, 0.1])
+    probs = scorer.score_batch([1.0, 2.0], [[0.1, 0.2], [0.3, 0.4]])
+    assert probs == pytest.approx([0.9, 0.1])
 
-    monkeypatch.setattr(two_tower_scorer.requests.Session, "post", boom)
 
-    f = TwoTowerFilter(TwoTowerScorer("http://model-server:9100"), threshold=0.99)
-    doc = IngestionDocument(content="d", embedding=[1.0, 0.0])
-    pages = [
-        CandidatePage(path="a.md", body="b", embedding=[0.1, 0.2]),
-        CandidatePage(path="b.md", body="b", embedding=[0.3, 0.4]),
-    ]
-    assert f.keep_relevant(doc, pages) == pages
+def test_tiles_doc_and_stacks_pages(monkeypatch: pytest.MonkeyPatch):
+    scorer, fake = _scorer(monkeypatch, [0.5, 0.5])
+    scorer.score_batch([1.0, 2.0], [[0.1, 0.2], [0.3, 0.4]])
+    assert fake.feed is not None
+    # wiki = the candidate pages, stacked
+    assert np.allclose(fake.feed["wiki"], [[0.1, 0.2], [0.3, 0.4]])
+    # doc = the one document vector tiled across both pages
+    assert np.allclose(fake.feed["doc"], [[1.0, 2.0], [1.0, 2.0]])
+    assert fake.feed["wiki"].dtype == np.float32
+
+
+def test_empty_pages_returns_empty_without_running(monkeypatch: pytest.MonkeyPatch):
+    scorer, fake = _scorer(monkeypatch, [])
+    assert scorer.score_batch([1.0, 2.0], []) == []
+    assert fake.feed is None  # never ran the graph
+
+
+def test_satisfies_scorer_protocol(monkeypatch: pytest.MonkeyPatch):
+    scorer, _ = _scorer(monkeypatch, [0.5])
+    s: Scorer = scorer  # structural conformance
+    assert hasattr(s, "score_batch")


### PR DESCRIPTION
## What

The **in-process serving** side of the two-tower pivot: the backend runs the exported ONNX graph with **onnxruntime** (~40 MB, no torch) inside the worker — **no separate model-server pod**. Pairs with the export tool (#408), plugs into the `Scorer` boundary (#397) so `TwoTowerFilter` is unchanged.

## Structure — two files, mirroring the cosine filter

Split by concern, the way cosine separates its scoring primitive from the filter:

- **`onnx_model.py`** — `OnnxModel`: load an ONNX graph, run a feed → output. **Model-agnostic**, and isolates onnxruntime's thin typing behind one `Any`-typed session (keeps everything else strict-clean, no backend-config relaxation).
- **`two_tower_scorer.py`** — `TwoTowerScorer(Scorer)`: the **two-tower-specific** piece — the `wiki`/`doc`/`prob` contract and tiling the document across candidate pages — delegating execution to `OnnxModel`. Model-consistent name, matching `CosineSimilarityFilter` / `TwoTowerFilter`.

So: `OnnxModel` = generic runtime (like `cosine_similarity_score` is a primitive); `TwoTowerScorer` = the model application (like `CosineSimilarityFilter`); `TwoTowerFilter` = the filter logic.

## Also

- **dep: `onnxruntime`** (brings numpy). torch stays out of the product entirely — only the offline export uses it.
- **Removed the now-dead HTTP `TwoTowerScorer` (#402)** + its test — the pivot replaces the separate-service/HTTP path with in-process scoring.

## Verification

- `TwoTowerScorer` loads the **real** exported A4 graph and its scores **match the torch reference exactly** (`0.2761, 0.0, 0.0002`) — both halves agree on the contract, output parity end-to-end.
- 4 mock-based tests (probs, tile+stack, empty→no-run, `Scorer` conformance). Ruff + strict basedpyright clean.

## Not in scope (next)

- Weights delivery — get the `.onnx` to the worker (mount / artifact download) + a `RELEVANCE_MODEL_PATH` config.
- Wire the filter into the reconcile flow — cosine (cold) or `TwoTowerFilter(TwoTowerScorer(path))` (warm, when a model is present).
- Training pipeline (deferred).

Serving path complete in code: `TwoTowerFilter → Scorer → TwoTowerScorer → OnnxModel → onnxruntime`, in-process.