### PR TITLE
fix(editor): inline hr widget — block decorations from a plugin freeze the render

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -221,6 +221,12 @@ const baseTheme = EditorView.theme({
     accentColor: "var(--accent-01)",
     cursor: "pointer",
   },
+  ".cm-md-hr": {
+    display: "inline-block",
+    width: "100%",
+    borderTop: "1px solid var(--border-02)",
+    verticalAlign: "middle",
+  },
   ".cm-comment-highlight": {
     backgroundColor: "var(--status-warning-01)",
   },

--- a/frontend/src/lib/editor/wysiwyg.ts
+++ b/frontend/src/lib/editor/wysiwyg.ts
@@ -60,13 +60,18 @@ class OrderedMarkerWidget extends WidgetType {
   }
 }
 
-/** Renders a `<hr>` in place of a `---`/`***`/`___` horizontal rule line. */
+/** Renders a full-width rule in place of a `---`/`***`/`___` horizontal rule
+ * line. Deliberately an *inline* widget (a styled span, `.cm-md-hr`) — CM6
+ * forbids block decorations from a ViewPlugin, and violating that throws
+ * mid-measure and freezes rendering of everything past the first viewport. */
 class HrWidget extends WidgetType {
   eq() {
     return true;
   }
   toDOM() {
-    return document.createElement("hr");
+    const span = document.createElement("span");
+    span.className = "cm-md-hr";
+    return span;
   }
 }
 
@@ -266,7 +271,7 @@ function buildDecorations(view: EditorView): DecorationSet {
           case "HorizontalRule":
             if (lineRevealed(state, node.from)) break;
             ranges.push(
-              Decoration.replace({ widget: new HrWidget(), block: true }).range(
+              Decoration.replace({ widget: new HrWidget() }).range(
                 node.from,
                 node.to,
               ),


### PR DESCRIPTION
## Problem

Any wiki page containing a horizontal rule (`---` line) below the initial viewport renders only its **first screenful** — everything after silently disappears, and the console fills with:

```
Uncaught RangeError: Block decorations may not be specified via plugins
```

(Live repro: "Focus for July 2026" on dev-wiki — the doc's `----` separator and entire Stretch section vanish.)

Root cause: `wysiwygMarkdown()` is a **ViewPlugin**, and CM6 forbids plugins from providing **block** decorations (they affect vertical layout, which must come from state, not view plugins). The `HorizontalRule` case used `Decoration.replace({ widget: new HrWidget(), block: true })` — fine until the viewport extends to a `---` line, at which point CM throws mid-measure and the view freezes at the first viewport forever. Shipped with the always-on WYSIWYG (#438); the data layers (git HEAD, session buffers, served body) were all verified intact while chasing this.

## Fix

Render the rule as an **inline** widget, which plugins may provide: a `.cm-md-hr` span styled to fill the line (`inline-block`, `width: 100%`, `border-top`). Visually equivalent for a rule line, since the widget replaces the whole line's text. Caret-on-line still reveals the raw dashes, unchanged.

Repo now has zero `block: true` decorations from plugins (grepped).

## Testing

- `bun run typecheck` + prettier clean.
- Root cause pinned from the live console stack on dev-wiki + code inspection (single `block: true` site in the repo).
- Deployed to the local test stack with a seeded copy of the exact prod page that reproduces the freeze — visual confirmation pending (needs a browser).