### PR TITLE
feat(deploy): deliver two-tower relevance model to the documents worker from S3

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -77,7 +77,7 @@ class Config(BaseModel):
     # never in the repo). The two-tower's threshold ships with the model (its
     # embedded cutoff) — the model is the single source of truth for it. Cosine has
     # its own scale, so it keeps its own configurable threshold.
-    ingest_relevance_model_path: str
+    ingest_relevance_two_tower_model_path: str
     ingest_relevance_cosine_threshold: float
 
     # Opt-in eval logging — captures reconciler inputs/outputs to ingest_eval_samples
@@ -200,7 +200,7 @@ def load_config() -> Config:
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),
         ingest_irrelevant_stop_n=_positive_int("INGEST_IRRELEVANT_STOP_N", 2),
         ingest_embed_model=os.environ.get("INGEST_EMBED_MODEL", "text-embedding-3-small"),
-        ingest_relevance_model_path=os.environ.get("INGEST_RELEVANCE_MODEL_PATH", ""),
+        ingest_relevance_two_tower_model_path=os.environ.get("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH", ""),
         # Cosine cold-start default: the study's 85%-filter operating point.
         ingest_relevance_cosine_threshold=_nonneg_float(
             "INGEST_RELEVANCE_COSINE_THRESHOLD", 0.4334

--- a/backend/app/ingest/relevance/factory.py
+++ b/backend/app/ingest/relevance/factory.py
@@ -1,7 +1,7 @@
 """Assemble the relevance filter for this deployment from config.
 
 Cold start (no model configured) → :class:`CosineSimilarityFilter`. Once a
-deployment has a trained model, ``INGEST_RELEVANCE_MODEL_PATH`` points at the
+deployment has a trained model, ``INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH`` points at the
 exported two-tower ONNX graph → :class:`TwoTowerFilter`. The two are
 interchangeable behind :class:`RelevanceFilter`, so callers just take whatever
 this returns.
@@ -24,7 +24,7 @@ def build_relevance_filter(config: Config | None = None) -> RelevanceFilter:
     """Return the relevance filter to run, per config (defaults to ``CONFIG``)."""
     cfg = config if config is not None else CONFIG
     return _select(
-        model_path=cfg.ingest_relevance_model_path,
+        model_path=cfg.ingest_relevance_two_tower_model_path,
         cosine_threshold=cfg.ingest_relevance_cosine_threshold,
     )
 
@@ -46,7 +46,7 @@ def _select(*, model_path: str, cosine_threshold: float) -> RelevanceFilter:
             return TwoTowerFilter(scorer, threshold=threshold)
         # A missing artifact shouldn't take the filter down — fall back to cosine.
         log.warning(
-            "INGEST_RELEVANCE_MODEL_PATH=%s does not exist; falling back to cosine",
+            "INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH=%s does not exist; falling back to cosine",
             model_path,
         )
     return CosineSimilarityFilter(threshold=cosine_threshold)

--- a/backend/app/scripts/download_relevance_model.py
+++ b/backend/app/scripts/download_relevance_model.py
@@ -1,0 +1,116 @@
+"""Download the two-tower relevance model (.onnx) from S3 to local disk.
+
+Runs as an init-container on the ``documents`` worker before the app starts, so
+the worker finds the warm model at ``INGEST_RELEVANCE_MODEL_PATH``. An empty
+``INGEST_RELEVANCE_MODEL_S3_URI`` means there's nothing to fetch — the worker
+then runs the cosine cold-start filter (see ``app.ingest.relevance.factory``).
+
+Any S3-compatible endpoint works (AWS S3, GCS interop, MinIO, Cloudflare R2) via
+boto3, same as the backup script. The download goes to a ``.part`` sibling and
+is renamed into place only once complete, so a failed transfer never leaves a
+truncated file that the scorer would try to load.
+
+A download failure is logged but exits 0 (not a hard error): the worker still
+starts and the factory falls back to cosine when the file is absent, keeping
+ingestion up rather than crash-looping on an S3 blip. The degradation is visible
+in the logs and in which filter the worker reports building.
+
+Configuration is env-based (the Helm chart's init-container sets these):
+
+- ``INGEST_RELEVANCE_MODEL_S3_URI`` — s3://bucket/key of the exported .onnx.
+- ``INGEST_RELEVANCE_MODEL_PATH``   — local destination the app reads. Required.
+- ``INGEST_RELEVANCE_MODEL_S3_ENDPOINT`` — optional endpoint URL for non-AWS.
+- ``INGEST_RELEVANCE_MODEL_S3_REGION``   — optional region.
+- Credentials via the standard AWS env vars / IAM role chain.
+
+Usage:
+
+    python -m app.scripts.download_relevance_model
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict
+
+from app.utils.logging import setup_logging
+
+log = logging.getLogger(__name__)
+
+
+class ModelDownloadConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    s3_uri: str
+    dest: str
+    endpoint_url: str | None = None
+    region: str | None = None
+
+    @staticmethod
+    def from_env() -> "ModelDownloadConfig":
+        dest = os.environ.get("INGEST_RELEVANCE_MODEL_PATH", "")
+        if not dest:
+            raise SystemExit("INGEST_RELEVANCE_MODEL_PATH is required")
+        return ModelDownloadConfig(
+            s3_uri=os.environ.get("INGEST_RELEVANCE_MODEL_S3_URI", ""),
+            dest=dest,
+            endpoint_url=os.environ.get("INGEST_RELEVANCE_MODEL_S3_ENDPOINT") or None,
+            region=os.environ.get("INGEST_RELEVANCE_MODEL_S3_REGION") or None,
+        )
+
+
+def parse_s3_uri(uri: str) -> tuple[str, str]:
+    """Split ``s3://bucket/path/to/key`` into ``(bucket, key)``."""
+    parsed = urlparse(uri)
+    if parsed.scheme != "s3" or not parsed.netloc:
+        raise ValueError(f"not an s3:// URI: {uri!r}")
+    key = parsed.path.lstrip("/")
+    if not key:
+        raise ValueError(f"s3 URI has no object key: {uri!r}")
+    return parsed.netloc, key
+
+
+def _s3_client(cfg: ModelDownloadConfig) -> Any:
+    """``boto3.client`` behind an ``Any`` boundary — botocore is untyped, so
+    the unavoidable Unknown is confined to this one seam."""
+    import boto3
+
+    return boto3.client(  # pyright: ignore
+        "s3", endpoint_url=cfg.endpoint_url, region_name=cfg.region
+    )
+
+
+def download(client: Any, cfg: ModelDownloadConfig) -> None:
+    """Fetch the model to a ``.part`` file, then rename it into ``cfg.dest``."""
+    bucket, key = parse_s3_uri(cfg.s3_uri)
+    dest = Path(cfg.dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    part = dest.with_suffix(dest.suffix + ".part")
+    client.download_file(bucket, key, str(part))  # pyright: ignore[reportUnknownMemberType]
+    part.replace(dest)
+    log.info("relevance model ready: s3://%s/%s -> %s (%d bytes)", bucket, key, dest, dest.stat().st_size)
+
+
+def main() -> int:
+    setup_logging()
+    cfg = ModelDownloadConfig.from_env()
+    if not cfg.s3_uri:
+        log.info("INGEST_RELEVANCE_MODEL_S3_URI unset; skipping (cosine cold-start filter)")
+        return 0
+    try:
+        download(_s3_client(cfg), cfg)
+    except Exception:
+        # Soft-fail: keep the worker startable on cosine rather than crash-loop.
+        log.exception("relevance model download failed; worker will fall back to cosine")
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/scripts/download_relevance_model.py
+++ b/backend/app/scripts/download_relevance_model.py
@@ -1,8 +1,8 @@
 """Download the two-tower relevance model (.onnx) from S3 to local disk.
 
 Runs as an init-container on the ``documents`` worker before the app starts, so
-the worker finds the warm model at ``INGEST_RELEVANCE_MODEL_PATH``. An empty
-``INGEST_RELEVANCE_MODEL_S3_URI`` means there's nothing to fetch — the worker
+the worker finds the warm model at ``INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH``. An empty
+``INGEST_RELEVANCE_TWO_TOWER_S3_URI`` means there's nothing to fetch — the worker
 then runs the cosine cold-start filter (see ``app.ingest.relevance.factory``).
 
 Any S3-compatible endpoint works (AWS S3, GCS interop, MinIO, Cloudflare R2) via
@@ -17,10 +17,10 @@ in the logs and in which filter the worker reports building.
 
 Configuration is env-based (the Helm chart's init-container sets these):
 
-- ``INGEST_RELEVANCE_MODEL_S3_URI`` — s3://bucket/key of the exported .onnx.
-- ``INGEST_RELEVANCE_MODEL_PATH``   — local destination the app reads. Required.
-- ``INGEST_RELEVANCE_MODEL_S3_ENDPOINT`` — optional endpoint URL for non-AWS.
-- ``INGEST_RELEVANCE_MODEL_S3_REGION``   — optional region.
+- ``INGEST_RELEVANCE_TWO_TOWER_S3_URI`` — s3://bucket/key of the exported .onnx.
+- ``INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH``   — local destination the app reads. Required.
+- ``INGEST_RELEVANCE_TWO_TOWER_S3_ENDPOINT`` — optional endpoint URL for non-AWS.
+- ``INGEST_RELEVANCE_TWO_TOWER_S3_REGION``   — optional region.
 - Credentials via the standard AWS env vars / IAM role chain.
 
 Usage:
@@ -54,14 +54,14 @@ class ModelDownloadConfig(BaseModel):
 
     @staticmethod
     def from_env() -> "ModelDownloadConfig":
-        download_to = os.environ.get("INGEST_RELEVANCE_MODEL_PATH", "")
+        download_to = os.environ.get("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH", "")
         if not download_to:
-            raise SystemExit("INGEST_RELEVANCE_MODEL_PATH is required")
+            raise SystemExit("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH is required")
         return ModelDownloadConfig(
-            s3_uri=os.environ.get("INGEST_RELEVANCE_MODEL_S3_URI", ""),
+            s3_uri=os.environ.get("INGEST_RELEVANCE_TWO_TOWER_S3_URI", ""),
             download_to=download_to,
-            endpoint_url=os.environ.get("INGEST_RELEVANCE_MODEL_S3_ENDPOINT") or None,
-            region=os.environ.get("INGEST_RELEVANCE_MODEL_S3_REGION") or None,
+            endpoint_url=os.environ.get("INGEST_RELEVANCE_TWO_TOWER_S3_ENDPOINT") or None,
+            region=os.environ.get("INGEST_RELEVANCE_TWO_TOWER_S3_REGION") or None,
         )
 
 
@@ -111,7 +111,7 @@ def main() -> int:
     setup_logging()
     cfg = ModelDownloadConfig.from_env()
     if not cfg.s3_uri:
-        log.info("INGEST_RELEVANCE_MODEL_S3_URI unset; skipping (cosine cold-start filter)")
+        log.info("INGEST_RELEVANCE_TWO_TOWER_S3_URI unset; skipping (cosine cold-start filter)")
         return 0
     try:
         download(_s3_client(cfg), cfg)

--- a/backend/app/scripts/download_relevance_model.py
+++ b/backend/app/scripts/download_relevance_model.py
@@ -48,18 +48,18 @@ class ModelDownloadConfig(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     s3_uri: str
-    dest: str
+    download_to: str
     endpoint_url: str | None = None
     region: str | None = None
 
     @staticmethod
     def from_env() -> "ModelDownloadConfig":
-        dest = os.environ.get("INGEST_RELEVANCE_MODEL_PATH", "")
-        if not dest:
+        download_to = os.environ.get("INGEST_RELEVANCE_MODEL_PATH", "")
+        if not download_to:
             raise SystemExit("INGEST_RELEVANCE_MODEL_PATH is required")
         return ModelDownloadConfig(
             s3_uri=os.environ.get("INGEST_RELEVANCE_MODEL_S3_URI", ""),
-            dest=dest,
+            download_to=download_to,
             endpoint_url=os.environ.get("INGEST_RELEVANCE_MODEL_S3_ENDPOINT") or None,
             region=os.environ.get("INGEST_RELEVANCE_MODEL_S3_REGION") or None,
         )
@@ -87,14 +87,24 @@ def _s3_client(cfg: ModelDownloadConfig) -> Any:
 
 
 def download(client: Any, cfg: ModelDownloadConfig) -> None:
-    """Fetch the model to a ``.part`` file, then rename it into ``cfg.dest``."""
+    """Fetch the model to a ``.part`` file, then rename it into ``cfg.download_to``."""
     bucket, key = parse_s3_uri(cfg.s3_uri)
-    dest = Path(cfg.dest)
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    part = dest.with_suffix(dest.suffix + ".part")
-    client.download_file(bucket, key, str(part))  # pyright: ignore[reportUnknownMemberType]
-    part.replace(dest)
-    log.info("relevance model ready: s3://%s/%s -> %s (%d bytes)", bucket, key, dest, dest.stat().st_size)
+    download_to = Path(cfg.download_to)
+    download_to.parent.mkdir(parents=True, exist_ok=True)
+    part = download_to.with_suffix(download_to.suffix + ".part")
+    try:
+        client.download_file(bucket, key, str(part))  # pyright: ignore[reportUnknownMemberType]
+    except Exception:
+        part.unlink(missing_ok=True)  # don't leave a truncated sibling behind
+        raise
+    part.replace(download_to)
+    log.info(
+        "relevance model ready: s3://%s/%s -> %s (%d bytes)",
+        bucket,
+        key,
+        download_to,
+        download_to.stat().st_size,
+    )
 
 
 def main() -> int:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -120,7 +120,7 @@ def tmp_config(tmp_path, monkeypatch):
         ingest_bm25_limit=20,
         ingest_irrelevant_stop_n=2,
         ingest_embed_model="text-embedding-3-small",
-        ingest_relevance_model_path="",
+        ingest_relevance_two_tower_model_path="",
         ingest_relevance_cosine_threshold=0.4334,
         ingest_eval_logging=False,
         ingest_eval_retention_days=90,

--- a/backend/tests/test_download_relevance_model.py
+++ b/backend/tests/test_download_relevance_model.py
@@ -44,7 +44,7 @@ def test_parse_s3_uri_rejects_bad(bad: str):
 def test_download_writes_dest_and_leaves_no_part(tmp_path: Path):
     dest = tmp_path / "sub" / "model.onnx"  # parent doesn't exist yet
     client = FakeS3({("b", "k/model.onnx"): b"onnx-bytes"})
-    cfg = ModelDownloadConfig(s3_uri="s3://b/k/model.onnx", dest=str(dest))
+    cfg = ModelDownloadConfig(s3_uri="s3://b/k/model.onnx", download_to=str(dest))
 
     download(client, cfg)
 
@@ -54,17 +54,19 @@ def test_download_writes_dest_and_leaves_no_part(tmp_path: Path):
 
 def test_failed_download_leaves_no_partial_file(tmp_path: Path):
     dest = tmp_path / "model.onnx"
+    part = dest.with_suffix(".onnx.part")
 
     class Boom:
         def download_file(self, *a: object, **k: object) -> None:
             Path(a[2] if len(a) > 2 else k["filename"]).write_bytes(b"partial")  # type: ignore[index]
             raise RuntimeError("network died mid-transfer")
 
-    cfg = ModelDownloadConfig(s3_uri="s3://b/k.onnx", dest=str(dest))
+    cfg = ModelDownloadConfig(s3_uri="s3://b/k.onnx", download_to=str(dest))
     with pytest.raises(RuntimeError):
         download(Boom(), cfg)
-    # The truncated .part never got promoted to dest.
+    # Neither the promoted dest nor the truncated .part is left behind.
     assert not dest.exists()
+    assert not part.exists()
 
 
 def test_main_soft_fails_on_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/backend/tests/test_download_relevance_model.py
+++ b/backend/tests/test_download_relevance_model.py
@@ -1,0 +1,81 @@
+"""Tests for the relevance-model download script.
+
+S3 is an in-memory recording fake (no network); the URI parsing and the
+temp-then-rename / soft-fail behavior are what's under test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.scripts import download_relevance_model as dl
+from app.scripts.download_relevance_model import (
+    ModelDownloadConfig,
+    download,
+    parse_s3_uri,
+)
+
+
+class FakeS3:
+    """Minimal stand-in for the boto3 S3 client surface we use."""
+
+    def __init__(self, objects: dict[tuple[str, str], bytes]) -> None:
+        self.objects = objects
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        Path(filename).write_bytes(self.objects[(bucket, key)])
+
+
+def test_parse_s3_uri_splits_bucket_and_key():
+    assert parse_s3_uri("s3://my-bucket/models/relevance/model.onnx") == (
+        "my-bucket",
+        "models/relevance/model.onnx",
+    )
+
+
+@pytest.mark.parametrize("bad", ["https://x/y", "s3://bucket", "s3:///key", "model.onnx"])
+def test_parse_s3_uri_rejects_bad(bad: str):
+    with pytest.raises(ValueError):
+        parse_s3_uri(bad)
+
+
+def test_download_writes_dest_and_leaves_no_part(tmp_path: Path):
+    dest = tmp_path / "sub" / "model.onnx"  # parent doesn't exist yet
+    client = FakeS3({("b", "k/model.onnx"): b"onnx-bytes"})
+    cfg = ModelDownloadConfig(s3_uri="s3://b/k/model.onnx", dest=str(dest))
+
+    download(client, cfg)
+
+    assert dest.read_bytes() == b"onnx-bytes"
+    assert not dest.with_suffix(".onnx.part").exists()  # renamed, not left behind
+
+
+def test_failed_download_leaves_no_partial_file(tmp_path: Path):
+    dest = tmp_path / "model.onnx"
+
+    class Boom:
+        def download_file(self, *a: object, **k: object) -> None:
+            Path(a[2] if len(a) > 2 else k["filename"]).write_bytes(b"partial")  # type: ignore[index]
+            raise RuntimeError("network died mid-transfer")
+
+    cfg = ModelDownloadConfig(s3_uri="s3://b/k.onnx", dest=str(dest))
+    with pytest.raises(RuntimeError):
+        download(Boom(), cfg)
+    # The truncated .part never got promoted to dest.
+    assert not dest.exists()
+
+
+def test_main_soft_fails_on_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("INGEST_RELEVANCE_MODEL_PATH", str(tmp_path / "model.onnx"))
+    monkeypatch.setenv("INGEST_RELEVANCE_MODEL_S3_URI", "s3://b/k.onnx")
+    monkeypatch.setattr(dl, "_s3_client", lambda cfg: (_ for _ in ()).throw(RuntimeError("no creds")))
+    # A download failure must not crash the worker init — exit 0, run cosine.
+    assert dl.main() == 0
+
+
+def test_main_skips_when_uri_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("INGEST_RELEVANCE_MODEL_PATH", str(tmp_path / "model.onnx"))
+    monkeypatch.delenv("INGEST_RELEVANCE_MODEL_S3_URI", raising=False)
+    assert dl.main() == 0

--- a/backend/tests/test_download_relevance_model.py
+++ b/backend/tests/test_download_relevance_model.py
@@ -70,14 +70,14 @@ def test_failed_download_leaves_no_partial_file(tmp_path: Path):
 
 
 def test_main_soft_fails_on_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("INGEST_RELEVANCE_MODEL_PATH", str(tmp_path / "model.onnx"))
-    monkeypatch.setenv("INGEST_RELEVANCE_MODEL_S3_URI", "s3://b/k.onnx")
+    monkeypatch.setenv("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH", str(tmp_path / "model.onnx"))
+    monkeypatch.setenv("INGEST_RELEVANCE_TWO_TOWER_S3_URI", "s3://b/k.onnx")
     monkeypatch.setattr(dl, "_s3_client", lambda cfg: (_ for _ in ()).throw(RuntimeError("no creds")))
     # A download failure must not crash the worker init — exit 0, run cosine.
     assert dl.main() == 0
 
 
 def test_main_skips_when_uri_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("INGEST_RELEVANCE_MODEL_PATH", str(tmp_path / "model.onnx"))
-    monkeypatch.delenv("INGEST_RELEVANCE_MODEL_S3_URI", raising=False)
+    monkeypatch.setenv("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH", str(tmp_path / "model.onnx"))
+    monkeypatch.delenv("INGEST_RELEVANCE_TWO_TOWER_S3_URI", raising=False)
     assert dl.main() == 0

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -46,6 +46,33 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- /* The relevance filter runs only in the documents worker; fetch the */ -}}
+      {{- /* warm model only there, and only when one is configured.           */ -}}
+      {{- $relevanceModel := and (eq $queue "documents") (not (empty $.Values.ingestRelevance.model.s3Uri)) }}
+      {{- $modelPath := printf "%s/model.onnx" $.Values.ingestRelevance.model.mountPath }}
+      {{- if $relevanceModel }}
+      initContainers:
+        - name: fetch-relevance-model
+          image: "{{ $.Values.image.backend.repository }}:{{ $.Values.image.backend.tag }}"
+          imagePullPolicy: {{ $.Values.image.backend.pullPolicy }}
+          command: ["python", "-m", "app.scripts.download_relevance_model"]
+          {{- with $.Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: INGEST_RELEVANCE_MODEL_PATH
+              value: {{ $modelPath | quote }}
+            - name: INGEST_RELEVANCE_MODEL_S3_URI
+              value: {{ $.Values.ingestRelevance.model.s3Uri | quote }}
+            - name: INGEST_RELEVANCE_MODEL_S3_ENDPOINT
+              value: {{ $.Values.ingestRelevance.model.endpoint | quote }}
+            - name: INGEST_RELEVANCE_MODEL_S3_REGION
+              value: {{ $.Values.ingestRelevance.model.region | quote }}
+          volumeMounts:
+            - name: relevance-model
+              mountPath: {{ $.Values.ingestRelevance.model.mountPath | quote }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ $.Values.image.backend.repository }}:{{ $.Values.image.backend.tag }}"
@@ -61,12 +88,24 @@ spec:
           {{- end }}
           env:
             {{- include "agent-workspace.backendEnv" $ | nindent 12 }}
+            {{- if $relevanceModel }}
+            - name: INGEST_RELEVANCE_MODEL_PATH
+              value: {{ $modelPath | quote }}
+            {{- end }}
           volumeMounts:
             {{- include "agent-workspace.backendVolumeMounts" $ | nindent 12 }}
+            {{- if $relevanceModel }}
+            - name: relevance-model
+              mountPath: {{ $.Values.ingestRelevance.model.mountPath | quote }}
+            {{- end }}
           resources:
             {{- toYaml $.Values.worker.resources | nindent 12 }}
       volumes:
         {{- include "agent-workspace.backendVolumes" $ | nindent 8 }}
+        {{- if $relevanceModel }}
+        - name: relevance-model
+          emptyDir: {}
+        {{- end }}
       # Co-schedule with the backend so the RWO PVCs land on the same node.
       affinity:
         podAffinity:

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -48,8 +48,8 @@ spec:
       {{- end }}
       {{- /* The relevance filter runs only in the documents worker; fetch the */ -}}
       {{- /* warm model only there, and only when one is configured.           */ -}}
-      {{- $relevanceModel := and (eq $queue "documents") (not (empty $.Values.ingestRelevance.model.s3Uri)) }}
-      {{- $modelPath := printf "%s/model.onnx" $.Values.ingestRelevance.model.mountPath }}
+      {{- $relevanceModel := and (eq $queue "documents") (not (empty $.Values.ingestRelevance.twoTower.s3Uri)) }}
+      {{- $modelPath := printf "%s/model.onnx" $.Values.ingestRelevance.twoTower.mountPath }}
       {{- if $relevanceModel }}
       initContainers:
         - name: fetch-relevance-model
@@ -61,17 +61,17 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
-            - name: INGEST_RELEVANCE_MODEL_PATH
+            - name: INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH
               value: {{ $modelPath | quote }}
-            - name: INGEST_RELEVANCE_MODEL_S3_URI
-              value: {{ $.Values.ingestRelevance.model.s3Uri | quote }}
-            - name: INGEST_RELEVANCE_MODEL_S3_ENDPOINT
-              value: {{ $.Values.ingestRelevance.model.endpoint | quote }}
-            - name: INGEST_RELEVANCE_MODEL_S3_REGION
-              value: {{ $.Values.ingestRelevance.model.region | quote }}
+            - name: INGEST_RELEVANCE_TWO_TOWER_S3_URI
+              value: {{ $.Values.ingestRelevance.twoTower.s3Uri | quote }}
+            - name: INGEST_RELEVANCE_TWO_TOWER_S3_ENDPOINT
+              value: {{ $.Values.ingestRelevance.twoTower.endpoint | quote }}
+            - name: INGEST_RELEVANCE_TWO_TOWER_S3_REGION
+              value: {{ $.Values.ingestRelevance.twoTower.region | quote }}
           volumeMounts:
             - name: relevance-model
-              mountPath: {{ $.Values.ingestRelevance.model.mountPath | quote }}
+              mountPath: {{ $.Values.ingestRelevance.twoTower.mountPath | quote }}
       {{- end }}
       containers:
         - name: worker
@@ -89,14 +89,14 @@ spec:
           env:
             {{- include "agent-workspace.backendEnv" $ | nindent 12 }}
             {{- if $relevanceModel }}
-            - name: INGEST_RELEVANCE_MODEL_PATH
+            - name: INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH
               value: {{ $modelPath | quote }}
             {{- end }}
           volumeMounts:
             {{- include "agent-workspace.backendVolumeMounts" $ | nindent 12 }}
             {{- if $relevanceModel }}
             - name: relevance-model
-              mountPath: {{ $.Values.ingestRelevance.model.mountPath | quote }}
+              mountPath: {{ $.Values.ingestRelevance.twoTower.mountPath | quote }}
             {{- end }}
           resources:
             {{- toYaml $.Values.worker.resources | nindent 12 }}

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -59,6 +59,24 @@ launchersEnabled: false
 # decision (committed / no_change / irrelevant). Off by default; enable on
 # environments where you want to collect real traffic for eval review.
 ingestEvalLogging: false
+
+# Warm two-tower relevance model. Leave s3Uri empty to run the cosine
+# cold-start filter (nothing is downloaded). When set, an init-container on the
+# documents worker pulls the exported .onnx from S3 into an emptyDir the worker
+# reads at <mountPath>/model.onnx. The weights are supplied at runtime, never
+# baked into the image or committed. A download failure degrades to cosine
+# rather than blocking startup. Credentials come from the standard AWS env /
+# IAM role chain (same as backup.s3); any S3-compatible endpoint works.
+ingestRelevance:
+  model:
+    # s3://<bucket>/<key> of the exported .onnx. Empty => cosine cold-start.
+    s3Uri: ""
+    # Optional endpoint URL for non-AWS backends (GCS interop, MinIO, R2).
+    endpoint: ""
+    # Optional region.
+    region: ""
+    # emptyDir mount on the documents worker; the file lands at <mountPath>/model.onnx.
+    mountPath: /models/relevance
 # Browser-facing wiki origin (e.g. "https://wiki.example.com", no
 # trailing slash). Backend advertises this URL in launcher launch URIs,
 # redirect targets, email links. Optional: when left empty the chart

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -68,7 +68,7 @@ ingestEvalLogging: false
 # rather than blocking startup. Credentials come from the standard AWS env /
 # IAM role chain (same as backup.s3); any S3-compatible endpoint works.
 ingestRelevance:
-  model:
+  twoTower:
     # s3://<bucket>/<key> of the exported .onnx. Empty => cosine cold-start.
     s3Uri: ""
     # Optional endpoint URL for non-AWS backends (GCS interop, MinIO, R2).


### PR DESCRIPTION
## What

Delivers the warm two-tower model to production **without putting weights in the repo or the image**, and names the config after the mechanism (`two_tower`) end to end. An init-container on the `documents` worker pulls the exported `.onnx` from S3 into an `emptyDir`; the worker reads it at `INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH`.

```
documents worker pod:
  initContainer fetch-relevance-model  → s3://…/model.onnx → /models/relevance/model.onnx (emptyDir)
  worker                               → INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH=/models/relevance/model.onnx
```

## Naming

#410 merged with the generic `ingest_relevance_model_path` / `INGEST_RELEVANCE_MODEL_PATH`. Since the warm path builds *specifically* a `TwoTowerScorer`/`TwoTowerFilter`, this PR renames the whole surface to the mechanism — mirroring the existing `INGEST_RELEVANCE_COSINE_THRESHOLD`:

| before | after |
|---|---|
| `ingest_relevance_model_path` (config) | `ingest_relevance_two_tower_model_path` |
| `INGEST_RELEVANCE_MODEL_PATH` | `INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH` |
| `INGEST_RELEVANCE_MODEL_S3_URI` / `_ENDPOINT` / `_REGION` | `INGEST_RELEVANCE_TWO_TOWER_S3_URI` / `_ENDPOINT` / `_REGION` |
| `ingestRelevance.model.*` (Helm) | `ingestRelevance.twoTower.*` |

Internal `model_path` params (in `onnx_model` / `two_tower_scorer` / factory `_select`) stay — they're scoped locals, not the config surface.

## Gating

- **`ingestRelevance.twoTower.s3Uri` empty (default)** → no init-container, no volume, no env, nothing read from S3. The worker runs the cosine cold-start filter. Cosine-only deployments are unchanged.
- **Only the `documents` worker** gets any of this — the sole place the relevance filter runs.

## `download_relevance_model.py`

- boto3 download behind the same `Any` S3 seam as `backup_to_s3.py`; any S3-compatible endpoint; creds via the standard AWS/IAM chain.
- **temp-then-rename** (`.part` → dest) so a failed transfer never leaves a truncated `.onnx`; the `.part` is unlinked on failure so a restarting init-container can't accumulate partials.
- **soft-fail** — a download error is logged loudly but exits 0, so an S3 blip degrades to cosine instead of crash-looping the documents worker (halting all ingestion). Consistent with the filter's fail-open design.

## Config (`values.yaml`)

```yaml
ingestRelevance:
  twoTower:
    s3Uri: ""                    # s3://bucket/key of the exported .onnx; empty => cosine
    endpoint: ""                 # optional, non-AWS S3-compatible endpoint
    region: ""                   # optional
    mountPath: /models/relevance # file lands at <mountPath>/model.onnx
```

## Verification

- **Full artifact chain proven with the real production model** (`…_0707_1409.inference.pt`): export → `.onnx` carries `cutoff=0.00156` + `embedding_model` → backend `TwoTowerScorer` loads it, `score_batch` returns real probabilities, factory builds `TwoTowerFilter(threshold=0.00156)`.
- 14 tests (5 factory, 9 download script). Ruff + strict basedpyright clean.
- `helm lint` passes; `helm template` verified: base render has **zero** init-containers/model refs; with `twoTower.s3Uri` set, exactly the documents worker gets the init-container, mounts on both containers, the emptyDir volume, and `INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH` on init + worker.

## To roll out

1. Export the `.onnx` (export tool, #408) and upload it to your bucket.
2. Set `ingestRelevance.twoTower.s3Uri` (+ endpoint/region if non-AWS).
3. Ensure the worker's SA/creds can read the object.

Weights on disk are inert until the filter is wired into `_reconcile_pushed_document` (separate PR; recommend shadow mode first).
