### PR TITLE
refactor(frontend): add `lib/swr-keys.ts` pathmap

### DIFF
--- a/frontend/src/hooks/useAppFocus.ts
+++ b/frontend/src/hooks/useAppFocus.ts
@@ -4,6 +4,7 @@ import { useMemo } from "react";
 import { usePathname } from "next/navigation";
 import useSWR from "swr";
 
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { isDocId, resolveDocId } from "@/lib/wikiHref";
 
 const WIKI_PREFIX = "/app/wiki/";
@@ -90,7 +91,7 @@ export function useAppFocus(): AppFocus {
     : "";
   const idInUrl = isDocId(firstSeg) ? firstSeg : null;
   const { data: resolved } = useSWR(
-    idInUrl ? `/wiki/id/${idInUrl}` : null,
+    idInUrl ? SWR_KEYS.docIdResolve(idInUrl) : null,
     () => resolveDocId(idInUrl as string),
     { revalidateOnFocus: false },
   );

--- a/frontend/src/lib/activities/hooks.ts
+++ b/frontend/src/lib/activities/hooks.ts
@@ -1,12 +1,7 @@
 import useSWR from "swr";
-import type { AppEvent } from "./types";
 
-function eventsPath(opts: { kind?: string; limit?: number }): string {
-  const qs = new URLSearchParams();
-  if (opts.kind) qs.set("kind", opts.kind);
-  if (opts.limit) qs.set("limit", String(opts.limit));
-  return `/events${qs.toString() ? `?${qs}` : ""}`;
-}
+import { SWR_KEYS } from "@/lib/swr-keys";
+import type { AppEvent } from "./types";
 
 export function useEvents(
   opts: { kind?: string; limit?: number } = {},
@@ -14,7 +9,7 @@ export function useEvents(
 ) {
   const { data, error, isLoading, isValidating, mutate } = useSWR<{
     events: AppEvent[];
-  }>(eventsPath(opts), swrConfig);
+  }>(SWR_KEYS.events(opts), swrConfig);
   return {
     events: data?.events ?? [],
     error: error as Error | undefined,

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -12,6 +12,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export interface TokenSummary {
   id: string;
@@ -30,7 +31,7 @@ export interface CreatedToken {
 
 export function useTokens() {
   const { data, error, isLoading, mutate } = useSWR<{ tokens: TokenSummary[] }>(
-    "/mcp/tokens",
+    SWR_KEYS.mcpTokens,
   );
   return {
     tokens: data?.tokens ?? [],

--- a/frontend/src/lib/craft.ts
+++ b/frontend/src/lib/craft.ts
@@ -3,6 +3,7 @@
 import useSWR from "swr";
 
 import { apiFetch, ApiError } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   createDestinationConfig,
   type DestinationConfig,
@@ -27,8 +28,9 @@ export interface CraftLaunchResponse {
 /** Connection status for the current user. `data` is undefined while the
  * feature is dark (the endpoint 404s) — callers treat that as "unavailable". */
 export function useCraftConnect() {
-  const { data, error, isLoading, mutate } =
-    useSWR<CraftConnectStatus>("/craft/connect");
+  const { data, error, isLoading, mutate } = useSWR<CraftConnectStatus>(
+    SWR_KEYS.craftConnect,
+  );
   // The endpoint 404s when Craft is dark; expose that as a typed flag so
   // callers don't have to cast `error` and check the status themselves.
   const isUnavailable = error instanceof ApiError && error.status === 404;

--- a/frontend/src/lib/documents.ts
+++ b/frontend/src/lib/documents.ts
@@ -1,11 +1,10 @@
 import useSWR from "swr";
 
+import { SWR_KEYS } from "@/lib/swr-keys";
 import type { DocumentActivityResponse } from "@/types";
 
 export function useDocumentActivity(path: string | null) {
-  const key = path
-    ? `/wiki/file/activity?path=${encodeURIComponent(path)}`
-    : null;
+  const key = path ? SWR_KEYS.documentActivity(path) : null;
   const { data, error, isLoading, mutate } =
     useSWR<DocumentActivityResponse>(key);
   return {

--- a/frontend/src/lib/fileview/hooks.ts
+++ b/frontend/src/lib/fileview/hooks.ts
@@ -7,12 +7,15 @@ import useSWR from "swr";
 
 import { getDeletedTombstone } from "@/lib/trash";
 import type { ListResponse } from "@/lib/fileview/types";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { resolveDocId, resolveIds } from "@/lib/wikiHref";
 
 /** The full flat wiki listing — backs the folder Explorer and the New Doc
  * destination picker. */
 export function useWikiTree() {
-  const { data, error, isLoading, mutate } = useSWR<ListResponse>("/wiki");
+  const { data, error, isLoading, mutate } = useSWR<ListResponse>(
+    SWR_KEYS.wikiTree,
+  );
   return { entries: data?.entries ?? [], error, isLoading, mutate };
 }
 
@@ -20,7 +23,7 @@ export function useWikiTree() {
  * deleted-URL panel. Enabled whenever `path` is non-null. */
 export function useDeletedTombstone(path: string | null) {
   const { data, error, isLoading } = useSWR(
-    path ? `/wiki/deleted?path=${encodeURIComponent(path)}` : null,
+    path ? SWR_KEYS.deletedTombstone(path) : null,
     () => getDeletedTombstone(path as string),
     { revalidateOnFocus: false },
   );
@@ -31,7 +34,7 @@ export function useDeletedTombstone(path: string | null) {
  * Enabled whenever `id` is non-null. */
 export function useDocIdResolve(id: string | null) {
   const { data, error, isLoading } = useSWR(
-    id ? `/wiki/id/${id}` : null,
+    id ? SWR_KEYS.docIdResolve(id) : null,
     () => resolveDocId(id as string),
     { revalidateOnFocus: false },
   );
@@ -45,7 +48,7 @@ export function useDocIdResolve(id: string | null) {
  * `wikiHref.ts:revalidateWiki`. */
 export function usePathToId(tag: string, path: string | null) {
   const { data, error, isLoading } = useSWR(
-    path ? [tag, path] : null,
+    path ? SWR_KEYS.pathToId(tag, path) : null,
     () => resolveIds([path as string]).then((m) => m[path as string] ?? null),
     { revalidateOnFocus: false },
   );

--- a/frontend/src/lib/health.ts
+++ b/frontend/src/lib/health.ts
@@ -1,5 +1,7 @@
 import useSWR from "swr";
 
+import { SWR_KEYS } from "@/lib/swr-keys";
+
 export interface QueueHealth {
   name: string;
   // Per-state breakdown. `ready` is what a worker can pick up right now;
@@ -21,7 +23,7 @@ export interface HealthResponse {
 
 export function useHealth(opts: { refreshIntervalMs?: number } = {}) {
   const { data, error, isLoading, isValidating, mutate } =
-    useSWR<HealthResponse>("/health", {
+    useSWR<HealthResponse>(SWR_KEYS.health, {
       refreshInterval: opts.refreshIntervalMs,
     });
   return {

--- a/frontend/src/lib/launchers.ts
+++ b/frontend/src/lib/launchers.ts
@@ -5,6 +5,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export type LauncherKind = "local_cli" | "in_app" | "web_handoff";
 
@@ -88,12 +89,9 @@ export function useLauncherCatalog(
     wikiPath?: string | null;
   } = {},
 ) {
-  const params = new URLSearchParams();
-  if (opts.machineId) params.set("machine_id", opts.machineId);
-  if (opts.wikiPath) params.set("wiki_path", opts.wikiPath);
-  const qs = params.toString();
-  const key = qs ? `/launchers?${qs}` : "/launchers";
-  const { data, error, isLoading, mutate } = useSWR<LauncherCatalog>(key);
+  const { data, error, isLoading, mutate } = useSWR<LauncherCatalog>(
+    SWR_KEYS.launcherCatalog(opts),
+  );
   return {
     launchers: data?.launchers ?? [],
     error: error as Error | undefined,
@@ -103,12 +101,10 @@ export function useLauncherCatalog(
 }
 
 export function useAgentSessions(wikiPath?: string) {
-  const key = wikiPath
-    ? `/agent-sessions?wiki_path=${encodeURIComponent(wikiPath)}`
-    : "/agent-sessions";
-  const { data, error, isLoading, mutate } = useSWR<AgentSessionList>(key, {
-    refreshInterval: 5000,
-  });
+  const { data, error, isLoading, mutate } = useSWR<AgentSessionList>(
+    SWR_KEYS.agentSessions(wikiPath),
+    { refreshInterval: 5000 },
+  );
   return {
     sessions: data?.sessions ?? [],
     error: error as Error | undefined,

--- a/frontend/src/lib/llm.ts
+++ b/frontend/src/lib/llm.ts
@@ -1,5 +1,7 @@
 import useSWR from "swr";
 
+import { SWR_KEYS } from "@/lib/swr-keys";
+
 export interface LLMStatus {
   configured: boolean;
   provider: string;
@@ -7,7 +9,7 @@ export interface LLMStatus {
 
 export function useLLMStatus(opts: { skip?: boolean } = {}) {
   const { data, error, isLoading, mutate } = useSWR<LLMStatus>(
-    opts.skip ? null : "/llm/status",
+    opts.skip ? null : SWR_KEYS.llmStatus,
   );
   return {
     status: data,

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -3,6 +3,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 // Mirrors app/models/notifications.py.
 export interface NotificationView {
@@ -32,7 +33,7 @@ export interface NotificationList {
  */
 export function useNotifications(opts: { activePoll?: boolean } = {}) {
   const { data, error, isLoading, mutate } = useSWR<NotificationList>(
-    "/notifications",
+    SWR_KEYS.notifications,
     { refreshInterval: opts.activePoll ? 5000 : 0 },
   );
   return {

--- a/frontend/src/lib/permissions.ts
+++ b/frontend/src/lib/permissions.ts
@@ -20,6 +20,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export type PrincipalKind = "user" | "group" | "everyone";
 export type ResourceKind = "page" | "folder";
@@ -84,7 +85,7 @@ export interface PageAcl {
 
 export function useGroups() {
   const { data, error, isLoading, mutate } = useSWR<{ groups: Group[] }>(
-    "/groups",
+    SWR_KEYS.groups,
   );
   return {
     groups: data?.groups ?? [],
@@ -98,7 +99,7 @@ export function useGroup(id: string | null) {
   const { data, error, isLoading, mutate } = useSWR<{
     group: Group;
     members: GroupMember[];
-  }>(id ? `/groups/${id}` : null);
+  }>(id ? SWR_KEYS.group(id) : null);
   return {
     group: data?.group ?? null,
     members: data?.members ?? [],
@@ -135,7 +136,7 @@ export interface WikiPathEntry {
 
 export function useWikiPaths() {
   const { data, error, isLoading } = useSWR<{ entries: WikiPathEntry[] }>(
-    "/wiki",
+    SWR_KEYS.wikiTree,
   );
   return {
     entries: data?.entries ?? [],
@@ -148,7 +149,7 @@ export function useWikiPaths() {
  * revalidates after a revoke. */
 export function useGroupShares(id: string | null) {
   const { data, error, isLoading, mutate } = useSWR<{ shares: GroupShare[] }>(
-    id ? `/groups/${id}/shares` : null,
+    id ? SWR_KEYS.groupShares(id) : null,
   );
   return {
     shares: data?.shares ?? [],
@@ -183,7 +184,7 @@ export function removeGroupMember(
 // --------------------------------------------------------------------------- //
 
 export function usePageAcl(path: string | null) {
-  const key = path ? `/wiki/acl?path=${encodeURIComponent(path)}` : null;
+  const key = path ? SWR_KEYS.pageAcl(path) : null;
   const { data, error, isLoading, mutate } = useSWR<PageAcl>(key);
   return {
     acl: data ?? null,

--- a/frontend/src/lib/slackConnect.ts
+++ b/frontend/src/lib/slackConnect.ts
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   createDestinationConfig,
   type DestinationConfig,
@@ -23,8 +24,9 @@ export interface SlackChannel {
 }
 
 export function useSlackConnectStatus() {
-  const { data, error, isLoading, mutate } =
-    useSWR<SlackConnectStatus>("/connectors/slack");
+  const { data, error, isLoading, mutate } = useSWR<SlackConnectStatus>(
+    SWR_KEYS.slackConnectStatus,
+  );
   return {
     status: data ?? null,
     error: error as Error | undefined,

--- a/frontend/src/lib/swr-keys.ts
+++ b/frontend/src/lib/swr-keys.ts
@@ -1,0 +1,86 @@
+/**
+ * Centralized SWR cache key registry.
+ *
+ * Every `use*` hook that calls `useSWR` should reference these constants
+ * instead of an inline string literal, so a typo can't silently create a
+ * second, unlinked cache entry for the same endpoint. Dynamic keys (per-id,
+ * per-path, or query-string endpoints) are builder functions.
+ */
+export const SWR_KEYS = {
+  // ── Wiki ──────────────────────────────────────────────────────────────
+  wikiTree: "/wiki",
+  wikiTrash: "/wiki/trash",
+  docIdResolve: (id: string) => `/wiki/id/${id}`,
+  deletedTombstone: (path: string) =>
+    `/wiki/deleted?path=${encodeURIComponent(path)}`,
+  updateHealth: (path: string) =>
+    `/wiki/update-health?path=${encodeURIComponent(path)}`,
+  documentActivity: (path: string) =>
+    `/wiki/file/activity?path=${encodeURIComponent(path)}`,
+  pageAcl: (path: string) => `/wiki/acl?path=${encodeURIComponent(path)}`,
+  /** `usePathToId`'s cache key is a `[tag, path]` tuple — `tag` namespaces two
+   * call sites resolving different concerns off the same `resolveIds`
+   * endpoint. Keep any tag in sync with the key matcher in
+   * `wikiHref.ts:revalidateWiki`. */
+  pathToId: (tag: string, path: string) => [tag, path] as const,
+
+  // ── Templates ─────────────────────────────────────────────────────────
+  templates: "/templates",
+  adminTemplates: "/admin/templates",
+
+  // ── Groups & permissions ──────────────────────────────────────────────
+  groups: "/groups",
+  group: (id: string) => `/groups/${id}`,
+  groupShares: (id: string) => `/groups/${id}/shares`,
+
+  // ── Notifications ─────────────────────────────────────────────────────
+  notifications: "/notifications",
+
+  // ── LLM ───────────────────────────────────────────────────────────────
+  llmStatus: "/llm/status",
+
+  // ── Agents / MCP ──────────────────────────────────────────────────────
+  mcpTokens: "/mcp/tokens",
+
+  // ── Craft ─────────────────────────────────────────────────────────────
+  craftConnect: "/craft/connect",
+
+  // ── Launchers / agent sessions ────────────────────────────────────────
+  launcherCatalog: (
+    opts: { machineId?: string | null; wikiPath?: string | null } = {},
+  ) => {
+    const params = new URLSearchParams();
+    if (opts.machineId) params.set("machine_id", opts.machineId);
+    if (opts.wikiPath) params.set("wiki_path", opts.wikiPath);
+    const qs = params.toString();
+    return qs ? `/launchers?${qs}` : "/launchers";
+  },
+  agentSessions: (wikiPath?: string) =>
+    wikiPath
+      ? `/agent-sessions?wiki_path=${encodeURIComponent(wikiPath)}`
+      : "/agent-sessions",
+
+  // ── Triggers ──────────────────────────────────────────────────────────
+  triggers: "/triggers",
+  triggerDestinations: "/triggers/destinations",
+  destinationConfigs: "/triggers/destination-configs",
+
+  // ── Slack ─────────────────────────────────────────────────────────────
+  slackConnectStatus: "/connectors/slack",
+
+  // ── Users ─────────────────────────────────────────────────────────────
+  adminUsers: "/admin/users",
+  userSearch: (query: string) =>
+    `/users/search?q=${encodeURIComponent(query.trim())}`,
+
+  // ── Health ────────────────────────────────────────────────────────────
+  health: "/health",
+
+  // ── Activities ────────────────────────────────────────────────────────
+  events: (opts: { kind?: string; limit?: number } = {}) => {
+    const qs = new URLSearchParams();
+    if (opts.kind) qs.set("kind", opts.kind);
+    if (opts.limit) qs.set("limit", String(opts.limit));
+    return `/events${qs.toString() ? `?${qs}` : ""}`;
+  },
+} as const;

--- a/frontend/src/lib/templates.ts
+++ b/frontend/src/lib/templates.ts
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export interface DocumentTemplate {
   id: string;
@@ -50,7 +51,7 @@ export async function listTemplateSummaries(): Promise<
 export function useTemplateSummaries() {
   const { data, error, isLoading, mutate } = useSWR<{
     templates: DocumentTemplateSummary[];
-  }>("/templates");
+  }>(SWR_KEYS.templates);
   return {
     templates: data?.templates ?? [],
     error: error as Error | undefined,
@@ -67,7 +68,7 @@ export function getTemplate(id: string): Promise<DocumentTemplate> {
 export function useAdminTemplates() {
   const { data, error, isLoading, mutate } = useSWR<{
     templates: DocumentTemplate[];
-  }>("/admin/templates");
+  }>(SWR_KEYS.adminTemplates);
   return {
     templates: data?.templates ?? [],
     error: error as Error | undefined,

--- a/frontend/src/lib/trash.ts
+++ b/frontend/src/lib/trash.ts
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 /** One soft-deleted item in the Trash (a page or a folder root). Mirrors the
  * backend `TrashEntryView`. `path` is where it lived; a restore moves it back
@@ -17,7 +18,7 @@ export interface TrashEntry {
 /** The Trash list, newest-first. ACL-filtered server-side. */
 export function useTrash() {
   const { data, error, isLoading, mutate } = useSWR<{ items: TrashEntry[] }>(
-    "/wiki/trash",
+    SWR_KEYS.wikiTrash,
   );
   return {
     items: data?.items ?? [],

--- a/frontend/src/lib/triggers.ts
+++ b/frontend/src/lib/triggers.ts
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 
 import { ApiError, apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export type TriggerKind = "delta" | "schedule";
 
@@ -71,7 +72,7 @@ export interface TriggerUpdateInput {
 
 export function useTriggers() {
   const { data, error, isLoading, mutate } = useSWR<{ triggers: Trigger[] }>(
-    "/triggers",
+    SWR_KEYS.triggers,
   );
   return {
     triggers: data?.triggers ?? [],
@@ -172,7 +173,7 @@ export async function getTriggerDestinations(): Promise<TriggerDestination[]> {
 
 export function useTriggerDestinations() {
   const { data } = useSWR<{ destinations: TriggerDestination[] }>(
-    "/triggers/destinations",
+    SWR_KEYS.triggerDestinations,
   );
   return data?.destinations ?? [];
 }
@@ -193,7 +194,7 @@ export interface DestinationConfig {
 export function useDestinationConfigs() {
   const { data, error, isLoading, mutate } = useSWR<{
     configs: DestinationConfig[];
-  }>("/triggers/destination-configs");
+  }>(SWR_KEYS.destinationConfigs);
   return {
     configs: data?.configs ?? [],
     error: error as Error | undefined,

--- a/frontend/src/lib/users.ts
+++ b/frontend/src/lib/users.ts
@@ -7,6 +7,7 @@
 import useSWR from "swr";
 
 import { apiFetch, apiFetchBlob } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 export interface UserLite {
   id: string;
@@ -17,9 +18,7 @@ export interface UserLite {
 /** Typeahead search. Pass `enabled=false` to suspend the request (e.g.
  * when the picker is closed). SWR dedupes identical keys. */
 export function useUserSearch(query: string, enabled = true) {
-  const key = enabled
-    ? `/users/search?q=${encodeURIComponent(query.trim())}`
-    : null;
+  const key = enabled ? SWR_KEYS.userSearch(query) : null;
   const { data, error, isLoading } = useSWR<{ users: UserLite[] }>(key);
   return {
     users: data?.users ?? [],
@@ -64,8 +63,9 @@ const EMPTY_COUNTS: AdminUserCounts = { active: 0, inactive: 0, invited: 0 };
  * groups), pending invites, and counts. Distinct from `useUserSearch`, which
  * any signed-in user can hit. */
 export function useAdminUsers() {
-  const { data, error, isLoading, mutate } =
-    useSWR<AdminUsersResponse>("/admin/users");
+  const { data, error, isLoading, mutate } = useSWR<AdminUsersResponse>(
+    SWR_KEYS.adminUsers,
+  );
   return {
     users: data?.users ?? [],
     invited: data?.invited ?? [],

--- a/frontend/src/lib/wiki.ts
+++ b/frontend/src/lib/wiki.ts
@@ -1,6 +1,7 @@
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 /** Last path segment as a display name — drops a trailing `.md`. Shared by the
  * share + transfer dialogs so the two copies don't drift. */
@@ -173,9 +174,7 @@ export interface UpdateHealth {
  * reload — the count moves slowly, so a coarser interval than the doc body's
  * is plenty. Pass `null` to disable (no path selected). */
 export function useUpdateHealth(path: string | null) {
-  const key = path
-    ? `/wiki/update-health?path=${encodeURIComponent(path)}`
-    : null;
+  const key = path ? SWR_KEYS.updateHealth(path) : null;
   const { data, error, isLoading, mutate } = useSWR<UpdateHealth>(key, {
     refreshInterval: 15_000,
   });


### PR DESCRIPTION
## Summary
- Adds `frontend/src/lib/swr-keys.ts`, mirroring `onyx/web/src/lib/swr-keys.ts`: a single `SWR_KEYS` map of static endpoint paths plus builder functions for dynamic/query-string/tuple keys.
- Every `use*` hook under `lib/` and `hooks/` that calls `useSWR` now references `SWR_KEYS` instead of an inline string/template literal — 17 files, 29 call sites (`useWikiTree`, `useTrash`, `useGroups`/`useGroup`/`useGroupShares`/`usePageAcl`/`useWikiPaths`, `useNotifications`, `useTemplateSummaries`/`useAdminTemplates`, `useTokens`, `useLLMStatus`, `useDocumentActivity`, `useLauncherCatalog`/`useAgentSessions`, `useSlackConnectStatus`, `useTriggers`/`useTriggerDestinations`/`useDestinationConfigs`, `useUserSearch`/`useAdminUsers`, `useHealth`, `useCraftConnect`, `useUpdateHealth`, `useDeletedTombstone`/`useDocIdResolve`/`usePathToId`, `useEvents`, `useAppFocus`).
- Two previously-duplicated literal endpoints (`"/wiki"` in both `permissions.ts:useWikiPaths` and `fileview/hooks.ts:useWikiTree`; `` `/wiki/id/${id}` `` in both `fileview/hooks.ts:useDocIdResolve` and `useAppFocus.ts`) now resolve through one shared key builder.
- Scope: only `useSWR`-backed hooks, per the ask — raw inline `useSWR` calls inside page/component files (e.g. `WikiTree.tsx`, `AppSidebar.tsx`) are out of scope here.

## Test plan
- [x] `bun run typecheck` passes
- [x] `pre-commit` hooks pass (prettier, tsc)
- [ ] Manual smoke test across a few affected surfaces (wiki explorer, groups admin, notifications, launcher catalog)