### PR TITLE
feat(editor): render task-list markers as toggleable checkboxes

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -8,7 +8,7 @@ import {
   sendableUpdates,
 } from "@codemirror/collab";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-import { markdown } from "@codemirror/lang-markdown";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import {
   ChangeSet,
   EditorState,
@@ -212,6 +212,14 @@ const baseTheme = EditorView.theme({
   ".cm-md-list-bullet, .cm-md-list-number": {
     color: "var(--text-03)",
     userSelect: "none",
+  },
+  ".cm-md-task-checkbox": {
+    width: "0.95em",
+    height: "0.95em",
+    margin: "0 0.35em 0 0",
+    verticalAlign: "middle",
+    accentColor: "var(--accent-01)",
+    cursor: "pointer",
   },
   ".cm-comment-highlight": {
     backgroundColor: "var(--status-warning-01)",
@@ -489,7 +497,10 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           }),
           history(),
           keymap.of([...defaultKeymap, ...historyKeymap]),
-          markdown(),
+          // GFM base (not the commonmark default) so task-list markers parse
+          // as TaskMarker — under commonmark, `[x]` in a list mis-parses as a
+          // link and the WYSIWYG renders it as an underlined `x`.
+          markdown({ base: markdownLanguage }),
           wysiwygMarkdown(),
           EditorView.lineWrapping,
           placeholderExt(placeholder ?? ""),

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -498,8 +498,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           history(),
           keymap.of([...defaultKeymap, ...historyKeymap]),
           // GFM base (not the commonmark default) so task-list markers parse
-          // as TaskMarker — under commonmark, `[x]` in a list mis-parses as a
-          // link and the WYSIWYG renders it as an underlined `x`.
+          // as TaskMarker.
           markdown({ base: markdownLanguage }),
           wysiwygMarkdown(),
           EditorView.lineWrapping,

--- a/frontend/src/lib/editor/wysiwyg.ts
+++ b/frontend/src/lib/editor/wysiwyg.ts
@@ -70,6 +70,41 @@ class HrWidget extends WidgetType {
   }
 }
 
+/** Renders a checkbox in place of a task item's `[ ]`/`[x]` marker. Clicking
+ * it rewrites the marker text in the doc — a normal local edit, so the toggle
+ * flows through the collab op stream and history like any keystroke. */
+class TaskCheckboxWidget extends WidgetType {
+  constructor(
+    readonly checked: boolean,
+    readonly markerLen: number,
+  ) {
+    super();
+  }
+  eq(other: TaskCheckboxWidget) {
+    return other.checked === this.checked && other.markerLen === this.markerLen;
+  }
+  toDOM(view: EditorView) {
+    const box = document.createElement("input");
+    box.type = "checkbox";
+    box.checked = this.checked;
+    box.className = "cm-md-task-checkbox";
+    box.addEventListener("mousedown", (e) => {
+      // Toggle without moving the caret into the marker (which would reveal
+      // the raw `[x]` mid-click).
+      e.preventDefault();
+      const pos = view.posAtDOM(box);
+      view.dispatch({
+        changes: {
+          from: pos,
+          to: pos + this.markerLen,
+          insert: this.checked ? "[ ]" : "[x]",
+        },
+      });
+    });
+    return box;
+  }
+}
+
 /** True if any selection range overlaps `[from, to]` (touching counts). */
 function spanRevealed(state: EditorState, from: number, to: number): boolean {
   return state.selection.ranges.some((r) => r.from <= to && r.to >= from);
@@ -191,6 +226,14 @@ function buildDecorations(view: EditorView): DecorationSet {
             break;
           case "ListMark": {
             if (lineRevealed(state, node.from)) break;
+            // A task item's checkbox (TaskMarker below) stands in for the
+            // bullet, so hide the `-` marker and its trailing space entirely.
+            if (node.node.nextSibling?.name === "Task") {
+              let to = node.to;
+              if (state.doc.sliceString(to, to + 1) === " ") to++;
+              ranges.push(Decoration.replace({}).range(node.from, to));
+              break;
+            }
             const parent = node.node.parent;
             const ordered = parent?.parent?.name === "OrderedList";
             const widget = ordered
@@ -200,6 +243,18 @@ function buildDecorations(view: EditorView): DecorationSet {
               : new BulletWidget();
             ranges.push(
               Decoration.replace({ widget }).range(node.from, node.to),
+            );
+            break;
+          }
+          case "TaskMarker": {
+            if (lineRevealed(state, node.from)) break;
+            const checked = /[xX]/.test(
+              state.doc.sliceString(node.from, node.to),
+            );
+            ranges.push(
+              Decoration.replace({
+                widget: new TaskCheckboxWidget(checked, node.to - node.from),
+              }).range(node.from, node.to),
             );
             break;
           }

--- a/frontend/src/lib/editor/wysiwyg.ts
+++ b/frontend/src/lib/editor/wysiwyg.ts
@@ -103,6 +103,11 @@ class TaskCheckboxWidget extends WidgetType {
     });
     return box;
   }
+  /** Clicks are fully handled by the widget's own listener — never let the
+   * editor also process them (e.g. place the caret through the checkbox). */
+  ignoreEvent() {
+    return true;
+  }
 }
 
 /** True if any selection range overlaps `[from, to]` (touching counts). */


### PR DESCRIPTION
## Problem

The WYSIWYG editor mis-renders GFM task lists (screenshot from prod: `- [ ]` shows as a literal bracket pair after the bullet, and `- [x]` shows as an underlined **x**). Root cause: `markdown()` defaults to the **commonmark** base, and task lists aren't CommonMark — they're a GFM extension. Under commonmark, `[x]` inside a list item parses as a *link*, the link-mark hiding swallows the brackets, and the `x` gets link styling. Task lists are all over the wiki (TODO pages), so this is highly visible.

## Fix

- `markdown({ base: markdownLanguage })` — the GFM base, so `[ ]`/`[x]` parse as `TaskMarker` (and stop being link-shaped).
- `TaskMarker` renders as a native checkbox via a CM widget: checked state from the marker text, `accent-01` accent, replacing the list bullet (the `-` mark + trailing space are hidden for task items, matching how GitHub renders them).
- **Clicking the checkbox toggles it**: the widget rewrites `[ ]` ↔ `[x]` in the doc, so the toggle is a normal local edit — it syncs through the collab op stream and lands in git history like any keystroke.
- Caret on the line reveals the raw `- [x]` markup, consistent with every other hidden mark.

GFM base side effects: tables/strikethrough/autolinks now *parse* but get no styling — they render as plain text exactly as before, no regression. Bonus: `markdown()`'s built-in Enter keymap now continues task lists (`- [ ] `) like it already did bullets.

## Testing

- `bun run typecheck` + prettier clean.
- Parse-level fix verified headlessly (script driving `EditorState` + `syntaxTree` on the exact prod repro line): commonmark yields `Link[[x]]` — the underlined-x bug — GFM base yields `TaskMarker[[x]]`.
- Visual rendering + click-toggle deployed to the local test stack for manual verification (checkbox widget itself needs a browser; not yet eyeballed).