### PR TITLE
feat(automanage): Path-2 review banner on the page/folder (frontend)

### DIFF
--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Button, MessageCard } from "@onyx-ai/opal/components";
+
+import { ApiError } from "@/lib/api";
+import {
+  type Proposal,
+  approveProposal,
+  fetchProposal,
+  rejectProposal,
+  useProposalsByPath,
+} from "@/lib/autoOrganize";
+
+interface Props {
+  /** The current wiki page or folder path. */
+  path: string;
+  /** The caller's write capability, used only to skip the fetch/flash for
+   * viewers — the server write-scopes the list regardless, so this is an
+   * optimization, not the authority. Defaults to true (always fetch). */
+  canWrite?: boolean;
+}
+
+/**
+ * Path-2 review banner: surfaces the pending Auto Organize cleanup proposals
+ * touching this page/folder to users who can act on them, with per-proposal
+ * approve/reject. The list is write-scoped server-side (a read-only viewer gets
+ * nothing), so we simply render nothing when it's empty. Execution is async, so
+ * after an approve we poll the proposal to report the applied / went-stale
+ * outcome rather than leaving it as a silent fire-and-forget.
+ */
+export function Path2ReviewBanner({ path, canWrite = true }: Props) {
+  const { proposals, refresh } = useProposalsByPath(path, canWrite);
+  if (proposals.length === 0) return null;
+
+  const n = proposals.length;
+  return (
+    <div className="mb-3">
+      <MessageCard
+        variant="warning"
+        title={`Auto Organize suggests ${n} cleanup${n === 1 ? "" : "s"} here`}
+        description="Approve a change to apply it, or reject to dismiss it (rejection is durable — it won't be suggested again)."
+        bottomChildren={
+          <ul className="m-0 flex list-none flex-col gap-2 pl-0">
+            {proposals.map((p) => (
+              <ProposalRow
+                key={p.id}
+                proposal={p}
+                onActioned={() => void refresh()}
+              />
+            ))}
+          </ul>
+        }
+      />
+    </div>
+  );
+}
+
+type Outcome =
+  | "idle"
+  | "working"
+  | "applied"
+  | "rejected"
+  | "stale"
+  | "applying"
+  | "error";
+
+const TERMINAL: Outcome[] = ["applied", "rejected", "stale", "applying"];
+
+function ProposalRow({
+  proposal,
+  onActioned,
+}: {
+  proposal: Proposal;
+  onActioned: () => void;
+}) {
+  const [outcome, setOutcome] = useState<Outcome>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const alive = useRef(true);
+  useEffect(() => () => void (alive.current = false), []);
+
+  // Execution runs async on the automanage_nearline worker; poll the proposal a
+  // few times so we can report applied / went-stale instead of just "approved".
+  async function pollOutcome() {
+    for (let i = 0; i < 8; i++) {
+      await new Promise((r) => setTimeout(r, 1000));
+      if (!alive.current) return;
+      try {
+        const fresh = await fetchProposal(proposal.id);
+        if (fresh.status === "applied") return setOutcome("applied");
+        if (fresh.status === "stale") return setOutcome("stale");
+      } catch {
+        return; // gone (e.g. purged) — stop polling
+      }
+    }
+    if (alive.current) setOutcome("applying"); // approved, still applying
+  }
+
+  async function act(kind: "approve" | "reject") {
+    setOutcome("working");
+    setError(null);
+    try {
+      if (kind === "approve") {
+        await approveProposal(proposal.id);
+        if (alive.current) await pollOutcome();
+      } else {
+        await rejectProposal(proposal.id);
+        if (alive.current) setOutcome("rejected");
+      }
+    } catch (e) {
+      if (!alive.current) return;
+      // 409 → someone else already actioned it; drop it from the list.
+      if (e instanceof ApiError && e.status === 409) return onActioned();
+      setOutcome("error");
+      setError(e instanceof Error ? e.message : "failed");
+    }
+  }
+
+  const statusLabel: Record<string, string> = {
+    applied: "Applied ✓",
+    rejected: "Rejected",
+    stale: "Skipped — the page changed since this was proposed",
+    applying: "Applying…",
+  };
+
+  return (
+    <li className="flex items-center justify-between gap-3 text-[13px] text-(--text-04)">
+      <span className="min-w-0 truncate">{proposal.summary}</span>
+      {TERMINAL.includes(outcome) ? (
+        <span className="shrink-0 text-(--text-03)">
+          {statusLabel[outcome]}
+        </span>
+      ) : (
+        <span className="flex shrink-0 items-center gap-2">
+          {outcome === "error" && error && (
+            <span className="text-(--status-danger-05)">{error}</span>
+          )}
+          <Button
+            size="sm"
+            prominence="secondary"
+            disabled={outcome === "working"}
+            onClick={() => void act("reject")}
+          >
+            Reject
+          </Button>
+          <Button
+            size="sm"
+            prominence="primary"
+            disabled={outcome === "working"}
+            onClick={() => void act("approve")}
+          >
+            {outcome === "working" ? "…" : "Approve"}
+          </Button>
+        </span>
+      )}
+    </li>
+  );
+}

--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 
-import { Button, MessageCard } from "@onyx-ai/opal/components";
+import { Button, MessageCard, Text } from "@onyx-ai/opal/components";
+import { ContentAction, Section } from "@onyx-ai/opal/layouts";
 
 import { ApiError } from "@/lib/api";
 import {
@@ -42,11 +43,11 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
         title={`Auto Organize suggests ${n} cleanup${n === 1 ? "" : "s"} here`}
         description="Approve a change to apply it, or reject to dismiss it (rejection is durable — it won't be suggested again)."
         bottomChildren={
-          <ul className="m-0 flex list-none flex-col gap-2 pl-0">
+          <Section flexDirection="column" gap={0.25} width="full">
             {proposals.map((p) => (
               <ProposalRow key={p.id} proposal={p} onActioned={refresh} />
             ))}
-          </ul>
+          </Section>
         }
       />
     </div>
@@ -63,6 +64,13 @@ type Outcome =
   | "error";
 
 const TERMINAL: Outcome[] = ["applied", "rejected", "stale", "applying"];
+
+const STATUS_LABEL: Record<string, string> = {
+  applied: "Applied ✓",
+  rejected: "Rejected",
+  stale: "Skipped — the page changed since this was proposed",
+  applying: "Applying…",
+};
 
 function ProposalRow({
   proposal,
@@ -135,43 +143,43 @@ function ProposalRow({
     }
   }
 
-  const statusLabel: Record<string, string> = {
-    applied: "Applied ✓",
-    rejected: "Rejected",
-    stale: "Skipped — the page changed since this was proposed",
-    applying: "Applying…",
-  };
-
   return (
-    <li className="flex items-center justify-between gap-3 text-[13px] text-(--text-04)">
-      <span className="min-w-0 truncate">{proposal.summary}</span>
-      {TERMINAL.includes(outcome) ? (
-        <span className="shrink-0 text-(--text-03)">
-          {statusLabel[outcome]}
-        </span>
-      ) : (
-        <span className="flex shrink-0 items-center gap-2">
-          {outcome === "error" && error && (
-            <span className="text-(--status-danger-05)">{error}</span>
-          )}
-          <Button
-            size="sm"
-            prominence="secondary"
-            disabled={outcome === "working"}
-            onClick={() => void act("reject")}
+    <ContentAction
+      sizePreset="main-ui"
+      variant="section"
+      title={proposal.summary}
+      titleMaxLines={1}
+      auxIcon={outcome === "error" ? "error" : undefined}
+      description={outcome === "error" ? (error ?? undefined) : undefined}
+      rightChildren={
+        TERMINAL.includes(outcome) ? (
+          <Text
+            font="secondary-body"
+            color={outcome === "applied" ? "status-success-05" : "text-03"}
           >
-            Reject
-          </Button>
-          <Button
-            size="sm"
-            prominence="primary"
-            disabled={outcome === "working"}
-            onClick={() => void act("approve")}
-          >
-            {outcome === "working" ? "…" : "Approve"}
-          </Button>
-        </span>
-      )}
-    </li>
+            {STATUS_LABEL[outcome]}
+          </Text>
+        ) : (
+          <Section flexDirection="row" gap={0.5} alignItems="center">
+            <Button
+              size="sm"
+              prominence="secondary"
+              disabled={outcome === "working"}
+              onClick={() => void act("reject")}
+            >
+              Reject
+            </Button>
+            <Button
+              size="sm"
+              prominence="primary"
+              disabled={outcome === "working"}
+              onClick={() => void act("approve")}
+            >
+              {outcome === "working" ? "…" : "Approve"}
+            </Button>
+          </Section>
+        )
+      }
+    />
   );
 }

--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -44,11 +44,7 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
         bottomChildren={
           <ul className="m-0 flex list-none flex-col gap-2 pl-0">
             {proposals.map((p) => (
-              <ProposalRow
-                key={p.id}
-                proposal={p}
-                onActioned={() => void refresh()}
-              />
+              <ProposalRow key={p.id} proposal={p} onActioned={refresh} />
             ))}
           </ul>
         }
@@ -80,21 +76,43 @@ function ProposalRow({
   const alive = useRef(true);
   useEffect(() => () => void (alive.current = false), []);
 
-  // Execution runs async on the automanage_nearline worker; poll the proposal a
-  // few times so we can report applied / went-stale instead of just "approved".
-  async function pollOutcome() {
-    for (let i = 0; i < 8; i++) {
-      await new Promise((r) => setTimeout(r, 1000));
+  // Once a row has shown its terminal outcome, briefly leave it up, then refresh
+  // the list so it drops out (it has left `pending`). `onActioned` is SWR's
+  // stable mutate, so this effect doesn't churn.
+  useEffect(() => {
+    if (
+      outcome !== "applied" &&
+      outcome !== "stale" &&
+      outcome !== "rejected"
+    ) {
+      return;
+    }
+    const t = setTimeout(() => {
+      if (alive.current) onActioned();
+    }, 4000);
+    return () => clearTimeout(t);
+  }, [outcome, onActioned]);
+
+  // Execution runs async on the automanage_nearline worker. Show "Applying…"
+  // and poll for the terminal status. A transient fetch error must NOT abort
+  // the poll (that would strand the row), and if it doesn't settle within the
+  // budget we drop back to the list — the proposal has left `pending`, so a
+  // refresh removes the row rather than freezing it at "Applying…".
+  async function pollApplied() {
+    setOutcome("applying");
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, Math.min(1000 + i * 250, 3000)));
       if (!alive.current) return;
       try {
         const fresh = await fetchProposal(proposal.id);
         if (fresh.status === "applied") return setOutcome("applied");
         if (fresh.status === "stale") return setOutcome("stale");
+        // still pending/approved → keep polling
       } catch {
-        return; // gone (e.g. purged) — stop polling
+        // transient failure (or the row was purged) — keep polling
       }
     }
-    if (alive.current) setOutcome("applying"); // approved, still applying
+    if (alive.current) onActioned(); // didn't settle in-window → refresh the list
   }
 
   async function act(kind: "approve" | "reject") {
@@ -103,7 +121,7 @@ function ProposalRow({
     try {
       if (kind === "approve") {
         await approveProposal(proposal.id);
-        if (alive.current) await pollOutcome();
+        if (alive.current) await pollApplied();
       } else {
         await rejectProposal(proposal.id);
         if (alive.current) setOutcome("rejected");

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -64,6 +64,11 @@ export interface Proposal {
 export function useProposalsByPath(path: string, enabled = true) {
   const { data, error, isLoading, mutate } = useSWR<{ proposals: Proposal[] }>(
     enabled ? SWR_KEYS.automanageProposals(path) : null,
+    // Don't auto-revalidate on focus/reconnect: an acted-on proposal leaves
+    // `pending`, so a background revalidation would drop its row and cancel the
+    // in-flight applied/went-stale poll. The banner refreshes explicitly (via
+    // `refresh`) once a row has shown its outcome.
+    { revalidateOnFocus: false, revalidateOnReconnect: false },
   );
   return {
     proposals: data?.proposals ?? [],

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -40,3 +40,56 @@ export function updateAutoOrganizeSettings(patch: {
     body: JSON.stringify(patch),
   });
 }
+
+/** One Auto Organize change proposal (a pending AI-initiated cleanup awaiting
+ * human review). Mirrors `app/models/automanage.py:ProposalView`. */
+export interface Proposal {
+  id: number;
+  op: string;
+  status: string;
+  source_paths: string[];
+  target_paths: string[];
+  summary: string;
+  created_via: string;
+  run_id: string | null;
+  created_at: string;
+}
+
+/** Pending proposals touching `path` (a page or folder subtree) that the caller
+ * can act on — the server write-scopes to edit access, so a read-only viewer
+ * gets an empty list. Backs the Path-2 review banner on the page/folder.
+ *
+ * `enabled` (default true) gates the fetch — pass the caller's known write
+ * capability to skip polling for viewers; the server remains the authority. */
+export function useProposalsByPath(path: string, enabled = true) {
+  const { data, error, isLoading, mutate } = useSWR<{ proposals: Proposal[] }>(
+    enabled ? SWR_KEYS.automanageProposals(path) : null,
+  );
+  return {
+    proposals: data?.proposals ?? [],
+    error,
+    isLoading,
+    refresh: mutate,
+  };
+}
+
+/** Fetch a single proposal's current state (used to surface the applied /
+ * went-stale outcome after a human approves — execution is async). */
+export function fetchProposal(id: number) {
+  return apiFetch<Proposal>(`/automanage/proposals/${id}`);
+}
+
+/** Approve a pending proposal (the approver becomes the acting user; execution
+ * is enqueued). Rejects with `ApiError` (409 if it's no longer pending). */
+export function approveProposal(id: number) {
+  return apiFetch<{ status: string }>(`/automanage/proposals/${id}/approve`, {
+    method: "POST",
+  });
+}
+
+/** Reject a pending proposal — a durable "don't propose this again". */
+export function rejectProposal(id: number) {
+  return apiFetch<{ status: string }>(`/automanage/proposals/${id}/reject`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/lib/swr-keys.ts
+++ b/frontend/src/lib/swr-keys.ts
@@ -41,6 +41,8 @@ export const SWR_KEYS = {
 
   // ── Auto Organize ─────────────────────────────────────────────────────
   autoOrganizeSettings: "/automanage/settings",
+  automanageProposals: (path: string) =>
+    `/automanage/proposals?path=${encodeURIComponent(path)}`,
 
   // ── Agents / MCP ──────────────────────────────────────────────────────
   mcpTokens: "/mcp/tokens",

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -36,6 +36,7 @@ import { HistoryPanel } from "@/components/wiki/HistoryPanel";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
+import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
@@ -874,6 +875,7 @@ export function FileView({ path }: FileViewProps) {
                     setPolicyOpen(true);
                   }}
                 />
+                <Path2ReviewBanner path={path} canWrite={canWrite} />
                 <CoeditPresenceBar
                   participants={coedit.participants}
                   typing={coedit.typing}

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -38,6 +38,7 @@ import {
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { TriggerPanel } from "@/components/triggers/TriggerPanel";
+import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { WikiHome } from "@/components/wiki/WikiHome";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { StartNewPage } from "@/components/wiki/StartNewPage";
@@ -440,6 +441,10 @@ function Explorer({ dir }: ExplorerProps) {
             setTriggerStatus(`Created trigger for ${t.scope_path}`)
           }
         />
+
+        {/* Auto Organize review banner for this folder's subtree (not root —
+            a wiki-wide review is the admin queue's job). */}
+        {dir && <Path2ReviewBanner path={dir} />}
 
         {triggerStatus && (
           <div className="mb-3 text-xs text-(--text-04)">{triggerStatus}</div>


### PR DESCRIPTION
Frontend for **Path-2 review** — pending Auto Organize cleanups are surfaced to *edit-access* users on the page/folder itself. Consumes #475's write-scoped `GET /api/automanage/proposals?path=`. Task #5.

## What
- **`Path2ReviewBanner`** (Opal `MessageCard`) lists the proposals touching the current path, each row with **Approve** / **Reject**. The endpoint is write-scoped server-side, so a read-only viewer gets an empty list → the banner renders nothing (no client-side permission logic to get wrong).
- Mounted on:
  - the **page** view (`FileView`, beside `UpdateHealthBanner`) — gated by `canWrite` to skip the fetch for viewers;
  - **non-root folder** views (`Explorer`) — root is left to the admin queue.
- **Applied / went-stale feedback** (the gap we flagged): execution is async on `automanage_nearline`, so after an approve the row polls the proposal and reports **Applied ✓**, **Skipped — the page changed since this was proposed**, or **Applying…**, instead of a silent fire-and-forget. Reject shows a durable **Rejected**. A **409** (another editor already actioned it) refreshes the list.
- lib: `useProposalsByPath` / `approveProposal` / `rejectProposal` / `fetchProposal` added to `autoOrganize.ts`; `SWR_KEYS.automanageProposals(path)`.

## Test plan
- `bun run typecheck` clean; prettier clean.
- Manual (once deployed): as an editor, a page/folder with a pending cleanup shows the banner; approve → row reports Applied/Skipped; reject → durable dismiss; a read-only viewer sees no banner.

Backend already verified/merged (#475). Next: **#6** Path-1 auto-applied visibility (Activity event when the AI auto-applies).

<img width="1027" height="361" alt="Screenshot 2026-07-21 at 3 26 40 PM" src="https://github.com/user-attachments/assets/ea23a873-f390-436d-82e5-2d21dfe51640" />
