### PR TITLE
feat(wiki): UI refresh — directory tree, app header, folder page

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -14,7 +14,7 @@
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@onyx-ai/opal": "^0.1.12",
+        "@onyx-ai/opal": "^0.1.17",
         "@radix-ui/react-popover": "^1.1.6",
         "@radix-ui/react-separator": "^1.1.0",
         "@radix-ui/react-slot": "^1.2.4",
@@ -74,6 +74,8 @@
     "@codemirror/state": ["@codemirror/state@6.7.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg=="],
 
     "@codemirror/view": ["@codemirror/view@6.43.4", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg=="],
+
+    "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
     "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
 
@@ -221,7 +223,7 @@
 
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
-    "@onyx-ai/opal": ["@onyx-ai/opal@0.1.12", "", { "dependencies": { "clsx": "^2.0.0", "copy-to-clipboard": "^3.3.3", "tailwind-merge": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.0", "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0", "@dnd-kit/sortable": "^8.0.0", "@dnd-kit/utilities": "^3.0.0", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-separator": "^1.0.0", "@radix-ui/react-slot": "^1.0.0", "@radix-ui/react-tabs": "^1.0.0", "@radix-ui/react-tooltip": "^1.0.0", "@tanstack/react-table": "^8.0.0", "formik": "^2.0.0", "next": ">=14.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-markdown": "^9.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.0" } }, "sha512-rFWg1X//v5hB5gC94hLCAQwj8iC9WbzukKRJJcJie7qW0AkcBG64RmDjS9p5ae5At9D9YvswjLeBbajtDZer1A=="],
+    "@onyx-ai/opal": ["@onyx-ai/opal@0.1.17", "", { "dependencies": { "clsx": "^2.0.0", "copy-to-clipboard": "^3.3.3", "tailwind-merge": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.0.0", "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0", "@dnd-kit/sortable": "^8.0.0", "@dnd-kit/utilities": "^3.0.0", "@radix-ui/react-popover": "^1.0.0", "@radix-ui/react-separator": "^1.0.0", "@radix-ui/react-slot": "^1.0.0", "@radix-ui/react-tabs": "^1.0.0", "@radix-ui/react-tooltip": "^1.0.0", "@tanstack/react-table": "^8.0.0", "formik": "^2.0.0", "next": ">=14.0.0", "react": "^18.0.0 || ^19.0.0", "react-day-picker": "^9.0.0", "react-dom": "^18.0.0 || ^19.0.0", "react-markdown": "^9.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.0" } }, "sha512-B0Ko9HxDeOwx2pE8G4C905BPygdJRSWDUv1C4qHDkTd3/v2BSoTBHlwZTrkp7u48yT7tEZ4ZZHPrGVvYL3zxWg=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -288,6 +290,8 @@
     "@rushstack/eslint-patch": ["@rushstack/eslint-patch@1.16.1", "", {}, "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
+    "@tabby_ai/hijri-converter": ["@tabby_ai/hijri-converter@1.0.5", "", {}, "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
@@ -518,6 +522,10 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
+
+    "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -1012,6 +1020,8 @@
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-day-picker": ["react-day-picker@9.14.0", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "@tabby_ai/hijri-converter": "1.0.5", "date-fns": "^4.1.0", "date-fns-jalali": "4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@onyx-ai/opal": "^0.1.12",
+    "@onyx-ai/opal": "^0.1.17",
     "@radix-ui/react-popover": "^1.1.6",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.2.4",

--- a/frontend/src/app/admin/braintrust/page.tsx
+++ b/frontend/src/app/admin/braintrust/page.tsx
@@ -165,7 +165,7 @@ function BraintrustForm() {
         clearDisabled={saving || !settings.api_key_set}
       />
 
-      <div className="flex items-center justify-between rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-02) px-[14px] py-3">
+      <div className="flex items-center justify-between rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-02) px-[14px] py-3">
         <div>
           <div className="text-[13px] font-medium">
             Tracing is currently{" "}
@@ -252,5 +252,5 @@ function KeyField({
 }
 
 const inputClass =
-  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--radius-04) text-sm";
 const lblClass = "mb-1 text-[13px] font-medium";

--- a/frontend/src/app/admin/health/page.tsx
+++ b/frontend/src/app/admin/health/page.tsx
@@ -59,7 +59,7 @@ export default function AdminHealthPage() {
           description={`Backend liveness and queue depth. Polls every ${POLL_MS / 1000}s.`}
         />
 
-        <section className="mb-5 flex items-center gap-3 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+        <section className="mb-5 flex items-center gap-3 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
           <span
             aria-hidden
             style={{ background: statusColor }}
@@ -108,7 +108,7 @@ export default function AdminHealthPage() {
               return (
                 <li
                   key={q.name}
-                  className="mb-[10px] rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-[14px]"
+                  className="mb-[10px] rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-[14px]"
                 >
                   <div className="mb-2 flex items-baseline justify-between">
                     <div className="text-sm">
@@ -129,7 +129,7 @@ export default function AdminHealthPage() {
                   </div>
                   <div
                     style={{ marginBottom: haveCounts ? 8 : 0 }}
-                    className="h-[6px] overflow-hidden rounded-(--border-radius-04) bg-(--background-tint-02)"
+                    className="h-[6px] overflow-hidden rounded-(--radius-04) bg-(--background-tint-02)"
                   >
                     <div
                       style={{

--- a/frontend/src/app/admin/ingest/page.tsx
+++ b/frontend/src/app/admin/ingest/page.tsx
@@ -235,7 +235,7 @@ function IngestForm() {
                       ? settings.api_key_hint
                       : "No key yet — click Regenerate"
                 }
-                className={`box-border w-full flex-1 rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm ${freshKey ? "font-mono" : ""}`}
+                className={`box-border w-full flex-1 rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 text-sm ${freshKey ? "font-mono" : ""}`}
               />
               {freshKey && keyVisible && (
                 <Button
@@ -287,7 +287,7 @@ function IngestForm() {
             value={onyxBaseUrl}
             onChange={(e) => setOnyxBaseUrl(e.target.value)}
             placeholder="https://your-onyx.example.com"
-            className="box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 font-mono text-sm"
+            className="box-border w-full rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 font-mono text-sm"
           />
           <div className="mt-1.5 text-xs text-(--text-03)">
             The public origin of your Onyx deployment (no trailing slash). Users
@@ -306,7 +306,7 @@ function IngestForm() {
             max={5000000}
             value={maxDocChars}
             onChange={(e) => setMaxDocChars(e.target.value)}
-            className="box-border w-[160px] rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
+            className="box-border w-[160px] rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
           />
         </label>
 
@@ -326,7 +326,7 @@ function IngestForm() {
             min={0}
             value={warnDefault}
             onChange={(e) => setWarnDefault(e.target.value)}
-            className="box-border w-[160px] rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
+            className="box-border w-[160px] rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
           />
         </label>
         <label>
@@ -338,7 +338,7 @@ function IngestForm() {
             min={0}
             value={autoCap}
             onChange={(e) => setAutoCap(e.target.value)}
-            className="box-border w-[160px] rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
+            className="box-border w-[160px] rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
           />
         </label>
         <div className="flex items-center gap-3">
@@ -425,7 +425,7 @@ function SelectorModelSection({
         model.
       </div>
       {!editing ? (
-        <div className="flex items-center justify-between rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) px-4 py-3">
+        <div className="flex items-center justify-between rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) px-4 py-3">
           <span
             className={`text-sm ${selModel && selModel !== settings.model ? "text-(--text-05)" : "text-(--text-03)"}`}
           >
@@ -441,7 +441,7 @@ function SelectorModelSection({
           </Button>
         </div>
       ) : (
-        <div className="flex flex-col rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01)">
+        <div className="flex flex-col rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01)">
           <div className="flex flex-col gap-1 p-3">
             {hasNoModels && (
               <div className="py-1 pb-2 text-[13px] text-(--text-03)">
@@ -458,7 +458,7 @@ function SelectorModelSection({
             <button
               type="button"
               onClick={() => setSelModel("")}
-              className={`flex cursor-pointer items-center gap-3 rounded-(--border-radius-04) border px-3 py-[10px] text-left ${selModel === "" ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
+              className={`flex cursor-pointer items-center gap-3 rounded-(--radius-04) border px-3 py-[10px] text-left ${selModel === "" ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
             >
               <div
                 className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${selModel === "" ? "bg-(--background-tint-inverted-00)" : "border-[1.5px] border-(--border-02) bg-transparent"}`}
@@ -480,7 +480,7 @@ function SelectorModelSection({
                   key={`${p}:${m}`}
                   type="button"
                   onClick={() => setSelModel(m)}
-                  className={`flex cursor-pointer items-center gap-3 rounded-(--border-radius-04) border px-3 py-[10px] text-left ${isSelected ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
+                  className={`flex cursor-pointer items-center gap-3 rounded-(--radius-04) border px-3 py-[10px] text-left ${isSelected ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
                 >
                   <div
                     className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-full ${isSelected ? "bg-(--background-tint-inverted-00)" : "border-[1.5px] border-(--border-02) bg-transparent"}`}

--- a/frontend/src/app/admin/language-models/page.tsx
+++ b/frontend/src/app/admin/language-models/page.tsx
@@ -266,7 +266,7 @@ function AgentModelSection({
     <section>
       <div className={sectionHeaderClass}>Default model</div>
       {!editing ? (
-        <div className="flex items-center justify-between rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) px-4 py-3">
+        <div className="flex items-center justify-between rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) px-4 py-3">
           <div>
             {settings.provider &&
             PROVIDER_META[settings.provider as Provider] ? (
@@ -294,7 +294,7 @@ function AgentModelSection({
           </Button>
         </div>
       ) : (
-        <div className="flex flex-col rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01)">
+        <div className="flex flex-col rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01)">
           <div className="flex flex-col gap-1 p-3">
             {options.map(({ provider: p, model: m }) => {
               const isSelected = selProvider === p && selModel === m;
@@ -306,7 +306,7 @@ function AgentModelSection({
                     setSelProvider(p);
                     setSelModel(m);
                   }}
-                  className={`flex cursor-pointer items-center gap-3 rounded-(--border-radius-04) border px-3 py-[10px] text-left ${isSelected ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
+                  className={`flex cursor-pointer items-center gap-3 rounded-(--radius-04) border px-3 py-[10px] text-left ${isSelected ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
                 >
                   <div
                     className={`flex h-[16px] w-[16px] shrink-0 items-center justify-center rounded-full ${isSelected ? "border-none bg-(--background-tint-inverted-00)" : "border-[1.5px] border-(--border-02) bg-transparent"}`}
@@ -382,11 +382,11 @@ function ProviderCard({
   const hint = keyHint(provider, settings);
 
   return (
-    <div className="overflow-hidden rounded-(--border-radius-08) border border-(--border-01)">
+    <div className="overflow-hidden rounded-(--radius-08) border border-(--border-01)">
       {/* Card header row */}
       <div className="flex items-center gap-3 bg-(--background-tint-01) px-4 py-3">
         {/* Provider initial icon */}
-        <div className="flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-(--border-radius-04) bg-(--background-tint-02) text-[13px] font-bold text-(--text-04)">
+        <div className="flex h-[32px] w-[32px] shrink-0 items-center justify-center rounded-(--radius-04) bg-(--background-tint-02) text-[13px] font-bold text-(--text-04)">
           {meta.initial}
         </div>
 
@@ -583,10 +583,10 @@ function ProviderForm({
                 key={id}
                 type="button"
                 onClick={() => toggleModel(id)}
-                className={`flex cursor-pointer items-center gap-[10px] rounded-(--border-radius-08) border px-3 py-[10px] text-left ${checked ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
+                className={`flex cursor-pointer items-center gap-[10px] rounded-(--radius-08) border px-3 py-[10px] text-left ${checked ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
               >
                 <div
-                  className={`flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-(--border-radius-04) ${checked ? "border-none bg-(--background-tint-inverted-00)" : "border-[1.5px] border-(--border-02) bg-transparent"}`}
+                  className={`flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-(--radius-04) ${checked ? "border-none bg-(--background-tint-inverted-00)" : "border-[1.5px] border-(--border-02) bg-transparent"}`}
                 >
                   {checked && (
                     <span className="flex text-(--text-inverted-05)">
@@ -738,7 +738,7 @@ function ModelListEditor({
         {models.map((id) => (
           <div
             key={id}
-            className="flex items-center justify-between rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) py-[6px] pr-2 pl-3"
+            className="flex items-center justify-between rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) py-[6px] pr-2 pl-3"
           >
             <span className="font-mono text-[13px] text-(--text-05)">{id}</span>
             <Button
@@ -1143,7 +1143,7 @@ function FormActions({
 }
 
 const inputClass =
-  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--radius-04) text-sm";
 const lblClass = "mb-1 text-[13px] font-medium";
 const sectionHeaderClass =
   "text-[13px] font-semibold text-(--text-04) uppercase tracking-[0.05em] mb-3";

--- a/frontend/src/app/admin/slack/page.tsx
+++ b/frontend/src/app/admin/slack/page.tsx
@@ -167,4 +167,4 @@ function SlackAppForm() {
 }
 
 const inputClass =
-  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--radius-04) text-sm";

--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -98,12 +98,12 @@ function TemplatesList() {
         </Button>
       </div>
       {reorderError && (
-        <div className="rounded-(--border-radius-04) border border-(--status-error-02) bg-(--status-error-01) px-3 py-2 text-[13px] text-(--status-text-error-05)">
+        <div className="rounded-(--radius-04) border border-(--status-error-02) bg-(--status-error-01) px-3 py-2 text-[13px] text-(--status-text-error-05)">
           {reorderError}
         </div>
       )}
       {visibleTemplates.length === 0 ? (
-        <div className="rounded-(--border-radius-08) border border-dashed border-(--border-01) p-6 text-center text-(--text-03)">
+        <div className="rounded-(--radius-08) border border-dashed border-(--border-01) p-6 text-center text-(--text-03)">
           No templates yet. Click "New template" to define the first one.
         </div>
       ) : (
@@ -111,7 +111,7 @@ function TemplatesList() {
           {visibleTemplates.map((t, i) => (
             <li
               key={t.id}
-              className="flex items-center gap-3 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-3"
+              className="flex items-center gap-3 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-3"
             >
               <ReorderHandle
                 disabled={reordering !== null}
@@ -226,7 +226,7 @@ function ArrowButton({
       disabled={disabled}
       title={title}
       aria-label={title}
-      className={`flex h-[18px] w-[24px] items-center justify-center rounded-(--border-radius-04) border border-(--border-01) bg-transparent p-0 text-(--text-04) ${disabled ? "cursor-not-allowed opacity-35" : "cursor-pointer"}`}
+      className={`flex h-[18px] w-[24px] items-center justify-center rounded-(--radius-04) border border-(--border-01) bg-transparent p-0 text-(--text-04) ${disabled ? "cursor-not-allowed opacity-35" : "cursor-pointer"}`}
     >
       {direction === "up" ? (
         <SvgChevronUp size={10} />
@@ -314,7 +314,7 @@ function TemplateModal({
       <form
         onSubmit={onSubmit}
         onClick={(e) => e.stopPropagation()}
-        className="flex max-h-[90vh] w-[min(640px,100%)] flex-col gap-3 overflow-y-auto rounded-(--border-radius-12) bg-(--background-tint-00) p-5 shadow-(--shadow-modal)"
+        className="flex max-h-[90vh] w-[min(640px,100%)] flex-col gap-3 overflow-y-auto rounded-(--radius-12) bg-(--background-tint-00) p-5 shadow-(--shadow-modal)"
       >
         <h2 className="m-0 text-lg">
           {initial ? "Edit template" : "New template"}
@@ -410,5 +410,5 @@ function TemplateModal({
 const BLANK_TEMPLATE_NAME = "Blank";
 
 const inputClass =
-  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--radius-04) text-sm";
 const lblClass = "mb-1 text-[13px] font-medium";

--- a/frontend/src/app/admin/users/users.module.css
+++ b/frontend/src/app/admin/users/users.module.css
@@ -28,7 +28,7 @@
   padding: 10px 12px;
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   cursor: pointer;
   text-align: left;
 }
@@ -116,7 +116,7 @@
   background: transparent;
   padding: 2px 4px;
   margin: -2px -4px;
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   cursor: pointer;
   text-align: left;
 }
@@ -170,7 +170,7 @@
 }
 .dialog {
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   width: min(460px, 100%);
   box-shadow: var(--shadow-modal);
   display: flex;
@@ -207,7 +207,7 @@
   min-height: 40px;
   padding: 6px 8px;
   border: 1px solid var(--border-02);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   background: var(--background-tint-00);
   cursor: text;
 }
@@ -216,7 +216,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 4px 2px 8px;
-  border-radius: var(--border-radius-full);
+  border-radius: var(--radius-round);
   background: var(--background-tint-02);
   border: 1px solid var(--border-02);
   max-width: 100%;
@@ -233,7 +233,7 @@
   height: 16px;
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-full);
+  border-radius: var(--radius-round);
   color: var(--text-03);
   cursor: pointer;
 }

--- a/frontend/src/app/admin/web/page.tsx
+++ b/frontend/src/app/admin/web/page.tsx
@@ -236,4 +236,4 @@ function KeyField({
 }
 
 const inputClass =
-  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--border-radius-04) text-sm";
+  "w-full py-2 px-[10px] box-border border border-(--border-01) rounded-(--radius-04) text-sm";

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -115,7 +115,7 @@ function AgentsBarHost() {
 // Folds the app sidebar to its icon rail while the folder tree is open (the
 // mock pairs the tree panel with a folded sidebar), and restores the user's
 // pre-tree fold state when the tree closes. Manual unfolding while the tree
-// is open is respected until the next open.
+// is open is respected until the tree closes.
 function SidebarAutoFold() {
   const { view } = useLeftPanel();
   const { folded, setFolded } = useSidebarState();

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
-import { RootLayout, SidebarStateProvider } from "@onyx-ai/opal/layouts";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  RootLayout,
+  SidebarStateProvider,
+  useSidebarState,
+} from "@onyx-ai/opal/layouts";
 import { MessageCard } from "@onyx-ai/opal/components";
 import { markdown } from "@onyx-ai/opal/utils";
 import AppSidebar from "@/sections/sidebar/AppSidebar";
@@ -108,11 +112,38 @@ function AgentsBarHost() {
   return <div ref={host?.setEl} className="shrink-0" />;
 }
 
+// Folds the app sidebar to its icon rail while the folder tree is open (the
+// mock pairs the tree panel with a folded sidebar), and restores the user's
+// pre-tree fold state when the tree closes. Manual unfolding while the tree
+// is open is respected until the next open.
+function SidebarAutoFold() {
+  const { view } = useLeftPanel();
+  const { folded, setFolded } = useSidebarState();
+  // "init" makes the mount count as a transition, so a session that loads
+  // with the tree already open still folds.
+  const prevView = useRef<string>("init");
+  const foldedBeforeTree = useRef(folded);
+  useEffect(() => {
+    const was = prevView.current;
+    prevView.current = view ?? "closed";
+    if (view === "wiki-tree" && was !== "wiki-tree") {
+      foldedBeforeTree.current = was === "init" ? false : folded;
+      setFolded(true);
+    } else if (view !== "wiki-tree" && was === "wiki-tree") {
+      setFolded(foldedBeforeTree.current);
+    }
+    // `folded` is read only at the open transition, not a reactive input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view, setFolded]);
+  return null;
+}
+
 function AppContent({ children }: AppContentProps) {
   const { view, isOnWikiRoute } = useLeftPanel();
   return (
     <WikiHeaderActionsProvider>
       <WikiItemActionsProvider active={isOnWikiRoute}>
+        <SidebarAutoFold />
         {view !== null && (
           <RootLayout.LeftPanel>
             {view === "wiki-tree" && <WikiTree />}

--- a/frontend/src/app/app/layout.tsx
+++ b/frontend/src/app/app/layout.tsx
@@ -112,10 +112,21 @@ function AgentsBarHost() {
   return <div ref={host?.setEl} className="shrink-0" />;
 }
 
+// The user's persisted fold preference. Read only after mount: the server
+// renders unfolded, and folding post-hydration keeps server and client HTML
+// identical (reading localStorage during render caused hydration mismatches).
+function storedFoldPreference(): boolean {
+  const stored = window.localStorage.getItem(COLLAPSED_KEY);
+  if (stored === "1") return true;
+  if (stored === "0") return false;
+  return window.innerWidth < 724;
+}
+
 // Folds the app sidebar to its icon rail while the folder tree is open (the
 // mock pairs the tree panel with a folded sidebar), and restores the user's
 // pre-tree fold state when the tree closes. Manual unfolding while the tree
-// is open is respected until the tree closes.
+// is open is respected until the tree closes. Also applies the stored fold
+// preference on mount, since the first render is always unfolded (SSR).
 function SidebarAutoFold() {
   const { view } = useLeftPanel();
   const { folded, setFolded } = useSidebarState();
@@ -127,10 +138,13 @@ function SidebarAutoFold() {
     const was = prevView.current;
     prevView.current = view ?? "closed";
     if (view === "wiki-tree" && was !== "wiki-tree") {
-      foldedBeforeTree.current = was === "init" ? false : folded;
+      foldedBeforeTree.current =
+        was === "init" ? storedFoldPreference() : folded;
       setFolded(true);
     } else if (view !== "wiki-tree" && was === "wiki-tree") {
       setFolded(foldedBeforeTree.current);
+    } else if (was === "init" && storedFoldPreference()) {
+      setFolded(true);
     }
     // `folded` is read only at the open transition, not a reactive input.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -175,18 +189,12 @@ interface LayoutProps {
 }
 
 export default function Layout({ children }: LayoutProps) {
-  const [defaultFolded] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    const stored = window.localStorage.getItem(COLLAPSED_KEY);
-    if (stored === "1") return true;
-    if (stored === "0") return false;
-    return window.innerWidth < 724;
-  });
-
   return (
     <LeftPanelProvider>
+      {/* defaultFolded stays false so server and client render the same HTML.
+          SidebarAutoFold applies the stored preference after hydration. */}
       <SidebarStateProvider
-        defaultFolded={defaultFolded}
+        defaultFolded={false}
         onFoldedChange={(folded) => {
           window.localStorage.setItem(COLLAPSED_KEY, folded ? "1" : "0");
         }}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -193,7 +193,7 @@ body {
   background: var(--background-tint-02);
   color: var(--text-05);
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   padding: 1px 6px;
   font-size: 0.92em;
 }
@@ -201,7 +201,7 @@ body {
   background: var(--background-tint-02);
   color: var(--text-05);
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   padding: 12px 14px;
   overflow-x: auto;
 }

--- a/frontend/src/components/agents/ConnectOnyxCraft.tsx
+++ b/frontend/src/components/agents/ConnectOnyxCraft.tsx
@@ -42,7 +42,7 @@ export function ConnectOnyxCraft({ onConnected }: Props) {
   // A non-dark error (500/timeout) surfaces rather than silently hiding.
   if (error || !status) {
     return (
-      <div className="rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+      <div className="rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
         Couldn&apos;t load your Onyx connection. Try again in a moment.
       </div>
     );
@@ -82,7 +82,7 @@ export function ConnectOnyxCraft({ onConnected }: Props) {
 
   if (status.connected) {
     return (
-      <div className="flex items-center gap-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]">
+      <div className="flex items-center gap-3 rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]">
         <div className="min-w-0 flex-1">
           <div className="text-sm font-medium text-(--status-text-success-05)">
             ✓ Connected to Onyx
@@ -116,7 +116,7 @@ export function ConnectOnyxCraft({ onConnected }: Props) {
     // Not a <form>: this drops into surfaces that are already inside a form
     // (the Run Agent panel), and a nested form submits the outer one — which
     // reloads the page and drops the connect. Submit via button + Enter key.
-    <div className="rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-01) p-3">
+    <div className="rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-01) p-3">
       <label className="text-[13px] text-(--text-04)">
         Onyx Personal Access Token
         <input
@@ -131,7 +131,7 @@ export function ConnectOnyxCraft({ onConnected }: Props) {
             }
           }}
           placeholder="onyx_pat_…"
-          className="mt-1 box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 font-mono text-sm"
+          className="mt-1 box-border w-full rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 font-mono text-sm"
           maxLength={1024}
         />
       </label>
@@ -153,7 +153,7 @@ export function ConnectOnyxCraft({ onConnected }: Props) {
         , then paste it here.
       </div>
       {err && (
-        <div className="mt-[10px] mb-1 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+        <div className="mt-[10px] mb-1 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
           {err}
         </div>
       )}

--- a/frontend/src/components/agents/InstallHelperPane.module.css
+++ b/frontend/src/components/agents/InstallHelperPane.module.css
@@ -2,7 +2,7 @@
   flex: 1;
   padding: 6px 8px;
   background: var(--background-tint-02);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   font-family: ui-monospace, Menlo, monospace;
   font-size: 12px;
   color: var(--text-05);

--- a/frontend/src/components/agents/SetupWizard.module.css
+++ b/frontend/src/components/agents/SetupWizard.module.css
@@ -30,7 +30,7 @@
   gap: 10px;
   padding: 10px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   cursor: pointer;
 }
 
@@ -64,7 +64,7 @@
 .checklistCard {
   padding: 12px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
 }
 
 .checklistHeader {

--- a/frontend/src/components/agents/ToolCard.module.css
+++ b/frontend/src/components/agents/ToolCard.module.css
@@ -7,7 +7,7 @@
   padding: 12px;
   background: var(--background-tint-00);
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   gap: 8px;
 }
 

--- a/frontend/src/components/agents/WorkingDirInput.module.css
+++ b/frontend/src/components/agents/WorkingDirInput.module.css
@@ -2,7 +2,7 @@
   width: 100%;
   padding: 8px 10px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   font-size: 14px;
   font-family: inherit;
 }

--- a/frontend/src/components/chat/ChatHistoryPanel.tsx
+++ b/frontend/src/components/chat/ChatHistoryPanel.tsx
@@ -78,7 +78,7 @@ export function ChatHistoryPanel({
           onClick={onClose}
           title="Back to chat"
           aria-label="Back to chat"
-          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-(--border-radius-04) border-none bg-transparent text-(--text-04)"
+          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-(--radius-04) border-none bg-transparent text-(--text-04)"
         >
           <SvgArrowLeft size={16} />
         </button>
@@ -87,7 +87,7 @@ export function ChatHistoryPanel({
         </div>
         <button
           onClick={onNewChat}
-          className="cursor-pointer rounded-(--border-radius-04) border-none bg-(--background-tint-inverted-00) px-[10px] py-[5px] text-xs font-semibold text-(--text-inverted-05)"
+          className="cursor-pointer rounded-(--radius-04) border-none bg-(--background-tint-inverted-00) px-[10px] py-[5px] text-xs font-semibold text-(--text-inverted-05)"
         >
           + New chat
         </button>
@@ -97,7 +97,7 @@ export function ChatHistoryPanel({
         {error && (
           <div
             role="alert"
-            className="mx-1 mt-1 mb-2 rounded-(--border-radius-04) border border-(--status-error-02) bg-(--status-error-01) px-[10px] py-2 text-xs text-(--status-text-error-05)"
+            className="mx-1 mt-1 mb-2 rounded-(--radius-04) border border-(--status-error-02) bg-(--status-error-01) px-[10px] py-2 text-xs text-(--status-text-error-05)"
           >
             {error}
           </div>
@@ -155,7 +155,7 @@ function SessionRow({
           onClick();
         }
       }}
-      className={`flex cursor-pointer items-center gap-[6px] rounded-(--border-radius-04) px-[10px] py-2 ${
+      className={`flex cursor-pointer items-center gap-[6px] rounded-(--radius-04) px-[10px] py-2 ${
         active
           ? "bg-(--background-tint-04)"
           : hover
@@ -178,7 +178,7 @@ function SessionRow({
           onClick={onDelete}
           title="Delete"
           aria-label="Delete chat"
-          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-(--border-radius-04) border-none bg-transparent text-(--text-02)"
+          className="flex h-6 w-6 cursor-pointer items-center justify-center rounded-(--radius-04) border-none bg-transparent text-(--text-02)"
         >
           <SvgTrash size={14} />
         </button>

--- a/frontend/src/components/chat/ChatWidget.module.css
+++ b/frontend/src/components/chat/ChatWidget.module.css
@@ -33,13 +33,13 @@
 .markdownCode {
   background: var(--background-tint-03);
   padding: 0 4px;
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
 }
 
 .markdownPre {
   background: var(--background-tint-03);
   padding: 8px;
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   white-space: pre-wrap;
 }
 

--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -545,7 +545,7 @@ export function ChatWidget() {
 
   if (mode === "closed") {
     return (
-      <div className="fixed right-5 bottom-5 z-[1000] rounded-(--border-radius-12) shadow-(--shadow-fab)">
+      <div className="fixed right-5 bottom-5 z-[1000] rounded-(--radius-12) shadow-(--shadow-fab)">
         <Button
           icon={SvgBubbleText}
           variant="action"
@@ -568,7 +568,7 @@ export function ChatWidget() {
       className={
         isExpanded
           ? "fixed top-0 right-0 z-[1000] h-screen border-l border-(--border-02) bg-(--background-tint-00) shadow-(--shadow-panel)"
-          : "fixed right-5 bottom-5 z-[1000] rounded-(--border-radius-12) border border-(--border-01) bg-(--background-tint-00) shadow-(--shadow-modal)"
+          : "fixed right-5 bottom-5 z-[1000] rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-00) shadow-(--shadow-modal)"
       }
       style={
         isExpanded
@@ -583,7 +583,7 @@ export function ChatWidget() {
           contained and lets it cover the chat header. The resize handle in
           expanded mode lives outside this so it can extend past the left edge. */}
       <div
-        className={`relative flex h-full w-full flex-col overflow-hidden ${isExpanded ? "" : "rounded-(--border-radius-12)"}`}
+        className={`relative flex h-full w-full flex-col overflow-hidden ${isExpanded ? "" : "rounded-(--radius-12)"}`}
       >
         <header className="flex shrink-0 items-center gap-2 border-b border-(--border-01) bg-(--background-tint-01) px-3 py-[10px]">
           <div className="text-sm font-semibold">Chat</div>
@@ -647,7 +647,7 @@ export function ChatWidget() {
         {error && (
           <div
             role="alert"
-            className="mx-3 mb-2 flex items-start gap-2 rounded-(--border-radius-04) border border-(--status-error-02) bg-(--status-error-01) px-[10px] py-2 text-xs text-(--status-text-error-05)"
+            className="mx-3 mb-2 flex items-start gap-2 rounded-(--radius-04) border border-(--status-error-02) bg-(--status-error-01) px-[10px] py-2 text-xs text-(--status-text-error-05)"
           >
             <div className="flex-1 whitespace-pre-wrap">{error}</div>
             {items.length > 0 && items[items.length - 1].kind === "user" && (
@@ -683,7 +683,7 @@ export function ChatWidget() {
             placeholder="Send a message…"
             rows={2}
             disabled={sending}
-            className="box-border min-w-0 flex-1 resize-none rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) p-2 font-[inherit] text-[13px] text-(--text-05) outline-none focus:border-(--border-05)"
+            className="box-border min-w-0 flex-1 resize-none rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) p-2 font-[inherit] text-[13px] text-(--text-05) outline-none focus:border-(--border-05)"
           />
           <Button
             type="submit"
@@ -888,7 +888,7 @@ function Bubble({
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"} min-w-0`}>
       <div
-        className={`max-w-[85%] min-w-0 rounded-(--border-radius-08) px-3 py-2 text-[13px] leading-[1.5] ${
+        className={`max-w-[85%] min-w-0 rounded-(--radius-08) px-3 py-2 text-[13px] leading-[1.5] ${
           isUser
             ? "bg-(--background-tint-inverted-00) text-(--text-inverted-05)"
             : "bg-(--background-tint-02) text-(--text-05)"

--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -50,13 +50,13 @@ function sizeStyle(size: ButtonSize): CSSProperties {
     return {
       padding: "6px 12px",
       fontSize: 12,
-      borderRadius: "var(--border-radius-04)",
+      borderRadius: "var(--radius-04)",
     };
   }
   return {
     padding: "8px 14px",
     fontSize: 13,
-    borderRadius: "var(--border-radius-08)",
+    borderRadius: "var(--radius-08)",
   };
 }
 

--- a/frontend/src/components/common/ConfirmDialog.module.css
+++ b/frontend/src/components/common/ConfirmDialog.module.css
@@ -13,7 +13,7 @@
 
 .dialog {
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   width: min(420px, 100%);
   box-shadow: var(--shadow-modal);
   display: flex;

--- a/frontend/src/components/triggers/TriggerHistoryModal.tsx
+++ b/frontend/src/components/triggers/TriggerHistoryModal.tsx
@@ -60,7 +60,7 @@ export function TriggerHistoryModal({
       }}
       className="fixed inset-0 z-[100] flex items-center justify-center bg-(--mask-03)"
     >
-      <div className="flex max-h-[92vh] w-[min(640px,92vw)] flex-col gap-[14px] overflow-y-auto rounded-(--border-radius-12) bg-(--background-tint-00) p-6 shadow-(--shadow-modal)">
+      <div className="flex max-h-[92vh] w-[min(640px,92vw)] flex-col gap-[14px] overflow-y-auto rounded-(--radius-12) bg-(--background-tint-00) p-6 shadow-(--shadow-modal)">
         <div className="flex items-start justify-between">
           <div>
             <h2 className="m-0 text-[18px] font-bold">Edit history</h2>
@@ -88,7 +88,7 @@ export function TriggerHistoryModal({
         {loading && <LoadingSpinner />}
 
         {error && (
-          <div className="rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+          <div className="rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
             {error}
           </div>
         )}
@@ -104,7 +104,7 @@ export function TriggerHistoryModal({
                 <button
                   type="button"
                   onClick={() => onSelectVersion(c.sha)}
-                  className="flex w-full cursor-pointer items-baseline justify-between gap-3 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) px-3 py-[10px] text-left font-[inherit]"
+                  className="flex w-full cursor-pointer items-baseline justify-between gap-3 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) px-3 py-[10px] text-left font-[inherit]"
                 >
                   <span className="text-[13px] text-(--text-05)">
                     {formatTs(c.ts)}

--- a/frontend/src/components/wiki/ActiveSessionsList.module.css
+++ b/frontend/src/components/wiki/ActiveSessionsList.module.css
@@ -2,7 +2,7 @@
   padding: 8px;
   background: var(--background-tint-03);
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   font-size: 12px;
 }
 

--- a/frontend/src/components/wiki/CommentsPanel.module.css
+++ b/frontend/src/components/wiki/CommentsPanel.module.css
@@ -7,7 +7,7 @@
   width: 400px;
   min-height: 0;
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   padding: 8px;
   gap: 8px;
 }
@@ -45,7 +45,7 @@
    not rows inside one panel. */
 .thread {
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   padding: 14px;
   background: var(--background-tint-00);
   box-shadow: var(--shadow-sm);
@@ -73,7 +73,7 @@
 
 .draft {
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   padding: 10px;
   background: var(--background-tint-02);
 }
@@ -86,7 +86,7 @@
   background: var(--background-tint-03);
   border-left: 3px solid var(--border-01);
   padding: 4px 8px;
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   margin-bottom: 6px;
   white-space: pre-wrap;
   word-break: break-word;
@@ -135,7 +135,7 @@
   height: 28px;
   padding: 0;
   border: none;
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   background: transparent;
   color: var(--text-03);
   cursor: pointer;
@@ -159,7 +159,7 @@
 .mention {
   color: var(--text-05);
   background: var(--background-tint-03);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   padding: 0 3px;
   font-weight: 500;
 }
@@ -189,7 +189,7 @@
   font-size: 13px;
   padding: 8px 10px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   background: var(--background-tint-00);
   color: var(--text-05);
 }

--- a/frontend/src/components/wiki/DiffView.module.css
+++ b/frontend/src/components/wiki/DiffView.module.css
@@ -40,7 +40,7 @@
 .toggle {
   display: inline-flex;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   overflow: hidden;
   flex-shrink: 0;
 }

--- a/frontend/src/components/wiki/MentionTextarea.module.css
+++ b/frontend/src/components/wiki/MentionTextarea.module.css
@@ -13,7 +13,7 @@
   font-size: 13px;
   padding: 8px 10px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   background: var(--background-tint-00);
   color: var(--text-05);
 }
@@ -35,7 +35,7 @@
   overflow-y: auto;
   background: var(--background-tint-00);
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   box-shadow: var(--shadow-modal);
   z-index: var(--z-popover);
 }
@@ -45,7 +45,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   cursor: pointer;
   font-size: 13px;
   color: var(--text-05);
@@ -62,7 +62,7 @@
   flex-shrink: 0;
   width: 22px;
   height: 22px;
-  border-radius: var(--border-radius-round);
+  border-radius: var(--radius-round);
   background: var(--background-tint-03);
   color: var(--text-04);
   font-size: 10px;

--- a/frontend/src/components/wiki/RunAgentPanel.module.css
+++ b/frontend/src/components/wiki/RunAgentPanel.module.css
@@ -38,7 +38,7 @@
   justify-content: center;
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   color: var(--text-03);
   cursor: pointer;
 }
@@ -77,7 +77,7 @@
   height: 36px;
   padding: 6px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   background: var(--background-tint-00);
   cursor: pointer;
   text-align: left;
@@ -138,7 +138,7 @@
   gap: 4px;
   padding: 6px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   background: var(--background-tint-00);
 }
 
@@ -164,7 +164,7 @@
   align-self: flex-start;
   max-width: 100%;
   padding: 2px 4px;
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
   background: var(--background-tint-04);
 }
 
@@ -194,7 +194,7 @@
   height: 16px;
   border: none;
   background: transparent;
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   color: var(--text-03);
   cursor: pointer;
 }

--- a/frontend/src/components/wiki/ShareDialog.module.css
+++ b/frontend/src/components/wiki/ShareDialog.module.css
@@ -13,7 +13,7 @@
 
 .dialog {
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   width: min(480px, 100%);
   max-height: calc(100vh - 80px);
   box-shadow: var(--shadow-modal);
@@ -70,7 +70,7 @@
   min-height: 48px;
   padding: 6px 8px;
   background: var(--background-tint-02);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
 }
 /* Scope + permission are white-fill boxes on the grey container — no border.
    Scope is the wider of the two. */
@@ -79,7 +79,7 @@
   display: flex;
   min-width: 0;
   background: var(--background-tint-00);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
 }
 .scopeBox {
   flex: 1.7 1.7 0;
@@ -120,7 +120,7 @@
   min-height: 48px;
   padding: 6px 8px;
   background: var(--background-tint-02);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
 }
 .rowText {
   display: flex;

--- a/frontend/src/components/wiki/StartNewPage.module.css
+++ b/frontend/src/components/wiki/StartNewPage.module.css
@@ -1,0 +1,49 @@
+/* "Start a new page" section shared by Home and folder pages: section header,
+   3-card template grid, More Templates row (mock 709:259993). */
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 16px 4px;
+}
+
+.secHead {
+  font-size: 16px;
+  line-height: 24px;
+  font-weight: 600;
+  color: var(--text-04);
+}
+
+.templates {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  padding: 8px;
+}
+.templateCell {
+  display: flex;
+  min-width: 0;
+}
+
+/* "More Templates" row container, aligning the LineItemButton with the card
+   grid's 8px side padding (mock 319:27988). */
+.moreRow {
+  padding: 0 8px;
+}
+.moreChevron {
+  color: var(--text-03);
+  flex: 0 0 auto;
+}
+
+/* Blank-page glyph, a plain OPAL plus-circle icon, not an interactive Button. */
+.blankGlyph {
+  display: inline-flex;
+  color: var(--text-03);
+}
+
+@media (max-width: 720px) {
+  .templates {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/wiki/StartNewPage.module.css
+++ b/frontend/src/components/wiki/StartNewPage.module.css
@@ -36,10 +36,19 @@
   flex: 0 0 auto;
 }
 
-/* Blank-page glyph, a plain OPAL plus-circle icon, not an interactive Button. */
+/* Blank-page glyph: the mock's square-plus, layered from the square and plus
+   icons. Not an interactive Button. */
 .blankGlyph {
+  position: relative;
   display: inline-flex;
   color: var(--text-03);
+}
+.blankGlyphPlus {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/components/wiki/StartNewPage.module.css
+++ b/frontend/src/components/wiki/StartNewPage.module.css
@@ -1,5 +1,5 @@
 /* "Start a new page" section shared by Home and folder pages: section header,
-   3-card template grid, More Templates row (mock 709:259993). */
+   3-column template grid, More Templates row (mock 709:259993). */
 
 .sectionHeader {
   display: flex;

--- a/frontend/src/components/wiki/StartNewPage.tsx
+++ b/frontend/src/components/wiki/StartNewPage.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import useSWR from "swr";
 import { LineItemButton, SelectCard, Text } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
-import { SvgChevronRight, SvgPlusCircle } from "@onyx-ai/opal/icons";
+import { SvgChevronRight, SvgPlus, SvgSquare } from "@onyx-ai/opal/icons";
 import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
 import styles from "@/components/wiki/StartNewPage.module.css";
@@ -48,8 +48,13 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
           <TemplateCard
             title="Blank page"
             glyph={
+              // The mock's square-plus glyph, composed from published icons
+              // until @onyx-ai/opal ships an SvgSquarePlus.
               <span className={styles.blankGlyph}>
-                <SvgPlusCircle size={22} />
+                <SvgSquare size={20} />
+                <span className={styles.blankGlyphPlus}>
+                  <SvgPlus size={12} />
+                </span>
               </span>
             }
             onClick={() => startNewPage(blankTemplate?.id)}

--- a/frontend/src/components/wiki/StartNewPage.tsx
+++ b/frontend/src/components/wiki/StartNewPage.tsx
@@ -26,8 +26,9 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
   // The "Blank" template is the empty-start entry point (carries an
   // auto-update policy). Route the blank card through it when present, and
   // keep it out of the featured row so it isn't shown twice.
-  const blankTemplate = (templates ?? []).find((t) => t.name === "Blank");
-  const nonBlank = (templates ?? []).filter((t) => t.name !== "Blank");
+  const all = templates ?? [];
+  const blankTemplate = all.find((t) => t.name === "Blank");
+  const nonBlank = all.filter((t) => t.name !== "Blank");
   const featured = expanded ? nonBlank : nonBlank.slice(0, 2);
   const hasMore = !expanded && nonBlank.length > 2;
 

--- a/frontend/src/components/wiki/StartNewPage.tsx
+++ b/frontend/src/components/wiki/StartNewPage.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import useSWR from "swr";
+import { LineItemButton, SelectCard, Text } from "@onyx-ai/opal/components";
+import { Section } from "@onyx-ai/opal/layouts";
+import { SvgChevronRight, SvgPlusCircle } from "@onyx-ai/opal/icons";
+import { listTemplateSummaries } from "@/lib/templates";
+import type { DocumentTemplateSummary } from "@/lib/templates";
+import styles from "@/components/wiki/StartNewPage.module.css";
+
+/**
+ * "Start a new page" section (mock 709:259993): a Blank card + the first two
+ * featured templates + a More Templates row. Shared by the Home landing and
+ * folder pages; `dir` scopes where the new page is created ("" = wiki root).
+ */
+export function StartNewPage({ dir = "" }: { dir?: string }) {
+  const router = useRouter();
+  const { data: templates } = useSWR<DocumentTemplateSummary[]>(
+    "templates:summaries",
+    listTemplateSummaries,
+  );
+  // The "Blank" template is the empty-start entry point (carries an
+  // auto-update policy). Route the blank card through it when present, and
+  // keep it out of the featured row so it isn't shown twice.
+  const blankTemplate = (templates ?? []).find((t) => t.name === "Blank");
+  const featured = (templates ?? [])
+    .filter((t) => t.name !== "Blank")
+    .slice(0, 2);
+
+  function startNewPage(templateId?: string) {
+    const qs = templateId
+      ? `?new=1&template=${encodeURIComponent(templateId)}`
+      : "?new=1";
+    router.push(dir ? `/app/wiki/${dir}${qs}` : `/app/wiki${qs}`);
+  }
+
+  return (
+    <>
+      <div className={styles.sectionHeader}>
+        <span className={styles.secHead}>Start a new page</span>
+      </div>
+      <div className={styles.templates}>
+        <div className={styles.templateCell}>
+          <TemplateCard
+            title="Blank page"
+            glyph={
+              <span className={styles.blankGlyph}>
+                <SvgPlusCircle size={22} />
+              </span>
+            }
+            onClick={() => startNewPage(blankTemplate?.id)}
+          />
+        </div>
+        {featured.map((t) => (
+          <div key={t.id} className={styles.templateCell}>
+            <TemplateCard
+              title={t.name}
+              description={t.description ?? ""}
+              note={
+                t.ingestion_auto_update_disabled ? "Auto-update off" : undefined
+              }
+              onClick={() => startNewPage(t.id)}
+            />
+          </div>
+        ))}
+      </div>
+      <div className={styles.moreRow}>
+        <LineItemButton
+          variant="body"
+          sizePreset="main-ui"
+          title="More Templates"
+          width="full"
+          rightChildren={
+            <SvgChevronRight size={18} className={styles.moreChevron} />
+          }
+          onClick={() => startNewPage()}
+        />
+      </div>
+    </>
+  );
+}
+
+function TemplateCard({
+  title,
+  description,
+  note,
+  glyph,
+  onClick,
+}: {
+  title: string;
+  description?: string;
+  note?: string;
+  glyph?: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <SelectCard
+      state="empty"
+      onClick={onClick}
+      padding="sm"
+      rounding="lg"
+      border="solid"
+    >
+      <Section
+        flexDirection="column"
+        alignItems="start"
+        justifyContent="start"
+        gap={0.25}
+        width="full"
+        height="full"
+      >
+        <Text font="main-ui-action" color="text-05" nowrap>
+          {title}
+        </Text>
+        {glyph ? (
+          glyph
+        ) : (
+          <>
+            {description ? (
+              <Text font="secondary-body" color="text-03">
+                {description}
+              </Text>
+            ) : null}
+            {note ? (
+              <Text font="secondary-body" color="text-02">
+                {note}
+              </Text>
+            ) : null}
+          </>
+        )}
+      </Section>
+    </SelectCard>
+  );
+}

--- a/frontend/src/components/wiki/StartNewPage.tsx
+++ b/frontend/src/components/wiki/StartNewPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { useState } from "react";
 import useSWR from "swr";
 import { LineItemButton, SelectCard, Text } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
@@ -11,11 +12,13 @@ import styles from "@/components/wiki/StartNewPage.module.css";
 
 /**
  * "Start a new page" section (mock 709:259993): a Blank card + the first two
- * featured templates + a More Templates row. Shared by the Home landing and
- * folder pages; `dir` scopes where the new page is created ("" = wiki root).
+ * featured templates, with a More Templates row that expands the full gallery
+ * in place (mock 709:260311). Shared by the Home landing and folder pages.
+ * `dir` scopes where the new page is created ("" = wiki root).
  */
 export function StartNewPage({ dir = "" }: { dir?: string }) {
   const router = useRouter();
+  const [expanded, setExpanded] = useState(false);
   const { data: templates } = useSWR<DocumentTemplateSummary[]>(
     "templates:summaries",
     listTemplateSummaries,
@@ -24,9 +27,9 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
   // auto-update policy). Route the blank card through it when present, and
   // keep it out of the featured row so it isn't shown twice.
   const blankTemplate = (templates ?? []).find((t) => t.name === "Blank");
-  const featured = (templates ?? [])
-    .filter((t) => t.name !== "Blank")
-    .slice(0, 2);
+  const nonBlank = (templates ?? []).filter((t) => t.name !== "Blank");
+  const featured = expanded ? nonBlank : nonBlank.slice(0, 2);
+  const hasMore = !expanded && nonBlank.length > 2;
 
   function startNewPage(templateId?: string) {
     const qs = templateId
@@ -65,18 +68,20 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
           </div>
         ))}
       </div>
-      <div className={styles.moreRow}>
-        <LineItemButton
-          variant="body"
-          sizePreset="main-ui"
-          title="More Templates"
-          width="full"
-          rightChildren={
-            <SvgChevronRight size={18} className={styles.moreChevron} />
-          }
-          onClick={() => startNewPage()}
-        />
-      </div>
+      {hasMore && (
+        <div className={styles.moreRow}>
+          <LineItemButton
+            variant="body"
+            sizePreset="main-ui"
+            title="More Templates"
+            width="full"
+            rightChildren={
+              <SvgChevronRight size={18} className={styles.moreChevron} />
+            }
+            onClick={() => setExpanded(true)}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/frontend/src/components/wiki/TransferModal.module.css
+++ b/frontend/src/components/wiki/TransferModal.module.css
@@ -13,7 +13,7 @@
 
 .dialog {
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   width: min(480px, 100%);
   max-height: calc(100vh - 80px);
   box-shadow: var(--shadow-modal);
@@ -64,7 +64,7 @@
   min-height: 48px;
   padding: 6px 8px;
   background: var(--background-tint-02);
-  border-radius: var(--border-radius-08);
+  border-radius: var(--radius-08);
 }
 .rowText {
   display: flex;

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -4,8 +4,8 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  /* Drawer hosts pin their own width (400px slide-ins). Inline hosts (the
-     folder page's side column) size the panel via their container. */
+  /* Drawer hosts pin their own width. Inline hosts (the folder page's side
+     column) size the panel via their container. */
   width: 100%;
   max-width: 400px;
   min-height: 0;

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -10,7 +10,7 @@
   max-width: 400px;
   min-height: 0;
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   padding: 8px;
   gap: 8px;
 }
@@ -47,7 +47,7 @@
 /* One floating card holding both controls, matching the mockup. */
 .card {
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   padding: 16px;
   background: var(--background-tint-00);
   box-shadow: var(--shadow-sm);
@@ -99,7 +99,7 @@
   font-size: 13px;
   padding: 8px 10px;
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-04);
+  border-radius: var(--radius-04);
   background: var(--background-tint-00);
   color: var(--text-05);
 }

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -53,7 +53,16 @@
   box-shadow: var(--shadow-sm);
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 16px;
+}
+
+/* Inline host (folder page side column): the card is the whole surface
+   (mock 1673:32813, white on border-01 at radius-12), so the drawer's tint
+   wrapper chrome drops away. */
+.inline {
+  background: transparent;
+  padding: 0;
+  max-width: none;
 }
 
 .row {
@@ -75,12 +84,10 @@
   color: var(--text-03);
 }
 
-/* The 24h auto-update count sits at the foot of the card, fenced off from the
-   settings above by a hairline and centered against its "Update History" link. */
+/* The 24h auto-update count sits at the foot of the card, centered against
+   its "Update History" link (the mock separates rows by spacing alone). */
 .activityRow {
   align-items: center;
-  padding-top: 14px;
-  border-top: 1px solid var(--border-01);
 }
 
 .instruction {

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -57,12 +57,17 @@
 }
 
 /* Inline host (folder page side column): the card is the whole surface
-   (mock 1673:32813, white on border-01 at radius-12), so the drawer's tint
-   wrapper chrome drops away. */
+   (mock 1673:32813, border-01 at radius-12), so the drawer's tint wrapper
+   chrome drops away and the card fill stays the page background itself
+   rather than painting its own. */
 .inline {
   background: transparent;
   padding: 0;
   max-width: none;
+}
+.inline .card {
+  background: transparent;
+  box-shadow: none;
 }
 
 .row {

--- a/frontend/src/components/wiki/UpdatePolicyPanel.module.css
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.module.css
@@ -4,7 +4,10 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  width: 400px;
+  /* Drawer hosts pin their own width (400px slide-ins). Inline hosts (the
+     folder page's side column) size the panel via their container. */
+  width: 100%;
+  max-width: 400px;
   min-height: 0;
   background: var(--background-tint-01);
   border-radius: var(--border-radius-12);

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, Switch, Text } from "@onyx-ai/opal/components";
-import { SvgEdit, SvgHistory, SvgX } from "@onyx-ai/opal/icons";
+import { SvgAddLines, SvgHistory, SvgX } from "@onyx-ai/opal/icons";
 import { useEffect, useRef, useState } from "react";
 
 import { ApiError } from "@/lib/api";
@@ -162,7 +162,9 @@ export function UpdatePolicyPanel({
   const aiSwitchOn = pendingAiOn ?? effAiManaged;
 
   return (
-    <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
+    <div
+      className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""} ${onClose ? "" : styles.inline}`}
+    >
       {/* Title + close only in drawer hosts. The inline folder-page card
           starts straight at the policy rows (mock 1673:32813). */}
       {onClose && (
@@ -278,9 +280,8 @@ export function UpdatePolicyPanel({
               </div>
               {!editing && (
                 <Button
-                  icon={SvgEdit}
-                  prominence="tertiary"
-                  size="sm"
+                  icon={SvgAddLines}
+                  prominence="secondary"
                   tooltip="Edit instructions"
                   onClick={() => {
                     setDraft(ownInstruction);
@@ -348,9 +349,8 @@ export function UpdatePolicyPanel({
                 </div>
                 {onShowHistory && (
                   <Button
-                    icon={SvgHistory}
+                    rightIcon={SvgHistory}
                     prominence="tertiary"
-                    size="sm"
                     onClick={onShowHistory}
                   >
                     Update History

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -16,7 +16,9 @@ import styles from "./UpdatePolicyPanel.module.css";
 
 interface Props {
   path: string;
-  onClose: () => void;
+  // Renders the close control when set. Omit when the panel is inlined in a
+  // page column (folder pages) rather than shown as a dismissable drawer.
+  onClose?: () => void;
   fullHeight?: boolean;
   // When set, the activity row shows an "Update History" link that calls this.
   // Omit on surfaces with no history view (e.g. the folder explorer drawer).
@@ -161,20 +163,24 @@ export function UpdatePolicyPanel({
 
   return (
     <div className={`${styles.panel} ${fullHeight ? styles.fullHeight : ""}`}>
-      <div className={styles.headerRow}>
-        <div className={styles.headerTitle}>
-          <Text font="main-ui-action" color="text-04">
-            Update Policy
-          </Text>
+      {/* Title + close only in drawer hosts. The inline folder-page card
+          starts straight at the policy rows (mock 1673:32813). */}
+      {onClose && (
+        <div className={styles.headerRow}>
+          <div className={styles.headerTitle}>
+            <Text font="main-ui-action" color="text-04">
+              Update Policy
+            </Text>
+          </div>
+          <Button
+            icon={SvgX}
+            prominence="tertiary"
+            size="sm"
+            tooltip="Close"
+            onClick={onClose}
+          />
         </div>
-        <Button
-          icon={SvgX}
-          prominence="tertiary"
-          size="sm"
-          tooltip="Close"
-          onClick={onClose}
-        />
-      </div>
+      )}
 
       <div className={styles.scroll}>
         {loading ? (

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -83,7 +83,7 @@ export function WikiHeader() {
       {/* Page-level actions portal here from the active wiki route (see
           WikiHeaderActionsProvider). Pushed right by the flex spacer. */}
       <div className="flex-1" />
-      <div ref={host?.setEl} className="flex items-center gap-1" />
+      <div ref={host?.setEl} className="flex items-center gap-2" />
       <NotificationBell />
       <CraftNotifier />
     </div>

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import useSWR from "swr";
 import { Button } from "@onyx-ai/opal/components";
-import { SvgFolder } from "@onyx-ai/opal/icons";
+import { SvgChevronRight, SvgTextLines } from "@onyx-ai/opal/icons";
 import { NotificationBell } from "@/components/common/NotificationBell";
 import { CraftNotifier } from "@/components/wiki/CraftNotifier";
 import { useAppFocus } from "@/hooks/useAppFocus";
@@ -33,7 +33,7 @@ export function WikiHeader() {
     () => resolveIds(segmentPaths),
   );
   const crumbs: Array<{ label: string; href: string }> = [
-    { label: "Wiki", href: "/app/wiki" },
+    { label: "Home", href: "/app/wiki" },
   ];
   segments.forEach((seg, i) => {
     const path = segmentPaths[i];
@@ -46,18 +46,24 @@ export function WikiHeader() {
 
   return (
     <div className="flex h-14 items-center gap-3 px-4">
-      <Button
-        icon={SvgFolder}
-        prominence="tertiary"
-        tooltip={treeVisible ? "Collapse tree" : "Expand tree"}
-        onClick={toggleTree}
-      />
+      {/* The expand control lives here only while the tree is closed. When
+          open, the collapse control sits in the tree panel's own header. */}
+      {!treeVisible && (
+        <Button
+          icon={SvgTextLines}
+          prominence="tertiary"
+          tooltip="Expand tree"
+          onClick={toggleTree}
+        />
+      )}
       <nav className="flex flex-wrap items-center gap-1.5 text-sm">
         {crumbs.map((c, i) => {
           const last = i === crumbs.length - 1;
           return (
             <span key={c.href} className="flex items-center gap-1.5">
-              {i > 0 && <span className="text-(--text-02)">/</span>}
+              {i > 0 && (
+                <SvgChevronRight size={12} className="text-(--text-02)" />
+              )}
               {last ? (
                 <span className="font-semibold text-(--text-05)">
                   {c.label}

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import useSWR from "swr";
 import { Button } from "@onyx-ai/opal/components";
-import { SvgChevronRight, SvgTextLines } from "@onyx-ai/opal/icons";
+import { SvgChevronRight, SvgListTree } from "@onyx-ai/opal/icons";
 import { NotificationBell } from "@/components/common/NotificationBell";
 import { CraftNotifier } from "@/components/wiki/CraftNotifier";
 import { useAppFocus } from "@/hooks/useAppFocus";
@@ -50,7 +50,7 @@ export function WikiHeader() {
           open, the collapse control sits in the tree panel's own header. */}
       {!treeVisible && (
         <Button
-          icon={SvgTextLines}
+          icon={SvgListTree}
           prominence="tertiary"
           tooltip="Expand tree"
           onClick={toggleTree}

--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -106,49 +106,6 @@
 }
 
 /* Templates strip */
-.templates {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  padding: 8px;
-}
-.templateCell {
-  display: flex;
-  min-width: 0;
-}
-
-/* "More Templates" — full-width row: label left, chevron far right (mock 319:27988). */
-.moreRow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  box-sizing: border-box;
-  margin: 0 8px;
-  width: calc(100% - 16px);
-  padding: 8px;
-  border: none;
-  background: transparent;
-  border-radius: var(--border-radius-04);
-  cursor: pointer;
-}
-.moreRow:hover {
-  background: var(--background-tint-03);
-}
-.moreLabel {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-04);
-}
-.moreChevron {
-  color: var(--text-03);
-  flex: 0 0 auto;
-}
-
-/* Blank-page glyph — plain OPAL plus-circle icon, not an interactive Button. */
-.blankGlyph {
-  display: inline-flex;
-  color: var(--text-03);
-}
 
 /* AI input — box left edge aligns with the card grid (padding 8px); the octagon
    mark hangs into the left gutter, vertically centered, out of the input flow. */
@@ -258,7 +215,6 @@
   .column {
     width: 100%;
   }
-  .templates,
   .recentGrid {
     grid-template-columns: 1fr;
   }

--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -90,13 +90,6 @@
   padding: 8px 16px 4px;
 }
 
-.secHead {
-  font-size: 16px;
-  line-height: 24px;
-  font-weight: 600;
-  color: var(--text-04);
-}
-
 .secHeadLg {
   font-size: 18px;
   line-height: 28px;
@@ -104,8 +97,6 @@
   letter-spacing: -0.18px;
   color: var(--text-04);
 }
-
-/* Templates strip */
 
 /* AI input — box left edge aligns with the card grid (padding 8px); the octagon
    mark hangs into the left gutter, vertically centered, out of the input flow. */

--- a/frontend/src/components/wiki/WikiHome.module.css
+++ b/frontend/src/components/wiki/WikiHome.module.css
@@ -32,7 +32,7 @@
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   background: var(--background-tint-03);
   color: var(--text-05);
 }

--- a/frontend/src/components/wiki/WikiHome.tsx
+++ b/frontend/src/components/wiki/WikiHome.tsx
@@ -14,21 +14,17 @@ import {
   SelectCard,
   Text,
 } from "@onyx-ai/opal/components";
-import { Section } from "@onyx-ai/opal/layouts";
 import {
   SvgArrowUp,
-  SvgChevronRight,
   SvgMoreHorizontal,
   SvgOnyxOctagon,
-  SvgPlusCircle,
 } from "@onyx-ai/opal/icons";
 import { SvgOnyxLogo } from "@onyx-ai/opal/logos";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { relativeTime } from "@/lib/time";
-import { listTemplateSummaries } from "@/lib/templates";
-import type { DocumentTemplateSummary } from "@/lib/templates";
 import { AI_DRAFT_KEY, generateDraft, type RecentPage } from "@/lib/wiki";
 import { wikiHref, wikiPath } from "@/lib/wikiHref";
+import { StartNewPage } from "@/components/wiki/StartNewPage";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import styles from "@/components/wiki/WikiHome.module.css";
 
@@ -42,25 +38,6 @@ export function WikiHome() {
     "/wiki/recent?limit=12",
   );
   const recent = recentData?.pages ?? [];
-
-  const { data: templates } = useSWR<DocumentTemplateSummary[]>(
-    "templates:summaries",
-    listTemplateSummaries,
-  );
-  // The "Blank" template is the empty-start entry point (carries an auto-update
-  // policy); route the blank card through it when present, and keep it out of
-  // the featured row so it isn't shown twice.
-  const blankTemplate = (templates ?? []).find((t) => t.name === "Blank");
-  const featured = (templates ?? [])
-    .filter((t) => t.name !== "Blank")
-    .slice(0, 2);
-
-  function startNewPage(templateId?: string) {
-    const qs = templateId
-      ? `?new=1&template=${encodeURIComponent(templateId)}`
-      : "?new=1";
-    router.push(`/app/wiki${qs}`);
-  }
 
   async function onAiSubmit(e: FormEvent) {
     e.preventDefault();
@@ -105,45 +82,7 @@ export function WikiHome() {
           <Divider />
         </div>
 
-        {/* Start a new page */}
-        <div className={styles.sectionHeader}>
-          <span className={styles.secHead}>Start a new page</span>
-        </div>
-        <div className={styles.templates}>
-          <div className={styles.templateCell}>
-            <TemplateCard
-              title="Blank page"
-              glyph={
-                <span className={styles.blankGlyph}>
-                  <SvgPlusCircle size={22} />
-                </span>
-              }
-              onClick={() => startNewPage(blankTemplate?.id)}
-            />
-          </div>
-          {featured.map((t) => (
-            <div key={t.id} className={styles.templateCell}>
-              <TemplateCard
-                title={t.name}
-                description={t.description ?? ""}
-                note={
-                  t.ingestion_auto_update_disabled
-                    ? "Auto-update off"
-                    : undefined
-                }
-                onClick={() => startNewPage(t.id)}
-              />
-            </div>
-          ))}
-        </div>
-        <button
-          type="button"
-          className={styles.moreRow}
-          onClick={() => startNewPage()}
-        >
-          <span className={styles.moreLabel}>More Templates</span>
-          <SvgChevronRight size={18} className={styles.moreChevron} />
-        </button>
+        <StartNewPage />
 
         {/* Write with AI */}
         <div className={styles.aiRow}>
@@ -203,59 +142,6 @@ export function WikiHome() {
         )}
       </div>
     </main>
-  );
-}
-
-function TemplateCard({
-  title,
-  description,
-  note,
-  glyph,
-  onClick,
-}: {
-  title: string;
-  description?: string;
-  note?: string;
-  glyph?: React.ReactNode;
-  onClick: () => void;
-}) {
-  return (
-    <SelectCard
-      state="empty"
-      onClick={onClick}
-      padding="sm"
-      rounding="lg"
-      border="solid"
-    >
-      <Section
-        flexDirection="column"
-        alignItems="start"
-        justifyContent="start"
-        gap={0.25}
-        width="full"
-        height="full"
-      >
-        <Text font="main-ui-action" color="text-05" nowrap>
-          {title}
-        </Text>
-        {glyph ? (
-          glyph
-        ) : (
-          <>
-            {description ? (
-              <Text font="secondary-body" color="text-03">
-                {description}
-              </Text>
-            ) : null}
-            {note ? (
-              <Text font="secondary-body" color="text-02">
-                {note}
-              </Text>
-            ) : null}
-          </>
-        )}
-      </Section>
-    </SelectCard>
   );
 }
 

--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -20,6 +20,9 @@ export interface WikiItemMenuProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   align?: "start" | "center" | "end";
+  /** Replace the provider's rename/delete with surface-local flows (e.g. the
+   * folder explorer's inline rename and styled confirm). */
+  overrides?: { rename?: () => void; remove?: () => void };
   children: ReactNode;
 }
 
@@ -34,6 +37,7 @@ export default function WikiItemMenu({
   open,
   onOpenChange,
   align = "start",
+  overrides,
   children,
 }: WikiItemMenuProps) {
   const actions = useRowActions();
@@ -77,7 +81,7 @@ export default function WikiItemMenu({
             sizePreset="main-ui"
             icon={SvgEdit}
             title="Rename"
-            onClick={run(actions.rename)}
+            onClick={run(overrides?.rename ?? actions.rename)}
           />
           <LineItemButton
             variant="body"
@@ -112,7 +116,8 @@ export default function WikiItemMenu({
               title="Delete"
               onClick={() => {
                 onOpenChange(false);
-                actions.remove(path, isFolder);
+                if (overrides?.remove) overrides.remove();
+                else actions.remove(path, isFolder);
               }}
             />
           </span>

--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -9,8 +9,8 @@ import {
   SvgLink,
   SvgPlus,
   SvgShare,
-  SvgSparkle,
   SvgTrash,
+  SvgZap,
 } from "@onyx-ai/opal/icons";
 import { useRowActions } from "@/providers/WikiItemActionsProvider";
 
@@ -102,7 +102,7 @@ export default function WikiItemMenu({
             <LineItemButton
               variant="body"
               sizePreset="main-ui"
-              icon={SvgSparkle}
+              icon={SvgZap}
               title="Launch Agent"
               onClick={run(actions.launchAgent)}
             />

--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -5,7 +5,9 @@ import { Divider, LineItemButton, Popover } from "@onyx-ai/opal/components";
 import {
   SvgEdit,
   SvgFolderIn,
+  SvgFolderPlus,
   SvgLink,
+  SvgPlus,
   SvgShare,
   SvgSparkle,
   SvgTrash,
@@ -23,8 +25,8 @@ export interface WikiItemMenuProps {
 
 /**
  * Per-item "⋯" actions menu. Spec: 160px wide, compact line items, dividers,
- * Delete in danger red. Folders omit "Launch Agent". The caller supplies the
- * trigger as `children`.
+ * Delete in danger red. Folders lead with New Page / New Folder and omit
+ * "Launch Agent". The caller supplies the trigger as `children`.
  */
 export default function WikiItemMenu({
   path,
@@ -44,6 +46,25 @@ export default function WikiItemMenu({
       <Popover.Trigger asChild>{children}</Popover.Trigger>
       <Popover.Content align={align} sideOffset={4} width="fit">
         <div className="box-border flex w-[160px] flex-col gap-[2px]">
+          {isFolder && (
+            <>
+              <LineItemButton
+                variant="body"
+                sizePreset="main-ui"
+                icon={SvgPlus}
+                title="New Page"
+                onClick={run(actions.newPage)}
+              />
+              <LineItemButton
+                variant="body"
+                sizePreset="main-ui"
+                icon={SvgFolderPlus}
+                title="New Folder"
+                onClick={run(actions.newFolder)}
+              />
+              <Divider />
+            </>
+          )}
           <LineItemButton
             variant="body"
             sizePreset="main-ui"

--- a/frontend/src/components/wiki/WikiItemModals.module.css
+++ b/frontend/src/components/wiki/WikiItemModals.module.css
@@ -14,7 +14,7 @@
 
 .dialog {
   background: var(--background-tint-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   width: min(440px, 100%);
   max-height: calc(100vh - 80px);
   box-shadow: var(--shadow-modal);

--- a/frontend/src/components/wiki/WikiSearch.tsx
+++ b/frontend/src/components/wiki/WikiSearch.tsx
@@ -272,7 +272,7 @@ export const WikiSearch = forwardRef<WikiSearchHandle, WikiSearchProps>(
             <div
               ref={dropdownRef}
               role="listbox"
-              className="fixed z-[120] w-[360px] overflow-y-auto rounded-(--border-radius-08) border border-(--border-02) bg-(--background-tint-00) shadow-(--shadow-modal)"
+              className="fixed z-[120] w-[360px] overflow-y-auto rounded-(--radius-08) border border-(--border-02) bg-(--background-tint-00) shadow-(--shadow-modal)"
               // Anchor-derived geometry stays inline — it's measured at runtime,
               // not a design token. z-[120] must stack above the OPAL SidebarTab
               // hit-target anchor (absolute inset-0 z-99) on the nav tabs below

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -1,6 +1,6 @@
-/* Directory tree panel (mock 319:26456): tint card, "Wiki" header with a
-   collapse control, search + create actions, nested tree with indent guides.
-   The list scrolls instead of the panel growing. */
+/* Directory tree panel (mock 319:26456): tint card, "Wiki Directory" header
+   with a collapse control, search + create actions, nested tree with indent
+   guides. The list scrolls instead of the panel growing. */
 
 .panel {
   display: flex;
@@ -58,8 +58,8 @@
 }
 
 /* Tree list. The header/search zone above stays fixed and only this list
-   scrolls, vertically. Long names truncate with an ellipsis (OPAL's default)
-   so the panel never scrolls horizontally (annotated mock on 705:142872). */
+   scrolls, vertically. Long names truncate with an ellipsis (.rowLabel) so
+   the panel never scrolls horizontally (annotated mock on 705:142872). */
 .list {
   flex: 1;
   min-height: 0;

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -91,13 +91,15 @@
   padding-left: 4px;
 }
 
-/* Fixed 12px chevron column (mock's Fold slot). The internal button centers
-   in it and overhangs without shifting the glyph column. */
+/* Fixed chevron column (mock's Fold slot). The internal button centers in it
+   and overhangs, so the extra margin keeps its hover pill clear of the
+   file/folder glyph. */
 .chevronSlot {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 12px;
+  width: 14px;
+  margin-right: 4px;
   flex-shrink: 0;
   color: var(--text-02);
 }

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -68,23 +68,38 @@
   width: 100%;
 }
 
-/* Row label: leading file/folder glyph inline with the name (the SidebarTab
-   icon slot holds the expand chevron for folders). */
+/* Row label: chevron column, then glyph inline with the name. Label color and
+   weight follow the mock's Main UI/Body on text-04 (705:142966). The glyph
+   strokes at text-03 and the chevron at text-02 match the mock's icon
+   opacities (0.55 / 0.45). */
 .rowLabel {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
   min-width: 0;
-  color: inherit;
+  color: var(--text-04);
+  font-weight: 500;
 }
 .rowLabel > svg {
   flex-shrink: 0;
   color: var(--text-03);
 }
-.rowLabel > span {
+.rowLabel > span:last-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  padding-left: 4px;
+}
+
+/* Fixed 12px chevron column (mock's Fold slot). The internal button centers
+   in it and overhangs without shifting the glyph column. */
+.chevronSlot {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  flex-shrink: 0;
+  color: var(--text-02);
 }
 
 /* Expanded folder's children, indented one level per depth with the mock's

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -6,9 +6,11 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  /* Fixed panel width per the annotated mock (comment on 705:142872). */
+  /* Fixed 312px card inset 4px from its region (mock 705:142934 sits at
+     x=4,y=4 in the 320 frame) so the border and radius read as a card. */
   width: 312px;
-  height: 100%;
+  height: calc(100% - 8px);
+  margin: 4px;
   box-sizing: border-box;
   background: var(--background-tint-01);
   border: 1px solid var(--border-01);

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -1,12 +1,13 @@
-/* Permanent directory sidebar. Shows one level at a time; the list scrolls
-   instead of the panel growing. Panel surface matches the mock: filled
-   tint card (#fafafa → bg-panel), #e6e6e6 → border-default, 12px radius. */
+/* Directory tree panel (mock 319:26456): tint card, "Wiki" header with a
+   collapse control, search + create actions, nested tree with indent guides.
+   The list scrolls instead of the panel growing. */
 
 .panel {
   display: flex;
   flex-direction: column;
   gap: 2px;
   width: 100%;
+  height: 100%;
   box-sizing: border-box;
   background: var(--background-tint-01);
   border: 1px solid var(--border-01);
@@ -19,20 +20,33 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 4px 4px 8px 12px;
+  padding: 4px 4px 4px 8px;
   box-sizing: border-box;
 }
 
-.actions {
-  display: flex;
-  flex-direction: row;
-  gap: 4px;
+.headerTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-05);
 }
 
-/* Inline new-folder input (OPAL InputTypeIn) — appears under the header when
-   the +folder button is toggled. */
-.folderForm {
-  padding: 2px 4px 6px;
+/* Search input + new-page / new-folder actions on one row. The input flexes.
+   The buttons keep their intrinsic size. */
+.searchRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 4px 4px;
+}
+.searchRow > :first-child {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Inline folder-create row, nested inside its target folder like a tree row. */
+.newFolderRow {
+  padding: 2px 4px;
 }
 .folderError {
   padding: 2px 8px 6px;
@@ -40,11 +54,12 @@
   color: var(--status-text-error-05);
 }
 
-/* Tree list — scrolls both axes rather than growing or truncating. Vertical
-   when it outgrows the viewport; horizontal when deep nesting + long names
+/* Tree list. Scrolls both axes rather than growing or truncating. Vertical
+   when it outgrows the viewport, horizontal when deep nesting and long names
    run past the panel width (labels keep their natural width below). */
 .list {
-  max-height: calc(100vh - 120px);
+  flex: 1;
+  min-height: 0;
   overflow: auto;
   width: 100%;
 }
@@ -57,62 +72,28 @@
   white-space: nowrap;
 }
 
-/* Expanded folder's children — indented one level (mock's "Folded" pl-8).
-   Recursion accumulates 8px per depth; sized to content so it can overflow. */
+/* Row label: leading file/folder glyph inline with the name (the SidebarTab
+   icon slot holds the expand chevron for folders). */
+.rowLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+}
+.rowLabel > svg {
+  flex-shrink: 0;
+  color: var(--text-03);
+}
+
+/* Expanded folder's children, indented one level per depth with the mock's
+   vertical guide line. Sized to content so deep names can overflow. */
 .nested {
   width: max-content;
   min-width: 100%;
-  padding-left: 8px;
+  margin-left: 12px;
+  padding-left: 4px;
+  border-left: 1px solid var(--border-01);
   box-sizing: border-box;
-}
-
-/* Row wrapper — SidebarTab with the "⋯" menu overlaying its leading icon. */
-.rowWrap {
-  position: relative;
-  width: 100%;
-}
-.tab {
-  width: 100%;
-}
-/* "⋯" overlay — pinned over the leading icon slot (container p-2 = 8px + icon
-   box), hidden until the row is hovered or its menu is open. */
-.rowMenu {
-  position: absolute;
-  left: 6px;
-  top: 50%;
-  transform: translateY(-50%);
-  z-index: 1;
-  opacity: 0;
-  transition: opacity 0.12s ease;
-}
-.rowWrap:hover .rowMenu,
-.rowMenu:focus-within,
-.rowMenu[data-open] {
-  opacity: 1;
-}
-/* Hide the file/folder icon while the "⋯" is showing, so it reads as a swap.
-   Scoped to .tab so the menu's own icon (in .rowMenu) is unaffected. */
-.rowWrap:hover .tab :global(svg),
-.rowWrap:has(.rowMenu[data-open]) .tab :global(svg) {
-  visibility: hidden;
-}
-/* "⋯" trigger — sized to sit in the icon slot, transparent so it reads as the
-   swapped-in icon (the real icon is hidden underneath while hovered). */
-.moreBtn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  padding: 0;
-  border: none;
-  border-radius: var(--border-radius-08);
-  background: transparent;
-  color: var(--text-03);
-  cursor: pointer;
-}
-.moreBtn:hover {
-  color: var(--text-05);
 }
 
 .empty {

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -14,7 +14,7 @@
   box-sizing: border-box;
   background: var(--background-tint-01);
   border: 1px solid var(--border-01);
-  border-radius: var(--border-radius-12);
+  border-radius: var(--radius-12);
   padding: 4px;
 }
 

--- a/frontend/src/components/wiki/WikiTree.module.css
+++ b/frontend/src/components/wiki/WikiTree.module.css
@@ -6,7 +6,8 @@
   display: flex;
   flex-direction: column;
   gap: 2px;
-  width: 100%;
+  /* Fixed panel width per the annotated mock (comment on 705:142872). */
+  width: 312px;
   height: 100%;
   box-sizing: border-box;
   background: var(--background-tint-01);
@@ -54,22 +55,15 @@
   color: var(--status-text-error-05);
 }
 
-/* Tree list. Scrolls both axes rather than growing or truncating. Vertical
-   when it outgrows the viewport, horizontal when deep nesting and long names
-   run past the panel width (labels keep their natural width below). */
+/* Tree list. The header/search zone above stays fixed and only this list
+   scrolls, vertically. Long names truncate with an ellipsis (OPAL's default)
+   so the panel never scrolls horizontally (annotated mock on 705:142872). */
 .list {
   flex: 1;
   min-height: 0;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   width: 100%;
-}
-
-/* Let row labels keep their full width (OPAL truncates with an ellipsis by
-   default) so long/deep names overflow and drive the horizontal scroll. */
-.list :global(p) {
-  overflow: visible;
-  text-overflow: clip;
-  white-space: nowrap;
 }
 
 /* Row label: leading file/folder glyph inline with the name (the SidebarTab
@@ -78,18 +72,22 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
   color: inherit;
 }
 .rowLabel > svg {
   flex-shrink: 0;
   color: var(--text-03);
 }
+.rowLabel > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* Expanded folder's children, indented one level per depth with the mock's
-   vertical guide line. Sized to content so deep names can overflow. */
+   vertical guide line. */
 .nested {
-  width: max-content;
-  min-width: 100%;
   margin-left: 12px;
   padding-left: 4px;
   border-left: 1px solid var(--border-01);

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -310,7 +310,7 @@ function FolderNode({
 }
 
 /**
- * Directory tree panel (mock 319:26456): "Wiki" header with a collapse
+ * Directory tree panel (mock 319:26456): "Wiki Directory" header with a collapse
  * control, a search row with new-page / new-folder actions, then the nested
  * tree. Search filters the tree to matching paths with ancestors held open.
  */

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 
 import {
@@ -164,8 +164,6 @@ function NewFolderRow({
   const [name, setName] = useState("New Folder");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => inputRef.current?.select(), []);
 
   async function submit() {
     const clean = name.trim().replace(/^\/+|\/+$/g, "");
@@ -188,7 +186,7 @@ function NewFolderRow({
   return (
     <div className={styles.newFolderRow}>
       <InputTypeIn
-        ref={inputRef}
+        onFocus={(e) => e.currentTarget.select()}
         value={name}
         onChange={(e) => setName(e.target.value)}
         aria-label="New folder name"

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -1,27 +1,38 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 
 import {
   Button,
+  Divider,
   InputTypeIn,
   SidebarTab,
   Text,
 } from "@onyx-ai/opal/components";
 import {
+  SvgCheck,
+  SvgChevronDown,
+  SvgChevronRight,
   SvgFileText,
+  SvgFold,
   SvgFolder,
   SvgFolderOpen,
   SvgFolderPlus,
   SvgMoreHorizontal,
   SvgPlus,
+  SvgTextLines,
 } from "@onyx-ai/opal/icons";
 
 import { apiFetch } from "@/lib/api";
 import { revalidateWiki } from "@/lib/wikiHref";
-import { useActiveFolder } from "@/providers/WikiItemActionsProvider";
+import { useLeftPanel } from "@/providers/LeftPanelProvider";
+import {
+  useActiveFolder,
+  useFolderCreate,
+  useRowActions,
+} from "@/providers/WikiItemActionsProvider";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import styles from "@/components/wiki/WikiTree.module.css";
 
@@ -55,22 +66,33 @@ function childrenOf(entries: Entry[], dir: string) {
   };
 }
 
-type IconComponent = React.ComponentProps<typeof SidebarTab>["icon"];
+type IconComponent = NonNullable<
+  React.ComponentProps<typeof SidebarTab>["icon"]
+>;
+
+/** Invisible icon-slot filler so file rows keep the chevron column's exact
+ * geometry and their glyph aligns with folder glyphs. */
+const GlyphSpacer: IconComponent = (props) => (
+  <svg {...props} aria-hidden="true" />
+);
 
 /**
- * One tree row: an OPAL SidebarTab plus the hover-/open-revealed "⋯" menu. The
- * row goes to its `selected` state while its menu is open, matching the mock's
- * selected `Projects` row (657:29879).
+ * One tree row. Folders lead with an expand chevron (icon slot) + a folder
+ * glyph inline with the label. Files fill the chevron slot with a spacer so
+ * their glyph aligns with folder glyphs. The "⋯" menu sits in SidebarTab's
+ * right slot, revealed on the tab's own group hover or while its menu is open.
  */
 function Row({
-  icon,
+  chevron,
+  glyph: Glyph,
   label,
   path,
   isFolder,
   active = false,
   onClick,
 }: {
-  icon: IconComponent;
+  chevron?: IconComponent;
+  glyph: React.ComponentType<{ size?: number }>;
   label: string;
   path: string;
   isFolder: boolean;
@@ -79,69 +101,154 @@ function Row({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   return (
-    <div className={styles.rowWrap}>
-      <div className={styles.tab}>
-        <SidebarTab
-          variant="sidebar-light"
-          icon={icon}
-          selected={menuOpen || active}
-          onClick={onClick}
+    <SidebarTab
+      variant="sidebar-light"
+      icon={chevron ?? GlyphSpacer}
+      selected={menuOpen || active}
+      onClick={onClick}
+      rightChildren={
+        <span
+          className={`flex transition-opacity duration-100 ${
+            menuOpen
+              ? "opacity-100"
+              : "opacity-0 group-hover/SidebarTab:opacity-100 focus-within:opacity-100"
+          }`}
+          onClick={(e) => e.stopPropagation()}
         >
-          {label}
-        </SidebarTab>
-      </div>
-      {/* "⋯" overlays the leading file/folder icon, revealed on hover. */}
-      <div className={styles.rowMenu} data-open={menuOpen || undefined}>
-        <WikiItemMenu
-          path={path}
-          isFolder={isFolder}
-          open={menuOpen}
-          onOpenChange={setMenuOpen}
-        >
-          <button
-            type="button"
-            className={styles.moreBtn}
-            aria-label="More actions"
-            onClick={(e) => e.stopPropagation()}
+          <WikiItemMenu
+            path={path}
+            isFolder={isFolder}
+            open={menuOpen}
+            onOpenChange={setMenuOpen}
+            align="start"
           >
-            <SvgMoreHorizontal size={16} />
-          </button>
-        </WikiItemMenu>
-      </div>
+            <Button
+              prominence="tertiary"
+              size="sm"
+              icon={SvgMoreHorizontal}
+              aria-label="More actions"
+            />
+          </WikiItemMenu>
+        </span>
+      }
+    >
+      <span className={styles.rowLabel}>
+        <Glyph size={16} />
+        <span>{label}</span>
+      </span>
+    </SidebarTab>
+  );
+}
+
+/**
+ * Inline folder-create row (mock 852:350261): a prefilled input, text
+ * selected, confirmed with the check button / Enter, cancelled with Escape.
+ */
+function NewFolderRow({
+  dir,
+  onDone,
+  onCancel,
+}: {
+  dir: string;
+  onDone: () => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState("New Folder");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => inputRef.current?.select(), []);
+
+  async function submit() {
+    const clean = name.trim().replace(/^\/+|\/+$/g, "");
+    if (!clean || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiFetch("/wiki/folder", {
+        method: "POST",
+        body: JSON.stringify({ path: dir ? `${dir}/${clean}` : clean }),
+      });
+      void revalidateWiki();
+      onDone();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "create failed");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={styles.newFolderRow}>
+      <InputTypeIn
+        ref={inputRef}
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        aria-label="New folder name"
+        autoFocus
+        onKeyDown={(e) => {
+          if (e.key === "Enter") void submit();
+          if (e.key === "Escape") onCancel();
+        }}
+        rightChildren={
+          // Keep focus in the input across the click so Enter/Escape still work
+          // if the request errors.
+          <span onMouseDown={(e) => e.preventDefault()}>
+            <Button
+              prominence="tertiary"
+              size="sm"
+              icon={SvgCheck}
+              aria-label="Create folder"
+              disabled={busy}
+              onClick={() => void submit()}
+            />
+          </span>
+        }
+      />
+      {error && <div className={styles.folderError}>{error}</div>}
     </div>
   );
 }
 
 /** A folder row that expands inline to show its children, indented one level
- * (8px) via `.nested` — matching the mock's "Folded" group. */
+ * with the mock's vertical guide line. */
 function FolderNode({
   entries,
   dir,
   name,
   onOpenFile,
   expanded,
+  searchOpen,
   onToggle,
   activeFolder,
   onSetActive,
+  creatingIn,
+  onCreateDone,
+  onCreateCancel,
 }: {
   entries: Entry[];
   dir: string;
   name: string;
   onOpenFile: (path: string) => void;
   expanded: Set<string>;
+  searchOpen: boolean;
   onToggle: (path: string) => void;
   activeFolder: string;
   onSetActive: (path: string) => void;
+  creatingIn: string | null;
+  onCreateDone: () => void;
+  onCreateCancel: () => void;
 }) {
   const full = dir ? `${dir}/${name}` : name;
-  const open = expanded.has(full);
+  const creatingHere = creatingIn === full;
+  const open = searchOpen || expanded.has(full) || creatingHere;
   const { folders, files } = open
     ? childrenOf(entries, full)
     : { folders: [], files: [] };
   return (
     <>
       <Row
-        icon={open ? SvgFolderOpen : SvgFolder}
+        chevron={open ? SvgChevronDown : SvgChevronRight}
+        glyph={open ? SvgFolderOpen : SvgFolder}
         label={name}
         path={full}
         isFolder
@@ -152,8 +259,15 @@ function FolderNode({
           onToggle(full);
         }}
       />
-      {open && (folders.length > 0 || files.length > 0) && (
+      {open && (
         <div className={styles.nested}>
+          {creatingHere && (
+            <NewFolderRow
+              dir={full}
+              onDone={onCreateDone}
+              onCancel={onCreateCancel}
+            />
+          )}
           {folders.map((f) => (
             <FolderNode
               key={f}
@@ -162,15 +276,19 @@ function FolderNode({
               name={f}
               onOpenFile={onOpenFile}
               expanded={expanded}
+              searchOpen={searchOpen}
               onToggle={onToggle}
               activeFolder={activeFolder}
               onSetActive={onSetActive}
+              creatingIn={creatingIn}
+              onCreateDone={onCreateDone}
+              onCreateCancel={onCreateCancel}
             />
           ))}
           {files.map((f) => (
             <Row
               key={f}
-              icon={SvgFileText}
+              glyph={SvgFileText}
               label={f.replace(/\.md$/, "")}
               path={`${full}/${f}`}
               isFolder={false}
@@ -184,28 +302,32 @@ function FolderNode({
 }
 
 /**
- * Permanent directory sidebar — a nested, expandable tree. Per-row contextual
- * actions come from the surrounding WikiItemActionsProvider (shared with the
- * recent-pages grid). The list scrolls rather than the panel growing.
+ * Directory tree panel (mock 319:26456): "Wiki" header with a collapse
+ * control, a search row with new-page / new-folder actions, then the nested
+ * tree. Search filters the tree to matching paths with ancestors held open.
  */
 export function WikiTree() {
   const router = useRouter();
+  const { toggleTree } = useLeftPanel();
+  const actions = useRowActions();
   const { data } = useSWR<{ entries: Entry[] }>("/wiki");
   const entries = data?.entries ?? [];
-  const { folders, files } = childrenOf(entries, "");
-  // Navigates to a page or a folder — the same /app/wiki/<path> route renders
+
+  const [query, setQuery] = useState("");
+  const q = query.trim().toLowerCase();
+  const visible = q
+    ? entries.filter((e) => e.path.toLowerCase().includes(q))
+    : entries;
+  const { folders, files } = childrenOf(visible, "");
+  // Navigates to a page or a folder. The same /app/wiki/<path> route renders
   // both (a folder shows its directory listing).
   const openFile = (path: string) => router.push(`/app/wiki/${path}`);
 
-  const [addingFolder, setAddingFolder] = useState(false);
-  const [folderName, setFolderName] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
   // The folder new pages/folders are created inside ("" = wiki root). State
-  // lives in the provider so deletes can reset it. Clicking a folder row makes
-  // it active; the active row is highlighted (`selected`).
+  // lives in the provider so deletes can reset it and the "⋯" menu can start
+  // an inline create from any row.
   const { activeFolder, setActiveFolder } = useActiveFolder();
+  const { creatingIn, setCreatingIn } = useFolderCreate();
   const activeLabel = activeFolder.split("/").pop() ?? "";
 
   // Expanded folders, persisted to sessionStorage so they survive a refresh.
@@ -215,131 +337,114 @@ export function WikiTree() {
       const raw = sessionStorage.getItem(EXPANDED_KEY);
       if (raw) setExpanded(new Set(JSON.parse(raw) as string[]));
     } catch {
-      // sessionStorage unavailable (private mode) — start collapsed.
+      // sessionStorage unavailable (private mode), start collapsed.
     }
   }, []);
+  const persistExpanded = (next: Set<string>) => {
+    try {
+      sessionStorage.setItem(EXPANDED_KEY, JSON.stringify([...next]));
+    } catch {
+      // ignore persistence failure
+    }
+  };
   const toggleFolder = (path: string) => {
     setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(path)) next.delete(path);
       else next.add(path);
-      try {
-        sessionStorage.setItem(EXPANDED_KEY, JSON.stringify([...next]));
-      } catch {
-        // ignore persistence failure
-      }
+      persistExpanded(next);
       return next;
     });
   };
 
-  // Expand a folder (idempotent) so a freshly-created child is visible.
-  const expandFolder = (path: string) => {
-    if (!path) return;
+  // Hold every ancestor of the create-target open so the inline row is
+  // reachable when a row menu's New Folder fires from a collapsed subtree.
+  useEffect(() => {
+    if (!creatingIn) return;
     setExpanded((prev) => {
-      if (prev.has(path)) return prev;
-      const next = new Set(prev).add(path);
-      try {
-        sessionStorage.setItem(EXPANDED_KEY, JSON.stringify([...next]));
-      } catch {
-        // ignore persistence failure
+      const next = new Set(prev);
+      let cur = "";
+      for (const seg of creatingIn.split("/").filter(Boolean)) {
+        cur = cur ? `${cur}/${seg}` : seg;
+        next.add(cur);
       }
+      persistExpanded(next);
       return next;
     });
-  };
-
-  const refresh = () => void revalidateWiki();
-
-  // New pages route to NewDocView for the active folder; new folders create
-  // inside it. Both fall back to the wiki root when nothing is active.
-  const newPage = () =>
-    router.push(
-      activeFolder ? `/app/wiki/${activeFolder}?new=1` : "/app/wiki?new=1",
-    );
-
-  async function createFolder(e: FormEvent) {
-    e.preventDefault();
-    const name = folderName.trim().replace(/^\/+|\/+$/g, "");
-    if (!name) return;
-    const path = activeFolder ? `${activeFolder}/${name}` : name;
-    setBusy(true);
-    setError(null);
-    try {
-      await apiFetch("/wiki/folder", {
-        method: "POST",
-        body: JSON.stringify({ path }),
-      });
-      setFolderName("");
-      setAddingFolder(false);
-      expandFolder(activeFolder);
-      refresh();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "create failed");
-    } finally {
-      setBusy(false);
-    }
-  }
+  }, [creatingIn]);
 
   return (
     <div className={styles.panel}>
       <div className={styles.header}>
-        <Text font="secondary-body" color="text-03">
-          Directory
-        </Text>
-        <div className={styles.actions}>
-          <Button
-            prominence="tertiary"
-            size="sm"
-            icon={SvgPlus}
-            tooltip={activeFolder ? `New page in ${activeLabel}` : "New page"}
-            onClick={newPage}
-          />
-          <Button
-            prominence="tertiary"
-            size="sm"
-            icon={SvgFolderPlus}
-            tooltip={
-              activeFolder ? `New folder in ${activeLabel}` : "New folder"
-            }
-            onClick={() => setAddingFolder((v) => !v)}
-          />
-        </div>
+        <span className={styles.headerTitle}>
+          {/* Mock icon is `list-tree` (SvgListTree once @onyx-ai/opal ships it,
+              with SvgFold below becoming SvgArrowWallLeft). */}
+          <SvgTextLines size={16} />
+          <Text font="main-ui-action" color="text-05">
+            Wiki
+          </Text>
+        </span>
+        <Button
+          prominence="tertiary"
+          icon={SvgFold}
+          tooltip="Close Panel"
+          onClick={toggleTree}
+        />
       </div>
 
-      {addingFolder && (
-        <form className={styles.folderForm} onSubmit={createFolder}>
-          <InputTypeIn
-            value={folderName}
-            onChange={(e) => setFolderName(e.target.value)}
-            placeholder={
-              activeFolder
-                ? `folder-name (in ${activeLabel})`
-                : "folder-name (or subdir/folder-name)"
-            }
-            aria-label="New folder name"
-            autoFocus
-          />
-        </form>
-      )}
-      {error && <div className={styles.folderError}>{error}</div>}
+      <div className={styles.searchRow}>
+        <InputTypeIn
+          searchIcon
+          clearButton
+          placeholder="Search wiki..."
+          aria-label="Search wiki"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <Button
+          prominence="tertiary"
+          icon={SvgPlus}
+          tooltip={activeFolder ? `New page in ${activeLabel}` : "New page"}
+          onClick={() => actions.newPage(activeFolder)}
+        />
+        <Button
+          prominence="tertiary"
+          icon={SvgFolderPlus}
+          tooltip={activeFolder ? `New folder in ${activeLabel}` : "New folder"}
+          onClick={() => setCreatingIn(activeFolder)}
+        />
+      </div>
+      <Divider />
 
       <div className={styles.list}>
+        {creatingIn === "" && (
+          <NewFolderRow
+            dir=""
+            onDone={() => setCreatingIn(null)}
+            onCancel={() => setCreatingIn(null)}
+          />
+        )}
         {folders.map((f) => (
           <FolderNode
             key={f}
-            entries={entries}
+            entries={visible}
             dir=""
             name={f}
             onOpenFile={openFile}
             expanded={expanded}
+            searchOpen={q !== ""}
             onToggle={toggleFolder}
             activeFolder={activeFolder}
             onSetActive={setActiveFolder}
+            creatingIn={creatingIn}
+            onCreateDone={() => setCreatingIn(null)}
+            onCreateCancel={() => setCreatingIn(null)}
           />
         ))}
         {files.map((f) => (
           <Row
             key={f}
-            icon={SvgFileText}
+            glyph={SvgFileText}
             label={f.replace(/\.md$/, "")}
             path={f}
             isFolder={false}
@@ -349,7 +454,7 @@ export function WikiTree() {
         {folders.length === 0 && files.length === 0 && (
           <div className={styles.empty}>
             <Text font="secondary-body" color="text-03">
-              No pages yet
+              {q ? "No matches" : "No pages yet"}
             </Text>
           </div>
         )}

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -12,11 +12,11 @@ import {
   Text,
 } from "@onyx-ai/opal/components";
 import {
+  SvgArrowWallRight,
   SvgCheck,
   SvgChevronDown,
   SvgChevronRight,
   SvgFileText,
-  SvgFold,
   SvgFolder,
   SvgFolderOpen,
   SvgFolderPlus,
@@ -69,6 +69,13 @@ function childrenOf(entries: Entry[], dir: string) {
 type IconComponent = NonNullable<
   React.ComponentProps<typeof SidebarTab>["icon"]
 >;
+
+/** The mock's `arrow-wall-left` collapse glyph. The published icon set ships
+ * only the right-facing variant, whose 180° rotation is the exact mirror.
+ * Swap for SvgArrowWallLeft once @onyx-ai/opal publishes it. */
+const ArrowWallLeft: IconComponent = (props) => (
+  <SvgArrowWallRight {...props} style={{ transform: "rotate(180deg)" }} />
+);
 
 /** Invisible icon-slot filler so file rows keep the chevron column's exact
  * geometry and their glyph aligns with folder glyphs. */
@@ -386,7 +393,7 @@ export function WikiTree() {
         </span>
         <Button
           prominence="tertiary"
-          icon={SvgFold}
+          icon={ArrowWallLeft}
           tooltip="Close Panel"
           onClick={toggleTree}
         />

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -381,7 +381,7 @@ export function WikiTree() {
               with SvgFold below becoming SvgArrowWallLeft). */}
           <SvgTextLines size={16} />
           <Text font="main-ui-action" color="text-05">
-            Wiki
+            Wiki Directory
           </Text>
         </span>
         <Button
@@ -396,8 +396,8 @@ export function WikiTree() {
         <InputTypeIn
           searchIcon
           clearButton
-          placeholder="Search wiki..."
-          aria-label="Search wiki"
+          placeholder="Search wiki directory..."
+          aria-label="Search wiki directory"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -12,7 +12,7 @@ import {
   Text,
 } from "@onyx-ai/opal/components";
 import {
-  SvgArrowWallRight,
+  SvgArrowWallLeft,
   SvgCheck,
   SvgChevronDown,
   SvgChevronRight,
@@ -20,9 +20,9 @@ import {
   SvgFolder,
   SvgFolderOpen,
   SvgFolderPlus,
+  SvgListTree,
   SvgMoreHorizontal,
   SvgPlus,
-  SvgTextLines,
 } from "@onyx-ai/opal/icons";
 
 import { apiFetch } from "@/lib/api";
@@ -66,31 +66,16 @@ function childrenOf(entries: Entry[], dir: string) {
   };
 }
 
-type IconComponent = NonNullable<
-  React.ComponentProps<typeof SidebarTab>["icon"]
->;
-
-/** The mock's `arrow-wall-left` collapse glyph. The published icon set ships
- * only the right-facing variant, whose 180° rotation is the exact mirror.
- * Swap for SvgArrowWallLeft once @onyx-ai/opal publishes it. */
-const ArrowWallLeft: IconComponent = (props) => (
-  <SvgArrowWallRight {...props} style={{ transform: "rotate(180deg)" }} />
-);
-
-/** Invisible icon-slot filler so file rows keep the chevron column's exact
- * geometry and their glyph aligns with folder glyphs. */
-const GlyphSpacer: IconComponent = (props) => (
-  <svg {...props} aria-hidden="true" />
-);
-
 /**
- * One tree row. Folders lead with an expand chevron (icon slot) + a folder
- * glyph inline with the label. Files fill the chevron slot with a spacer so
+ * One tree row. Folders lead with an internal-style chevron button that
+ * expands/collapses WITHOUT navigating (mock annotation on 705:142966), while
+ * the row itself opens the item. Files fill the chevron column with a spacer so
  * their glyph aligns with folder glyphs. The "⋯" menu sits in SidebarTab's
  * right slot, revealed on the tab's own group hover or while its menu is open.
  */
 function Row({
-  chevron,
+  expanded,
+  onToggle,
   glyph: Glyph,
   label,
   path,
@@ -98,7 +83,8 @@ function Row({
   active = false,
   onClick,
 }: {
-  chevron?: IconComponent;
+  expanded?: boolean;
+  onToggle?: () => void;
   glyph: React.ComponentType<{ size?: number }>;
   label: string;
   path: string;
@@ -110,7 +96,6 @@ function Row({
   return (
     <SidebarTab
       variant="sidebar-light"
-      icon={chevron ?? GlyphSpacer}
       selected={menuOpen || active}
       onClick={onClick}
       rightChildren={
@@ -140,6 +125,22 @@ function Row({
       }
     >
       <span className={styles.rowLabel}>
+        {isFolder && onToggle ? (
+          <span
+            className={styles.chevronSlot}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Button
+              prominence="internal"
+              size="sm"
+              icon={expanded ? SvgChevronDown : SvgChevronRight}
+              aria-label={expanded ? "Collapse folder" : "Expand folder"}
+              onClick={onToggle}
+            />
+          </span>
+        ) : (
+          <span className={styles.chevronSlot} />
+        )}
         <Glyph size={16} />
         <span>{label}</span>
       </span>
@@ -254,7 +255,8 @@ function FolderNode({
   return (
     <>
       <Row
-        chevron={open ? SvgChevronDown : SvgChevronRight}
+        expanded={open}
+        onToggle={() => onToggle(full)}
         glyph={open ? SvgFolderOpen : SvgFolder}
         label={name}
         path={full}
@@ -263,7 +265,6 @@ function FolderNode({
         onClick={() => {
           onOpenFile(full); // navigate the main view to the folder listing
           onSetActive(full);
-          onToggle(full);
         }}
       />
       {open && (
@@ -384,16 +385,14 @@ export function WikiTree() {
     <div className={styles.panel}>
       <div className={styles.header}>
         <span className={styles.headerTitle}>
-          {/* Mock icon is `list-tree` (SvgListTree once @onyx-ai/opal ships it,
-              with SvgFold below becoming SvgArrowWallLeft). */}
-          <SvgTextLines size={16} />
+          <SvgListTree size={16} />
           <Text font="main-ui-action" color="text-05">
             Wiki Directory
           </Text>
         </span>
         <Button
           prominence="tertiary"
-          icon={ArrowWallLeft}
+          icon={SvgArrowWallLeft}
           tooltip="Close Panel"
           onClick={toggleTree}
         />

--- a/frontend/src/lib/coeditor/components.tsx
+++ b/frontend/src/lib/coeditor/components.tsx
@@ -123,7 +123,7 @@ const baseTheme = EditorView.theme({
   "&": {
     height: "100%",
     fontSize: "0.875rem",
-    borderRadius: "var(--border-radius-08)",
+    borderRadius: "var(--radius-08)",
     border: "1px solid var(--border-01)",
     backgroundColor: "var(--background-00)",
     color: "var(--text-05)",
@@ -156,7 +156,7 @@ const baseTheme = EditorView.theme({
     fontFamily:
       "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
     backgroundColor: "var(--background-tint-01)",
-    borderRadius: "var(--border-radius-04, 4px)",
+    borderRadius: "var(--radius-04, 4px)",
     padding: "0.1em 0.3em",
   },
   ".cm-md-code-block": {
@@ -164,7 +164,7 @@ const baseTheme = EditorView.theme({
       "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
     display: "block",
     backgroundColor: "var(--background-tint-01)",
-    borderRadius: "var(--border-radius-08)",
+    borderRadius: "var(--radius-08)",
   },
   ".cm-md-blockquote": {
     display: "inline-block",

--- a/frontend/src/lib/fileview/components.tsx
+++ b/frontend/src/lib/fileview/components.tsx
@@ -972,13 +972,13 @@ export function FileView({ path }: FileViewProps) {
       />
 
       {error && (
-        <div className="mb-3 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+        <div className="mb-3 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
           {error}
         </div>
       )}
 
       {viewingOld && !loading && !error && (
-        <div className="mb-3 flex items-center gap-3 rounded-(--border-radius-08) border border-(--status-warning-02) bg-(--status-warning-01) px-3 py-2 text-[13px] text-(--status-text-warning-05)">
+        <div className="mb-3 flex items-center gap-3 rounded-(--radius-08) border border-(--status-warning-02) bg-(--status-warning-01) px-3 py-2 text-[13px] text-(--status-text-warning-05)">
           <span>
             Viewing an older version
             {viewingSha ? ` (${viewingSha.slice(0, 7)})` : ""}.
@@ -1254,7 +1254,7 @@ export function FileView({ path }: FileViewProps) {
       {selTool && (
         <div
           onMouseDown={(e) => e.preventDefault()}
-          className="fixed z-[80] -translate-x-1/2 -translate-y-full rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-(--shadow-popover)"
+          className="fixed z-[80] -translate-x-1/2 -translate-y-full rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-(--shadow-popover)"
           style={{
             left: selTool.x,
             top: selTool.y - 8,
@@ -1298,7 +1298,7 @@ function ActiveAgentsBar({
   const count = agents.length + sessions.length;
   const expandable = count > 0;
   return (
-    <div className="mb-3 overflow-hidden rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01)">
+    <div className="mb-3 overflow-hidden rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01)">
       <button
         onClick={expandable ? onToggle : undefined}
         aria-expanded={expandable ? open : undefined}
@@ -1363,7 +1363,7 @@ function ActiveAgentRow({ a, isLast }: ActiveAgentRowProps) {
         (isLast ? `` : ` border-b border-(--border-01)`)
       }
     >
-      <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-[6px] py-[1px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
+      <span className="shrink-0 rounded-(--radius-04) bg-(--background-tint-03) px-[6px] py-[1px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
         {a.activity}
       </span>
 
@@ -1416,7 +1416,7 @@ function ActiveSessionRow({ s, isLast, onClose }: ActiveSessionRowProps) {
         (isLast ? `` : ` border-b border-(--border-01)`)
       }
     >
-      <span className="shrink-0 rounded-(--border-radius-04) bg-(--background-tint-03) px-[6px] py-[1px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
+      <span className="shrink-0 rounded-(--radius-04) bg-(--background-tint-03) px-[6px] py-[1px] text-[10px] font-semibold tracking-[0.3px] text-(--text-05) uppercase">
         {s.status}
       </span>
 
@@ -1487,7 +1487,7 @@ export function TemplateGallery({
   // line. On wide screens the user scrolls / clicks chevrons through
   // the row; on narrow screens the same layout becomes a swipe strip.
   return (
-    <div className="flex flex-col gap-[10px] rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-[14px]">
+    <div className="flex flex-col gap-[10px] rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) p-[14px]">
       <div className="flex items-baseline gap-2">
         <span className="text-[13px] font-semibold text-(--text-05)">
           Start from a template
@@ -1656,7 +1656,7 @@ function TemplateCard({
       type="button"
       onClick={onClick}
       disabled={busy}
-      className={`box-border flex h-full min-h-[64px] w-full flex-col gap-1 rounded-(--border-radius-04) border px-3 py-[10px] text-left text-(--text-05) transition-[background,border-color] duration-[80ms] ease-in-out ${busy ? "cursor-wait opacity-[0.7]" : "cursor-pointer"} ${active ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
+      className={`box-border flex h-full min-h-[64px] w-full flex-col gap-1 rounded-(--radius-04) border px-3 py-[10px] text-left text-(--text-05) transition-[background,border-color] duration-[80ms] ease-in-out ${busy ? "cursor-wait opacity-[0.7]" : "cursor-pointer"} ${active ? "border-(--border-01) bg-(--background-tint-03)" : "border-(--border-01) bg-(--background-tint-00)"}`}
       onMouseEnter={(e) => {
         if (!active && !busy) {
           e.currentTarget.style.background = "var(--background-tint-03)";
@@ -1804,7 +1804,7 @@ export function FilenameRow({
   placeholder = "filename",
 }: FilenameRowProps) {
   return (
-    <div className="flex shrink-0 items-stretch overflow-hidden rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00)">
+    <div className="flex shrink-0 items-stretch overflow-hidden rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00)">
       {parent && (
         <span className="flex items-center border-r border-(--border-01) bg-(--background-tint-02) px-[10px] font-mono text-[13px] text-(--text-04)">
           {parent}/

--- a/frontend/src/providers/LeftPanelProvider.tsx
+++ b/frontend/src/providers/LeftPanelProvider.tsx
@@ -4,6 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -46,10 +47,12 @@ interface LeftPanelProviderProps {
 export function LeftPanelProvider({ children }: LeftPanelProviderProps) {
   const focus = useAppFocus();
   const [activitiesOpen, setActivitiesOpen] = useState(false);
-  const [treeOpen, setTreeOpen] = useState<boolean>(() => {
-    if (typeof window === "undefined") return true;
-    return window.localStorage.getItem(TREE_OPEN_KEY) !== "0";
-  });
+  // Starts open on server and client alike so hydration matches. The stored
+  // preference applies after mount.
+  const [treeOpen, setTreeOpen] = useState(true);
+  useEffect(() => {
+    if (window.localStorage.getItem(TREE_OPEN_KEY) === "0") setTreeOpen(false);
+  }, []);
 
   const isOnWikiRoute = focus.isWiki();
 

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   createContext,
   useContext,
@@ -28,6 +29,10 @@ interface RowActions {
   copyLink: (path: string) => void;
   launchAgent: (path: string) => void;
   remove: (path: string, isFolder: boolean) => void;
+  /** Route to the new-page flow scoped to a folder ("" = wiki root). */
+  newPage: (dir: string) => void;
+  /** Start the tree's inline folder-create row inside `dir` ("" = wiki root). */
+  newFolder: (dir: string) => void;
 }
 
 const ActionsContext = createContext<RowActions | null>(null);
@@ -50,6 +55,21 @@ export function useActiveFolder(): ActiveFolder {
   if (!ctx)
     throw new Error(
       "useActiveFolder must be used within WikiItemActionsProvider",
+    );
+  return ctx;
+}
+
+interface FolderCreate {
+  /** Folder the inline create-row is open in, null when closed. "" = wiki root. */
+  creatingIn: string | null;
+  setCreatingIn: (dir: string | null) => void;
+}
+const FolderCreateContext = createContext<FolderCreate | null>(null);
+export function useFolderCreate(): FolderCreate {
+  const ctx = useContext(FolderCreateContext);
+  if (!ctx)
+    throw new Error(
+      "useFolderCreate must be used within WikiItemActionsProvider",
     );
   return ctx;
 }
@@ -84,6 +104,7 @@ export function WikiItemActionsProvider({
   children,
   active = true,
 }: WikiItemActionsProviderProps) {
+  const router = useRouter();
   const { data } = useSWR<{ entries: Entry[] }>(active ? "/wiki" : null);
   const entries = data?.entries ?? [];
 
@@ -93,6 +114,7 @@ export function WikiItemActionsProvider({
   const [agentPath, setAgentPath] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
   const [activeFolder, setActiveFolder] = useState("");
+  const [creatingIn, setCreatingIn] = useState<string | null>(null);
 
   useEffect(() => {
     if (!toast) return;
@@ -118,6 +140,9 @@ export function WikiItemActionsProvider({
     rename: setRenamePath,
     move: setMovePath,
     launchAgent: setAgentPath,
+    newPage: (dir) =>
+      router.push(dir ? `/app/wiki/${dir}?new=1` : "/app/wiki?new=1"),
+    newFolder: setCreatingIn,
     copyLink: async (path) => {
       // Share the durable id-based URL so the link survives a later
       // rename/move (falls back to a path URL only when the page genuinely
@@ -158,7 +183,9 @@ export function WikiItemActionsProvider({
   return (
     <ActionsContext.Provider value={actions}>
       <ActiveFolderContext.Provider value={{ activeFolder, setActiveFolder }}>
-        {children}
+        <FolderCreateContext.Provider value={{ creatingIn, setCreatingIn }}>
+          {children}
+        </FolderCreateContext.Provider>
       </ActiveFolderContext.Provider>
 
       {/* Overlays are portaled to <body> so they escape any sticky/sidebar

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -229,7 +229,7 @@ export function WikiItemActionsProvider({
               wikiPath={agentPath}
             />
             {toast && (
-              <div className="fixed bottom-8 left-1/2 z-(--z-toast) -translate-x-1/2 rounded-(--border-radius-08) bg-(--background-tint-04) px-3.5 py-2 text-[13px] text-text-05 shadow-(--shadow-popover)">
+              <div className="fixed bottom-8 left-1/2 z-(--z-toast) -translate-x-1/2 rounded-(--radius-08) bg-(--background-tint-04) px-3.5 py-2 text-[13px] text-text-05 shadow-(--shadow-popover)">
                 {toast}
               </div>
             )}

--- a/frontend/src/sections/sidebar/AdminSidebar.tsx
+++ b/frontend/src/sections/sidebar/AdminSidebar.tsx
@@ -23,7 +23,7 @@ export default function AdminSidebar() {
 
   return (
     <SidebarLayouts.Root>
-      <SidebarLayouts.Header logo={sidebarLogo}>
+      <SidebarLayouts.Header renderAppLogo={sidebarLogo}>
         <InputTypeIn
           variant="internal"
           searchIcon

--- a/frontend/src/sections/sidebar/AppSidebar.tsx
+++ b/frontend/src/sections/sidebar/AppSidebar.tsx
@@ -88,7 +88,7 @@ export default function AppSidebar() {
 
   return (
     <SidebarLayouts.Root foldable>
-      <SidebarLayouts.Header logo={sidebarLogo}>
+      <SidebarLayouts.Header renderAppLogo={sidebarLogo}>
         {folded ? (
           <Button
             icon={SvgSearch}

--- a/frontend/src/sections/sidebar/shared.tsx
+++ b/frontend/src/sections/sidebar/shared.tsx
@@ -2,15 +2,20 @@
 
 import { Text } from "@onyx-ai/opal/components";
 import { SvgOnyxLogo, SvgOnyxLogoTyped } from "@onyx-ai/opal/logos";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 
-export function sidebarLogo(folded: boolean | undefined) {
-  return (
+/** Logo factory for `SidebarLayouts.Header`'s `renderAppLogo`: the returned
+ * component is rendered by the header at its own icon size. */
+export function sidebarLogo(
+  folded: boolean | undefined,
+): IconFunctionComponent {
+  const Logo: IconFunctionComponent = ({ size }) => (
     <div className="flex items-center gap-2 px-1">
       {folded ? (
-        <SvgOnyxLogo size={28} />
+        <SvgOnyxLogo size={size} />
       ) : (
         <>
-          <SvgOnyxLogoTyped size={28} />
+          <SvgOnyxLogoTyped size={size} />
           <Text font="heading-h3" color="text-03">
             Wiki
           </Text>
@@ -18,4 +23,5 @@ export function sidebarLogo(folded: boolean | undefined) {
       )}
     </div>
   );
+  return Logo;
 }

--- a/frontend/src/views/agents-and-actions/AgentsAndActionsPage.tsx
+++ b/frontend/src/views/agents-and-actions/AgentsAndActionsPage.tsx
@@ -61,7 +61,7 @@ function OnyxCraftSection() {
   if (isLoading || isUnavailable) return null;
 
   return (
-    <section className="mb-4 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+    <section className="mb-4 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
       <h2 className="m-0 mb-1 text-base">Onyx Craft</h2>
       <p className="m-0 mb-3 text-[13px] text-(--text-03)">
         Connect your Onyx account to launch Craft builds from any wiki page with
@@ -84,21 +84,21 @@ function EndpointBlock() {
   }, []);
 
   return (
-    <section className="mb-4 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+    <section className="mb-4 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
       <div className="mb-1.5 text-[13px] text-(--text-03)">MCP server URL</div>
       <div className="flex items-center gap-2">
-        <code className="flex-1 overflow-x-auto rounded-(--border-radius-04) bg-(--background-tint-02) px-[10px] py-2 font-mono text-xs text-(--text-05)">
+        <code className="flex-1 overflow-x-auto rounded-(--radius-04) bg-(--background-tint-02) px-[10px] py-2 font-mono text-xs text-(--text-05)">
           {endpoint || "—"}
         </code>
         <CopyButton text={endpoint} />
       </div>
       <div className="mt-2 text-xs text-(--text-03)">
         Send the API key in the{" "}
-        <code className="rounded-(--border-radius-04) bg-(--background-tint-02) px-1 py-px font-mono text-xs">
+        <code className="rounded-(--radius-04) bg-(--background-tint-02) px-1 py-px font-mono text-xs">
           Authorization
         </code>{" "}
         header as{" "}
-        <code className="rounded-(--border-radius-04) bg-(--background-tint-02) px-1 py-px font-mono text-xs">
+        <code className="rounded-(--radius-04) bg-(--background-tint-02) px-1 py-px font-mono text-xs">
           Bearer mcp_…
         </code>
         .
@@ -113,7 +113,7 @@ function TokenManager() {
   const [reveal, setReveal] = useState<CreatedToken | null>(null);
 
   return (
-    <section className="mb-4 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+    <section className="mb-4 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
       <div className="mb-3 flex items-center justify-between">
         <h2 className="m-0 text-base">API keys</h2>
         <Button
@@ -125,7 +125,7 @@ function TokenManager() {
       </div>
 
       {error && (
-        <div className="mb-2 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+        <div className="mb-2 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
           {error.message || "Failed to load keys."}
         </div>
       )}
@@ -192,7 +192,7 @@ function TokenRow({ token, onRevoked }: TokenRowProps) {
   }
 
   return (
-    <li className="mt-2 flex items-center gap-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]">
+    <li className="mt-2 flex items-center gap-3 rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-00) px-3 py-[10px]">
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-(--text-05)">{token.name}</div>
         <div className="mt-0.5 text-xs text-(--text-03)">
@@ -236,7 +236,7 @@ function CreateForm({ onCancel, onCreated }: CreateFormProps) {
   return (
     <form
       onSubmit={onSubmit}
-      className="mb-3 rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-01) p-3"
+      className="mb-3 rounded-(--radius-04) border border-(--border-01) bg-(--background-tint-01) p-3"
     >
       <label className="text-[13px] text-(--text-04)">
         Agent name
@@ -245,7 +245,7 @@ function CreateForm({ onCancel, onCreated }: CreateFormProps) {
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="e.g. Claude Code, Cursor, Codex"
-          className="mt-1 box-border w-full rounded-(--border-radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
+          className="mt-1 box-border w-full rounded-(--radius-04) border border-(--border-01) px-[10px] py-2 text-sm"
           maxLength={80}
         />
         <div className="mt-1.5 text-xs text-(--text-03)">
@@ -255,7 +255,7 @@ function CreateForm({ onCancel, onCreated }: CreateFormProps) {
         </div>
       </label>
       {err && (
-        <div className="mt-[10px] mb-2 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+        <div className="mt-[10px] mb-2 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
           {err}
         </div>
       )}
@@ -278,12 +278,12 @@ interface RevealOnceProps {
 
 function RevealOnce({ token, onClose }: RevealOnceProps) {
   return (
-    <div className="mb-3 rounded-(--border-radius-04) border border-(--status-warning-02) bg-(--status-warning-01) p-[14px]">
+    <div className="mb-3 rounded-(--radius-04) border border-(--status-warning-02) bg-(--status-warning-01) p-[14px]">
       <div className="text-sm font-semibold text-(--status-text-warning-05)">
         Copy your key now — this is the only time it&apos;ll be shown.
       </div>
       <div className="mt-[10px] flex items-center gap-2">
-        <code className="flex-1 overflow-x-auto rounded-(--border-radius-04) bg-(--background-tint-02) px-[10px] py-2 font-mono text-xs text-(--text-05)">
+        <code className="flex-1 overflow-x-auto rounded-(--radius-04) bg-(--background-tint-02) px-[10px] py-2 font-mono text-xs text-(--text-05)">
           {token.token}
         </code>
         <CopyButton text={token.token} />
@@ -320,7 +320,7 @@ function ClientConfigHelp() {
   );
 
   return (
-    <section className="mb-4 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+    <section className="mb-4 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
       <button
         onClick={() => setOpen((v) => !v)}
         className="flex cursor-pointer items-center gap-1.5 border-none bg-transparent p-0 text-sm font-medium text-(--text-05)"
@@ -332,12 +332,12 @@ function ClientConfigHelp() {
         <div className="mt-3">
           <div className="mb-1.5 text-[13px] text-(--text-04)">
             Sample{" "}
-            <code className="rounded-(--border-radius-04) bg-(--background-tint-02) px-1 py-px font-mono text-xs">
+            <code className="rounded-(--radius-04) bg-(--background-tint-02) px-1 py-px font-mono text-xs">
               mcp_servers.json
             </code>{" "}
             entry — replace the placeholder with your generated key:
           </div>
-          <pre className="max-w-full flex-1 overflow-x-auto rounded-(--border-radius-04) bg-(--background-tint-02) p-3 px-[10px] py-2 font-mono text-xs whitespace-pre text-(--text-05)">
+          <pre className="max-w-full flex-1 overflow-x-auto rounded-(--radius-04) bg-(--background-tint-02) p-3 px-[10px] py-2 font-mono text-xs whitespace-pre text-(--text-05)">
             {claudeCodeSnippet}
           </pre>
         </div>
@@ -400,7 +400,7 @@ function CodingToolsSection() {
   }, [wizardOpen]);
 
   return (
-    <section className="mb-4 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
+    <section className="mb-4 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-4">
       <div className="mb-1 flex items-center justify-between">
         <h2 className="m-0 text-base">Coding tools</h2>
         <Button onClick={() => setWizardOpen(true)}>Set up tools</Button>
@@ -445,7 +445,7 @@ function CodingToolsSection() {
             aria-modal="true"
             aria-label="Set up launcher"
             tabIndex={-1}
-            className="max-h-[90vh] w-[min(560px,92vw)] overflow-y-auto rounded-(--border-radius-12) bg-(--background-tint-00) p-[22px] shadow-(--shadow-modal)"
+            className="max-h-[90vh] w-[min(560px,92vw)] overflow-y-auto rounded-(--radius-12) bg-(--background-tint-00) p-[22px] shadow-(--shadow-modal)"
           >
             <SetupWizard
               onDone={() => setWizardOpen(false)}

--- a/frontend/src/views/auth/LoginPage.tsx
+++ b/frontend/src/views/auth/LoginPage.tsx
@@ -61,7 +61,7 @@ function LoginForm() {
             // this uses a native <a> styled to look like the primary action button.
             <a
               href="/api/auth/oidc/login"
-              className="box-border block w-full rounded-(--border-radius-08) border border-(--background-tint-inverted-00) bg-(--background-tint-inverted-00) px-3.5 py-2 text-center text-[13px] leading-[1.2] font-semibold text-(--text-inverted-05) no-underline"
+              className="box-border block w-full rounded-(--radius-08) border border-(--background-tint-inverted-00) bg-(--background-tint-inverted-00) px-3.5 py-2 text-center text-[13px] leading-[1.2] font-semibold text-(--text-inverted-05) no-underline"
             >
               Sign in with Google
             </a>

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -602,9 +602,7 @@ function Explorer({ dir }: { dir: string }) {
           header button + drawer. */}
       {!isMobile && (
         <aside className="w-[360px] shrink-0 overflow-y-auto p-2">
-          <div className="overflow-hidden rounded-(--radius-12) border border-(--border-01)">
-            <UpdatePolicyPanel path={dir} />
-          </div>
+          <UpdatePolicyPanel path={dir} />
         </aside>
       )}
       {policyOpen && isMobile && (
@@ -931,6 +929,19 @@ type SortMode = "name-asc" | "name-desc" | "recent";
 const ROW_CLASS =
   "mb-1 flex h-11 items-center rounded-(--radius-12) py-1 pr-2 pl-1";
 
+/* The mock's row menu glyph is vertical dots. The published icon set has only
+ * the horizontal variant, whose 90° rotation is identical geometry. Swap for
+ * an SvgMoreVertical once @onyx-ai/opal ships one. Button sizes icons via the
+ * style prop, so the transform must merge with it, never replace it. */
+const MoreVertical: NonNullable<
+  React.ComponentProps<typeof Button>["icon"]
+> = ({ style, ...props }) => (
+  <SvgMoreHorizontal
+    {...props}
+    style={{ ...style, transform: "rotate(90deg)" }}
+  />
+);
+
 /* The mock's shaded leading box: a 36px tint square holding the row's
    file/folder glyph (Qualifier Container, tint-01 on radius-08). */
 function RowQualifier({ children }: { children: React.ReactNode }) {
@@ -1121,8 +1132,10 @@ function Row({
           <span className="w-[110px] shrink-0 text-xs whitespace-nowrap text-(--text-02)">
             {updatedAt ? relativeTime(updatedAt, "short") : "—"}
           </span>
+          {/* White container pops the menu trigger off the grey hover row
+              (mock's Button/Icon Button, tint-00 on radius-08). */}
           <span
-            className={`flex transition-opacity duration-100 ${hover || menuOpen ? "opacity-100" : "opacity-0"}`}
+            className={`flex rounded-(--radius-08) bg-(--background-tint-00) transition-opacity duration-100 ${hover || menuOpen ? "opacity-100" : "opacity-0"}`}
             onClick={(e) => e.stopPropagation()}
           >
             <WikiItemMenu
@@ -1135,8 +1148,7 @@ function Row({
             >
               <Button
                 prominence="tertiary"
-                size="sm"
-                icon={SvgMoreHorizontal}
+                icon={MoreVertical}
                 disabled={busy}
                 aria-label={`More actions for ${label}`}
               />

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -198,9 +198,7 @@ function Explorer({ dir }: { dir: string }) {
   const [createBusy, setCreateBusy] = useState(false);
   const [triggerModalOpen, setTriggerModalOpen] = useState(false);
   const [triggerStatus, setTriggerStatus] = useState<string | null>(null);
-  const [sort, setSort] = useState<"name-asc" | "name-desc" | "recent">(
-    "name-asc",
-  );
+  const [sort, setSort] = useState<SortMode>("name-asc");
   const [renaming, setRenaming] = useState<string | null>(null);
   const [dragSource, setDragSource] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<string | null>(null);
@@ -356,9 +354,9 @@ function Explorer({ dir }: { dir: string }) {
   }
 
   // Folder-level actions portal into the single pinned header (mock
-  // 705:142993): New Page + new-folder, then share / trigger past a divider.
-  // The update policy lives inline in the side column. Mobile keeps it behind
-  // a header button + drawer instead.
+  // 705:142993): New Page + new-folder, then share / trigger / launch-agent
+  // past a divider. The update policy lives inline in the side column. Mobile
+  // keeps it behind a header button + drawer instead.
   const headerActions = (
     <>
       <Button
@@ -410,19 +408,8 @@ function Explorer({ dir }: { dir: string }) {
 
   const parentDir = dir.split("/").slice(0, -1).join("/");
   const cycleSort = () =>
-    setSort((s) =>
-      s === "name-asc"
-        ? "name-desc"
-        : s === "name-desc"
-          ? "recent"
-          : "name-asc",
-    );
-  const sortLabel =
-    sort === "name-asc"
-      ? "Name (A → Z)"
-      : sort === "name-desc"
-        ? "Name (Z → A)"
-        : "Recently updated";
+    setSort((s) => SORT_ORDER[(SORT_ORDER.indexOf(s) + 1) % SORT_ORDER.length]);
+  const sortLabel = SORT_LABEL[sort];
 
   return (
     <main className="flex h-full min-h-0">
@@ -527,7 +514,7 @@ function Explorer({ dir }: { dir: string }) {
             {(() => {
               const dirEntries = subdirs.map((d) => ({ ...d, isFile: false }));
               const fileEntries = files.map((f) => ({ ...f, isFile: true }));
-              // Folders always above docs; ordering within each group is set by `sort`.
+              // Folders always above docs. Ordering within each group is set by `sort`.
               const ordered = [...dirEntries, ...fileEntries];
               return ordered.map(({ name, updated_at, isFile }) => {
                 const childPath = (dir ? dir + "/" : "") + name;
@@ -932,6 +919,12 @@ function NewDocView({ dir }: { dir: string }) {
 }
 
 type SortMode = "name-asc" | "name-desc" | "recent";
+const SORT_ORDER: SortMode[] = ["name-asc", "name-desc", "recent"];
+const SORT_LABEL: Record<SortMode, string> = {
+  "name-asc": "Name (A → Z)",
+  "name-desc": "Name (Z → A)",
+  recent: "Recently updated",
+};
 
 /* Shared card-row chrome for the folder listing: borderless white cards on
    the table's tint background (mock rows 4857:368063). */

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -12,17 +12,21 @@ import {
 import { createPortal } from "react-dom";
 import {
   Button,
+  Divider,
   EmptyMessageCard,
   MessageCard,
+  Text,
 } from "@onyx-ai/opal/components";
 import {
   SvgAlertTriangle,
+  SvgArrowUpDown,
+  SvgChevronLeft,
   SvgDocFile,
-  SvgEdit,
   SvgFolder,
   SvgFolderPlus,
+  SvgLock,
+  SvgMoreHorizontal,
   SvgPlus,
-  SvgShare,
   SvgShield,
   SvgTrash,
   SvgWorkflow,
@@ -32,7 +36,9 @@ import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { TriggerPanel } from "@/components/triggers/TriggerPanel";
 import { WikiHome } from "@/components/wiki/WikiHome";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
+import { StartNewPage } from "@/components/wiki/StartNewPage";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
+import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import { apiFetch, ApiError } from "@/lib/api";
 import { isDocId, wikiHref, wikiPath, revalidateWiki } from "@/lib/wikiHref";
 import { formatRelative } from "@/lib/format";
@@ -344,23 +350,19 @@ function Explorer({ dir }: { dir: string }) {
     }
   }
 
-  // Folder-level actions portal into the single pinned header as icon buttons;
-  // the breadcrumb there is the shared one (WikiHeader), so this view renders
-  // no header of its own.
+  // Folder-level actions portal into the single pinned header (mock
+  // 705:142993): New Page + new-folder, then share / trigger past a divider.
+  // The update policy lives inline in the side column. Mobile keeps it behind
+  // a header button + drawer instead.
   const headerActions = (
     <>
       <Button
-        icon={SvgWorkflow}
         prominence="tertiary"
-        tooltip="Trigger"
-        onClick={() => setTriggerModalOpen(true)}
-      />
-      <Button
-        icon={SvgShield}
-        prominence="tertiary"
-        tooltip="Update Policy"
-        onClick={() => setPolicyOpen(true)}
-      />
+        rightIcon={SvgPlus}
+        onClick={() => router.push(`/app/wiki/${dir}?new=1`)}
+      >
+        New Page
+      </Button>
       <Button
         icon={SvgFolderPlus}
         prominence="tertiary"
@@ -370,155 +372,234 @@ function Explorer({ dir }: { dir: string }) {
           setCreating((v) => (v === "folder" ? null : "folder"));
         }}
       />
+      <span aria-hidden className="mx-1 h-5 w-px bg-(--border-01)" />
       <Button
-        icon={SvgPlus}
-        variant="action"
-        tooltip="New document"
-        onClick={() => router.push(`/app/wiki/${dir}?new=1`)}
+        prominence="tertiary"
+        rightIcon={SvgLock}
+        onClick={() => setSharePath(dir)}
+      >
+        Share
+      </Button>
+      <Button
+        icon={SvgWorkflow}
+        prominence="tertiary"
+        tooltip="Trigger"
+        onClick={() => setTriggerModalOpen(true)}
       />
+      {isMobile && (
+        <Button
+          icon={SvgShield}
+          prominence="tertiary"
+          tooltip="Update Policy"
+          onClick={() => setPolicyOpen(true)}
+        />
+      )}
     </>
   );
 
+  const parentDir = dir.split("/").slice(0, -1).join("/");
+  const cycleSort = () =>
+    setSort((s) =>
+      s === "name-asc"
+        ? "name-desc"
+        : s === "name-desc"
+          ? "recent"
+          : "name-asc",
+    );
+  const sortLabel =
+    sort === "name-asc"
+      ? "Name (A → Z)"
+      : sort === "name-desc"
+        ? "Name (Z → A)"
+        : "Recently updated";
+
   return (
-    <main
-      className={`h-full overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
-    >
+    <main className="flex h-full min-h-0">
       {host?.el && createPortal(headerActions, host.el)}
 
-      <TriggerPanel
-        open={triggerModalOpen}
-        initial={{ scope_path: dir || "/" }}
-        lockScope
-        onClose={() => setTriggerModalOpen(false)}
-        onSaved={(t) => setTriggerStatus(`Created trigger for ${t.scope_path}`)}
-      />
+      <div
+        className={`min-w-0 flex-1 overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
+      >
+        <TriggerPanel
+          open={triggerModalOpen}
+          initial={{ scope_path: dir || "/" }}
+          lockScope
+          onClose={() => setTriggerModalOpen(false)}
+          onSaved={(t) =>
+            setTriggerStatus(`Created trigger for ${t.scope_path}`)
+          }
+        />
 
-      {triggerStatus && (
-        <div className="mb-3 text-xs text-(--text-04)">{triggerStatus}</div>
-      )}
+        {triggerStatus && (
+          <div className="mb-3 text-xs text-(--text-04)">{triggerStatus}</div>
+        )}
 
-      {creating && (
-        <form
-          onSubmit={onCreate}
-          className="mb-4 flex gap-2 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-3"
-        >
-          <input
-            autoFocus
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder="folder-name (or subdir/folder-name)"
-            disabled={createBusy}
-            className="flex-1 rounded-(--border-radius-04) border border-(--border-01) p-2 text-sm"
-          />
-          <Button
-            type="submit"
-            variant="action"
-            disabled={createBusy || !newName.trim()}
+        {creating && (
+          <form
+            onSubmit={onCreate}
+            className="mb-4 flex gap-2 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-3"
           >
-            Create folder
-          </Button>
-          <Button
-            type="button"
-            onClick={() => {
-              setCreating(null);
-              setNewName("");
-            }}
-          >
-            Cancel
-          </Button>
-        </form>
-      )}
+            <input
+              autoFocus
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="folder-name (or subdir/folder-name)"
+              disabled={createBusy}
+              className="flex-1 rounded-(--border-radius-04) border border-(--border-01) p-2 text-sm"
+            />
+            <Button
+              type="submit"
+              variant="action"
+              disabled={createBusy || !newName.trim()}
+            >
+              Create folder
+            </Button>
+            <Button
+              type="button"
+              onClick={() => {
+                setCreating(null);
+                setNewName("");
+              }}
+            >
+              Cancel
+            </Button>
+          </form>
+        )}
 
-      {error && (
-        <div className="mb-3 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
-          {error}
+        {error && (
+          <div className="mb-3 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+            {error}
+          </div>
+        )}
+
+        {subdirs.length === 0 && files.length === 0 && !error && (
+          <p className="text-sm text-(--text-03)">
+            This folder is empty. Create a document to get started.
+          </p>
+        )}
+
+        {(subdirs.length > 0 || files.length > 0) && (
+          // Column header line (mock 709:144294): Name spans, Last Updated
+          // carries the sort control cycling name ascending, descending, recent.
+          <div className="flex items-center px-3 pb-1">
+            <span className="min-w-0 flex-1">
+              <Text font="main-ui-action" color="text-04">
+                Name
+              </Text>
+            </span>
+            <Text font="main-ui-action" color="text-04" nowrap>
+              Last Updated
+            </Text>
+            <Button
+              icon={SvgArrowUpDown}
+              prominence="tertiary"
+              size="sm"
+              tooltip={`Sort: ${sortLabel}`}
+              onClick={cycleSort}
+            />
+          </div>
+        )}
+
+        <ul className="m-0 list-none p-0">
+          {dir && (
+            <BackRow
+              onClick={() =>
+                router.push(parentDir ? `/app/wiki/${parentDir}` : "/app/wiki")
+              }
+            />
+          )}
+          {(() => {
+            const dirEntries = subdirs.map((d) => ({ ...d, isFile: false }));
+            const fileEntries = files.map((f) => ({ ...f, isFile: true }));
+            // Folders always above docs; ordering within each group is set by `sort`.
+            const ordered = [...dirEntries, ...fileEntries];
+            return ordered.map(({ name, updated_at, isFile }) => {
+              const childPath = (dir ? dir + "/" : "") + name;
+              return (
+                <Row
+                  key={(isFile ? "f:" : "d:") + name}
+                  icon={
+                    isFile ? (
+                      <SvgDocFile size={20} aria-hidden />
+                    ) : (
+                      <SvgFolder size={20} aria-hidden />
+                    )
+                  }
+                  label={name}
+                  updatedAt={updated_at}
+                  href={`/app/wiki/${childPath}`}
+                  path={childPath}
+                  isFile={isFile}
+                  busy={busyPath === childPath}
+                  onDelete={() => onDelete(childPath)}
+                  renaming={renaming === childPath}
+                  onStartRename={() => setRenaming(childPath)}
+                  onCancelRename={() => setRenaming(null)}
+                  onSubmitRename={(v) => onRenameSubmit(childPath, v)}
+                  onDragStart={() => setDragSource(childPath)}
+                  onDragEnd={() => {
+                    setDragSource(null);
+                    setDropTarget(null);
+                  }}
+                  dropActive={!isFile && dropTarget === childPath}
+                  onFolderDragOver={
+                    isFile
+                      ? undefined
+                      : () => {
+                          if (dragSource && dragSource !== childPath) {
+                            setDropTarget(childPath);
+                          }
+                        }
+                  }
+                  onFolderDragLeave={
+                    isFile
+                      ? undefined
+                      : () =>
+                          setDropTarget((cur) =>
+                            cur === childPath ? null : cur,
+                          )
+                  }
+                  onFolderDrop={
+                    isFile
+                      ? undefined
+                      : () => {
+                          if (dragSource && dragSource !== childPath) {
+                            onMove(dragSource, childPath);
+                          }
+                          setDragSource(null);
+                          setDropTarget(null);
+                        }
+                  }
+                />
+              );
+            });
+          })()}
+        </ul>
+        <div className="my-2">
+          <Divider />
         </div>
-      )}
+        <StartNewPage dir={dir} />
 
-      {subdirs.length === 0 && files.length === 0 && !error && (
-        <p className="text-sm text-(--text-03)">
-          This folder is empty. Create a document to get started.
-        </p>
-      )}
+        {sharePath && (
+          <ShareDialog
+            path={sharePath}
+            open
+            onClose={() => setSharePath(null)}
+          />
+        )}
+      </div>
 
-      {(subdirs.length > 0 || files.length > 0) && (
-        <SortBar value={sort} onChange={setSort} />
+      {/* Folder policy applies to every page under this folder. Desktop shows
+          it inline in the side column (mock 1673:32813). Mobile keeps the
+          header button + drawer. */}
+      {!isMobile && (
+        <aside className="w-[360px] shrink-0 overflow-y-auto p-2">
+          <div className="overflow-hidden rounded-(--border-radius-12) border border-(--border-01)">
+            <UpdatePolicyPanel path={dir} />
+          </div>
+        </aside>
       )}
-
-      <ul className="m-0 list-none p-0">
-        {(() => {
-          const dirEntries = subdirs.map((d) => ({ ...d, isFile: false }));
-          const fileEntries = files.map((f) => ({ ...f, isFile: true }));
-          // Folders always above docs; ordering within each group is set by `sort`.
-          const ordered = [...dirEntries, ...fileEntries];
-          return ordered.map(({ name, updated_at, isFile }) => {
-            const childPath = (dir ? dir + "/" : "") + name;
-            return (
-              <Row
-                key={(isFile ? "f:" : "d:") + name}
-                icon={
-                  isFile ? (
-                    <SvgDocFile size={20} aria-hidden />
-                  ) : (
-                    <SvgFolder size={20} aria-hidden />
-                  )
-                }
-                label={name}
-                updatedAt={updated_at}
-                href={`/app/wiki/${childPath}`}
-                path={childPath}
-                isFile={isFile}
-                busy={busyPath === childPath}
-                onDelete={() => onDelete(childPath)}
-                onShare={() => setSharePath(childPath)}
-                renaming={renaming === childPath}
-                onStartRename={() => setRenaming(childPath)}
-                onCancelRename={() => setRenaming(null)}
-                onSubmitRename={(v) => onRenameSubmit(childPath, v)}
-                onDragStart={() => setDragSource(childPath)}
-                onDragEnd={() => {
-                  setDragSource(null);
-                  setDropTarget(null);
-                }}
-                dropActive={!isFile && dropTarget === childPath}
-                onFolderDragOver={
-                  isFile
-                    ? undefined
-                    : () => {
-                        if (dragSource && dragSource !== childPath) {
-                          setDropTarget(childPath);
-                        }
-                      }
-                }
-                onFolderDragLeave={
-                  isFile
-                    ? undefined
-                    : () =>
-                        setDropTarget((cur) => (cur === childPath ? null : cur))
-                }
-                onFolderDrop={
-                  isFile
-                    ? undefined
-                    : () => {
-                        if (dragSource && dragSource !== childPath) {
-                          onMove(dragSource, childPath);
-                        }
-                        setDragSource(null);
-                        setDropTarget(null);
-                      }
-                }
-              />
-            );
-          });
-        })()}
-      </ul>
-      {sharePath && (
-        <ShareDialog path={sharePath} open onClose={() => setSharePath(null)} />
-      )}
-      {policyOpen && (
-        // Folder policy applies to every page under this folder. Shown as a
-        // right-side drawer (the folder listing isn't a flex row like the page
-        // view), reusing the same panel — ``dir`` is the folder path ("" = root).
+      {policyOpen && isMobile && (
         <>
           <div
             onClick={() => setPolicyOpen(false)}
@@ -837,27 +918,30 @@ function NewDocView({ dir }: { dir: string }) {
 
 type SortMode = "name-asc" | "name-desc" | "recent";
 
-function SortBar({
-  value,
-  onChange,
-}: {
-  value: SortMode;
-  onChange: (v: SortMode) => void;
-}) {
+/* Shared card-row chrome for the folder listing (mock table rows 0:599). */
+const ROW_CLASS =
+  "mb-1 flex h-11 items-center rounded-(--border-radius-08) border border-(--border-01) px-2";
+
+function BackRow({ onClick }: { onClick: () => void }) {
   return (
-    <div className="mb-2 flex items-center gap-2 text-xs text-(--text-03)">
-      <label htmlFor="wiki-sort">Sort:</label>
-      <select
-        id="wiki-sort"
-        value={value}
-        onChange={(e) => onChange(e.target.value as SortMode)}
-        className="rounded-(--border-radius-04) border border-(--border-01) bg-(--background-tint-00) px-2 py-1 text-xs text-(--text-05)"
-      >
-        <option value="name-asc">Name (A → Z)</option>
-        <option value="name-desc">Name (Z → A)</option>
-        <option value="recent">Recently updated</option>
-      </select>
-    </div>
+    // raw-ok: the whole 44px table row is the click target. OPAL has no
+    // full-width table-row button primitive (LineItemButton is menu-scale).
+    <li
+      role="button"
+      tabIndex={0}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onClick();
+      }}
+      className={`${ROW_CLASS} cursor-pointer bg-(--background-tint-00) hover:bg-(--background-tint-02)`}
+    >
+      <span className="mr-[10px] flex text-(--text-03)">
+        <SvgChevronLeft size={20} aria-hidden />
+      </span>
+      <span className="flex flex-1 items-center text-sm text-(--text-05)">
+        Back
+      </span>
+    </li>
   );
 }
 
@@ -870,7 +954,6 @@ function Row({
   isFile,
   busy,
   onDelete,
-  onShare,
   renaming,
   onStartRename,
   onCancelRename,
@@ -890,7 +973,6 @@ function Row({
   isFile: boolean;
   busy: boolean;
   onDelete: () => void;
-  onShare?: () => void;
   renaming: boolean;
   onStartRename: () => void;
   onCancelRename: () => void;
@@ -904,6 +986,7 @@ function Row({
 }) {
   const router = useRouter();
   const [hover, setHover] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [draft, setDraft] = useState(label);
 
   useEffect(() => {
@@ -964,7 +1047,7 @@ function Row({
       }
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
-      className={`flex items-center border-b border-(--border-01) px-3 py-[10px] ${dropActive ? "bg-(--background-tint-03) outline outline-2 outline-(--background-tint-inverted-00)" : hover ? "bg-(--background-tint-02)" : "bg-transparent"} ${busy ? "opacity-50" : "opacity-100"} ${renaming ? "cursor-default" : "cursor-pointer"}`}
+      className={`${ROW_CLASS} ${dropActive ? "bg-(--background-tint-03) outline outline-2 outline-(--background-tint-inverted-00)" : hover || menuOpen ? "bg-(--background-tint-02)" : "bg-(--background-tint-00)"} ${busy ? "opacity-50" : "opacity-100"} ${renaming ? "cursor-default" : "cursor-pointer"}`}
     >
       <span className="mr-[10px] flex text-(--text-03)">{icon}</span>
       {renaming ? (
@@ -1010,44 +1093,36 @@ function Row({
         // <li>. flex: 1 keeps it stretching to fill the space between
         // icon and action buttons, so any click on the label area
         // still hits the row's onClick.
-        <span className="flex flex-1 items-center gap-[10px] text-sm text-(--text-05)">
+        <span className="flex min-w-0 flex-1 items-center gap-[10px] overflow-hidden text-sm text-ellipsis whitespace-nowrap text-(--text-05)">
           {label}
         </span>
       )}
       {!renaming && (
         <>
-          <span className="mr-2 text-xs whitespace-nowrap text-(--text-02)">
+          <span className="w-[110px] shrink-0 text-xs whitespace-nowrap text-(--text-02)">
             {updatedAt ? relativeTime(updatedAt, "short") : "—"}
           </span>
-          {onShare && (
-            <button
-              onClick={onShare}
-              disabled={busy}
-              title="Share"
-              aria-label={`Share ${label}`}
-              className={`flex items-center border-none bg-transparent p-[6px] ${busy ? "cursor-not-allowed" : "cursor-pointer"} ${hover ? "text-(--text-04)" : "text-transparent"}`}
+          <span
+            className={`flex transition-opacity duration-100 ${hover || menuOpen ? "opacity-100" : "opacity-0"}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <WikiItemMenu
+              path={path}
+              isFolder={!isFile}
+              open={menuOpen}
+              onOpenChange={setMenuOpen}
+              align="end"
+              overrides={{ rename: onStartRename, remove: onDelete }}
             >
-              <SvgShare size={16} />
-            </button>
-          )}
-          <button
-            onClick={onStartRename}
-            disabled={busy}
-            title="Rename"
-            aria-label={`Rename ${label}`}
-            className={`flex items-center border-none bg-transparent p-[6px] ${busy ? "cursor-not-allowed" : "cursor-pointer"} ${hover ? "text-(--text-04)" : "text-transparent"}`}
-          >
-            <SvgEdit size={16} />
-          </button>
-          <button
-            onClick={onDelete}
-            disabled={busy}
-            title="Delete"
-            aria-label={`Delete ${label}`}
-            className={`flex items-center border-none bg-transparent p-[6px] ${busy ? "cursor-not-allowed" : "cursor-pointer"} ${hover ? "text-(--status-text-error-05)" : "text-transparent"}`}
-          >
-            <SvgTrash size={16} />
-          </button>
+              <Button
+                prominence="tertiary"
+                size="sm"
+                icon={SvgMoreHorizontal}
+                disabled={busy}
+                aria-label={`More actions for ${label}`}
+              />
+            </WikiItemMenu>
+          </span>
         </>
       )}
     </li>

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -14,12 +14,14 @@ import {
   Button,
   Divider,
   EmptyMessageCard,
+  InputTypeIn,
   MessageCard,
   Text,
 } from "@onyx-ai/opal/components";
 import {
   SvgAlertTriangle,
   SvgArrowUpDown,
+  SvgCheck,
   SvgChevronLeft,
   SvgDocFile,
   SvgFolder,
@@ -478,103 +480,109 @@ function Explorer({ dir }: { dir: string }) {
           </p>
         )}
 
-        {(subdirs.length > 0 || files.length > 0) && (
-          // Column header line (mock 709:144294): Name spans, Last Updated
-          // carries the sort control cycling name ascending, descending, recent.
-          <div className="flex items-center px-3 pb-1">
-            <span className="min-w-0 flex-1">
-              <Text font="main-ui-action" color="text-04">
-                Name
+        {/* Table surface: header line + white rows on a tint container
+            (mock's Table, tint-01 on radius-08, rows tint-00 on radius-12). */}
+        <div className="rounded-(--radius-08) bg-(--background-tint-01) p-1">
+          {(subdirs.length > 0 || files.length > 0) && (
+            // Column header line (mock 709:144294): Name spans, Last Updated
+            // carries the sort control cycling name ascending, descending, recent.
+            <div className="flex items-center px-3 pt-1 pb-2">
+              <span className="min-w-0 flex-1">
+                <Text font="main-ui-action" color="text-04">
+                  Name
+                </Text>
+              </span>
+              <Text font="main-ui-action" color="text-04" nowrap>
+                Last Updated
               </Text>
-            </span>
-            <Text font="main-ui-action" color="text-04" nowrap>
-              Last Updated
-            </Text>
-            <Button
-              icon={SvgArrowUpDown}
-              prominence="tertiary"
-              size="sm"
-              tooltip={`Sort: ${sortLabel}`}
-              onClick={cycleSort}
-            />
-          </div>
-        )}
-
-        <ul className="m-0 list-none p-0">
-          {dir && (
-            <BackRow
-              onClick={() =>
-                router.push(parentDir ? `/app/wiki/${parentDir}` : "/app/wiki")
-              }
-            />
+              <Button
+                icon={SvgArrowUpDown}
+                prominence="tertiary"
+                size="sm"
+                tooltip={`Sort: ${sortLabel}`}
+                onClick={cycleSort}
+              />
+            </div>
           )}
-          {(() => {
-            const dirEntries = subdirs.map((d) => ({ ...d, isFile: false }));
-            const fileEntries = files.map((f) => ({ ...f, isFile: true }));
-            // Folders always above docs; ordering within each group is set by `sort`.
-            const ordered = [...dirEntries, ...fileEntries];
-            return ordered.map(({ name, updated_at, isFile }) => {
-              const childPath = (dir ? dir + "/" : "") + name;
-              return (
-                <Row
-                  key={(isFile ? "f:" : "d:") + name}
-                  icon={
-                    isFile ? (
-                      <SvgDocFile size={20} aria-hidden />
-                    ) : (
-                      <SvgFolder size={20} aria-hidden />
-                    )
-                  }
-                  label={name}
-                  updatedAt={updated_at}
-                  href={`/app/wiki/${childPath}`}
-                  path={childPath}
-                  isFile={isFile}
-                  busy={busyPath === childPath}
-                  onDelete={() => onDelete(childPath)}
-                  renaming={renaming === childPath}
-                  onStartRename={() => setRenaming(childPath)}
-                  onCancelRename={() => setRenaming(null)}
-                  onSubmitRename={(v) => onRenameSubmit(childPath, v)}
-                  onDragStart={() => setDragSource(childPath)}
-                  onDragEnd={() => {
-                    setDragSource(null);
-                    setDropTarget(null);
-                  }}
-                  dropActive={!isFile && dropTarget === childPath}
-                  onFolderDragOver={
-                    isFile
-                      ? undefined
-                      : () => {
-                          if (dragSource && dragSource !== childPath) {
-                            setDropTarget(childPath);
+
+          <ul className="m-0 list-none p-0">
+            {dir && (
+              <BackRow
+                onClick={() =>
+                  router.push(
+                    parentDir ? `/app/wiki/${parentDir}` : "/app/wiki",
+                  )
+                }
+              />
+            )}
+            {(() => {
+              const dirEntries = subdirs.map((d) => ({ ...d, isFile: false }));
+              const fileEntries = files.map((f) => ({ ...f, isFile: true }));
+              // Folders always above docs; ordering within each group is set by `sort`.
+              const ordered = [...dirEntries, ...fileEntries];
+              return ordered.map(({ name, updated_at, isFile }) => {
+                const childPath = (dir ? dir + "/" : "") + name;
+                return (
+                  <Row
+                    key={(isFile ? "f:" : "d:") + name}
+                    icon={
+                      isFile ? (
+                        <SvgDocFile size={18} aria-hidden />
+                      ) : (
+                        <SvgFolder size={18} aria-hidden />
+                      )
+                    }
+                    label={name}
+                    updatedAt={updated_at}
+                    href={`/app/wiki/${childPath}`}
+                    path={childPath}
+                    isFile={isFile}
+                    busy={busyPath === childPath}
+                    onDelete={() => onDelete(childPath)}
+                    renaming={renaming === childPath}
+                    onStartRename={() => setRenaming(childPath)}
+                    onCancelRename={() => setRenaming(null)}
+                    onSubmitRename={(v) => onRenameSubmit(childPath, v)}
+                    onDragStart={() => setDragSource(childPath)}
+                    onDragEnd={() => {
+                      setDragSource(null);
+                      setDropTarget(null);
+                    }}
+                    dropActive={!isFile && dropTarget === childPath}
+                    onFolderDragOver={
+                      isFile
+                        ? undefined
+                        : () => {
+                            if (dragSource && dragSource !== childPath) {
+                              setDropTarget(childPath);
+                            }
                           }
-                        }
-                  }
-                  onFolderDragLeave={
-                    isFile
-                      ? undefined
-                      : () =>
-                          setDropTarget((cur) =>
-                            cur === childPath ? null : cur,
-                          )
-                  }
-                  onFolderDrop={
-                    isFile
-                      ? undefined
-                      : () => {
-                          if (dragSource && dragSource !== childPath) {
-                            onMove(dragSource, childPath);
+                    }
+                    onFolderDragLeave={
+                      isFile
+                        ? undefined
+                        : () =>
+                            setDropTarget((cur) =>
+                              cur === childPath ? null : cur,
+                            )
+                    }
+                    onFolderDrop={
+                      isFile
+                        ? undefined
+                        : () => {
+                            if (dragSource && dragSource !== childPath) {
+                              onMove(dragSource, childPath);
+                            }
+                            setDragSource(null);
+                            setDropTarget(null);
                           }
-                          setDragSource(null);
-                          setDropTarget(null);
-                        }
-                  }
-                />
-              );
-            });
-          })()}
-        </ul>
+                    }
+                  />
+                );
+              });
+            })()}
+          </ul>
+        </div>
         <div className="my-2">
           <Divider />
         </div>
@@ -918,9 +926,20 @@ function NewDocView({ dir }: { dir: string }) {
 
 type SortMode = "name-asc" | "name-desc" | "recent";
 
-/* Shared card-row chrome for the folder listing (mock table rows 0:599). */
+/* Shared card-row chrome for the folder listing: borderless white cards on
+   the table's tint background (mock rows 4857:368063). */
 const ROW_CLASS =
-  "mb-1 flex h-11 items-center rounded-(--radius-08) border border-(--border-01) px-2";
+  "mb-1 flex h-11 items-center rounded-(--radius-12) py-1 pr-2 pl-1";
+
+/* The mock's shaded leading box: a 36px tint square holding the row's
+   file/folder glyph (Qualifier Container, tint-01 on radius-08). */
+function RowQualifier({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="mr-2 flex size-9 shrink-0 items-center justify-center rounded-(--radius-08) bg-(--background-tint-01) text-(--text-03)">
+      {children}
+    </span>
+  );
+}
 
 function BackRow({ onClick }: { onClick: () => void }) {
   return (
@@ -935,9 +954,9 @@ function BackRow({ onClick }: { onClick: () => void }) {
       }}
       className={`${ROW_CLASS} cursor-pointer bg-(--background-tint-00) hover:bg-(--background-tint-02)`}
     >
-      <span className="mr-[10px] flex text-(--text-03)">
-        <SvgChevronLeft size={20} aria-hidden />
-      </span>
+      <RowQualifier>
+        <SvgChevronLeft size={18} aria-hidden />
+      </RowQualifier>
       <span className="flex flex-1 items-center text-sm text-(--text-05)">
         Back
       </span>
@@ -1049,16 +1068,19 @@ function Row({
       onMouseLeave={() => setHover(false)}
       className={`${ROW_CLASS} ${dropActive ? "bg-(--background-tint-03) outline outline-2 outline-(--background-tint-inverted-00)" : hover || menuOpen ? "bg-(--background-tint-02)" : "bg-(--background-tint-00)"} ${busy ? "opacity-50" : "opacity-100"} ${renaming ? "cursor-default" : "cursor-pointer"}`}
     >
-      <span className="mr-[10px] flex text-(--text-03)">{icon}</span>
+      <RowQualifier>{icon}</RowQualifier>
       {renaming ? (
+        // Mock rename state (890:418642): the name cell becomes an input with
+        // its text preselected, confirmed by the check button or Enter.
         <form
           onSubmit={(e) => {
             e.preventDefault();
             onSubmitRename(draft);
           }}
-          className="flex flex-1 gap-1.5"
+          className="flex min-w-0 flex-1 items-center"
         >
-          <input
+          <InputTypeIn
+            ref={(el) => el?.select()}
             autoFocus
             value={draft}
             onChange={(e) => setDraft(e.target.value)}
@@ -1068,25 +1090,22 @@ function Row({
                 onCancelRename();
               }
             }}
-            disabled={busy}
-            className="flex-1 rounded-(--radius-04) border border-(--border-01) px-2 py-1 text-sm"
+            aria-label={`Rename ${label}`}
+            rightChildren={
+              // Keep focus in the input across the click so Escape still
+              // works if the request errors.
+              <span onMouseDown={(e) => e.preventDefault()}>
+                <Button
+                  prominence="tertiary"
+                  size="sm"
+                  icon={SvgCheck}
+                  aria-label="Save name"
+                  disabled={busy || !draft.trim()}
+                  onClick={() => onSubmitRename(draft)}
+                />
+              </span>
+            }
           />
-          <Button
-            type="submit"
-            size="sm"
-            variant="action"
-            disabled={busy || !draft.trim()}
-          >
-            Save
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            onClick={onCancelRename}
-            disabled={busy}
-          >
-            Cancel
-          </Button>
         </form>
       ) : (
         // The label is a plain span — the click target is the parent

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -32,6 +32,7 @@ import {
   SvgShield,
   SvgTrash,
   SvgWorkflow,
+  SvgZap,
 } from "@onyx-ai/opal/icons";
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
@@ -41,6 +42,7 @@ import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { StartNewPage } from "@/components/wiki/StartNewPage";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
+import { useRowActions } from "@/providers/WikiItemActionsProvider";
 import { apiFetch, ApiError } from "@/lib/api";
 import { isDocId, wikiHref, wikiPath, revalidateWiki } from "@/lib/wikiHref";
 import { formatRelative } from "@/lib/format";
@@ -173,6 +175,7 @@ function Explorer({ dir }: { dir: string }) {
   const router = useRouter();
   const isMobile = useIsMobile();
   const host = useHeaderActionsHost();
+  const rowActions = useRowActions();
   const { entries, error: listError, mutate: mutatePaths } = useWikiTree();
   const [mutationError, setMutationError] = useState<string | null>(null);
   const confirmDialog = useConfirm();
@@ -374,7 +377,7 @@ function Explorer({ dir }: { dir: string }) {
           setCreating((v) => (v === "folder" ? null : "folder"));
         }}
       />
-      <span aria-hidden className="mx-1 h-5 w-px bg-(--border-01)" />
+      <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
       <Button
         prominence="tertiary"
         rightIcon={SvgLock}
@@ -387,6 +390,12 @@ function Explorer({ dir }: { dir: string }) {
         prominence="tertiary"
         tooltip="Trigger"
         onClick={() => setTriggerModalOpen(true)}
+      />
+      <Button
+        icon={SvgZap}
+        prominence="tertiary"
+        tooltip="Launch Agent"
+        onClick={() => rowActions.launchAgent(dir)}
       />
       {isMobile && (
         <Button

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -437,7 +437,7 @@ function Explorer({ dir }: { dir: string }) {
         {creating && (
           <form
             onSubmit={onCreate}
-            className="mb-4 flex gap-2 rounded-(--border-radius-08) border border-(--border-01) bg-(--background-tint-01) p-3"
+            className="mb-4 flex gap-2 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) p-3"
           >
             <input
               autoFocus
@@ -445,7 +445,7 @@ function Explorer({ dir }: { dir: string }) {
               onChange={(e) => setNewName(e.target.value)}
               placeholder="folder-name (or subdir/folder-name)"
               disabled={createBusy}
-              className="flex-1 rounded-(--border-radius-04) border border-(--border-01) p-2 text-sm"
+              className="flex-1 rounded-(--radius-04) border border-(--border-01) p-2 text-sm"
             />
             <Button
               type="submit"
@@ -467,7 +467,7 @@ function Explorer({ dir }: { dir: string }) {
         )}
 
         {error && (
-          <div className="mb-3 rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+          <div className="mb-3 rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
             {error}
           </div>
         )}
@@ -594,7 +594,7 @@ function Explorer({ dir }: { dir: string }) {
           header button + drawer. */}
       {!isMobile && (
         <aside className="w-[360px] shrink-0 overflow-y-auto p-2">
-          <div className="overflow-hidden rounded-(--border-radius-12) border border-(--border-01)">
+          <div className="overflow-hidden rounded-(--radius-12) border border-(--border-01)">
             <UpdatePolicyPanel path={dir} />
           </div>
         </aside>
@@ -885,7 +885,7 @@ function NewDocView({ dir }: { dir: string }) {
       />
 
       {error && (
-        <div className="rounded-(--border-radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
+        <div className="rounded-(--radius-04) bg-(--status-error-01) p-[10px] text-[13px] text-(--status-text-error-05)">
           {error}
         </div>
       )}
@@ -910,7 +910,7 @@ function NewDocView({ dir }: { dir: string }) {
             ? "Start typing, or pick a template above…"
             : "Start typing your new document…"
         }
-        className="box-border min-h-0 w-full flex-1 resize-none rounded-(--border-radius-08) border border-(--border-01) p-4 font-mono text-sm leading-[1.6] outline-none"
+        className="box-border min-h-0 w-full flex-1 resize-none rounded-(--radius-08) border border-(--border-01) p-4 font-mono text-sm leading-[1.6] outline-none"
       />
     </main>
   );
@@ -920,7 +920,7 @@ type SortMode = "name-asc" | "name-desc" | "recent";
 
 /* Shared card-row chrome for the folder listing (mock table rows 0:599). */
 const ROW_CLASS =
-  "mb-1 flex h-11 items-center rounded-(--border-radius-08) border border-(--border-01) px-2";
+  "mb-1 flex h-11 items-center rounded-(--radius-08) border border-(--border-01) px-2";
 
 function BackRow({ onClick }: { onClick: () => void }) {
   return (
@@ -1069,7 +1069,7 @@ function Row({
               }
             }}
             disabled={busy}
-            className="flex-1 rounded-(--border-radius-04) border border-(--border-01) px-2 py-1 text-sm"
+            className="flex-1 rounded-(--radius-04) border border-(--border-01) px-2 py-1 text-sm"
           />
           <Button
             type="submit"

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -437,14 +437,15 @@ function Explorer({ dir }: { dir: string }) {
             onSubmit={onCreate}
             className="mb-4 flex gap-2 rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) p-3"
           >
-            <input
-              autoFocus
-              value={newName}
-              onChange={(e) => setNewName(e.target.value)}
-              placeholder="folder-name (or subdir/folder-name)"
-              disabled={createBusy}
-              className="flex-1 rounded-(--radius-04) border border-(--border-01) p-2 text-sm"
-            />
+            <span className="min-w-0 flex-1">
+              <InputTypeIn
+                autoFocus
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="folder-name (or subdir/folder-name)"
+                aria-label="New folder name"
+              />
+            </span>
             <Button
               type="submit"
               variant="action"
@@ -1093,7 +1094,7 @@ function Row({
           className="flex min-w-0 flex-1 items-center"
         >
           <InputTypeIn
-            ref={(el) => el?.select()}
+            onFocus={(e) => e.currentTarget.select()}
             autoFocus
             value={draft}
             onChange={(e) => setDraft(e.target.value)}


### PR DESCRIPTION
## Description

First slice of the wiki UI refresh (Figma "Onyx Wiki", section 898-482565).

- **Tree panel**: Wiki Directory header + close control, search-with-filter, chevron-expand without navigating, right-edge row menus, inline new-folder row, fixed 312px card, ellipsis truncation, mock row colors.
- **App header**: Home-rooted breadcrumbs with chevron separators; expand control only while the tree is closed; app sidebar auto-folds to its icon rail while the tree is open.
- **Folder page**: header action cluster (New Page, new folder, Share, trigger, launch-agent), Name/Last Updated column line with cycling sort, Back row, 44px card rows with shaded icon qualifiers and hover kebab menus, inline rename with check confirm, update-policy card inlined in the side column (drawer stays on mobile), shared Start-a-new-page section with in-place More Templates expansion.
- **Fixes ridden along**: app-wide rename of the undefined `--border-radius-*` tokens to opal's real `--radius-*` (38 files were silently square), opal bump to 0.1.17 (new list-tree / arrow-wall-left / zap icons + `renderAppLogo` header API migration).

Pending opal icons (`square-plus`, `more-vertical`) use composed/rotated stand-ins with swap comments.

Note: This just gets the UI looking correct. I will worry about directory/organizational refactoring later

## How Has This Been Tested?

<img width="3452" height="1584" alt="2026-07-16 17 41 17" src="https://github.com/user-attachments/assets/55b0a9d8-cfc0-4de7-8f0e-58a02fb6735f" />


## Additional Options

- [ ] This change should be cherry-picked to the latest release branch
- [x] Override Linear Check