### PR TITLE
fix(wiki): breadcrumb and blank page card fixes

### DIFF
--- a/frontend/src/chromes/header/WikiHeader.tsx
+++ b/frontend/src/chromes/header/WikiHeader.tsx
@@ -1,9 +1,16 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
-import { Button } from "@onyx-ai/opal/components";
-import { SvgChevronRight, SvgListTree } from "@onyx-ai/opal/icons";
+import { Button, LineItemButton, Popover } from "@onyx-ai/opal/components";
+import {
+  SvgChevronRight,
+  SvgFolder,
+  SvgListTree,
+  SvgMoreHorizontal,
+} from "@onyx-ai/opal/icons";
 import { NotificationBell } from "@/components/common/NotificationBell";
 import { CraftNotifier } from "@/components/wiki/CraftNotifier";
 import { useAppFocus } from "@/hooks/useAppFocus";
@@ -15,11 +22,68 @@ function segmentLabel(segment: string): string {
   return segment.replace(/\.md$/, "").replace(/_/g, " ");
 }
 
+// Trailing crumbs kept visible when the path folds (the current page plus
+// its nearest ancestors). Home always renders separately.
+const FOLD_TRAIL = 4;
+
+/** Fold-menu row that reveals its full label via tooltip only when the
+ *  fixed-width popover truncates it. */
+function FoldedCrumb({
+  label,
+  onSelect,
+}: {
+  label: string;
+  onSelect: () => void;
+}) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [clipped, setClipped] = useState(false);
+  // Opal 0.1.17's ContentMd re-adds a native title attr on every render,
+  // which fights the Opal tooltip. Stripped after renders and again on
+  // hover, which rerenders through the tooltip's open state.
+  const stripNativeTitle = () => {
+    rowRef.current
+      ?.querySelector("[class*='truncate']")
+      ?.removeAttribute("title");
+  };
+  useEffect(() => {
+    // The truncate class marks Opal's one-line title span, the measured element.
+    const text = rowRef.current?.querySelector<HTMLElement>(
+      "[class*='truncate']",
+    );
+    if (!text) return;
+    // Shim for @onyx-ai/opal 0.1.17, delete when Opal ships the title-row
+    // min-w-0 fix: the row refuses to shrink beside the icon, which pushes
+    // the ellipsis outside the popover's clipped box.
+    if (text.parentElement) text.parentElement.style.minWidth = "0";
+    stripNativeTitle();
+    setClipped(text.scrollWidth > text.clientWidth);
+    // clipped in the deps reruns the strip after the gating rerender puts
+    // the title attr back.
+  }, [label, clipped]);
+  return (
+    // The ref sits on a wrapper because LineItemButton's ref prop does not
+    // reach a DOM node in opal 0.1.17.
+    <div ref={rowRef} onPointerEnter={stripNativeTitle}>
+      <LineItemButton
+        title={label}
+        titleMaxLines={1}
+        icon={SvgFolder}
+        sizePreset="main-ui"
+        variant="section"
+        tooltip={clipped ? label : undefined}
+        onClick={onSelect}
+      />
+    </div>
+  );
+}
+
 export function WikiHeader() {
+  const router = useRouter();
   const { view, toggleTree } = useLeftPanel();
   const treeVisible = view === "wiki-tree";
   const { wikiPath } = useAppFocus();
   const host = useHeaderActionsHost();
+  const [foldOpen, setFoldOpen] = useState(false);
 
   const segments = wikiPath ? wikiPath.split("/") : [];
   // Ancestor + self segment paths, resolved to ids so each crumb links to the
@@ -44,6 +108,13 @@ export function WikiHeader() {
     });
   });
 
+  // Deep paths fold their middle ancestors into a "…" popover (root→leaf
+  // order). The folder tree is the tool for deep hierarchies, crumbs only
+  // hop nearby levels.
+  const isFolded = crumbs.length > FOLD_TRAIL + 1;
+  const folded = isFolded ? crumbs.slice(1, -FOLD_TRAIL) : [];
+  const trail = isFolded ? crumbs.slice(-FOLD_TRAIL) : crumbs.slice(1);
+
   return (
     <div className="flex h-14 items-center gap-3 px-4">
       {/* The expand control lives here only while the tree is closed. When
@@ -56,22 +127,62 @@ export function WikiHeader() {
           onClick={toggleTree}
         />
       )}
-      <nav className="flex flex-wrap items-center gap-1.5 text-sm">
-        {crumbs.map((c, i) => {
-          const last = i === crumbs.length - 1;
+      {/* min-w-0 + nowrap + overflow-hidden: one line, always. The container
+          only clips, the per-crumb truncate classes render the ellipsis. */}
+      <nav className="flex min-w-0 items-center gap-1.5 overflow-hidden text-sm whitespace-nowrap">
+        <Link
+          href={crumbs[0].href}
+          className="shrink-0 text-(--text-03) hover:text-(--text-05)"
+        >
+          {crumbs[0].label}
+        </Link>
+        {folded.length > 0 && (
+          <span className="flex shrink-0 items-center gap-1.5">
+            <SvgChevronRight size={12} className="text-(--text-02)" />
+            <Popover open={foldOpen} onOpenChange={setFoldOpen}>
+              <Popover.Trigger asChild>
+                <span className="inline-flex">
+                  <Button
+                    icon={SvgMoreHorizontal}
+                    prominence="tertiary"
+                    size="sm"
+                    tooltip="Show full path"
+                  />
+                </span>
+              </Popover.Trigger>
+              <Popover.Content width="lg" align="start">
+                <Popover.Menu>
+                  {folded.map((c) => (
+                    <FoldedCrumb
+                      key={c.href}
+                      label={c.label}
+                      onSelect={() => {
+                        setFoldOpen(false);
+                        router.push(c.href);
+                      }}
+                    />
+                  ))}
+                </Popover.Menu>
+              </Popover.Content>
+            </Popover>
+          </span>
+        )}
+        {trail.map((c, i) => {
+          const last = i === trail.length - 1;
           return (
-            <span key={c.href} className="flex items-center gap-1.5">
-              {i > 0 && (
-                <SvgChevronRight size={12} className="text-(--text-02)" />
-              )}
+            <span
+              key={c.href}
+              className={`flex items-center gap-1.5 ${last ? "min-w-0" : "shrink-0"}`}
+            >
+              <SvgChevronRight size={12} className="text-(--text-02)" />
               {last ? (
-                <span className="font-semibold text-(--text-05)">
+                <span className="overflow-hidden font-semibold text-ellipsis text-(--text-05)">
                   {c.label}
                 </span>
               ) : (
                 <Link
                   href={c.href}
-                  className="text-(--text-03) hover:text-(--text-05)"
+                  className="max-w-44 truncate text-(--text-03) hover:text-(--text-05)"
                 >
                   {c.label}
                 </Link>
@@ -82,7 +193,7 @@ export function WikiHeader() {
       </nav>
       {/* Page-level actions portal here from the active wiki route (see
           WikiHeaderActionsProvider). Pushed right by the flex spacer. */}
-      <div className="flex-1" />
+      <div className="min-w-4 flex-1" />
       <div ref={host?.setEl} className="flex items-center gap-2" />
       <NotificationBell />
       <CraftNotifier />

--- a/frontend/src/components/wiki/StartNewPage.module.css
+++ b/frontend/src/components/wiki/StartNewPage.module.css
@@ -21,8 +21,16 @@
   gap: 8px;
   padding: 8px;
 }
+/* SelectCard strips className and style, so the mock's chip shadow and a
+   radius matching the card's corners live on the grid cell instead. */
 .templateCell {
   display: flex;
+  min-width: 0;
+  border-radius: var(--radius-12);
+  box-shadow: var(--shadow-chip);
+}
+.templateCell > * {
+  flex: 1;
   min-width: 0;
 }
 
@@ -36,14 +44,15 @@
   flex: 0 0 auto;
 }
 
-/* Blank-page glyph: the mock's square-plus, layered from the square and plus
-   icons. Not an interactive Button. */
-.blankGlyph {
+/* Blank-page glyph layers: the plus centers over the square inside
+   IconContainer's glyph slot. */
+.glyphStack {
   position: relative;
   display: inline-flex;
-  color: var(--text-03);
+  align-items: center;
+  justify-content: center;
 }
-.blankGlyphPlus {
+.glyphPlus {
   position: absolute;
   inset: 0;
   display: flex;

--- a/frontend/src/components/wiki/StartNewPage.tsx
+++ b/frontend/src/components/wiki/StartNewPage.tsx
@@ -3,9 +3,16 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import useSWR from "swr";
-import { LineItemButton, SelectCard, Text } from "@onyx-ai/opal/components";
+import {
+  IconContainer,
+  LineItemButton,
+  SelectCard,
+  Text,
+} from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 import { SvgChevronRight, SvgPlus, SvgSquare } from "@onyx-ai/opal/icons";
+import { cn } from "@onyx-ai/opal/utils";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
 import styles from "@/components/wiki/StartNewPage.module.css";
@@ -48,16 +55,7 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
         <div className={styles.templateCell}>
           <TemplateCard
             title="Blank page"
-            glyph={
-              // The mock's square-plus glyph, composed from published icons
-              // until @onyx-ai/opal ships an SvgSquarePlus.
-              <span className={styles.blankGlyph}>
-                <SvgSquare size={20} />
-                <span className={styles.blankGlyphPlus}>
-                  <SvgPlus size={12} />
-                </span>
-              </span>
-            }
+            glyph={<IconContainer size="main-ui" icon={SquarePlusGlyph} />}
             onClick={() => startNewPage(blankTemplate?.id)}
           />
         </div>
@@ -92,6 +90,17 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
   );
 }
 
+// Square-plus layered from published icons, sized by IconContainer's glyph
+// class. Swap to Opal's SvgSquarePlus when it ships (onyx #13153).
+const SquarePlusGlyph: IconFunctionComponent = ({ className }) => (
+  <span className={cn(styles.glyphStack, className)}>
+    <SvgSquare size={16} />
+    <span className={styles.glyphPlus}>
+      <SvgPlus size={8} />
+    </span>
+  </span>
+);
+
 function TemplateCard({
   title,
   description,
@@ -106,22 +115,18 @@ function TemplateCard({
   onClick: () => void;
 }) {
   return (
-    <SelectCard
-      state="empty"
-      onClick={onClick}
-      padding="sm"
-      rounding="lg"
-      border="solid"
-    >
+    // Mock card chrome (709:259996): tint fill, radius 12 (default rounding),
+    // no border. Filled is the select-card variant's visible-background rest.
+    <SelectCard state="filled" onClick={onClick} padding="sm" border="none">
       <Section
         flexDirection="column"
         alignItems="start"
         justifyContent="start"
-        gap={0.25}
+        gap={glyph ? 0.75 : 0.25}
         width="full"
         height="full"
       >
-        <Text font="main-ui-action" color="text-05" nowrap>
+        <Text font="main-ui-action" color="text-03" nowrap>
           {title}
         </Text>
         {glyph ? (


### PR DESCRIPTION
## Description

Merges into main. Two fixes:

**Breadcrumb fold** (`src/chromes/header/WikiHeader.tsx`) — the crumb trail never wraps. Paths deeper than five crumbs collapse their middle ancestors behind a dots chip whose fixed 240px popover lists the hidden folders root to leaf, one line each with an ellipsis, and a hover tooltip shows the full name only for truncated rows. Includes opal 0.1.17 shims (wrapper-div ref, title-row min-width, native `title` attr strip), each verified by rendering the real installed components in a browser harness and marked for deletion when the upstream Opal fixes land (onyx #13153).

**Blank page card** (`StartNewPage`) — matches mock 709:259996: filled select-card state, no border, radius 12, chip shadow on the grid cell, title at `text-03`. The glyph renders in Opal's `IconContainer`, layering the published square and plus icons until Opal ships `SvgSquarePlus`.

No new icon files anywhere. The icons are added to Opal itself (onyx #13153). The Home crumb stays text until the `home` glyph ships.

## How Has This Been Tested?

## Additional Options

- [ ] This change should be considered for cherry-picking to the release branch
- [x] Override Linear Check