### PR TITLE
feat(automanage): approve/reject endpoints + review coordination

### DIFF
--- a/backend/app/api/detection.py
+++ b/backend/app/api/detection.py
@@ -10,10 +10,11 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.auth import User
+from app.auth import User, require_can
 from app.auth.deps import require_admin, require_user
 from app.models.detection import (
     DetectionRunView,
+    ProposalActionResponse,
     ProposalsResponse,
     ProposalView,
     RunsResponse,
@@ -21,8 +22,12 @@ from app.models.detection import (
 )
 from app.tasks.detection import run_detection_sweep
 from app.wiki import acl
-from app.wiki.automanage import runs
-from app.wiki.change_proposals import ProposalStatus, get as get_proposal, list_by_status
+from app.wiki.automanage import review, runs
+from app.wiki.change_proposals import (
+    ProposalStatus,
+    get as get_proposal,
+    list_by_status,
+)
 
 router = APIRouter()
 
@@ -74,3 +79,39 @@ def get_one_proposal(
     if not _can_see(user, proposal):
         raise HTTPException(status_code=403, detail="not permitted")
     return ProposalView(**proposal)
+
+
+def _load_writable(proposal_id: int, user: User) -> dict[str, Any]:
+    """Fetch a proposal and require the caller can *write* every path it
+    touches — they become the acting user, so the change must fit their
+    permissions (PRD: executed on behalf of someone who could do it by hand).
+    Raises 404 if missing, 403 (via require_can) if not covered."""
+    proposal = get_proposal(proposal_id)
+    if proposal is None:
+        raise HTTPException(status_code=404, detail="proposal not found")
+    for path in list(proposal["source_paths"]) + list(proposal["target_paths"]):
+        require_can("write", path, user)
+    return proposal
+
+
+@router.post("/proposals/{proposal_id}/approve", response_model=ProposalActionResponse)
+def approve_one(
+    proposal_id: int, user: User = Depends(require_user)
+) -> ProposalActionResponse:
+    """Approve a pending proposal and enqueue its execution. The approver
+    becomes the acting user. 409 if it isn't pending (already actioned)."""
+    _load_writable(proposal_id, user)
+    if not review.approve(proposal_id, user_id=user.id):
+        raise HTTPException(status_code=409, detail="proposal is not pending")
+    return ProposalActionResponse(status="approved")
+
+
+@router.post("/proposals/{proposal_id}/reject", response_model=ProposalActionResponse)
+def reject_one(
+    proposal_id: int, user: User = Depends(require_user)
+) -> ProposalActionResponse:
+    """Reject a pending proposal (durable do-not-propose). 409 if not pending."""
+    _load_writable(proposal_id, user)
+    if not review.reject(proposal_id, user_id=user.id):
+        raise HTTPException(status_code=409, detail="proposal is not pending")
+    return ProposalActionResponse(status="rejected")

--- a/backend/app/models/detection.py
+++ b/backend/app/models/detection.py
@@ -1,6 +1,8 @@
 """HTTP shapes for the Wiki Auto Management detection admin API."""
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel
 
 
@@ -45,3 +47,11 @@ class ProposalView(BaseModel):
 
 class ProposalsResponse(BaseModel):
     proposals: list[ProposalView]
+
+
+class ProposalActionResponse(BaseModel):
+    """Result of approving/rejecting a proposal. On approve, execution is
+    enqueued on the detection queue, so ``status`` reflects the decision, not
+    the applied state."""
+
+    status: Literal["approved", "rejected"]

--- a/backend/app/wiki/automanage/review.py
+++ b/backend/app/wiki/automanage/review.py
@@ -1,0 +1,73 @@
+"""Proposal review coordination — the seam between an approval *decision* and
+*execution*.
+
+Both approval sources funnel through here so they share one execution path:
+
+- **human review** — the approve/reject endpoints (`app/api/detection.py`);
+- **AI-managed auto-approval** — `ai_management_allowed` scopes need no human
+  approval, so the runner can `auto_approve` and execute directly (wired in a
+  follow-up).
+
+The only thing that differs between them is the status transition; **enqueuing
+execution is the common piece** (`_dispatch_execution`), factored out here so
+neither path re-implements it and the API router stays thin.
+"""
+from __future__ import annotations
+
+from app.wiki import change_proposals
+from app.wiki.change_proposals import ProposalStatus
+
+
+def _dispatch_execution(proposal_id: int) -> None:
+    """Enqueue execution of an approved proposal on the detection queue — the
+    shared step every approval path calls. Imported lazily so this domain
+    module doesn't hard-depend on the tasks layer at import time (tasks import
+    automanage, not the reverse)."""
+    from app.tasks.detection import execute_proposal
+
+    execute_proposal(proposal_id)
+
+
+def _actionable_after(proposal_id: int, transitioned: bool) -> bool:
+    """Whether execution should be (re-)dispatched. True if we just transitioned
+    the proposal to ``approved``, OR it is *already* ``approved`` — the latter
+    is the recovery case: a prior approval committed the DB transition but its
+    enqueue failed (Redis blip / queue full), leaving the proposal stuck. Since
+    the executor is idempotent on status, re-dispatching is safe, so a retried
+    approve heals it instead of dead-ending at 409. Missing or terminal
+    (applied/rejected/stale/expired) → not actionable."""
+    if transitioned:
+        return True
+    p = change_proposals.get(proposal_id)
+    return p is not None and p["status"] == ProposalStatus.APPROVED.value
+
+
+def approve(proposal_id: int, *, user_id: str) -> bool:
+    """Human approval: transition ``pending → approved`` (the approver becomes
+    the acting user), then execute. Idempotent on an already-approved proposal
+    (re-dispatches). Returns False if the proposal is missing or terminal."""
+    transitioned = change_proposals.approve(proposal_id, user_id=user_id)
+    if not _actionable_after(proposal_id, transitioned):
+        return False
+    _dispatch_execution(proposal_id)
+    return True
+
+
+def auto_approve(proposal_id: int, *, acting_user_id: str) -> bool:
+    """AI-managed auto-approval (no human): ``pending → approved`` with no
+    reviewer, then execute — the same execution path as human approval. For
+    scopes with ``ai_management_allowed`` effective. Idempotent on an
+    already-approved proposal. Returns False if missing or terminal."""
+    transitioned = change_proposals.auto_approve(
+        proposal_id, acting_user_id=acting_user_id
+    )
+    if not _actionable_after(proposal_id, transitioned):
+        return False
+    _dispatch_execution(proposal_id)
+    return True
+
+
+def reject(proposal_id: int, *, user_id: str, reason: str | None = None) -> bool:
+    """Reject a pending proposal (durable do-not-propose). No execution.
+    Returns False if it wasn't pending."""
+    return change_proposals.reject(proposal_id, user_id=user_id, reason=reason)

--- a/backend/tests/test_detection_proposal_actions_api.py
+++ b/backend/tests/test_detection_proposal_actions_api.py
@@ -1,0 +1,96 @@
+"""Approve / reject endpoints for pending cleanup proposals.
+
+Approve requires *write* on every path the proposal touches (the approver
+becomes the acting user) and enqueues execution; `immediate_mode` runs it inline
+so the folder is actually trashed within the request.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.tasks.queues import detection_queue
+from app.wiki import acl
+from app.wiki import git as wiki_git
+from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalOp,
+    create as create_proposal,
+    get as get_proposal,
+)
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def client(tmp_repo):
+    return TestClient(create_app())
+
+
+def _mk(folder: str) -> int:
+    meta = wiki_git.last_commit_meta_for_path(folder)
+    base = meta[0] if meta else "0" * 40
+    return create_proposal(
+        op=ProposalOp.DELETE_EMPTY_FOLDER,
+        source_paths=[folder],
+        target_paths=[],
+        base_shas={folder: base},
+        summary=f"Delete empty folder “{folder}”",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+
+
+def _status(pid: int) -> str:
+    p = get_proposal(pid)
+    assert p is not None
+    return p["status"]
+
+
+def test_approve_executes_and_applies(client):
+    uid = seed_user(uid="u1", email="u@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    wiki_git.commit_file("stale/.gitkeep", "", "create", author=None)
+    pid = _mk("stale")
+
+    with detection_queue.immediate_mode():
+        r = client.post(f"/api/detection/proposals/{pid}/approve")
+    assert r.status_code == 200 and r.json()["status"] == "approved"
+    assert _status(pid) == "applied"
+    assert "stale/.gitkeep" not in wiki_git.list_paths()  # trashed
+
+
+def test_approve_requires_write(client):
+    owner = seed_user(uid="owner", email="o@x.com", is_admin=True)  # first = admin
+    other = seed_user(uid="other", email="ot@x.com", is_admin=False)
+    wiki_git.commit_file("restricted/.gitkeep", "", "create", author=None)
+    pid = _mk("restricted")
+    acl.set_owner("restricted", owner)  # owner + admins only
+
+    login_fastapi(client, other)
+    assert client.post(f"/api/detection/proposals/{pid}/approve").status_code == 403
+    assert _status(pid) == "pending"  # untouched
+
+
+def test_reject_marks_rejected_and_leaves_folder(client):
+    uid = seed_user(uid="u1", email="u@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    wiki_git.commit_file("junk/.gitkeep", "", "create", author=None)
+    pid = _mk("junk")
+
+    r = client.post(f"/api/detection/proposals/{pid}/reject")
+    assert r.status_code == 200 and r.json()["status"] == "rejected"
+    assert _status(pid) == "rejected"
+    assert "junk/.gitkeep" in wiki_git.list_paths()  # untouched
+
+
+def test_approve_twice_conflicts(client):
+    uid = seed_user(uid="u1", email="u@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    wiki_git.commit_file("dup/.gitkeep", "", "create", author=None)
+    pid = _mk("dup")
+
+    with detection_queue.immediate_mode():
+        assert client.post(f"/api/detection/proposals/{pid}/approve").status_code == 200
+        # already applied → no longer pending → 409
+        assert client.post(f"/api/detection/proposals/{pid}/approve").status_code == 409

--- a/backend/tests/test_detection_review.py
+++ b/backend/tests/test_detection_review.py
@@ -1,0 +1,104 @@
+"""Proposal review coordination — the shared approval→execution seam.
+
+Both approval sources (human `approve`, AI-managed `auto_approve`) run the same
+execution path; `reject` never executes. `immediate_mode` runs the enqueued
+execution inline.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.auth.users import AI_USER_ID
+from app.tasks.queues import detection_queue
+from app.wiki import git as wiki_git
+from app.wiki.automanage import review
+from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalOp,
+    create as create_proposal,
+    get as get_proposal,
+)
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def repo(tmp_repo):
+    return tmp_repo
+
+
+def _mk(folder: str) -> int:
+    return create_proposal(
+        op=ProposalOp.DELETE_EMPTY_FOLDER,
+        source_paths=[folder],
+        target_paths=[],
+        base_shas={folder: "0" * 40},
+        summary=f"Delete empty folder “{folder}”",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+
+
+def _get(pid: int) -> dict:
+    p = get_proposal(pid)
+    assert p is not None
+    return p
+
+
+def test_human_approve_executes_and_binds_reviewer(repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("stale/.gitkeep", "", "create", author=None)
+    pid = _mk("stale")
+    with detection_queue.immediate_mode():
+        assert review.approve(pid, user_id=uid)
+    p = _get(pid)
+    assert p["status"] == "applied"
+    assert p["reviewed_by_user_id"] == uid  # human reviewer bound
+    assert "stale/.gitkeep" not in wiki_git.list_paths()
+
+
+def test_auto_approve_executes_without_a_reviewer(repo):
+    # The AI system user is seeded by migration; use it as the acting principal.
+    wiki_git.commit_file("ai-managed/.gitkeep", "", "create", author=None)
+    pid = _mk("ai-managed")
+    with detection_queue.immediate_mode():
+        assert review.auto_approve(pid, acting_user_id=AI_USER_ID)
+    p = _get(pid)
+    assert p["status"] == "applied"  # same execution path as human approval
+    assert p["reviewed_by_user_id"] is None  # auto: no human reviewer
+    assert p["acting_user_id"] == AI_USER_ID
+    assert "ai-managed/.gitkeep" not in wiki_git.list_paths()
+
+
+def test_reject_does_not_execute(repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("junk/.gitkeep", "", "create", author=None)
+    pid = _mk("junk")
+    assert review.reject(pid, user_id=uid, reason="not wanted")
+    p = _get(pid)
+    assert p["status"] == "rejected"
+    assert "junk/.gitkeep" in wiki_git.list_paths()  # untouched
+
+
+def test_approve_non_pending_returns_false(repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("x/.gitkeep", "", "create", author=None)
+    pid = _mk("x")
+    with detection_queue.immediate_mode():
+        assert review.approve(pid, user_id=uid)
+        assert review.approve(pid, user_id=uid) is False  # already applied
+
+
+def test_approve_recovers_stuck_approved(repo):
+    # Simulate a prior approval whose enqueue failed: the DB transition to
+    # 'approved' committed, but execution never ran. A retried approve must
+    # re-dispatch (heal) rather than dead-end.
+    from app.wiki.change_proposals import approve as cp_approve
+
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("stuck/.gitkeep", "", "create", author=None)
+    pid = _mk("stuck")
+    assert cp_approve(pid, user_id=uid)  # pending -> approved, no dispatch
+    assert _get(pid)["status"] == "approved"
+
+    with detection_queue.immediate_mode():
+        assert review.approve(pid, user_id=uid) is True  # re-dispatches
+    assert _get(pid)["status"] == "applied"


### PR DESCRIPTION
The **approval surface** for Wiki Auto Management — the human review endpoints plus the seam that drives the executor. **Stacked on #434** (the executor).

## What's here
- **`automanage/review.py`** — the coordination seam between an approval *decision* and *execution*. `approve()` / `auto_approve()` share one `_dispatch_execution()` (the common piece); `reject()` never executes. Human vs. AI-managed differ *only* in the status transition, so the future AI-managed auto-approve path reuses this untouched.
  - **Idempotent recovery**: if a prior approval committed the `pending→approved` DB transition but its enqueue failed (Redis blip / queue full), a retried approve **re-dispatches** rather than dead-ending at 409 — the executor's status guard makes the duplicate a no-op.
- **Thin router**: `POST /proposals/{id}/approve` (`require_can("write", …)` on every path — the approver becomes the acting user) and `/reject`; `409` if not pending. `ProposalActionResponse.status` is `Literal["approved","rejected"]`.

## Tests (green; basedpyright + ruff clean)
Review coordination — human `approve` binds the reviewer; `auto_approve` leaves reviewer NULL but hits the same execution path; `reject` no-exec; not-pending → False; **stuck-`approved` retry recovery**. API — approve executes + applies, requires write (403 for non-writer), reject, approve-twice → 409.

## Review order
#434 (executor) → **this**. Then the pending-cleanups queue UI, and wiring `review.auto_approve` into the runner for `ai_management_allowed` scopes.