### PR TITLE
feat(ingest): shadow-mode relevance filter in reconcile

### DIFF
--- a/backend/app/ingest/eval_sample.py
+++ b/backend/app/ingest/eval_sample.py
@@ -46,6 +46,10 @@ def log_sample(
         "filtered_by_selector",
         "filtered_by_bm25_score",
         "filtered_by_search_rank",
+        # Shadow only: the relevance filter would have dropped this pair before
+        # the LLM stages. The reconciler still processed it (shadow changes
+        # nothing) — so this label marks would-be drops, not actual ones.
+        "filtered_by_relevance",
     ],
     bm25_score: float | None,
     commit_sha: str | None,

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -69,6 +69,15 @@ ingest_outcomes_total = Counter(
     ["outcome", "wiki_path"],
 )
 
+ingest_relevance_shadow_total = Counter(
+    "ingest_relevance_shadow_total",
+    "Shadow-mode relevance-filter decisions, one per candidate page. The filter "
+    "is evaluated before the LLM stages but never actually drops anything — "
+    "'dropped' counts pages it *would* filter out, 'kept' the rest. Lets us "
+    "measure the filter's effect on real traffic before enforcing it.",
+    ["decision", "wiki_path"],  # decision: kept | dropped
+)
+
 ingest_document_results_total = Counter(
     "ingest_document_results_total",
     "Per-document terminal outcome of ingest reconciliation, one increment per "

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -25,12 +25,15 @@ import time
 from typing import Any, Literal
 
 from app.config import CONFIG
+from app.ingest import enrich as ingest_enrich
 from app.ingest import eval_sample as ingest_eval_sample
 from app.ingest import intent as ingest_intent
 from app.ingest import search as ingest_search
 from app.ingest import settings as ingest_settings
+from app.ingest.relevance import build_relevance_filter
 from app.ingest.source_tiers import is_filtered
 from app.ingest.models import WikiUpdateCandidate
+from app.ingest.types import CandidatePage, IngestionDocument
 from app.llm.agents import ingest_batch_reconciler, ingest_selector, nl_updater
 from app.llm.agents.common import IRRELEVANT_SENTINEL
 from app.wiki import utils as wiki_utils
@@ -45,6 +48,7 @@ from app.metrics import (
     ingest_llm_calls_per_doc,
     ingest_outcomes_total,
     ingest_queue_depth,
+    ingest_relevance_shadow_total,
     ingest_requests_total,
     ingest_selector_candidates_filtered,
     ingest_selector_duration_seconds,
@@ -264,6 +268,70 @@ def process_pushed_document(push: dict[str, Any]) -> None:
         _reconcile_pushed_document(push)
 
 
+def _shadow_relevance_filter(
+    push: dict[str, Any],
+    candidates: list[WikiUpdateCandidate],
+    *,
+    source_type: str | None,
+    title: str | None,
+    url: str,
+    content: str,
+) -> None:
+    """Shadow-run the relevance filter over ``candidates`` and record what it
+    *would* drop — without changing anything. The reconciler still sees every
+    candidate; this only emits a metric per page (kept/dropped) and, for would-be
+    drops, an eval sample tagged ``filtered_by_relevance``.
+
+    Whole thing is best-effort and fail-open: any failure (no embedding, scorer
+    error, DB hiccup) is swallowed so shadow observation never perturbs a live
+    ingest. The document embedding is computed once here.
+    """
+    try:
+        doc = ingest_enrich.with_document_embedding(
+            IngestionDocument(
+                content=content,
+                id=push.get("source_document_id"),
+                title=title,
+                source_type=source_type,
+                url=url or None,
+                metadata=push.get("metadata") or None,
+            )
+        )
+        pages = ingest_enrich.with_page_embeddings(
+            [CandidatePage(path=c.hit.path, body=c.body) for c in candidates]
+        )
+        kept_paths = {p.path for p in build_relevance_filter().keep_relevant(doc, pages)}
+    except Exception:
+        log.warning("relevance shadow: evaluation failed, skipping", exc_info=True)
+        return
+
+    for c in candidates:
+        dropped = c.hit.path not in kept_paths
+        ingest_relevance_shadow_total.labels(
+            decision="dropped" if dropped else "kept", wiki_path=c.hit.path
+        ).inc()
+        if not dropped:
+            continue
+        log.info("relevance shadow: would drop path=%s (bm25=%.3f)", c.hit.path, c.hit.score)
+        try:
+            ingest_eval_sample.log_sample(
+                source_document_id=push.get("source_document_id"),
+                source_type=source_type,
+                source_title=title,
+                source_url=url if url else None,
+                source_content=content,
+                wiki_path=c.hit.path,
+                wiki_body_before=c.body,
+                outcome="filtered_by_relevance",
+                bm25_score=c.hit.score,
+                commit_sha=None,
+            )
+        except Exception:
+            log.warning(
+                "ingest_eval_sample: failed to log filtered_by_relevance sample", exc_info=True
+            )
+
+
 def _reconcile_pushed_document(push: dict[str, Any]) -> None:
     """Reconcile a document pushed from an external system into the wiki.
 
@@ -465,6 +533,16 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
         ingest_outcomes_total.labels(outcome="no_candidates", wiki_path="").inc()
         ingest_document_results_total.labels(result="no_candidates").inc()
         return
+
+    # Shadow-mode relevance filter: score what the embedding filter *would* drop
+    # here, before the LLM stages, without changing the candidate set. Gated on
+    # eval logging (it pays one document-embed call) so only data-collecting
+    # deployments run it. Lets us validate the cosine / two-tower filter against
+    # real traffic before it's allowed to actually drop candidates.
+    if CONFIG.ingest_eval_logging:
+        _shadow_relevance_filter(
+            push, readable, source_type=source_type, title=title, url=url, content=content
+        )
 
     # Stage 3: weak-model pre-filter (skipped when selector_model is unset or
     # matches the main model).

--- a/backend/tests/test_relevance_shadow.py
+++ b/backend/tests/test_relevance_shadow.py
@@ -1,0 +1,94 @@
+"""Shadow-mode relevance filter in the ingest reconcile.
+
+`_shadow_relevance_filter` must record what the filter *would* drop (metric +
+`filtered_by_relevance` eval sample) without changing the candidate set. It is
+best-effort and fail-open.
+"""
+
+from __future__ import annotations
+
+import pytest
+from prometheus_client import REGISTRY
+from sqlalchemy import select
+
+from app.db.fts import SearchHit
+from app.db.models import IngestEvalSample
+from app.db.session import session
+from app.ingest.models import WikiUpdateCandidate
+from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.types import CandidatePage, IngestionDocument
+from app.tasks import wiki_update
+
+
+class _DropByPath(RelevanceFilter):
+    """Fake filter: keeps every page except those in ``drop``."""
+
+    def __init__(self, drop: set[str]) -> None:
+        self._drop = drop
+
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        return page.path not in self._drop
+
+
+def _candidate(path: str, score: float = 5.0) -> WikiUpdateCandidate:
+    hit = SearchHit(doc_id=path, path=path, title=None, snippet="", score=score)
+    return WikiUpdateCandidate(hit=hit, body=f"body of {path}")
+
+
+@pytest.fixture(autouse=True)
+def _no_embedding_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enrichment hits the OpenAI API / embedding store; the filter decision is
+    what's under test, so make enrichment a pass-through."""
+    monkeypatch.setattr(wiki_update.ingest_enrich, "with_document_embedding", lambda d: d)
+    monkeypatch.setattr(wiki_update.ingest_enrich, "with_page_embeddings", lambda ps: ps)
+
+
+def _shadow_rows(paths: set[str]) -> set[str]:
+    with session() as s:
+        return {
+            r.wiki_path
+            for r in s.scalars(
+                select(IngestEvalSample).where(
+                    IngestEvalSample.outcome == "filtered_by_relevance"
+                )
+            ).all()
+            if r.wiki_path in paths
+        }
+
+
+def test_shadow_records_would_be_drops_only(tmp_db, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(wiki_update, "build_relevance_filter", lambda: _DropByPath({"a.md"}))
+    cands = [_candidate("a.md"), _candidate("b.md")]
+
+    before = REGISTRY.get_sample_value(
+        "ingest_relevance_shadow_total", {"decision": "dropped", "wiki_path": "a.md"}
+    ) or 0.0
+
+    wiki_update._shadow_relevance_filter(
+        {"source_document_id": "d1"}, cands,
+        source_type="slack", title="T", url="", content="hello",
+    )
+
+    # Only a.md is recorded as a would-be drop; b.md is not.
+    assert _shadow_rows({"a.md", "b.md"}) == {"a.md"}
+
+    after = REGISTRY.get_sample_value(
+        "ingest_relevance_shadow_total", {"decision": "dropped", "wiki_path": "a.md"}
+    )
+    assert after == before + 1
+    assert REGISTRY.get_sample_value(
+        "ingest_relevance_shadow_total", {"decision": "kept", "wiki_path": "b.md"}
+    )
+
+
+def test_shadow_fails_open_on_filter_error(tmp_db, monkeypatch: pytest.MonkeyPatch):
+    def _boom() -> RelevanceFilter:
+        raise RuntimeError("model load blew up")
+
+    monkeypatch.setattr(wiki_update, "build_relevance_filter", _boom)
+    # Must not raise, and must record nothing.
+    wiki_update._shadow_relevance_filter(
+        {"source_document_id": "d2"}, [_candidate("c.md")],
+        source_type=None, title=None, url="", content="x",
+    )
+    assert _shadow_rows({"c.md"}) == set()


### PR DESCRIPTION
## What

Wires `build_relevance_filter()` into the ingest reconcile as a **shadow pass** — the first time the relevance filter is actually consulted on real traffic. It scores what the embedding filter *would* drop, records it, and **changes nothing**: the reconciler still processes every candidate.

## Where

In `_reconcile_pushed_document`, right after the candidate set is finalized (post source-filter → BM25 → policy/cap) and **before** the LLM stages (selector + batch reconcile). That's exactly where the filter would run in enforce mode — it's cheaper than the LLM selector — so the shadow drop-set is measured against the real pre-LLM candidate set.

```
BM25 candidates → policy/cap → [SHADOW relevance filter] → LLM selector → LLM reconcile
                                        observes, drops nothing
```

## Behavior

- **Per-page metric** `ingest_relevance_shadow_total{decision=kept|dropped, wiki_path}` — drop-rate visible in Grafana.
- **Would-be drops** written as `ingest_eval_samples` rows tagged `filtered_by_relevance` (new `Text` outcome value — no migration; the column is free text). Sits alongside the existing `filtered_by_selector` / `filtered_by_bm25_score` samples for side-by-side eval review.
- **Gated on `ingest_eval_logging`** — the pass costs one document-embed call, so only data-collecting deployments run it (dev-wiki already has it on). Page vectors come from the existing `page_embeddings` store (no per-page API calls).
- **Fail-open, best-effort** — any failure (no embedding, scorer error, DB hiccup) is swallowed; shadow observation never perturbs a live ingest. Matches the filter's own fail-open contract.

## What it does *not* do

- It never drops a candidate. Enforcement is a separate, gated follow-up.
- With no model configured, `build_relevance_filter()` returns the cosine cold-start filter — so shadow data starts flowing immediately, before any `.onnx` is deployed.

## Verification

- New `test_relevance_shadow.py`: records would-be drops only (metric + `filtered_by_relevance` sample for the dropped path, nothing for the kept one); fails open (no raise, no rows) when the filter build throws.
- 59 existing ingest tests (pipeline, selector, factory) still green — no behavior change to the reconciler. Ruff + strict basedpyright clean.

## Next

- **Enforce mode** — a gated switch to actually drop the shadow-identified candidates, once the shadow data validates the operating point.
- Pairs with the delivery (#412, merged) and export tool (#408) for the warm two-tower model; cosine shadow needs neither.
