### PR TITLE
fix(wiki): fold popover truncation and tooltip polish

### DIFF
--- a/frontend/src/components/wiki/StartNewPage.module.css
+++ b/frontend/src/components/wiki/StartNewPage.module.css
@@ -21,8 +21,16 @@
   gap: 8px;
   padding: 8px;
 }
+/* SelectCard strips className and style, so the mock's chip shadow and a
+   radius matching the card's corners live on the grid cell instead. */
 .templateCell {
   display: flex;
+  min-width: 0;
+  border-radius: var(--radius-12);
+  box-shadow: var(--shadow-chip);
+}
+.templateCell > * {
+  flex: 1;
   min-width: 0;
 }
 
@@ -36,14 +44,15 @@
   flex: 0 0 auto;
 }
 
-/* Blank-page glyph: the mock's square-plus, layered from the square and plus
-   icons. Not an interactive Button. */
-.blankGlyph {
+/* Blank-page glyph layers: the plus centers over the square inside
+   IconContainer's glyph slot. */
+.glyphStack {
   position: relative;
   display: inline-flex;
-  color: var(--text-03);
+  align-items: center;
+  justify-content: center;
 }
-.blankGlyphPlus {
+.glyphPlus {
   position: absolute;
   inset: 0;
   display: flex;

--- a/frontend/src/components/wiki/StartNewPage.tsx
+++ b/frontend/src/components/wiki/StartNewPage.tsx
@@ -3,9 +3,16 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import useSWR from "swr";
-import { LineItemButton, SelectCard, Text } from "@onyx-ai/opal/components";
+import {
+  IconContainer,
+  LineItemButton,
+  SelectCard,
+  Text,
+} from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 import { SvgChevronRight, SvgPlus, SvgSquare } from "@onyx-ai/opal/icons";
+import { cn } from "@onyx-ai/opal/utils";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { listTemplateSummaries } from "@/lib/templates";
 import type { DocumentTemplateSummary } from "@/lib/templates";
 import styles from "@/components/wiki/StartNewPage.module.css";
@@ -48,16 +55,7 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
         <div className={styles.templateCell}>
           <TemplateCard
             title="Blank page"
-            glyph={
-              // The mock's square-plus glyph, composed from published icons
-              // until @onyx-ai/opal ships an SvgSquarePlus.
-              <span className={styles.blankGlyph}>
-                <SvgSquare size={20} />
-                <span className={styles.blankGlyphPlus}>
-                  <SvgPlus size={12} />
-                </span>
-              </span>
-            }
+            glyph={<IconContainer size="main-ui" icon={SquarePlusGlyph} />}
             onClick={() => startNewPage(blankTemplate?.id)}
           />
         </div>
@@ -92,6 +90,17 @@ export function StartNewPage({ dir = "" }: { dir?: string }) {
   );
 }
 
+// Square-plus layered from published icons, sized by IconContainer's glyph
+// class. Swap to Opal's SvgSquarePlus when it ships (onyx #13153).
+const SquarePlusGlyph: IconFunctionComponent = ({ className }) => (
+  <span className={cn(styles.glyphStack, className)}>
+    <SvgSquare size={16} />
+    <span className={styles.glyphPlus}>
+      <SvgPlus size={8} />
+    </span>
+  </span>
+);
+
 function TemplateCard({
   title,
   description,
@@ -106,22 +115,18 @@ function TemplateCard({
   onClick: () => void;
 }) {
   return (
-    <SelectCard
-      state="empty"
-      onClick={onClick}
-      padding="sm"
-      rounding="lg"
-      border="solid"
-    >
+    // Mock card chrome (709:259996): tint fill, radius 12 (default rounding),
+    // no border. Filled is the select-card variant's visible-background rest.
+    <SelectCard state="filled" onClick={onClick} padding="sm" border="none">
       <Section
         flexDirection="column"
         alignItems="start"
         justifyContent="start"
-        gap={0.25}
+        gap={glyph ? 0.75 : 0.25}
         width="full"
         height="full"
       >
-        <Text font="main-ui-action" color="text-05" nowrap>
+        <Text font="main-ui-action" color="text-03" nowrap>
           {title}
         </Text>
         {glyph ? (

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import { Button, LineItemButton, Popover } from "@onyx-ai/opal/components";
 import {
@@ -25,6 +25,36 @@ function segmentLabel(segment: string): string {
 // Trailing crumbs kept visible when the path folds (the current page plus
 // its nearest ancestors). Home always renders separately.
 const FOLD_TRAIL = 4;
+
+/** Fold-menu row that reveals its full label via tooltip only when the
+ *  fixed-width popover truncates it. */
+function FoldedCrumb({
+  label,
+  onSelect,
+}: {
+  label: string;
+  onSelect: () => void;
+}) {
+  const rowRef = useRef<HTMLElement>(null);
+  const [clipped, setClipped] = useState(false);
+  useEffect(() => {
+    // Relies on Opal's title Text carrying a truncate class at one line.
+    const text = rowRef.current?.querySelector("[class*='truncate']");
+    if (text) setClipped(text.scrollWidth > text.clientWidth);
+  }, [label]);
+  return (
+    <LineItemButton
+      ref={rowRef}
+      title={label}
+      titleMaxLines={1}
+      icon={SvgFolder}
+      sizePreset="main-ui"
+      variant="section"
+      tooltip={clipped ? label : undefined}
+      onClick={onSelect}
+    />
+  );
+}
 
 export function WikiHeader() {
   const router = useRouter();
@@ -99,16 +129,13 @@ export function WikiHeader() {
                   />
                 </span>
               </Popover.Trigger>
-              <Popover.Content width="fit" align="start">
+              <Popover.Content width="lg" align="start">
                 <Popover.Menu>
                   {folded.map((c) => (
-                    <LineItemButton
+                    <FoldedCrumb
                       key={c.href}
-                      title={c.label}
-                      icon={SvgFolder}
-                      sizePreset="main-ui"
-                      variant="section"
-                      onClick={() => {
+                      label={c.label}
+                      onSelect={() => {
                         setFoldOpen(false);
                         router.push(c.href);
                       }}

--- a/frontend/src/components/wiki/WikiHeader.tsx
+++ b/frontend/src/components/wiki/WikiHeader.tsx
@@ -35,24 +35,45 @@ function FoldedCrumb({
   label: string;
   onSelect: () => void;
 }) {
-  const rowRef = useRef<HTMLElement>(null);
+  const rowRef = useRef<HTMLDivElement>(null);
   const [clipped, setClipped] = useState(false);
+  // Opal 0.1.17's ContentMd re-adds a native title attr on every render,
+  // which fights the Opal tooltip. Stripped after renders and again on
+  // hover, which rerenders through the tooltip's open state.
+  const stripNativeTitle = () => {
+    rowRef.current
+      ?.querySelector("[class*='truncate']")
+      ?.removeAttribute("title");
+  };
   useEffect(() => {
-    // Relies on Opal's title Text carrying a truncate class at one line.
-    const text = rowRef.current?.querySelector("[class*='truncate']");
-    if (text) setClipped(text.scrollWidth > text.clientWidth);
-  }, [label]);
+    // The truncate class marks Opal's one-line title span, the measured element.
+    const text = rowRef.current?.querySelector<HTMLElement>(
+      "[class*='truncate']",
+    );
+    if (!text) return;
+    // Shim for @onyx-ai/opal 0.1.17, delete when Opal ships the title-row
+    // min-w-0 fix: the row refuses to shrink beside the icon, which pushes
+    // the ellipsis outside the popover's clipped box.
+    if (text.parentElement) text.parentElement.style.minWidth = "0";
+    stripNativeTitle();
+    setClipped(text.scrollWidth > text.clientWidth);
+    // clipped in the deps reruns the strip after the gating rerender puts
+    // the title attr back.
+  }, [label, clipped]);
   return (
-    <LineItemButton
-      ref={rowRef}
-      title={label}
-      titleMaxLines={1}
-      icon={SvgFolder}
-      sizePreset="main-ui"
-      variant="section"
-      tooltip={clipped ? label : undefined}
-      onClick={onSelect}
-    />
+    // The ref sits on a wrapper because LineItemButton's ref prop does not
+    // reach a DOM node in opal 0.1.17.
+    <div ref={rowRef} onPointerEnter={stripNativeTitle}>
+      <LineItemButton
+        title={label}
+        titleMaxLines={1}
+        icon={SvgFolder}
+        sizePreset="main-ui"
+        variant="section"
+        tooltip={clipped ? label : undefined}
+        onClick={onSelect}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

Breadcrumb fixes split out of #450 when it retargeted to main. These depend on `WikiHeader.tsx`, which is created by the #439/#440 stack, so this PR stays stacked on `nikg/wiki-side-panel-tabs` and merges after #440.

- **Fold popover** — fixed 240px width, rows clamp to one line via `titleMaxLines`, hover tooltip with the full name only on truncated rows.
- **Opal 0.1.17 shim** — verified by rendering the real installed components in a browser harness: the ref moves to a wrapper div (LineItemButton's ref prop reaches no DOM node), the title row's min-width is freed so the ellipsis lands inside the popover clip, and the native `title` attribute is stripped so the Opal tooltip is the only hover surface. Upstream fixes in onyx #13153.

No new icon files. The home-icon crumb waits for Opal to ship the `home` glyph (onyx #13153), and the Blank page card commit carried here (merging via #450, patch-identical, auto-drops on the post-merge rebase) layers the published square and plus icons inside `IconContainer` until `SvgSquarePlus` ships.

## How Has This Been Tested?

## Additional Options

- [ ] This change should be considered for cherry-picking to the release branch
- [x] Override Linear Check