### PR TITLE
chore(helm): bump chart to 0.3.32 (publish relevance-model delivery)

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.31
+version: 0.3.32
 appVersion: "0.1.0"


### PR DESCRIPTION
## Why

The `dev-wiki-deploy` workflow installs the chart from the **gh-pages Helm repo**, not from `main`. #412 added the documents-worker `fetch-relevance-model` init-container + `ingestRelevance.twoTower` values, but **did not bump `Chart.yaml`**. Since `chart-releaser` runs with `skip_existing: true`, it skipped the already-published `0.3.31` and published nothing — so gh-pages still serves the **pre-#412** chart (packaged 2026-07-10).

Result: deploying dev-wiki today pulls `0.3.31` and never renders the init-container, so the two-tower model is never fetched/loaded.

## What

Bump `0.3.31 → 0.3.32`. On merge, `helm-release.yml` (chart-releaser) packages the current chart — which includes #412 — and publishes `0.3.32` to gh-pages.

## After merge

1. Confirm gh-pages `index.yaml` shows `0.3.32`.
2. Trigger `dev-wiki-deploy.yml` — it pulls `0.3.32` (init-container renders; the model bucket + IRSA SA + `s3Uri` are already in place, and the `.onnx` is uploaded).
3. Verify `build_relevance_filter()` → `TwoTowerFilter 0.00156` on the documents worker.

No content change beyond the version — the chart diff since `0.3.31` is #412 (and anything else merged to `deploy/helm/**` since 2026-07-10).