### PR TITLE
refactor(tasks): group worker queues into 2 pods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,11 +251,12 @@ working dir, identity, and commit-on-write. Path validation goes through
 ### Background work — Redis Streams queues, not threads
 
 If something might take more than ~100ms, queue it. Tasks live under
-`app/tasks/` and bind to one of four `TaskQueue` instances in
+`app/tasks/` and bind to one of five `TaskQueue` instances in
 `app/tasks/queues.py` — `documents_queue` (LLM doc-reconciliation),
 `triggers_queue` (NL trigger eval, delta + scheduled), `coedit_queue`
 (co-edit session checkpoints — commits a live buffer, AI-merges on a
-concurrent commit), or `lightweight_maintenance_queue` (sub-second
+concurrent commit), `automanage_queue` (Wiki Auto Management — whole-space
+sweeps + proposal execution), or `lightweight_maintenance_queue` (sub-second
 upkeep — BM25 reindex, agent-activity expiration cleanup). Each queue is
 a Redis Stream (`queue:<name>`), so each queue's backlog is isolated; the
 abstraction itself is in `app/tasks/queue.py`. Each queue has its own worker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,11 +259,14 @@ concurrent commit), `automanage_queue` (Wiki Auto Management — whole-space
 sweeps + proposal execution), or `lightweight_maintenance_queue` (sub-second
 upkeep — BM25 reindex, agent-activity expiration cleanup). Each queue is
 a Redis Stream (`queue:<name>`), so each queue's backlog is isolated; the
-abstraction itself is in `app/tasks/queue.py`. Each queue has its own worker
-process (`python -m app.tasks.run_worker <queue>`); make sure new
-task modules are imported by `run_worker.py` so they register on
-boot. The variable names and the `queues.py` filename are kept
-from the TaskQueue era so call sites didn't have to change.
+abstraction itself is in `app/tasks/queue.py`. Queues are the isolation unit,
+but a worker **process** can host several of them — `run_worker` takes one or
+more queue names and runs each as its own consumer/thread pool, so a group
+shares one process's ~185 MiB import-graph floor while backlogs stay isolated.
+Deployment runs two pods: `worker-coedit` (the only real-time path) and
+`worker-background` (the rest) — see `docker-compose.yml` and the helm
+`worker.groups` values. Make sure new task modules are imported by
+`run_worker.py` so they register on boot.
 
 The placement rule for `lightweight_maintenance_queue`: handlers must
 be sub-second, no LLM, no external HTTP, no wiki commits. Anything

--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -22,7 +22,7 @@ from app.models.automanage import (
     RunsResponse,
     SweepTriggerResponse,
 )
-from app.tasks.detection import run_detection_sweep
+from app.tasks.automanage import run_detection_sweep
 from app.wiki import acl
 from app.wiki.automanage import review, runs, settings
 from app.wiki.change_proposals import (

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1463,7 +1463,7 @@ class AIManagementSettings(Base):
     per-page ``ai_management_allowed`` policies are untouched, so re-enabling
     resumes exactly where they left off. ``schedule`` drives the recurring
     detection sweep (``off`` / ``daily`` / ``weekly``); the periodic tasks in
-    ``app/tasks/detection.py`` read it each fire. Named generically (not
+    ``app/tasks/automanage.py`` read it each fire. Named generically (not
     detection-specific) so it can hold future AI-management-wide settings.
     """
 

--- a/backend/app/tasks/automanage.py
+++ b/backend/app/tasks/automanage.py
@@ -1,6 +1,5 @@
-"""Wiki Auto Management detection tasks — bound to the dedicated ``detection``
-queue (its own worker; see ``app/tasks/queues.py`` for why it isn't a
-co-tenant of any other queue).
+"""Wiki Auto Management tasks — bound to the ``automanage`` queue (see
+``app/tasks/queues.py`` for the queue's profile and rationale).
 
 Emit-only: a sweep detects and writes ``change_proposals``; it never mutates
 the wiki. Execution happens later, on approval.
@@ -10,23 +9,22 @@ from __future__ import annotations
 import logging
 
 from app.tasks.queue import crontab
-from app.tasks.queues import detection_queue
+from app.tasks.queues import automanage_queue
 from app.wiki.automanage import executor, runner, settings
 
 log = logging.getLogger(__name__)
 
 
-@detection_queue.task()
+@automanage_queue.task()
 def run_detection_sweep(triggered_by_user_id: str | None) -> None:
     """Whole-space detection sweep. ``triggered_by_user_id`` is the admin who
     kicked it off (NULL for a system/scheduled run)."""
     runner.run_sweep(triggered_by_user_id=triggered_by_user_id)
 
 
-@detection_queue.task()
+@automanage_queue.task()
 def execute_proposal(proposal_id: int) -> None:
-    """Apply an approved proposal (commits to git — hence the detection queue,
-    not a co-tenant)."""
+    """Apply an approved proposal (commits to git)."""
     executor.execute(proposal_id)
 
 
@@ -48,13 +46,13 @@ def _run_scheduled_sweep(cadence: str) -> None:
 
 # 08:00 UTC — off-peak, ahead of the daily trash purge (10:00). Cron is
 # evaluated in UTC (no DST). Weekly fires Mondays (day_of_week=1).
-@detection_queue.periodic_task(crontab(hour="8", minute="0"))
+@automanage_queue.periodic_task(crontab(hour="8", minute="0"))
 def scheduled_daily_sweep() -> None:
     """Daily recurring sweep — runs only when ``schedule`` is ``daily``."""
     _run_scheduled_sweep("daily")
 
 
-@detection_queue.periodic_task(crontab(day_of_week="1", hour="8", minute="0"))
+@automanage_queue.periodic_task(crontab(day_of_week="1", hour="8", minute="0"))
 def scheduled_weekly_sweep() -> None:
     """Weekly recurring sweep (Mondays) — runs only when ``schedule`` is
     ``weekly``."""

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -104,6 +104,14 @@ def crontab(
 _stop_event = threading.Event()
 
 
+def install_signal_handlers() -> None:
+    """Public entry point: install SIGTERM/SIGINT handlers that set the shared
+    stop event. Call once from a process's main thread (e.g. ``run_worker``)
+    before spawning consumer threads. A no-op off the main thread, so
+    ``run_consumer`` calling it from a worker thread is harmless."""
+    _install_signal_handlers()
+
+
 def _install_signal_handlers() -> None:
     if threading.current_thread() is not threading.main_thread():
         return

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -74,10 +74,12 @@ Queues:
       (``prune_ingest_eval_samples``) — a daily, per-run-bounded indexed
       ``DELETE`` of rows past ``INGEST_EVAL_RETENTION_DAYS``.
 
-Each consumer runs as a separate worker container — see
-``docker-compose.yml`` (``worker-documents``, ``worker-triggers``,
-``worker-coedit``, ``worker-lightweight-maintenance``) and
-``app/tasks/run_worker.py``.
+Queues are the *isolation* unit (each its own Redis stream + consumer/thread
+pool); worker **processes** are the *memory* unit and may host several queues
+at once, each as its own consumer. Deployment groups them into two pods —
+``worker-coedit`` (the only real-time path) and ``worker-background`` (the
+rest) — see ``docker-compose.yml``, the ``worker.groups`` values in the helm
+chart, and ``app/tasks/run_worker.py``.
 """
 from __future__ import annotations
 

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -46,7 +46,7 @@ Queues:
   a Postgres advisory lock (``coedit.checkpoint_lock_key``), not single-threading
   — different sessions checkpoint in parallel; the same session is serialized.
 
-* ``detection_queue`` — **Wiki Auto Management detection + execution.** A
+* ``automanage_queue`` — **Wiki Auto Management detection + execution.** A
   whole-space sweep walks the wiki, runs the detectors, and emits
   ``change_proposals`` (mechanical today; fuzzy-dup/misplacement will add LLM
   calls), and on approval the executor commits structural changes to git. That
@@ -87,8 +87,8 @@ from app.tasks.queue import QueueFullError, TaskQueue
 __all__ = [
     "QueueFullError",
     "QUEUES",
+    "automanage_queue",
     "coedit_queue",
-    "detection_queue",
     "documents_queue",
     "lightweight_maintenance_queue",
     "triggers_queue",
@@ -102,7 +102,7 @@ def _make(name: str) -> TaskQueue:
 documents_queue = _make("documents")
 triggers_queue = _make("triggers")
 coedit_queue = _make("coedit")
-detection_queue = _make("detection")
+automanage_queue = _make("automanage")
 lightweight_maintenance_queue = _make("lightweight_maintenance")
 
 # Map queue-name → instance, used by run_worker.py to launch the right
@@ -111,6 +111,6 @@ QUEUES = {
     "documents": documents_queue,
     "triggers": triggers_queue,
     "coedit": coedit_queue,
-    "detection": detection_queue,
+    "automanage": automanage_queue,
     "lightweight_maintenance": lightweight_maintenance_queue,
 }

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -1,15 +1,26 @@
 """Entry point for a worker container.
 
-Run with: ``python -m app.tasks.run_worker <queue>`` where ``<queue>`` is
-one of ``documents``, ``triggers``, ``coedit``, ``automanage``, or
-``lightweight_maintenance``. Each queue gets its own worker process — see
-``app/tasks/queues.py`` for the queue rationale.
+Run with: ``python -m app.tasks.run_worker <queue> [<queue> ...]`` where each
+``<queue>`` is one of ``documents``, ``triggers``, ``coedit``, ``automanage``,
+or ``lightweight_maintenance``.
 
-We import every task module up front (regardless of which queue we're
-serving) so all ``@<queue>.task()`` decorators run and the per-queue
-handler registry is populated. The consumer then only pulls from the
-queue it was launched with; tasks bound to other queues are inert in
-this process.
+**Queues vs pods.** A queue is a Redis stream + its own consumer (a thread
+pool); that's the *isolation* unit, and it's cheap. A worker **process/pod** is
+the *memory* unit — it pays a ~185 MiB import-graph floor regardless of how many
+queues it serves. So a single process can host several queues, each as its own
+consumer (thread pool): backlogs stay isolated (separate streams) and run
+concurrently (the work is I/O-bound, so the GIL is released during LLM/HTTP/DB/
+git), while the memory floor is paid once. Pass several queue names to group
+them into one process; pass one to give a queue its own process.
+
+Deployment (see ``docker-compose.yml`` / helm ``worker.groups``) currently runs
+two pods: ``coedit`` alone (the only real-time, user-visible-freshness path) and
+a ``background`` pod hosting the rest.
+
+We import every task module up front (regardless of which queues we're serving)
+so all ``@<queue>.task()`` decorators run and the handler registry is populated.
+Each consumer only pulls from its own queue; tasks bound to unserved queues are
+inert in this process.
 """
 
 from __future__ import annotations
@@ -17,6 +28,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import logging
+import threading
 import time
 
 from prometheus_client import start_http_server
@@ -24,7 +36,7 @@ from sqlalchemy import text
 
 from app.config import verify_secret_key
 from app.tasks.queues import QUEUES
-from app.tasks.queue import run_consumer
+from app.tasks.queue import install_signal_handlers, run_consumer
 from app.utils.logging import setup_logging
 
 _TASK_MODULES = (
@@ -98,10 +110,12 @@ _CONCURRENCY = {
     "lightweight_maintenance": 4,
 }
 
-# Per-queue Prometheus port. Distinct ports so all three workers can run on
-# the same host (local dev / launch.json compound) without binding the same
-# socket. In k8s each pod has its own IP, but we keep the mapping consistent
-# so the helm chart's named ``metrics`` containerPort matches the queue.
+# Per-queue Prometheus port. Distinct ports so multiple worker processes can run
+# on the same host (local dev / launch.json compound) without binding the same
+# socket. A process serving several queues binds one server (the lowest port of
+# its queues); the collector reports depth for every queue regardless, so one
+# server per process is enough. The helm chart derives each group's containerPort
+# the same way.
 _METRICS_PORT = {
     "documents": 9091,
     "triggers": 9092,
@@ -112,24 +126,42 @@ _METRICS_PORT = {
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Run a task-queue consumer for one queue.")
-    parser.add_argument("queue", choices=sorted(QUEUES.keys()))
+    parser = argparse.ArgumentParser(
+        description="Run task-queue consumers for one or more queues in this process."
+    )
+    parser.add_argument("queues", nargs="+", choices=sorted(QUEUES.keys()))
     args = parser.parse_args()
 
     setup_logging()
     verify_secret_key()
+    # Install signal handlers once on the main thread; the per-queue consumers
+    # run in threads (where install is a no-op) and all observe the same stop
+    # event, so one SIGTERM drains every consumer in this process.
+    install_signal_handlers()
     # Metrics are observability, not a hard dependency: a taken port (e.g.
     # another local stack on the same host) must not stop the worker consuming.
-    port = _METRICS_PORT[args.queue]
+    port = min(_METRICS_PORT[q] for q in args.queues)
     try:
         start_http_server(port)
     except OSError as e:
         log.warning("metrics server not started on :%d (%s)", port, e)
     _wait_for_db()
-    queue = QUEUES[args.queue]
-    concurrency = _CONCURRENCY[args.queue]
 
-    run_consumer(queue, concurrency=concurrency)
+    # One consumer (thread pool) per queue, each in its own thread; run_consumer
+    # blocks until the stop event drains its pool, so we join them all.
+    threads = [
+        threading.Thread(
+            target=run_consumer,
+            args=(QUEUES[q],),
+            kwargs={"concurrency": _CONCURRENCY[q]},
+            name=f"consumer-{q}",
+        )
+        for q in args.queues
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
 
 
 if __name__ == "__main__":

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -1,9 +1,9 @@
 """Entry point for a worker container.
 
 Run with: ``python -m app.tasks.run_worker <queue>`` where ``<queue>`` is
-one of ``documents``, ``triggers``, ``coedit``, or ``lightweight_maintenance``.
-Each queue gets its own worker process — see ``app/tasks/queues.py`` for the
-queue rationale.
+one of ``documents``, ``triggers``, ``coedit``, ``automanage``, or
+``lightweight_maintenance``. Each queue gets its own worker process — see
+``app/tasks/queues.py`` for the queue rationale.
 
 We import every task module up front (regardless of which queue we're
 serving) so all ``@<queue>.task()`` decorators run and the per-queue
@@ -30,10 +30,10 @@ from app.utils.logging import setup_logging
 _TASK_MODULES = (
     "app.tasks.agent_activity",
     "app.tasks.chat_title",
+    "app.tasks.automanage",
     "app.tasks.coedit_checkpoint",
     "app.tasks.coedit_rebase",
     "app.tasks.craft",
-    "app.tasks.detection",
     "app.tasks.wiki_update",
     "app.tasks.expire_launch_artifacts",
     "app.tasks.ingest_eval_retention",
@@ -91,12 +91,10 @@ _CONCURRENCY = {
     "documents": 1,
     "triggers": 4,
     "coedit": 4,
-    # Detection: only the admin whole-space sweep runs here today, and two
-    # concurrent sweeps would just duplicate work — so serialize at 1. Bump
-    # when a second task type lands (single-page checks / proposal executes)
-    # that should slip past a running sweep; git safety then comes from the
-    # commit lock, not single-threading.
-    "detection": 1,
+    # Automanage: whole-space sweeps + proposal execution. Two concurrent sweeps
+    # would just duplicate work, so serialize at 1; executes are safe under the
+    # git commit lock.
+    "automanage": 1,
     "lightweight_maintenance": 4,
 }
 
@@ -109,7 +107,7 @@ _METRICS_PORT = {
     "triggers": 9092,
     "lightweight_maintenance": 9093,
     "coedit": 9094,
-    "detection": 9095,
+    "automanage": 9095,
 }
 
 

--- a/backend/app/wiki/automanage/review.py
+++ b/backend/app/wiki/automanage/review.py
@@ -20,11 +20,11 @@ from app.wiki.change_proposals import ProposalStatus
 
 
 def _dispatch_execution(proposal_id: int) -> None:
-    """Enqueue execution of an approved proposal on the detection queue — the
+    """Enqueue execution of an approved proposal on the automanage queue — the
     shared step every approval path calls. Imported lazily so this domain
     module doesn't hard-depend on the tasks layer at import time (tasks import
     automanage, not the reverse)."""
-    from app.tasks.detection import execute_proposal
+    from app.tasks.automanage import execute_proposal
 
     execute_proposal(proposal_id)
 

--- a/backend/app/wiki/automanage/settings.py
+++ b/backend/app/wiki/automanage/settings.py
@@ -3,7 +3,7 @@
 
 ``enabled`` is the master kill switch; ``schedule`` drives the recurring
 detection sweep (``off`` / ``daily`` / ``weekly``, read each fire by the
-periodic tasks in ``app/tasks/detection.py``). Free functions over the row
+periodic tasks in ``app/tasks/automanage.py``). Free functions over the row
 returning a frozen pydantic model, mirroring ``app/ingest/settings.py``. The
 switch is a feature gate only — it never touches per-page
 ``ai_management_allowed`` policy, so disabling then re-enabling resumes exactly

--- a/backend/tests/test_detection_api.py
+++ b/backend/tests/test_detection_api.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import create_app
-from app.tasks.queues import detection_queue
+from app.tasks.queues import automanage_queue
 from tests._auth import login_fastapi
 from tests._seed import seed_user
 
@@ -34,7 +34,7 @@ def test_admin_sweep_records_a_run(client):
     uid = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
     login_fastapi(client, uid)
 
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         resp = client.post("/api/automanage/sweep")
     assert resp.status_code == 202
     assert resp.json()["status"] == "queued"

--- a/backend/tests/test_detection_proposal_actions_api.py
+++ b/backend/tests/test_detection_proposal_actions_api.py
@@ -10,7 +10,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import create_app
-from app.tasks.queues import detection_queue
+from app.tasks.queues import automanage_queue
 from app.wiki import acl
 from app.wiki import git as wiki_git
 from app.wiki.change_proposals import (
@@ -53,7 +53,7 @@ def test_approve_executes_and_applies(client):
     wiki_git.commit_file("stale/.gitkeep", "", "create", author=None)
     pid = _mk("stale")
 
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         r = client.post(f"/api/automanage/proposals/{pid}/approve")
     assert r.status_code == 200 and r.json()["status"] == "approved"
     assert _status(pid) == "applied"
@@ -90,7 +90,7 @@ def test_approve_twice_conflicts(client):
     wiki_git.commit_file("dup/.gitkeep", "", "create", author=None)
     pid = _mk("dup")
 
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         assert client.post(f"/api/automanage/proposals/{pid}/approve").status_code == 200
         # already applied → no longer pending → 409
         assert client.post(f"/api/automanage/proposals/{pid}/approve").status_code == 409

--- a/backend/tests/test_detection_review.py
+++ b/backend/tests/test_detection_review.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 
 from app.auth.users import AI_USER_ID
-from app.tasks.queues import detection_queue
+from app.tasks.queues import automanage_queue
 from app.wiki import git as wiki_git
 from app.wiki.automanage import review
 from app.wiki.change_proposals import (
@@ -47,7 +47,7 @@ def test_human_approve_executes_and_binds_reviewer(repo):
     uid = seed_user(uid="u1", email="u@x.com")
     wiki_git.commit_file("stale/.gitkeep", "", "create", author=None)
     pid = _mk("stale")
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         assert review.approve(pid, user_id=uid)
     p = _get(pid)
     assert p["status"] == "applied"
@@ -59,7 +59,7 @@ def test_auto_approve_executes_without_a_reviewer(repo):
     # The AI system user is seeded by migration; use it as the acting principal.
     wiki_git.commit_file("ai-managed/.gitkeep", "", "create", author=None)
     pid = _mk("ai-managed")
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         assert review.auto_approve(pid, acting_user_id=AI_USER_ID)
     p = _get(pid)
     assert p["status"] == "applied"  # same execution path as human approval
@@ -82,7 +82,7 @@ def test_approve_non_pending_returns_false(repo):
     uid = seed_user(uid="u1", email="u@x.com")
     wiki_git.commit_file("x/.gitkeep", "", "create", author=None)
     pid = _mk("x")
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         assert review.approve(pid, user_id=uid)
         assert review.approve(pid, user_id=uid) is False  # already applied
 
@@ -99,6 +99,6 @@ def test_approve_recovers_stuck_approved(repo):
     assert cp_approve(pid, user_id=uid)  # pending -> approved, no dispatch
     assert _get(pid)["status"] == "approved"
 
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         assert review.approve(pid, user_id=uid) is True  # re-dispatches
     assert _get(pid)["status"] == "applied"

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from app.auth.users import AI_USER_ID
-from app.tasks.queues import detection_queue
+from app.tasks.queues import automanage_queue
 from app.wiki import git as wiki_git
 from app.wiki import update_policy
 from app.wiki.automanage import runner, runs
@@ -93,7 +93,7 @@ def test_ai_managed_scope_auto_applies(repo):
     # archive opts into AI management → auto-approved + executed as the AI user,
     # no human queue. old is unset → stays pending.
     update_policy.set_policy("archive", ai_management_allowed=True)
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         runner.run_sweep(triggered_by_user_id=None)
 
     applied = {p["source_paths"][0]: p for p in list_by_status(ProposalStatus.APPLIED)}
@@ -109,7 +109,7 @@ def test_ai_managed_scope_auto_applies(repo):
 
 def test_unset_scope_stays_pending(repo):
     # No policy anywhere → both empties wait for human review, nothing executes.
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         runner.run_sweep(triggered_by_user_id=None)
     assert list_by_status(ProposalStatus.APPLIED) == []
     pending = {p["source_paths"][0] for p in list_by_status(ProposalStatus.PENDING)}

--- a/backend/tests/test_detection_scheduled_sweep.py
+++ b/backend/tests/test_detection_scheduled_sweep.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import pytest
 
-from app.tasks import detection
-from app.tasks.queues import detection_queue
+from app.tasks import automanage
+from app.tasks.queues import automanage_queue
 from app.wiki.automanage import settings
 
 
@@ -21,36 +21,36 @@ def swept(monkeypatch):
     default, so ``immediate_mode`` is what runs the handler body inline."""
     calls: list[str | None] = []
     monkeypatch.setattr(
-        detection.runner,
+        automanage.runner,
         "run_sweep",
         lambda *, triggered_by_user_id: calls.append(triggered_by_user_id),
     )
-    with detection_queue.immediate_mode():
+    with automanage_queue.immediate_mode():
         yield calls
 
 
 def test_daily_runs_only_when_schedule_daily(tmp_db, swept):
     settings.update(schedule="daily")
-    detection.scheduled_daily_sweep()
-    detection.scheduled_weekly_sweep()
+    automanage.scheduled_daily_sweep()
+    automanage.scheduled_weekly_sweep()
     assert swept == [None]  # daily fired (system run), weekly skipped
 
 
 def test_weekly_runs_only_when_schedule_weekly(tmp_db, swept):
     settings.update(schedule="weekly")
-    detection.scheduled_weekly_sweep()
-    detection.scheduled_daily_sweep()
+    automanage.scheduled_weekly_sweep()
+    automanage.scheduled_daily_sweep()
     assert swept == [None]  # weekly fired, daily skipped
 
 
 def test_off_schedule_never_sweeps(tmp_db, swept):
     # default schedule is "off"
-    detection.scheduled_daily_sweep()
-    detection.scheduled_weekly_sweep()
+    automanage.scheduled_daily_sweep()
+    automanage.scheduled_weekly_sweep()
     assert swept == []
 
 
 def test_kill_switch_overrides_schedule(tmp_db, swept):
     settings.update(enabled=False, schedule="daily")
-    detection.scheduled_daily_sweep()
+    automanage.scheduled_daily_sweep()
     assert swept == []  # frozen despite a daily schedule

--- a/backend/tests/test_task_queue_metrics.py
+++ b/backend/tests/test_task_queue_metrics.py
@@ -101,7 +101,7 @@ def test_task_queue_collector_labels_every_queue(monkeypatch):
         "documents",
         "triggers",
         "coedit",
-        "detection",
+        "automanage",
         "lightweight_maintenance",
     }
     assert all(s.value == 2 for s in depth.samples)

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,12 +1,12 @@
 {{- /*
 One Deployment per queue. The backend's `app.tasks.run_worker`
 requires a queue argument (`documents`, `triggers`, `coedit`,
-`detection`, or `lightweight_maintenance`), and each queue gets its own
+`automanage`, or `lightweight_maintenance`), and each queue gets its own
 consumer process to keep slow LLM doc work from backpressuring fast paths
 like the BM25 reindex, co-edit checkpoints, or agent-activity cleanup.
 */ -}}
 {{- /* Per-queue Prometheus port — must match _METRICS_PORT in app/tasks/run_worker.py. */ -}}
-{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "coedit" 9094 "detection" 9095 -}}
+{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "coedit" 9094 "automanage" 9095 -}}
 {{- range $queue := .Values.worker.queues }}
 ---
 apiVersion: apps/v1

--- a/deploy/helm/agent-workspace/templates/worker-deployment.yaml
+++ b/deploy/helm/agent-workspace/templates/worker-deployment.yaml
@@ -1,22 +1,22 @@
 {{- /*
-One Deployment per queue. The backend's `app.tasks.run_worker`
-requires a queue argument (`documents`, `triggers`, `coedit`,
-`automanage`, or `lightweight_maintenance`), and each queue gets its own
-consumer process to keep slow LLM doc work from backpressuring fast paths
-like the BM25 reindex, co-edit checkpoints, or agent-activity cleanup.
+One Deployment per worker group. The backend's `app.tasks.run_worker` takes one
+or more queue names and runs each as its own consumer (thread pool) in a single
+process — queues stay isolated (separate Redis streams) while a group shares one
+process's memory floor. Groups are defined in `.Values.worker.groups`; queue
+names must exist in `backend/app/tasks/queues.py:QUEUES`, and `metricsPort` must
+equal the lowest run_worker `_METRICS_PORT` among the group's queues (run_worker
+binds that port).
 */ -}}
-{{- /* Per-queue Prometheus port — must match _METRICS_PORT in app/tasks/run_worker.py. */ -}}
-{{- $metricsPorts := dict "documents" 9091 "triggers" 9092 "lightweight_maintenance" 9093 "coedit" 9094 "automanage" 9095 -}}
-{{- range $queue := .Values.worker.queues }}
+{{- range $group := .Values.worker.groups }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "agent-workspace.fullname" $ }}-worker-{{ $queue | replace "_" "-" }}
+  name: {{ include "agent-workspace.fullname" $ }}-worker-{{ $group.name | replace "_" "-" }}
   labels:
     {{- include "agent-workspace.labels" $ | nindent 4 }}
     app.kubernetes.io/component: worker
-    agent-workspace.onyx.app/queue: {{ $queue }}
+    agent-workspace.onyx.app/worker-group: {{ $group.name }}
 spec:
   replicas: {{ $.Values.worker.replicaCount }}
   # The worker mounts the same RWO wiki-data PVC as the backend; Recreate
@@ -29,13 +29,13 @@ spec:
       app.kubernetes.io/name: {{ include "agent-workspace.name" $ }}
       app.kubernetes.io/instance: {{ $.Release.Name }}
       app.kubernetes.io/component: worker
-      agent-workspace.onyx.app/queue: {{ $queue }}
+      agent-workspace.onyx.app/worker-group: {{ $group.name }}
   template:
     metadata:
       labels:
         {{- include "agent-workspace.labels" $ | nindent 8 }}
         app.kubernetes.io/component: worker
-        agent-workspace.onyx.app/queue: {{ $queue }}
+        agent-workspace.onyx.app/worker-group: {{ $group.name }}
     spec:
       serviceAccountName: {{ include "agent-workspace.serviceAccountName" $ }}
       {{- with $.Values.imagePullSecrets }}
@@ -46,9 +46,9 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- /* The relevance filter runs only in the documents worker; fetch the */ -}}
-      {{- /* warm model only there, and only when one is configured.           */ -}}
-      {{- $relevanceModel := and (eq $queue "documents") (not (empty $.Values.ingestRelevance.twoTower.s3Uri)) }}
+      {{- /* The relevance filter runs only where the documents queue lives;   */ -}}
+      {{- /* fetch the warm model only there, and only when one is configured.  */ -}}
+      {{- $relevanceModel := and (has "documents" $group.queues) (not (empty $.Values.ingestRelevance.twoTower.s3Uri)) }}
       {{- $modelPath := printf "%s/model.onnx" $.Values.ingestRelevance.twoTower.mountPath }}
       {{- if $relevanceModel }}
       initContainers:
@@ -77,10 +77,16 @@ spec:
         - name: worker
           image: "{{ $.Values.image.backend.repository }}:{{ $.Values.image.backend.tag }}"
           imagePullPolicy: {{ $.Values.image.backend.pullPolicy }}
-          command: ["python", "-m", "app.tasks.run_worker", {{ $queue | quote }}]
+          command:
+            - python
+            - -m
+            - app.tasks.run_worker
+            {{- range $q := $group.queues }}
+            - {{ $q | quote }}
+            {{- end }}
           ports:
             - name: metrics
-              containerPort: {{ index $metricsPorts $queue }}
+              containerPort: {{ $group.metricsPort }}
               protocol: TCP
           {{- with $.Values.securityContext }}
           securityContext:

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -137,7 +137,7 @@ worker:
     - documents
     - triggers
     - coedit
-    - detection
+    - automanage
     - lightweight_maintenance
   resources:
     requests:

--- a/deploy/helm/agent-workspace/values.yaml
+++ b/deploy/helm/agent-workspace/values.yaml
@@ -125,20 +125,25 @@ backend:
     periodSeconds: 10
 
 worker:
-  # One Deployment is created per queue; replicaCount applies per queue.
+  # One Deployment is created per group; replicaCount applies per group.
   # Keep at 1 — backend + worker pods share an RWO wiki-data PVC and must
-  # co-schedule, AND the per-queue periodic-task scheduler runs in-process
-  # (running multiple replicas would double-fire the cron tasks).
+  # co-schedule, AND the in-process periodic-task scheduler would double-fire
+  # cron tasks across multiple replicas.
   replicaCount: 1
-  # Five Redis Stream queues, one consumer process each. Match
-  # `backend/app/tasks/queues.py:QUEUES` (and the $metricsPorts dict in
-  # worker-deployment.yaml). Adding one requires corresponding code.
-  queues:
-    - documents
-    - triggers
-    - coedit
-    - automanage
-    - lightweight_maintenance
+  # Worker groups: each Deployment runs one process that consumes the listed
+  # queues, each as its own consumer (thread pool) — queues stay isolated
+  # (separate Redis streams) while sharing one process's memory floor. Every
+  # queue name must exist in `backend/app/tasks/queues.py:QUEUES`; `metricsPort`
+  # must equal the lowest run_worker `_METRICS_PORT` among the group's queues
+  # (run_worker binds that port). `coedit` is isolated as the only real-time
+  # path; the rest share `background`.
+  groups:
+    - name: coedit
+      queues: [coedit]
+      metricsPort: 9094
+    - name: background
+      queues: [documents, triggers, automanage, lightweight_maintenance]
+      metricsPort: 9091
   resources:
     requests:
       cpu: 100m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,10 +161,10 @@ services:
       opensearch:
         condition: service_healthy
 
-  worker-detection:
+  worker-automanage:
     profiles: ["app"]
     build: ./backend
-    command: ["python", "-m", "app.tasks.run_worker", "detection"]
+    command: ["python", "-m", "app.tasks.run_worker", "automanage"]
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,53 +91,11 @@ services:
       opensearch:
         condition: service_healthy
 
-  # Three workers, one per queue (see backend/app/tasks/queues.py).
-  worker-documents:
-    profiles: ["app"]
-    build: ./backend
-    command: ["python", "-m", "app.tasks.run_worker", "documents"]
-    env_file: .env
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
-      - REDIS_URL=redis://redis:6379/0
-      - OPENSEARCH_URL=http://opensearch:9200
-      - WIKI_DIR=/data/wiki
-      - DEV_MODE=true
-    volumes:
-      - ./local_data:/data
-    depends_on:
-      backend:
-        condition: service_started
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      opensearch:
-        condition: service_healthy
-
-  worker-triggers:
-    profiles: ["app"]
-    build: ./backend
-    command: ["python", "-m", "app.tasks.run_worker", "triggers"]
-    env_file: .env
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
-      - REDIS_URL=redis://redis:6379/0
-      - OPENSEARCH_URL=http://opensearch:9200
-      - WIKI_DIR=/data/wiki
-      - DEV_MODE=true
-    volumes:
-      - ./local_data:/data
-    depends_on:
-      backend:
-        condition: service_started
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      opensearch:
-        condition: service_healthy
-
+  # Two worker pods (see backend/app/tasks/queues.py + run_worker.py). Queues
+  # stay independent (own Redis stream + thread pool); pods are grouped to share
+  # the ~185 MiB Python import-graph floor. `coedit` is the only real-time,
+  # user-visible-freshness path, so it gets its own pod; everything else runs in
+  # one `background` process, each queue as its own consumer.
   worker-coedit:
     profiles: ["app"]
     build: ./backend
@@ -161,33 +119,19 @@ services:
       opensearch:
         condition: service_healthy
 
-  worker-automanage:
+  worker-background:
     profiles: ["app"]
     build: ./backend
-    command: ["python", "-m", "app.tasks.run_worker", "automanage"]
-    env_file: .env
-    environment:
-      - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki
-      - REDIS_URL=redis://redis:6379/0
-      - OPENSEARCH_URL=http://opensearch:9200
-      - WIKI_DIR=/data/wiki
-      - DEV_MODE=true
-    volumes:
-      - ./local_data:/data
-    depends_on:
-      backend:
-        condition: service_started
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      opensearch:
-        condition: service_healthy
-
-  worker-lightweight-maintenance:
-    profiles: ["app"]
-    build: ./backend
-    command: ["python", "-m", "app.tasks.run_worker", "lightweight_maintenance"]
+    command:
+      [
+        "python",
+        "-m",
+        "app.tasks.run_worker",
+        "documents",
+        "triggers",
+        "automanage",
+        "lightweight_maintenance",
+      ]
     env_file: .env
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/agent_wiki


### PR DESCRIPTION
Stacked on #473 (base = `bo/automanage-queue-groups`; retarget to `main` after #473's rename merges). This is the **grouping** half we split out of #473.

**Queues are the isolation unit; worker processes are the memory unit.** A queue is cheap (a Redis stream + its own consumer/thread pool); a worker pod pays a ~185 MiB import-graph floor regardless of how many queues it serves. So one process can host several queues — each its own consumer — keeping backlogs isolated (separate streams; I/O-bound work releases the GIL) while paying the floor once.

- `run_worker` now takes **one or more** queue names, spawns one `run_consumer` (thread pool) per queue in its own thread, binds one metrics server (lowest port among its queues), and installs signal handlers once on the main thread (new public `queue.install_signal_handlers`) so one SIGTERM drains every consumer.
- **Deployment: 5 pods → 2.** `coedit` — the only real-time, user-visible-freshness path — keeps its own pod; `documents`/`triggers`/`automanage`/`lightweight_maintenance` share a `background` pod. docker-compose has two worker services; helm switches per-queue → `worker.groups` (per-group Deployment, `metricsPort` per group).
- Per-queue concurrency and isolation unchanged.

Verified locally (before the rename/grouping re-slice): 2 worker pods up, `worker-background` runs all four consumers at correct concurrency, an admin sweep runs end-to-end on the grouped `automanage` consumer; **~558 MiB across 2 pods vs ~985 MiB across the old 5 (~430 MiB saved)**; `helm template` renders exactly 2 worker Deployments.

Doctrine + the (still-planned) `automanage_nearline`/`automanage_offline` split are documented on the wiki: `Engineering Projects/Agent Wiki Project/design/Queues and Workers.md`.

## Test plan
- ruff + basedpyright clean; automanage/queue suite green; `docker compose config` parses (2 worker services); `helm template` renders 2 worker Deployments.