### PR TITLE
fix(editor): sequence teardown flush → checkpoint → leave so final edits can't be dropped

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -503,19 +503,59 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       view.current = v;
       onServerFrame(applyFrame);
       registerFlush(async () => {
-        // Drive the push chain, then wait until every op is confirmed (sendable
-        // drained by echoes) so the server has all our edits before checkpoint.
-        // Time out rather than hang / silently checkpoint a stale buffer.
+        // Deliver every un-acked local op over plain HTTP, treating a 200 as
+        // delivered. Unlike `doPush`, this must not wait for stream echoes to
+        // drain `sendableUpdates` — flush runs during teardown, when the SSE
+        // stream (and even the view) may be gone, so an echo may never arrive.
+        // The server CAS makes a duplicate send harmless (409). Time out
+        // rather than hang / silently checkpoint a stale buffer.
         const deadline = Date.now() + 5000;
-        void doPush();
-        while (sendableUpdates(v.state).length > 0) {
+        while (true) {
           if (Date.now() > deadline) {
             throw new Error(
               "Could not sync your latest edits — check your connection.",
             );
           }
-          await new Promise((r) => setTimeout(r, 40));
-          void doPush();
+          if (pushing.current) {
+            // An op is in flight (doPush or a concurrent flush) — wait for it
+            // rather than double-sending at the same version.
+            await new Promise((r) => setTimeout(r, 40));
+            continue;
+          }
+          const updates = sendableUpdates(v.state);
+          if (updates.length === 0) return;
+          let version = getSyncedVersion(v.state);
+          let start = 0;
+          if (version === sentAtVersion.current) {
+            // updates[0] already got its 200 (it's only un-drained because its
+            // echo hasn't landed) — the rest are based one version later.
+            start = 1;
+            version += 1;
+            if (updates.length === 1) return;
+          }
+          pushing.current = true;
+          try {
+            for (let i = start; i < updates.length; i++) {
+              await sendOp(
+                session.id,
+                version,
+                changeSetToChanges(updates[i]!.changes),
+                session.clientId,
+              );
+              sentAtVersion.current = version;
+              version += 1;
+            }
+            return;
+          } catch (e) {
+            if (e instanceof ApiError && e.status === 409) {
+              // A peer's op interleaved — rebase through the op log and retry.
+              await pull();
+              continue;
+            }
+            throw e;
+          } finally {
+            pushing.current = false;
+          }
         }
       });
       registerSetDoc((text: string) => {
@@ -526,7 +566,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
 
       return () => {
         onServerFrame(null);
-        registerFlush(null);
+        // Deliberately NOT registerFlush(null): the session teardown in
+        // useCoeditSession runs after this cleanup on unmount and needs the
+        // flush for its final flush → checkpoint → leave sequence. The flush
+        // only reads `v.state` and POSTs — both safe after `v.destroy()` —
+        // and the hook clears it once it has taken ownership.
         registerSetDoc(null);
         v.destroy();
         view.current = null;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -549,6 +549,10 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           } catch (e) {
             if (e instanceof ApiError && e.status === 409) {
               // A peer's op interleaved — rebase through the op log and retry.
+              // Safe even when the teardown flush runs after `v.destroy()`:
+              // CM6's dispatch on a destroyed view still advances the state
+              // (it only skips DOM work — see EditorView.update's destroyed
+              // path), so receiveUpdates rebases and the retry sees it.
               await pull();
               continue;
             }

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -4,10 +4,11 @@
  *
  * On `enabled` it joins the session for `path`, streams inbound frames, and
  * exposes presence (`participants`/`typing`/`peers`) and autosave
- * (`saveStatus`). Teardown (flush + best-effort checkpoint + leave +
- * `onEnd`) happens entirely inside the hook's own effect cleanup — driven by
- * `enabled`/`path` changing or the component unmounting, never by the caller
- * invoking a function. The *document* is owned by the editor via
+ * (`saveStatus`). Teardown (flush → checkpoint → leave → stream abort, in
+ * that order — leaving/disconnecting first would let the server's last-leave
+ * forced commit race ahead of the final ops) happens entirely inside the
+ * hook's own effect cleanup — driven by `enabled`/`path` changing or the
+ * component unmounting, never by the caller invoking a function. The *document* is owned by the editor via
  * `@codemirror/collab` (see `Coeditor`), not here — the hook just hands the
  * editor what it needs to run collab (`session` = id/clientId/start
  * version+doc), forwards inbound `op`/`resync` frames to it (`onServerFrame`),
@@ -259,10 +260,11 @@ export function useCoeditSession(opts: {
     [myUserId],
   );
 
-  // Tears the session down and fires `onEnd` — the one and only "session is
-  // over" signal. Only called from the join effect's cleanup below, so this
-  // is always a genuine end (disable, path change, or unmount), never a
-  // silent mid-session reset.
+  // Tears down the *local* session state (timers, presence, handles) and
+  // fires `onEnd` — the one and only "session is over" signal. The network
+  // side (flush, checkpoint, leave, stream abort) is NOT done here: the join
+  // effect's cleanup below — the only caller — sequences those explicitly,
+  // because their order matters (see the comment there).
   const stop = useCallback(() => {
     clearAutosaveTimers();
     if (cursorThrottle.current) {
@@ -278,13 +280,9 @@ export function useCoeditSession(opts: {
     pendingCursor.current = null;
     setTyping([]);
     setPeers([]);
-    abort.current?.abort();
-    abort.current = null;
-    const sid = sessionId.current;
     sessionId.current = null;
     setActive(false);
     setSession(null);
-    if (sid !== null) void leaveSession(sid).catch(() => {});
     onEnd?.();
   }, [clearAutosaveTimers, onEnd]);
 
@@ -331,7 +329,17 @@ export function useCoeditSession(opts: {
       });
       setActive(true);
       try {
-        await streamSession(snap.session_id, onFrame, ctrl.signal);
+        // Gate on `cancelled`: the stream outlives the effect during teardown
+        // (it's aborted only after the final flush/checkpoint/leave below), and
+        // a late frame from the old session must not leak into state a new
+        // session now owns.
+        await streamSession(
+          snap.session_id,
+          (frame) => {
+            if (!cancelled) onFrame(frame);
+          },
+          ctrl.signal,
+        );
       } catch {
         // Stream ended/dropped after a successful join (including our own
         // cleanup's abort) — the session/doc are already usable, so this
@@ -341,25 +349,48 @@ export function useCoeditSession(opts: {
 
     return () => {
       cancelled = true;
-      // Capture before the synchronous `stop()` below clears them, so a
-      // trailing checkpoint can still cover the last idle-autosave window
-      // (the periodic autosave while mounted is the primary durability path;
-      // this is best-effort for the tail end of it, e.g. a path change or
-      // unmount mid-edit — small race against `stop()`'s own `leaveSession`
-      // call, not worth blocking teardown to sequence perfectly).
+      // Teardown must run flush → checkpoint → leave → abort, in that strict
+      // order. The server force-commits and closes the session when the last
+      // participant is gone, and BOTH leaving and dropping the SSE stream
+      // count as "gone" — so leaving (or aborting) before the final ops and
+      // checkpoint have landed lets that forced commit race ahead of them:
+      // it commits a buffer missing the tail, `close_if_clean` closes the
+      // session, and the late ops bounce off a closed session (silent loss).
+      // Leaving last means the forced commit only ever sees a clean,
+      // fully-flushed buffer.
       const sid = sessionId.current;
+      // The editor never unregisters its flush (see Coeditor's cleanup) so
+      // it's still here even when the child unmounted first; clear it as we
+      // take ownership of the final call.
       const flush = flushFn.current;
+      flushFn.current = null;
+      const ctrl = abort.current;
+      abort.current = null;
       stop();
-      if (sid !== null) {
-        void (async () => {
-          try {
-            await flush?.();
-          } catch {
-            return;
-          }
-          void checkpointSession(sid, { keepalive: true }).catch(() => {});
-        })();
+      if (sid === null) {
+        ctrl?.abort();
+        return;
       }
+      void (async () => {
+        try {
+          await flush?.();
+        } catch {
+          // Best-effort: the tail couldn't be delivered (offline, or a peer's
+          // concurrent edit mid-teardown). Still checkpoint — committing what
+          // the server has beats leaving it all to the forced commit.
+        }
+        try {
+          await checkpointSession(sid, { keepalive: true });
+        } catch {
+          // The last-leave forced commit below is the backstop.
+        }
+        try {
+          await leaveSession(sid, { keepalive: true });
+        } catch {
+          // The server-side leave on SSE disconnect is the backstop.
+        }
+        ctrl?.abort();
+      })();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, path, retryToken]);

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -32,9 +32,15 @@ export function getSession(sessionId: number): Promise<CoeditSession> {
   return apiFetch(`/coedit/session?session_id=${sessionId}`);
 }
 
-/** Leave the session, allowing the server to clean up presence + buffer if empty. */
-export function leaveSession(sessionId: number): Promise<void> {
+/** Leave the session, allowing the server to clean up presence + buffer if
+ * empty. `init` lets teardown pass `{ keepalive: true }` so the request
+ * survives the page tearing down. */
+export function leaveSession(
+  sessionId: number,
+  init?: RequestInit,
+): Promise<void> {
   return apiFetch("/coedit/leave", {
+    ...init,
     method: "POST",
     body: JSON.stringify({ session_id: sessionId }),
   });


### PR DESCRIPTION
## Problem

The always-on-editor cutover (#438) replaced the Save button's strictly awaited `flush → checkpoint → leave` with an effect cleanup that fired `POST /coedit/leave` (and the SSE abort) **first**, then kicked off the flush + trailing checkpoint as a detached async chain.

The server force-commits and closes a session when its last participant is gone — and both leaving and dropping the SSE stream count as gone. So on "type, then navigate within ~2s" (before the idle autosave fires), the forced commit could run before the final ops arrived:

1. `/leave` lands → roster empty → forced checkpoint enqueued
2. worker commits the buffer **without** the tail ops → buffer clean → `close_if_clean` seals the session
3. the late `/op` and trailing `/checkpoint` get 404s, both swallowed client-side → **last edits silently lost**

(If the ops landed between commit and close instead, the session lingered dirty + participant-less until the 5-minute scan — commit delayed ~6 min, moves/renames blocked meanwhile.)

Two latent bugs made the trailing flush unable to save the day even when it ran:

- The flush waited for its ops' **SSE echoes** to drain `sendableUpdates` — but teardown had already aborted the stream, so with any pending op it always spun to its 5s deadline, threw, and the trailing checkpoint was skipped.
- On unmount, React destroys the child editor before the hook's cleanup runs, and `Coeditor`'s cleanup nulled the registered flush — so the hook captured `null` exactly when it mattered.

## Fix

Teardown now runs one sequenced chain: **flush → checkpoint → leave → abort**, so the server's last-leave forced commit only ever sees a clean, fully-flushed buffer, and the session closes promptly.

- **flush** no longer depends on echoes: it delivers each un-acked op over HTTP and treats a 200 as delivered (the server CAS makes duplicate sends harmless 409s), rebasing via the op log on a real 409 (peer op interleaved). Works even after the view is destroyed — it only reads `v.state` and POSTs.
- **Coeditor** no longer unregisters its flush on cleanup; the hook clears it as it takes ownership of the final call, making the capture immune to React's child-before-parent cleanup order.
- **checkpoint/leave** go out with `keepalive: true`; the SSE abort moves to the end of the chain since a dropped stream is itself a leave signal. Stream frames are gated on the effect's `cancelled` flag so the still-open stream can't leak old-session frames into a successor session's state.

Backend untouched — the last-leave machinery (`_checkpoint_if_last_left`, `close_if_clean`) was built assuming leave arrives after the client is done; this restores that assumption on the client.

## Not in scope

The viewer/editor participant split (viewers currently join the session just by opening a page, which redefines "last leave" and blocks moves) — separate design change, discussed with Bo, coming separately.

## Testing

- `bun run typecheck` clean; prettier clean.
- Manual timeline reasoning traced against `app/api/coedit.py` (`/leave`, `/stream` finally-block) and `app/tasks/coedit_checkpoint.py` (`close_if_clean` dedupe): with leave last, every race window resolves to either "ops committed by our checkpoint" or "ops committed by the forced checkpoint", never a closed-session 404.