### PR TITLE
feat(automanage): auto-approve proposals in AI-managed scopes

### DIFF
--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -26,9 +26,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from app.auth.users import AI_USER_ID
 from app.wiki import git
 from app.wiki import update_policy
-from app.wiki.automanage import runs
+from app.wiki.automanage import review, runs
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
@@ -60,12 +61,13 @@ _CREATED_VIA = {
 }
 
 
-def _forbidden_paths(drafts: list[ProposalDraft]) -> set[str]:
-    """Paths across ``drafts`` in an explicitly do-not-manage scope (effective
-    ``ai_management_allowed`` is False), resolved in a single query."""
+def _resolve_management(drafts: list[ProposalDraft]) -> dict[str, bool | None]:
+    """Effective ``ai_management_allowed`` tri-state for every path across
+    ``drafts``, resolved in one query. Per draft: any path False → skip
+    (hands-off); all paths True → auto-manage (auto-approve + execute as the AI
+    system user); otherwise → pending for human review."""
     paths = {p for d in drafts for p in d.source_paths + d.target_paths}
-    resolved = update_policy.resolve_ai_management_for_paths(paths)
-    return {p for p, v in resolved.items() if v is False}
+    return update_policy.resolve_ai_management_for_paths(paths)
 
 
 def _base_shas(source_paths: list[str]) -> dict[str, str] | None:
@@ -106,12 +108,13 @@ def run_detection(
                 continue
             drafts = detector.detect(scope)
             # One policy query per detector, not one per path per draft.
-            forbidden = _forbidden_paths(drafts)
+            mgmt = _resolve_management(drafts)
             for draft in drafts:
+                draft_paths = draft.source_paths + draft.target_paths
                 if draft.dedupe_key in taken:
                     continue
-                if any(p in forbidden for p in draft.source_paths + draft.target_paths):
-                    continue
+                if any(mgmt.get(p) is False for p in draft_paths):
+                    continue  # explicitly hands-off scope
                 if emitted >= MAX_PROPOSALS_PER_RUN:
                     log.warning(
                         "detection run %s hit per-run cap (%d); "
@@ -124,7 +127,7 @@ def run_detection(
                 base_shas = _base_shas(draft.source_paths)
                 if base_shas is None:
                     continue
-                create_proposal(
+                proposal = create_proposal(
                     op=draft.op,
                     source_paths=draft.source_paths,
                     target_paths=draft.target_paths,
@@ -136,6 +139,23 @@ def run_detection(
                 )
                 taken.add(draft.dedupe_key)
                 emitted += 1
+                # Whole operation inside an AI-managed scope → auto-apply as the
+                # AI system user (no human queue). Otherwise it waits for a
+                # human in the pending-cleanups queue.
+                if draft_paths and all(mgmt.get(p) is True for p in draft_paths):
+                    if not review.auto_approve(
+                        proposal["id"], acting_user_id=AI_USER_ID
+                    ):
+                        # Shouldn't happen for a just-created proposal; if a race
+                        # transitioned it out of pending, it stays pending (a
+                        # human can still action it) — surface the anomaly loudly.
+                        log.warning(
+                            "detection run %s: auto-approve did not take for "
+                            "proposal %s (%s); left pending",
+                            run_id,
+                            proposal["id"],
+                            draft.dedupe_key,
+                        )
         runs.mark_completed(
             run_id, paths_scanned=len(paths), proposals_emitted=emitted
         )

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 
 import pytest
 
+from app.auth.users import AI_USER_ID
+from app.tasks.queues import detection_queue
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
 from app.wiki.automanage import runner, runs
 from app.wiki.automanage.detectors.empty_folder import _EmptyFolderDetector
 from app.wiki.change_proposals import ProposalStatus, list_by_status, reject
@@ -77,11 +81,36 @@ def test_rejected_is_not_reproposed(repo):
 
 
 def test_forbidden_scope_is_skipped(repo):
-    from app.wiki import update_policy
-
     update_policy.set_policy("archive", ai_management_allowed=False)
     result = runner.run_sweep(triggered_by_user_id=None)
     folders = {p["source_paths"][0] for p in list_by_status(ProposalStatus.PENDING)}
     assert "archive" not in folders  # explicitly do-not-manage
     assert "old" in folders
     assert result["proposals_emitted"] == 1
+
+
+def test_ai_managed_scope_auto_applies(repo):
+    # archive opts into AI management → auto-approved + executed as the AI user,
+    # no human queue. old is unset → stays pending.
+    update_policy.set_policy("archive", ai_management_allowed=True)
+    with detection_queue.immediate_mode():
+        runner.run_sweep(triggered_by_user_id=None)
+
+    applied = {p["source_paths"][0]: p for p in list_by_status(ProposalStatus.APPLIED)}
+    assert "archive" in applied
+    assert applied["archive"]["reviewed_by_user_id"] is None  # no human reviewer
+    assert applied["archive"]["acting_user_id"] == AI_USER_ID
+    assert "archive/.gitkeep" not in wiki_git.list_paths()  # trashed
+
+    pending = {p["source_paths"][0] for p in list_by_status(ProposalStatus.PENDING)}
+    assert pending == {"old"}  # unset scope waits for a human
+    assert "old/.gitkeep" in wiki_git.list_paths()  # untouched
+
+
+def test_unset_scope_stays_pending(repo):
+    # No policy anywhere → both empties wait for human review, nothing executes.
+    with detection_queue.immediate_mode():
+        runner.run_sweep(triggered_by_user_id=None)
+    assert list_by_status(ProposalStatus.APPLIED) == []
+    pending = {p["source_paths"][0] for p in list_by_status(ProposalStatus.PENDING)}
+    assert pending == {"archive", "old"}


### PR DESCRIPTION
Wires the **automatic path** for Wiki Auto Management: a proposal whose paths are all in an `ai_management_allowed=true` scope is auto-approved and executed **as the AI system user** at emit time — no human queue. Reuses the `review.auto_approve` seam and the same executor from #434/#444.

## What's here
- **Runner (emit-time)**: resolve the `ai_management_allowed` tri-state once per detector's drafts, then per draft:
  - any path `False` → skip (hands-off)
  - **all paths `True` → create + `review.auto_approve(AI_USER_ID)`** (auto-apply)
  - otherwise → `pending` for human review

## Authorization model (per discussion)
- **Gate on the policy flag, not "AI can write."** Unmanaged folders are implicit-public — the AI can already write them — but they must default to human review. `ai_management_allowed` is the intent signal.
- **No ACL grant, single source of truth.** Setting `ai_management_allowed=true` is itself **write-gated** (the `PUT /update-policy` + MCP tool require write) and audited (`update_policies.updated_by_user_id`), so enabling it *is* an authorized user delegating the scope to the AI. That satisfies the PRD "no standalone AI rights" intent without mirroring an ACL entry that the executor wouldn't even check.
- Acting principal = the **AI system user**; `reviewed_by` stays NULL, so "auto-applied by AI" is distinguishable from "approved by <person>".

## Tests (green; basedpyright + ruff clean; 50 across the detection suite)
AI-managed scope auto-applies (executed, `reviewed_by` NULL, `acting_user_id` = AI, folder trashed) while an unset sibling stays `pending`; unset-everywhere stays `pending`, nothing executed. (The existing `paths_scanned` assertion also caught — and now guards against — a variable-shadowing bug during development.)

## Deferred
Activity digest of auto-applied actions; stuck-`approved` reconcile for the auto path (no human to retry); per-user delegation (separate Phase-2 model).