### PR TITLE
feat(automanage): delete_empty_folder executor + execute task

### DIFF
--- a/backend/app/tasks/detection.py
+++ b/backend/app/tasks/detection.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 from app.tasks.queues import detection_queue
-from app.wiki.automanage import runner
+from app.wiki.automanage import executor, runner
 
 log = logging.getLogger(__name__)
 
@@ -20,3 +20,10 @@ def run_detection_sweep(triggered_by_user_id: str | None) -> None:
     """Whole-space detection sweep. ``triggered_by_user_id`` is the admin who
     kicked it off (NULL for a system/scheduled run)."""
     runner.run_sweep(triggered_by_user_id=triggered_by_user_id)
+
+
+@detection_queue.task()
+def execute_proposal(proposal_id: int) -> None:
+    """Apply an approved proposal (commits to git — hence the detection queue,
+    not a co-tenant)."""
+    executor.execute(proposal_id)

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -1,0 +1,96 @@
+"""Executor for approved change proposals.
+
+Detection only *emits* proposals; this is the only place that acts on one.
+Phase 1 is human-approved only (delegation/auto-apply is Phase 2). On approval
+a proposal is handed here (via the detection queue) to apply the structural
+change and migrate path-keyed state, then mark itself ``applied``.
+
+``delete_empty_folder`` is the first — and today only — op. It executes as a
+**trash-move** (soft delete): the folder is moved into ``.trash/`` exactly like
+`DELETE /wiki/file`, so `after_doc_trashed` re-points the folder's ACL/policy
+row and tombstones its doc id, and the delete stays losslessly restorable —
+honoring the PRD's "no information is ever deleted" invariant.
+
+Re-validation (PRD): a stale proposal never executes. For an empty-folder
+delete the meaningful precondition is that the folder is *still empty* — a page
+added since detection means the proposal no longer applies, so it goes stale
+rather than deleting content.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.auth import users
+from app.models.wiki import PathMove
+from app.wiki import change_proposals, git, notify, trash
+from app.wiki.change_proposals import ProposalOp, ProposalStatus
+
+log = logging.getLogger(__name__)
+
+
+def _git_author(user_id: str | None) -> str | None:
+    """`name <email>` for commit attribution, or None for the default identity."""
+    if user_id is None:
+        return None
+    u = users.get_by_id(user_id)
+    if u is None:
+        return None
+    return f"{u.get('name') or u['email']} <{u['email']}>"
+
+
+def _folder_still_empty(folder: str) -> bool:
+    """True if ``folder`` still exists and holds only ``.gitkeep`` markers (no
+    ``.md`` page, no other tracked file). Git tracks files, not dirs, so an
+    absent folder yields no tracked files → not empty (nothing to delete)."""
+    under = list(git.list_paths(folder))
+    return bool(under) and all(p.rsplit("/", 1)[-1] == ".gitkeep" for p in under)
+
+
+def execute(proposal_id: int) -> None:
+    """Apply an approved proposal. No-op (logged) if it isn't ``approved`` — a
+    concurrent reject/expire/apply already moved it on."""
+    p = change_proposals.get(proposal_id)
+    if p is None:
+        log.warning("execute: proposal %s is gone", proposal_id)
+        return
+    if p["status"] != ProposalStatus.APPROVED.value:
+        log.info(
+            "execute: proposal %s not approved (%s) — skip", proposal_id, p["status"]
+        )
+        return
+    op = p["op"]
+    if op == ProposalOp.DELETE_EMPTY_FOLDER.value:
+        _execute_delete_empty_folder(p)
+        return
+    # Only delete_empty_folder has a producer today; other ops are added here
+    # alongside their detectors.
+    raise ValueError(f"no executor for op {op!r}")
+
+
+def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
+    proposal_id = p["id"]
+    folder = p["source_paths"][0]
+
+    if not _folder_still_empty(folder):
+        change_proposals.mark_stale(
+            proposal_id, reason=f"{folder!r} is no longer an empty folder"
+        )
+        log.info("execute: proposal %s stale — %s not empty", proposal_id, folder)
+        return
+
+    author = _git_author(p["acting_user_id"])
+    dest = trash.trash_location(trash.new_trash_id(), folder)
+    sha, moves = git.move_path(
+        folder, dest, trash.trash_commit_message(folder), author=author
+    )
+    notify.after_doc_trashed(
+        moves, sha, author, root_move=PathMove(old=folder, new=dest)
+    )
+    change_proposals.mark_applied(proposal_id, applied_sha=sha)
+    log.info(
+        "execute: proposal %s applied — trashed empty folder %s (sha=%s)",
+        proposal_id,
+        folder,
+        sha[:8],
+    )

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -1,0 +1,81 @@
+"""Executor for approved delete_empty_folder proposals.
+
+Executes as a trash-move (soft delete) against a real tmp repo, re-validating
+the folder is still empty first.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.wiki import git as wiki_git
+from app.wiki.automanage import executor
+from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalOp,
+    approve,
+    create,
+    get,
+)
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def repo(tmp_repo):
+    return tmp_repo
+
+
+def _proposal_for(folder: str) -> int:
+    meta = wiki_git.last_commit_meta_for_path(folder)
+    base = meta[0] if meta else "0" * 40
+    return create(
+        op=ProposalOp.DELETE_EMPTY_FOLDER,
+        source_paths=[folder],
+        target_paths=[],
+        base_shas={folder: base},
+        summary=f"Delete empty folder “{folder}”",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+
+
+def test_execute_trashes_empty_folder(repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("stale/.gitkeep", "", "create stale folder", author=None)
+    pid = _proposal_for("stale")
+    assert approve(pid, user_id=uid)  # pending -> approved
+
+    executor.execute(pid)
+
+    # The folder is gone from the tracked tree (moved into .trash/).
+    assert "stale/.gitkeep" not in wiki_git.list_paths()
+    p = get(pid)
+    assert p is not None
+    assert p["status"] == "applied"
+    assert p["applied_sha"]
+
+
+def test_execute_skips_folder_that_is_no_longer_empty(repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("live/.gitkeep", "", "keep", author=None)
+    pid = _proposal_for("live")
+    assert approve(pid, user_id=uid)
+    # A page lands in the folder after approval — it must not be deleted.
+    wiki_git.commit_file("live/page.md", "# Page\n", "add a page", author=None)
+
+    executor.execute(pid)
+
+    p = get(pid)
+    assert p is not None
+    assert p["status"] == "stale"
+    assert "live/page.md" in wiki_git.list_paths()  # untouched
+
+
+def test_execute_is_noop_when_not_approved(repo):
+    wiki_git.commit_file("x/.gitkeep", "", "create", author=None)
+    pid = _proposal_for("x")  # still pending — never approved
+
+    executor.execute(pid)
+
+    p = get(pid)
+    assert p is not None
+    assert p["status"] == "pending"  # unchanged
+    assert "x/.gitkeep" in wiki_git.list_paths()  # untouched


### PR DESCRIPTION
The **execution** machinery for Wiki Auto Management — given an *approved* proposal, apply it and mark it applied. Deliberately independent of *how* a proposal got approved (human review or AI-managed auto-approval), so both approval paths reuse this. The approve/reject surface that drives it is a **stacked follow-up**.

## What's here
- **`executor.execute(proposal_id)`** — guards `status == approved` (no-op otherwise, so re-runs are safe); for `delete_empty_folder` **re-validates the folder is still empty** (a page added since detection → `mark_stale`, never delete content); executes as a **trash-move** (soft delete via `after_doc_trashed` — re-points the folder's ACL/policy row, tombstones its doc id, losslessly restorable per the PRD "no information is ever deleted" invariant); commit attributed to the acting user; `mark_applied`.
- **`execute_proposal` task** on the `detection` queue (it commits, so it belongs on detection's own queue).

## Tests (green; basedpyright + ruff clean)
Executor trashes an empty folder; skips a no-longer-empty folder (→ `stale`, untouched); no-ops when the proposal isn't approved.

## Next (stacked)
The approve/reject endpoints + the `review.py` coordination seam (human `approve` / AI-managed `auto_approve` funnel into this one execution path). Then the pending-cleanups queue UI.