### PR TITLE
feat(wiki): source ranges, map ingested content to its source

### DIFF
--- a/backend/app/db/migrations/versions/d8b2f1a05c93_source_ranges.py
+++ b/backend/app/db/migrations/versions/d8b2f1a05c93_source_ranges.py
@@ -1,0 +1,62 @@
+"""source ranges
+
+Adds ``source_ranges``, the content-level map from a span of a wiki page to the
+ingested document that produced it. One row per changed span of an ingest
+commit, anchored like a comment (``doc_path`` + ``anchor_sha`` + offsets) so the
+same remap keeps it accurate and a rewrite retires it. Guarded with the
+inspector because ``0001_initial`` builds fresh databases from the current
+models.
+
+Revision ID: d8b2f1a05c93
+Revises: c7a1f0e3b2d9
+Create Date: 2026-07-17 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "d8b2f1a05c93"
+down_revision: str | None = "c7a1f0e3b2d9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("source_ranges"):
+        return
+    op.create_table(
+        "source_ranges",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("provenance_id", sa.Integer(), nullable=False),
+        sa.Column("doc_path", sa.Text(), nullable=False),
+        sa.Column("anchor_sha", sa.Text(), nullable=False),
+        sa.Column("start_offset", sa.Integer(), nullable=False),
+        sa.Column("end_offset", sa.Integer(), nullable=False),
+        sa.Column("quoted_text", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), server_default=sa.text("'live'"), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("status IN ('live', 'retired')", name="source_ranges_status_check"),
+        sa.ForeignKeyConstraint(["provenance_id"], ["provenance_ledger.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_source_ranges_doc_path_status", "source_ranges", ["doc_path", "status"])
+    op.create_index("idx_source_ranges_provenance_id", "source_ranges", ["provenance_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("source_ranges"):
+        op.drop_table("source_ranges")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1501,6 +1501,42 @@ class ProvenanceLedger(Base):
     )
 
 
+class SourceRange(Base):
+    """A span of a wiki page mapped to the ingested document that produced it.
+
+    One row per changed span of an ingest commit. Anchored like a comment
+    (``doc_path`` + ``anchor_sha`` + ``[start_offset, end_offset)``) so the remap
+    in ``app/wiki/provenance_remap.py`` keeps it accurate across later edits and
+    retires it (``status='retired'``) when its span is rewritten. ``provenance_id``
+    links to the ledger row that carries the source document.
+    """
+
+    __tablename__ = "source_ranges"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    provenance_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("provenance_ledger.id", ondelete="CASCADE"), nullable=False
+    )
+    doc_path: Mapped[str] = mapped_column(Text, nullable=False)
+    anchor_sha: Mapped[str] = mapped_column(Text, nullable=False)
+    start_offset: Mapped[int] = mapped_column(Integer, nullable=False)
+    end_offset: Mapped[int] = mapped_column(Integer, nullable=False)
+    quoted_text: Mapped[str] = mapped_column(Text, nullable=False)
+    # SourceRangeStatus values (app/models/wiki.py), mirrored by the CHECK below.
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'live'"))
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('live', 'retired')", name="source_ranges_status_check"
+        ),
+        Index("idx_source_ranges_doc_path_status", "doc_path", "status"),
+        Index("idx_source_ranges_provenance_id", "provenance_id"),
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Comments — human discussion anchored to wiki pages (Postgres-only)          #
 # --------------------------------------------------------------------------- #

--- a/backend/app/db/provenance.py
+++ b/backend/app/db/provenance.py
@@ -1,23 +1,23 @@
-"""Repo for the provenance ledger. One append-only row per
-``(commit_sha, doc_path)`` in ``provenance_ledger`` recording who produced a
-wiki commit and, for ingestion, the source document.
+"""Repo for the provenance ledger and its source ranges. One append-only row per
+``(commit_sha, doc_path)`` in ``provenance_ledger`` records who produced a wiki
+commit and, for ingestion, the source document; ``source_ranges`` maps the spans
+an ingest commit changed to that document, anchored like a comment.
 
-All provenance DB access lives here. Callers pass primitives and get ids or
-plain dicts back. The service in ``app/wiki/provenance.py`` classifies the
-writer, falls back to the git author, and maps to the pydantic read shapes on
-top of these functions.
+All provenance DB access lives here. Callers pass primitives and get ids or plain
+dicts back. The service in ``app/wiki/provenance.py`` classifies the writer,
+falls back to the git author, and maps to the pydantic read shapes on top.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, insert, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
-from app.db.models import ProvenanceLedger, User
+from app.db.models import ProvenanceLedger, SourceRange, User
 from app.db.session import session
-from app.models.wiki import ActorKind
+from app.models.wiki import ActorKind, SourceRangeStatus
 
 # Ledger columns a reader needs; returned as a plain dict so callers don't hold
 # an ORM row past the session.
@@ -86,14 +86,12 @@ def insert_ledger(
 
 
 def rename_doc(old_path: str, new_path: str) -> None:
-    """Re-key ledger rows from a moved page's old path to its new one, so readers
-    that key on ``doc_path`` still reach commits made under the old name."""
+    """Re-key ledger rows and source ranges from a moved page's old path to its
+    new one, so readers that key on ``doc_path`` still reach commits made under
+    the old name."""
     with session() as s:
-        s.execute(
-            update(ProvenanceLedger)
-            .where(ProvenanceLedger.doc_path == old_path)
-            .values(doc_path=new_path)
-        )
+        for model in (ProvenanceLedger, SourceRange):
+            s.execute(update(model).where(model.doc_path == old_path).values(doc_path=new_path))
 
 
 def delete_for_doc(doc_path: str) -> None:
@@ -126,8 +124,21 @@ def ledger_rows_for_commits(commit_shas: list[str], doc_path: str) -> list[dict[
 
 
 def ingestion_source_rows(doc_path: str, limit: int) -> list[dict[str, Any]]:
-    """Ingestion ledger rows for a page, newest first, capped at ``limit`` — the
-    raw rows behind the Sources list, before dedup."""
+    """Ingestion ledger rows still credited to a page, newest first, capped at
+    ``limit`` — the raw rows behind the Sources list, before dedup. A row is kept
+    while it has a live span or has captured no spans at all, and drops only once
+    every span it captured is retired."""
+    live_span = (
+        select(SourceRange.id)
+        .where(
+            SourceRange.provenance_id == ProvenanceLedger.id,
+            SourceRange.status == SourceRangeStatus.LIVE.value,
+        )
+        .exists()
+    )
+    any_span = (
+        select(SourceRange.id).where(SourceRange.provenance_id == ProvenanceLedger.id).exists()
+    )
     with session() as s:
         rows = (
             s.execute(
@@ -135,6 +146,7 @@ def ingestion_source_rows(doc_path: str, limit: int) -> list[dict[str, Any]]:
                 .where(
                     ProvenanceLedger.doc_path == doc_path,
                     ProvenanceLedger.actor_kind == ActorKind.INGESTION.value,
+                    or_(live_span, ~any_span),
                 )
                 .order_by(ProvenanceLedger.id.desc())
                 .limit(limit)
@@ -143,3 +155,65 @@ def ingestion_source_rows(doc_path: str, limit: int) -> list[dict[str, Any]]:
             .all()
         )
     return [_ledger_dict(r) for r in rows]
+
+
+# --------------------------------------------------------------------------- #
+# Source ranges                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def replace_source_ranges(provenance_id: int, rows: list[dict[str, Any]]) -> None:
+    """Replace the source ranges linked to a ledger row with ``rows`` (each a
+    span dict). Idempotent per ledger row: existing ranges are cleared first, so
+    re-processing a commit does not duplicate them."""
+    with session() as s:
+        s.execute(delete(SourceRange).where(SourceRange.provenance_id == provenance_id))
+        if rows:
+            s.execute(insert(SourceRange), [{"provenance_id": provenance_id, **r} for r in rows])
+
+
+def live_ranges_needing_remap(doc_path: str, head_sha: str) -> list[dict[str, Any]]:
+    """Live source ranges on a page whose anchor is not at HEAD, for the remap
+    pass to re-derive against the current body."""
+    with session() as s:
+        rows = s.scalars(
+            select(SourceRange).where(
+                SourceRange.doc_path == doc_path,
+                SourceRange.status == SourceRangeStatus.LIVE.value,
+                SourceRange.anchor_sha != head_sha,
+            )
+        ).all()
+        return [
+            {
+                "id": r.id,
+                "anchor_sha": r.anchor_sha,
+                "start_offset": r.start_offset,
+                "end_offset": r.end_offset,
+            }
+            for r in rows
+        ]
+
+
+def apply_range_remap(
+    range_id: int, *, start_offset: int, end_offset: int, quoted_text: str, anchor_sha: str
+) -> None:
+    """Advance a source range's anchor to a new commit after a successful remap."""
+    with session() as s:
+        r = s.get(SourceRange, range_id)
+        if r is None:
+            return
+        r.start_offset = start_offset
+        r.end_offset = end_offset
+        r.quoted_text = quoted_text
+        r.anchor_sha = anchor_sha
+
+
+def retire_range(range_id: int) -> None:
+    """Mark a source range retired: its span was rewritten, so it no longer
+    points at content its source produced. The row and its span stay for history,
+    but a source drops off a page's list once none of its spans are live."""
+    with session() as s:
+        r = s.get(SourceRange, range_id)
+        if r is None:
+            return
+        r.status = SourceRangeStatus.RETIRED.value

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -74,6 +74,14 @@ class ActorKind(str, Enum):
     SYSTEM = "system"
 
 
+class SourceRangeStatus(str, Enum):
+    """Valid ``source_ranges.status`` values. Single source of truth, mirrored
+    by the CHECK constraint in ``app/db/models.py``."""
+
+    LIVE = "live"
+    RETIRED = "retired"
+
+
 class WriteProvenance(BaseModel):
     """Source facts for an ingestion write, threaded through the commit gateway
     into the provenance ledger. Set only for ingestion writes.

--- a/backend/app/wiki/anchor_remap.py
+++ b/backend/app/wiki/anchor_remap.py
@@ -1,0 +1,89 @@
+"""Shared skeleton for re-anchoring span records when a commit changes a page body.
+
+Comments and ingest source ranges both anchor a ``[start_offset, end_offset)``
+range to a page at an ``anchor_sha`` and re-derive it against later commits. This
+holds the one non-trivial part they share: run synchronously from
+``app.wiki.notify`` right after a write, batch the git reads by ``anchor_sha``
+(a page's records almost always share the previous HEAD, so it reads the old
+body once and the new body once), follow renames, and run the pure
+``comment_anchor.remap_range`` diff per record. The per-type differences (which
+records are stale, and what to do with a survivor vs a lost span) are the three
+callbacks.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Callable
+from typing import Any
+
+from app.wiki import comment_anchor
+from app.wiki import git as wiki_git
+from app.wiki.git import UnknownSha
+
+log = logging.getLogger(__name__)
+
+# (doc_path, head_sha) -> stale rows, each a dict with id/anchor_sha/start_offset/end_offset.
+FetchStale = Callable[[str, str], list[dict[str, Any]]]
+# (row_id, *, start_offset, end_offset, quoted_text, anchor_sha) -> None.
+OnRemapped = Callable[..., None]
+# (row_id) -> None.
+OnLost = Callable[[Any], None]
+
+
+def remap_anchored(
+    path: str, *, fetch_stale: FetchStale, on_remapped: OnRemapped, on_lost: OnLost
+) -> None:
+    """Bring every stale anchored span on ``path`` up to the current HEAD."""
+    if not path.endswith(".md"):
+        return
+    head = wiki_git.head_sha_for_path(path)
+    if head is None:
+        return  # untracked / no commits touch this path
+    rows = fetch_stale(path, head)
+    if not rows:
+        return
+    try:
+        new_body = wiki_git.read_file(path, head)
+    except UnknownSha:
+        log.warning("remap_anchored: cannot read %s at HEAD %s", path, head)
+        return
+
+    by_anchor: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in rows:
+        by_anchor[r["anchor_sha"]].append(r)
+
+    for anchor_sha, group in by_anchor.items():
+        old_body = _read_old_body(path, anchor_sha)
+        if old_body is None:
+            continue
+        for r in group:
+            result = comment_anchor.remap_range(
+                old_body, new_body, r["start_offset"], r["end_offset"]
+            )
+            if result is None:
+                on_lost(r["id"])
+            else:
+                start, end = result
+                on_remapped(
+                    r["id"],
+                    start_offset=start,
+                    end_offset=end,
+                    quoted_text=new_body[start:end],
+                    anchor_sha=head,
+                )
+
+
+def _read_old_body(path: str, anchor_sha: str) -> str | None:
+    """Read the page body at ``anchor_sha``, following any rename. Returns
+    ``None`` (caller skips the group) when the anchor commit is not reachable,
+    leaving those records untouched to retry on the next commit."""
+    old_path = wiki_git.path_at_ref(path, anchor_sha)
+    if old_path is None:
+        log.warning("remap_anchored: anchor %s not in history of %s", anchor_sha, path)
+        return None
+    try:
+        return wiki_git.read_file(old_path, anchor_sha)
+    except UnknownSha:
+        log.warning("remap_anchored: cannot read %s at anchor %s", old_path, anchor_sha)
+        return None

--- a/backend/app/wiki/comment_remap.py
+++ b/backend/app/wiki/comment_remap.py
@@ -1,93 +1,21 @@
 """Re-anchor wiki page comments when a commit changes the page body.
 
-Runs **synchronously** from ``app.wiki.notify`` right after a write commits, so
-a comment's stored offsets are correct as soon as the save returns — no
-eventual-consistency window. This applies uniformly to human saves, API edits,
-and agent rewrites, since all of them land as commits through ``notify``.
-
-It's cheap to do inline because the git reads are **batched by anchor_sha**: in
-steady state every comment on a page shares the same anchor (the previous
-HEAD), so we read the old body once and the new body once regardless of how
-many comments the page has, then run an in-memory ``difflib`` diff per comment
-(see ``app/wiki/comment_anchor.py``). Two git reads plus pure-CPU diffs sit well
-within a request budget.
-
-The caller in ``notify`` swallows failures so a remap hiccup can never break a
-save, and the API read path remaps inline if it ever sees a stale anchor — so
+A thin binding of the shared ``anchor_remap`` skeleton to the comments repo. The
+caller in ``notify`` swallows failures so a remap hiccup can never break a save,
+and the API read path remaps inline if it ever sees a stale anchor, so
 correctness never depends on this having run.
 """
 from __future__ import annotations
 
-import logging
-from collections import defaultdict
-from typing import Any
-
-from app.wiki import comment_anchor, comments
-from app.wiki import git as wiki_git
-from app.wiki.git import UnknownSha
-
-log = logging.getLogger(__name__)
+from app.wiki import comments
+from app.wiki.anchor_remap import remap_anchored
 
 
 def remap_comments(path: str) -> None:
     """Bring every stale comment anchor on ``path`` up to the current HEAD."""
-    if not path.endswith(".md"):
-        return
-    head = wiki_git.head_sha_for_path(path)
-    if head is None:
-        return  # untracked / no commits touch this path
-    roots = comments.roots_needing_remap(path, head)
-    if not roots:
-        return
-    try:
-        new_body = wiki_git.read_file(path, head)
-    except UnknownSha:
-        log.warning("remap_comments: cannot read %s at HEAD %s", path, head)
-        return
-
-    # Group by the commit each comment is anchored at: comments on a page
-    # almost always share one anchor_sha (the previous HEAD), so this reads
-    # each old body once rather than once per comment.
-    by_anchor: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for c in roots:
-        by_anchor[c["anchor_sha"]].append(c)
-
-    for anchor_sha, group in by_anchor.items():
-        old_body = _read_old_body(path, anchor_sha)
-        if old_body is None:
-            continue
-        for c in group:
-            _apply(c, old_body, new_body, head)
-
-
-def _read_old_body(path: str, anchor_sha: str) -> str | None:
-    """Read the page body at ``anchor_sha``, following any rename so
-    ``git show <sha>:<path>`` resolves. Returns ``None`` (caller skips the
-    group) when the anchor commit isn't reachable — better to leave those
-    comments untouched and retry on the next commit than to guess."""
-    old_path = wiki_git.path_at_ref(path, anchor_sha)
-    if old_path is None:
-        log.warning("remap_comments: anchor %s not in history of %s", anchor_sha, path)
-        return None
-    try:
-        return wiki_git.read_file(old_path, anchor_sha)
-    except UnknownSha:
-        log.warning("remap_comments: cannot read %s at anchor %s", old_path, anchor_sha)
-        return None
-
-
-def _apply(c: dict[str, Any], old_body: str, new_body: str, head: str) -> None:
-    result = comment_anchor.remap_range(
-        old_body, new_body, c["start_offset"], c["end_offset"]
+    remap_anchored(
+        path,
+        fetch_stale=comments.roots_needing_remap,
+        on_remapped=comments.apply_remap,
+        on_lost=comments.orphan,
     )
-    if result is None:
-        comments.orphan(c["id"])
-    else:
-        start, end = result
-        comments.apply_remap(
-            c["id"],
-            start_offset=start,
-            end_offset=end,
-            quoted_text=new_body[start:end],
-            anchor_sha=head,
-        )

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -40,6 +40,7 @@ from app.tasks.update_frequency import check_update_frequency
 from app.triggers import repo as triggers_repo
 from app.wiki import acl, agent_activity, coedit, comments, constants as wiki_constants, doc_ids, drafts, update_policy
 from app.wiki.comment_remap import remap_comments
+from app.wiki.provenance_remap import remap_source_ranges
 from app.models.wiki import ChangeKind, PathMove
 
 log = logging.getLogger(__name__)
@@ -64,6 +65,15 @@ def _delete_provenance_safe(doc_path: str) -> None:
         db_provenance.delete_for_doc(doc_path)
     except Exception:
         log.exception("provenance delete failed for %s", doc_path)
+
+
+def _remap_source_ranges_safe(path: str) -> None:
+    """Re-anchor ingest source ranges inline, but never let a remap failure
+    abort a save. A stale range self-heals on the next edit."""
+    try:
+        remap_source_ranges(path)
+    except Exception:
+        log.exception("source range remap failed for %s", path)
 
 
 def _remap_comments_safe(path: str) -> None:
@@ -120,6 +130,7 @@ def after_doc_write(
     # Drift any comments anchored to this page onto the new body. A no-op on
     # CREATE (no comments yet); the real work is on EDIT.
     _remap_comments_safe(rel_path)
+    _remap_source_ranges_safe(rel_path)
     mcp_pubsub.publish_doc_update(rel_path, sha, change_kind)
     # Fold this commit into any open co-edit session for the page (skip for a
     # session's own checkpoint commit — trigger_coedit_rebase=False).
@@ -303,6 +314,8 @@ def after_path_move(
             # Other live pointers follow the page to its new path.
             agent_activity.rename_doc(old_p, new_p)
             _rename_provenance_safe(old_p, new_p)
+            # Ranges are re-keyed to new_p now, so the remap query finds them.
+            _remap_source_ranges_safe(new_p)
             drafts.rename(old_p, new_p)
             page_dirs.rename_page(old_wiki_path=old_p, new_wiki_path=new_p)
         elif old_is_md:

--- a/backend/app/wiki/provenance.py
+++ b/backend/app/wiki/provenance.py
@@ -7,12 +7,16 @@ saves, agent tool calls, and connector ingestion are all captured in one place.
 Commits that bypass the gateway (seeding, ``.gitkeep`` creates, move and trash
 commits) have no row, and readers fall back to the git author. This is the
 structured record the byline, History, and the Sources tab read from.
+
+For ingestion, ``source_ranges`` maps the spans an ingest commit changed to the
+document it came from, anchored like a comment so it survives later edits.
 """
 
 from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Sequence
+from difflib import SequenceMatcher
 from typing import Any
 
 from app.auth.users import UserKind
@@ -76,6 +80,43 @@ def record(
         agent_session_id=agent_session_id,
         source_values=source.model_dump() if source else {},
     )
+
+
+# --------------------------------------------------------------------------- #
+# Source ranges: map an ingest commit's changed spans to its source document    #
+# --------------------------------------------------------------------------- #
+
+
+def changed_spans(old_body: str, new_body: str) -> list[tuple[int, int]]:
+    """Character spans in ``new_body`` that differ from ``old_body`` (the
+    replace and insert hunks), for attributing an ingest commit's edits to the
+    document it came from."""
+    return [
+        (j1, j2)
+        for tag, _i1, _i2, j1, j2 in SequenceMatcher(
+            None, old_body, new_body, autojunk=False
+        ).get_opcodes()
+        if tag in ("replace", "insert")
+    ]
+
+
+def capture_source_ranges(
+    *, provenance_id: int, doc_path: str, anchor_sha: str, old_body: str, new_body: str
+) -> None:
+    """Record which spans of ``new_body`` an ingest commit changed, linked to its
+    ledger row. Idempotent per ledger row: the repo replaces any existing ranges,
+    so re-processing a commit does not duplicate them."""
+    rows = [
+        {
+            "doc_path": doc_path,
+            "anchor_sha": anchor_sha,
+            "start_offset": start,
+            "end_offset": end,
+            "quoted_text": new_body[start:end],
+        }
+        for start, end in changed_spans(old_body, new_body)
+    ]
+    repo.replace_source_ranges(provenance_id, rows)
 
 
 # --------------------------------------------------------------------------- #
@@ -151,9 +192,15 @@ def head_attribution(doc_path: str, head_sha: str | None) -> Attribution | None:
 
 
 def sources_for_path(doc_path: str) -> list[SourceRef]:
-    """Distinct ingested documents that have contributed to a page, newest
-    first, deduped on source document id (falling back to url or title). Rows
-    carrying none of the three cannot be told apart, so each is kept."""
+    """Distinct ingested documents still credited to a page, newest first,
+    deduped on source document id (falling back to url or title). Rows carrying
+    none of the three cannot be told apart, so each is kept.
+
+    A source stays listed until there is positive evidence its content is gone:
+    the repo drops a row only once every span its ingest captured has been
+    retired. A row whose ingest captured no spans (a no-content ingest, or one
+    made before span capture existed) carries no such evidence, so it stays.
+    """
     seen: set[str] = set()
     out: list[SourceRef] = []
     for row in repo.ingestion_source_rows(doc_path, _SOURCES_SCAN_LIMIT):

--- a/backend/app/wiki/provenance_remap.py
+++ b/backend/app/wiki/provenance_remap.py
@@ -1,0 +1,21 @@
+"""Re-anchor ingest source ranges when a commit changes the page body.
+
+A thin binding of the shared ``anchor_remap`` skeleton to the provenance repo. A
+range whose span survives is advanced to the new HEAD, one whose span was
+rewritten is retired. The caller in ``notify`` swallows failures so a remap
+hiccup can never break a save.
+"""
+from __future__ import annotations
+
+from app.db import provenance as db_provenance
+from app.wiki.anchor_remap import remap_anchored
+
+
+def remap_source_ranges(path: str) -> None:
+    """Bring every live source range on ``path`` up to the current HEAD."""
+    remap_anchored(
+        path,
+        fetch_stale=db_provenance.live_ranges_needing_remap,
+        on_remapped=db_provenance.apply_range_remap,
+        on_lost=db_provenance.retire_range,
+    )

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -330,7 +330,7 @@ def _commit_resolved(
     # Best-effort, the commit already succeeded, so a ledger failure must
     # never turn a successful save into an error.
     try:
-        provenance.record(
+        provenance_id = provenance.record(
             commit_sha=sha,
             doc_path=path,
             user_id=user.id if user is not None else None,
@@ -338,8 +338,18 @@ def _commit_resolved(
             agent_session_id=launcher_sid,
             source=source,
         )
+        # Ingestion also records which spans it changed, linked to this ledger
+        # row, so the content can later be mapped back to the document it came from.
+        if source is not None and provenance_id is not None:
+            provenance.capture_source_ranges(
+                provenance_id=provenance_id,
+                doc_path=path,
+                anchor_sha=sha,
+                old_body=old_body,
+                new_body=body,
+            )
     except Exception:
-        log.warning("provenance.record failed for %s @ %s", path, sha, exc_info=True)
+        log.warning("provenance record/capture failed for %s @ %s", path, sha, exc_info=True)
 
     if user is not None and record_activity:
         upsert_kwargs: dict[str, Any] = dict(

--- a/backend/tests/test_migration_chain.py
+++ b/backend/tests/test_migration_chain.py
@@ -1,0 +1,62 @@
+"""Alembic migration chain integrity.
+
+CI only ever builds a schema through ``init_db`` (``alembic upgrade head``, on
+top of ``0001``'s ``create_all``), so a stray ``down_revision`` that forks the
+history or a migration that can't be re-run is invisible to it. These assert one
+head (no divergence) and that the provenance migrations survive a real
+down-then-up round trip, which nothing else exercises.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import command
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+
+from app.db.session import _alembic_config, get_engine
+
+# The write-side migration. Its down_revision is the point we roll back to.
+_PROVENANCE_LEDGER = "c7a1f0e3b2d9"
+_PROVENANCE_TABLES = ("provenance_ledger", "source_ranges")
+
+
+def _current_revision() -> str | None:
+    with get_engine().connect() as conn:
+        return MigrationContext.configure(conn).get_current_revision()
+
+
+def _has_table(name: str) -> bool:
+    return sa.inspect(get_engine()).has_table(name)
+
+
+def test_single_head_revision():
+    """Exactly one head. A forked or dangling down_revision shows up here."""
+    heads = ScriptDirectory.from_config(_alembic_config()).get_heads()
+    assert len(heads) == 1, f"diverged migration history, expected one head, got {heads}"
+
+
+def test_provenance_migrations_round_trip(tmp_db):
+    """Downgrade past the provenance migrations then upgrade back to head.
+
+    The fixture leaves the schema at head. Rolling back drops the source-range
+    and ledger tables and re-running the chain recreates them, so a broken
+    downgrade or a create that no longer matches the model fails here rather
+    than only on a real production upgrade.
+    """
+    cfg = _alembic_config()
+    script = ScriptDirectory.from_config(cfg)
+    head = script.get_heads()[0]
+    before_provenance = script.get_revision(_PROVENANCE_LEDGER).down_revision
+    assert isinstance(before_provenance, str)  # linear parent, not a merge point
+
+    assert _current_revision() == head
+    assert all(_has_table(t) for t in _PROVENANCE_TABLES)
+
+    command.downgrade(cfg, before_provenance)
+    assert _current_revision() == before_provenance
+    assert not any(_has_table(t) for t in _PROVENANCE_TABLES)
+
+    command.upgrade(cfg, "head")
+    assert _current_revision() == head
+    assert all(_has_table(t) for t in _PROVENANCE_TABLES)

--- a/backend/tests/test_provenance_reads.py
+++ b/backend/tests/test_provenance_reads.py
@@ -1,5 +1,5 @@
-"""Provenance read side (app/wiki/provenance.py). Attribution resolution, the
-batched history lookup, and the per-page source list. Real DB for the queries.
+"""Provenance read side (app/wiki/provenance.py). Attribution resolution and
+the batched history lookup. Real DB for the queries.
 """
 
 from __future__ import annotations
@@ -93,30 +93,3 @@ def test_head_attribution_from_ledger(tmp_db):
     assert a is not None
     assert a.actor_kind == "ingestion"
     assert a.source_title == "Doc"
-
-
-def test_sources_for_path_dedups_newest_first(tmp_db):
-    for sha, doc_id in [("s1", "dup"), ("s2", "dup"), ("s3", "other")]:
-        provenance.record(
-            commit_sha=sha,
-            doc_path="P.md",
-            user_id=None,
-            agent_name=None,
-            agent_session_id=None,
-            source=WriteProvenance(source_document_id=doc_id, source_title=sha),
-        )
-    ids = [s.source_document_id for s in provenance.sources_for_path("P.md")]
-    assert ids == ["other", "dup"]
-
-
-def test_sources_for_path_keeps_anonymous_rows(tmp_db):
-    for sha in ["a1", "a2"]:
-        provenance.record(
-            commit_sha=sha,
-            doc_path="P.md",
-            user_id=None,
-            agent_name=None,
-            agent_session_id=None,
-            source=WriteProvenance(source_type="slack"),
-        )
-    assert len(provenance.sources_for_path("P.md")) == 2

--- a/backend/tests/test_source_ranges.py
+++ b/backend/tests/test_source_ranges.py
@@ -1,0 +1,256 @@
+"""Source ranges (app/wiki/provenance.py service + app/db/provenance.py repo +
+provenance_remap.py). Diff-to-span
+capture, the ledger-id return that links them, the remap CRUD and orchestration,
+move follow, and the per-page source list. Real DB, and a tmp git repo
+for the remap tests.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.db.models import ProvenanceLedger, SourceRange
+from app.db.session import session
+from app.models.wiki import WriteProvenance
+from app.wiki import git as wiki_git
+from app.db import provenance as db_provenance
+from app.wiki import notify, provenance, provenance_remap
+
+_PATH = "notes.md"
+
+
+def _ingest(
+    sha: str,
+    *,
+    body: str = "body text",
+    doc_path: str = _PATH,
+    source: WriteProvenance | None = None,
+) -> int:
+    """Record an ingestion ledger row and capture its spans from an empty base.
+    Returns the ledger id."""
+    pid = provenance.record(
+        commit_sha=sha,
+        doc_path=doc_path,
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=source or WriteProvenance(source_document_id="d1"),
+    )
+    assert pid is not None
+    provenance.capture_source_ranges(
+        provenance_id=pid, doc_path=doc_path, anchor_sha=sha, old_body="", new_body=body
+    )
+    return pid
+
+
+def _seed_range(anchor_sha: str = "c1", doc_path: str = "P.md") -> int:
+    """Ingest one span and return its range id."""
+    pid = _ingest(anchor_sha, doc_path=doc_path)
+    with session() as s:
+        rid = s.scalar(select(SourceRange.id).where(SourceRange.provenance_id == pid))
+    assert rid is not None
+    return rid
+
+
+def test_changed_spans_reports_new_body_replace_and_insert():
+    assert provenance.changed_spans("hello world", "hello brave world") == [(6, 12)]
+    assert provenance.changed_spans("abc", "aXc") == [(1, 2)]
+    assert provenance.changed_spans("ab", "abcd") == [(2, 4)]
+
+
+def test_changed_spans_ignores_pure_deletion_and_no_change():
+    assert provenance.changed_spans("abc", "ac") == []
+    assert provenance.changed_spans("same", "same") == []
+
+
+def test_record_returns_ledger_id(tmp_db):
+    pid = provenance.record(
+        commit_sha="c1",
+        doc_path="P.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(source_document_id="d1"),
+    )
+    assert isinstance(pid, int)
+    with session() as s:
+        assert s.get(ProvenanceLedger, pid) is not None
+
+
+def test_record_returns_existing_id_on_conflict(tmp_db):
+    def _rec() -> int | None:
+        return provenance.record(
+            commit_sha="dup",
+            doc_path="P.md",
+            user_id=None,
+            agent_name=None,
+            agent_session_id=None,
+            source=None,
+        )
+
+    first = _rec()
+    assert first is not None
+    assert _rec() == first
+
+
+def test_capture_source_ranges_links_to_ledger(tmp_db):
+    pid = provenance.record(
+        commit_sha="c1",
+        doc_path="P.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(source_document_id="d1"),
+    )
+    assert pid is not None
+    provenance.capture_source_ranges(
+        provenance_id=pid,
+        doc_path="P.md",
+        anchor_sha="c1",
+        old_body="hello world",
+        new_body="hello brave world",
+    )
+    with session() as s:
+        rows = s.scalars(select(SourceRange).where(SourceRange.provenance_id == pid)).all()
+    assert len(rows) == 1
+    r = rows[0]
+    assert (r.start_offset, r.end_offset) == (6, 12)
+    assert r.quoted_text == "brave "
+    assert r.status == "live"
+    assert r.anchor_sha == "c1"
+
+
+def test_capture_source_ranges_no_op_when_unchanged(tmp_db):
+    pid = provenance.record(
+        commit_sha="c1",
+        doc_path="P.md",
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(source_document_id="d1"),
+    )
+    assert pid is not None
+    provenance.capture_source_ranges(
+        provenance_id=pid, doc_path="P.md", anchor_sha="c1", old_body="same", new_body="same"
+    )
+    with session() as s:
+        assert s.scalars(select(SourceRange)).all() == []
+
+
+def test_live_ranges_needing_remap_selects_stale_live_only(tmp_db):
+    rid = _seed_range("old-sha")
+    assert [r["id"] for r in db_provenance.live_ranges_needing_remap("P.md", "new-head")] == [rid]
+    # a range already at HEAD is not stale
+    assert db_provenance.live_ranges_needing_remap("P.md", "old-sha") == []
+
+
+def test_apply_range_remap_advances_anchor(tmp_db):
+    rid = _seed_range("old-sha")
+    db_provenance.apply_range_remap(
+        rid, start_offset=2, end_offset=5, quoted_text="dy ", anchor_sha="new-head"
+    )
+    with session() as s:
+        r = s.get(SourceRange, rid)
+    assert r is not None
+    assert (r.start_offset, r.end_offset, r.anchor_sha, r.status) == (2, 5, "new-head", "live")
+
+
+def test_retire_range_marks_retired_and_drops_from_remap(tmp_db):
+    rid = _seed_range("old-sha")
+    db_provenance.retire_range(rid)
+    with session() as s:
+        r = s.get(SourceRange, rid)
+    assert r is not None and r.status == "retired"
+    assert db_provenance.live_ranges_needing_remap("P.md", "new-head") == []
+
+
+def test_rename_doc_repoints_ledger_and_ranges(tmp_db):
+    _seed_range("c1")
+    db_provenance.rename_doc("P.md", "Moved.md")
+    with session() as s:
+        assert (
+            s.scalars(select(ProvenanceLedger).where(ProvenanceLedger.doc_path == "P.md")).all()
+            == []
+        )
+        assert s.scalars(select(SourceRange).where(SourceRange.doc_path == "P.md")).all() == []
+        assert (
+            len(s.scalars(select(SourceRange).where(SourceRange.doc_path == "Moved.md")).all()) == 1
+        )
+
+
+def test_remap_source_ranges_advances_surviving_span(tmp_repo):
+    body1 = "The target sentence stays put.\n"
+    sha1 = wiki_git.commit_file(_PATH, body1, "create")
+    pid = _ingest(sha1, body=body1)
+    sha2 = wiki_git.commit_file(_PATH, "Intro added.\n" + body1, "edit")
+    provenance_remap.remap_source_ranges(_PATH)
+    with session() as s:
+        r = s.scalars(select(SourceRange).where(SourceRange.provenance_id == pid)).one()
+    assert r.status == "live"
+    assert r.anchor_sha == sha2
+
+
+def test_remap_source_ranges_retires_rewritten_span(tmp_repo):
+    body1 = "This whole line gets replaced.\n"
+    sha1 = wiki_git.commit_file(_PATH, body1, "create")
+    pid = _ingest(sha1, body=body1)
+    wiki_git.commit_file(_PATH, "Completely different content here now.\n", "edit")
+    provenance_remap.remap_source_ranges(_PATH)
+    with session() as s:
+        r = s.scalars(select(SourceRange).where(SourceRange.provenance_id == pid)).one()
+    assert r.status == "retired"
+
+
+def test_after_path_move_follows_and_remaps_source_ranges(tmp_repo):
+    body = "The ingested sentence.\n"
+    sha1 = wiki_git.commit_file("a.md", body, "seed", author=None)
+    pid = _ingest(sha1, body=body, doc_path="a.md")
+    move_sha, moves = wiki_git.move_path("a.md", "b.md", "move", author=None)
+    notify.after_path_move(moves, move_sha, actor=None)
+    with session() as s:
+        r = s.scalars(select(SourceRange).where(SourceRange.provenance_id == pid)).one()
+    # followed the move, and re-anchored to the move commit (remap ran after re-key)
+    assert r.doc_path == "b.md"
+    assert r.anchor_sha == move_sha
+    assert r.status == "live"
+
+
+def test_sources_for_path_hides_source_once_all_spans_retired(tmp_db):
+    _ingest("s1", body="alpha text", source=WriteProvenance(source_document_id="d1"))
+    pid2 = _ingest("s2", body="beta text", source=WriteProvenance(source_document_id="d2"))
+    with session() as s:
+        rid = s.scalar(select(SourceRange.id).where(SourceRange.provenance_id == pid2))
+    assert rid is not None
+    db_provenance.retire_range(rid)
+    # d1 has a live span. d2's only span is retired, so d2 drops off
+    ids = [r.source_document_id for r in provenance.sources_for_path(_PATH)]
+    assert ids == ["d1"]
+
+
+def test_sources_for_path_shows_ingest_with_no_captured_range(tmp_db):
+    # a row that never captured a span (no-content ingest, or pre-capture) has no
+    # evidence its content is gone, so it stays listed
+    provenance.record(
+        commit_sha="s1",
+        doc_path=_PATH,
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(source_document_id="d1"),
+    )
+    ids = [r.source_document_id for r in provenance.sources_for_path(_PATH)]
+    assert ids == ["d1"]
+
+
+def test_sources_for_path_dedups_newest_live_first(tmp_db):
+    _ingest("s1", body="a", source=WriteProvenance(source_document_id="dup", source_title="s1"))
+    _ingest("s2", body="b", source=WriteProvenance(source_document_id="dup", source_title="s2"))
+    _ingest("s3", body="c", source=WriteProvenance(source_document_id="other", source_title="s3"))
+    ids = [r.source_document_id for r in provenance.sources_for_path(_PATH)]
+    assert ids == ["other", "dup"]
+
+
+def test_sources_for_path_keeps_anonymous_rows(tmp_db):
+    _ingest("a1", body="x", source=WriteProvenance(source_type="slack"))
+    _ingest("a2", body="y", source=WriteProvenance(source_type="slack"))
+    assert len(provenance.sources_for_path(_PATH)) == 2


### PR DESCRIPTION
## Description

Stacked on #422 (review that first; this PR's diff is scoped to source ranges).

The ledger says which document an ingest commit came from, but not which part of the page it touched. This adds `source_ranges`: one row per span an ingest commit changed, linked to its ledger row and anchored like a comment (`doc_path` + `anchor_sha` + offsets). Captured at the commit gateway by diffing the parent body against the result; `record()` now returns the ledger id so ranges attach to it.

A shared `anchor_remap` skeleton (extracted from `comment_remap`, which now uses it too) re-anchors ranges on every later commit and retires one whose span is rewritten. Page moves re-point ranges alongside the ledger.

Nothing reads `source_ranges` yet. The Sources tab and highlight consume it in the frontend phase.

Design: `Engineering Projects/Agent Wiki Project/design/source_attribution/source_attribution_plan`

## How Has This Been Tested?

- `pre-commit run --files` on all changed files: ruff + basedpyright (strict) passed
- `basedpyright` project-wide: 0 errors, 0 warnings
- `pytest -xv tests/test_source_ranges.py`: 12 passed (incl. remap advance + retire over a tmp git repo)
- Regression: comment_remap, comment_notify, provenance, gateway/ingest/move/trash all green

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check