### PR TITLE
feat(automanage): write-scoped proposal listing + per-path filter (Path-2 review backend)

### DIFF
--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -123,11 +123,15 @@ def list_proposals(
     hard row cap *before* the filter would silently hide a caller's proposals
     sitting past it. If the pending set ever grows large, push the checks into
     SQL and paginate."""
+    # Proposal paths are stored canonical (no surrounding slashes), so normalize
+    # the query the same way — `/docs`, `docs/`, `docs` all match, and the root
+    # (`""` / `"/"`) normalizes to empty → no scope filter (the whole wiki).
+    scope = path.strip().strip("/") if path else ""
     pending = list_by_status(ProposalStatus.PENDING, limit=None)
     visible = [
         p
         for p in pending
-        if (path is None or _touches(p, path)) and _can_act(user, p)
+        if (not scope or _touches(p, scope)) and _can_act(user, p)
     ]
     return ProposalsResponse(proposals=[ProposalView(**p) for p in visible])
 

--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -41,6 +41,29 @@ def _can_see(user: User, proposal: dict[str, Any]) -> bool:
     return all(acl.can(user.id, user.is_admin, "read", p) for p in paths)
 
 
+def _can_act(user: User, proposal: dict[str, Any]) -> bool:
+    """A proposal is actionable — and so listed — only if the caller can *write*
+    every path it touches. This is the same envelope approve/reject enforce
+    (``_require_writable``), so the listing is exactly the set the caller could
+    approve. It also implies read, so it never leaks a restricted scope."""
+    paths = list(proposal["source_paths"]) + list(proposal["target_paths"])
+    return all(acl.can(user.id, user.is_admin, "write", p) for p in paths)
+
+
+def _paths_overlap(a: str, b: str) -> bool:
+    """True if two wiki paths are the same or one is an ancestor of the other."""
+    return a == b or a.startswith(b + "/") or b.startswith(a + "/")
+
+
+def _touches(proposal: dict[str, Any], scope: str) -> bool:
+    """True if the proposal acts within ``scope`` — any of its paths equals
+    ``scope`` or is an ancestor/descendant of it. So a page surfaces proposals on
+    itself (or an enclosing folder), and a folder surfaces proposals anywhere in
+    its subtree."""
+    paths = list(proposal["source_paths"]) + list(proposal["target_paths"])
+    return any(_paths_overlap(p, scope) for p in paths)
+
+
 @router.get("/settings", response_model=DetectionSettingsView)
 def get_settings(user: User = Depends(require_admin)) -> DetectionSettingsView:
     """The org-wide Auto Organize settings (kill switch + sweep schedule)."""
@@ -83,17 +106,29 @@ def list_runs(user: User = Depends(require_admin)) -> RunsResponse:
 
 
 @router.get("/proposals", response_model=ProposalsResponse)
-def list_proposals(user: User = Depends(require_user)) -> ProposalsResponse:
-    """Pending cleanup proposals the caller may review — filtered to those whose
-    every path the caller can read (an unreadable path would leak its scope).
+def list_proposals(
+    path: str | None = None, user: User = Depends(require_user)
+) -> ProposalsResponse:
+    """Pending cleanup proposals the caller can act on — those whose every path
+    the caller can **write** (the same envelope approve/reject enforce, so the
+    list is exactly what the caller could approve; edit access, not read, per the
+    Path-2 review model).
 
-    Fetches all pending (``limit=None``) before ACL-filtering: the pending queue
-    is a bounded working set (drained by review + TTL expiry, capped per sweep),
-    and a hard row cap *before* the filter would silently hide a caller's
-    readable proposals sitting past it. If the pending set ever grows large,
-    push the visibility check into SQL and paginate."""
+    Pass ``path`` to scope to the proposals touching a page or folder subtree —
+    this backs the Path-2 review banner shown on the page/folder itself. Without
+    it, the full actionable pending set (the admin queue; admins bypass ACL).
+
+    Fetches all pending (``limit=None``) before filtering: the pending queue is a
+    bounded working set (drained by review + TTL expiry, capped per sweep), and a
+    hard row cap *before* the filter would silently hide a caller's proposals
+    sitting past it. If the pending set ever grows large, push the checks into
+    SQL and paginate."""
     pending = list_by_status(ProposalStatus.PENDING, limit=None)
-    visible = [p for p in pending if _can_see(user, p)]
+    visible = [
+        p
+        for p in pending
+        if (path is None or _touches(p, path)) and _can_act(user, p)
+    ]
     return ProposalsResponse(proposals=[ProposalView(**p) for p in visible])
 
 

--- a/backend/tests/test_detection_proposals_api.py
+++ b/backend/tests/test_detection_proposals_api.py
@@ -134,3 +134,8 @@ def test_path_filter_scopes_to_subtree(client):
     assert folders("docs/old") == {"docs/old"}  # exact
     assert folders("archive") == {"archive"}
     assert folders("nope") == set()  # no overlap
+    # Query path is normalized like other wiki paths (surrounding slashes /
+    # root are tolerated), so a banner request isn't silently empty.
+    assert folders("/docs") == {"docs/old"}
+    assert folders("docs/") == {"docs/old"}
+    assert folders("/") == {"docs/old", "archive"}  # root → no filter

--- a/backend/tests/test_detection_proposals_api.py
+++ b/backend/tests/test_detection_proposals_api.py
@@ -1,7 +1,10 @@
-"""Pending-cleanups read API — list/get proposals, visibility-scoped.
+"""Pending-cleanups read API — list/get proposals.
 
-A proposal is visible only to a caller who can read every path it touches, so
-its existence never leaks a restricted scope.
+The **listing** is write-scoped (Path-2 review): a proposal is listed only to a
+caller who can *write* every path it touches — the same envelope approve/reject
+enforce, so the list is exactly what the caller could act on. A single-proposal
+fetch stays read-scoped (viewing). ``?path=`` scopes the listing to proposals
+touching a page/folder subtree — the on-page review banner.
 """
 from __future__ import annotations
 
@@ -87,3 +90,47 @@ def test_restricted_proposal_hidden_from_non_reader(client):
     # And an admin sees it via bypass.
     login_fastapi(client, admin)
     assert client.get(f"/api/automanage/proposals/{pid}").status_code == 200
+
+
+def test_read_only_user_excluded_from_list_but_can_view(client):
+    # The listing is write-scoped: a reader (read but not write) can *view* a
+    # proposal but it's not in their actionable list; the writer/owner sees it.
+    seed_user(uid="admin_1", email="a@x.com", is_admin=True)  # first = admin
+    owner = seed_user(uid="owner_1", email="o@x.com", is_admin=False)
+    reader = seed_user(uid="reader_1", email="r@x.com", is_admin=False)
+    pid = _mk("ro")
+    acl.set_owner("ro", owner)  # manage the path (owner + admin write)
+    acl.grant(
+        resource_kind="folder",
+        resource_path="ro",
+        principal_kind="user",
+        principal_id=reader,
+        permission="read",
+        granted_by_user_id=owner,
+    )
+
+    login_fastapi(client, reader)
+    listed = {p["source_paths"][0] for p in client.get("/api/automanage/proposals").json()["proposals"]}
+    assert "ro" not in listed  # read-only → not actionable, not listed
+    assert client.get(f"/api/automanage/proposals/{pid}").status_code == 200  # but viewable
+
+    login_fastapi(client, owner)
+    listed = {p["source_paths"][0] for p in client.get("/api/automanage/proposals").json()["proposals"]}
+    assert "ro" in listed  # writer sees it
+
+
+def test_path_filter_scopes_to_subtree(client):
+    uid = seed_user(uid="admin_1", email="a@x.com", is_admin=True)
+    login_fastapi(client, uid)
+    _mk("docs/old")
+    _mk("archive")
+
+    def folders(path=None):
+        q = f"/api/automanage/proposals?path={path}" if path else "/api/automanage/proposals"
+        return {p["source_paths"][0] for p in client.get(q).json()["proposals"]}
+
+    assert folders() == {"docs/old", "archive"}  # no filter → all
+    assert folders("docs") == {"docs/old"}  # ancestor folder → subtree match
+    assert folders("docs/old") == {"docs/old"}  # exact
+    assert folders("archive") == {"archive"}
+    assert folders("nope") == set()  # no overlap


### PR DESCRIPTION
Backend for **Path-2 review**: proposals for non-AI-managed scopes are surfaced to *edit-access* users on the page/folder itself (the frontend banner comes next). Task #4 of the Auto Organize follow-ups.

## Changes
- **`GET /api/automanage/proposals` is now write-scoped.** A proposal is listed only if the caller can **write** every path it touches (`_can_act`) — the same envelope `approve`/`reject` enforce (`_require_writable`), so the list is exactly the set the caller could act on. This is the Path-2 model: edit access, not read. Admins still bypass ACL; implicit-public (unmanaged) paths still list for everyone.
- **New `?path=<p>` query param** scopes the listing to proposals touching a page or folder subtree (`_touches`: any proposal path equals `p` or is an ancestor/descendant of it). This is the per-path fetch the on-page/folder review banner will call.
- Single-proposal `GET /proposals/{id}` stays **read-scoped** (viewing a preview is fine; acting still requires write).

## Test plan
- ruff + basedpyright clean.
- `test_detection_proposals_api` + `test_detection_proposal_actions_api` green (10); broader automanage/detection suite green (65).
- New tests: a read-only user is excluded from the list but can still view a proposal; `?path` matches subtree/exact and excludes non-overlapping; existing admin/owner/restricted-visibility cases still hold under write-scoping.

Next: **#5** page/folder review banner (frontend, approve/reject + applied/went-stale feedback), then **#6** Path-1 auto-applied visibility.