### PR TITLE
fix(metrics): trashed policy rows no longer break the auto-update-enabled gauge

### DIFF
--- a/backend/app/wiki/filesystem.py
+++ b/backend/app/wiki/filesystem.py
@@ -20,6 +20,12 @@ TRASH_DIR = ".trash"
 TRASH_PREFIX = TRASH_DIR + "/"
 
 
+def is_trash_path(rel_path: str) -> bool:
+    """Whether ``rel_path`` lives in the reserved ``.trash/`` area."""
+    normalized = os.path.normpath(rel_path)
+    return normalized == TRASH_DIR or normalized.startswith(TRASH_PREFIX)
+
+
 def safe_rel_path(rel_path: str) -> str:
     """Reject path traversal and the reserved ``.trash/`` area. Returns a
     normalized path or raises ValueError."""
@@ -27,7 +33,7 @@ def safe_rel_path(rel_path: str) -> str:
         log.warning("rejected unsafe wiki path: %r", rel_path)
         raise ValueError(f"unsafe path: {rel_path!r}")
     normalized = os.path.normpath(rel_path)
-    if normalized == TRASH_DIR or normalized.startswith(TRASH_PREFIX):
+    if is_trash_path(normalized):
         log.warning("rejected access to trash path: %r", rel_path)
         raise ValueError(f"path is in trash and not directly accessible: {rel_path!r}")
     return normalized

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -374,6 +374,11 @@ def _disabled_true_scopes() -> list[str]:
 
     Small — only managed scopes, not pages. Drives the auto-update-enabled
     metric without enumerating every wiki page.
+
+    Trashed scopes are excluded: a deleted page keeps its policy row (restore
+    brings the policy back), but a ``.trash/`` path can't affect any live page
+    — and ``kind_for_path`` rejects trash paths, which would abort the whole
+    count and make the metric silently fall back to "all enabled".
     """
     with session() as s:
         rows = s.execute(
@@ -381,7 +386,7 @@ def _disabled_true_scopes() -> list[str]:
                 UpdatePolicy.ingestion_auto_update_disabled.is_(True)
             )
         ).scalars().all()
-    return list(rows)
+    return [p for p in rows if not filesystem.is_trash_path(p)]
 
 
 def count_ingest_enabled_pages(

--- a/backend/tests/test_update_policy.py
+++ b/backend/tests/test_update_policy.py
@@ -362,3 +362,29 @@ def test_ai_management_clearing_can_delete_row(tmp_db):
     # The flag was the row's only setting; clearing it removes the row.
     assert result is None
     assert update_policy.get("a/page.md") is None
+
+
+def test_count_ingest_enabled_pages_skips_trashed_scopes(tmp_db):
+    # Deleting a page keeps its policy row, re-keyed under .trash/ (restore
+    # brings the policy back). A trashed disabled row must neither abort the
+    # count (kind_for_path rejects trash paths — the metric would silently
+    # fall back to "all enabled") nor subtract from live pages.
+    from sqlalchemy import update as sa_update
+
+    from app.db.models import UpdatePolicy
+    from app.db.session import session
+
+    update_policy.set_policy("solo.md", ingestion_auto_update_disabled=True)
+    update_policy.set_policy("doomed.md", ingestion_auto_update_disabled=True)
+    # Re-key one row into the trash the way the delete flow does (direct DB
+    # update; set_policy itself rejects trash paths).
+    with session() as s:
+        s.execute(
+            sa_update(UpdatePolicy)
+            .where(UpdatePolicy.path == "doomed.md")
+            .values(path=".trash/abc123/doomed.md")
+        )
+
+    enabled = update_policy.count_ingest_enabled_pages(10, lambda prefix: [])
+    # solo.md subtracted; the trashed scope ignored — and no exception.
+    assert enabled == 9


### PR DESCRIPTION
## Bug

The dashboard's **Wiki Pages (Auto-update)** stat reads equal to **Wiki Pages** (all pages enabled) on dev-wiki, while ~11 live pages genuinely have ingestion auto-update disabled.

Chain: deleting a page keeps its update-policy row, re-keyed under `.trash/` (so restore brings the policy back) → `_disabled_true_scopes()` returns that row → `count_ingest_enabled_pages` → `kind_for_path` → `safe_rel_path` **raises** on trash paths → the metric collector's `except Exception` falls back to `enabled = total`. One trashed disabled row (`.trash/448037c393f5/demo.md`) silently flipped the gauge to "everything enabled" (and warned on every scrape).

## Fix

`_disabled_true_scopes()` excludes trash rows — a `.trash/` scope can't affect any live page, and keeping it out means the count never trips on it. Adds `filesystem.is_trash_path()` (the check `safe_rel_path` already did inline, now shared).

## Test

`test_count_ingest_enabled_pages_skips_trashed_scopes` — re-keys a disabled row into `.trash/` the way the delete flow does (direct DB update; `set_policy` rejects trash paths) and asserts the count subtracts only the live disabled page, without raising. Full update-policy suite green; ruff + strict basedpyright clean.

## After deploy

`wiki_pages_auto_update_enabled` on dev-wiki should drop from 138 (= total) to ~127, and the per-scrape warning in the backend log stops.