### PR TITLE
feat(automanage): admin detection sweep API

### DIFF
--- a/backend/app/api/detection.py
+++ b/backend/app/api/detection.py
@@ -1,0 +1,30 @@
+"""Admin API for Wiki Auto Management detection — trigger a sweep, read run history.
+
+Thin HTTP layer: enqueue the sweep task and read the ``detection_runs`` ledger.
+All detection logic lives in ``app/wiki/automanage/``. Admin-only — a sweep
+reads across the whole wiki.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from app.auth import User
+from app.auth.deps import require_admin
+from app.models.detection import DetectionRunView, RunsResponse, SweepTriggerResponse
+from app.tasks.detection import run_detection_sweep
+from app.wiki.automanage import runs
+
+router = APIRouter()
+
+
+@router.post("/sweep", response_model=SweepTriggerResponse, status_code=202)
+def trigger_sweep(user: User = Depends(require_admin)) -> SweepTriggerResponse:
+    """Kick off a whole-space detection sweep on the detection queue."""
+    run_detection_sweep(user.id)
+    return SweepTriggerResponse()
+
+
+@router.get("/runs", response_model=RunsResponse)
+def list_runs(user: User = Depends(require_admin)) -> RunsResponse:
+    """Most recent detection runs first — the admin sweep history."""
+    return RunsResponse(runs=[DetectionRunView(**r) for r in runs.list_recent()])

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.api import (
     coedit,
     comments,
     craft,
+    detection,
     documents,
     wiki,
     email_verify,
@@ -240,6 +241,7 @@ def create_app() -> FastAPI:
     app.include_router(installer.router, prefix="/api")
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")
     app.include_router(triggers.router, prefix="/api/triggers")
+    app.include_router(detection.router, prefix="/api/detection")
     app.include_router(wiki.router, prefix="/api/wiki")
     app.include_router(coedit.router, prefix="/api/coedit")
     app.include_router(comments.router, prefix="/api/comments")

--- a/backend/app/models/detection.py
+++ b/backend/app/models/detection.py
@@ -1,0 +1,29 @@
+"""HTTP shapes for the Wiki Auto Management detection admin API."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SweepTriggerResponse(BaseModel):
+    """Result of asking for a sweep. The sweep runs on the detection queue, so
+    the request only enqueues it."""
+
+    status: str = "queued"
+
+
+class DetectionRunView(BaseModel):
+    """One ``detection_runs`` row for the admin sweep history."""
+
+    id: str
+    trigger: str
+    status: str
+    triggered_by_user_id: str | None
+    paths_scanned: int
+    proposals_emitted: int
+    error: str | None
+    started_at: str
+    finished_at: str | None
+
+
+class RunsResponse(BaseModel):
+    runs: list[DetectionRunView]

--- a/backend/tests/test_detection_api.py
+++ b/backend/tests/test_detection_api.py
@@ -1,0 +1,53 @@
+"""Admin detection API — sweep trigger + run history, admin-gated.
+
+The sweep runs on the detection queue; ``immediate_mode`` runs it inline so the
+request completes synchronously and a ``detection_runs`` row is recorded. With
+the real (2-day) age gate the fresh tmp repo yields no proposals — this asserts
+the pipe (run recorded, admin gating), not detector output.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.tasks.queues import detection_queue
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_repo, tmp_config):
+    from app.wiki import git as wiki_git
+
+    wiki_git.commit_file("guide.md", "# Guide\n", "seed", author=None)
+    return TestClient(create_app())
+
+
+def test_sweep_requires_admin(client):
+    uid = seed_user(uid="usr_x", email="x@x.com", is_admin=False)
+    login_fastapi(client, uid)
+    assert client.post("/api/detection/sweep").status_code == 403
+
+
+def test_admin_sweep_records_a_run(client):
+    uid = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
+    login_fastapi(client, uid)
+
+    with detection_queue.immediate_mode():
+        resp = client.post("/api/detection/sweep")
+    assert resp.status_code == 202
+    assert resp.json()["status"] == "queued"
+
+    runs = client.get("/api/detection/runs").json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["status"] == "completed"
+    assert runs[0]["trigger"] == "sweep"
+    assert runs[0]["triggered_by_user_id"] == uid
+    assert runs[0]["paths_scanned"] >= 1
+
+
+def test_runs_list_requires_admin(client):
+    uid = seed_user(uid="usr_y", email="y@x.com", is_admin=False)
+    login_fastapi(client, uid)
+    assert client.get("/api/detection/runs").status_code == 403


### PR DESCRIPTION
Split from the original #426, part 3 of 3 (queue → runner → API). **Stacked on #429** (runner), which is on #428 (queue), on #427 (schema).

The thin admin HTTP surface that triggers the runner:
- `POST /api/detection/sweep` — enqueue a whole-space sweep (`require_admin`).
- `GET /api/detection/runs` — recent run history (`require_admin`).
- pydantic shapes in `app/models/detection.py`; router registered in `main.py`.

## Tests
Admin gating (403 for non-admin on both routes); sweep records a completed run.

## Review order
#427 (schema) → #428 (queue) → #429 (runner) → **#426 (this)**. Still all generate-only — the approve→executor is a later slice.