### PR TITLE
fix(automanage): re-check kill switch at the runner chokepoint

### DIFF
--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -29,7 +29,7 @@ from typing import Any
 from app.auth.users import AI_USER_ID
 from app.wiki import git
 from app.wiki import update_policy
-from app.wiki.automanage import review, runs
+from app.wiki.automanage import review, runs, settings
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
@@ -94,6 +94,16 @@ def run_detection(
     created_via = _CREATED_VIA.get(trigger)
     if created_via is None:
         raise ValueError(f"no change-proposal entry point for trigger {trigger.value!r}")
+
+    # Master kill switch, re-checked at the one chokepoint every sweep/detection
+    # flow passes through — so a disable that lands after a caller's own check
+    # (e.g. a scheduled sweep between reading settings and starting) still keeps
+    # this run from emitting any proposals. The action layer (auto_approve /
+    # approve / executor) re-checks too, so nothing emitted in the residual race
+    # window can be applied while disabled.
+    if not settings.is_enabled():
+        log.info("detection: Auto Organize disabled — %s run skipped", trigger.value)
+        return {"run_id": None, "paths_scanned": 0, "proposals_emitted": 0}
 
     run_id = runs.start(trigger=trigger, triggered_by_user_id=triggered_by_user_id)
     try:

--- a/backend/tests/test_detection_settings.py
+++ b/backend/tests/test_detection_settings.py
@@ -10,7 +10,7 @@ from fastapi.testclient import TestClient
 
 from app.main import create_app
 from app.wiki import git as wiki_git
-from app.wiki.automanage import executor, review, settings
+from app.wiki.automanage import executor, review, runner, settings
 from app.wiki.change_proposals import (
     ProposalCreatedVia,
     ProposalOp,
@@ -75,6 +75,15 @@ def test_approve_and_reject_frozen_when_disabled(repo):
     assert review.reject(pid, user_id=uid) is False
     p = get_proposal(pid)
     assert p is not None and p["status"] == "pending"  # frozen, untouched
+
+
+def test_runner_emits_nothing_when_disabled(repo):
+    # A disable that lands before the runner starts (or after a caller's own
+    # check) freezes emission at the chokepoint: no run row, no proposals.
+    settings.update(enabled=False)
+    result = runner.run_sweep(triggered_by_user_id=None)
+    assert result["run_id"] is None
+    assert result["proposals_emitted"] == 0
 
 
 def test_executor_skips_when_disabled(repo):


### PR DESCRIPTION
Addresses the review comment on #468 (**"Disable Race Still Starts Sweep"**) that landed after #468 was already merged — so it wasn't in that PR.

## Problem
The scheduled-sweep tasks read `settings` and then call `run_sweep()`. If an admin disables Auto Organize in that window, the sweep proceeds on the stale enabled state and can emit proposals after the kill switch was flipped off — contrary to the freeze contract.

## Fix
Move the authoritative kill-switch check into `run_detection` — the single chokepoint **every** sweep/detection flow passes through (on-demand, scheduled, and future on-create). A disable that lands after a caller's own check still keeps the run from emitting anything.

The residual micro-race (disable between this check and a `create_proposal`) is harmless: the action layer (`auto_approve` / `approve` / `executor`) already re-checks `is_enabled()`, so nothing emitted in that window can be applied while disabled.

## Test plan
- New `test_runner_emits_nothing_when_disabled`: a disabled sweep returns `run_id=None`, `proposals_emitted=0`, and creates no run row.
- ruff + basedpyright clean; `test_detection_settings.py` green.