### PR TITLE
fix(db): resolve forked alembic heads (chain source_ranges after coedit)

### DIFF
--- a/backend/app/db/migrations/versions/d8b2f1a05c93_source_ranges.py
+++ b/backend/app/db/migrations/versions/d8b2f1a05c93_source_ranges.py
@@ -8,7 +8,7 @@ inspector because ``0001_initial`` builds fresh databases from the current
 models.
 
 Revision ID: d8b2f1a05c93
-Revises: c7a1f0e3b2d9
+Revises: b3e8f5a90c27
 Create Date: 2026-07-17 00:00:00.000000+00:00
 """
 
@@ -21,7 +21,7 @@ import sqlalchemy as sa
 
 
 revision: str = "d8b2f1a05c93"
-down_revision: str | None = "c7a1f0e3b2d9"
+down_revision: str | None = "b3e8f5a90c27"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Description

Main has two alembic heads, so `alembic upgrade head` fails. That runs in `init_db` on every boot and in CI, so this blocks deploys and every PR's tests.

- **Bug:** #460 (`b3e8f5a90c27` coedit) and #446 (`d8b2f1a05c93` source_ranges) both set `down_revision = c7a1f0e3b2d9`, forking the chain into two heads.
- **Fix:** re-point `source_ranges` after the coedit migration. Single linear chain `c7a1f0e3b2d9 -> b3e8f5a90c27 -> d8b2f1a05c93`. The `source_ranges -> provenance_ledger` FK still resolves, since `c7a1f0e3b2d9` runs first.
- **Safe:** nothing is deployed yet, so relabeling a merged migration cannot desync a live `alembic_version`.

Verified: `alembic heads` shows one head, upgrade + downgrade run clean, and the `init_db`-backed suites pass again.

## How Has This Been Tested?

## Additional Options
- [ ] This PR should be cherry-picked into the latest release branch
- [x] Override Linear Check