### PR TITLE
fix(editor): always hide markdown markup, never reveal on caret or focus

### DIFF
--- a/frontend/src/lib/editor/wysiwyg.ts
+++ b/frontend/src/lib/editor/wysiwyg.ts
@@ -1,11 +1,11 @@
-/** Typora-style live-preview WYSIWYG decorations for the markdown editor.
+/** Live-preview WYSIWYG decorations for the markdown editor.
  *
  * Walks the `@lezer/markdown` syntax tree on every doc/selection change and
  * builds a `DecorationSet` that hides markup characters (`#`, `**`, `` ` ``,
  * `> `, link brackets/URLs) and applies `cm-md-*` classes to the surrounding
- * span for visual styling. The raw markup for a span is revealed again while
- * the editor is focused and the selection touches it, so the user can still
- * see/edit what they typed — an unfocused editor is pure preview.
+ * span for visual styling. Markup stays hidden unconditionally, regardless of
+ * caret position or focus — the rendered form is the only form the user ever
+ * sees.
  *
  * Storage is untouched — this only decorates the view; the doc string (and
  * the collab op stream, which operates on that string) never changes.
@@ -116,37 +116,15 @@ class TaskCheckboxWidget extends WidgetType {
   }
 }
 
-/** True if any selection range overlaps `[from, to]` (touching counts). */
-function spanRevealed(state: EditorState, from: number, to: number): boolean {
-  return state.selection.ranges.some((r) => r.from <= to && r.to >= from);
-}
-
-/** True if any selection range overlaps the line containing `pos`. */
-function lineRevealed(state: EditorState, pos: number): boolean {
-  const line = state.doc.lineAt(pos);
-  return spanRevealed(state, line.from, line.to);
-}
-
-/** The enclosing node whose range gates reveal for a markup-mark child (e.g.
- * `EmphasisMark`'s parent `StrongEmphasis`). Falls back to the mark itself. */
-function revealScope(node: SyntaxNodeRef): { from: number; to: number } {
-  const parent = node.node.parent;
-  return parent ? { from: parent.from, to: parent.to } : node;
-}
-
-/** Hides `node`'s range unless `revealed` says the selection touches its
- * enclosing span, extending the hidden range over one trailing space (the
- * un-tokenized gap after `#`/`>` markers) so hiding it doesn't leave a stray
- * leading space. */
+/** Hides `node`'s range unconditionally, extending the hidden range over one
+ * trailing space (the un-tokenized gap after `#`/`>` markers) so hiding it
+ * doesn't leave a stray leading space. */
 function hideMark(
   state: EditorState,
   node: SyntaxNodeRef,
   ranges: Range<Decoration>[],
-  revealed: (from: number, to: number) => boolean,
   swallowTrailingSpace = false,
 ): void {
-  const scope = revealScope(node);
-  if (revealed(scope.from, scope.to)) return;
   let to = node.to;
   if (swallowTrailingSpace && state.doc.sliceString(to, to + 1) === " ") to++;
   ranges.push(Decoration.replace({}).range(node.from, to));
@@ -154,13 +132,6 @@ function hideMark(
 
 function buildDecorations(view: EditorView): DecorationSet {
   const { state } = view;
-  // CM always has a selection — a freshly mounted editor rests at doc start —
-  // so gate reveal on focus: an unfocused editor is being *read*, and must not
-  // expose line 1's raw markup under a caret the user never placed.
-  const canReveal = view.hasFocus;
-  const revealedSpan = (from: number, to: number) =>
-    canReveal && spanRevealed(state, from, to);
-  const revealedLine = (pos: number) => canReveal && lineRevealed(state, pos);
   const ranges: Range<Decoration>[] = [];
 
   for (const { from, to } of view.visibleRanges) {
@@ -228,24 +199,23 @@ function buildDecorations(view: EditorView): DecorationSet {
             );
             break;
           case "HeaderMark":
-            hideMark(state, node, ranges, revealedSpan, true);
+            hideMark(state, node, ranges, true);
             break;
           case "QuoteMark":
-            hideMark(state, node, ranges, revealedSpan, true);
+            hideMark(state, node, ranges, true);
             break;
           case "EmphasisMark":
           case "CodeMark":
           case "LinkMark":
-            hideMark(state, node, ranges, revealedSpan);
+            hideMark(state, node, ranges);
             break;
           case "URL":
             // Only the URL inside a `[text](url)` link is markup to hide —
             // a bare autolink's URL is its own visible content.
             if (node.node.parent?.name === "Link")
-              hideMark(state, node, ranges, revealedSpan);
+              hideMark(state, node, ranges);
             break;
           case "ListMark": {
-            if (revealedLine(node.from)) break;
             // A task item's checkbox (TaskMarker below) stands in for the
             // bullet, so hide the `-` marker and its trailing space entirely.
             if (node.node.nextSibling?.name === "Task") {
@@ -267,7 +237,6 @@ function buildDecorations(view: EditorView): DecorationSet {
             break;
           }
           case "TaskMarker": {
-            if (revealedLine(node.from)) break;
             const checked = /[xX]/.test(
               state.doc.sliceString(node.from, node.to),
             );
@@ -279,7 +248,6 @@ function buildDecorations(view: EditorView): DecorationSet {
             break;
           }
           case "HorizontalRule":
-            if (revealedLine(node.from)) break;
             ranges.push(
               Decoration.replace({ widget: new HrWidget() }).range(
                 node.from,
@@ -296,8 +264,8 @@ function buildDecorations(view: EditorView): DecorationSet {
 }
 
 /** Live-preview markdown decorations: hides markup characters and applies
- * `cm-md-*` visual styling, revealing raw syntax while the editor is focused
- * and the caret is inside a span. Requires `markdown()` (from
+ * `cm-md-*` visual styling, unconditionally — neither caret position nor
+ * focus ever reveals raw syntax. Requires `markdown()` (from
  * `@codemirror/lang-markdown`) earlier in the extension list so `syntaxTree`
  * has a parse to walk. */
 export function wysiwygMarkdown() {
@@ -311,9 +279,7 @@ export function wysiwygMarkdown() {
         if (
           update.docChanged ||
           update.selectionSet ||
-          update.viewportChanged ||
-          // Reveal is focus-gated, so focus/blur changes what's hidden.
-          update.focusChanged
+          update.viewportChanged
         ) {
           this.decorations = buildDecorations(update.view);
         }

--- a/frontend/src/lib/editor/wysiwyg.ts
+++ b/frontend/src/lib/editor/wysiwyg.ts
@@ -276,11 +276,7 @@ export function wysiwygMarkdown() {
         this.decorations = buildDecorations(view);
       }
       update(update: ViewUpdate) {
-        if (
-          update.docChanged ||
-          update.selectionSet ||
-          update.viewportChanged
-        ) {
+        if (update.docChanged || update.viewportChanged) {
           this.decorations = buildDecorations(update.view);
         }
       }


### PR DESCRIPTION
## Summary
- Removes the Typora-style "reveal raw markdown while the caret/selection touches it" behavior from `wysiwygMarkdown()` (`frontend/src/lib/editor/wysiwyg.ts`) — markup (`#`, `**`, `` ` ``, `> `, list markers, task markers, `---`) now stays hidden/rendered unconditionally, regardless of caret position or editor focus.
- Deletes `spanRevealed`/`lineRevealed`/`revealScope` and the `view.hasFocus`/`update.focusChanged` gating that #458 had added on top of the same reveal mechanism — there's no reveal path left at all now.
- Rebuilt on top of latest `main` (post-#451/#454/#455/#456/#458), so it also drops the newer `TaskMarker` case's reveal check.