### PR TITLE
feat(wiki): content-span read endpoint, map page spans to their source documents

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -80,7 +80,7 @@ from app.wiki import (
 )
 from app.ingest import settings as ingest_settings
 from app.models.update_policy import UpdateHealthResponse
-from app.models.wiki import ChangeKind, CommitMaxRetriesError, PageKind, PathMove
+from app.models.wiki import ChangeKind, CommitMaxRetriesError, PageKind, PathMove, SourceSpan
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -369,6 +369,22 @@ def get_document_by_path(
         sources=provenance.sources_for_path(rel),
         can_write=can_write,
     )
+
+
+@router.get("/source-spans", response_model=list[SourceSpan])
+def get_source_spans(
+    user: User = Depends(require_user),
+    path: str = "",
+) -> list[SourceSpan]:
+    """Live content-to-source spans for a page, for in-document highlighting."""
+    if not path:
+        raise HTTPException(status_code=400, detail="path required")
+    try:
+        rel = filesystem.safe_rel_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    require_can("read", rel, user)
+    return provenance.content_spans_for_path(rel)
 
 
 @router.put("/file", response_model=PutDocumentResponse)

--- a/backend/app/db/provenance.py
+++ b/backend/app/db/provenance.py
@@ -157,6 +157,32 @@ def ingestion_source_rows(doc_path: str, limit: int) -> list[dict[str, Any]]:
     return [_ledger_dict(r) for r in rows]
 
 
+def live_spans_for_doc(doc_path: str, anchor_sha: str) -> list[dict[str, Any]]:
+    """Live source ranges on a page anchored at ``anchor_sha``, with the source
+    facts of the ingest that produced each, ordered by start offset. Callers
+    pass HEAD so a span whose anchor lags (an unremapped leftover) is omitted
+    rather than returned with offsets against an older body."""
+    with session() as s:
+        rows = s.execute(
+            select(
+                SourceRange.start_offset,
+                SourceRange.end_offset,
+                ProvenanceLedger.source_document_id,
+                ProvenanceLedger.source_type,
+                ProvenanceLedger.source_url,
+                ProvenanceLedger.source_title,
+            )
+            .join(ProvenanceLedger, ProvenanceLedger.id == SourceRange.provenance_id)
+            .where(
+                SourceRange.doc_path == doc_path,
+                SourceRange.status == SourceRangeStatus.LIVE.value,
+                SourceRange.anchor_sha == anchor_sha,
+            )
+            .order_by(SourceRange.start_offset)
+        ).mappings().all()
+    return [dict(r) for r in rows]
+
+
 # --------------------------------------------------------------------------- #
 # Source ranges                                                                 #
 # --------------------------------------------------------------------------- #

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -125,6 +125,15 @@ class SourceRef(WriteProvenance):
     last_updated: str
 
 
+class SourceSpan(WriteProvenance):
+    """A live span of a page mapped to the document it was ingested from, for
+    in-document highlighting. Offsets are character positions into the page's
+    current body."""
+
+    start_offset: int
+    end_offset: int
+
+
 class CommitMaxRetriesError(Exception):
     """Raised by ``commit_and_fan_out`` when HEAD keeps moving past the retry budget."""
 

--- a/backend/app/wiki/anchor_remap.py
+++ b/backend/app/wiki/anchor_remap.py
@@ -2,8 +2,8 @@
 
 Comments and ingest source ranges both anchor a ``[start_offset, end_offset)``
 range to a page at an ``anchor_sha`` and re-derive it against later commits. This
-holds the one non-trivial part they share: run synchronously from
-``app.wiki.notify`` right after a write, batch the git reads by ``anchor_sha``
+holds the one non-trivial part they share: run synchronously at the call
+site, batch the git reads by ``anchor_sha``
 (a page's records almost always share the previous HEAD, so it reads the old
 body once and the new body once), follow renames, and run the pure
 ``comment_anchor.remap_range`` diff per record. The per-type differences (which

--- a/backend/app/wiki/provenance.py
+++ b/backend/app/wiki/provenance.py
@@ -14,6 +14,7 @@ document it came from, anchored like a comment so it survives later edits.
 
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Iterable, Sequence
 from difflib import SequenceMatcher
@@ -21,9 +22,11 @@ from typing import Any
 
 from app.auth.users import UserKind
 from app.db import provenance as repo
-from app.models.wiki import ActorKind, Attribution, SourceRef, WriteProvenance
-from app.wiki import git as wiki_git
+from app.models.wiki import ActorKind, Attribution, SourceRef, SourceSpan, WriteProvenance
+from app.wiki import git as wiki_git, provenance_remap
 from app.wiki.constants import INGEST_AUTHOR
+
+log = logging.getLogger(__name__)
 
 # The ledger's source columns, named once by the model that mirrors them.
 _SOURCE_FIELDS = tuple(WriteProvenance.model_fields)
@@ -211,3 +214,19 @@ def sources_for_path(doc_path: str) -> list[SourceRef]:
             seen.add(key)
         out.append(SourceRef(last_updated=row["created_at"], **_source_facts(row)))
     return out
+
+
+def content_spans_for_path(doc_path: str) -> list[SourceSpan]:
+    """Live spans of a page mapped to the documents they were ingested from, for
+    in-document highlighting. Stale spans are remapped to HEAD first, and only
+    spans anchored at HEAD are returned, so every offset lines up with the
+    page's current body. A remap hiccup degrades to fewer highlights, never a
+    failed read or a misplaced one."""
+    head_sha = wiki_git.head_sha_for_path(doc_path)
+    if head_sha is None:
+        return []
+    try:
+        provenance_remap.remap_source_ranges(doc_path)
+    except Exception:
+        log.exception("source range remap failed for %s", doc_path)
+    return [SourceSpan(**row) for row in repo.live_spans_for_doc(doc_path, head_sha)]

--- a/backend/app/wiki/provenance_remap.py
+++ b/backend/app/wiki/provenance_remap.py
@@ -2,7 +2,7 @@
 
 A thin binding of the shared ``anchor_remap`` skeleton to the provenance repo. A
 range whose span survives is advanced to the new HEAD, one whose span was
-rewritten is retired. The caller in ``notify`` swallows failures so a remap
+rewritten is retired. The write path (``notify``) swallows failures so a remap
 hiccup can never break a save.
 """
 from __future__ import annotations

--- a/backend/tests/test_source_ranges.py
+++ b/backend/tests/test_source_ranges.py
@@ -1,8 +1,7 @@
 """Source ranges (app/wiki/provenance.py service + app/db/provenance.py repo +
-provenance_remap.py). Diff-to-span
-capture, the ledger-id return that links them, the remap CRUD and orchestration,
-move follow, and the per-page source list. Real DB, and a tmp git repo
-for the remap tests.
+provenance_remap.py). Diff-to-span capture, the ledger-id return that links
+them, the remap CRUD and orchestration, move follow, the per-page source list,
+and the content-span read. Real DB, and a tmp git repo for the remap tests.
 """
 
 from __future__ import annotations
@@ -254,3 +253,51 @@ def test_sources_for_path_keeps_anonymous_rows(tmp_db):
     _ingest("a1", body="x", source=WriteProvenance(source_type="slack"))
     _ingest("a2", body="y", source=WriteProvenance(source_type="slack"))
     assert len(provenance.sources_for_path(_PATH)) == 2
+
+
+def test_live_spans_for_doc_orders_and_carries_source(tmp_db):
+    pid = provenance.record(
+        commit_sha="c1",
+        doc_path=_PATH,
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=WriteProvenance(source_document_id="d1", source_url="http://x"),
+    )
+    assert pid is not None
+    provenance.capture_source_ranges(
+        provenance_id=pid, doc_path=_PATH, anchor_sha="c1", old_body="ac", new_body="aXcY"
+    )
+    spans = db_provenance.live_spans_for_doc(_PATH, "c1")
+    assert [(s["start_offset"], s["end_offset"]) for s in spans] == [(1, 2), (3, 4)]
+    assert all(s["source_document_id"] == "d1" and s["source_url"] == "http://x" for s in spans)
+
+
+def test_live_spans_for_doc_excludes_retired(tmp_db):
+    pid = _ingest("c1", body="hello", source=WriteProvenance(source_document_id="d1"))
+    with session() as s:
+        rid = s.scalar(select(SourceRange.id).where(SourceRange.provenance_id == pid))
+    assert rid is not None
+    db_provenance.retire_range(rid)
+    assert db_provenance.live_spans_for_doc(_PATH, "c1") == []
+
+
+def test_content_spans_for_path_remaps_to_head(tmp_repo):
+    body1 = "The target sentence stays put.\n"
+    sha1 = wiki_git.commit_file(_PATH, body1, "create")
+    _ingest(sha1, body=body1)
+    prefix = "Intro added.\n"
+    wiki_git.commit_file(_PATH, prefix + body1, "edit")
+    spans = provenance.content_spans_for_path(_PATH)
+    assert len(spans) == 1
+    # the span followed the edit: its offset shifted by the prepended prefix
+    assert spans[0].start_offset == len(prefix)
+
+
+def test_content_spans_omit_span_stuck_on_unreachable_anchor(tmp_repo):
+    body = "Some page body here.\n"
+    wiki_git.commit_file(_PATH, body, "create")
+    # a span anchored to a sha the repo cannot read: remap skips it, and the
+    # head-anchored read then omits it instead of returning stale offsets
+    _ingest("deadbeef" * 5, body=body)
+    assert provenance.content_spans_for_path(_PATH) == []

--- a/backend/tests/test_source_spans_api.py
+++ b/backend/tests/test_source_spans_api.py
@@ -1,0 +1,66 @@
+"""GET /api/wiki/source-spans, live content-to-source spans for the FE
+highlighter. Real wiki repo so the read-path remap has a repo to read. Pages
+committed via wiki_git are unmanaged, so the ACL resolver grants read.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.models.wiki import WriteProvenance
+from app.wiki import git as wiki_git
+from app.wiki import provenance
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+_PATH = "guides/setup.md"
+_BODY = "Alpha beta gamma.\n"
+
+
+@pytest.fixture
+def client(tmp_repo):
+    return TestClient(create_app())
+
+
+def _seed_span(source: WriteProvenance) -> None:
+    sha = wiki_git.commit_file(_PATH, _BODY, "seed", author=None)
+    pid = provenance.record(
+        commit_sha=sha,
+        doc_path=_PATH,
+        user_id=None,
+        agent_name=None,
+        agent_session_id=None,
+        source=source,
+    )
+    assert pid is not None
+    provenance.capture_source_ranges(
+        provenance_id=pid, doc_path=_PATH, anchor_sha=sha, old_body="", new_body=_BODY
+    )
+
+
+def test_source_spans_returns_spans_with_source(client):
+    login_fastapi(client, seed_user("u1", email="u1@x.com", name="U"))
+    _seed_span(WriteProvenance(source_document_id="d1", source_title="Src One"))
+    resp = client.get("/api/wiki/source-spans", params={"path": _PATH})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    span = data[0]
+    assert (span["start_offset"], span["end_offset"]) == (0, len(_BODY))
+    assert span["source_document_id"] == "d1"
+    assert span["source_title"] == "Src One"
+
+
+def test_source_spans_empty_for_page_without_ingest(client):
+    login_fastapi(client, seed_user("u2", email="u2@x.com", name="U2"))
+    wiki_git.commit_file(_PATH, _BODY, "seed", author=None)
+    resp = client.get("/api/wiki/source-spans", params={"path": _PATH})
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_source_spans_requires_path(client):
+    login_fastapi(client, seed_user("u3", email="u3@x.com", name="U3"))
+    assert client.get("/api/wiki/source-spans").status_code == 400


### PR DESCRIPTION
## Description

The read side behind in-document source highlighting (the "this paragraph came from this Google Doc" part of source attribution).

- `GET /api/wiki/source-spans?path=` returns the live `source_ranges` for a page joined to their ingest source facts (`SourceSpan`: offsets + document id/type/url/title), ordered by offset.
- Spans are remapped to HEAD before reading, so offsets always line up with the page's current body (same backstop pattern as the comments GET path).
- Read-gated with the same ACL check as reading the page body.

Backend only. The FE highlighter that consumes this comes in the frontend phase.

## How Has This Been Tested?

## Additional Options
- [ ] This PR should be cherry-picked into the latest release branch
- [x] Override Linear Check