### PR TITLE
fix(embeddings): step-down retry so no page is silently unembeddable

### DIFF
--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -32,6 +32,15 @@ PAGE_CHAR_CAP = 24_000
 
 _BATCH = 128
 
+# The char caps above bound *characters*, but the model limits *tokens* (8192
+# for text-embedding-3-small). Dense/technical content tokenizes below the ~4
+# chars/token the caps assume, so a capped body can still exceed the token
+# limit. Rather than pick a char cap that's safe for every possible content
+# (impossible), shrink the input in fixed steps on a token-limit rejection and
+# retry — so no page is ever silently unembeddable.
+_STEP_DOWN_CHARS = 4_000
+_MIN_EMBED_CHARS = 4_000
+
 
 def model_name() -> str:
     return CONFIG.ingest_embed_model or DEFAULT_MODEL
@@ -93,7 +102,35 @@ def embed_texts(texts: list[str]) -> list[list[float]] | None:
         return None
 
 
+def _is_token_limit_error(e: Exception) -> bool:
+    """A token-limit 400 from the embeddings endpoint (vs. auth/network/etc.),
+    e.g. ``Invalid 'input[0]': maximum input length is 8192 tokens.``"""
+    return "maximum input length" in str(e).lower()
+
+
 def embed_text(text: str) -> list[float] | None:
-    """Embed a single text. ``None`` on failure / disabled / unconfigured."""
-    res = embed_texts([text])
-    return res[0] if res else None
+    """Embed a single text. ``None`` on failure / disabled / unconfigured.
+
+    On a token-limit rejection, retry with the input truncated in
+    ``_STEP_DOWN_CHARS`` steps down to ``_MIN_EMBED_CHARS`` — the char caps
+    can't guarantee the model's token limit, so shrink-and-retry rather than
+    drop the vector. Every other error is swallowed (best-effort → ``None``),
+    same as the batch path.
+    """
+    key = _api_key()
+    if not key:
+        return None
+    model = model_name()
+    limit = len(text)
+    while True:
+        try:
+            return openai_provider.embed(key, model, [text[:limit]])[0]
+        except Exception as e:
+            if _is_token_limit_error(e) and limit > _MIN_EMBED_CHARS:
+                limit = max(_MIN_EMBED_CHARS, limit - _STEP_DOWN_CHARS)
+                log.warning(
+                    "embeddings: input over the token limit, retrying at %d chars", limit
+                )
+                continue
+            log.warning("embeddings: embed_text failed", exc_info=True)
+            return None

--- a/backend/app/llm/embeddings.py
+++ b/backend/app/llm/embeddings.py
@@ -38,8 +38,8 @@ _BATCH = 128
 # limit. Rather than pick a char cap that's safe for every possible content
 # (impossible), shrink the input in fixed steps on a token-limit rejection and
 # retry — so no page is ever silently unembeddable.
-_STEP_DOWN_CHARS = 4_000
-_MIN_EMBED_CHARS = 4_000
+_STEP_DOWN_CHARS = 4_000  # stride per shrink-and-retry pass
+_MIN_EMBED_CHARS = 4_000  # give-up floor — independent of the stride; retune separately
 
 
 def model_name() -> str:
@@ -126,11 +126,21 @@ def embed_text(text: str) -> list[float] | None:
         try:
             return openai_provider.embed(key, model, [text[:limit]])[0]
         except Exception as e:
-            if _is_token_limit_error(e) and limit > _MIN_EMBED_CHARS:
-                limit = max(_MIN_EMBED_CHARS, limit - _STEP_DOWN_CHARS)
-                log.warning(
-                    "embeddings: input over the token limit, retrying at %d chars", limit
+            if _is_token_limit_error(e):
+                if limit > _MIN_EMBED_CHARS:
+                    limit = max(_MIN_EMBED_CHARS, limit - _STEP_DOWN_CHARS)
+                    log.warning(
+                        "embeddings: input over the token limit, retrying at %d chars", limit
+                    )
+                    continue
+                # Still over the limit at the floor: not transient — the content is too
+                # token-dense to embed. Distinct line so operators don't read this as a
+                # network/auth blip (that's the generic warning below).
+                log.error(
+                    "embeddings: content exceeds the token limit even at the %d-char floor; "
+                    "left unembedded",
+                    _MIN_EMBED_CHARS,
                 )
-                continue
+                return None
             log.warning("embeddings: embed_text failed", exc_info=True)
             return None

--- a/backend/tests/test_embed_text_stepdown.py
+++ b/backend/tests/test_embed_text_stepdown.py
@@ -1,0 +1,75 @@
+"""embed_text step-down retry on the embeddings token limit.
+
+The char caps bound characters, not tokens, so a capped body can still exceed
+the model's 8192-token limit. embed_text must shrink-and-retry until it fits
+rather than drop the vector — while leaving non-token errors as a plain None.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.llm import embeddings
+
+
+_TOKEN_ERR = "Invalid 'input[0]': maximum input length is 8192 tokens."
+
+
+@pytest.fixture(autouse=True)
+def _key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embeddings, "_api_key", lambda: "sk-test")
+    monkeypatch.setattr(embeddings, "model_name", lambda: "text-embedding-3-small")
+
+
+def test_stepdown_retries_until_it_fits(monkeypatch: pytest.MonkeyPatch):
+    """Fails at >20k chars (over token limit), succeeds once truncated."""
+    calls: list[int] = []
+
+    def fake_embed(key: str, model: str, inputs: list[str]) -> list[list[float]]:
+        n = len(inputs[0])
+        calls.append(n)
+        if n > 20_000:
+            raise RuntimeError(_TOKEN_ERR)
+        return [[0.1] * embeddings.EMBED_DIM]
+
+    monkeypatch.setattr(embeddings.openai_provider, "embed", fake_embed)
+
+    vec = embeddings.embed_text("x" * 24_000)
+
+    assert vec is not None and len(vec) == embeddings.EMBED_DIM
+    # 24000 (fail) -> 20000 (ok): stepped down by _STEP_DOWN_CHARS once.
+    assert calls == [24_000, 20_000]
+
+
+def test_non_token_error_returns_none_without_retry(monkeypatch: pytest.MonkeyPatch):
+    calls: list[int] = []
+
+    def fake_embed(key: str, model: str, inputs: list[str]) -> list[list[float]]:
+        calls.append(len(inputs[0]))
+        raise RuntimeError("Connection reset by peer")
+
+    monkeypatch.setattr(embeddings.openai_provider, "embed", fake_embed)
+
+    assert embeddings.embed_text("x" * 24_000) is None
+    assert calls == [24_000]  # no shrink-and-retry on a non-token error
+
+
+def test_gives_up_at_floor(monkeypatch: pytest.MonkeyPatch):
+    """Pathological content that overruns even at the floor: bounded, returns None."""
+    calls: list[int] = []
+
+    def fake_embed(key: str, model: str, inputs: list[str]) -> list[list[float]]:
+        calls.append(len(inputs[0]))
+        raise RuntimeError(_TOKEN_ERR)  # always too long
+
+    monkeypatch.setattr(embeddings.openai_provider, "embed", fake_embed)
+
+    assert embeddings.embed_text("x" * 24_000) is None
+    # Steps 24k -> 20k -> ... -> 4k (floor), then gives up. Bounded, ends at floor.
+    assert calls[0] == 24_000 and calls[-1] == embeddings._MIN_EMBED_CHARS
+    assert all(a > b for a, b in zip(calls, calls[1:]))  # strictly decreasing
+
+
+def test_no_key_returns_none(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(embeddings, "_api_key", lambda: "")
+    assert embeddings.embed_text("hello") is None

--- a/backend/tests/test_embed_text_stepdown.py
+++ b/backend/tests/test_embed_text_stepdown.py
@@ -54,7 +54,7 @@ def test_non_token_error_returns_none_without_retry(monkeypatch: pytest.MonkeyPa
     assert calls == [24_000]  # no shrink-and-retry on a non-token error
 
 
-def test_gives_up_at_floor(monkeypatch: pytest.MonkeyPatch):
+def test_gives_up_at_floor(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
     """Pathological content that overruns even at the floor: bounded, returns None."""
     calls: list[int] = []
 
@@ -64,10 +64,13 @@ def test_gives_up_at_floor(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setattr(embeddings.openai_provider, "embed", fake_embed)
 
-    assert embeddings.embed_text("x" * 24_000) is None
+    with caplog.at_level("ERROR"):
+        assert embeddings.embed_text("x" * 24_000) is None
     # Steps 24k -> 20k -> ... -> 4k (floor), then gives up. Bounded, ends at floor.
     assert calls[0] == 24_000 and calls[-1] == embeddings._MIN_EMBED_CHARS
     assert all(a > b for a, b in zip(calls, calls[1:]))  # strictly decreasing
+    # Distinct floor-exhaustion signal (not the generic transient-failure warning).
+    assert any("floor" in r.message and r.levelname == "ERROR" for r in caplog.records)
 
 
 def test_no_key_returns_none(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Problem

Dense/technical wiki pages fail to embed and vanish from the embedding store. The embed path caps by **characters** (`PAGE_CHAR_CAP=24_000`), but the model limits **tokens** (8192 for text-embedding-3-small). Technical content (code, markdown, IDs, links) tokenizes at ~2.9 chars/token, not the ~4 the cap assumes — so a 24k-char body can be >8192 tokens, the embed 400s (`maximum input length is 8192 tokens`), and `_embed_page` swallows it best-effort. The page is left **silently unembedded** → invisible to any embedding-based retrieval.

Found while backfilling dev-wiki: coverage went 8.8% → **99.3%**, with exactly **1 of 136** pages stuck on this (fittingly, the relevance-filter design doc — 29,787 chars, >8192 tokens even capped to 24k).

## Fix

`embed_text` now, on a **token-limit** rejection, truncates the input in `_STEP_DOWN_CHARS` (4,000) steps down to a `_MIN_EMBED_CHARS` (4,000) floor and retries — so it always finds a length that fits rather than dropping the vector. Non-token errors (auth/network/rate-limit) stay best-effort `None` — no blind retry. The char cap stays 24k as the first attempt, so normal pages are unchanged and only the rare dense page pays an extra call.

Chosen over lowering the char cap (no fixed cap is safe for all content) and over adding tiktoken (no new dependency) — it's content-agnostic and can't be defeated.

## Tests

`test_embed_text_stepdown.py`: retries-until-it-fits (24k→20k), non-token error → `None` with no retry, gives-up-at-floor (bounded, strictly decreasing), no-key → `None`. Ruff + strict basedpyright clean.

## Not in scope

- **Coverage metric** — a follow-up (there's a broader metrics cleanup pending); the floor-give-up case should surface rather than stay silent.
- **Chunk-and-pool** for giant pages — future; truncate-to-fit is the pragmatic recall floor for now.

## Rollout

Backend change → ships via merge → image build → deploy. After deploy, one backfill run (`reindex_all_inline`) closes the last page to 136/136. Prerequisite for embedding-based retrieval replacing BM25 (every page must be embeddable).