### PR TITLE
feat(automanage): detection runner + sweep task (generate proposals)

### DIFF
--- a/backend/app/tasks/detection.py
+++ b/backend/app/tasks/detection.py
@@ -1,0 +1,22 @@
+"""Wiki Auto Management detection tasks — bound to the dedicated ``detection``
+queue (its own worker; see ``app/tasks/queues.py`` for why it isn't a
+co-tenant of any other queue).
+
+Emit-only: a sweep detects and writes ``change_proposals``; it never mutates
+the wiki. Execution happens later, on approval.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.tasks.queues import detection_queue
+from app.wiki.automanage import runner
+
+log = logging.getLogger(__name__)
+
+
+@detection_queue.task()
+def run_detection_sweep(triggered_by_user_id: str | None) -> None:
+    """Whole-space detection sweep. ``triggered_by_user_id`` is the admin who
+    kicked it off (NULL for a system/scheduled run)."""
+    runner.run_sweep(triggered_by_user_id=triggered_by_user_id)

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -33,6 +33,7 @@ _TASK_MODULES = (
     "app.tasks.coedit_checkpoint",
     "app.tasks.coedit_rebase",
     "app.tasks.craft",
+    "app.tasks.detection",
     "app.tasks.wiki_update",
     "app.tasks.expire_launch_artifacts",
     "app.tasks.ingest_eval_retention",

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -1,0 +1,167 @@
+"""Detection runner — the substrate the detectors plug into.
+
+A trigger calls in here; the runner builds the ``Scope``, runs every
+applicable detector, applies the cross-cutting guardrails, attaches the drift
+anchors, persists surviving drafts as ``pending`` ``change_proposals``, and
+records the ``detection_runs`` row. Detectors stay pure (``scope → drafts``);
+everything stateful lives here so it's inherited uniformly.
+
+Emit-only: this never mutates the wiki. Execution happens later, on approval.
+
+Guardrails applied to every draft:
+- **Do-not-re-propose** — drop a draft whose op+path-set already has a pending,
+  approved, applied, or human-rejected proposal (`change_proposals.taken_dedupe_keys`).
+- **Forbidden scopes** — drop a draft touching any path whose effective
+  ``ai_management_allowed`` is explicitly ``False`` (the do-not-manage marker).
+- **Per-run cap** — stop emitting past ``MAX_PROPOSALS_PER_RUN`` and log the
+  truncation, so one run can't flood the queue.
+
+Permission-fingerprint partitioning (the pairing-time boundary in the design)
+is a duplicate/misplacement concern — the empty-folder detector proposes on a
+single path and never pairs across a visibility boundary, so it isn't exercised
+yet; the ACL fingerprint on the proposal is left null until that lands.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.wiki import git
+from app.wiki import update_policy
+from app.wiki.automanage import runs
+from app.wiki.automanage.detectors import DETECTORS
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalStatus,
+    create as create_proposal,
+    taken_dedupe_keys,
+)
+
+log = logging.getLogger(__name__)
+
+# Ceiling on proposals emitted by a single run — backpressure so one sweep
+# can't flood the pending-cleanups queue. Excess is logged, not silently
+# dropped.
+MAX_PROPOSALS_PER_RUN = 50
+
+# Statuses that block re-proposing the same op+path-set. expired/stale are
+# omitted so a timed-out or drifted proposal can recur.
+_BLOCKING_STATUSES = (
+    ProposalStatus.PENDING,
+    ProposalStatus.APPROVED,
+    ProposalStatus.APPLIED,
+    ProposalStatus.REJECTED,
+)
+
+_CREATED_VIA = {
+    TriggerKind.SWEEP: ProposalCreatedVia.SWEEP,
+    TriggerKind.ON_CREATE: ProposalCreatedVia.ON_CREATE,
+}
+
+
+def _forbidden_paths(drafts: list[ProposalDraft]) -> set[str]:
+    """Paths across ``drafts`` in an explicitly do-not-manage scope (effective
+    ``ai_management_allowed`` is False), resolved in a single query."""
+    paths = {p for d in drafts for p in d.source_paths + d.target_paths}
+    resolved = update_policy.resolve_ai_management_for_paths(paths)
+    return {p for p, v in resolved.items() if v is False}
+
+
+def _base_shas(source_paths: list[str]) -> dict[str, str] | None:
+    """Drift anchor per source path: the last commit that touched it. Returns
+    None if any source has no history (can't anchor → skip the draft)."""
+    shas: dict[str, str] = {}
+    for p in source_paths:
+        meta = git.last_commit_meta_for_path(p)
+        if meta is None:
+            return None
+        shas[p] = meta[0]
+    return shas
+
+
+def run_detection(
+    *, trigger: TriggerKind, triggered_by_user_id: str | None, paths: list[str]
+) -> dict[str, Any]:
+    """Run every applicable detector over ``paths`` and emit proposals.
+
+    Records a ``detection_runs`` row (running → completed/failed) and returns
+    ``{run_id, paths_scanned, proposals_emitted}``. Raises on failure after
+    marking the run failed, so the queue records the error too.
+    """
+    created_via = _CREATED_VIA.get(trigger)
+    if created_via is None:
+        raise ValueError(f"no change-proposal entry point for trigger {trigger.value!r}")
+
+    run_id = runs.start(trigger=trigger, triggered_by_user_id=triggered_by_user_id)
+    try:
+        scope = Scope(trigger=trigger, paths=tuple(paths), run_id=run_id)
+        taken = taken_dedupe_keys(_BLOCKING_STATUSES)
+        emitted = 0
+        capped = False
+        for detector in DETECTORS:
+            if capped:
+                break
+            if not detector.applicable(trigger):
+                continue
+            drafts = detector.detect(scope)
+            # One policy query per detector, not one per path per draft.
+            forbidden = _forbidden_paths(drafts)
+            for draft in drafts:
+                if draft.dedupe_key in taken:
+                    continue
+                if any(p in forbidden for p in draft.source_paths + draft.target_paths):
+                    continue
+                if emitted >= MAX_PROPOSALS_PER_RUN:
+                    log.warning(
+                        "detection run %s hit per-run cap (%d); "
+                        "remaining drafts deferred to next run",
+                        run_id,
+                        MAX_PROPOSALS_PER_RUN,
+                    )
+                    capped = True
+                    break
+                base_shas = _base_shas(draft.source_paths)
+                if base_shas is None:
+                    continue
+                create_proposal(
+                    op=draft.op,
+                    source_paths=draft.source_paths,
+                    target_paths=draft.target_paths,
+                    base_shas=base_shas,
+                    summary=draft.summary,
+                    created_via=created_via,
+                    proposed_bodies=draft.proposed_bodies,
+                    run_id=run_id,
+                )
+                taken.add(draft.dedupe_key)
+                emitted += 1
+        runs.mark_completed(
+            run_id, paths_scanned=len(paths), proposals_emitted=emitted
+        )
+        log.info(
+            "detection run %s (%s): scanned %d paths, emitted %d proposals",
+            run_id,
+            trigger.value,
+            len(paths),
+            emitted,
+        )
+    except Exception as e:
+        runs.mark_failed(run_id, error=str(e))
+        log.exception("detection run %s failed", run_id)
+        raise
+    return {
+        "run_id": run_id,
+        "paths_scanned": len(paths),
+        "proposals_emitted": emitted,
+    }
+
+
+def run_sweep(*, triggered_by_user_id: str | None) -> dict[str, Any]:
+    """Whole-space sweep — the admin-triggered trigger. Scope is every tracked
+    path so folder-subtree detectors (empty-folder) see complete subtrees."""
+    return run_detection(
+        trigger=TriggerKind.SWEEP,
+        triggered_by_user_id=triggered_by_user_id,
+        paths=list(git.list_paths()),
+    )

--- a/backend/app/wiki/change_proposals.py
+++ b/backend/app/wiki/change_proposals.py
@@ -175,6 +175,31 @@ def list_for_run(run_id: str) -> list[dict[str, Any]]:
         return [_to_dict(r) for r in rows]
 
 
+def taken_dedupe_keys(statuses: tuple[ProposalStatus, ...]) -> set[str]:
+    """Dedupe keys (``op`` + sorted source+target path-set) of every proposal
+    currently in one of ``statuses`` — the detection runner's do-not-re-propose
+    set. Pass ``(pending, approved, applied, rejected)`` to avoid re-emitting an
+    in-flight, already-applied, or human-rejected change; ``expired``/``stale``
+    are intentionally omitted so a timed-out or drifted proposal can recur.
+
+    Key format matches ``ProposalDraft.dedupe_key`` in the detector seam."""
+    with session() as s:
+        # Project only the three columns the key needs — full rows would
+        # deserialize proposed_bodies / base_shas we immediately discard.
+        rows = s.execute(
+            select(
+                ChangeProposal.op,
+                ChangeProposal.source_paths,
+                ChangeProposal.target_paths,
+            ).where(ChangeProposal.status.in_([st.value for st in statuses]))
+        ).all()
+        keys: set[str] = set()
+        for op, source_paths, target_paths in rows:
+            paths = ",".join(sorted(list(source_paths) + list(target_paths)))
+            keys.add(f"{op}:{paths}")
+        return keys
+
+
 def _transition(
     proposal_id: int,
     *,

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -278,6 +278,46 @@ def _resolve_chain(chain: list[str], by_path: dict[str, UpdatePolicy]) -> Resolv
     )
 
 
+def resolve_ai_management_for_paths(paths: Iterable[str]) -> dict[str, bool | None]:
+    """Effective ``ai_management_allowed`` **tri-state** for many paths in a
+    single query (see ``resolve_ai_management`` for the tri-state meaning).
+
+    Fetches the union of every path's scope chain once, then resolves each path
+    most-granular-wins. Keyed by the *input* path strings. Use this instead of
+    per-path calls when checking a batch of proposal paths."""
+    chains = {p: _scope_chain(normalize_path(p)) for p in paths}
+    if not chains:
+        return {}
+    scopes = {scope for chain in chains.values() for scope in chain}
+    with session() as s:
+        rows = s.scalars(
+            select(UpdatePolicy).where(UpdatePolicy.path.in_(scopes))
+        ).all()
+    by_path = {r.path: r for r in rows}
+    result: dict[str, bool | None] = {}
+    for p, chain in chains.items():
+        value: bool | None = None
+        for scope in chain:
+            row = by_path.get(scope)
+            if row is not None and row.ai_management_allowed is not None:
+                value = row.ai_management_allowed
+                break
+        result[p] = value
+    return result
+
+
+def resolve_ai_management(path: str) -> bool | None:
+    """Effective ``ai_management_allowed`` **tri-state** for ``path``.
+
+    ``None`` = unset everywhere in the scope chain (so AI management stays
+    propose→approve); ``True`` = opted in (may auto-apply); ``False`` =
+    explicitly forbidden (also the do-not-consolidate marker). Distinct from
+    ``ResolvedPolicy.ai_management_allowed``, which collapses to a bool and so
+    can't tell "forbidden" from "unset" — detection needs that difference to
+    skip forbidden scopes while still proposing on unset ones."""
+    return resolve_ai_management_for_paths([path]).get(path)
+
+
 def resolve_for_paths(paths: Iterable[str]) -> dict[str, ResolvedPolicy]:
     """Effective policy for many paths in a single query.
 

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -1,0 +1,87 @@
+"""Detection runner — the substrate that turns detectors into persisted
+proposals + a run record.
+
+Uses a zero-age empty-folder detector (via monkeypatched ``DETECTORS``) so the
+fresh tmp-repo commits qualify without forging commit dates; the age gate
+itself is covered in ``test_empty_folder_detector.py``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.wiki.automanage import runner, runs
+from app.wiki.automanage.detectors.empty_folder import _EmptyFolderDetector
+from app.wiki.change_proposals import ProposalStatus, list_by_status, reject
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_config):
+    from app.wiki import git as wiki_git
+
+    wiki_git.commit_file("team/plan.md", "# Plan\n", "seed", author=None)
+    wiki_git.commit_file("archive/.gitkeep", "", "create archive", author=None)
+    wiki_git.commit_file("old/notes.md", "# Notes\n", "seed", author=None)
+    wiki_git.commit_file("old/.gitkeep", "", "keep old", author=None)
+    wiki_git.delete_path("old/notes.md", "remove notes", author=None)
+    return tmp_config
+
+
+@pytest.fixture(autouse=True)
+def _eager_detector(monkeypatch):
+    monkeypatch.setattr(runner, "DETECTORS", [_EmptyFolderDetector(min_age_days=0)])
+
+
+def test_sweep_emits_proposals_and_records_run(repo):
+    result = runner.run_sweep(triggered_by_user_id=None)
+
+    assert result["proposals_emitted"] == 2
+    pending = list_by_status(ProposalStatus.PENDING)
+    assert {p["source_paths"][0] for p in pending} == {"archive", "old"}
+    for p in pending:
+        assert p["op"] == "delete_empty_folder"
+        assert p["target_paths"] == []
+        assert p["run_id"] == result["run_id"]
+        assert p["created_via"] == "sweep"
+        # Drift anchor attached by the runner.
+        assert p["base_shas"].get(p["source_paths"][0])
+
+    run = runs.get(result["run_id"])
+    assert run is not None
+    assert run["status"] == "completed"
+    assert run["trigger"] == "sweep"
+    assert run["proposals_emitted"] == 2
+    assert run["paths_scanned"] >= 3
+    assert run["finished_at"] is not None
+
+
+def test_dedupe_blocks_repropose_of_pending(repo):
+    first = runner.run_sweep(triggered_by_user_id=None)
+    assert first["proposals_emitted"] == 2
+    # Pending proposals from the first run block an identical second emit.
+    second = runner.run_sweep(triggered_by_user_id=None)
+    assert second["proposals_emitted"] == 0
+    assert len(list_by_status(ProposalStatus.PENDING)) == 2
+
+
+def test_rejected_is_not_reproposed(repo):
+    uid = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
+    runner.run_sweep(triggered_by_user_id=None)
+    for p in list_by_status(ProposalStatus.PENDING):
+        assert reject(p["id"], user_id=uid, reason="not wanted")
+    # No pending remain, but the rejected path-sets stay on the do-not-propose
+    # list, so a fresh sweep emits nothing.
+    again = runner.run_sweep(triggered_by_user_id=None)
+    assert again["proposals_emitted"] == 0
+    assert list_by_status(ProposalStatus.PENDING) == []
+
+
+def test_forbidden_scope_is_skipped(repo):
+    from app.wiki import update_policy
+
+    update_policy.set_policy("archive", ai_management_allowed=False)
+    result = runner.run_sweep(triggered_by_user_id=None)
+    folders = {p["source_paths"][0] for p in list_by_status(ProposalStatus.PENDING)}
+    assert "archive" not in folders  # explicitly do-not-manage
+    assert "old" in folders
+    assert result["proposals_emitted"] == 1


### PR DESCRIPTION
Split from #426, part 2 of 3 (queue → runner → API). **Stacked on #428** (detection queue), which is stacked on #427 (schema).

The generation engine, headless — emits `change_proposals`, does **not** execute them.

- **`runner.run_sweep`**: build `Scope` from all tracked paths → run every `applicable(trigger)` detector → guardrails → attach base-SHA drift anchors → persist `pending` `change_proposals` → record the `detection_runs` row.
  - Guardrails: do-not-re-propose (`change_proposals.taken_dedupe_keys` over pending/approved/applied/rejected); skip explicitly-forbidden scopes (`update_policy.resolve_ai_management` tri-state — the collapsed `ResolvedPolicy` bool can't tell *forbidden* from *unset*; batched one query per detector); per-run cap that also stops later detectors.
- **`run_detection_sweep`** task; `run_worker` imports it so it binds to the `detection` queue (idle in #428 until now).
- Guardrail helpers (`taken_dedupe_keys`, `resolve_ai_management`) live with the runner — nothing else uses them.

## Tests (green; basedpyright + ruff clean)
Emit + record a run, dedupe blocks re-propose, rejected path-sets stay do-not-propose, forbidden scope skipped.

## Not here
Admin HTTP trigger (part 3, #426). Approve→executor + permission-fingerprint partitioning + proposal TTL: later slices.