### PR TITLE
refactor(wiki): move raw `useSWR` calls into `lib/fileview/hooks.ts`

### DIFF
--- a/frontend/src/lib/fileview/hooks.ts
+++ b/frontend/src/lib/fileview/hooks.ts
@@ -30,12 +30,12 @@ export function useDeletedTombstone(path: string | null) {
 /** Resolve a doc id to its current binding (path/kind/deleted state).
  * Enabled whenever `id` is non-null. */
 export function useDocIdResolve(id: string | null) {
-  const { data, error } = useSWR(
+  const { data, error, isLoading } = useSWR(
     id ? `/wiki/id/${id}` : null,
     () => resolveDocId(id as string),
     { revalidateOnFocus: false },
   );
-  return { resolved: data, error };
+  return { resolved: data, error, isLoading };
 }
 
 /** Resolve a single path to its live id. Enabled whenever `path` is non-null.

--- a/frontend/src/lib/fileview/hooks.ts
+++ b/frontend/src/lib/fileview/hooks.ts
@@ -1,0 +1,53 @@
+"use client";
+
+/** SWR hooks backing the wiki route views (`WikiPage`, `Explorer`, `NewDocView`,
+ * `WikiTombstone`) — each wraps one `/wiki*` endpoint so its key, fetcher, and
+ * shaped return live in one place instead of an inline `useSWR` call. */
+import useSWR from "swr";
+
+import { getDeletedTombstone } from "@/lib/trash";
+import type { ListResponse } from "@/lib/fileview/types";
+import { resolveDocId, resolveIds } from "@/lib/wikiHref";
+
+/** The full flat wiki listing — backs the folder Explorer and the New Doc
+ * destination picker. */
+export function useWikiTree() {
+  const { data, error, isLoading, mutate } = useSWR<ListResponse>("/wiki");
+  return { entries: data?.entries ?? [], error, isLoading, mutate };
+}
+
+/** Tombstone info for a deleted page/folder by its original path, for the
+ * deleted-URL panel. Enabled whenever `path` is non-null. */
+export function useDeletedTombstone(path: string | null) {
+  const { data, error, isLoading } = useSWR(
+    path ? `/wiki/deleted?path=${encodeURIComponent(path)}` : null,
+    () => getDeletedTombstone(path as string),
+    { revalidateOnFocus: false },
+  );
+  return { entry: data, error, isLoading };
+}
+
+/** Resolve a doc id to its current binding (path/kind/deleted state).
+ * Enabled whenever `id` is non-null. */
+export function useDocIdResolve(id: string | null) {
+  const { data, error } = useSWR(
+    id ? `/wiki/id/${id}` : null,
+    () => resolveDocId(id as string),
+    { revalidateOnFocus: false },
+  );
+  return { resolved: data, error };
+}
+
+/** Resolve a single path to its live id. Enabled whenever `path` is non-null.
+ * `tag` namespaces the SWR cache key — callers resolving different concerns
+ * off the same `resolveIds` endpoint pass distinct tags (e.g. "id-fallback"
+ * vs "wiki-path-id"); keep any tag in sync with the key matcher in
+ * `wikiHref.ts:revalidateWiki`. */
+export function usePathToId(tag: string, path: string | null) {
+  const { data, error, isLoading } = useSWR(
+    path ? [tag, path] : null,
+    () => resolveIds([path as string]).then((m) => m[path as string] ?? null),
+    { revalidateOnFocus: false },
+  );
+  return { id: data ?? null, error, isLoading };
+}

--- a/frontend/src/lib/fileview/types.ts
+++ b/frontend/src/lib/fileview/types.ts
@@ -1,0 +1,12 @@
+/** Shared types for the wiki route views (`WikiPage`, `Explorer`, `NewDocView`). */
+
+export interface DocEntry {
+  path: string;
+  updated_at: string;
+}
+
+/** Full flat listing of every wiki doc — the `/wiki` response, used to derive
+ * folder trees and directory listings. */
+export interface ListResponse {
+  entries: DocEntry[];
+}

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -10,7 +10,6 @@ import {
   type FormEvent,
 } from "react";
 import { createPortal } from "react-dom";
-import useSWR from "swr";
 import {
   Button,
   EmptyMessageCard,
@@ -35,16 +34,9 @@ import { WikiHome } from "@/components/wiki/WikiHome";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { apiFetch, ApiError } from "@/lib/api";
-import {
-  isDocId,
-  wikiHref,
-  wikiPath,
-  resolveDocId,
-  resolveIds,
-  revalidateWiki,
-} from "@/lib/wikiHref";
+import { isDocId, wikiHref, wikiPath, revalidateWiki } from "@/lib/wikiHref";
 import { formatRelative } from "@/lib/format";
-import { getDeletedTombstone, restoreTrashed } from "@/lib/trash";
+import { restoreTrashed } from "@/lib/trash";
 import {
   FileView,
   TemplateGallery,
@@ -52,6 +44,12 @@ import {
   DestinationSelect,
   FilenameRow,
 } from "@/lib/fileview/components";
+import {
+  useWikiTree,
+  useDeletedTombstone,
+  useDocIdResolve,
+  usePathToId,
+} from "@/lib/fileview/hooks";
 import { pageTitle } from "@/lib/fileview/utils";
 import { useRequireAuth } from "@/lib/auth";
 import { useHeaderActionsHost } from "@/providers/WikiHeaderActionsProvider";
@@ -67,15 +65,6 @@ import {
 import { relativeTime } from "@/lib/time";
 import { useIsMobile } from "@/lib/viewport";
 import { AI_DRAFT_KEY } from "@/lib/wiki";
-
-interface DocEntry {
-  path: string;
-  updated_at: string;
-}
-
-interface ListResponse {
-  entries: DocEntry[];
-}
 
 /** A wiki URL that no longer points at a live doc — an unknown/expired id, or
  * a page that was deleted but is no longer in Trash (purged). A deleted page
@@ -110,15 +99,7 @@ function WikiTombstone({ path }: { path: string }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
-  const {
-    data: entry,
-    error,
-    isLoading,
-  } = useSWR(
-    `/wiki/deleted?path=${encodeURIComponent(path)}`,
-    () => getDeletedTombstone(path),
-    { revalidateOnFocus: false },
-  );
+  const { entry, error, isLoading } = useDeletedTombstone(path);
 
   if (isLoading)
     return (
@@ -184,12 +165,7 @@ function Explorer({ dir }: { dir: string }) {
   const router = useRouter();
   const isMobile = useIsMobile();
   const host = useHeaderActionsHost();
-  const {
-    data,
-    error: listError,
-    mutate: mutatePaths,
-  } = useSWR<ListResponse>("/wiki");
-  const entries = data?.entries ?? [];
+  const { entries, error: listError, mutate: mutatePaths } = useWikiTree();
   const [mutationError, setMutationError] = useState<string | null>(null);
   const confirmDialog = useConfirm();
   const error =
@@ -605,8 +581,8 @@ function NewDocView({ dir }: { dir: string }) {
   // Destination folder for the new doc — defaults to the route's folder but is
   // user-selectable (the AI flow lands at root, so the picker is how you place it).
   const [destDir, setDestDir] = useState(dir);
-  const { data: tree } = useSWR<ListResponse>("/wiki");
-  const folders = useMemo(() => collectFolders(tree?.entries ?? []), [tree]);
+  const { entries } = useWikiTree();
+  const folders = useMemo(() => collectFolders(entries), [entries]);
 
   // Drop the stash once consumed so it doesn't re-apply on remount / back-nav.
   useEffect(() => {
@@ -1097,10 +1073,8 @@ export default function WikiPage() {
   const commentId = searchParams?.get("comment") ?? null;
 
   // id mode: resolve the id to its current path / kind / deleted state.
-  const { data: resolved, error: resolveErr } = useSWR(
-    idMode ? `/wiki/id/${first}` : null,
-    () => resolveDocId(first as string),
-    { revalidateOnFocus: false },
+  const { resolved, error: resolveErr } = useDocIdResolve(
+    idMode ? (first as string) : null,
   );
 
   // Next.js may hand back percent-encoded segments (e.g. "local%20testing").
@@ -1122,13 +1096,12 @@ export default function WikiPage() {
   const idResolve404 =
     idMode && (resolveErr as ApiError | undefined)?.status === 404;
   const {
-    data: idFallback,
+    id: idFallback,
     error: idFallbackError,
     isLoading: idFallbackLoading,
-  } = useSWR(
-    idResolve404 && pathModePath ? ["id-fallback", pathModePath] : null,
-    () => resolveIds([pathModePath]).then((m) => m[pathModePath] ?? null),
-    { revalidateOnFocus: false },
+  } = usePathToId(
+    "id-fallback",
+    idResolve404 && pathModePath ? pathModePath : null,
   );
   // The doc/folder path we're viewing: from the resolved id, or (legacy path
   // URL) straight from the URL. An unresolved id contributes no path.
@@ -1142,14 +1115,10 @@ export default function WikiPage() {
   // path/id and are handled directly.
   const pathModeActive = !idMode && !!pathModePath && !isNewMode;
   const {
-    data: pathId,
+    id: pathId,
     error: pathIdError,
     isLoading: pathIdLoading,
-  } = useSWR(
-    pathModeActive ? ["wiki-path-id", pathModePath] : null,
-    () => resolveIds([pathModePath]).then((m) => m[pathModePath] ?? null),
-    { revalidateOnFocus: false },
-  );
+  } = usePathToId("wiki-path-id", pathModeActive ? pathModePath : null);
   useEffect(() => {
     if (!pathModeActive || !pathId) return;
     const suffix = commentId ? `?comment=${encodeURIComponent(commentId)}` : "";


### PR DESCRIPTION
## Summary
- `WikiPage.tsx` had 6 raw inline `useSWR` calls (2 of them literal duplicates of the same `/wiki` listing fetch), plus locally-defined `DocEntry`/`ListResponse` types.
- Adds `lib/fileview/hooks.ts` (`useWikiTree`, `useDeletedTombstone`, `useDocIdResolve`, `usePathToId`) and `lib/fileview/types.ts` (`DocEntry`, `ListResponse`), following this codebase's existing hook-wrapper convention (`lib/trash.ts:useTrash`, `lib/permissions.ts:useGroups`/etc.) rather than a flat SWR-key registry.
- `Explorer` and `NewDocView` now share one `useWikiTree()` call instead of two independent `useSWR<ListResponse>("/wiki")` calls.