### PR TITLE
feat(automanage): Auto Organize kill-switch toggle (admin UI)

### DIFF
--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -2,13 +2,20 @@
 
 import { useState } from "react";
 
-import { Button, Card, Text } from "@onyx-ai/opal/components";
+import { Button, Card, Switch, Text } from "@onyx-ai/opal/components";
 import { SvgSliders } from "@onyx-ai/opal/icons";
 import { ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 
-import { triggerSweep } from "@/lib/autoOrganize";
+import {
+  triggerSweep,
+  updateAutoOrganizeEnabled,
+  useAutoOrganizeSettings,
+} from "@/lib/autoOrganize";
 
 export function AutoOrganize() {
+  const { settings, isLoading, error, refresh } = useAutoOrganizeSettings();
+  const enabled = settings?.enabled ?? true;
+
   return (
     <div className="flex w-full flex-col gap-4">
       <Text font="main-ui-body" color="text-03">
@@ -16,12 +23,71 @@ export function AutoOrganize() {
         folders). Cleanups in AI-managed scopes are applied automatically;
         others are proposed for review.
       </Text>
-      <SweepControl />
+      <EnabledToggle
+        enabled={enabled}
+        loading={isLoading}
+        loadError={error instanceof Error ? error.message : null}
+        onChanged={() => void refresh()}
+      />
+      <SweepControl disabled={!enabled} />
     </div>
   );
 }
 
-function SweepControl() {
+interface EnabledToggleProps {
+  enabled: boolean;
+  loading: boolean;
+  loadError: string | null;
+  onChanged: () => void;
+}
+
+function EnabledToggle({
+  enabled,
+  loading,
+  loadError,
+  onChanged,
+}: EnabledToggleProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const message = loadError || error;
+
+  async function toggle(next: boolean) {
+    setBusy(true);
+    setError(null);
+    try {
+      await updateAutoOrganizeEnabled(next);
+      onChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "failed to update setting");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Card padding="xs" rounding="md" border="solid" background="heavy">
+      <div className="flex w-full flex-col gap-1 p-1">
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgSliders}
+          title="Auto Organize"
+          description="Master switch. When off, no sweeps run, nothing is auto-applied, and pending proposals are frozen — per-page settings are kept."
+          rightChildren={
+            <Switch
+              checked={enabled}
+              disabled={loading || busy}
+              onCheckedChange={(next) => void toggle(next)}
+            />
+          }
+        />
+        {message && <InputErrorText type="error">{message}</InputErrorText>}
+      </div>
+    </Card>
+  );
+}
+
+function SweepControl({ disabled }: { disabled: boolean }) {
   const [busy, setBusy] = useState(false);
   const [note, setNote] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -54,7 +120,7 @@ function SweepControl() {
               type="button"
               size="sm"
               prominence="secondary"
-              disabled={busy}
+              disabled={busy || disabled}
               onClick={() => void run()}
             >
               {busy ? "Starting…" : "Run a sweep"}

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -7,6 +7,7 @@ import { SvgSliders } from "@onyx-ai/opal/icons";
 import { ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 
 import {
+  type AutoOrganizeSettings,
   triggerSweep,
   updateAutoOrganizeEnabled,
   useAutoOrganizeSettings,
@@ -14,7 +15,10 @@ import {
 
 export function AutoOrganize() {
   const { settings, isLoading, error, refresh } = useAutoOrganizeSettings();
-  const enabled = settings?.enabled ?? true;
+  // Fail safe until the real setting loads: an unknown/failed state shows the
+  // switch off and keeps "Run a sweep" disabled, so an admin can't fire a
+  // sweep that the backend would 409 when the persisted setting is disabled.
+  const enabled = settings?.enabled ?? false;
 
   return (
     <div className="flex w-full flex-col gap-4">
@@ -27,7 +31,7 @@ export function AutoOrganize() {
         enabled={enabled}
         loading={isLoading}
         loadError={error instanceof Error ? error.message : null}
-        onChanged={() => void refresh()}
+        onUpdated={(next) => void refresh(next, { revalidate: false })}
       />
       <SweepControl disabled={!enabled} />
     </div>
@@ -38,14 +42,14 @@ interface EnabledToggleProps {
   enabled: boolean;
   loading: boolean;
   loadError: string | null;
-  onChanged: () => void;
+  onUpdated: (next: AutoOrganizeSettings) => void;
 }
 
 function EnabledToggle({
   enabled,
   loading,
   loadError,
-  onChanged,
+  onUpdated,
 }: EnabledToggleProps) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -55,8 +59,10 @@ function EnabledToggle({
     setBusy(true);
     setError(null);
     try {
-      await updateAutoOrganizeEnabled(next);
-      onChanged();
+      // Seed the cache from the PUT's authoritative response (no revalidating
+      // GET) so a rapid second toggle can't be clobbered by a stale in-flight
+      // read.
+      onUpdated(await updateAutoOrganizeEnabled(next));
     } catch (e) {
       setError(e instanceof Error ? e.message : "failed to update setting");
     } finally {

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -78,7 +78,7 @@ function EnabledToggle({
           variant="section"
           icon={SvgSliders}
           title="Auto Organize"
-          description="Master switch. When off, no sweeps run, nothing is auto-applied, and pending proposals are frozen — per-page settings are kept."
+          description="Master switch. When off, no sweeps run, nothing is auto-applied, and pending proposals are frozen."
           rightChildren={
             <Switch
               checked={enabled}

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -1,7 +1,33 @@
+import useSWR from "swr";
+
 import { apiFetch } from "@/lib/api";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 /** Kick off a whole-space detection sweep (admin only server-side). It runs on
  * the detection queue and emits change proposals; the request only enqueues. */
 export function triggerSweep() {
   return apiFetch<{ status: string }>("/detection/sweep", { method: "POST" });
+}
+
+/** Org-wide Auto Organize settings — the master kill switch. */
+export interface AutoOrganizeSettings {
+  enabled: boolean;
+  updated_at: string | null;
+}
+
+/** The kill-switch settings (admin only server-side). `refresh` re-reads after
+ * a mutation. */
+export function useAutoOrganizeSettings() {
+  const { data, error, isLoading, mutate } = useSWR<AutoOrganizeSettings>(
+    SWR_KEYS.autoOrganizeSettings,
+  );
+  return { settings: data, error, isLoading, refresh: mutate };
+}
+
+/** Flip the master kill switch. Returns the resulting settings. */
+export function updateAutoOrganizeEnabled(enabled: boolean) {
+  return apiFetch<AutoOrganizeSettings>("/detection/settings", {
+    method: "PUT",
+    body: JSON.stringify({ enabled }),
+  });
 }

--- a/frontend/src/lib/swr-keys.ts
+++ b/frontend/src/lib/swr-keys.ts
@@ -39,6 +39,9 @@ export const SWR_KEYS = {
   // ── LLM ───────────────────────────────────────────────────────────────
   llmStatus: "/llm/status",
 
+  // ── Auto Organize ─────────────────────────────────────────────────────
+  autoOrganizeSettings: "/detection/settings",
+
   // ── Agents / MCP ──────────────────────────────────────────────────────
   mcpTokens: "/mcp/tokens",
 


### PR DESCRIPTION
Frontend for the Auto Organize master kill switch (backend #462). Adds the enable/disable `Switch` to `/admin/auto-organize`, wired to `GET/PUT /api/detection/settings`.

- `lib/autoOrganize.ts` — `useAutoOrganizeSettings()` hook (SWR via `SWR_KEYS.autoOrganizeSettings`) + `updateAutoOrganizeEnabled()` mutation + `AutoOrganizeSettings` type.
- `AutoOrganize.tsx` — an `EnabledToggle` card above the sweep control; refetches settings after a toggle. When disabled, "Run a sweep" is disabled (the endpoint already returns 409).

## Test plan
- `bun run typecheck` clean.
- Toggle off → sweep button disabled; toggle on → enabled. Reload persists the state.
<img width="835" height="596" alt="Screenshot 2026-07-20 at 4 24 24 PM" src="https://github.com/user-attachments/assets/25d4135f-5821-4f31-8acf-af8e960203cb" />
