### PR TITLE
feat(coedit): caret-driven presence labels + peer caret mapping (frontend)

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -706,32 +706,29 @@ function readOnlyExtensions(readOnly: boolean) {
 
 interface CoeditPresenceBarProps {
   participants: CoeditParticipant[];
+  /** Peers with a live caret (from `useCoeditSession`) — a participant with
+   * an entry here is "editing", the rest are "viewing". */
+  peers: CoeditPeer[];
   typing: string[];
   selfUserId: string | null;
 }
 
-// "editing" means positioned to edit — a caret placed in the text — not
-// "has recently applied an op". Everyone on the page is in the live session;
-// the label — not membership — is what distinguishes editors from readers.
-// Event-driven, no timers: the state flips on caret placement and on the
-// blur / hidden-tab clear, so it can never disagree with the caret rendered
-// in the doc (the same signal drives both).
-function presenceLabel(p: CoeditParticipant): string {
-  return p.caret_active ? "editing" : "viewing";
-}
-
 // Live-session presence: who else is on the page — labeled "editing" while
-// their caret is placed in the text, "viewing" otherwise — and who's typing
-// right now. Complements the in-editor peer carets (CaretWidget/peersField
-// above) rather than duplicating them. Renders nothing when you're alone.
+// their caret is rendered in the content, "viewing" otherwise — and who's
+// typing right now. The label is DERIVED from the same peers list that
+// renders the carets (CaretWidget/peersField above), so bar and doc can
+// never disagree: if a person's cursor is in the content they're editing,
+// otherwise they're viewing. Renders nothing when you're alone.
 export function CoeditPresenceBar({
   participants,
+  peers,
   typing,
   selfUserId,
 }: CoeditPresenceBarProps) {
   const others = participants.filter((p) => p.user_id !== selfUserId);
   if (others.length === 0) return null;
   const typingSet = new Set(typing);
+  const caretSet = new Set(peers.map((p) => p.user_id));
   return (
     <div className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-(--text-03)">
       <span
@@ -742,7 +739,11 @@ export function CoeditPresenceBar({
         <span key={p.user_id} className="inline-flex items-center gap-1">
           <span className="font-medium text-(--text-04)">{p.user_display}</span>
           <span className="text-(--text-03) italic">
-            {typingSet.has(p.user_id) ? "typing…" : presenceLabel(p)}
+            {typingSet.has(p.user_id)
+              ? "typing…"
+              : caretSet.has(p.user_id)
+                ? "editing"
+                : "viewing"}
           </span>
         </span>
       ))}

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -641,6 +641,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         // only reads `v.state` and POSTs — both safe after `v.destroy()` —
         // and the hook clears it once it has taken ownership.
         registerSetDoc(null);
+        // A focused editor unmounting (in-app navigation, session
+        // replacement) never gets a focusChanged update — clear our caret
+        // for peers explicitly instead of leaving it parked until the
+        // server-side session leave catches up.
+        if (v.hasFocus) onCaretClearedRef.current();
         v.destroy();
         view.current = null;
       };

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -290,6 +290,10 @@ interface CoeditorProps {
   /** Fires when the editor loses focus — the local caret is no longer placed,
    * so peers drop it and presence flips us to "viewing". */
   onCaretCleared: () => void;
+  /** The current caret epoch while our caret is placed, else null — attached
+   * to every op so an edit asserts caret placement with the same ordering as
+   * cursor writes (see useCoeditSession.getCaretSeq). */
+  getCaretSeq: () => number | null;
   onServerFrame: (handler: ((frame: CoeditFrame) => void) | null) => void;
   reportDoc: (doc: string) => void;
   registerFlush: (fn: (() => Promise<void>) | null) => void;
@@ -338,6 +342,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       peers,
       onSelectionChange,
       onCaretCleared,
+      getCaretSeq,
       onServerFrame,
       reportDoc,
       registerFlush,
@@ -356,10 +361,12 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     // Latest callbacks without re-creating the editor.
     const onSelRef = useRef(onSelectionChange);
     const onCaretClearedRef = useRef(onCaretCleared);
+    const getCaretSeqRef = useRef(getCaretSeq);
     const reportDocRef = useRef(reportDoc);
     const onSelectionForCommentRef = useRef(onSelectionForComment);
     onSelRef.current = onSelectionChange;
     onCaretClearedRef.current = onCaretCleared;
+    getCaretSeqRef.current = getCaretSeq;
     reportDocRef.current = reportDoc;
     onSelectionForCommentRef.current = onSelectionForComment;
 
@@ -423,6 +430,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
             version,
             changeSetToChanges(updates[0]!.changes),
             session.clientId,
+            getCaretSeqRef.current(),
           );
           sentAtVersion.current = version;
         } catch (e) {
@@ -606,6 +614,9 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
                 version,
                 changeSetToChanges(updates[i]!.changes),
                 session.clientId,
+                // Null after a blur/teardown clear — the flushed tail then
+                // makes no caret assertion, so it can't resurrect the caret.
+                getCaretSeqRef.current(),
               );
               sentAtVersion.current = version;
               version += 1;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -24,13 +24,7 @@ import {
   placeholder as placeholderExt,
   WidgetType,
 } from "@codemirror/view";
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 import { ApiError } from "@/lib/api";
 import type {
   CoeditFrame,
@@ -115,18 +109,37 @@ function buildPeerDecorations(
   return Decoration.set(ranges, true);
 }
 
-/** Holds the peer list + its decorations. Rebuilds when peers change or the doc
- * changes (keeps offsets in range as text is edited); provides decorations to
- * the view via `EditorView.decorations`. */
+/** Holds the peer list + its decorations; provides decorations to the view via
+ * `EditorView.decorations`. A parked caret must keep pointing at the text its
+ * owner left it in, so held positions are mapped through every doc change.
+ * When a new peer array arrives, raw offsets are adopted only for entries with
+ * a fresh cursor frame (`seq` advanced) — an entry re-sent unchanged (the
+ * array was rebuilt by some other peer's frame) keeps its mapped position,
+ * since the raw offsets it carries are relative to an older doc. */
 const peersField = StateField.define<{
   peers: CoeditPeer[];
   deco: DecorationSet;
 }>({
   create: () => ({ peers: [], deco: Decoration.none }),
   update(value, tr) {
+    let incoming: CoeditPeer[] | null = null;
+    for (const e of tr.effects) if (e.is(setPeersEffect)) incoming = e.value;
+    if (incoming === null && !tr.docChanged) return value;
     let peers = value.peers;
-    for (const e of tr.effects) if (e.is(setPeersEffect)) peers = e.value;
-    if (peers === value.peers && !tr.docChanged) return value;
+    if (tr.docChanged) {
+      peers = peers.map((p) => ({
+        ...p,
+        anchor: tr.changes.mapPos(p.anchor),
+        head: tr.changes.mapPos(p.head),
+      }));
+    }
+    if (incoming !== null) {
+      const held = new Map(peers.map((p) => [p.user_id, p]));
+      peers = incoming.map((p) => {
+        const h = held.get(p.user_id);
+        return h && h.seq === p.seq ? h : p;
+      });
+    }
     return { peers, deco: buildPeerDecorations(peers, tr.state.doc.length) };
   },
   provide: (f) => EditorView.decorations.from(f, (v) => v.deco),
@@ -274,6 +287,9 @@ interface CoeditorProps {
   session: CoeditSessionHandle;
   peers: CoeditPeer[];
   onSelectionChange: (anchor: number, head: number, isEdit: boolean) => void;
+  /** Fires when the editor loses focus — the local caret is no longer placed,
+   * so peers drop it and presence flips us to "viewing". */
+  onCaretCleared: () => void;
   onServerFrame: (handler: ((frame: CoeditFrame) => void) | null) => void;
   reportDoc: (doc: string) => void;
   registerFlush: (fn: (() => Promise<void>) | null) => void;
@@ -321,6 +337,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       session,
       peers,
       onSelectionChange,
+      onCaretCleared,
       onServerFrame,
       reportDoc,
       registerFlush,
@@ -338,9 +355,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     const readOnlyCompartment = useRef(new Compartment());
     // Latest callbacks without re-creating the editor.
     const onSelRef = useRef(onSelectionChange);
+    const onCaretClearedRef = useRef(onCaretCleared);
     const reportDocRef = useRef(reportDoc);
     const onSelectionForCommentRef = useRef(onSelectionForComment);
     onSelRef.current = onSelectionChange;
+    onCaretClearedRef.current = onCaretCleared;
     reportDocRef.current = reportDoc;
     onSelectionForCommentRef.current = onSelectionForComment;
 
@@ -501,6 +520,12 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         // our caret/typing.
         if (applyingRemote.current) return;
         const sel = u.state.selection.main;
+        // Focus is caret presence: losing it clears our caret for peers;
+        // regaining it re-reports the position the clear removed.
+        if (u.focusChanged) {
+          if (u.view.hasFocus) onSelRef.current(sel.anchor, sel.head, false);
+          else onCaretClearedRef.current();
+        }
         if (u.docChanged) onSelRef.current(sel.anchor, sel.head, true);
         else if (u.selectionSet) onSelRef.current(sel.anchor, sel.head, false);
         if (u.selectionSet && onSelectionForCommentRef.current) {
@@ -669,39 +694,25 @@ interface CoeditPresenceBarProps {
   selfUserId: string | null;
 }
 
-// How recently a participant must have edited to be labeled "editing" rather
-// than "viewing". Everyone on the page is in the live session; the label — not
-// membership — is what distinguishes editors from readers. Generous on
-// purpose: a long think-pause mid-edit shouldn't demote the label, and every
-// op refreshes the timestamp, so only a genuinely idle editor decays.
-const EDITING_LABEL_WINDOW_MS = 30 * 60 * 1000;
-
-function presenceLabel(p: CoeditParticipant, now: number): string {
-  if (
-    p.last_edited_at !== null &&
-    now - Date.parse(p.last_edited_at) < EDITING_LABEL_WINDOW_MS
-  ) {
-    return "editing";
-  }
-  return "viewing";
+// "editing" means positioned to edit — a caret placed in the text — not
+// "has recently applied an op". Everyone on the page is in the live session;
+// the label — not membership — is what distinguishes editors from readers.
+// Event-driven, no timers: the state flips on caret placement and on the
+// blur / hidden-tab clear, so it can never disagree with the caret rendered
+// in the doc (the same signal drives both).
+function presenceLabel(p: CoeditParticipant): string {
+  return p.caret_active ? "editing" : "viewing";
 }
 
-// Live-session presence: who else is on the page — labeled "editing" when
-// they've applied an edit recently, "viewing" otherwise — and who's typing
+// Live-session presence: who else is on the page — labeled "editing" while
+// their caret is placed in the text, "viewing" otherwise — and who's typing
 // right now. Complements the in-editor peer carets (CaretWidget/peersField
 // above) rather than duplicating them. Renders nothing when you're alone.
-// The minute tick re-renders so an idle editor's label decays to "viewing"
-// even when no new presence frames arrive.
 export function CoeditPresenceBar({
   participants,
   typing,
   selfUserId,
 }: CoeditPresenceBarProps) {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const t = setInterval(() => setNow(Date.now()), 60_000);
-    return () => clearInterval(t);
-  }, []);
   const others = participants.filter((p) => p.user_id !== selfUserId);
   if (others.length === 0) return null;
   const typingSet = new Set(typing);
@@ -715,7 +726,7 @@ export function CoeditPresenceBar({
         <span key={p.user_id} className="inline-flex items-center gap-1">
           <span className="font-medium text-(--text-04)">{p.user_display}</span>
           <span className="text-(--text-03) italic">
-            {typingSet.has(p.user_id) ? "typing…" : presenceLabel(p, now)}
+            {typingSet.has(p.user_id) ? "typing…" : presenceLabel(p)}
           </span>
         </span>
       ))}

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -5,7 +5,9 @@
  * The "co-edit session" is the page's *live session*: everyone viewing the
  * page joins it (presence + real-time updates); editing is a capability
  * inside it (`canWrite`), and presence labels participants "viewing" vs
- * "editing" by whether they've actually edited.
+ * "editing" by whether they currently have a caret placed in the text
+ * (`caret_active` — position/intent, not edit facts; cleared on editor blur
+ * or a hidden tab, never by a timer).
  *
  * On `enabled` it joins the session for `path`, streams inbound frames, and
  * exposes presence (`participants`/`typing`/`peers`) and autosave
@@ -127,6 +129,9 @@ export function useCoeditSession(opts: {
   } | null>(null);
   const lastCursor = useRef<{ anchor: number; head: number } | null>(null);
   const typingIdle = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Client-local frame counter stamped onto peer entries (CoeditPeer.seq) so
+  // the editor can tell fresh cursor frames from re-sent array entries.
+  const frameSeq = useRef(0);
   // Inbound: per-peer expiry timers so a silent "typing" peer clears.
   const typingTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -238,6 +243,23 @@ export function useCoeditSession(opts: {
     [canWrite],
   );
 
+  const reportCaretCleared = useCallback(() => {
+    if (sessionId.current === null || !canWrite) return;
+    // Drop any queued position first — a throttled send landing after the
+    // clear would resurrect the caret.
+    pendingCursor.current = null;
+    lastCursor.current = null;
+    if (typingIdle.current) {
+      clearTimeout(typingIdle.current);
+      typingIdle.current = null;
+    }
+    // Immediate (clears are rare) + keepalive so the hidden-tab clear
+    // survives the page backgrounding.
+    void sendCursor(sessionId.current, null, null, false, {
+      keepalive: true,
+    }).catch(() => {});
+  }, [canWrite]);
+
   const onFrame = useCallback(
     (frame: CoeditFrame) => {
       if (frame.type === "presence") {
@@ -250,15 +272,34 @@ export function useCoeditSession(opts: {
       if (frame.type === "cursor") {
         if (myUserId !== null && frame.user_id === myUserId) return;
         const uid = frame.user_id;
-        setPeers((prev) => [
-          ...prev.filter((p) => p.user_id !== uid),
-          {
-            user_id: uid,
-            user_display: frame.user_display,
-            anchor: frame.anchor,
-            head: frame.head,
-          },
-        ]);
+        const anchor = frame.anchor;
+        const head = frame.head;
+        if (anchor === null || head === null) {
+          // The peer cleared their caret (editor blur / hidden tab).
+          setPeers((prev) => prev.filter((p) => p.user_id !== uid));
+        } else {
+          frameSeq.current += 1;
+          setPeers((prev) => [
+            ...prev.filter((p) => p.user_id !== uid),
+            {
+              user_id: uid,
+              user_display: frame.user_display,
+              anchor,
+              head,
+              seq: frameSeq.current,
+            },
+          ]);
+        }
+        // Roster broadcasts only arrive on join/leave, so the "editing" /
+        // "viewing" label rides the cursor frames themselves.
+        const caretActive = anchor !== null && head !== null;
+        setParticipants((prev) =>
+          prev.map((p) =>
+            p.user_id === uid && p.caret_active !== caretActive
+              ? { ...p, caret_active: caretActive }
+              : p,
+          ),
+        );
         const existing = typingTimers.current.get(uid);
         if (existing) clearTimeout(existing);
         typingTimers.current.delete(uid);
@@ -276,15 +317,15 @@ export function useCoeditSession(opts: {
         }
         return;
       }
-      // The roster's last_edited_at only refreshes on join/leave presence
-      // frames, so bump the author's locally from each op — their "editing"
-      // label flips in real time instead of waiting for a roster broadcast.
+      // An applied edit implies caret placement (mirrors the server's /op
+      // stamp) — flip the author's label even if their cursor ping was lost.
       if (frame.type === "op" && frame.author !== null) {
         const author = frame.author;
-        const nowIso = new Date().toISOString();
         setParticipants((prev) =>
           prev.map((p) =>
-            p.user_id === author ? { ...p, last_edited_at: nowIso } : p,
+            p.user_id === author && !p.caret_active
+              ? { ...p, caret_active: true }
+              : p,
           ),
         );
       }
@@ -312,6 +353,7 @@ export function useCoeditSession(opts: {
     for (const t of typingTimers.current.values()) clearTimeout(t);
     typingTimers.current.clear();
     pendingCursor.current = null;
+    lastCursor.current = null;
     setTyping([]);
     setPeers([]);
     sessionId.current = null;
@@ -433,7 +475,9 @@ export function useCoeditSession(opts: {
 
   // Best-effort checkpoint when the tab is backgrounded/closed — `keepalive`
   // lets the request survive the page tearing down. Covers the gap between
-  // the last edit and the idle-autosave timer firing.
+  // the last edit and the idle-autosave timer firing. A hidden tab also
+  // clears our caret: the user isn't positioned to edit anymore, and CM blur
+  // doesn't fire reliably on tab switches.
   useEffect(() => {
     if (!active) return;
     const checkpointNow = () => {
@@ -442,7 +486,10 @@ export function useCoeditSession(opts: {
       void checkpointSession(sid, { keepalive: true }).catch(() => {});
     };
     const onVisibilityChange = () => {
-      if (document.visibilityState === "hidden") checkpointNow();
+      if (document.visibilityState === "hidden") {
+        checkpointNow();
+        reportCaretCleared();
+      }
     };
     document.addEventListener("visibilitychange", onVisibilityChange);
     window.addEventListener("pagehide", checkpointNow);
@@ -450,7 +497,7 @@ export function useCoeditSession(opts: {
       document.removeEventListener("visibilitychange", onVisibilityChange);
       window.removeEventListener("pagehide", checkpointNow);
     };
-  }, [active, canWrite]);
+  }, [active, canWrite, reportCaretCleared]);
 
   return {
     active,
@@ -468,5 +515,6 @@ export function useCoeditSession(opts: {
     registerSetDoc,
     setDoc,
     reportSelection,
+    reportCaretCleared,
   };
 }

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -4,10 +4,11 @@
  *
  * The "co-edit session" is the page's *live session*: everyone viewing the
  * page joins it (presence + real-time updates); editing is a capability
- * inside it (`canWrite`), and presence labels participants "viewing" vs
- * "editing" by whether they currently have a caret placed in the text
- * (`caret_active` — position/intent, not edit facts; cleared on editor blur
- * or a hidden tab, never by a timer).
+ * inside it (`canWrite`), and presence labels a participant "editing" when
+ * their caret is rendered in the content, "viewing" otherwise — the label is
+ * derived from `peers`, so it can never disagree with the carets on screen.
+ * Nothing is persisted: carets appear from live cursor/op frames and go away
+ * on a clear (editor blur / hidden tab) or when the peer leaves.
  *
  * On `enabled` it joins the session for `path`, streams inbound frames, and
  * exposes presence (`participants`/`typing`/`peers`) and autosave
@@ -137,10 +138,10 @@ export function useCoeditSession(opts: {
   // `onFrame` needs the author's display to restore their caret). Synced on
   // join and on presence frames — the only points membership changes.
   const participantsRef = useRef<CoeditParticipant[]>([]);
-  // Our caret epoch: bumped on every place/clear transition, echoed on
-  // movement pings and ops. The server applies caret writes only when the
-  // epoch advances, so reordered requests can't resurrect stale state.
-  // Seeded from our own roster row on join (the row outlives connections).
+  // Our caret epoch: stamped fresh on every place/clear transition and
+  // echoed on movement pings and ops, so peers can drop reordered stale
+  // frames. Wall-clock based (monotonicized) — stays ordered across
+  // reconnects and tabs without any server-side state.
   const caretEpoch = useRef(0);
   const caretPlaced = useRef(false);
   // Latest caret epoch seen per peer — frames from older epochs are dropped.
@@ -221,7 +222,7 @@ export function useCoeditSession(opts: {
       // Reporting a position places the caret — a transition (first placement
       // or a refocus after a clear) opens a new epoch.
       if (!caretPlaced.current) {
-        caretEpoch.current += 1;
+        caretEpoch.current = Math.max(Date.now(), caretEpoch.current + 1);
         caretPlaced.current = true;
       }
       lastCursor.current = { anchor, head };
@@ -278,9 +279,9 @@ export function useCoeditSession(opts: {
   const reportCaretCleared = useCallback(() => {
     if (sessionId.current === null || !canWrite) return;
     // Clearing a placed caret opens a new epoch, so any still-in-flight
-    // place/op from the old epoch loses server-side too.
+    // place/op frame from the old epoch is dropped by peers.
     if (caretPlaced.current) {
-      caretEpoch.current += 1;
+      caretEpoch.current = Math.max(Date.now(), caretEpoch.current + 1);
       caretPlaced.current = false;
     }
     // Drop any queued position first — a throttled send landing after the
@@ -311,12 +312,7 @@ export function useCoeditSession(opts: {
         const ids = new Set(frame.participants.map((p) => p.user_id));
         setPeers((prev) => prev.filter((p) => ids.has(p.user_id)));
         setTyping((prev) => prev.filter((u) => ids.has(u)));
-        // Seed/prune the per-peer epoch guard from the roster.
-        for (const p of frame.participants) {
-          const known = peerCaretSeq.current.get(p.user_id) ?? 0;
-          if (p.caret_seq > known)
-            peerCaretSeq.current.set(p.user_id, p.caret_seq);
-        }
+        // Prune departed users from the per-peer epoch guard.
         for (const uid of peerCaretSeq.current.keys()) {
           if (!ids.has(uid)) peerCaretSeq.current.delete(uid);
         }
@@ -350,16 +346,6 @@ export function useCoeditSession(opts: {
             },
           ]);
         }
-        // Roster broadcasts only arrive on join/leave, so the "editing" /
-        // "viewing" label rides the cursor frames themselves.
-        const caretActive = anchor !== null && head !== null;
-        setParticipants((prev) =>
-          prev.map((p) =>
-            p.user_id === uid && p.caret_active !== caretActive
-              ? { ...p, caret_active: caretActive }
-              : p,
-          ),
-        );
         const existing = typingTimers.current.get(uid);
         if (existing) clearTimeout(existing);
         typingTimers.current.delete(uid);
@@ -377,13 +363,14 @@ export function useCoeditSession(opts: {
         }
         return;
       }
-      // An op carrying a caret epoch asserts caret placement (mirrors the
-      // server's stamp), and the op itself says where: the end of its last
-      // change, in post-edit coordinates. Restore both the label and the
-      // caret from it, so a lost cursor frame can't leave a peer marked
-      // "editing" with no caret rendered. Gated on the epoch like cursor
-      // frames — a stale op must not resurrect a cleared caret — and skipped
-      // entirely when the op makes no caret assertion (caret_seq null).
+      // An op carrying a caret epoch asserts caret placement, and the op
+      // itself says where: the end of its last change, in post-edit
+      // coordinates. Rendering the author's caret from it is what flips their
+      // label too (the label IS the rendered caret), so a lost cursor frame
+      // can't leave an active editor unlabeled. Gated on the epoch like
+      // cursor frames — a stale op must not resurrect a cleared caret — and
+      // skipped when the op makes no caret assertion (caret_seq null, e.g. a
+      // teardown flush after blur).
       if (
         frame.type === "op" &&
         frame.author !== null &&
@@ -392,13 +379,6 @@ export function useCoeditSession(opts: {
       ) {
         const author = frame.author;
         peerCaretSeq.current.set(author, frame.caret_seq);
-        setParticipants((prev) =>
-          prev.map((p) =>
-            p.user_id === author && !p.caret_active
-              ? { ...p, caret_active: true }
-              : p,
-          ),
-        );
         const display =
           myUserId !== null && author === myUserId
             ? undefined // never render self as a peer
@@ -495,18 +475,6 @@ export function useCoeditSession(opts: {
       setBuffer(snap.buffer);
       participantsRef.current = snap.participants;
       setParticipants(snap.participants);
-      // Resume our caret epoch from our own roster row — the row (and its
-      // caret_seq) outlives connections, and a rejoin restarting at 0 would
-      // lose every caret write to the epoch guard. Peers' rows seed the
-      // stale-frame guard the same way.
-      peerCaretSeq.current = new Map(
-        snap.participants.map((p) => [p.user_id, p.caret_seq]),
-      );
-      const mine =
-        myUserId !== null
-          ? snap.participants.find((p) => p.user_id === myUserId)
-          : undefined;
-      caretEpoch.current = Math.max(caretEpoch.current, mine?.caret_seq ?? 0);
       caretPlaced.current = false;
       setSession({
         id: snap.session_id,

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -126,6 +126,7 @@ export function useCoeditSession(opts: {
     anchor: number;
     head: number;
     typing: boolean;
+    seq: number;
   } | null>(null);
   const lastCursor = useRef<{ anchor: number; head: number } | null>(null);
   const typingIdle = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -136,6 +137,14 @@ export function useCoeditSession(opts: {
   // `onFrame` needs the author's display to restore their caret). Synced on
   // join and on presence frames — the only points membership changes.
   const participantsRef = useRef<CoeditParticipant[]>([]);
+  // Our caret epoch: bumped on every place/clear transition, echoed on
+  // movement pings and ops. The server applies caret writes only when the
+  // epoch advances, so reordered requests can't resurrect stale state.
+  // Seeded from our own roster row on join (the row outlives connections).
+  const caretEpoch = useRef(0);
+  const caretPlaced = useRef(false);
+  // Latest caret epoch seen per peer — frames from older epochs are dropped.
+  const peerCaretSeq = useRef<Map<string, number>>(new Map());
   // Inbound: per-peer expiry timers so a silent "typing" peer clears.
   const typingTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -209,19 +218,34 @@ export function useCoeditSession(opts: {
       // Cursor broadcasts are writes (the endpoint is write-gated); a pure
       // viewer's caret stays local.
       if (sessionId.current === null || !canWrite) return;
+      // Reporting a position places the caret — a transition (first placement
+      // or a refocus after a clear) opens a new epoch.
+      if (!caretPlaced.current) {
+        caretEpoch.current += 1;
+        caretPlaced.current = true;
+      }
       lastCursor.current = { anchor, head };
       // A caret move (isEdit=false) must not clobber the "typing…" a recent edit
       // set — browsers fire `select` right after every `input`, so onSelect
       // lands one keystroke behind onChange. Derive typing from the idle timer.
       const isTyping = isEdit || typingIdle.current !== null;
-      pendingCursor.current = { anchor, head, typing: isTyping };
+      pendingCursor.current = {
+        anchor,
+        head,
+        typing: isTyping,
+        seq: caretEpoch.current,
+      };
       const send = () => {
         const c = pendingCursor.current;
         pendingCursor.current = null;
         if (c && sessionId.current !== null) {
-          void sendCursor(sessionId.current, c.anchor, c.head, c.typing).catch(
-            () => {},
-          );
+          void sendCursor(
+            sessionId.current,
+            c.anchor,
+            c.head,
+            c.typing,
+            c.seq,
+          ).catch(() => {});
         }
       };
       if (!cursorThrottle.current) {
@@ -237,9 +261,13 @@ export function useCoeditSession(opts: {
           typingIdle.current = null;
           const lc = lastCursor.current;
           if (sessionId.current !== null && lc) {
-            void sendCursor(sessionId.current, lc.anchor, lc.head, false).catch(
-              () => {},
-            );
+            void sendCursor(
+              sessionId.current,
+              lc.anchor,
+              lc.head,
+              false,
+              caretEpoch.current,
+            ).catch(() => {});
           }
         }, TYPING_IDLE_MS);
       }
@@ -249,6 +277,12 @@ export function useCoeditSession(opts: {
 
   const reportCaretCleared = useCallback(() => {
     if (sessionId.current === null || !canWrite) return;
+    // Clearing a placed caret opens a new epoch, so any still-in-flight
+    // place/op from the old epoch loses server-side too.
+    if (caretPlaced.current) {
+      caretEpoch.current += 1;
+      caretPlaced.current = false;
+    }
     // Drop any queued position first — a throttled send landing after the
     // clear would resurrect the caret.
     pendingCursor.current = null;
@@ -259,10 +293,15 @@ export function useCoeditSession(opts: {
     }
     // Immediate (clears are rare) + keepalive so the hidden-tab clear
     // survives the page backgrounding.
-    void sendCursor(sessionId.current, null, null, false, {
+    void sendCursor(sessionId.current, null, null, false, caretEpoch.current, {
       keepalive: true,
     }).catch(() => {});
   }, [canWrite]);
+
+  const getCaretSeq = useCallback(
+    () => (caretPlaced.current ? caretEpoch.current : null),
+    [],
+  );
 
   const onFrame = useCallback(
     (frame: CoeditFrame) => {
@@ -272,11 +311,27 @@ export function useCoeditSession(opts: {
         const ids = new Set(frame.participants.map((p) => p.user_id));
         setPeers((prev) => prev.filter((p) => ids.has(p.user_id)));
         setTyping((prev) => prev.filter((u) => ids.has(u)));
+        // Seed/prune the per-peer epoch guard from the roster.
+        for (const p of frame.participants) {
+          const known = peerCaretSeq.current.get(p.user_id) ?? 0;
+          if (p.caret_seq > known)
+            peerCaretSeq.current.set(p.user_id, p.caret_seq);
+        }
+        for (const uid of peerCaretSeq.current.keys()) {
+          if (!ids.has(uid)) peerCaretSeq.current.delete(uid);
+        }
         return;
       }
       if (frame.type === "cursor") {
         if (myUserId !== null && frame.user_id === myUserId) return;
         const uid = frame.user_id;
+        // Drop frames from an older caret epoch — a place broadcast that was
+        // reordered behind a newer clear (or vice versa) must not apply.
+        if (frame.seq !== null) {
+          const known = peerCaretSeq.current.get(uid) ?? 0;
+          if (frame.seq < known) return;
+          peerCaretSeq.current.set(uid, frame.seq);
+        }
         const anchor = frame.anchor;
         const head = frame.head;
         if (anchor === null || head === null) {
@@ -322,13 +377,21 @@ export function useCoeditSession(opts: {
         }
         return;
       }
-      // An applied edit implies caret placement (mirrors the server's /op
-      // stamp), and the op itself says where: the end of its last change, in
-      // post-edit coordinates. Restore both the label and the caret from it,
-      // so a lost cursor frame can't leave a peer marked "editing" with no
-      // caret rendered.
-      if (frame.type === "op" && frame.author !== null) {
+      // An op carrying a caret epoch asserts caret placement (mirrors the
+      // server's stamp), and the op itself says where: the end of its last
+      // change, in post-edit coordinates. Restore both the label and the
+      // caret from it, so a lost cursor frame can't leave a peer marked
+      // "editing" with no caret rendered. Gated on the epoch like cursor
+      // frames — a stale op must not resurrect a cleared caret — and skipped
+      // entirely when the op makes no caret assertion (caret_seq null).
+      if (
+        frame.type === "op" &&
+        frame.author !== null &&
+        frame.caret_seq !== null &&
+        frame.caret_seq >= (peerCaretSeq.current.get(frame.author) ?? 0)
+      ) {
         const author = frame.author;
+        peerCaretSeq.current.set(author, frame.caret_seq);
         setParticipants((prev) =>
           prev.map((p) =>
             p.user_id === author && !p.caret_active
@@ -386,6 +449,8 @@ export function useCoeditSession(opts: {
     typingTimers.current.clear();
     pendingCursor.current = null;
     lastCursor.current = null;
+    caretPlaced.current = false;
+    peerCaretSeq.current.clear();
     setTyping([]);
     setPeers([]);
     sessionId.current = null;
@@ -430,6 +495,19 @@ export function useCoeditSession(opts: {
       setBuffer(snap.buffer);
       participantsRef.current = snap.participants;
       setParticipants(snap.participants);
+      // Resume our caret epoch from our own roster row — the row (and its
+      // caret_seq) outlives connections, and a rejoin restarting at 0 would
+      // lose every caret write to the epoch guard. Peers' rows seed the
+      // stale-frame guard the same way.
+      peerCaretSeq.current = new Map(
+        snap.participants.map((p) => [p.user_id, p.caret_seq]),
+      );
+      const mine =
+        myUserId !== null
+          ? snap.participants.find((p) => p.user_id === myUserId)
+          : undefined;
+      caretEpoch.current = Math.max(caretEpoch.current, mine?.caret_seq ?? 0);
+      caretPlaced.current = false;
       setSession({
         id: snap.session_id,
         clientId: clientId.current,
@@ -549,5 +627,6 @@ export function useCoeditSession(opts: {
     setDoc,
     reportSelection,
     reportCaretCleared,
+    getCaretSeq,
   };
 }

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -132,6 +132,10 @@ export function useCoeditSession(opts: {
   // Client-local frame counter stamped onto peer entries (CoeditPeer.seq) so
   // the editor can tell fresh cursor frames from re-sent array entries.
   const frameSeq = useRef(0);
+  // Roster mirror for synchronous display-name lookups (the op branch in
+  // `onFrame` needs the author's display to restore their caret). Synced on
+  // join and on presence frames — the only points membership changes.
+  const participantsRef = useRef<CoeditParticipant[]>([]);
   // Inbound: per-peer expiry timers so a silent "typing" peer clears.
   const typingTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(
     new Map(),
@@ -263,6 +267,7 @@ export function useCoeditSession(opts: {
   const onFrame = useCallback(
     (frame: CoeditFrame) => {
       if (frame.type === "presence") {
+        participantsRef.current = frame.participants;
         setParticipants(frame.participants);
         const ids = new Set(frame.participants.map((p) => p.user_id));
         setPeers((prev) => prev.filter((p) => ids.has(p.user_id)));
@@ -318,7 +323,10 @@ export function useCoeditSession(opts: {
         return;
       }
       // An applied edit implies caret placement (mirrors the server's /op
-      // stamp) — flip the author's label even if their cursor ping was lost.
+      // stamp), and the op itself says where: the end of its last change, in
+      // post-edit coordinates. Restore both the label and the caret from it,
+      // so a lost cursor frame can't leave a peer marked "editing" with no
+      // caret rendered.
       if (frame.type === "op" && frame.author !== null) {
         const author = frame.author;
         setParticipants((prev) =>
@@ -328,6 +336,30 @@ export function useCoeditSession(opts: {
               : p,
           ),
         );
+        const display =
+          myUserId !== null && author === myUserId
+            ? undefined // never render self as a peer
+            : participantsRef.current.find((p) => p.user_id === author)
+                ?.user_display;
+        if (display !== undefined && frame.changes.length > 0) {
+          let delta = 0;
+          let caret = 0;
+          for (const c of frame.changes) {
+            caret = c.from + delta + c.insert.length;
+            delta += c.insert.length - (c.to - c.from);
+          }
+          frameSeq.current += 1;
+          setPeers((prev) => [
+            ...prev.filter((p) => p.user_id !== author),
+            {
+              user_id: author,
+              user_display: display,
+              anchor: caret,
+              head: caret,
+              seq: frameSeq.current,
+            },
+          ]);
+        }
       }
       // op / resync → the editor's collab layer applies + rebases.
       serverFrame.current?.(frame);
@@ -396,6 +428,7 @@ export function useCoeditSession(opts: {
       if (cancelled) return;
       sessionId.current = snap.session_id;
       setBuffer(snap.buffer);
+      participantsRef.current = snap.participants;
       setParticipants(snap.participants);
       setSession({
         id: snap.session_id,

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -68,14 +68,19 @@ export function sendOp(
   });
 }
 
-/** Report the local caret/selection to the server so peers see live presence. */
+/** Report the local caret/selection to the server so peers see live presence.
+ * Null anchor/head clears the caret (editor blur / hidden tab) — peers drop it
+ * and presence flips the sender to "viewing". `init` lets the hidden-tab clear
+ * pass `{ keepalive: true }` so it survives the page backgrounding. */
 export function sendCursor(
   sessionId: number,
-  anchor: number,
-  head: number,
+  anchor: number | null,
+  head: number | null,
   typing: boolean,
+  init?: RequestInit,
 ): Promise<void> {
   return apiFetch("/coedit/cursor", {
+    ...init,
     method: "POST",
     body: JSON.stringify({ session_id: sessionId, anchor, head, typing }),
   });

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -56,6 +56,7 @@ export function sendOp(
   baseVersion: number,
   changes: CoeditChange[],
   clientId?: string,
+  caretSeq?: number | null,
 ): Promise<{ version: number }> {
   return apiFetch("/coedit/op", {
     method: "POST",
@@ -64,25 +65,33 @@ export function sendOp(
       base_version: baseVersion,
       changes,
       ...(clientId ? { client_id: clientId } : {}),
+      // An edit asserts caret placement at the sender's current epoch; omit
+      // when the caret is cleared so a late-flushed op can't resurrect it.
+      ...(caretSeq !== null && caretSeq !== undefined
+        ? { caret_seq: caretSeq }
+        : {}),
     }),
   });
 }
 
 /** Report the local caret/selection to the server so peers see live presence.
  * Null anchor/head clears the caret (editor blur / hidden tab) — peers drop it
- * and presence flips the sender to "viewing". `init` lets the hidden-tab clear
- * pass `{ keepalive: true }` so it survives the page backgrounding. */
+ * and presence flips the sender to "viewing". `seq` is the caret epoch that
+ * orders concurrent place/clear writes server-side. `init` lets the
+ * hidden-tab clear pass `{ keepalive: true }` so it survives the page
+ * backgrounding. */
 export function sendCursor(
   sessionId: number,
   anchor: number | null,
   head: number | null,
   typing: boolean,
+  seq: number,
   init?: RequestInit,
 ): Promise<void> {
   return apiFetch("/coedit/cursor", {
     ...init,
     method: "POST",
-    body: JSON.stringify({ session_id: sessionId, anchor, head, typing }),
+    body: JSON.stringify({ session_id: sessionId, anchor, head, typing, seq }),
   });
 }
 

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -8,23 +8,31 @@ export interface CoeditChange {
 }
 
 /** A session participant as returned by join / presence frames. The live
- * session is joined by everyone on the page; `last_edited_at` (null until the
- * participant applies an edit op) is what separates editors from viewers. */
+ * session is joined by everyone on the page; `caret_active` (true while they
+ * have a caret placed in the text) is what separates editors from viewers —
+ * event-driven, no decay: set by cursor placement / edits, cleared on editor
+ * blur / hidden tab, gone with the row on leave. */
 export interface CoeditParticipant {
   user_id: string;
   user_display: string;
   joined_at: string;
   last_seen_at: string;
   last_edited_at: string | null;
+  caret_active: boolean;
 }
 
 /** A peer's live caret/selection, from their latest `cursor` frame. Offsets are
- * UTF-16 code units (JS-native), collapsed (anchor === head) = caret. */
+ * UTF-16 code units (JS-native), collapsed (anchor === head) = caret. `seq` is
+ * a client-local counter bumped per received frame — it lets the editor tell a
+ * fresh frame (adopt its raw offsets) from an entry merely re-sent when the
+ * peer array was rebuilt (keep the position it has mapped through doc
+ * changes). */
 export interface CoeditPeer {
   user_id: string;
   user_display: string;
   anchor: number;
   head: number;
+  seq: number;
 }
 
 /** Snapshot returned by join / session (the live buffer + roster). */
@@ -52,8 +60,10 @@ export type CoeditFrame =
       session_id: number;
       user_id: string;
       user_display: string;
-      anchor: number;
-      head: number;
+      // Null anchor/head = the sender cleared their caret (editor blur /
+      // hidden tab) — drop it and flip their presence label to "viewing".
+      anchor: number | null;
+      head: number | null;
       typing: boolean;
     }
   | { type: "resync"; session_id: number; version: number };
@@ -122,4 +132,9 @@ export interface UseCoeditSession {
    * marks "typing…" + arms its auto-clear; `isEdit=false` (a caret move) reports
    * position without changing the typing state. Throttled + coalesced. */
   reportSelection: (anchor: number, head: number, isEdit: boolean) => void;
+  /** Report that the local caret is gone (editor blur / hidden tab) — peers
+   * drop it and presence flips us to "viewing". Sent immediately (clears are
+   * rare), dropping any queued position so a throttled send can't resurrect
+   * the caret. */
+  reportCaretCleared: () => void;
 }

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -8,20 +8,15 @@ export interface CoeditChange {
 }
 
 /** A session participant as returned by join / presence frames. The live
- * session is joined by everyone on the page; `caret_active` (true while they
- * have a caret placed in the text) is what separates editors from viewers —
- * event-driven, no decay: set by cursor placement / edits, cleared on editor
- * blur / hidden tab, gone with the row on leave. */
+ * session is joined by everyone on the page. The "editing"/"viewing" label
+ * is NOT carried here — it derives from `CoeditPeer` (a rendered caret IS
+ * the editing state), so the roster is membership + display names only. */
 export interface CoeditParticipant {
   user_id: string;
   user_display: string;
   joined_at: string;
   last_seen_at: string;
   last_edited_at: string | null;
-  caret_active: boolean;
-  /** Caret epoch that ordered the last applied caret write — seeds the
-   * stale-frame guard, and a rejoining editor's own epoch counter. */
-  caret_seq: number;
 }
 
 /** A peer's live caret/selection, from their latest `cursor` frame. Offsets are

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -19,6 +19,9 @@ export interface CoeditParticipant {
   last_seen_at: string;
   last_edited_at: string | null;
   caret_active: boolean;
+  /** Caret epoch that ordered the last applied caret write — seeds the
+   * stale-frame guard, and a rejoining editor's own epoch counter. */
+  caret_seq: number;
 }
 
 /** A peer's live caret/selection, from their latest `cursor` frame. Offsets are
@@ -54,6 +57,9 @@ export type CoeditFrame =
       changes: CoeditChange[];
       author: string | null;
       client_id: string | null;
+      // The author's caret epoch when placed — an edit asserts caret
+      // placement at that epoch. Null = no caret assertion.
+      caret_seq: number | null;
     }
   | {
       type: "cursor";
@@ -65,6 +71,9 @@ export type CoeditFrame =
       anchor: number | null;
       head: number | null;
       typing: boolean;
+      // Sender's caret epoch: frames older than the latest epoch seen for
+      // this user are dropped, so reordered place/clear can't apply stale.
+      seq: number | null;
     }
   | { type: "resync"; session_id: number; version: number };
 
@@ -137,4 +146,8 @@ export interface UseCoeditSession {
    * rare), dropping any queued position so a throttled send can't resurrect
    * the caret. */
   reportCaretCleared: () => void;
+  /** The current caret epoch while our caret is placed, else null. Ops carry
+   * it so an edit asserts caret placement with the same ordering guarantees
+   * as cursor writes (null = the op makes no caret assertion). */
+  getCaretSeq: () => number | null;
 }

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -913,6 +913,7 @@ export function FileView({ path }: FileViewProps) {
                   peers={coedit.peers}
                   onSelectionChange={coedit.reportSelection}
                   onCaretCleared={coedit.reportCaretCleared}
+                  getCaretSeq={coedit.getCaretSeq}
                   onServerFrame={coedit.onServerFrame}
                   reportDoc={coedit.reportDoc}
                   registerFlush={coedit.registerFlush}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -876,6 +876,7 @@ export function FileView({ path }: FileViewProps) {
                 />
                 <CoeditPresenceBar
                   participants={coedit.participants}
+                  peers={coedit.peers}
                   typing={coedit.typing}
                   selfUserId={user?.id ?? null}
                 />

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -912,6 +912,7 @@ export function FileView({ path }: FileViewProps) {
                   session={coedit.session}
                   peers={coedit.peers}
                   onSelectionChange={coedit.reportSelection}
+                  onCaretCleared={coedit.reportCaretCleared}
                   onServerFrame={coedit.onServerFrame}
                   reportDoc={coedit.reportDoc}
                   registerFlush={coedit.registerFlush}


### PR DESCRIPTION
Frontend half of #476 (merged) — rebased onto main, frontend-only diff.

## What

- **The label is the caret.** `CoeditPresenceBar` labels a participant "editing" iff they have an entry in `peers` — the same list that renders the carets — so the bar and the doc cannot disagree, by construction. No timers, no persisted state, no 30-minute window.
- **Blur / hidden tab clears the caret.** The editor reports focus loss (`u.focusChanged`, plus an explicit clear when a focused editor unmounts), and the hook's `visibilitychange` handler clears on hidden; both send a null-position cursor with `keepalive`. Queued throttled positions are dropped first so they can't resurrect the caret. Refocusing re-reports the position.
- **Ops render the author's caret** (end of the op's last change, post-edit coordinates), so an active typist whose cursor ping was lost still shows a caret + "editing".
- **Reordered frames can't apply stale state**: the client stamps a wall-clock caret epoch per place/clear transition (monotonic across reconnects with no server state), echoes it on pings and ops, and receivers drop frames older than the newest epoch seen per peer.
- **Parked carets stop drifting.** `peersField` maps held positions through doc changes (`tr.changes.mapPos`); `CoeditPeer.seq` (client-local counter) distinguishes fresh frames from re-sent array entries.

Known behavior: a **late joiner** sees peers as "viewing" until their next cursor frame or edit — self-consistent (no caret rendered on their screen) and self-correcting within seconds for anyone actively working.

## Testing

- `bun run typecheck` clean; backend suites covering the wire shape pass on the base PR.
- Manually verified on a local two-user stack (labels flip on click-in / blur / tab-switch; parked caret stays anchored while the other user edits; late-join shows "viewing" until the peer next acts, as intended).
<img width="551" height="360" alt="Screenshot 2026-07-21 at 1 47 44 PM" src="https://github.com/user-attachments/assets/5632359e-d5ea-4d8f-8eb7-9dc9be3ebf56" />
<img width="745" height="434" alt="Screenshot 2026-07-21 at 1 47 40 PM" src="https://github.com/user-attachments/assets/ff4374a0-7c51-4cd7-9bfe-cb83397b8880" />


