### PR TITLE
feat(coedit): read-gated join + viewer/editor presence + can_write on reads

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -45,6 +45,7 @@ def _participants_out(session_id: int) -> list[ParticipantOut]:
             user_display=p.user_display,
             joined_at=p.joined_at,
             last_seen_at=p.last_seen_at,
+            last_edited_at=p.last_edited_at,
         )
         for p in coedit.list_participants(session_id)
     ]
@@ -54,11 +55,14 @@ def _participants_out(session_id: int) -> list[ParticipantOut]:
 def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
     """Open (or join) the live session for a page and return its buffer.
 
-    Joining is editing, so it requires write. A fresh session is seeded from the
+    Joining is opening the page — presence + the live op stream — so it
+    requires only read; *writing* is gated at ``/op``/``/cursor``. A
+    participant who never sends an op shows as "viewing" in presence
+    (``last_edited_at`` stays NULL). A fresh session is seeded from the
     page's current HEAD; an already-open session is adopted as-is (its live
     buffer wins).
     """
-    require_can("write", req.path, user)
+    require_can("read", req.path, user)
     head = git.head_sha_for_path(req.path)
     initial = git.read_file_opt(req.path) or ""
     sess = coedit.open_session(req.path, base_sha=head, initial_buffer=initial)
@@ -125,7 +129,7 @@ def op(req: OpRequest, user: User = Depends(require_user)) -> OpResponse:
         raise HTTPException(status_code=422, detail=str(e)) from e
     if out is None:
         raise HTTPException(status_code=409, detail="stale base_version; re-sync and retry")
-    coedit.touch(req.session_id, user.id)
+    coedit.touch(req.session_id, user.id, edited=True)
     coedit_channel.broadcast_op(
         req.session_id, out.version, req.changes, user.id, client_id=req.client_id
     )
@@ -223,9 +227,9 @@ def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResp
     if sess is None or sess.status != coedit.SessionStatus.ACTIVE.value:
         raise HTTPException(status_code=404, detail="no active session")
     # Opening the stream makes the user a session participant (roster +
-    # heartbeat + commit attribution), so it requires write — symmetric with
-    # POST /join. Read-only observation would be a separate non-participant path.
-    require_can("write", sess.path, user)
+    # heartbeat), which is page-open presence, not edit intent — so it
+    # requires read, symmetric with POST /join. Writes stay gated at /op.
+    require_can("read", sess.path, user)
 
     coedit.join(session_id, user.id)
     # Announce the new participant to existing connections *before* registering

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -295,6 +295,9 @@ def get_document_by_path(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
     require_can("read", rel, user)
+    from app.wiki import acl as _acl
+
+    can_write = _acl.can(user.id, user.is_admin, "write", rel)
     head_sha = wiki_git.head_sha_for_path(rel)
     # Stable id: reading a live page lazily backfills its row (pre-id pages);
     # historical/deleted reads only report an id if a live row exists.
@@ -311,7 +314,9 @@ def get_document_by_path(
             body = wiki_git.read_file(historical, ref=ref)
         except wiki_git.UnknownSha as exc:
             raise HTTPException(status_code=404, detail="not found at ref") from exc
-        return GetDocumentResponse(path=rel, body=body, head_sha=head_sha, ref=ref, id=page_id)
+        return GetDocumentResponse(
+            path=rel, body=body, head_sha=head_sha, ref=ref, id=page_id, can_write=can_write
+        )
 
     # Session-aware live read: when a co-edit session is open on this page, its
     # Postgres buffer holds the freshest edits. The checkpoint that commits the
@@ -362,6 +367,7 @@ def get_document_by_path(
         id=page_id,
         attribution=provenance.head_attribution(rel, head_sha),
         sources=provenance.sources_for_path(rel),
+        can_write=can_write,
     )
 
 

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
-from app.auth import User, require_can
+from app.auth import PermissionDenied, User, require_can
 from app.auth.deps import require_user
 from app.models.file_system import (
     ActivityRowView,
@@ -153,10 +153,8 @@ def list_documents(
 ) -> ListDocumentsResponse:
     raw = wiki_git.list_paths_with_mtime(prefix)
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
         md_paths = [p for p, _ in raw if p.endswith(".md")]
-        visible = set(_acl.filter_paths_in_python(user.id, False, md_paths))
+        visible = set(acl.filter_paths_in_python(user.id, False, md_paths))
         # Keep non-md paths (folders, .gitkeep) so the explorer can render
         # the tree; permission checks happen on actual page access.
         raw = [(p, ts) for p, ts in raw if not p.endswith(".md") or p in visible]
@@ -250,9 +248,7 @@ def list_recent_pages(
     raw = wiki_git.paths_authored_by(user.email)
     md = [(p, ts) for p, ts in raw if p.endswith(".md")]
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
-        visible = set(_acl.filter_paths_in_python(user.id, False, [p for p, _ in md]))
+        visible = set(acl.filter_paths_in_python(user.id, False, [p for p, _ in md]))
         md = [(p, ts) for p, ts in md if p in visible]
     # Newest first; empty timestamps sink to the bottom.
     md.sort(key=lambda pt: pt[1], reverse=True)
@@ -294,10 +290,14 @@ def get_document_by_path(
         rel = filesystem.safe_rel_path(path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
-    require_can("read", rel, user)
-    from app.wiki import acl as _acl
 
-    can_write = _acl.can(user.id, user.is_admin, "write", rel)
+    # One ACL resolution serves both the read gate and can_write — require_can
+    # plus a separate can("write") would run the grants query twice on this
+    # hot path. Same error shape as require_can (PermissionDenied → 403).
+    perms = acl.effective(user.id, user.is_admin, rel)
+    if "read" not in perms:
+        raise PermissionDenied(f"forbidden: read on {rel}")
+    can_write = "write" in perms
     head_sha = wiki_git.head_sha_for_path(rel)
     # Stable id: reading a live page lazily backfills its row (pre-id pages);
     # historical/deleted reads only report an id if a live row exists.
@@ -860,9 +860,7 @@ def list_recent_docs(user: User = Depends(require_user)) -> RecentDocsResponse:
     # revoke access after the fact, so re-filter on every read.
     paths = [p for p in paths if filesystem.absolute(p).is_file()]
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
-        paths = _acl.filter_paths_in_python(user.id, False, paths)
+        paths = acl.filter_paths_in_python(user.id, False, paths)
     ids = doc_ids.ids_for_paths(paths)
     items = [DocRef(path=p, id=ids.get(p)) for p in paths]
     return RecentDocsResponse(paths=paths, items=items)
@@ -888,9 +886,7 @@ def list_starred_docs(user: User = Depends(require_user)) -> StarredDocsResponse
     # after the star must hide the entry.
     paths = [p for p in paths if filesystem.absolute(p).is_file()]
     if not user.is_admin:
-        from app.wiki import acl as _acl
-
-        paths = _acl.filter_paths_in_python(user.id, False, paths)
+        paths = acl.filter_paths_in_python(user.id, False, paths)
     ids = doc_ids.ids_for_paths(paths)
     items = [DocRef(path=p, id=ids.get(p)) for p in paths]
     return StarredDocsResponse(paths=paths, items=items)

--- a/backend/app/db/migrations/versions/b3e8f5a90c27_coedit_participant_last_edited_at.py
+++ b/backend/app/db/migrations/versions/b3e8f5a90c27_coedit_participant_last_edited_at.py
@@ -2,9 +2,9 @@
 
 Adds ``coedit_participants.last_edited_at`` — when the participant last
 applied an edit op (NULL for a participant who has only viewed). Presence
-uses it to label roster members "viewing" vs "editing" now that joining a
-session means opening the page, not editing it. Guarded with the inspector
-because ``0001_initial`` builds fresh databases from the current models.
+uses it to label roster members "viewing" vs "editing". Guarded with the
+inspector because ``0001_initial`` builds fresh databases from the current
+models.
 
 Revision ID: b3e8f5a90c27
 Revises: f1a2b3c4d5e6

--- a/backend/app/db/migrations/versions/b3e8f5a90c27_coedit_participant_last_edited_at.py
+++ b/backend/app/db/migrations/versions/b3e8f5a90c27_coedit_participant_last_edited_at.py
@@ -7,7 +7,7 @@ inspector because ``0001_initial`` builds fresh databases from the current
 models.
 
 Revision ID: b3e8f5a90c27
-Revises: f1a2b3c4d5e6
+Revises: c7a1f0e3b2d9
 Create Date: 2026-07-20 00:00:00.000000+00:00
 """
 from __future__ import annotations
@@ -18,7 +18,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision: str = "b3e8f5a90c27"
-down_revision: str | None = "f1a2b3c4d5e6"
+down_revision: str | None = "c7a1f0e3b2d9"
 branch_labels: Sequence[str] | None = None
 depends_on: Sequence[str] | None = None
 

--- a/backend/app/db/migrations/versions/b3e8f5a90c27_coedit_participant_last_edited_at.py
+++ b/backend/app/db/migrations/versions/b3e8f5a90c27_coedit_participant_last_edited_at.py
@@ -1,0 +1,41 @@
+"""coedit_participant_last_edited_at
+
+Adds ``coedit_participants.last_edited_at`` — when the participant last
+applied an edit op (NULL for a participant who has only viewed). Presence
+uses it to label roster members "viewing" vs "editing" now that joining a
+session means opening the page, not editing it. Guarded with the inspector
+because ``0001_initial`` builds fresh databases from the current models.
+
+Revision ID: b3e8f5a90c27
+Revises: f1a2b3c4d5e6
+Create Date: 2026-07-20 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b3e8f5a90c27"
+down_revision: str | None = "f1a2b3c4d5e6"
+branch_labels: Sequence[str] | None = None
+depends_on: Sequence[str] | None = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    if not _has_column("coedit_participants", "last_edited_at"):
+        op.add_column(
+            "coedit_participants",
+            sa.Column("last_edited_at", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _has_column("coedit_participants", "last_edited_at"):
+        op.drop_column("coedit_participants", "last_edited_at")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1005,6 +1005,10 @@ class CoeditParticipant(Base):
     last_seen_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
+    # When this participant last applied an edit op, ISO 8601 UTC. NULL for a
+    # participant who has only viewed — presence renders them "viewing", not
+    # "editing" (joining a session is page-open, not edit intent).
+    last_edited_at: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (Index("idx_coedit_participants_user", "user_id"),)
 

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -57,6 +57,9 @@ class ParticipantOut(BaseModel):
     user_display: str
     joined_at: str
     last_seen_at: str
+    # None until the participant applies an edit op — presence renders such
+    # members "viewing" rather than "editing".
+    last_edited_at: str | None = None
 
 
 class JoinResponse(BaseModel):

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -179,7 +179,9 @@ class GetDocumentResponse(BaseModel):
     # Whether the caller may edit this page. Joining the co-edit session is
     # read-gated (page-open presence), so the frontend uses this to suppress
     # ops/cursors and render read-only affordances for read-only viewers.
-    can_write: bool = True
+    # Required (no default): every constructor must resolve it from the ACL,
+    # so a new call site can't silently advertise write access.
+    can_write: bool
 
 
 class PutDocumentResponse(BaseModel):

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -176,6 +176,10 @@ class GetDocumentResponse(BaseModel):
     id: str | None = None  # stable wiki_doc_id; None for historical/deleted reads
     attribution: Attribution | None = None
     sources: list[SourceRef] = Field(default_factory=list)
+    # Whether the caller may edit this page. Joining the co-edit session is
+    # read-gated (page-open presence), so the frontend uses this to suppress
+    # ops/cursors and render read-only affordances for read-only viewers.
+    can_write: bool = True
 
 
 class PutDocumentResponse(BaseModel):

--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -57,7 +57,9 @@ def checkpoint_coedit_session(session_id: int) -> None:
 
 @coedit_queue.periodic_task(crontab(minute="*"))
 def scan_and_checkpoint() -> None:
-    """Enqueue a checkpoint for every dirty session that's idle or overdue."""
+    """Enqueue a checkpoint for every dirty session that's idle or overdue,
+    and purge closed never-edited sessions (view-only leftovers — see
+    ``coedit.purge_viewer_sessions``)."""
     due = coedit.sessions_due_for_checkpoint(
         idle_seconds=_IDLE_SECONDS, max_interval_seconds=_MAX_INTERVAL_SECONDS
     )
@@ -65,3 +67,6 @@ def scan_and_checkpoint() -> None:
         checkpoint_coedit_session(sess.id)
     if due:
         log.info("coedit checkpoint scan: enqueued %d session(s)", len(due))
+    purged = coedit.purge_viewer_sessions()
+    if purged:
+        log.info("coedit checkpoint scan: purged %d viewer-only session(s)", purged)

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -102,6 +102,9 @@ class ParticipantRow(BaseModel):
     user_display: str
     joined_at: str
     last_seen_at: str
+    # NULL until the participant applies an edit op — presence renders such
+    # members "viewing" (joining a session is page-open, not edit intent).
+    last_edited_at: str | None = None
 
 
 def _session_row(s: CoeditSession) -> SessionRow:
@@ -126,6 +129,7 @@ def _participant_row(p: CoeditParticipant, user_display: str) -> ParticipantRow:
         user_display=user_display,
         joined_at=p.joined_at,
         last_seen_at=p.last_seen_at,
+        last_edited_at=p.last_edited_at,
     )
 
 
@@ -736,12 +740,18 @@ def join(session_id: int, user_id: str) -> None:
             )
 
 
-def touch(session_id: int, user_id: str) -> None:
-    """Refresh a participant's ``last_seen_at`` (presence heartbeat)."""
+def touch(session_id: int, user_id: str, *, edited: bool = False) -> None:
+    """Refresh a participant's ``last_seen_at`` (presence heartbeat).
+
+    ``edited=True`` (the ``/op`` path) also stamps ``last_edited_at``, which is
+    what flips their presence label from "viewing" to "editing"."""
     with session() as s:
         existing = s.get(CoeditParticipant, (session_id, user_id))
         if existing is not None:
-            existing.last_seen_at = _iso(_now())
+            now = _iso(_now())
+            existing.last_seen_at = now
+            if edited:
+                existing.last_edited_at = now
 
 
 def leave(session_id: int, user_id: str) -> None:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -27,7 +27,7 @@ from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import delete, func, or_, select, update
 from sqlalchemy.exc import IntegrityError
 
 from app.db.models import CoeditOp, CoeditParticipant, CoeditSession, User
@@ -654,6 +654,38 @@ def close_if_clean(session_id: int) -> bool:
             .execution_options(synchronize_session=False)
         ).one_or_none()
         return closed is not None
+
+
+def purge_viewer_sessions(limit: int = 500) -> int:
+    """Delete closed sessions that never received an edit op. Returns the count.
+
+    With join-on-landing, every page view mints a session whose buffer is a
+    full copy of the page — a closed ``version == 0`` row carries no ops, no
+    participants (removed on leave; FK cascade catches stragglers), and nothing
+    the op-log or checkpoint dedupe ever references, so it is pure dead weight.
+    Runs against *closed* rows only: deleting at the close point instead would
+    race a concurrent join into an FK violation, while a closed session is a
+    soft state joins already tolerate. Bounded so the periodic scan stays
+    cheap; the backlog drains across successive runs.
+    """
+    with session() as s:
+        ids = s.scalars(
+            select(CoeditSession.id)
+            .where(
+                CoeditSession.status == SessionStatus.CLOSED.value,
+                CoeditSession.version == 0,
+                CoeditSession.checkpointed_version == 0,
+            )
+            .limit(limit)
+        ).all()
+        if not ids:
+            return 0
+        s.execute(
+            delete(CoeditSession)
+            .where(CoeditSession.id.in_(ids))
+            .execution_options(synchronize_session=False)
+        )
+        return len(ids)
 
 
 # Namespace for checkpoint advisory-lock keys. The whole DB shares one 64-bit

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -59,7 +59,7 @@ def test_join_is_idempotent_and_shared(client):
     assert {p["user_id"] for p in second["participants"]} == {a, b}
 
 
-def test_join_without_write_is_forbidden(client):
+def test_join_without_read_is_forbidden(client):
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
     _seed_page()
@@ -71,10 +71,11 @@ def test_join_without_write_is_forbidden(client):
     assert client.post("/api/coedit/join", json={"path": _PATH}).status_code == 403
 
 
-def test_stream_requires_write(client):
-    # Opening the stream is editing (it joins the roster), so a non-writer is
-    # rejected — symmetric with /join. require_can raises before the response
-    # starts streaming, so this returns 403 without hanging.
+def test_stream_requires_read(client):
+    # Opening the stream joins the roster (page-open presence), gated on read
+    # — symmetric with /join; writes are gated at /op. require_can raises
+    # before the response starts streaming, so this returns 403 without
+    # hanging.
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
     _seed_page()
@@ -85,6 +86,69 @@ def test_stream_requires_write(client):
 
     login_fastapi(client, other)
     assert client.get(f"/api/coedit/stream?session_id={sid}").status_code == 403
+
+
+def test_read_only_user_joins_as_viewer_but_cannot_edit(client):
+    # Joining is page-open presence (read-gated); the write boundary is /op
+    # and /cursor. A read-only user lands in the roster with no
+    # last_edited_at — presence renders them "viewing".
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    reader = users_repo.create(email="reader@x.com", password="hunter2-x", name="Reader")
+    _seed_page()
+    acl.set_owner(_PATH, owner)  # owner-only page...
+    acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=reader,
+        permission="read",
+        granted_by_user_id=owner,
+    )  # ...plus an explicit read grant for the viewer
+
+    login_fastapi(client, reader)
+    resp = client.post("/api/coedit/join", json={"path": _PATH})
+    assert resp.status_code == 200
+    sid = resp.json()["session_id"]
+    me = [p for p in resp.json()["participants"] if p["user_id"] == reader]
+    assert me and me[0]["last_edited_at"] is None
+
+    op = client.post(
+        "/api/coedit/op",
+        json={
+            "session_id": sid,
+            "base_version": 0,
+            "changes": [{"from": 0, "to": 0, "insert": "x"}],
+        },
+    )
+    assert op.status_code == 403
+    cursor = client.post(
+        "/api/coedit/cursor",
+        json={"session_id": sid, "anchor": 0, "head": 0, "typing": False},
+    )
+    assert cursor.status_code == 403
+
+    # The read tells the frontend not to offer editing at all.
+    doc = client.get(f"/api/wiki/file?path={_PATH}")
+    assert doc.status_code == 200
+    assert doc.json()["can_write"] is False
+
+    login_fastapi(client, owner)
+    assert client.get(f"/api/wiki/file?path={_PATH}").json()["can_write"] is True
+
+
+def test_op_stamps_last_edited_at(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page()
+
+    joined = client.post("/api/coedit/join", json={"path": _PATH}).json()
+    sid = joined["session_id"]
+    assert joined["participants"][0]["last_edited_at"] is None
+
+    _apply_op(client, sid, 0, [{"from": 0, "to": 0, "insert": "x"}])
+    after = client.get(f"/api/coedit/session?session_id={sid}").json()
+    me = [p for p in after["participants"] if p["user_id"] == uid]
+    assert me and me[0]["last_edited_at"] is not None
 
 
 def test_leave_removes_participant(client):

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -381,3 +381,28 @@ def test_ops_since_with_head_returns_ops_after_version(users):
     assert coedit.ops_since_with_head(s.id, 2).ops == []
     # Head version comes back alongside the ops, from one consistent read.
     assert coedit.ops_since_with_head(s.id, 0).head_version == 2
+
+
+def test_purge_viewer_sessions_deletes_only_closed_never_edited(users):
+    # Viewer-only session: opened (buffer seeded), no ops, closed.
+    viewer_only = coedit.open_session("viewed.md", base_sha=None, initial_buffer="body")
+    coedit.join(viewer_only.id, "usr_a")
+    coedit.leave(viewer_only.id, "usr_a")
+    coedit.close_session(viewer_only.id)
+
+    # Edited session: has an op, closed after checkpoint — must be retained
+    # (its coedit_ops history hangs off it).
+    edited = coedit.open_session("edited.md", base_sha=None, initial_buffer="hi")
+    coedit.apply_op(edited.id, base_version=0, changes=[_ch(0, 0, "x")], author_user_id="usr_a")
+    coedit.mark_checkpointed(edited.id, base_sha="sha", version=1)
+    coedit.close_session(edited.id)
+
+    # Active viewer-only session: still occupied — must be retained.
+    active = coedit.open_session("open.md", base_sha=None, initial_buffer="live")
+
+    assert coedit.purge_viewer_sessions() == 1
+    assert coedit.get_session(viewer_only.id) is None
+    assert coedit.get_session(edited.id) is not None
+    assert coedit.get_session(active.id) is not None
+    # Idempotent: nothing left to purge.
+    assert coedit.purge_viewer_sessions() == 0


### PR DESCRIPTION
## Problem

Since the always-on editor (#438), opening a page joins its co-edit session — but the session API still treats every participant as an editor:

- `/coedit/join` and `/coedit/stream` are **write**-gated, so a read-only user gets a 403 just for opening a page they're allowed to read.
- The roster has no viewer/editor distinction, so presence shows everyone as "also editing" — people who are just reading included.

Decision (Bo): keep **join-on-landing** — every viewer stays in the session and gets the true real-time op stream (no checkpoint-lag for readers) — and re-draw the permission/presence boundary instead.

## Change

- **Join + stream are read-gated** (page-open presence); `/op` and `/cursor` keep requiring write — the actual edit boundary. A read-only user can open the page and watch edits live, but any attempt to edit 403s.
- **`coedit_participants.last_edited_at`** (new nullable column, migration `b3e8f5a90c27`, inspector-guarded like its predecessors): stamped by the `/op` path (`touch(edited=True)`), NULL for participants who have only viewed. Exposed on `ParticipantOut` → presence frames, so the frontend can label roster members **viewing** vs **editing**.
- **`GET /wiki/file` gains `can_write`** so the frontend knows to suppress op/cursor sends and render read-only affordances (defaults `true`, additive).

Viewer-only sessions stay cheap: their buffer never gets ops so it stays clean — the checkpoint scan skips them, live-rebase of inbound commits is trivial, and they close when the last person leaves. `last_edited_at` also gives us a lossless-recycle lever for parked-tab sessions if we ever want one.

## Frontend follow-up (stacked, next PR)

Presence bar labels ("viewing"/"editing" from `last_edited_at`), read-only editor mode from `can_write`.

## Testing

- `tests/test_coedit_api.py`: renamed the two gate tests to match the new semantics (join/stream forbidden without **read**), new `test_read_only_user_joins_as_viewer_but_cannot_edit` (join+roster OK, op/cursor 403, `can_write` false for reader / true for owner), new `test_op_stamps_last_edited_at`.
- 139 tests green across coedit api/repo/checkpoint, doc-ids, acl; ruff + strict basedpyright clean.