### PR TITLE
feat(automanage): detection_runs table + runs repo (inert)

### DIFF
--- a/backend/app/db/migrations/versions/f1a2b3c4d5e6_detection_runs.py
+++ b/backend/app/db/migrations/versions/f1a2b3c4d5e6_detection_runs.py
@@ -1,0 +1,83 @@
+"""detection_runs
+
+Adds ``detection_runs`` — the Wiki Auto Management detection-run ledger (one
+row per sweep / single-page check: trigger, lifecycle status, who triggered
+it, scan stats). Its ``id`` is what ``change_proposals.run_id`` references, so
+a run joins to everything it emitted. Guarded with the inspector because
+``0001_initial`` builds fresh databases from the current models.
+
+Revision ID: f1a2b3c4d5e6
+Revises: 76caae98c2b2
+Create Date: 2026-07-16 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "f1a2b3c4d5e6"
+down_revision: str | None = "76caae98c2b2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("detection_runs"):
+        return
+    op.create_table(
+        "detection_runs",
+        sa.Column("id", sa.Text(), primary_key=True),
+        sa.Column("trigger", sa.Text(), nullable=False),
+        sa.Column(
+            "status", sa.Text(), nullable=False, server_default=sa.text("'running'")
+        ),
+        sa.Column(
+            "triggered_by_user_id",
+            sa.Text(),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "paths_scanned", sa.Integer(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column(
+            "proposals_emitted",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text(
+                "to_char((now() AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS')"
+            ),
+        ),
+        sa.Column("finished_at", sa.Text(), nullable=True),
+        sa.CheckConstraint(
+            "trigger IN ('sweep', 'on_create', 'on_write')",
+            name="detection_runs_trigger_check",
+        ),
+        sa.CheckConstraint(
+            "status IN ('running', 'completed', 'failed')",
+            name="detection_runs_status_check",
+        ),
+    )
+    op.create_index(
+        "idx_detection_runs_status",
+        "detection_runs",
+        ["status", "started_at"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("detection_runs"):
+        op.drop_table("detection_runs")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1403,6 +1403,54 @@ class ChangeProposal(Base):
     )
 
 
+class DetectionRun(Base):
+    """One Wiki Auto Management detection run — a sweep or a single-page check.
+
+    The substrate stamps a run before detecting, records scan stats as it goes,
+    and closes it ``completed``/``failed`` at the end. ``id`` is the value
+    proposals carry in ``change_proposals.run_id``, so a run and everything it
+    emitted join on it (batched notifications, per-run detector-quality stats).
+    ``trigger`` mirrors ``app/wiki/automanage/detectors/base.py:TriggerKind``.
+    """
+
+    __tablename__ = "detection_runs"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    trigger: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'running'")
+    )
+    # Admin who triggered the sweep; NULL for system/scheduled runs.
+    triggered_by_user_id: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    # Scan stats, filled in as the run progresses.
+    paths_scanned: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    proposals_emitted: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
+    # Populated when status='failed'.
+    error: Mapped[str | None] = mapped_column(Text)
+    started_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    finished_at: Mapped[str | None] = mapped_column(Text)
+
+    __table_args__ = (
+        CheckConstraint(
+            "trigger IN ('sweep', 'on_create', 'on_write')",
+            name="detection_runs_trigger_check",
+        ),
+        CheckConstraint(
+            "status IN ('running', 'completed', 'failed')",
+            name="detection_runs_status_check",
+        ),
+        Index("idx_detection_runs_status", "status", "started_at"),
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Comments — human discussion anchored to wiki pages (Postgres-only)          #
 # --------------------------------------------------------------------------- #

--- a/backend/app/wiki/automanage/runs.py
+++ b/backend/app/wiki/automanage/runs.py
@@ -1,0 +1,116 @@
+"""Detection-run repo — the ``detection_runs`` ledger.
+
+One row per detection run (sweep or single-page check). The runner stamps a
+``running`` row before it detects, then closes it ``completed``/``failed`` with
+scan stats. A run's ``id`` is what proposals carry in ``change_proposals.run_id``,
+so a run and everything it emitted join on it.
+
+Free functions over ``DetectionRun``; each opens its own session and returns
+plain dicts, like ``app/wiki/change_proposals.py``.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import select, update
+
+from app.db.models import DetectionRun
+from app.db.session import execute_dml, session
+from app.wiki.automanage.detectors.base import TriggerKind
+
+
+class RunStatus(str, Enum):
+    """Lifecycle: ``running → completed | failed``. The DB CHECK mirrors these."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _to_dict(row: DetectionRun) -> dict[str, Any]:
+    return {
+        "id": row.id,
+        "trigger": row.trigger,
+        "status": row.status,
+        "triggered_by_user_id": row.triggered_by_user_id,
+        "paths_scanned": row.paths_scanned,
+        "proposals_emitted": row.proposals_emitted,
+        "error": row.error,
+        "started_at": row.started_at,
+        "finished_at": row.finished_at,
+    }
+
+
+def start(*, trigger: TriggerKind, triggered_by_user_id: str | None) -> str:
+    """Insert a ``running`` run and return its id (the ``run_id`` proposals
+    carry). ``triggered_by_user_id`` is the admin for a manual sweep, NULL for
+    system/scheduled runs."""
+    run_id = uuid.uuid4().hex
+    with session() as s:
+        s.add(
+            DetectionRun(
+                id=run_id,
+                trigger=trigger.value,
+                status=RunStatus.RUNNING.value,
+                triggered_by_user_id=triggered_by_user_id,
+                started_at=_now(),
+            )
+        )
+    return run_id
+
+
+def mark_completed(run_id: str, *, paths_scanned: int, proposals_emitted: int) -> None:
+    with session() as s:
+        touched = execute_dml(
+            s,
+            update(DetectionRun)
+            .where(DetectionRun.id == run_id)
+            .values(
+                status=RunStatus.COMPLETED.value,
+                paths_scanned=paths_scanned,
+                proposals_emitted=proposals_emitted,
+                finished_at=_now(),
+            ),
+        )
+    if not touched:
+        raise ValueError(f"detection run {run_id!r} not found")
+
+
+def mark_failed(run_id: str, *, error: str) -> None:
+    with session() as s:
+        touched = execute_dml(
+            s,
+            update(DetectionRun)
+            .where(DetectionRun.id == run_id)
+            .values(
+                status=RunStatus.FAILED.value,
+                error=error,
+                finished_at=_now(),
+            ),
+        )
+    if not touched:
+        raise ValueError(f"detection run {run_id!r} not found")
+
+
+def get(run_id: str) -> dict[str, Any] | None:
+    with session() as s:
+        row = s.get(DetectionRun, run_id)
+        return _to_dict(row) if row is not None else None
+
+
+def list_recent(*, limit: int = 50) -> list[dict[str, Any]]:
+    """Most recent runs first — the admin sweep history."""
+    with session() as s:
+        rows = s.scalars(
+            select(DetectionRun)
+            .order_by(DetectionRun.started_at.desc(), DetectionRun.id.desc())
+            .limit(limit)
+        ).all()
+        return [_to_dict(r) for r in rows]

--- a/backend/tests/test_detection_runs.py
+++ b/backend/tests/test_detection_runs.py
@@ -1,0 +1,63 @@
+"""detection_runs repo — the run ledger (inert until the runner lands).
+
+Lifecycle: start (running) → mark_completed | mark_failed, plus get / list.
+"""
+from __future__ import annotations
+
+from app.wiki.automanage import runs
+from app.wiki.automanage.detectors.base import TriggerKind
+
+
+def test_start_creates_running_run(tmp_db):
+    run_id = runs.start(trigger=TriggerKind.SWEEP, triggered_by_user_id=None)
+    row = runs.get(run_id)
+    assert row is not None
+    assert row["status"] == "running"
+    assert row["trigger"] == "sweep"
+    assert row["triggered_by_user_id"] is None
+    assert row["paths_scanned"] == 0
+    assert row["proposals_emitted"] == 0
+    assert row["finished_at"] is None
+
+
+def test_mark_completed_records_stats(tmp_db):
+    run_id = runs.start(trigger=TriggerKind.SWEEP, triggered_by_user_id=None)
+    runs.mark_completed(run_id, paths_scanned=12, proposals_emitted=3)
+    row = runs.get(run_id)
+    assert row is not None
+    assert row["status"] == "completed"
+    assert row["paths_scanned"] == 12
+    assert row["proposals_emitted"] == 3
+    assert row["finished_at"] is not None
+
+
+def test_mark_failed_records_error(tmp_db):
+    run_id = runs.start(trigger=TriggerKind.ON_CREATE, triggered_by_user_id=None)
+    runs.mark_failed(run_id, error="boom")
+    row = runs.get(run_id)
+    assert row is not None
+    assert row["status"] == "failed"
+    assert row["error"] == "boom"
+    assert row["finished_at"] is not None
+
+
+def test_list_recent_newest_first(tmp_db):
+    # Distinct started_at so ordering is deterministic (start() stamps to the
+    # second, so two same-second runs wouldn't have a stable order).
+    from app.db.models import DetectionRun
+    from app.db.session import session
+
+    with session() as s:
+        s.add(DetectionRun(id="older", trigger="sweep", started_at="2026-07-16 10:00:00"))
+        s.add(DetectionRun(id="newer", trigger="sweep", started_at="2026-07-16 11:00:00"))
+    ids = [r["id"] for r in runs.list_recent()]
+    assert ids.index("newer") < ids.index("older")
+
+
+def test_mark_unknown_run_raises(tmp_db):
+    import pytest
+
+    with pytest.raises(ValueError):
+        runs.mark_completed("nope", paths_scanned=1, proposals_emitted=0)
+    with pytest.raises(ValueError):
+        runs.mark_failed("nope", error="x")


### PR DESCRIPTION
First half of the split detection-substrate work (was #426): the inert schema, landing on its own like `change_proposals` (#366) did.

## What's here
- **`detection_runs`** table — one row per detection run (trigger, lifecycle `running`/`completed`/`failed`, who triggered it, `paths_scanned`/`proposals_emitted`). Its `id` is what `change_proposals.run_id` references.
- Inspector-guarded migration, following the `change_proposals` migration pattern (`0001_initial` builds fresh DBs from current models, so the create is guarded with `has_table`).
- **`runs`** repo: `start` / `mark_completed` / `mark_failed` / `get` / `list_recent` — free functions returning dicts, like `change_proposals`.
- Repo test covering the lifecycle.

## Inert
No code emits runs yet. The dedicated `detection` queue, the runner, and the admin sweep endpoint that populate this table are the stacked follow-up (which *generates* proposals; execution is a later slice still).

## Verified
Migration applies on a fresh DB and in every per-test schema; basedpyright + ruff clean; repo test green.