### PR TITLE
feat(editor): viewing/editing presence labels + read-only viewer mode

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -1,4 +1,9 @@
-"""Co-editing live channel — SSE down, HTTP POST up (cookie-authed humans).
+"""The page live-session channel — SSE down, HTTP POST up (cookie-authed humans).
+
+A "co-edit session" is the page's *live session*: everyone viewing the page
+joins it (read-gated — presence + real-time updates), and editing is a
+capability inside it (`/op`/`/cursor` are write-gated; `last_edited_at`
+separates editors from viewers in presence).
 
 Thin HTTP layer: gate by page permission, drive the ``app/wiki/coedit.py`` store
 and the ``app/wiki/coedit_channel.py`` broadcast layer. The SSE stream is a

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -1,10 +1,10 @@
-"""Co-editing session store — the Postgres editing buffer.
+"""Live-session store — the Postgres editing buffer.
 
 The DB is the source of truth for an in-progress *live* edit. There is **one
-active session per page** (path-keyed); multiple humans join it and converge on
-a single server-authoritative ``buffer_text`` + monotonic ``version``. A
-single-user edit is just a 1-participant session — the model the per-user draft
-will eventually fold into.
+active session per page** (path-keyed); everyone viewing the page joins it
+(the session is the page's live channel — participants include pure viewers,
+distinguished from editors by ``last_edited_at``), and its editors converge on
+a single server-authoritative ``buffer_text`` + monotonic ``version``.
 
 This module is the *storage* seam only: get-or-create a session, join/leave/
 touch participants, and compare-and-swap the buffer. The op/patch channel and

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -23,7 +23,13 @@ import {
   placeholder as placeholderExt,
   WidgetType,
 } from "@codemirror/view";
-import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { ApiError } from "@/lib/api";
 import type {
   CoeditFrame,
@@ -272,6 +278,10 @@ interface CoeditorProps {
   registerFlush: (fn: (() => Promise<void>) | null) => void;
   registerSetDoc: (fn: ((text: string) => void) | null) => void;
   placeholder?: string;
+  /** Render the doc without accepting edits — for participants whose
+   * `can_write` is false. They stay in the live session (presence + real-time
+   * updates); only local mutation is disabled. */
+  readOnly?: boolean;
   /** Comment thread spans to highlight in the doc (the active/selected thread
    * gets the stronger highlight). */
   commentHighlights?: CommentHighlightTarget[];
@@ -315,6 +325,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       registerFlush,
       registerSetDoc,
       placeholder,
+      readOnly,
       commentHighlights,
       onSelectionForComment,
     },
@@ -513,6 +524,8 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           markdown({ base: markdownLanguage }),
           wysiwygMarkdown(),
           EditorView.lineWrapping,
+          EditorState.readOnly.of(!!readOnly),
+          EditorView.editable.of(!readOnly),
           placeholderExt(placeholder ?? ""),
           peersField,
           commentsField,
@@ -631,15 +644,37 @@ interface CoeditPresenceBarProps {
   selfUserId: string | null;
 }
 
-// Co-editing presence: who else is in the session and who's typing right now,
-// as a name/typing summary above the editor — complements the in-editor peer
-// carets (CaretWidget/peersField above) rather than duplicating them. Renders
-// nothing when you're alone.
+// How recently a participant must have edited to be labeled "editing" rather
+// than "viewing". Everyone on the page is in the live session; the label — not
+// membership — is what distinguishes editors from readers.
+const EDITING_LABEL_WINDOW_MS = 5 * 60 * 1000;
+
+function presenceLabel(p: CoeditParticipant, now: number): string {
+  if (
+    p.last_edited_at !== null &&
+    now - Date.parse(p.last_edited_at) < EDITING_LABEL_WINDOW_MS
+  ) {
+    return "editing";
+  }
+  return "viewing";
+}
+
+// Live-session presence: who else is on the page — labeled "editing" when
+// they've applied an edit recently, "viewing" otherwise — and who's typing
+// right now. Complements the in-editor peer carets (CaretWidget/peersField
+// above) rather than duplicating them. Renders nothing when you're alone.
+// The minute tick re-renders so an idle editor's label decays to "viewing"
+// even when no new presence frames arrive.
 export function CoeditPresenceBar({
   participants,
   typing,
   selfUserId,
 }: CoeditPresenceBarProps) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(t);
+  }, []);
   const others = participants.filter((p) => p.user_id !== selfUserId);
   if (others.length === 0) return null;
   const typingSet = new Set(typing);
@@ -652,12 +687,11 @@ export function CoeditPresenceBar({
       {others.map((p) => (
         <span key={p.user_id} className="inline-flex items-center gap-1">
           <span className="font-medium text-(--text-04)">{p.user_display}</span>
-          {typingSet.has(p.user_id) && (
-            <span className="text-(--text-03) italic">typing…</span>
-          )}
+          <span className="text-(--text-03) italic">
+            {typingSet.has(p.user_id) ? "typing…" : presenceLabel(p, now)}
+          </span>
         </span>
       ))}
-      <span>also editing</span>
     </div>
   );
 }

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -11,6 +11,7 @@ import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import {
   ChangeSet,
+  Compartment,
   EditorState,
   StateEffect,
   StateField,
@@ -333,6 +334,8 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
   ) {
     const host = useRef<HTMLDivElement | null>(null);
     const view = useRef<EditorView | null>(null);
+    // Swappable slot for the read-only facets — see readOnlyExtensions.
+    const readOnlyCompartment = useRef(new Compartment());
     // Latest callbacks without re-creating the editor.
     const onSelRef = useRef(onSelectionChange);
     const reportDocRef = useRef(reportDoc);
@@ -524,8 +527,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           markdown({ base: markdownLanguage }),
           wysiwygMarkdown(),
           EditorView.lineWrapping,
-          EditorState.readOnly.of(!!readOnly),
-          EditorView.editable.of(!readOnly),
+          // In a compartment so a later `readOnly` prop change reconfigures
+          // the live editor (facets are otherwise baked in at create time —
+          // e.g. can_write flipping after a permissions change must not
+          // leave the editor writable).
+          readOnlyCompartment.current.of(readOnlyExtensions(!!readOnly)),
           placeholderExt(placeholder ?? ""),
           peersField,
           commentsField,
@@ -629,6 +635,18 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       });
     }, [commentHighlights]);
 
+    // Reconfigure the read-only facets when the prop changes — they're baked
+    // into the state at create time otherwise, and a `can_write` correction
+    // (e.g. permissions revoked mid-session) must not leave the editor
+    // writable.
+    useEffect(() => {
+      view.current?.dispatch({
+        effects: readOnlyCompartment.current.reconfigure(
+          readOnlyExtensions(!!readOnly),
+        ),
+      });
+    }, [readOnly]);
+
     return (
       <div
         ref={host}
@@ -638,6 +656,13 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
   },
 );
 
+/** The facets that make the editor a pure preview for `readOnly` viewers.
+ * Always installed through `readOnlyCompartment` so a prop change can
+ * reconfigure the live editor. */
+function readOnlyExtensions(readOnly: boolean) {
+  return [EditorState.readOnly.of(readOnly), EditorView.editable.of(!readOnly)];
+}
+
 interface CoeditPresenceBarProps {
   participants: CoeditParticipant[];
   typing: string[];
@@ -646,8 +671,10 @@ interface CoeditPresenceBarProps {
 
 // How recently a participant must have edited to be labeled "editing" rather
 // than "viewing". Everyone on the page is in the live session; the label — not
-// membership — is what distinguishes editors from readers.
-const EDITING_LABEL_WINDOW_MS = 5 * 60 * 1000;
+// membership — is what distinguishes editors from readers. Generous on
+// purpose: a long think-pause mid-edit shouldn't demote the label, and every
+// op refreshes the timestamp, so only a genuinely idle editor decays.
+const EDITING_LABEL_WINDOW_MS = 30 * 60 * 1000;
 
 function presenceLabel(p: CoeditParticipant, now: number): string {
   if (

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -276,6 +276,18 @@ export function useCoeditSession(opts: {
         }
         return;
       }
+      // The roster's last_edited_at only refreshes on join/leave presence
+      // frames, so bump the author's locally from each op — their "editing"
+      // label flips in real time instead of waiting for a roster broadcast.
+      if (frame.type === "op" && frame.author !== null) {
+        const author = frame.author;
+        const nowIso = new Date().toISOString();
+        setParticipants((prev) =>
+          prev.map((p) =>
+            p.user_id === author ? { ...p, last_edited_at: nowIso } : p,
+          ),
+        );
+      }
       // op / resync → the editor's collab layer applies + rebases.
       serverFrame.current?.(frame);
     },

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -1,6 +1,11 @@
 "use client";
 
-/** React hook that owns a live co-edit session's lifecycle + presence.
+/** React hook that owns a page's live-session lifecycle + presence.
+ *
+ * The "co-edit session" is the page's *live session*: everyone viewing the
+ * page joins it (presence + real-time updates); editing is a capability
+ * inside it (`canWrite`), and presence labels participants "viewing" vs
+ * "editing" by whether they've actually edited.
  *
  * On `enabled` it joins the session for `path`, streams inbound frames, and
  * exposes presence (`participants`/`typing`/`peers`) and autosave
@@ -8,7 +13,8 @@
  * that order — leaving/disconnecting first would let the server's last-leave
  * forced commit race ahead of the final ops) happens entirely inside the
  * hook's own effect cleanup — driven by `enabled`/`path` changing or the
- * component unmounting, never by the caller invoking a function. The *document* is owned by the editor via
+ * component unmounting, never by the caller invoking a function. The
+ * *document* is owned by the editor via
  * `@codemirror/collab` (see `Coeditor`), not here — the hook just hands the
  * editor what it needs to run collab (`session` = id/clientId/start
  * version+doc), forwards inbound `op`/`resync` frames to it (`onServerFrame`),
@@ -58,16 +64,30 @@ function newClientId(): string {
   return crypto.randomUUID();
 }
 
-/** Manage the full lifecycle of a co-edit session: join, stream, presence, and save.
- * Disable with `enabled: false` to leave the session and tear down the stream. */
+/** Manage the full lifecycle of a page's live session: join, stream,
+ * presence, and save. Disable with `enabled: false` to leave the session and
+ * tear down the stream. */
 export function useCoeditSession(opts: {
   path: string;
   enabled: boolean;
   committedBody: string;
   myUserId: string | null;
+  /** Whether the user may edit this page (`can_write` from the file read).
+   * False joins the live session as a pure viewer: presence + real-time
+   * updates flow as usual, but every write call (ops come from the read-only
+   * editor anyway, cursor pings, checkpoints) is suppressed — the server
+   * would 403 them. Defaults to true. */
+  canWrite?: boolean;
   onEnd?: () => void;
 }): UseCoeditSession {
-  const { path, enabled, committedBody, myUserId, onEnd } = opts;
+  const {
+    path,
+    enabled,
+    committedBody,
+    myUserId,
+    canWrite = true,
+    onEnd,
+  } = opts;
 
   const [buffer, setBuffer] = useState("");
   const [participants, setParticipants] = useState<CoeditParticipant[]>([]);
@@ -140,7 +160,7 @@ export function useCoeditSession(opts: {
   // Flush + checkpoint without leaving the session — the autosave action.
   const checkpoint = useCallback(async () => {
     const sid = sessionId.current;
-    if (sid === null) return;
+    if (sid === null || !canWrite) return;
     setSaveStatus("saving");
     try {
       await flushFn.current?.();
@@ -149,7 +169,7 @@ export function useCoeditSession(opts: {
     } catch {
       setSaveStatus("error");
     }
-  }, []);
+  }, [canWrite]);
 
   const runAutoCheckpoint = useCallback(() => {
     clearAutosaveTimers();
@@ -177,7 +197,9 @@ export function useCoeditSession(opts: {
 
   const reportSelection = useCallback(
     (anchor: number, head: number, isEdit: boolean) => {
-      if (sessionId.current === null) return;
+      // Cursor broadcasts are writes (the endpoint is write-gated); a pure
+      // viewer's caret stays local.
+      if (sessionId.current === null || !canWrite) return;
       lastCursor.current = { anchor, head };
       // A caret move (isEdit=false) must not clobber the "typing…" a recent edit
       // set — browsers fire `select` right after every `input`, so onSelect
@@ -213,7 +235,7 @@ export function useCoeditSession(opts: {
         }, TYPING_IDLE_MS);
       }
     },
-    [],
+    [canWrite],
   );
 
   const onFrame = useCallback(
@@ -379,10 +401,12 @@ export function useCoeditSession(opts: {
           // concurrent edit mid-teardown). Still checkpoint — committing what
           // the server has beats leaving it all to the forced commit.
         }
-        try {
-          await checkpointSession(sid, { keepalive: true });
-        } catch {
-          // The last-leave forced commit below is the backstop.
+        if (canWrite) {
+          try {
+            await checkpointSession(sid, { keepalive: true });
+          } catch {
+            // The last-leave forced commit below is the backstop.
+          }
         }
         try {
           await leaveSession(sid, { keepalive: true });
@@ -402,7 +426,7 @@ export function useCoeditSession(opts: {
     if (!active) return;
     const checkpointNow = () => {
       const sid = sessionId.current;
-      if (sid === null) return;
+      if (sid === null || !canWrite) return;
       void checkpointSession(sid, { keepalive: true }).catch(() => {});
     };
     const onVisibilityChange = () => {
@@ -414,7 +438,7 @@ export function useCoeditSession(opts: {
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pagehide", checkpointNow);
     };
-  }, [active]);
+  }, [active, canWrite]);
 
   return {
     active,

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -1,9 +1,10 @@
-/** API client for the co-editing session endpoints (`/api/coedit/*`).
+/** API client for the live-session endpoints (`/api/coedit/*`).
  *
- * A page is edited by joining a live session: the shared buffer lives on the
- * server, edits are sent as range-change ops, and inbound ops/presence/resync
- * arrive over an SSE stream. Save (checkpoint) commits the buffer to git; save
- * or disconnect leaves the session. See the backend in `app/api/coedit.py` and
+ * Every page view joins the page's live session: the shared buffer lives on
+ * the server, and inbound ops/presence/resync arrive over an SSE stream —
+ * viewers get real-time updates, editors additionally send range-change ops
+ * (write-gated server-side). Checkpoint commits the buffer to git; leaving or
+ * disconnecting exits the session. See the backend in `app/api/coedit.py` and
  * the design in `design/Co-Editing.md`.
  *
  * Offsets are UTF-16 code units — which is exactly what JS string indexing and

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -7,12 +7,15 @@ export interface CoeditChange {
   insert: string;
 }
 
-/** A session participant as returned by join / presence frames. */
+/** A session participant as returned by join / presence frames. The live
+ * session is joined by everyone on the page; `last_edited_at` (null until the
+ * participant applies an edit op) is what separates editors from viewers. */
 export interface CoeditParticipant {
   user_id: string;
   user_display: string;
   joined_at: string;
   last_seen_at: string;
+  last_edited_at: string | null;
 }
 
 /** A peer's live caret/selection, from their latest `cursor` frame. Offsets are

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -90,6 +90,9 @@ interface FileResponse {
   body: string;
   ref?: string;
   head_sha?: string | null;
+  // Whether the caller may edit this page. False renders the live session as
+  // a pure viewer: read-only editor, no cursor/checkpoint sends.
+  can_write?: boolean;
 }
 
 // Minimal doc-entry shape needed by collectFolders / DestinationSelect.
@@ -154,6 +157,10 @@ export function FileView({ path }: FileViewProps) {
   // (latest) version; otherwise it's the sha being viewed and is what we
   // pass back as `base_sha` on save so the server records a rollback.
   const [headSha, setHeadSha] = useState<string | null>(null);
+  // From the file read's `can_write` — false renders the live session as a
+  // pure viewer (read-only editor, no write calls). Optimistic `true` until
+  // the read lands; the server rejects any write regardless.
+  const [canWrite, setCanWrite] = useState(true);
   const [viewingSha, setViewingSha] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [commits, setCommits] = useState<CommitInfo[] | null>(null);
@@ -283,16 +290,18 @@ export function FileView({ path }: FileViewProps) {
     [path, parentSlug, currentBasenameNoExt, router],
   );
 
-  // Live co-editing session: joined whenever the current (non-historical)
-  // version is showing, left when the user opens an old commit — see
-  // `useCoeditSession`'s `enabled` doc. No explicit Save; teardown (checkpoint
-  // + leave) fires from the hook itself on that transition/unmount, not from
-  // a button here.
+  // The page's live session: everyone viewing the current (non-historical)
+  // version joins it — presence plus real-time updates; editing is just a
+  // capability inside it (`canWrite`, ops write-gated server-side). Left when
+  // the user opens an old commit — see `useCoeditSession`'s `enabled` doc. No
+  // explicit Save; teardown (checkpoint + leave) fires from the hook itself
+  // on that transition/unmount, not from a button here.
   const coedit = useCoeditSession({
     path,
     enabled: !viewingVersion,
     committedBody: body,
     myUserId: user?.id ?? null,
+    canWrite,
     onEnd: () => {
       void refreshComments();
       void refreshDraftState();
@@ -391,6 +400,7 @@ export function FileView({ path }: FileViewProps) {
       .then((r) => {
         setBody(r.body);
         setHeadSha(r.head_sha ?? null);
+        setCanWrite(r.can_write ?? true);
       })
       .catch((e) => setError(e instanceof Error ? e.message : "failed to load"))
       .finally(() => setLoading(false));
@@ -906,6 +916,7 @@ export function FileView({ path }: FileViewProps) {
                   reportDoc={coedit.reportDoc}
                   registerFlush={coedit.registerFlush}
                   registerSetDoc={coedit.registerSetDoc}
+                  readOnly={!canWrite}
                   commentHighlights={commentHighlights}
                   onSelectionForComment={handleSelectionForComment}
                   placeholder="Start typing, or pick a template above…"
@@ -916,7 +927,7 @@ export function FileView({ path }: FileViewProps) {
                 // dead end, not a permanent "Connecting…".
                 <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 text-[13px] text-(--text-03)">
                   <span>
-                    Couldn't connect to the editing session: {coedit.joinError}
+                    Couldn't connect to the live session: {coedit.joinError}
                   </span>
                   <Button size="sm" onClick={coedit.retryJoin}>
                     Retry


### PR DESCRIPTION
Frontend half of #460 (stacked on its merge).

## What

- **Honest presence labels**: each live-session participant is labeled from `last_edited_at` — **"editing"** if they've applied an edit in the last 5 minutes, **"viewing"** otherwise, with "typing…" overlaying as before. The hardcoded "also editing" (which tagged every reader as an editor) is gone. A minute tick decays an idle editor's label back to "viewing" even when no new presence frames arrive.
- **Read-only viewer mode**: `can_write` from the file read drives the whole surface — the editor renders read-only (`EditorState.readOnly` + `editable` off, so the reveal-on-focus stays off and it reads as pure preview), and the hook suppresses every write call the server would 403: cursor pings, autosave, pagehide/teardown checkpoints. Viewers keep presence and real-time updates; `leave` still fires on exit.
- **Terminology sweep** (requested by Bo): comments now define the "co-edit session" as the page's **live session** — joined by everyone on the page, editing a capability inside it — in the hook/svc headers, FileView, and the two backend module docstrings (comment-only backend change; no rename of routes/tables/queues per the earlier decision).

## Testing

- `bun run typecheck` + prettier clean; backend ruff/basedpyright/pytest clean (backend diff is docstrings only).
- Deployed to the local stacks for visual confirmation (labels + read-only need a browser).


<img width="718" height="333" alt="Screenshot 2026-07-20 at 3 28 16 PM" src="https://github.com/user-attachments/assets/3b1b6388-7998-45ed-b029-93a635d626dc" />

<img width="503" height="320" alt="Screenshot 2026-07-20 at 3 27 07 PM" src="https://github.com/user-attachments/assets/2b7a2055-95eb-44ff-b418-b1991f94f2e3" />


