### PR TITLE
fix(editor): align doc text with the Opal type system

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -142,7 +142,7 @@ const baseTheme = EditorView.theme({
     // @onyx-ai/opal styles.css) — the doc text matches the design system's
     // content type ramp. CM manages these nodes, so the utility class can't
     // be applied directly; reference the same tokens instead.
-    fontSize: "var(--height-font-label)",
+    fontSize: "var(--height-font-label, 1rem)",
     fontWeight: "450",
     color: "var(--text-04)",
   },
@@ -152,7 +152,7 @@ const baseTheme = EditorView.theme({
     // The app's font (set on <html> by next/font in layout.tsx) — the doc
     // text must match DocTitle and the rest of the chrome.
     fontFamily: "var(--font-hanken-grotesk, system-ui, sans-serif)",
-    lineHeight: "var(--height-line-label)",
+    lineHeight: "var(--height-line-label, 1.5rem)",
     padding: "0 var(--cm-gutter, 2rem)",
     scrollbarWidth: "thin",
     scrollbarColor: "var(--border-03) transparent",

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -138,14 +138,21 @@ const peersField = StateField.define<{
 const baseTheme = EditorView.theme({
   "&": {
     height: "100%",
-    fontSize: "0.875rem",
-    color: "var(--text-05)",
+    // Opal's Main Content/Body preset (see `font-main-content-body` in
+    // @onyx-ai/opal styles.css) — the doc text matches the design system's
+    // content type ramp. CM manages these nodes, so the utility class can't
+    // be applied directly; reference the same tokens instead.
+    fontSize: "var(--height-font-label)",
+    fontWeight: "450",
+    color: "var(--text-04)",
   },
   "&.cm-focused": { outline: "none" },
   ".cm-scroller": {
     overflow: "auto",
-    fontFamily: "var(--font-sans, system-ui, -apple-system, sans-serif)",
-    lineHeight: "1.6",
+    // The app's font (set on <html> by next/font in layout.tsx) — the doc
+    // text must match DocTitle and the rest of the chrome.
+    fontFamily: "var(--font-hanken-grotesk, system-ui, sans-serif)",
+    lineHeight: "var(--height-line-label)",
     padding: "0 var(--cm-gutter, 2rem)",
     scrollbarWidth: "thin",
     scrollbarColor: "var(--border-03) transparent",
@@ -186,15 +193,13 @@ const baseTheme = EditorView.theme({
   ".cm-md-strong": { fontWeight: "bold" },
   ".cm-md-em": { fontStyle: "italic" },
   ".cm-md-code-inline": {
-    fontFamily:
-      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+    fontFamily: "var(--font-dm-mono, ui-monospace, monospace)",
     backgroundColor: "var(--background-tint-01)",
     borderRadius: "var(--radius-04, 4px)",
     padding: "0.1em 0.3em",
   },
   ".cm-md-code-block": {
-    fontFamily:
-      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+    fontFamily: "var(--font-dm-mono, ui-monospace, monospace)",
     display: "block",
     backgroundColor: "var(--background-tint-01)",
     borderRadius: "var(--radius-08)",
@@ -252,7 +257,7 @@ const baseTheme = EditorView.theme({
     borderRadius: "3px",
     color: "var(--text-inverse, #fff)",
     whiteSpace: "nowrap",
-    fontFamily: "var(--font-sans, system-ui)",
+    fontFamily: "var(--font-hanken-grotesk, system-ui, sans-serif)",
     pointerEvents: "none",
     userSelect: "none",
   },


### PR DESCRIPTION
## Problem

Doc content renders in the wrong font entirely: the editor theme asks for `var(--font-sans, system-ui, …)`, and `--font-sans` is not defined anywhere in the app — so every page body silently falls back to the system font while `DocTitle` and the rest of the chrome render Hanken Grotesk. Size/leading/color were also off-spec (14px / 1.6 / `--text-05`), and code spans hardcoded a `ui-monospace` stack instead of the app's DM Mono.

Figma targets (from Bo):
- **Title — Heading/H1 Headline**: Hanken Grotesk 24/36, weight 600, −1% tracking, Text/04
- **Content — Main Content/Body**: Hanken Grotesk 16/24, 0 tracking, Text/04

## Fix

Point the editor theme at the Opal tokens that already encode those presets (CM manages its own DOM nodes, so Opal's `font-main-content-body` utility class can't be applied directly — the theme references the same variables instead):

- doc text: `--height-font-label` (16px) / `--height-line-label` (24px) / weight 450 / `--text-04` / `--font-hanken-grotesk`
- inline code + code blocks: `var(--font-dm-mono)`
- peer caret labels: `--font-hanken-grotesk`

**No title change needed**: Opal `Content`'s headline preset already renders the H1 Headline spec — its `heading-h2` utility resolves to `--height-font-h1-headline` (24px) / `--height-line-h1-headline` (36px) / 600 / −0.24px, i.e. exactly the Figma values (the utility's name is just confusing).

## Testing

- `bun run typecheck` + prettier clean.
- Deployed to the local test stack for visual confirmation (pending eyeball).