### PR TITLE
feat(automanage): pending-cleanups read API (list/get proposals)

### DIFF
--- a/backend/app/api/detection.py
+++ b/backend/app/api/detection.py
@@ -6,15 +6,32 @@ reads across the whole wiki.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
 
 from app.auth import User
-from app.auth.deps import require_admin
-from app.models.detection import DetectionRunView, RunsResponse, SweepTriggerResponse
+from app.auth.deps import require_admin, require_user
+from app.models.detection import (
+    DetectionRunView,
+    ProposalsResponse,
+    ProposalView,
+    RunsResponse,
+    SweepTriggerResponse,
+)
 from app.tasks.detection import run_detection_sweep
+from app.wiki import acl
 from app.wiki.automanage import runs
+from app.wiki.change_proposals import ProposalStatus, get as get_proposal, list_by_status
 
 router = APIRouter()
+
+
+def _can_see(user: User, proposal: dict[str, Any]) -> bool:
+    """A proposal is visible only if the user can read every path it touches —
+    so its existence (and the paths in it) never leaks a restricted scope."""
+    paths = list(proposal["source_paths"]) + list(proposal["target_paths"])
+    return all(acl.can(user.id, user.is_admin, "read", p) for p in paths)
 
 
 @router.post("/sweep", response_model=SweepTriggerResponse, status_code=202)
@@ -28,3 +45,32 @@ def trigger_sweep(user: User = Depends(require_admin)) -> SweepTriggerResponse:
 def list_runs(user: User = Depends(require_admin)) -> RunsResponse:
     """Most recent detection runs first — the admin sweep history."""
     return RunsResponse(runs=[DetectionRunView(**r) for r in runs.list_recent()])
+
+
+@router.get("/proposals", response_model=ProposalsResponse)
+def list_proposals(user: User = Depends(require_user)) -> ProposalsResponse:
+    """Pending cleanup proposals the caller may review — filtered to those whose
+    every path the caller can read (an unreadable path would leak its scope).
+
+    Fetches all pending (``limit=None``) before ACL-filtering: the pending queue
+    is a bounded working set (drained by review + TTL expiry, capped per sweep),
+    and a hard row cap *before* the filter would silently hide a caller's
+    readable proposals sitting past it. If the pending set ever grows large,
+    push the visibility check into SQL and paginate."""
+    pending = list_by_status(ProposalStatus.PENDING, limit=None)
+    visible = [p for p in pending if _can_see(user, p)]
+    return ProposalsResponse(proposals=[ProposalView(**p) for p in visible])
+
+
+@router.get("/proposals/{proposal_id}", response_model=ProposalView)
+def get_one_proposal(
+    proposal_id: int, user: User = Depends(require_user)
+) -> ProposalView:
+    """A single proposal preview. 404 if missing; 403 if the caller can't read
+    every path it touches."""
+    proposal = get_proposal(proposal_id)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="proposal not found")
+    if not _can_see(user, proposal):
+        raise HTTPException(status_code=403, detail="not permitted")
+    return ProposalView(**proposal)

--- a/backend/app/models/detection.py
+++ b/backend/app/models/detection.py
@@ -27,3 +27,21 @@ class DetectionRunView(BaseModel):
 
 class RunsResponse(BaseModel):
     runs: list[DetectionRunView]
+
+
+class ProposalView(BaseModel):
+    """One ``change_proposals`` row for the pending-cleanups queue."""
+
+    id: int
+    op: str
+    status: str
+    source_paths: list[str]
+    target_paths: list[str]
+    summary: str
+    created_via: str
+    run_id: str | None
+    created_at: str
+
+
+class ProposalsResponse(BaseModel):
+    proposals: list[ProposalView]

--- a/backend/app/wiki/change_proposals.py
+++ b/backend/app/wiki/change_proposals.py
@@ -151,17 +151,21 @@ def get(proposal_id: int) -> dict[str, Any] | None:
 
 
 def list_by_status(
-    status: ProposalStatus, *, limit: int = 100
+    status: ProposalStatus, *, limit: int | None = 100
 ) -> list[dict[str, Any]]:
-    """Proposals in ``status``, oldest first (queue order)."""
+    """Proposals in ``status``, oldest first (queue order). ``limit=None``
+    returns all — the pending-cleanups list uses that so its ACL filter runs
+    over the whole set (a hard cap *before* filtering would silently hide a
+    caller's readable proposals sitting past it)."""
     with session() as s:
-        rows = s.scalars(
+        q = (
             select(ChangeProposal)
             .where(ChangeProposal.status == status.value)
             .order_by(ChangeProposal.created_at.asc(), ChangeProposal.id.asc())
-            .limit(limit)
-        ).all()
-        return [_to_dict(r) for r in rows]
+        )
+        if limit is not None:
+            q = q.limit(limit)
+        return [_to_dict(r) for r in s.scalars(q).all()]
 
 
 def list_for_run(run_id: str) -> list[dict[str, Any]]:

--- a/backend/tests/test_detection_proposals_api.py
+++ b/backend/tests/test_detection_proposals_api.py
@@ -1,0 +1,89 @@
+"""Pending-cleanups read API — list/get proposals, visibility-scoped.
+
+A proposal is visible only to a caller who can read every path it touches, so
+its existence never leaks a restricted scope.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import acl
+from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalOp,
+    create as create_proposal,
+)
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_repo, tmp_config):
+    return TestClient(create_app())
+
+
+def _mk(folder: str) -> int:
+    return create_proposal(
+        op=ProposalOp.DELETE_EMPTY_FOLDER,
+        source_paths=[folder],
+        target_paths=[],
+        base_shas={folder: "deadbeef"},
+        summary=f"Delete empty folder “{folder}”",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+
+
+def test_admin_lists_all_pending(client):
+    uid = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    _mk("old")
+    _mk("archive")
+    resp = client.get("/api/detection/proposals")
+    assert resp.status_code == 200
+    folders = {p["source_paths"][0] for p in resp.json()["proposals"]}
+    assert folders == {"old", "archive"}
+
+
+def test_get_one_and_404(client):
+    uid = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    pid = _mk("old")
+    got = client.get(f"/api/detection/proposals/{pid}")
+    assert got.status_code == 200
+    assert got.json()["op"] == "delete_empty_folder"
+    assert client.get("/api/detection/proposals/999999").status_code == 404
+
+
+def test_public_proposal_visible_to_any_user(client):
+    seed_user(uid="admin_1", email="a@x.com", is_admin=True)  # first user = admin
+    uid = seed_user(uid="usr_2", email="u2@x.com", is_admin=False)
+    login_fastapi(client, uid)
+    _mk("public-folder")  # no owner/ACL → implicit-public
+    folders = {p["source_paths"][0] for p in client.get("/api/detection/proposals").json()["proposals"]}
+    assert "public-folder" in folders
+
+
+def test_restricted_proposal_hidden_from_non_reader(client):
+    admin = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
+    # Non-admin owner: exercises the ownership path in effective(), not the
+    # admin-bypass short-circuit.
+    owner = seed_user(uid="owner_1", email="o@x.com", is_admin=False)
+    other = seed_user(uid="other_1", email="ot@x.com", is_admin=False)
+    pid = _mk("restricted")
+    acl.set_owner("restricted", owner)  # owner + admins only
+
+    # The non-reader can't see it in the list, and gets 403 on direct fetch.
+    login_fastapi(client, other)
+    listed = {p["source_paths"][0] for p in client.get("/api/detection/proposals").json()["proposals"]}
+    assert "restricted" not in listed
+    assert client.get(f"/api/detection/proposals/{pid}").status_code == 403
+
+    # The non-admin owner sees it via ownership.
+    login_fastapi(client, owner)
+    assert client.get(f"/api/detection/proposals/{pid}").status_code == 200
+
+    # And an admin sees it via bypass.
+    login_fastapi(client, admin)
+    assert client.get(f"/api/detection/proposals/{pid}").status_code == 200


### PR DESCRIPTION
Kicks off the **approve → executor** work. This PR is the read surface only — the pending-cleanups review queue needs a way to see proposals before we add approve/reject/execute.

## What's here
- `GET /api/detection/proposals` — pending proposals the caller may review, **visibility-scoped**: filtered to proposals whose *every* path the caller can read (`acl.can`), so a proposal's existence (and its paths) never leaks a restricted scope.
- `GET /api/detection/proposals/{id}` — single preview; `404` if missing, `403` if the caller can't read every path it touches.
- `ProposalView` / `ProposalsResponse` shapes.
- Gated `require_user` (not admin) — the affected owners review proposals, not just admins.

## Tests (green; basedpyright + ruff clean)
Admin lists all pending; get-one + 404; public proposal visible to any user; restricted proposal (owned folder) hidden from a non-reader (absent from list + 403 on fetch) but visible to owner/admin.

## Next (stacked)
Approve/reject endpoints + the `delete_empty_folder` executor (trash-move soft delete via `after_doc_trashed`, re-validate empty + base-SHA, `mark_applied`). Then the queue UI (frontend).