### PR TITLE
feat(wiki): provenance ledger, record commit authorship (write side)

### DIFF
--- a/backend/app/db/migrations/versions/c7a1f0e3b2d9_provenance_ledger.py
+++ b/backend/app/db/migrations/versions/c7a1f0e3b2d9_provenance_ledger.py
@@ -1,0 +1,71 @@
+"""provenance ledger
+
+Adds ``provenance_ledger``, the structured record of who produced each wiki
+commit and, for ingestion, which source document it came from. Guarded with
+the inspector because ``0001_initial`` builds fresh databases from the current
+models.
+
+Revision ID: c7a1f0e3b2d9
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-13 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c7a1f0e3b2d9"
+down_revision: str | None = "f1a2b3c4d5e6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("provenance_ledger"):
+        return
+    op.create_table(
+        "provenance_ledger",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("commit_sha", sa.Text(), nullable=False),
+        sa.Column("doc_path", sa.Text(), nullable=False),
+        sa.Column("actor_kind", sa.Text(), nullable=False),
+        sa.Column("user_id", sa.Text(), nullable=True),
+        sa.Column("agent_name", sa.Text(), nullable=True),
+        sa.Column("agent_session_id", sa.Text(), nullable=True),
+        sa.Column("source_document_id", sa.Text(), nullable=True),
+        sa.Column("source_type", sa.Text(), nullable=True),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("source_title", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "actor_kind IN ('human', 'agent', 'ingestion', 'system')",
+            name="provenance_ledger_actor_kind_check",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["agent_session_id"], ["agent_sessions.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("commit_sha", "doc_path", name="uq_provenance_ledger_commit_path"),
+    )
+    op.create_index("idx_provenance_ledger_doc_path", "provenance_ledger", ["doc_path"])
+    op.create_index("idx_provenance_ledger_user_id", "provenance_ledger", ["user_id"])
+    op.create_index(
+        "idx_provenance_ledger_source_document_id", "provenance_ledger", ["source_document_id"]
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("provenance_ledger"):
+        op.drop_table("provenance_ledger")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1452,6 +1452,56 @@ class DetectionRun(Base):
 
 
 # --------------------------------------------------------------------------- #
+# Provenance: who produced each commit, and for ingestion, from what source    #
+# --------------------------------------------------------------------------- #
+
+
+class ProvenanceLedger(Base):
+    """Who produced each wiki commit and, for ingestion, which source document
+    it came from. Append-only, one row per ``(commit_sha, doc_path)``.
+
+    ``doc_path`` follows a page move (``provenance.rename_doc``) so readers can
+    key on the current path. The ``source_*`` columns are populated only for
+    ``actor_kind='ingestion'``. A human or agent write leaves them NULL.
+    """
+
+    __tablename__ = "provenance_ledger"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    commit_sha: Mapped[str] = mapped_column(Text, nullable=False)
+    doc_path: Mapped[str] = mapped_column(Text, nullable=False)
+    # ActorKind values (app/models/wiki.py), mirrored by the CHECK below.
+    actor_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    user_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    agent_name: Mapped[str | None] = mapped_column(Text)
+    agent_session_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("agent_sessions.id", ondelete="SET NULL")
+    )
+    source_document_id: Mapped[str | None] = mapped_column(Text)
+    source_type: Mapped[str | None] = mapped_column(Text)
+    source_url: Mapped[str | None] = mapped_column(Text)
+    source_title: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "actor_kind IN ('human', 'agent', 'ingestion', 'system')",
+            name="provenance_ledger_actor_kind_check",
+        ),
+        UniqueConstraint(
+            "commit_sha", "doc_path", name="uq_provenance_ledger_commit_path"
+        ),
+        Index("idx_provenance_ledger_doc_path", "doc_path"),
+        Index("idx_provenance_ledger_user_id", "user_id"),
+        Index("idx_provenance_ledger_source_document_id", "source_document_id"),
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Comments — human discussion anchored to wiki pages (Postgres-only)          #
 # --------------------------------------------------------------------------- #
 

--- a/backend/app/db/provenance.py
+++ b/backend/app/db/provenance.py
@@ -1,0 +1,85 @@
+"""Repo for the provenance ledger. One append-only row per
+``(commit_sha, doc_path)`` in ``provenance_ledger`` recording who produced a
+wiki commit and, for ingestion, the source document.
+
+All provenance DB access lives here. Callers pass primitives and get ids or
+plain dicts back. The service in ``app/wiki/provenance.py`` classifies the
+writer, falls back to the git author, and maps to the pydantic read shapes on
+top of these functions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.db.models import ProvenanceLedger, User
+from app.db.session import session
+
+
+def user_kind(user_id: str) -> str | None:
+    """The ``users.kind`` for a bound user, for classifying their write."""
+    with session() as s:
+        return s.scalar(select(User.kind).where(User.id == user_id))
+
+
+def insert_ledger(
+    *,
+    commit_sha: str,
+    doc_path: str,
+    actor_kind: str,
+    user_id: str | None,
+    agent_name: str | None,
+    agent_session_id: str | None,
+    source_values: dict[str, Any],
+) -> int | None:
+    """Insert one ledger row, idempotent on ``(commit_sha, doc_path)``. Returns
+    the row id whether it was inserted now or already present, so a caller can
+    attach source ranges to it."""
+    with session() as s:
+        inserted = s.execute(
+            pg_insert(ProvenanceLedger)
+            .values(
+                commit_sha=commit_sha,
+                doc_path=doc_path,
+                actor_kind=actor_kind,
+                user_id=user_id,
+                agent_name=agent_name,
+                agent_session_id=agent_session_id,
+                **source_values,
+            )
+            .on_conflict_do_nothing(index_elements=["commit_sha", "doc_path"])
+            .returning(ProvenanceLedger.id)
+        ).scalar_one_or_none()
+        if inserted is not None:
+            return inserted
+        return s.scalar(
+            select(ProvenanceLedger.id).where(
+                ProvenanceLedger.commit_sha == commit_sha,
+                ProvenanceLedger.doc_path == doc_path,
+            )
+        )
+
+
+def rename_doc(old_path: str, new_path: str) -> None:
+    """Re-key ledger rows from a moved page's old path to its new one, so readers
+    that key on ``doc_path`` still reach commits made under the old name."""
+    with session() as s:
+        s.execute(
+            update(ProvenanceLedger)
+            .where(ProvenanceLedger.doc_path == old_path)
+            .values(doc_path=new_path)
+        )
+
+
+def delete_for_doc(doc_path: str) -> None:
+    """Delete every ledger row for a path. Source ranges cascade via their FK.
+
+    For a page that left ``.md`` space, where there is no new doc to carry its
+    provenance onto and a row left behind would misattribute whatever later
+    takes the old path.
+    """
+    with session() as s:
+        s.execute(delete(ProvenanceLedger).where(ProvenanceLedger.doc_path == doc_path))

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -1,4 +1,5 @@
 """Internal domain types for the wiki layer."""
+
 from __future__ import annotations
 
 from enum import Enum
@@ -60,6 +61,33 @@ class CommitResult(NamedTuple):
     sha: str
     old_body: str
     new_body: str
+
+
+class ActorKind(str, Enum):
+    """Valid ``provenance_ledger.actor_kind`` values. Single source of truth,
+    mirrored by the CHECK constraint in ``app/db/models.py`` (same pattern as
+    ``UserKind``)."""
+
+    HUMAN = "human"
+    AGENT = "agent"
+    INGESTION = "ingestion"
+    SYSTEM = "system"
+
+
+class WriteProvenance(BaseModel):
+    """Source facts for an ingestion write, threaded through the commit gateway
+    into the provenance ledger. Set only for ingestion writes.
+
+    Field names mirror the ``provenance_ledger`` source columns so the ledger
+    insert can spread them.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    source_document_id: str | None = None
+    source_type: str | None = None
+    source_url: str | None = None
+    source_title: str | None = None
 
 
 class CommitMaxRetriesError(Exception):

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -55,7 +55,7 @@ from app.auth import UserMissingError, load_user, set_current_user
 from app.tasks import update_frequency
 from app.tasks.queues import documents_queue
 from app.wiki import agent_activity, constants as wiki_constants, git as wiki_git, update_policy
-from app.models.wiki import ChangeKind, CommitMaxRetriesError
+from app.models.wiki import ChangeKind, CommitMaxRetriesError, WriteProvenance
 
 
 log = logging.getLogger(__name__)
@@ -510,6 +510,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                 break
         elif result is not None:
             consecutive_irrelevant = 0
+            source_document_id = push.get("source_document_id")
             message = f"ingest({source_label}): update {c.path}"
             meta_lines: list[str] = []
             if title:
@@ -527,6 +528,12 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                     base_body=c.body,
                     ai_merge=True,
                     skip_acl=True,
+                    source=WriteProvenance(
+                        source_document_id=source_document_id,
+                        source_type=source_type,
+                        source_url=url or None,
+                        source_title=title or None,
+                    ),
                 )
             except CommitMaxRetriesError:
                 log.warning("process_pushed_document: max retries for %s, skipping", c.path)

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import logging
 
-from app.db import fts, page_dirs
+from app.db import fts, page_dirs, provenance as db_provenance
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks import coedit_rebase as coedit_rebase_trigger
 from app.tasks.reindex import drop_page_embedding, index_path
@@ -43,6 +43,27 @@ from app.wiki.comment_remap import remap_comments
 from app.models.wiki import ChangeKind, PathMove
 
 log = logging.getLogger(__name__)
+
+
+def _rename_provenance_safe(old_path: str, new_path: str) -> None:
+    """Follow the provenance ledger to a moved page, but never let a ledger
+    failure abort the rest of the move. The ledger is best-effort. A failed
+    re-point leaves that page's older rows on the old path, degrading its
+    attribution, not the move.
+    """
+    try:
+        db_provenance.rename_doc(old_path, new_path)
+    except Exception:
+        log.exception("provenance rename failed for %s -> %s", old_path, new_path)
+
+
+def _delete_provenance_safe(doc_path: str) -> None:
+    """Drop provenance for a page that left .md space, but never let a ledger
+    failure abort the rest of the move. Best-effort, like the rename."""
+    try:
+        db_provenance.delete_for_doc(doc_path)
+    except Exception:
+        log.exception("provenance delete failed for %s", doc_path)
 
 
 def _remap_comments_safe(path: str) -> None:
@@ -119,8 +140,8 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
 
     Drops every Postgres row that is a *live pointer* to the page: the
     owner + page-level ACL rows (folder ACLs above are untouched), the
-    agent-activity rail, template-draft state, and per-(user, machine)
-    working-dir bindings. Comments are kept as tombstones (orphaned, not
+    agent-activity rail, the provenance ledger, template-draft state, and
+    per-(user, machine) working-dir bindings. Comments are kept as tombstones (orphaned, not
     deleted) since they have archival value; the rest are operational state
     with none. Point-in-time records (launch history, eval samples) are left
     alone.
@@ -150,6 +171,7 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     # later recreated at this path; agent_activity is TTL'd but cleared here
     # for symmetry with the move-out-of-.md-space path.
     agent_activity.delete_for_doc(rel_path)
+    _delete_provenance_safe(rel_path)
     drafts.delete(rel_path)
     page_dirs.delete_all_for_page(rel_path)
     fan_out_trigger_eval(rel_path, sha, ChangeKind.DELETE, actor)
@@ -204,6 +226,7 @@ def after_doc_trashed(
         # (do NOT re-anchor/re-index it — the .trash/ copy stays hidden).
         comments.reassign_doc_path(mv.old, mv.new)
         agent_activity.rename_doc(mv.old, mv.new)
+        _rename_provenance_safe(mv.old, mv.new)
         drafts.rename(mv.old, mv.new)
         page_dirs.rename_page(old_wiki_path=mv.old, new_wiki_path=mv.new)
     # Trigger YAMLs moved into .trash are excluded from loading, so reconverging
@@ -279,6 +302,7 @@ def after_path_move(
             _remap_comments_safe(new_p)
             # Other live pointers follow the page to its new path.
             agent_activity.rename_doc(old_p, new_p)
+            _rename_provenance_safe(old_p, new_p)
             drafts.rename(old_p, new_p)
             page_dirs.rename_page(old_wiki_path=old_p, new_wiki_path=new_p)
         elif old_is_md:
@@ -287,6 +311,7 @@ def after_path_move(
             # on a path that no longer exists.
             comments.orphan_all_for_doc(old_p)
             agent_activity.delete_for_doc(old_p)
+            _delete_provenance_safe(old_p)
             drafts.delete(old_p)
             page_dirs.delete_all_for_page(old_p)
     # Triggers store their scope_path inside the moved YAML (and the YAML's

--- a/backend/app/wiki/provenance.py
+++ b/backend/app/wiki/provenance.py
@@ -1,0 +1,62 @@
+"""Provenance service. Classifies who produced each wiki commit and records it
+through the ``app/db/provenance`` repo.
+
+One append-only ledger row per ``(commit_sha, doc_path)`` is written from the
+commit gateway (``commit_and_fan_out``) right after a commit lands, so human
+saves, agent tool calls, and connector ingestion are all captured in one place.
+Commits that bypass the gateway (seeding, ``.gitkeep`` creates, move and trash
+commits) have no row, and readers fall back to the git author. This is the
+structured record the byline, the Sources tab, and the source-to-pages reverse
+lookup read from.
+"""
+
+from __future__ import annotations
+
+from app.auth.users import UserKind
+from app.db import provenance as repo
+from app.models.wiki import ActorKind, WriteProvenance
+
+
+def _actor_kind(
+    user_kind: str | None, agent_name: str | None, source: WriteProvenance | None
+) -> ActorKind:
+    """Classify a write from the identity facts in scope at commit time.
+
+    A ``WriteProvenance`` marks an ingestion write and wins over everything,
+    even when the connector omitted the source document id. Otherwise a write
+    with no bound user, or one made by a non-person principal, is ``system``,
+    and a bound agent name separates an agent write from a plain human save.
+    """
+    if source is not None:
+        return ActorKind.INGESTION
+    if user_kind is None or user_kind == UserKind.SYSTEM.value:
+        return ActorKind.SYSTEM
+    if agent_name:
+        return ActorKind.AGENT
+    return ActorKind.HUMAN
+
+
+def record(
+    *,
+    commit_sha: str,
+    doc_path: str,
+    user_id: str | None,
+    agent_name: str | None,
+    agent_session_id: str | None,
+    source: WriteProvenance | None,
+) -> int | None:
+    """Record one provenance row for a landed commit and return its ledger id.
+
+    Idempotent on ``(commit_sha, doc_path)`` via the repo: a re-delivered task
+    reuses the existing row's id rather than erroring on the write path.
+    """
+    kind = repo.user_kind(user_id) if user_id else None
+    return repo.insert_ledger(
+        commit_sha=commit_sha,
+        doc_path=doc_path,
+        actor_kind=_actor_kind(kind, agent_name, source).value,
+        user_id=user_id,
+        agent_name=agent_name,
+        agent_session_id=agent_session_id,
+        source_values=source.model_dump() if source else {},
+    )

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -20,13 +20,19 @@ from typing import Any
 from app.auth import current_user
 from app.llm.agents import merge_conflict_update
 from app.llm.agents.tools.errors import ToolError
-from app.models.wiki import ChangeKind, CommitMaxRetriesError, CommitResult
+from app.models.wiki import (
+    ChangeKind,
+    CommitMaxRetriesError,
+    CommitResult,
+    WriteProvenance,
+)
 from app.wiki import (
     agent_activity,
     filesystem,
     git as wiki_git,
     links,
     notify as wiki_notify,
+    provenance,
 )
 
 log = logging.getLogger(__name__)
@@ -164,6 +170,7 @@ def commit_and_fan_out(
     max_retries: int = _MERGE_MAX_RETRIES,
     record_activity: bool = True,
     trigger_coedit_rebase: bool = True,
+    source: WriteProvenance | None = None,
 ) -> CommitResult | None:
     """The single write gateway: commit ``body`` to ``path``, fan out to triggers.
 
@@ -212,6 +219,7 @@ def commit_and_fan_out(
             path, body, message, change_kind, activity_ttl,
             old_body=_read_head_or_empty(path), record_activity=record_activity,
             trigger_coedit_rebase=trigger_coedit_rebase,
+            source=source,
         )
 
     # Read-modify-write: 3-way merge against concurrent changes, retrying when
@@ -249,6 +257,7 @@ def commit_and_fan_out(
                     old_body=current, record_activity=record_activity,
                     expected_head=head_sha,
                     trigger_coedit_rebase=trigger_coedit_rebase,
+                    source=source,
                 )
             except (wiki_git.GitNothingToCommitError, wiki_git.GitHeadMovedError):
                 # A concurrent writer committed in the window between our
@@ -287,6 +296,7 @@ def _commit_resolved(
     record_activity: bool = True,
     expected_head: str | None = None,
     trigger_coedit_rebase: bool = True,
+    source: WriteProvenance | None = None,
 ) -> CommitResult:
     """Commit ``body``, record activity, and run the reindex + trigger fan-out.
 
@@ -302,20 +312,36 @@ def _commit_resolved(
     author = author_string()
     sha = wiki_git.commit_file(path, body, message, author=author, expected_head=expected_head)
 
-    if user is not None and record_activity:
-        agent_name = agent_activity.agent_name_var.get()
-        # if a launcher session is driving this commit, override
-        # agent_name with the manifest's tool_id so the UI attributes
-        # the edit to "claude-code" / "codex" instead of nothing.
-        from app.launchers.current_session import current_agent_session_id
+    # Resolve the acting agent once: an explicit agent_name_var wins, else a
+    # driving launcher session's tool_id, so the activity rail and the
+    # provenance ledger both attribute the edit to "claude-code" / "codex".
+    from app.launchers.current_session import current_agent_session_id
+
+    launcher_sid = current_agent_session_id()
+    agent_name = agent_activity.agent_name_var.get()
+    if launcher_sid is not None and agent_name is None:
         from app.db import agent_sessions as _sessions
 
-        launcher_sid = current_agent_session_id()
-        if launcher_sid is not None and agent_name is None:
-            sess_row = _sessions.get(launcher_sid)
-            if sess_row is not None:
-                agent_name = sess_row["tool_id"]
+        sess_row = _sessions.get(launcher_sid)
+        if sess_row is not None:
+            agent_name = sess_row["tool_id"]
 
+    # Provenance ledger: one row per commit that lands through this gateway.
+    # Best-effort, the commit already succeeded, so a ledger failure must
+    # never turn a successful save into an error.
+    try:
+        provenance.record(
+            commit_sha=sha,
+            doc_path=path,
+            user_id=user.id if user is not None else None,
+            agent_name=agent_name,
+            agent_session_id=launcher_sid,
+            source=source,
+        )
+    except Exception:
+        log.warning("provenance.record failed for %s @ %s", path, sha, exc_info=True)
+
+    if user is not None and record_activity:
         upsert_kwargs: dict[str, Any] = dict(
             user_id=user.id,
             agent_name=agent_name,

--- a/backend/tests/test_provenance_ledger.py
+++ b/backend/tests/test_provenance_ledger.py
@@ -1,0 +1,174 @@
+"""Provenance ledger (app/wiki/provenance.py service + app/db/provenance.py
+repo). Actor classification, the append-only insert, the move re-key, and the
+delete cleanup.
+Real DB. The table lands via the migration chain.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.auth.users import UserKind
+from app.db.models import ProvenanceLedger, User
+from app.db.session import session
+from app.db import provenance as db_provenance
+from app.models.wiki import WriteProvenance
+from app.wiki import git as wiki_git
+from app.wiki import notify, provenance
+from tests._seed import seed_user
+
+
+def test_actor_kind_ingestion_wins_over_user():
+    src = WriteProvenance(source_document_id="doc-1", source_type="slack")
+    assert provenance._actor_kind("human", "Claude Code", src) == "ingestion"
+
+
+def test_actor_kind_agent_when_agent_name_bound():
+    assert provenance._actor_kind("human", "Claude Code", None) == "agent"
+
+
+def test_actor_kind_human_plain_edit():
+    assert provenance._actor_kind("human", None, None) == "human"
+
+
+def test_actor_kind_system_for_system_principal_and_userless():
+    assert provenance._actor_kind(UserKind.SYSTEM.value, "x", None) == "system"
+    assert provenance._actor_kind(None, None, None) == "system"
+
+
+def test_actor_kind_ingestion_without_document_id():
+    # A connector may omit the id, but a WriteProvenance is still an ingest write.
+    src = WriteProvenance(source_type="slack", source_url="https://s/x")
+    assert provenance._actor_kind(None, None, src) == "ingestion"
+
+
+def test_record_persists_ingestion_row(tmp_db):
+    provenance.record(
+        commit_sha="abc123",
+        doc_path="Foo/Bar.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(
+            source_document_id="doc-9",
+            source_type="gdrive",
+            source_url="https://example.com/q3",
+            source_title="Q3 Planning",
+        ),
+    )
+    with session() as s:
+        row = s.scalar(select(ProvenanceLedger).where(ProvenanceLedger.commit_sha == "abc123"))
+    assert row is not None
+    assert row.actor_kind == "ingestion"
+    assert row.doc_path == "Foo/Bar.md"
+    assert row.source_document_id == "doc-9"
+    assert row.source_url == "https://example.com/q3"
+
+
+def test_record_persists_human_row(tmp_db):
+    uid = seed_user("usr_prov", email="prov@x.com")
+    provenance.record(
+        commit_sha="human1",
+        doc_path="P.md",
+        user_id=uid,
+        agent_name=None,
+        agent_session_id=None,
+        source=None,
+    )
+    with session() as s:
+        row = s.scalar(select(ProvenanceLedger).where(ProvenanceLedger.commit_sha == "human1"))
+    assert row is not None
+    assert row.actor_kind == "human"
+    assert row.user_id == uid
+    assert row.source_document_id is None
+
+
+def test_record_idempotent_on_commit_and_path(tmp_db):
+    for _ in range(2):
+        provenance.record(
+            commit_sha="dup1",
+            doc_path="P.md",
+            user_id=None,
+            agent_name=None,
+            agent_session_id=None,
+            source=None,
+        )
+    with session() as s:
+        rows = s.scalars(
+            select(ProvenanceLedger).where(ProvenanceLedger.commit_sha == "dup1")
+        ).all()
+    assert len(rows) == 1
+    assert rows[0].actor_kind == "system"
+
+
+def test_record_classifies_a_system_principal(tmp_db):
+    uid = seed_user("usr_sys", email="sys@x.com")
+    with session() as s:
+        u = s.get(User, uid)
+        assert u is not None
+        u.kind = UserKind.SYSTEM.value
+    provenance.record(
+        commit_sha="s1",
+        doc_path="P.md",
+        user_id=uid,
+        agent_name="x",
+        agent_session_id=None,
+        source=None,
+    )
+    with session() as s:
+        row = s.scalar(select(ProvenanceLedger).where(ProvenanceLedger.commit_sha == "s1"))
+    assert row is not None
+    assert row.actor_kind == "system"
+
+
+def test_rename_doc_follows_a_page_move(tmp_db):
+    provenance.record(
+        commit_sha="m1",
+        doc_path="Old.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=None,
+    )
+    db_provenance.rename_doc("Old.md", "New.md")
+    with session() as s:
+        row = s.scalar(select(ProvenanceLedger).where(ProvenanceLedger.commit_sha == "m1"))
+    assert row is not None
+    assert row.doc_path == "New.md"
+
+
+def test_delete_for_doc_removes_ledger_rows(tmp_db):
+    provenance.record(
+        commit_sha="m1",
+        doc_path="Gone.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=None,
+    )
+    db_provenance.delete_for_doc("Gone.md")
+    with session() as s:
+        assert (
+            s.scalars(select(ProvenanceLedger).where(ProvenanceLedger.doc_path == "Gone.md")).all()
+            == []
+        )
+
+
+def test_after_doc_delete_drops_provenance(tmp_repo):
+    sha = wiki_git.commit_file("Doomed.md", "# Doomed\n", "seed", author=None)
+    provenance.record(
+        commit_sha=sha,
+        doc_path="Doomed.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=None,
+    )
+    notify.after_doc_delete("Doomed.md", sha, actor=None)
+    with session() as s:
+        assert (
+            s.scalars(
+                select(ProvenanceLedger).where(ProvenanceLedger.doc_path == "Doomed.md")
+            ).all()
+            == []
+        )


### PR DESCRIPTION
## Description

Wiki pages are written by people, by agents acting for a person, and by the Onyx ingestion pipeline, but nothing recorded which. This adds `provenance_ledger`, one append-only row per commit recording who produced it and, for ingestion, which source document it came from.

The row is written at the single commit gateway (`commit_and_fan_out`), so every write landing through it is covered in one place rather than per entry point. Commits that bypass the gateway (seeding, `.gitkeep` creates, move and trash) have no row, and readers fall back to the git author.

The git author string stays the transport copy. This table is the queryable one the byline and Sources tab read from. The ledger write is best-effort: the commit has already landed, so a failure logs and never fails the save. `doc_path` follows a page move, so a renamed page keeps its attribution.

Nothing reads the table yet.

Design: `Engineering Projects/Agent Wiki Project/design/source_attribution/source_attribution_plan`

## How Has This Been Tested?

- `pre-commit run --files` on all changed files: ruff + basedpyright (strict) passed
- `basedpyright` project-wide: 0 errors, 0 warnings
- `pytest -xv tests/test_provenance_ledger.py`: 10 passed
- Regression, 107 passed: gateway ai-merge, merge-retry, agent-activity, MCP writes, trash, ingest pipeline

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check