### PR TITLE
fix(editor): full-width scroll so the scrollbar sits flush at the window edge

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -128,11 +128,13 @@ const peersField = StateField.define<{
 /** Base CodeMirror theme: full-height layout, borderless (the WYSIWYG surface
  * reads as part of the page, not a boxed textarea), prose-font scroller,
  * Opal tokens, and styles for the `.cm-coedit-caret` / `.cm-coedit-caret-label`
- * widgets. The scroller is full-width so its scrollbar sits flush at the
- * far-right edge (matching the old read view); the text stays capped and
- * centered by `.cm-content` (`max-width` + `margin: auto`), lining up with the
- * `max-w-[768px]` `DocTitle` above it. `.cm-scroller` carries the horizontal
- * gutter so the caret never hugs the edge on a narrow viewport. */
+ * widgets. The scroller spans the full width so its scrollbar sits flush at
+ * the far-right edge; the text is capped and centered by `.cm-content`
+ * (`max-width` + `margin: auto`) to line up with the `max-w-[768px]`
+ * `DocTitle` above it. `.cm-scroller` takes its horizontal gutter from the
+ * `--cm-gutter` custom property that the surrounding column sets (so the text
+ * gutter tracks the page's responsive padding at every breakpoint), and it
+ * uses a slim scrollbar with a transparent track. */
 const baseTheme = EditorView.theme({
   "&": {
     height: "100%",
@@ -144,7 +146,20 @@ const baseTheme = EditorView.theme({
     overflow: "auto",
     fontFamily: "var(--font-sans, system-ui, -apple-system, sans-serif)",
     lineHeight: "1.6",
-    padding: "0 2rem",
+    padding: "0 var(--cm-gutter, 2rem)",
+    scrollbarWidth: "thin",
+    scrollbarColor: "var(--border-03) transparent",
+  },
+  ".cm-scroller::-webkit-scrollbar": { width: "12px", height: "12px" },
+  ".cm-scroller::-webkit-scrollbar-track": { backgroundColor: "transparent" },
+  ".cm-scroller::-webkit-scrollbar-thumb": {
+    backgroundColor: "var(--border-03)",
+    borderRadius: "9999px",
+    border: "3px solid transparent",
+    backgroundClip: "content-box",
+  },
+  ".cm-scroller::-webkit-scrollbar-thumb:hover": {
+    backgroundColor: "var(--text-04)",
   },
   ".cm-content": {
     padding: "0.5rem 0",

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -128,9 +128,11 @@ const peersField = StateField.define<{
 /** Base CodeMirror theme: full-height layout, borderless (the WYSIWYG surface
  * reads as part of the page, not a boxed textarea), prose-font scroller,
  * Opal tokens, and styles for the `.cm-coedit-caret` / `.cm-coedit-caret-label`
- * widgets. No horizontal `.cm-content` padding — the surrounding column
- * (`FileView`'s `max-w-[768px]` wrapper, shared with `DocTitle`) owns the
- * left/right margin, so the editor's text lines up with the title above it. */
+ * widgets. The scroller is full-width so its scrollbar sits flush at the
+ * far-right edge (matching the old read view); the text stays capped and
+ * centered by `.cm-content` (`max-width` + `margin: auto`), lining up with the
+ * `max-w-[768px]` `DocTitle` above it. `.cm-scroller` carries the horizontal
+ * gutter so the caret never hugs the edge on a narrow viewport. */
 const baseTheme = EditorView.theme({
   "&": {
     height: "100%",
@@ -142,8 +144,15 @@ const baseTheme = EditorView.theme({
     overflow: "auto",
     fontFamily: "var(--font-sans, system-ui, -apple-system, sans-serif)",
     lineHeight: "1.6",
+    padding: "0 2rem",
   },
-  ".cm-content": { padding: "0.5rem 0", caretColor: "var(--text-05)" },
+  ".cm-content": {
+    padding: "0.5rem 0",
+    width: "100%",
+    maxWidth: "768px",
+    marginInline: "auto",
+    caretColor: "var(--text-05)",
+  },
   ".cm-line": { padding: "0" },
   ".cm-cursor, .cm-dropCursor": { borderLeftColor: "var(--text-05)" },
   "&.cm-focused .cm-selectionBackground, ::selection": {

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -807,113 +807,121 @@ export function FileView({ path }: FileViewProps) {
 
       {!loading && !error && (
         <>
-          {/* Fixed-height, capped + centered column with its own internal
-              scroll (you edit against a pinned viewport, not a growing
-              page) — the live editor when showing the current version, or
-              DiffView when viewing an old commit. */}
-          <div className="flex min-h-0 flex-1 justify-center">
-            <div className="flex w-full max-w-[768px] min-w-0 flex-col gap-3">
-              {viewingVersion && diffData ? (
-                <div className="flex min-h-0 flex-1 overflow-hidden">
-                  <DiffView
-                    data={diffData!}
-                    commit={
-                      commits?.find((c) => c.sha === viewingSha) ?? undefined
-                    }
-                    loadBody={async () => {
-                      const sha = viewingSha;
-                      if (!sha) return "";
-                      const r = await apiFetch<FileResponse>(
-                        `/wiki/file?path=${encodeURIComponent(
-                          path,
-                        )}&ref=${encodeURIComponent(sha)}`,
-                      );
-                      return r.body;
-                    }}
-                  />
+          {/* The live editor when showing the current version, or DiffView
+              when viewing an old commit. The editor pins the viewport (its own
+              internal scroll) but spans full width so the scrollbar sits flush
+              at the far-right edge; the text is capped + centered. */}
+          {viewingVersion && diffData ? (
+            <div className="flex min-h-0 flex-1 justify-center">
+              <div className="flex min-h-0 w-full max-w-[768px] min-w-0 flex-1 overflow-hidden">
+                <DiffView
+                  data={diffData!}
+                  commit={
+                    commits?.find((c) => c.sha === viewingSha) ?? undefined
+                  }
+                  loadBody={async () => {
+                    const sha = viewingSha;
+                    if (!sha) return "";
+                    const r = await apiFetch<FileResponse>(
+                      `/wiki/file?path=${encodeURIComponent(
+                        path,
+                      )}&ref=${encodeURIComponent(sha)}`,
+                    );
+                    return r.body;
+                  }}
+                />
+              </div>
+            </div>
+          ) : (
+            // Live editor: the scroll lives on the full-width editor so its
+            // scrollbar sits flush at the far-right edge (matching the old read
+            // view); the text stays capped + centered by the editor theme. The
+            // banners stay capped + centered above it, aligned with the text
+            // and DocTitle (`empty:hidden` drops the gap when none render).
+            <div
+              className={`flex min-h-0 flex-1 flex-col gap-3 ${
+                isMobile ? "-mx-3" : "-mx-8"
+              }`}
+            >
+              <div className="mx-auto flex w-full max-w-[768px] min-w-0 shrink-0 flex-col gap-3 empty:hidden">
+                <UpdateHealthBanner
+                  path={path}
+                  onOpenPolicy={() => {
+                    setHistoryOpen(false);
+                    setCommentsOpen(false);
+                    setAutomationsOpen(false);
+                    setTriggerModalOpen(false);
+                    setEditingTrigger(null);
+                    setPolicyOpen(true);
+                  }}
+                />
+                <CoeditPresenceBar
+                  participants={coedit.participants}
+                  typing={coedit.typing}
+                  selfUserId={user?.id ?? null}
+                />
+                {(() => {
+                  // Cards visible while the body is still "empty enough"
+                  // to discard without losing user work: truly blank, or
+                  // still verbatim equal to the template the user just
+                  // applied (so they can keep swapping templates).
+                  const isBlank = coedit.buffer.trim() === "";
+                  const matchesApplied =
+                    appliedTemplateBody !== null &&
+                    coedit.buffer === appliedTemplateBody;
+                  const showGallery =
+                    (isBlank || matchesApplied) &&
+                    templates !== null &&
+                    templates.length > 0;
+                  if (!showGallery) return null;
+                  return (
+                    <TemplateGallery
+                      templates={templates!}
+                      activeId={matchesApplied ? appliedTemplateId : null}
+                      applyingId={applyingTemplateId}
+                      blankActive={isBlank && appliedTemplateId === null}
+                      onPick={(t) => void onPickTemplate(t)}
+                      onBlank={() => void onPickBlank()}
+                    />
+                  );
+                })()}
+              </div>
+              {coedit.session ? (
+                <Coeditor
+                  key={coedit.session.id}
+                  ref={coeditorRef}
+                  session={coedit.session}
+                  peers={coedit.peers}
+                  onSelectionChange={coedit.reportSelection}
+                  onServerFrame={coedit.onServerFrame}
+                  reportDoc={coedit.reportDoc}
+                  registerFlush={coedit.registerFlush}
+                  registerSetDoc={coedit.registerSetDoc}
+                  commentHighlights={commentHighlights}
+                  onSelectionForComment={handleSelectionForComment}
+                  placeholder="Start typing, or pick a template above…"
+                />
+              ) : coedit.joinError ? (
+                // The join handshake itself failed — there's no read-only
+                // fallback to fall back to, so this has to be an actionable
+                // dead end, not a permanent "Connecting…".
+                <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 text-[13px] text-(--text-03)">
+                  <span>
+                    Couldn't connect to the editing session: {coedit.joinError}
+                  </span>
+                  <Button size="sm" onClick={coedit.retryJoin}>
+                    Retry
+                  </Button>
                 </div>
               ) : (
-                <>
-                  <UpdateHealthBanner
-                    path={path}
-                    onOpenPolicy={() => {
-                      setHistoryOpen(false);
-                      setCommentsOpen(false);
-                      setAutomationsOpen(false);
-                      setTriggerModalOpen(false);
-                      setEditingTrigger(null);
-                      setPolicyOpen(true);
-                    }}
-                  />
-                  <CoeditPresenceBar
-                    participants={coedit.participants}
-                    typing={coedit.typing}
-                    selfUserId={user?.id ?? null}
-                  />
-                  {(() => {
-                    // Cards visible while the body is still "empty enough"
-                    // to discard without losing user work: truly blank, or
-                    // still verbatim equal to the template the user just
-                    // applied (so they can keep swapping templates).
-                    const isBlank = coedit.buffer.trim() === "";
-                    const matchesApplied =
-                      appliedTemplateBody !== null &&
-                      coedit.buffer === appliedTemplateBody;
-                    const showGallery =
-                      (isBlank || matchesApplied) &&
-                      templates !== null &&
-                      templates.length > 0;
-                    if (!showGallery) return null;
-                    return (
-                      <TemplateGallery
-                        templates={templates!}
-                        activeId={matchesApplied ? appliedTemplateId : null}
-                        applyingId={applyingTemplateId}
-                        blankActive={isBlank && appliedTemplateId === null}
-                        onPick={(t) => void onPickTemplate(t)}
-                        onBlank={() => void onPickBlank()}
-                      />
-                    );
-                  })()}
-                  {coedit.session ? (
-                    <Coeditor
-                      key={coedit.session.id}
-                      ref={coeditorRef}
-                      session={coedit.session}
-                      peers={coedit.peers}
-                      onSelectionChange={coedit.reportSelection}
-                      onServerFrame={coedit.onServerFrame}
-                      reportDoc={coedit.reportDoc}
-                      registerFlush={coedit.registerFlush}
-                      registerSetDoc={coedit.registerSetDoc}
-                      commentHighlights={commentHighlights}
-                      onSelectionForComment={handleSelectionForComment}
-                      placeholder="Start typing, or pick a template above…"
-                    />
-                  ) : coedit.joinError ? (
-                    // The join handshake itself failed — there's no read-only
-                    // fallback to fall back to, so this has to be an actionable
-                    // dead end, not a permanent "Connecting…".
-                    <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 text-[13px] text-(--text-03)">
-                      <span>
-                        Couldn't connect to the editing session:{" "}
-                        {coedit.joinError}
-                      </span>
-                      <Button size="sm" onClick={coedit.retryJoin}>
-                        Retry
-                      </Button>
-                    </div>
-                  ) : (
-                    // Joining the session; the editor mounts once we have its
-                    // start version + doc.
-                    <div className="flex min-h-0 flex-1 items-center justify-center text-[13px] text-(--text-03)">
-                      Connecting…
-                    </div>
-                  )}
-                </>
+                // Joining the session; the editor mounts once we have its
+                // start version + doc.
+                <div className="flex min-h-0 flex-1 items-center justify-center text-[13px] text-(--text-03)">
+                  Connecting…
+                </div>
               )}
             </div>
-          </div>
+          )}
           {/* Desktop side panels dock at the app's right edge (full height,
               beside the header) by portaling into the shell's right-panel host,
               so they never eat into the reading column above. Mobile keeps the

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -833,17 +833,26 @@ export function FileView({ path }: FileViewProps) {
               </div>
             </div>
           ) : (
-            // Live editor: the scroll lives on the full-width editor so its
-            // scrollbar sits flush at the far-right edge (matching the old read
-            // view); the text stays capped + centered by the editor theme. The
-            // banners stay capped + centered above it, aligned with the text
-            // and DocTitle (`empty:hidden` drops the gap when none render).
+            // Live editor: the full-width editor owns the scroll, so its
+            // scrollbar sits flush at the far-right edge while the text stays
+            // capped + centered by the editor theme. `--cm-gutter` mirrors the
+            // negative margin (which cancels `<main>`'s padding) so the editor
+            // text keeps the same side gutter as the DocTitle at every
+            // breakpoint. The banners stay capped + centered above it, aligned
+            // with the text and DocTitle (`empty:hidden` drops the gap when
+            // none render).
             <div
               className={`flex min-h-0 flex-1 flex-col gap-3 ${
-                isMobile ? "-mx-3" : "-mx-8"
+                isMobile
+                  ? "-mx-3 [--cm-gutter:0.75rem]"
+                  : "-mx-8 [--cm-gutter:2rem]"
               }`}
             >
-              <div className="mx-auto flex w-full max-w-[768px] min-w-0 shrink-0 flex-col gap-3 empty:hidden">
+              <div
+                className={`mx-auto flex w-full max-w-[768px] min-w-0 shrink-0 flex-col gap-3 empty:hidden ${
+                  isMobile ? "px-3" : ""
+                }`}
+              >
                 <UpdateHealthBanner
                   path={path}
                   onOpenPolicy={() => {


### PR DESCRIPTION
## Problem

On every doc, the scrollbar sits at the right edge of the centered ~768px text column, floating ~400px in from the window's right edge on wide screens — instead of hugging the far-right edge the way it did before.

**Cause:** PR #438 ("always-on WYSIWYG + autosave") removed the read view and made the CodeMirror editor always-on. Its editor was a *fixed-width* (`max-w-[768px]`) column with its own internal scroll, so the scrollbar moved from the window edge onto that column's edge. The old read view instead used a **full-width** scroll container (`overflow-y-auto -mx-8 px-8`) with the text centered inside, keeping the scrollbar flush at the far right.

## Fix

Restore the old read-view scroll geometry on the always-on editor:

- The editor now spans **full width** — its `.cm-scroller` reaches the window edge via `-mx-8`/`-mx-3` (canceling `<main>`'s padding, same trick the old read container used), so the scrollbar is **flush at the far-right edge**.
- The **text stays capped + centered** via the editor theme: `.cm-content` gets `max-width: 768px; margin-inline: auto`, and `.cm-scroller` carries the horizontal gutter so the caret never hugs the edge on a narrow viewport.
- Banners (`UpdateHealthBanner` / `CoeditPresenceBar` / `TemplateGallery`) and the `DocTitle` stay centered at 768px and aligned with the editor text.
- Diff-of-an-old-commit view is unchanged (still a centered, capped column).

Editing UX (pinned viewport / internal scroll, cursors, `scrollToOffset`, comment anchoring) is preserved — only the scroller's width and the text-centering seam moved.

## Verification

Built the full stack from `main` + this change and drove it headlessly on a doc with overflowing content (no side panel, 1920px):

| | `.cm-scroller` width | scrollbar right edge (viewport 1920) |
|---|---|---|
| before | 768px | **1523** (floating mid-window) |
| after | 1533px (full-width) | **1905** (flush at window edge) |

Text remains centered in a ~768px column, aligned with the title. Typecheck passes.