### PR TITLE
feat(ingest): RelevanceService — relevance filter as a reusable service

### DIFF
--- a/backend/app/ingest/relevance/__init__.py
+++ b/backend/app/ingest/relevance/__init__.py
@@ -16,11 +16,14 @@ tests) construct a scorer directly, via ``app.ingest.relevance.two_tower_scorer`
 from app.ingest.relevance.cosine_filter import CosineSimilarityFilter
 from app.ingest.relevance.factory import build_relevance_filter
 from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.relevance.service import RelevanceResult, RelevanceService
 from app.ingest.relevance.two_tower_filter import Scorer, TwoTowerFilter
 
 __all__ = [
     "CosineSimilarityFilter",
     "RelevanceFilter",
+    "RelevanceResult",
+    "RelevanceService",
     "Scorer",
     "TwoTowerFilter",
     "build_relevance_filter",

--- a/backend/app/ingest/relevance/service.py
+++ b/backend/app/ingest/relevance/service.py
@@ -1,0 +1,73 @@
+"""The relevance filter as a service.
+
+Given a document and its candidate pages, enrich their embeddings, run the
+configured :class:`RelevanceFilter`, and return which pages were kept vs
+dropped. Reconcile-agnostic: it takes the pipeline carriers
+(:class:`IngestionDocument`, :class:`CandidatePage`) and returns a plain
+:class:`RelevanceResult`, so the *caller* decides what to do with it — observe
+in shadow, or actually drop in enforce mode. This keeps the filtering logic in
+one place instead of inlined in the reconcile task.
+
+Fail-open: any failure (or empty input) keeps every page, matching the filter
+contract — filtering never removes a candidate the pipeline would otherwise
+have considered.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from app.ingest import enrich
+from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.types import CandidatePage, IngestionDocument
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RelevanceResult:
+    """The input pages partitioned by the filter's verdict.
+
+    ``kept`` + ``dropped`` together are exactly the input pages (the caller's own
+    objects, each in input order). ``dropped`` is what enforce mode would remove
+    and what shadow mode records.
+    """
+
+    kept: list[CandidatePage]
+    dropped: list[CandidatePage]
+
+
+class RelevanceService:
+    """Runs a :class:`RelevanceFilter` over a document's candidate pages.
+
+    Holds the filter (built once, e.g. the two-tower model loaded on
+    construction) so ``evaluate`` doesn't rebuild it per call.
+    """
+
+    def __init__(self, relevance_filter: RelevanceFilter) -> None:
+        self._filter = relevance_filter
+
+    def evaluate(
+        self, doc: IngestionDocument, pages: list[CandidatePage]
+    ) -> RelevanceResult:
+        """Enrich embeddings, filter, and partition ``pages`` into kept/dropped.
+
+        Fail-open: on any error every page is kept, so a filter hiccup never
+        drops a candidate. Returns the caller's own page objects, in input order.
+        """
+        if not pages:
+            return RelevanceResult(kept=[], dropped=[])
+        try:
+            enriched_doc = enrich.with_document_embedding(doc)
+            enriched_pages = enrich.with_page_embeddings(list(pages))
+            kept_paths = {
+                p.path for p in self._filter.keep_relevant(enriched_doc, enriched_pages)
+            }
+        except Exception:
+            log.warning(
+                "relevance service: evaluate failed; keeping all candidates", exc_info=True
+            )
+            return RelevanceResult(kept=list(pages), dropped=[])
+        kept = [p for p in pages if p.path in kept_paths]
+        dropped = [p for p in pages if p.path not in kept_paths]
+        return RelevanceResult(kept=kept, dropped=dropped)

--- a/backend/tests/test_relevance_service.py
+++ b/backend/tests/test_relevance_service.py
@@ -1,0 +1,87 @@
+"""RelevanceService — enrich + filter + partition into kept/dropped, fail-open.
+
+Enrichment is stubbed (it hits the embedding API / store); the filter is a fake
+so the service's own logic — partitioning and fail-open — is what's tested.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.ingest import enrich
+from app.ingest.relevance.filter import RelevanceFilter
+from app.ingest.relevance.service import RelevanceResult, RelevanceService
+from app.ingest.types import CandidatePage, IngestionDocument
+
+
+class _DropByPath(RelevanceFilter):
+    """Keeps every page except those in ``drop``."""
+
+    def __init__(self, drop: set[str]) -> None:
+        self._drop = drop
+
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        return page.path not in self._drop
+
+
+class _Boom(RelevanceFilter):
+    def is_relevant(self, doc: IngestionDocument, page: CandidatePage) -> bool:
+        raise RuntimeError("scorer exploded")
+
+
+@pytest.fixture(autouse=True)
+def _no_embedding_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enrichment hits the embedding API / store; make it a pass-through so the
+    filter decision is what's under test."""
+    monkeypatch.setattr(enrich, "with_document_embedding", lambda d: d)
+    monkeypatch.setattr(enrich, "with_page_embeddings", lambda ps: ps)
+
+
+def _doc() -> IngestionDocument:
+    return IngestionDocument(content="hello", id="d1", title="T")
+
+
+def _pages(*paths: str) -> list[CandidatePage]:
+    return [CandidatePage(path=p, body=f"body {p}") for p in paths]
+
+
+def test_partitions_kept_and_dropped_in_input_order():
+    svc = RelevanceService(_DropByPath({"b.md"}))
+    pages = _pages("a.md", "b.md", "c.md")
+
+    result = svc.evaluate(_doc(), pages)
+
+    assert [p.path for p in result.kept] == ["a.md", "c.md"]
+    assert [p.path for p in result.dropped] == ["b.md"]
+    # Returns the caller's own objects.
+    assert result.kept[0] is pages[0]
+    assert result.dropped[0] is pages[1]
+
+
+def test_empty_pages_is_empty_result():
+    result = RelevanceService(_DropByPath(set())).evaluate(_doc(), [])
+    assert result == RelevanceResult(kept=[], dropped=[])
+
+
+def test_keep_all_when_filter_keeps_all():
+    result = RelevanceService(_DropByPath(set())).evaluate(_doc(), _pages("a.md", "b.md"))
+    assert [p.path for p in result.kept] == ["a.md", "b.md"]
+    assert result.dropped == []
+
+
+def test_fails_open_on_filter_error():
+    pages = _pages("a.md", "b.md")
+    result = RelevanceService(_Boom()).evaluate(_doc(), pages)
+    # Any failure keeps every page — never drops a candidate.
+    assert result.kept == pages
+    assert result.dropped == []
+
+
+def test_fails_open_on_enrich_error(monkeypatch: pytest.MonkeyPatch):
+    def boom(_d: IngestionDocument) -> IngestionDocument:
+        raise RuntimeError("embed API down")
+
+    monkeypatch.setattr(enrich, "with_document_embedding", boom)
+    pages = _pages("a.md", "b.md")
+    result = RelevanceService(_DropByPath({"a.md"})).evaluate(_doc(), pages)
+    assert result.kept == pages and result.dropped == []

--- a/backend/tests/test_relevance_service.py
+++ b/backend/tests/test_relevance_service.py
@@ -45,7 +45,7 @@ def _pages(*paths: str) -> list[CandidatePage]:
     return [CandidatePage(path=p, body=f"body {p}") for p in paths]
 
 
-def test_partitions_kept_and_dropped_in_input_order():
+def test_partitions_kept_and_dropped_in_input_order() -> None:
     svc = RelevanceService(_DropByPath({"b.md"}))
     pages = _pages("a.md", "b.md", "c.md")
 
@@ -58,18 +58,18 @@ def test_partitions_kept_and_dropped_in_input_order():
     assert result.dropped[0] is pages[1]
 
 
-def test_empty_pages_is_empty_result():
+def test_empty_pages_is_empty_result() -> None:
     result = RelevanceService(_DropByPath(set())).evaluate(_doc(), [])
     assert result == RelevanceResult(kept=[], dropped=[])
 
 
-def test_keep_all_when_filter_keeps_all():
+def test_keep_all_when_filter_keeps_all() -> None:
     result = RelevanceService(_DropByPath(set())).evaluate(_doc(), _pages("a.md", "b.md"))
     assert [p.path for p in result.kept] == ["a.md", "b.md"]
     assert result.dropped == []
 
 
-def test_fails_open_on_filter_error():
+def test_fails_open_on_filter_error() -> None:
     pages = _pages("a.md", "b.md")
     result = RelevanceService(_Boom()).evaluate(_doc(), pages)
     # Any failure keeps every page — never drops a candidate.
@@ -77,7 +77,7 @@ def test_fails_open_on_filter_error():
     assert result.dropped == []
 
 
-def test_fails_open_on_enrich_error(monkeypatch: pytest.MonkeyPatch):
+def test_fails_open_on_enrich_error(monkeypatch: pytest.MonkeyPatch) -> None:
     def boom(_d: IngestionDocument) -> IngestionDocument:
         raise RuntimeError("embed API down")
 


### PR DESCRIPTION
## What

Extracts the relevance-filter orchestration into a reconcile-agnostic **`RelevanceService`** (PR A of splitting the old shadow-filter PR into service + wiring).

```
RelevanceService(relevance_filter).evaluate(doc, pages) -> RelevanceResult(kept, dropped)
```

- Owns: enrich embeddings (doc + pages) → run the `RelevanceFilter` → partition the input pages into `kept` / `dropped`.
- Takes the pipeline carriers (`IngestionDocument`, `CandidatePage`); returns a plain result. **Decides nothing about shadow vs enforce** — the caller does. So the eventual shadow→enforce switch is a call-site change (`log result.dropped` → `use result.kept`), not a service change.
- Holds the filter (built once — e.g. the two-tower model loaded on construction), so `evaluate` doesn't rebuild it per call.
- **Fail-open:** any error (or empty input) keeps every page, matching the filter contract — filtering never removes a candidate the pipeline would otherwise consider.

## Why split

The old approach inlined all of this as a private helper in `wiki_update.py`, mixing filter logic with reconcile-specific types and shadow logging. This PR is the **pure, testable service**; the **shadow wiring** into `_reconcile_pushed_document` (map candidates → `CandidatePage`, call `evaluate`, log the result) is the paired follow-up PR, keeping each reviewable on its own.

## Tests

`test_relevance_service.py`: kept/dropped partition (input order, caller's own objects), empty input, keep-all, fail-open on filter error, fail-open on enrich error. Ruff + strict basedpyright clean.

## Not in scope

- Reconcile wiring / shadow observability (metric + `filtered_by_relevance` eval samples) → follow-up PR.
- Enforce mode → later, once shadow data validates the operating point.