### PR TITLE
feat(automanage): scheduled Auto Organize sweep (off/daily/weekly)

### DIFF
--- a/backend/app/api/detection.py
+++ b/backend/app/api/detection.py
@@ -43,9 +43,11 @@ def _can_see(user: User, proposal: dict[str, Any]) -> bool:
 
 @router.get("/settings", response_model=DetectionSettingsView)
 def get_settings(user: User = Depends(require_admin)) -> DetectionSettingsView:
-    """The org-wide Auto Organize settings (the kill switch)."""
+    """The org-wide Auto Organize settings (kill switch + sweep schedule)."""
     s = settings.get()
-    return DetectionSettingsView(enabled=s.enabled, updated_at=s.updated_at)
+    return DetectionSettingsView(
+        enabled=s.enabled, schedule=s.schedule, updated_at=s.updated_at
+    )
 
 
 @router.put("/settings", response_model=DetectionSettingsView)
@@ -54,9 +56,14 @@ def update_settings(
 ) -> DetectionSettingsView:
     """Update the Auto Organize settings. Turning ``enabled`` off makes the
     whole feature inert (no detection, no proposals, no auto-apply; pending
-    proposals frozen) — per-page policies are untouched."""
-    s = settings.update(enabled=req.enabled, updated_by_user_id=user.id)
-    return DetectionSettingsView(enabled=s.enabled, updated_at=s.updated_at)
+    proposals frozen) — per-page policies are untouched. ``schedule`` drives the
+    recurring sweep (off / daily / weekly)."""
+    s = settings.update(
+        enabled=req.enabled, schedule=req.schedule, updated_by_user_id=user.id
+    )
+    return DetectionSettingsView(
+        enabled=s.enabled, schedule=s.schedule, updated_at=s.updated_at
+    )
 
 
 @router.post("/sweep", response_model=SweepTriggerResponse, status_code=202)

--- a/backend/app/db/migrations/versions/5c4a9e1b7d38_ai_management_schedule.py
+++ b/backend/app/db/migrations/versions/5c4a9e1b7d38_ai_management_schedule.py
@@ -1,0 +1,55 @@
+"""ai_management_settings.schedule
+
+Adds the recurring-sweep ``schedule`` column (off / daily / weekly) to the
+Auto Organize settings singleton. Guarded with the inspector because
+``0001_initial`` builds fresh databases from the current models, which already
+include the column.
+
+Revision ID: 5c4a9e1b7d38
+Revises: 3f6b8d0a1c25
+Create Date: 2026-07-20 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "5c4a9e1b7d38"
+down_revision: str | Sequence[str] | None = "3f6b8d0a1c25"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("ai_management_settings")}
+    if "schedule" in cols:
+        return
+    op.add_column(
+        "ai_management_settings",
+        sa.Column(
+            "schedule", sa.Text(), nullable=False, server_default=sa.text("'off'")
+        ),
+    )
+    op.create_check_constraint(
+        "ai_management_settings_schedule_check",
+        "ai_management_settings",
+        "schedule IN ('off', 'daily', 'weekly')",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("ai_management_settings")}
+    if "schedule" not in cols:
+        return
+    op.drop_constraint(
+        "ai_management_settings_schedule_check",
+        "ai_management_settings",
+        type_="check",
+    )
+    op.drop_column("ai_management_settings", "schedule")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1461,9 +1461,10 @@ class AIManagementSettings(Base):
     ``enabled`` is the master kill switch: when false the whole feature is inert
     (no detection, no proposals, no auto-apply, human approve/reject frozen);
     per-page ``ai_management_allowed`` policies are untouched, so re-enabling
-    resumes exactly where they left off. Named generically (not
-    detection-specific) so it can hold future AI-management-wide settings (e.g.
-    the sweep schedule).
+    resumes exactly where they left off. ``schedule`` drives the recurring
+    detection sweep (``off`` / ``daily`` / ``weekly``); the periodic tasks in
+    ``app/tasks/detection.py`` read it each fire. Named generically (not
+    detection-specific) so it can hold future AI-management-wide settings.
     """
 
     __tablename__ = "ai_management_settings"
@@ -1471,6 +1472,9 @@ class AIManagementSettings(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
     enabled: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("true")
+    )
+    schedule: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'off'")
     )
     updated_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
@@ -1481,6 +1485,10 @@ class AIManagementSettings(Base):
 
     __table_args__ = (
         CheckConstraint("id = 1", name="ai_management_settings_singleton"),
+        CheckConstraint(
+            "schedule IN ('off', 'daily', 'weekly')",
+            name="ai_management_settings_schedule_check",
+        ),
     )
 
 

--- a/backend/app/models/detection.py
+++ b/backend/app/models/detection.py
@@ -14,9 +14,10 @@ class SweepTriggerResponse(BaseModel):
 
 
 class DetectionSettingsView(BaseModel):
-    """Org-wide Auto Organize settings (the kill switch)."""
+    """Org-wide Auto Organize settings (the kill switch + sweep schedule)."""
 
     enabled: bool
+    schedule: str
     updated_at: str | None
 
 
@@ -24,6 +25,7 @@ class DetectionSettingsUpdate(BaseModel):
     """Patch for the Auto Organize settings — only the fields provided change."""
 
     enabled: bool | None = None
+    schedule: Literal["off", "daily", "weekly"] | None = None
 
 
 class DetectionRunView(BaseModel):

--- a/backend/app/tasks/detection.py
+++ b/backend/app/tasks/detection.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import logging
 
+from app.tasks.queue import crontab
 from app.tasks.queues import detection_queue
-from app.wiki.automanage import executor, runner
+from app.wiki.automanage import executor, runner, settings
 
 log = logging.getLogger(__name__)
 
@@ -27,3 +28,34 @@ def execute_proposal(proposal_id: int) -> None:
     """Apply an approved proposal (commits to git — hence the detection queue,
     not a co-tenant)."""
     executor.execute(proposal_id)
+
+
+def _run_scheduled_sweep(cadence: str) -> None:
+    """Fire a system sweep only when the configured schedule matches ``cadence``
+    and the kill switch is on. Both cadence crons fire on their fixed cron
+    cadence regardless; the settings row is the single source of truth for
+    whether a sweep actually runs, so an admin flipping the schedule takes
+    effect on the next fire with no scheduler restart."""
+    s = settings.get()
+    if not s.enabled:
+        log.info("scheduled sweep (%s): Auto Organize disabled — skip", cadence)
+        return
+    if s.schedule != cadence:
+        return
+    log.info("scheduled sweep (%s): starting", cadence)
+    runner.run_sweep(triggered_by_user_id=None)
+
+
+# 08:00 UTC — off-peak, ahead of the daily trash purge (10:00). Cron is
+# evaluated in UTC (no DST). Weekly fires Mondays (day_of_week=1).
+@detection_queue.periodic_task(crontab(hour="8", minute="0"))
+def scheduled_daily_sweep() -> None:
+    """Daily recurring sweep — runs only when ``schedule`` is ``daily``."""
+    _run_scheduled_sweep("daily")
+
+
+@detection_queue.periodic_task(crontab(day_of_week="1", hour="8", minute="0"))
+def scheduled_weekly_sweep() -> None:
+    """Weekly recurring sweep (Mondays) — runs only when ``schedule`` is
+    ``weekly``."""
+    _run_scheduled_sweep("weekly")

--- a/backend/app/wiki/automanage/settings.py
+++ b/backend/app/wiki/automanage/settings.py
@@ -1,11 +1,13 @@
 """Org-wide AI-management (Auto Organize) settings — the
 ``ai_management_settings`` singleton (id=1).
 
-``enabled`` is the master kill switch. Free functions over the row returning a
-frozen pydantic model, mirroring ``app/ingest/settings.py``. The switch is a
-feature gate only — it never touches per-page ``ai_management_allowed`` policy,
-so disabling then re-enabling resumes exactly where the per-page opt-ins left
-off.
+``enabled`` is the master kill switch; ``schedule`` drives the recurring
+detection sweep (``off`` / ``daily`` / ``weekly``, read each fire by the
+periodic tasks in ``app/tasks/detection.py``). Free functions over the row
+returning a frozen pydantic model, mirroring ``app/ingest/settings.py``. The
+switch is a feature gate only — it never touches per-page
+``ai_management_allowed`` policy, so disabling then re-enabling resumes exactly
+where the per-page opt-ins left off.
 """
 from __future__ import annotations
 
@@ -17,12 +19,15 @@ from app.db.models import AIManagementSettings as AIManagementSettingsRow
 from app.db.session import session
 
 DEFAULT_ENABLED = True
+DEFAULT_SCHEDULE = "off"
+VALID_SCHEDULES = ("off", "daily", "weekly")
 
 
 class AIManagementSettings(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     enabled: bool
+    schedule: str
     updated_at: str | None
     updated_by_user_id: str | None
 
@@ -32,17 +37,20 @@ def _now() -> str:
 
 
 def get() -> AIManagementSettings:
-    """Current settings, or the defaults when no row exists yet (feature on)."""
+    """Current settings, or the defaults when no row exists yet (feature on,
+    schedule off)."""
     with session() as s:
         row = s.get(AIManagementSettingsRow, 1)
         if row is None:
             return AIManagementSettings(
                 enabled=DEFAULT_ENABLED,
+                schedule=DEFAULT_SCHEDULE,
                 updated_at=None,
                 updated_by_user_id=None,
             )
         return AIManagementSettings(
             enabled=row.enabled,
+            schedule=row.schedule,
             updated_at=row.updated_at,
             updated_by_user_id=row.updated_by_user_id,
         )
@@ -57,9 +65,12 @@ def is_enabled() -> bool:
 def update(
     *,
     enabled: bool | None = None,
+    schedule: str | None = None,
     updated_by_user_id: str | None = None,
 ) -> AIManagementSettings:
     """Patch semantics: only fields passed change. Returns the resulting settings."""
+    if schedule is not None and schedule not in VALID_SCHEDULES:
+        raise ValueError(f"invalid schedule: {schedule!r}")
     with session() as s:
         row = s.get(AIManagementSettingsRow, 1)
         if row is None:
@@ -67,6 +78,8 @@ def update(
             s.add(row)
         if enabled is not None:
             row.enabled = enabled
+        if schedule is not None:
+            row.schedule = schedule
         row.updated_at = _now()
         row.updated_by_user_id = updated_by_user_id
     return get()

--- a/backend/tests/test_detection_scheduled_sweep.py
+++ b/backend/tests/test_detection_scheduled_sweep.py
@@ -1,0 +1,56 @@
+"""Scheduled Auto Organize sweeps — the two cadence crons gate on the settings
+row, not on the cron cadence itself.
+
+Both crons fire on their fixed schedule; whether a sweep actually runs is
+decided at fire time by ``ai_management_settings`` (kill switch + schedule), so
+an admin flipping the schedule takes effect on the next fire.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.tasks import detection
+from app.tasks.queues import detection_queue
+from app.wiki.automanage import settings
+
+
+@pytest.fixture
+def swept(monkeypatch):
+    """Run the cadence crons synchronously and capture ``runner.run_sweep``
+    calls instead of running a real sweep. The task decorators enqueue by
+    default, so ``immediate_mode`` is what runs the handler body inline."""
+    calls: list[str | None] = []
+    monkeypatch.setattr(
+        detection.runner,
+        "run_sweep",
+        lambda *, triggered_by_user_id: calls.append(triggered_by_user_id),
+    )
+    with detection_queue.immediate_mode():
+        yield calls
+
+
+def test_daily_runs_only_when_schedule_daily(tmp_db, swept):
+    settings.update(schedule="daily")
+    detection.scheduled_daily_sweep()
+    detection.scheduled_weekly_sweep()
+    assert swept == [None]  # daily fired (system run), weekly skipped
+
+
+def test_weekly_runs_only_when_schedule_weekly(tmp_db, swept):
+    settings.update(schedule="weekly")
+    detection.scheduled_weekly_sweep()
+    detection.scheduled_daily_sweep()
+    assert swept == [None]  # weekly fired, daily skipped
+
+
+def test_off_schedule_never_sweeps(tmp_db, swept):
+    # default schedule is "off"
+    detection.scheduled_daily_sweep()
+    detection.scheduled_weekly_sweep()
+    assert swept == []
+
+
+def test_kill_switch_overrides_schedule(tmp_db, swept):
+    settings.update(enabled=False, schedule="daily")
+    detection.scheduled_daily_sweep()
+    assert swept == []  # frozen despite a daily schedule

--- a/backend/tests/test_detection_settings.py
+++ b/backend/tests/test_detection_settings.py
@@ -27,17 +27,21 @@ from tests._seed import seed_user
 # --------------------------------------------------------------------------- #
 
 
-def test_default_is_enabled(tmp_db):
+def test_default_is_enabled_off_schedule(tmp_db):
     s = settings.get()
     assert s.enabled is True
+    assert s.schedule == "off"
     assert settings.is_enabled() is True
 
 
-def test_update_toggles(tmp_db):
+def test_update_toggles_and_validates(tmp_db):
     assert settings.update(enabled=False).enabled is False
     assert settings.is_enabled() is False
-    assert settings.update(enabled=True).enabled is True
-    assert settings.is_enabled() is True
+    assert settings.update(schedule="daily").schedule == "daily"
+    # enabled untouched by a schedule-only patch
+    assert settings.get().enabled is False
+    with pytest.raises(ValueError):
+        settings.update(schedule="hourly")
 
 
 # --------------------------------------------------------------------------- #
@@ -102,6 +106,7 @@ def test_settings_api_get_put_and_sweep_gate(client):
 
     assert client.get("/api/detection/settings").json() == {
         "enabled": True,
+        "schedule": "off",
         "updated_at": None,
     }
     put = client.put("/api/detection/settings", json={"enabled": False})
@@ -114,9 +119,16 @@ def test_settings_api_get_put_and_sweep_gate(client):
     assert client.post("/api/detection/sweep").status_code == 202
 
 
-def test_settings_api_requires_admin(client):
+def test_settings_api_requires_admin_and_validates(client):
     seed_user(uid="admin_1", email="a@x.com", is_admin=True)  # first = admin
     uid = seed_user(uid="usr_2", email="u2@x.com", is_admin=False)
     login_fastapi(client, uid)
     assert client.get("/api/detection/settings").status_code == 403
     assert client.put("/api/detection/settings", json={"enabled": False}).status_code == 403
+
+    login_fastapi(client, "admin_1")
+    # The app translates request-validation errors to 400 (main.py handler).
+    assert (
+        client.put("/api/detection/settings", json={"schedule": "hourly"}).status_code
+        == 400
+    )


### PR DESCRIPTION
Backend for **task #3** — a recurring detection sweep on an admin-set cadence. Stacks on the merged kill switch (#462/#466); re-adds the `schedule` field that was deferred out of #462.

## What
- **`ai_management_settings.schedule`** column (`off`/`daily`/`weekly`) + inspector-guarded `add_column` migration. Fresh DBs get it from `0001_initial`'s `create_all`; existing (prod) DBs get it via the `add_column` — both verified.
- Settings repo + admin `GET/PUT /api/detection/settings` carry `schedule` (validated `Literal`).
- Two `@detection_queue.periodic_task` crons — **daily 08:00 UTC** and **weekly Mondays 08:00 UTC**. Each reads the settings row *at fire time* and runs a system sweep (`triggered_by_user_id=None`) only when `schedule` matches its cadence **and** the kill switch is on.

## Why this shape
- The settings row is the single source of truth, so an admin changing the schedule takes effect on the next fire — no scheduler restart, no per-schedule cron registration.
- The master kill switch still freezes scheduled sweeps (checked before cadence).
- Registering the first periodic task on `detection_queue` spawns that worker's leader-elected scheduler thread; restart-safe last-run tracking rides the existing `cron_state` table — no new table, no compose/infra change.

## Test plan
- `ruff` + `basedpyright` clean; single alembic head.
- Migration verified on a fresh DB and a prod-like DB (table present without `schedule`).
- Tests: schedule repo round-trip + validation, cadence gating (daily-only vs weekly-only vs off), kill-switch override. Full detection/automanage suite (62) green.

Follow-up: a small stacked **frontend** PR adds the Off/Daily/Weekly selector to `/admin/auto-organize`.