### PR TITLE
refactor(chromes): tighten sidebarLogo type, simplify rendering

### DIFF
--- a/frontend/src/chromes/sidebar/shared.tsx
+++ b/frontend/src/chromes/sidebar/shared.tsx
@@ -7,15 +7,14 @@ import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 /** Logo factory for `SidebarLayouts.Header`'s `renderAppLogo`: the returned
  * component is rendered by the header at its own icon size. */
 export function sidebarLogo(folded: boolean): IconFunctionComponent {
-  return ({ size }) =>
-    folded ? (
-      <SvgOnyxLogo size={size} />
-    ) : (
-      <div className="flex items-center gap-2">
-        <SvgOnyxLogoTyped size={size} />
-        <Text font="heading-h3" color="text-03">
-          Wiki
-        </Text>
-      </div>
-    );
+  return folded
+    ? SvgOnyxLogo
+    : ({ size }) => (
+        <div className="flex items-center gap-2">
+          <SvgOnyxLogoTyped size={size} />
+          <Text font="heading-h3" color="text-03">
+            Wiki
+          </Text>
+        </div>
+      );
 }

--- a/frontend/src/chromes/sidebar/shared.tsx
+++ b/frontend/src/chromes/sidebar/shared.tsx
@@ -6,22 +6,16 @@ import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 
 /** Logo factory for `SidebarLayouts.Header`'s `renderAppLogo`: the returned
  * component is rendered by the header at its own icon size. */
-export function sidebarLogo(
-  folded: boolean | undefined,
-): IconFunctionComponent {
-  const Logo: IconFunctionComponent = ({ size }) => (
-    <div className="flex items-center gap-2 px-1">
-      {folded ? (
-        <SvgOnyxLogo size={size} />
-      ) : (
-        <>
-          <SvgOnyxLogoTyped size={size} />
-          <Text font="heading-h3" color="text-03">
-            Wiki
-          </Text>
-        </>
-      )}
-    </div>
-  );
-  return Logo;
+export function sidebarLogo(folded: boolean): IconFunctionComponent {
+  return ({ size }) =>
+    folded ? (
+      <SvgOnyxLogo size={size} />
+    ) : (
+      <div className="flex items-center gap-2">
+        <SvgOnyxLogoTyped size={size} />
+        <Text font="heading-h3" color="text-03">
+          Wiki
+        </Text>
+      </div>
+    );
 }


### PR DESCRIPTION
## Description

- Narrows `sidebarLogo`'s `folded` param from `boolean | undefined` to `boolean`, matching Opal's actual `renderAppLogo: (folded: boolean) => IconFunctionComponent` signature.
- Drops the wrapping `div`/Fragment in favor of returning each branch (folded vs. expanded) directly.

## Screenshots + Videos

The logo is now properly aligned.

<img width="58" height="1079" alt="image" src="https://github.com/user-attachments/assets/8fc0fd7a-2293-42be-8e0e-8d18009b2531" />