### PR TITLE
fix(db): single alembic head — re-chain source_ranges after coedit migration

### DIFF
--- a/backend/app/db/migrations/versions/d8b2f1a05c93_source_ranges.py
+++ b/backend/app/db/migrations/versions/d8b2f1a05c93_source_ranges.py
@@ -8,7 +8,7 @@ inspector because ``0001_initial`` builds fresh databases from the current
 models.
 
 Revision ID: d8b2f1a05c93
-Revises: c7a1f0e3b2d9
+Revises: b3e8f5a90c27
 Create Date: 2026-07-17 00:00:00.000000+00:00
 """
 
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 
 
 revision: str = "d8b2f1a05c93"
-down_revision: str | None = "c7a1f0e3b2d9"
+down_revision: str | None = "b3e8f5a90c27"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
**Main is currently broken for fresh boots**: #446 (source ranges) and #460 (coedit viewer presence) merged with migrations that both revise `c7a1f0e3b2d9` — two alembic heads, so `init_db()`'s `alembic upgrade head` crashes with *Multiple head revisions* on any new deploy (including tonight's nightly) and every CI pytest run against merged main (first seen as #461's red CI). #446's CI predated #460's merge, which is how it slipped through.

One-line fix: `d8b2f1a05c93.down_revision` → `b3e8f5a90c27`, restoring a linear chain. Safe: no environment has applied the two migrations in conflicting order — dev-wiki hasn't applied either yet, and CI/test schemas are ephemeral.

Verified: `alembic heads` reports a single head; full local pytest runs `alembic upgrade head` per test schema.

**Please merge ahead of everything else** — it unblocks all PR CI and tonight's deploy.