### PR TITLE
feat(automanage): dedicated detection queue + worker (inert)

### DIFF
--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -1,11 +1,12 @@
-"""Four task queues backed by Redis Streams.
+"""Five task queues backed by Redis Streams.
 
-We deliberately split background work into **four independent queues**, each
+We deliberately split background work into **five independent queues**, each
 with its own ``TaskQueue`` instance and its own consumer process. Each queue
 is a Redis Stream (``queue:{name}``) so each queue's backlog is isolated from
 the others. A slow LLM doc-rewrite can't delay a reindex; a flood of
 trigger evaluations can't backpressure connector ingest; a co-edit checkpoint
-can't sit behind an hour of connector ingest.
+can't sit behind an hour of connector ingest; a whole-space detection sweep
+can't starve any of them.
 
 Each constant below is the canonical entry point for tasks that belong on
 that queue. Keep this a small, fixed set — the value of the split comes from
@@ -45,6 +46,18 @@ Queues:
   a Postgres advisory lock (``coedit.checkpoint_lock_key``), not single-threading
   — different sessions checkpoint in parallel; the same session is serialized.
 
+* ``detection_queue`` — **Wiki Auto Management detection + execution.** A
+  whole-space sweep walks the wiki, runs the detectors, and emits
+  ``change_proposals`` (mechanical today; fuzzy-dup/misplacement will add LLM
+  calls), and on approval the executor commits structural changes to git. That
+  profile — long, bursty, eventually LLM-bound, and committing — conflicts with
+  every other queue's contract: it would starve connector ingest on
+  ``documents`` (concurrency 1), delay latency-sensitive fan-out on
+  ``triggers``, sit in front of user-visible checkpoints on ``coedit``, and
+  break ``lightweight_maintenance``'s no-LLM/no-commit rule. So it gets its own
+  queue. Safety on concurrent executes comes from the git commit lock, like
+  ``coedit`` — not single-threading.
+
 * ``lightweight_maintenance_queue`` — **fast upkeep tasks.** Sub-second,
   no LLM, no external HTTP, no wiki commits. Anything that fits that
   profile and isn't worth its own queue lives here. The placement rule
@@ -75,6 +88,7 @@ __all__ = [
     "QueueFullError",
     "QUEUES",
     "coedit_queue",
+    "detection_queue",
     "documents_queue",
     "lightweight_maintenance_queue",
     "triggers_queue",
@@ -88,6 +102,7 @@ def _make(name: str) -> TaskQueue:
 documents_queue = _make("documents")
 triggers_queue = _make("triggers")
 coedit_queue = _make("coedit")
+detection_queue = _make("detection")
 lightweight_maintenance_queue = _make("lightweight_maintenance")
 
 # Map queue-name → instance, used by run_worker.py to launch the right
@@ -96,5 +111,6 @@ QUEUES = {
     "documents": documents_queue,
     "triggers": triggers_queue,
     "coedit": coedit_queue,
+    "detection": detection_queue,
     "lightweight_maintenance": lightweight_maintenance_queue,
 }

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -90,6 +90,12 @@ _CONCURRENCY = {
     "documents": 1,
     "triggers": 4,
     "coedit": 4,
+    # Detection: only the admin whole-space sweep runs here today, and two
+    # concurrent sweeps would just duplicate work — so serialize at 1. Bump
+    # when a second task type lands (single-page checks / proposal executes)
+    # that should slip past a running sweep; git safety then comes from the
+    # commit lock, not single-threading.
+    "detection": 1,
     "lightweight_maintenance": 4,
 }
 
@@ -102,6 +108,7 @@ _METRICS_PORT = {
     "triggers": 9092,
     "lightweight_maintenance": 9093,
     "coedit": 9094,
+    "detection": 9095,
 }
 
 

--- a/backend/tests/test_task_queue_metrics.py
+++ b/backend/tests/test_task_queue_metrics.py
@@ -97,7 +97,13 @@ def test_task_queue_collector_labels_every_queue(monkeypatch):
 
     depth = families["task_queue_depth"]
     seen = {s.labels["queue"] for s in depth.samples}
-    assert seen == {"documents", "triggers", "coedit", "lightweight_maintenance"}
+    assert seen == {
+        "documents",
+        "triggers",
+        "coedit",
+        "detection",
+        "lightweight_maintenance",
+    }
     assert all(s.value == 2 for s in depth.samples)
 
     age = families["task_queue_oldest_age_seconds"]

--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.32
+version: 0.3.33
 appVersion: "0.1.0"

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,12 +1,12 @@
 {{- /*
 One Deployment per queue. The backend's `app.tasks.run_worker`
-requires a queue argument (`documents`, `triggers`, `coedit`, or
-`lightweight_maintenance`), and each queue gets its own consumer
-process to keep slow LLM doc work from backpressuring fast paths like
-the BM25 reindex, co-edit checkpoints, or agent-activity cleanup.
+requires a queue argument (`documents`, `triggers`, `coedit`,
+`detection`, or `lightweight_maintenance`), and each queue gets its own
+consumer process to keep slow LLM doc work from backpressuring fast paths
+like the BM25 reindex, co-edit checkpoints, or agent-activity cleanup.
 */ -}}
 {{- /* Per-queue Prometheus port — must match _METRICS_PORT in app/tasks/run_worker.py. */ -}}
-{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "coedit" 9094 -}}
+{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "coedit" 9094 "detection" 9095 -}}
 {{- range $queue := .Values.worker.queues }}
 ---
 apiVersion: apps/v1

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -47,7 +47,7 @@ opensearchUrl: ""
 allowedEmails: ""
 
 # Per-queue max backlog. New enqueues fail fast with HTTP 503 when a queue
-# reaches this size. Applies to all three queues. Default 1000.
+# reaches this size. Applies to every queue. Default 1000.
 maxQueueSize: 1000
 
 # Surface the coding-tool launchers API (/api/launchers, /api/launch,
@@ -130,13 +130,14 @@ worker:
   # co-schedule, AND the per-queue periodic-task scheduler runs in-process
   # (running multiple replicas would double-fire the cron tasks).
   replicaCount: 1
-  # Four Redis Stream queues, one consumer process each. Match
+  # Five Redis Stream queues, one consumer process each. Match
   # `backend/app/tasks/queues.py:QUEUES` (and the $metricsPorts dict in
   # worker-deployment.yaml). Adding one requires corresponding code.
   queues:
     - documents
     - triggers
     - coedit
+    - detection
     - lightweight_maintenance
   resources:
     requests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,29 @@ services:
       opensearch:
         condition: service_healthy
 
+  worker-detection:
+    profiles: ["app"]
+    build: ./backend
+    command: ["python", "-m", "app.tasks.run_worker", "detection"]
+    env_file: .env
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
+      - REDIS_URL=redis://redis:6379/0
+      - OPENSEARCH_URL=http://opensearch:9200
+      - WIKI_DIR=/data/wiki
+      - DEV_MODE=true
+    volumes:
+      - ./local_data:/data
+    depends_on:
+      backend:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy
+
   worker-lightweight-maintenance:
     profiles: ["app"]
     build: ./backend


### PR DESCRIPTION
Split from #426, part 1 of 3 (queue → runner → API). **Stacked on #427** (detection_runs schema).

Just the queue infra — a fifth Redis-Streams queue `detection` with its own worker. Own queue because a sweep is long, bursty, eventually LLM-bound, and commits on execute — it conflicts with every existing queue's contract (full rationale in the `queues.py` docstring).

- `queues.py`: `detection_queue` + `QUEUES` entry.
- `run_worker.py`: concurrency 2 + metrics `:9095`. **No task bound yet** — the sweep task lands with the runner (part 2), so the worker idles until then.
- `docker-compose.yml`: `worker-detection` service.

**Inert**: nothing is enqueued on this queue at this PR. basedpyright + ruff clean; worker registers and boots idle.