### PR TITLE
feat(automanage): add Detector seam + empty-folder detector

### DIFF
--- a/backend/app/wiki/automanage/__init__.py
+++ b/backend/app/wiki/automanage/__init__.py
@@ -1,0 +1,8 @@
+"""Wiki Auto Management — AI-initiated structural cleanup of the wiki.
+
+Detection (this package's ``detectors/`` seam + the runner) finds duplicates,
+misplaced pages, and stale hierarchy and emits ``change_proposals``; a human
+(or an AI-managed scope) approves before anything touches the wiki. Design:
+``design/Wiki Auto Management — Engineering.md`` and its Detection sub-page.
+"""
+from __future__ import annotations

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -1,0 +1,28 @@
+"""Detector registry — the technique axis of Wiki Auto Management detection.
+
+Add a technique by dropping a module here that exposes a module-level
+``DETECTOR`` and appending it to ``DETECTORS``. The runner iterates this list,
+filters by ``applicable(trigger)``, and feeds each the trigger-built ``Scope``
+— it never hard-codes a detector. Mirrors ``app/llm/providers/__init__.py``.
+"""
+from __future__ import annotations
+
+from app.wiki.automanage.detectors import empty_folder
+from app.wiki.automanage.detectors.base import (
+    Detector,
+    ProposalDraft,
+    Scope,
+    TriggerKind,
+)
+
+DETECTORS: list[Detector] = [
+    empty_folder.DETECTOR,
+]
+
+__all__ = [
+    "DETECTORS",
+    "Detector",
+    "ProposalDraft",
+    "Scope",
+    "TriggerKind",
+]

--- a/backend/app/wiki/automanage/detectors/base.py
+++ b/backend/app/wiki/automanage/detectors/base.py
@@ -1,0 +1,103 @@
+"""The detector seam — the *technique* axis of Wiki Auto Management detection.
+
+Detection varies on two orthogonal axes (see the design page ``design/Wiki
+Auto Management — Detection.md``): a **trigger** decides *when* detection runs
+and over *what scope*; a **technique** decides *what pattern* to look for.
+This module is the technique axis: a ``Detector`` is a pure function
+``scope → proposals`` that a trigger-built ``Scope`` is fed through.
+
+Detectors run in **parallel**, each independent — they are not stages of one
+pipeline. The one genuine cheap→expensive cascade (BM25 → LLM) lives *inside*
+the future fuzzy-duplicate detector, never here. The substrate (the runner)
+owns everything a detector should inherit for free: scope selection,
+permission-fingerprint partitioning, guardrails, and persistence to
+``change_proposals``. Keep this protocol minimal — ``applicable`` + ``detect``
+only. Detector-specific config lives in the detector's own module.
+
+Mirrors the LLM-providers seam (``app/llm/providers/``): one module per
+detector under ``app/wiki/automanage/detectors/``, each exposing a
+module-level ``DETECTOR``, registered in ``__init__.py``.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.wiki.change_proposals import ProposalOp
+
+
+class TriggerKind(str, Enum):
+    """*When* detection runs and over what scope. ``SWEEP`` is the whole space
+    (full, then incremental); ``ON_CREATE`` / ``ON_WRITE`` pin the scope to a
+    single page and its neighbors. Scheduled/background is a v2 trigger."""
+
+    SWEEP = "sweep"
+    ON_CREATE = "on_create"
+    ON_WRITE = "on_write"
+
+
+class Scope(BaseModel):
+    """What a trigger produces and a detector consumes — a set of tracked
+    paths plus the run context, frozen so a detector can't mutate shared input.
+
+    ``paths`` is the complete set of tracked files relevant to this scope. For
+    a detector whose determination depends on a folder's *whole* subtree (e.g.
+    empty-folder), the trigger must include every file under the candidate
+    folders — a full ``SWEEP`` does this by construction; an incremental scope
+    must expand changed paths to cover their folder siblings.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    trigger: TriggerKind
+    paths: list[str] = Field(default_factory=list)
+    run_id: str | None = None
+    head_sha: str | None = None
+
+
+class ProposalDraft(BaseModel):
+    """A detector's emitted candidate, before the runner persists it as a
+    ``pending`` row via ``change_proposals.create``. This is the technique↔
+    substrate contract: the detector names the operation and the paths; the
+    runner attaches base SHAs, the audience fingerprint, run id, and TTL.
+
+    Arity mirrors ``ProposalOp`` (``delete_empty_folder`` has no target;
+    merge/split carry ``proposed_bodies``). ``dedupe_key`` lets the runner's
+    do-not-re-propose guard match this draft against rejected history without
+    re-deriving the op's identity.
+    """
+
+    op: ProposalOp
+    source_paths: list[str]
+    target_paths: list[str] = Field(default_factory=list)
+    summary: str
+    proposed_bodies: dict[str, str] | None = None
+
+    @property
+    def dedupe_key(self) -> str:
+        """Stable identity for the guardrail set — op + sorted path-set."""
+        paths = ",".join(sorted(self.source_paths + self.target_paths))
+        return f"{self.op.value}:{paths}"
+
+
+@runtime_checkable
+class Detector(Protocol):
+    """One detection technique. Registered as a module-level ``DETECTOR``.
+
+    ``detect`` must be **pure**: no DB writes, no git mutation (reading git is
+    fine). The runner persists results and owns partitioning/guardrails, so a
+    detector stays trivially unit-testable on a seeded ``Scope``.
+    """
+
+    name: str
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        """Which matrix cells this detector fills — whether it should run under
+        ``trigger`` at all."""
+        ...
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        """Find candidates in ``scope`` and return drafts. Pure."""
+        ...

--- a/backend/app/wiki/automanage/detectors/base.py
+++ b/backend/app/wiki/automanage/detectors/base.py
@@ -52,7 +52,7 @@ class Scope(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     trigger: TriggerKind
-    paths: list[str] = Field(default_factory=list)
+    paths: tuple[str, ...] = Field(default_factory=tuple)
     run_id: str | None = None
     head_sha: str | None = None
 

--- a/backend/app/wiki/automanage/detectors/empty_folder.py
+++ b/backend/app/wiki/automanage/detectors/empty_folder.py
@@ -22,6 +22,7 @@ directories deepest-first within that folder.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 
 from app.wiki import git
@@ -53,7 +54,7 @@ def _parent_dir(folder: str) -> str:
     return folder.rsplit("/", 1)[0] if "/" in folder else ""
 
 
-def _maximal_empty_folders(paths: list[str]) -> list[str]:
+def _maximal_empty_folders(paths: Sequence[str]) -> list[str]:
     """The maximal empty folders among ``paths``, sorted for determinism.
 
     Pure over the tracked-file list. A folder is empty when every tracked file

--- a/backend/app/wiki/automanage/detectors/empty_folder.py
+++ b/backend/app/wiki/automanage/detectors/empty_folder.py
@@ -1,0 +1,118 @@
+"""Empty-folder detector — the first, mechanical technique (no LLM, ~free).
+
+Proposes ``delete_empty_folder`` for a folder that holds no pages and has been
+empty long enough that it isn't just a folder someone made moments ago and is
+about to fill.
+
+A wiki folder is a directory materialized by a committed ``.gitkeep`` marker
+(git can't track empty directories — see ``create_folder`` in
+``app/api/wiki.py``). "Empty" here means the folder's entire subtree contains
+*only* ``.gitkeep`` markers: no ``.md`` page, and nothing else either (a
+lingering folder-scoped ``.trigger_*.yaml`` keeps the folder alive, so it is
+deliberately *not* treated as empty). "Empty since" is the last commit that
+touched anything under the folder — the removal/move that emptied it, or its
+creation — read from ``git.last_commit_meta_for_path``, which accepts a folder
+prefix. A folder younger than ``min_age_days`` is left alone.
+
+For nested empties we emit one proposal for the **maximal** empty folder (the
+shallowest whose parent is not itself empty); deleting it cascades the empty
+descendants, so N redundant proposals collapse to one. The executor removes
+directories deepest-first within that folder.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.wiki import git
+from app.wiki.automanage.detectors.base import (
+    ProposalDraft,
+    Scope,
+    TriggerKind,
+)
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# Detector-specific config lives on the detector, not the protocol. The grace
+# window before a folder that went empty is worth proposing for deletion.
+EMPTY_FOLDER_MIN_AGE_DAYS = 2
+
+_GITKEEP = ".gitkeep"
+
+
+def _ancestor_dirs(path: str) -> list[str]:
+    """Every directory prefix of a tracked file path, excluding the file
+    itself and the repo root (``""``). ``a/b/c.md`` → ``["a", "a/b"]``."""
+    parts = path.split("/")
+    return ["/".join(parts[:i]) for i in range(1, len(parts))]
+
+
+def _parent_dir(folder: str) -> str:
+    """The parent folder, or ``""`` (root) for a top-level folder."""
+    return folder.rsplit("/", 1)[0] if "/" in folder else ""
+
+
+def _maximal_empty_folders(paths: list[str]) -> list[str]:
+    """The maximal empty folders among ``paths``, sorted for determinism.
+
+    Pure over the tracked-file list. A folder is empty when every tracked file
+    beneath it is a ``.gitkeep``; it is *maximal* when its parent isn't also
+    empty (so a proposal on the parent doesn't already subsume it)."""
+    all_folders: set[str] = set()
+    non_empty: set[str] = set()
+    for p in paths:
+        dirs = _ancestor_dirs(p)
+        all_folders.update(dirs)
+        if p.rsplit("/", 1)[-1] != _GITKEEP:
+            # A real file makes every folder above it non-empty.
+            non_empty.update(dirs)
+    empty = all_folders - non_empty
+    return sorted(f for f in empty if _parent_dir(f) not in empty)
+
+
+def _empty_long_enough(empty_since_iso: str, now: datetime, min_age_days: int) -> bool:
+    """Pure age gate. ``empty_since_iso`` is a strict-ISO commit timestamp
+    (git ``%aI``). A malformed value fails closed (not stale)."""
+    try:
+        since = datetime.fromisoformat(empty_since_iso)
+    except ValueError:
+        log.warning("empty-folder: unparseable commit ts %r", empty_since_iso)
+        return False
+    return now - since >= timedelta(days=min_age_days)
+
+
+class _EmptyFolderDetector:
+    name = "empty_folder"
+
+    def __init__(self, *, min_age_days: int = EMPTY_FOLDER_MIN_AGE_DAYS) -> None:
+        self.min_age_days = min_age_days
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        # A page *create* can never empty a folder; a sweep or a write (which
+        # may be a delete/move that empties one) can.
+        return trigger in (TriggerKind.SWEEP, TriggerKind.ON_WRITE)
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        if not self.applicable(scope.trigger):
+            return []
+        now = datetime.now(timezone.utc)
+        drafts: list[ProposalDraft] = []
+        for folder in _maximal_empty_folders(scope.paths):
+            meta = git.last_commit_meta_for_path(folder)
+            if meta is None:
+                continue
+            _sha, _author, ts_iso, _msg = meta
+            if not _empty_long_enough(ts_iso, now, self.min_age_days):
+                continue
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.DELETE_EMPTY_FOLDER,
+                    source_paths=[folder],
+                    summary=f"Delete empty folder “{folder}”",
+                )
+            )
+        return drafts
+
+
+DETECTOR = _EmptyFolderDetector()

--- a/backend/tests/test_empty_folder_detector.py
+++ b/backend/tests/test_empty_folder_detector.py
@@ -85,10 +85,10 @@ def repo(tmp_repo, tmp_config):
     return tmp_config
 
 
-def _paths(cfg) -> list[str]:
+def _paths(cfg) -> tuple[str, ...]:
     from app.wiki import git as wiki_git
 
-    return wiki_git.list_paths()
+    return tuple(wiki_git.list_paths())
 
 
 def test_detect_emits_delete_for_empty_folders(repo):

--- a/backend/tests/test_empty_folder_detector.py
+++ b/backend/tests/test_empty_folder_detector.py
@@ -1,0 +1,117 @@
+"""Empty-folder detector — the first Wiki Auto Management detection technique.
+
+Pure helpers (folder enumeration + age gate) are tested directly; ``detect``
+runs against a real tmp wiki repo with the age gate opened so we don't have to
+forge commit dates.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.wiki.automanage.detectors import empty_folder as ef
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+
+# --------------------------------------------------------------------------- #
+# _maximal_empty_folders (pure)                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_folder_with_only_gitkeep_is_empty():
+    assert ef._maximal_empty_folders(["ops/.gitkeep"]) == ["ops"]
+
+
+def test_folder_with_a_page_is_not_empty():
+    assert ef._maximal_empty_folders(["ops/.gitkeep", "ops/runbook.md"]) == []
+
+
+def test_nested_empties_collapse_to_maximal_ancestor():
+    # ops/ and ops/old/ are both empty; only the shallowest is proposed.
+    paths = ["ops/.gitkeep", "ops/old/.gitkeep"]
+    assert ef._maximal_empty_folders(paths) == ["ops"]
+
+
+def test_empty_sibling_beside_populated_sibling():
+    paths = ["team/live/plan.md", "team/live/.gitkeep", "team/archive/.gitkeep"]
+    assert ef._maximal_empty_folders(paths) == ["team/archive"]
+
+
+def test_folder_holding_a_trigger_file_is_not_empty():
+    # A lingering folder-scoped trigger keeps the folder alive.
+    paths = ["ops/.gitkeep", "ops/.trigger_7.yaml"]
+    assert ef._maximal_empty_folders(paths) == []
+
+
+def test_root_is_never_proposed():
+    assert ef._maximal_empty_folders([".gitkeep"]) == []
+
+
+# --------------------------------------------------------------------------- #
+# _empty_long_enough (pure)                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_age_gate_blocks_recent_and_allows_old():
+    now = datetime(2026, 7, 16, tzinfo=timezone.utc)
+    recent = "2026-07-15T12:00:00+00:00"  # ~0.5 days
+    old = "2026-07-10T12:00:00+00:00"  # ~6 days
+    assert ef._empty_long_enough(recent, now, min_age_days=2) is False
+    assert ef._empty_long_enough(old, now, min_age_days=2) is True
+
+
+def test_age_gate_fails_closed_on_garbage():
+    now = datetime(2026, 7, 16, tzinfo=timezone.utc)
+    assert ef._empty_long_enough("not-a-date", now, min_age_days=2) is False
+
+
+# --------------------------------------------------------------------------- #
+# detect (real tmp repo)                                                      #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_config):
+    from app.wiki import git as wiki_git
+
+    # A populated folder, an empty folder, and a page later removed.
+    wiki_git.commit_file("team/plan.md", "# Plan\n", "seed", author=None)
+    wiki_git.commit_file("archive/.gitkeep", "", "create folder archive", author=None)
+    wiki_git.commit_file("old/notes.md", "# Notes\n", "seed", author=None)
+    wiki_git.commit_file("old/.gitkeep", "", "keep old", author=None)
+    wiki_git.delete_path("old/notes.md", "remove notes", author=None)
+    return tmp_config
+
+
+def _paths(cfg) -> list[str]:
+    from app.wiki import git as wiki_git
+
+    return wiki_git.list_paths()
+
+
+def test_detect_emits_delete_for_empty_folders(repo):
+    det = ef._EmptyFolderDetector(min_age_days=0)  # ignore age for this case
+    scope = Scope(trigger=TriggerKind.SWEEP, paths=_paths(repo))
+    drafts = det.detect(scope)
+    folders = {d.source_paths[0] for d in drafts}
+    # `archive` (created empty) and `old` (emptied by the delete) qualify;
+    # `team` holds a page and must not.
+    assert folders == {"archive", "old"}
+    for d in drafts:
+        assert d.op is ProposalOp.DELETE_EMPTY_FOLDER
+        assert d.target_paths == []
+
+
+def test_detect_respects_age_gate(repo):
+    # With a 365-day floor, the just-committed empties are too young.
+    det = ef._EmptyFolderDetector(min_age_days=365)
+    scope = Scope(trigger=TriggerKind.SWEEP, paths=_paths(repo))
+    assert det.detect(scope) == []
+
+
+def test_detect_skips_on_create_trigger(repo):
+    det = ef._EmptyFolderDetector(min_age_days=0)
+    scope = Scope(trigger=TriggerKind.ON_CREATE, paths=_paths(repo))
+    assert det.detect(scope) == []


### PR DESCRIPTION
First slice of **Wiki Auto Management** detection. Ships the *technique axis* — the `Detector` seam and the first detector — kept independent of any queue/DB infra so it's fully unit-testable. Design: [Wiki Auto Management — Detection](/app/wiki/Engineering%20Projects/Agent%20Wiki%20Project/design/Wiki%20Auto%20Management%20%E2%80%94%20Detection.md).

## What's here

- **`detectors/base.py`** — the `Detector` protocol (`applicable` + `detect`, nothing more), `TriggerKind`, and pydantic `Scope` / `ProposalDraft` (the technique↔substrate contract). Mirrors the LLM-providers seam (`app/llm/providers/`).
- **`detectors/empty_folder.py`** — the first, mechanical detector (no LLM, ~free):
  - maximal-empty-folder enumeration — nested empties collapse to a single proposal;
  - `.gitkeep`-only emptiness — a lingering folder-scoped `.trigger_*.yaml` keeps a folder alive, so it's deliberately not treated as empty;
  - an **≥ X-days age gate** (`EMPTY_FOLDER_MIN_AGE_DAYS = 2`) read from `git.last_commit_meta_for_path(<folder>)`, so a folder just created and about to be filled is never proposed.
- **`detectors/__init__.py`** — the `DETECTORS` registry; adding a technique is dropping a file + appending.
- **tests** — pure enumeration cases, pure age arithmetic, and `detect()` against a real tmp repo (including a page delete that empties a folder). 11 tests, ruff + basedpyright clean.

## Design shape

Detection has **two orthogonal axes** — *trigger* (when/scope) × *technique* (what pattern). Techniques are **independent parallel detectors** over a shared substrate, not stages of one funnel; the only genuine cheap→expensive cascade (BM25→LLM) lives *inside* the future fuzzy-dup detector. This PR is one technique; the substrate owns partitioning/guardrails/persistence.

## Not in this PR (follow-ups)

- Substrate: `detection_runs` table, a dedicated `detection` queue + worker, the runner (guardrails + permission-fingerprint partitioning + persistence), and the admin sweep endpoint.
- The approve→executor path (`delete_empty_folder` through `app/wiki/git.py`) and the pending-cleanups queue UI.

## Notes

- The detector reads git but never mutates; `detect()` is pure so it stays unit-testable on a seeded `Scope`.