### PR TITLE
feat(wiki): structured attribution on history and doc reads (read side)

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -69,6 +69,7 @@ from app.wiki import (
     filesystem,
     git as wiki_git,
     notify as wiki_notify,
+    provenance,
     recents as wiki_recents,
     search as wiki_search,
     starred as wiki_starred,
@@ -311,6 +312,7 @@ def get_document_by_path(
         except wiki_git.UnknownSha as exc:
             raise HTTPException(status_code=404, detail="not found at ref") from exc
         return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref, id=page_id)
+
     # Session-aware live read: when a co-edit session is open on this page, its
     # Postgres buffer holds the freshest edits. The checkpoint that commits the
     # buffer to git runs asynchronously, so HEAD lags — reading it would show
@@ -347,12 +349,19 @@ def get_document_by_path(
                     exc_info=True,
                 )
                 body = current
-        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, id=page_id)
-    abs_path = filesystem.absolute(rel)
-    if not abs_path.is_file():
-        raise HTTPException(status_code=404, detail="not found")
+    else:
+        abs_path = filesystem.absolute(rel)
+        if not abs_path.is_file():
+            raise HTTPException(status_code=404, detail="not found")
+        body = abs_path.read_text()
+    # Page-level (current HEAD), so both live reads share them.
     return GetDocumentResponse(
-        path=rel, body=abs_path.read_text(), head_sha=head_sha, id=page_id
+        path=rel,
+        body=body,
+        head_sha=head_sha,
+        id=page_id,
+        attribution=provenance.head_attribution(rel, head_sha),
+        sources=provenance.sources_for_path(rel),
     )
 
 
@@ -942,6 +951,7 @@ def file_history(
                 deprecated.add(token)
     head_sha = rows[0].sha if rows else None
     fires = triggers_repo.fire_counts_by_sha({r.sha for r in rows})
+    attr_by_sha = provenance.for_history(rows, rel)
     visible = [
         CommitView(
             sha=r.sha,
@@ -952,6 +962,7 @@ def file_history(
             added=r.added,
             removed=r.removed,
             triggered=fires.get(r.sha, 0),
+            attribution=attr_by_sha[r.sha],
         )
         for r in rows
         if r.sha not in deprecated

--- a/backend/app/db/provenance.py
+++ b/backend/app/db/provenance.py
@@ -12,11 +12,33 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.db.models import ProvenanceLedger, User
 from app.db.session import session
+from app.models.wiki import ActorKind
+
+# Ledger columns a reader needs; returned as a plain dict so callers don't hold
+# an ORM row past the session.
+_LEDGER_COLUMNS = (
+    "id",
+    "commit_sha",
+    "doc_path",
+    "actor_kind",
+    "user_id",
+    "agent_name",
+    "agent_session_id",
+    "source_document_id",
+    "source_type",
+    "source_url",
+    "source_title",
+    "created_at",
+)
+
+
+def _ledger_dict(row: ProvenanceLedger) -> dict[str, Any]:
+    return {c: getattr(row, c) for c in _LEDGER_COLUMNS}
 
 
 def user_kind(user_id: str) -> str | None:
@@ -83,3 +105,41 @@ def delete_for_doc(doc_path: str) -> None:
     """
     with session() as s:
         s.execute(delete(ProvenanceLedger).where(ProvenanceLedger.doc_path == doc_path))
+
+
+def ledger_rows_for_commits(commit_shas: list[str], doc_path: str) -> list[dict[str, Any]]:
+    """Ledger rows for the given commits on a path, each with the owner's display
+    name (name or email) under ``owner_display``. Batched to one query."""
+    if not commit_shas:
+        return []
+    owner_display = func.coalesce(User.name, User.email)
+    with session() as s:
+        rows = s.execute(
+            select(ProvenanceLedger, owner_display.label("owner_display"))
+            .join(User, User.id == ProvenanceLedger.user_id, isouter=True)
+            .where(
+                ProvenanceLedger.doc_path == doc_path,
+                ProvenanceLedger.commit_sha.in_(commit_shas),
+            )
+        ).all()
+    return [{**_ledger_dict(row), "owner_display": display} for row, display in rows]
+
+
+def ingestion_source_rows(doc_path: str, limit: int) -> list[dict[str, Any]]:
+    """Ingestion ledger rows for a page, newest first, capped at ``limit`` — the
+    raw rows behind the Sources list, before dedup."""
+    with session() as s:
+        rows = (
+            s.execute(
+                select(ProvenanceLedger)
+                .where(
+                    ProvenanceLedger.doc_path == doc_path,
+                    ProvenanceLedger.actor_kind == ActorKind.INGESTION.value,
+                )
+                .order_by(ProvenanceLedger.id.desc())
+                .limit(limit)
+            )
+            .scalars()
+            .all()
+        )
+    return [_ledger_dict(r) for r in rows]

--- a/backend/app/llm/agents/tools/list_history.py
+++ b/backend/app/llm/agents/tools/list_history.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
-from app.wiki import git as wiki_git
+from app.wiki import git as wiki_git, provenance
 
 DEFAULT_LIMIT = 20
 MAX_LIMIT = 100
@@ -38,10 +38,17 @@ def handle(args: dict[str, Any]) -> Any:
     rows = wiki_git.history(path, limit=limit)
     if not rows:
         return {"path": path, "history": [], "note": "no history"}
+    attr = provenance.for_history(rows, path)
     return {
         "path": path,
         "history": [
-            {"sha": r.sha, "author": r.author, "ts": r.ts, "message": r.message}
+            {
+                "sha": r.sha,
+                "author": r.author,
+                "ts": r.ts,
+                "message": r.message,
+                "attribution": attr[r.sha].model_dump(),
+            }
             for r in rows
         ],
     }

--- a/backend/app/llm/agents/tools/read_doc.py
+++ b/backend/app/llm/agents/tools/read_doc.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
-from app.wiki import agent_activity, git as wiki_git, update_policy
+from app.wiki import agent_activity, git as wiki_git, provenance, update_policy
 
 
 def handle(args: dict[str, Any]) -> Any:
@@ -66,4 +66,13 @@ def handle(args: dict[str, Any]) -> Any:
     instruction = update_policy.resolve_for_path(path).update_instruction
     if instruction:
         result["update_instruction"] = instruction
+
+    if is_head:
+        attr = provenance.head_attribution(path, head_sha)
+    else:
+        # A historical read resolves from the ledger only.
+        attr = provenance.for_commits([sha], path).get(sha) if sha else None
+    result["attribution"] = attr.model_dump() if attr is not None else None
+    # Sources are page-level at current HEAD, including on a historical read.
+    result["sources"] = [sr.model_dump() for sr in provenance.sources_for_path(path)]
     return result

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from app.models.wiki import PageKind
+from app.models.wiki import Attribution, PageKind, SourceRef
 
 
 # --------------------------------------------------------------------------- #
@@ -174,6 +174,8 @@ class GetDocumentResponse(BaseModel):
     head_sha: str | None
     ref: str | None = None  # only set when reading at a specific ref
     id: str | None = None  # stable wiki_doc_id; None for historical/deleted reads
+    attribution: Attribution | None = None
+    sources: list[SourceRef] = Field(default_factory=list)
 
 
 class PutDocumentResponse(BaseModel):
@@ -299,6 +301,7 @@ class CommitView(BaseModel):
     added: int = 0
     removed: int = 0
     triggered: int = 0  # number of automations this commit fired
+    attribution: Attribution | None = None
 
 
 class FileHistoryResponse(BaseModel):

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -90,6 +90,33 @@ class WriteProvenance(BaseModel):
     source_title: str | None = None
 
 
+class Attribution(BaseModel):
+    """Structured provenance for one commit, resolved ledger-first with a git
+    author-string parse as the fallback for any commit with no ledger row.
+
+    ``person`` and ``agent`` describe a human or agent write, ``source_*`` an
+    ingestion write.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    actor_kind: ActorKind
+    person: str | None = None
+    agent: str | None = None
+    source_document_id: str | None = None
+    source_type: str | None = None
+    source_url: str | None = None
+    source_title: str | None = None
+
+
+class SourceRef(WriteProvenance):
+    """One ingested document that has contributed to a page (the Sources tab
+    list). Compact by design: identity and links, no content ranges.
+    """
+
+    last_updated: str
+
+
 class CommitMaxRetriesError(Exception):
     """Raised by ``commit_and_fan_out`` when HEAD keeps moving past the retry budget."""
 

--- a/backend/app/wiki/provenance.py
+++ b/backend/app/wiki/provenance.py
@@ -1,20 +1,36 @@
-"""Provenance service. Classifies who produced each wiki commit and records it
-through the ``app/db/provenance`` repo.
+"""Provenance service. Classifies who produced each wiki commit, records it
+through the ``app/db/provenance`` repo, and resolves attribution for reads.
 
 One append-only ledger row per ``(commit_sha, doc_path)`` is written from the
 commit gateway (``commit_and_fan_out``) right after a commit lands, so human
 saves, agent tool calls, and connector ingestion are all captured in one place.
 Commits that bypass the gateway (seeding, ``.gitkeep`` creates, move and trash
 commits) have no row, and readers fall back to the git author. This is the
-structured record the byline, the Sources tab, and the source-to-pages reverse
-lookup read from.
+structured record the byline, History, and the Sources tab read from.
 """
 
 from __future__ import annotations
 
+import re
+from collections.abc import Iterable, Sequence
+from typing import Any
+
 from app.auth.users import UserKind
 from app.db import provenance as repo
-from app.models.wiki import ActorKind, WriteProvenance
+from app.models.wiki import ActorKind, Attribution, SourceRef, WriteProvenance
+from app.wiki import git as wiki_git
+from app.wiki.constants import INGEST_AUTHOR
+
+# The ledger's source columns, named once by the model that mirrors them.
+_SOURCE_FIELDS = tuple(WriteProvenance.model_fields)
+
+# Cap the ingest-row scan behind sources_for_path so a heavily re-ingested page
+# cannot load an unbounded result set to dedup down to a handful of documents. A
+# source last seen beyond this many recent ingest commits drops off the list.
+_SOURCES_SCAN_LIMIT = 500
+
+_VIA_RE = re.compile(r"^(.*?)\s+via\s+(.+)$", re.IGNORECASE)
+_INGEST_NAME = INGEST_AUTHOR.split(" <", 1)[0]
 
 
 def _actor_kind(
@@ -60,3 +76,91 @@ def record(
         agent_session_id=agent_session_id,
         source_values=source.model_dump() if source else {},
     )
+
+
+# --------------------------------------------------------------------------- #
+# Read side: resolve a commit's provenance for the byline, History, Sources    #
+# --------------------------------------------------------------------------- #
+
+
+def _agent_label(raw: str) -> str:
+    """Display label for an agent, from either a stored slug or a git author
+    tail. Unrecognized agents keep the name they came with."""
+    key = raw.strip().lower().removeprefix("launcher-")
+    if "claude" in key:
+        return "Claude Code"
+    if "codex" in key or "openai" in key:
+        return "Codex"
+    if "onyx" in key or "craft" in key:
+        return "Onyx Craft"
+    return raw.strip() or "agent"
+
+
+def _from_author(author: str) -> Attribution:
+    """Parse a git author name into an Attribution. The fallback for any commit
+    with no ledger row."""
+    name = author.strip()
+    if name == _INGEST_NAME:
+        return Attribution(actor_kind=ActorKind.INGESTION)
+    m = _VIA_RE.match(name)
+    if m:
+        person = m.group(1).strip() or "Unknown"
+        return Attribution(
+            actor_kind=ActorKind.AGENT, person=person, agent=_agent_label(m.group(2))
+        )
+    return Attribution(actor_kind=ActorKind.HUMAN, person=name or "Unknown")
+
+
+def _source_facts(row: dict[str, Any]) -> dict[str, Any]:
+    return {f: row[f] for f in _SOURCE_FIELDS}
+
+
+def _to_attribution(row: dict[str, Any]) -> Attribution:
+    return Attribution(
+        actor_kind=ActorKind(row["actor_kind"]),
+        person=row["owner_display"],
+        agent=_agent_label(row["agent_name"]) if row["agent_name"] else None,
+        **_source_facts(row),
+    )
+
+
+def for_commits(commit_shas: Iterable[str], doc_path: str) -> dict[str, Attribution]:
+    """Ledger attribution for the given commits on a path, keyed by sha. One
+    batched query behind a history render."""
+    rows = repo.ledger_rows_for_commits(list(commit_shas), doc_path)
+    return {row["commit_sha"]: _to_attribution(row) for row in rows}
+
+
+def for_history(rows: Sequence[wiki_git.CommitInfo], doc_path: str) -> dict[str, Attribution]:
+    """Attribution for every commit in a history render, keyed by sha. The
+    ledger row where there is one, a parse of the git author name where there
+    is not."""
+    hits = for_commits([r.sha for r in rows], doc_path)
+    return {r.sha: hits.get(r.sha) or _from_author(r.author) for r in rows}
+
+
+def head_attribution(doc_path: str, head_sha: str | None) -> Attribution | None:
+    """Attribution for a page's current HEAD commit, for the byline."""
+    if head_sha is None:
+        return None
+    hit = for_commits([head_sha], doc_path).get(head_sha)
+    if hit is not None:
+        return hit
+    meta = wiki_git.last_commit_meta_for_path(doc_path)
+    return _from_author(meta[1]) if meta else None
+
+
+def sources_for_path(doc_path: str) -> list[SourceRef]:
+    """Distinct ingested documents that have contributed to a page, newest
+    first, deduped on source document id (falling back to url or title). Rows
+    carrying none of the three cannot be told apart, so each is kept."""
+    seen: set[str] = set()
+    out: list[SourceRef] = []
+    for row in repo.ingestion_source_rows(doc_path, _SOURCES_SCAN_LIMIT):
+        key = row["source_document_id"] or row["source_url"] or row["source_title"]
+        if key is not None:
+            if key in seen:
+                continue
+            seen.add(key)
+        out.append(SourceRef(last_updated=row["created_at"], **_source_facts(row)))
+    return out

--- a/backend/tests/test_provenance_reads.py
+++ b/backend/tests/test_provenance_reads.py
@@ -1,0 +1,122 @@
+"""Provenance read side (app/wiki/provenance.py). Attribution resolution, the
+batched history lookup, and the per-page source list. Real DB for the queries.
+"""
+
+from __future__ import annotations
+
+from app.models.wiki import WriteProvenance
+from app.wiki import provenance
+from app.wiki.git import CommitInfo
+from tests._seed import seed_user
+
+
+def test_from_author_agent_via():
+    a = provenance._from_author("Nik via launcher-claude-code")
+    assert a.actor_kind == "agent"
+    assert a.person == "Nik"
+    assert a.agent == "Claude Code"
+
+
+def test_from_author_ingestion_name():
+    assert provenance._from_author("Onyx Ingest").actor_kind == "ingestion"
+
+
+def test_from_author_plain_human():
+    a = provenance._from_author("Jane Doe")
+    assert a.actor_kind == "human"
+    assert a.person == "Jane Doe"
+
+
+def test_for_history_mixes_ledger_rows_and_author_fallback(tmp_db):
+    uid = seed_user("usr_h", email="h@x.com", name="Nik")
+    provenance.record(
+        commit_sha="has-row",
+        doc_path="P.md",
+        user_id=uid,
+        agent_name=None,
+        agent_session_id=None,
+        source=None,
+    )
+    rows = [
+        CommitInfo(sha="has-row", author="ignored", ts="t", message="m", body=""),
+        CommitInfo(sha="no-row", author="Nik via launcher-claude-code", ts="t", message="m", body=""),
+    ]
+    got = provenance.for_history(rows, "P.md")
+    # the ledger row wins, and the row-less commit falls back to its author
+    assert got["has-row"].person == "Nik"
+    assert got["has-row"].actor_kind == "human"
+    assert got["no-row"].actor_kind == "agent"
+    assert got["no-row"].agent == "Claude Code"
+
+
+def test_for_commits_joins_user_display(tmp_db):
+    uid = seed_user("usr_r", email="r@x.com", name="Nik")
+    provenance.record(
+        commit_sha="c1",
+        doc_path="P.md",
+        user_id=uid,
+        agent_name="onyx-craft",
+        agent_session_id=None,
+        source=None,
+    )
+    got = provenance.for_commits(["c1", "missing"], "P.md")
+    assert set(got) == {"c1"}
+    assert got["c1"].actor_kind == "agent"
+    assert got["c1"].person == "Nik"
+    # ledger agent slug is normalized the same way the author-parse fallback is
+    assert got["c1"].agent == "Onyx Craft"
+
+
+def test_for_commits_preserves_unmapped_agent_label(tmp_db):
+    uid = seed_user("usr_ai", email="ai@x.com", name="AI")
+    provenance.record(
+        commit_sha="c2",
+        doc_path="P.md",
+        user_id=uid,
+        agent_name="Wiki AI Assistant",
+        agent_session_id=None,
+        source=None,
+    )
+    assert provenance.for_commits(["c2"], "P.md")["c2"].agent == "Wiki AI Assistant"
+
+
+def test_head_attribution_from_ledger(tmp_db):
+    provenance.record(
+        commit_sha="head1",
+        doc_path="P.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(source_document_id="d1", source_title="Doc"),
+    )
+    a = provenance.head_attribution("P.md", "head1")
+    assert a is not None
+    assert a.actor_kind == "ingestion"
+    assert a.source_title == "Doc"
+
+
+def test_sources_for_path_dedups_newest_first(tmp_db):
+    for sha, doc_id in [("s1", "dup"), ("s2", "dup"), ("s3", "other")]:
+        provenance.record(
+            commit_sha=sha,
+            doc_path="P.md",
+            user_id=None,
+            agent_name=None,
+            agent_session_id=None,
+            source=WriteProvenance(source_document_id=doc_id, source_title=sha),
+        )
+    ids = [s.source_document_id for s in provenance.sources_for_path("P.md")]
+    assert ids == ["other", "dup"]
+
+
+def test_sources_for_path_keeps_anonymous_rows(tmp_db):
+    for sha in ["a1", "a2"]:
+        provenance.record(
+            commit_sha=sha,
+            doc_path="P.md",
+            user_id=None,
+            agent_name=None,
+            agent_session_id=None,
+            source=WriteProvenance(source_type="slack"),
+        )
+    assert len(provenance.sources_for_path("P.md")) == 2


### PR DESCRIPTION
## Description

Stacked on #421 (review that first; this PR's diff is scoped to the read side).

The ledger records who produced each commit but nothing exposes it. This resolves a commit's provenance ledger-first, falling back to parsing the git author name for any commit with no ledger row (seeds, moves, and the gateway's best-effort swallow all produce row-less commits, so the fallback is load-bearing, not a migration artifact).

It surfaces as a structured `Attribution` on `GET /wiki/file/history` and `GET /wiki/file`, and on MCP `list_history` and `read_doc`, plus a compact per-page list of the ingested documents behind a page. Agent slugs are normalized to display labels in one place, so the ledger and the fallback agree.

Nothing renders it yet. The frontend byline and Sources tab, and deleting the frontend's duplicate author-string regex, come in the frontend phase.

Design: `Engineering Projects/Agent Wiki Project/design/source_attribution/source_attribution_plan`

## How Has This Been Tested?

- `pre-commit run --files` on all changed files: ruff + basedpyright (strict) passed
- `basedpyright` project-wide: 0 errors, 0 warnings
- `pytest -xv tests/test_provenance_reads.py`: 9 passed
- Regression, 72 passed: coedit API, doc tools, MCP server tools, read_page, wiki diff API

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check