### PR TITLE
chore: add plans/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,10 @@ backend/runs/
 *.swp
 .vscode/settings.json
 
-# claude code — entire dir is local-only (runtime state + per-user settings).
+# tooling
+# Claude Code - entire dir is local-only (runtime state + per-user settings).
 .claude/
+plans/
 
 # terraform (deploy/terraform/ is a template; lock file is intentionally not tracked here)
 *.tfstate


### PR DESCRIPTION
## Summary

- Adds `plans/` to `.gitignore` so local planning documents are not tracked
- Minor cleanup: standardize the Claude Code comment casing

🤖 Generated with [Claude Code](https://claude.com/claude-code)