### PR TITLE
feat(coedit): idle auto-unfocus + SSE reconnect with catch-up pull

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -412,7 +412,9 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       // timer is armed only while focused and re-armed on every local edit /
       // caret move; suspended timers fire on wake, so a slept laptop unfocuses
       // right when the user returns.
-      const idleUnfocus = { current: null as ReturnType<typeof setTimeout> | null };
+      const idleUnfocus = {
+        current: null as ReturnType<typeof setTimeout> | null,
+      };
       const armIdleUnfocus = () => {
         if (idleUnfocus.current) clearTimeout(idleUnfocus.current);
         idleUnfocus.current = null;
@@ -560,7 +562,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         }
         if (u.docChanged) onSelRef.current(sel.anchor, sel.head, true);
         else if (u.selectionSet) onSelRef.current(sel.anchor, sel.head, false);
-        // Any local activity (or a focus flip) restarts the idle-unfocus clock.
+        // Any local activity (or a focus flip) restarts the idle-unfocus
+        // clock. Remote-applied ops can't reach this line: CM update
+        // listeners run synchronously inside dispatchRemote's
+        // applyingRemote bracket, so they exit at the early-return above —
+        // a busy peer can't keep an idle user's caret alive.
         if (u.focusChanged || u.docChanged || u.selectionSet) armIdleUnfocus();
         if (u.selectionSet && onSelectionForCommentRef.current) {
           const draft = selectionToDraft(u.state);

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -33,6 +33,7 @@ import type {
   CoeditSessionHandle,
 } from "@/lib/editor/types";
 import { getOps, sendOp } from "@/lib/editor/svc";
+import { IDLE_UNFOCUS_MS } from "@/lib/editor/constants";
 import {
   changeSetToChanges,
   colorFor,
@@ -298,6 +299,10 @@ interface CoeditorProps {
   reportDoc: (doc: string) => void;
   registerFlush: (fn: (() => Promise<void>) | null) => void;
   registerSetDoc: (fn: ((text: string) => void) | null) => void;
+  /** Register the editor's "pull missed ops" fn — the hook calls it after an
+   * SSE reconnect and when the tab becomes visible again, so a returning user
+   * catches up instead of interacting with a stale doc. */
+  registerCatchUp: (fn: (() => void) | null) => void;
   placeholder?: string;
   /** Render the doc without accepting edits — for participants whose
    * `can_write` is false. They stay in the live session (presence + real-time
@@ -347,6 +352,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       reportDoc,
       registerFlush,
       registerSetDoc,
+      registerCatchUp,
       placeholder,
       readOnly,
       commentHighlights,
@@ -398,6 +404,24 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       // The synced version we last sent an op at — so we don't re-send the same
       // op while awaiting its echo (which advances synced past this).
       const sentAtVersion = { current: -1 };
+
+      // Idle auto-unfocus: N minutes without local activity blurs the editor.
+      // The blur runs the normal focus-loss path (caret clear broadcast,
+      // presence flips to "viewing", reveal-on-focus collapses to preview),
+      // so an untouched tab can't hold an "editing" caret indefinitely. The
+      // timer is armed only while focused and re-armed on every local edit /
+      // caret move; suspended timers fire on wake, so a slept laptop unfocuses
+      // right when the user returns.
+      const idleUnfocus = { current: null as ReturnType<typeof setTimeout> | null };
+      const armIdleUnfocus = () => {
+        if (idleUnfocus.current) clearTimeout(idleUnfocus.current);
+        idleUnfocus.current = null;
+        if (!v.hasFocus) return;
+        idleUnfocus.current = setTimeout(() => {
+          idleUnfocus.current = null;
+          if (v.hasFocus) v.contentDOM.blur();
+        }, IDLE_UNFOCUS_MS);
+      };
 
       const dispatchRemote = (spec: Parameters<EditorView["dispatch"]>[0]) => {
         applyingRemote.current = true;
@@ -536,6 +560,8 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         }
         if (u.docChanged) onSelRef.current(sel.anchor, sel.head, true);
         else if (u.selectionSet) onSelRef.current(sel.anchor, sel.head, false);
+        // Any local activity (or a focus flip) restarts the idle-unfocus clock.
+        if (u.focusChanged || u.docChanged || u.selectionSet) armIdleUnfocus();
         if (u.selectionSet && onSelectionForCommentRef.current) {
           const draft = selectionToDraft(u.state);
           const coords = draft ? u.view.coordsAtPos(sel.head) : null;
@@ -643,6 +669,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           changes: { from: 0, to: v.state.doc.length, insert: text },
         });
       });
+      registerCatchUp(() => void pull());
 
       return () => {
         onServerFrame(null);
@@ -652,6 +679,8 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         // only reads `v.state` and POSTs — both safe after `v.destroy()` —
         // and the hook clears it once it has taken ownership.
         registerSetDoc(null);
+        registerCatchUp(null);
+        if (idleUnfocus.current) clearTimeout(idleUnfocus.current);
         // A focused editor unmounting (in-app navigation, session
         // replacement) never gets a focusChanged update — clear our caret
         // for peers explicitly instead of leaving it parked until the

--- a/frontend/src/lib/editor/constants.ts
+++ b/frontend/src/lib/editor/constants.ts
@@ -24,3 +24,12 @@ export const AUTOSAVE_IDLE_MS = 2000;
 
 /** Hard cap: force a checkpoint at least this often even under continuous typing. */
 export const AUTOSAVE_MAX_INTERVAL_MS = 30000;
+
+/** Ms of no local activity (edits, caret moves) before the editor auto-blurs.
+ * Blurring routes through the normal focus-loss path, so the idle user's
+ * caret clears for peers and their presence label drops to "viewing" —
+ * an untouched tab can't hold an "editing" caret forever. */
+export const IDLE_UNFOCUS_MS = 5 * 60 * 1000;
+
+/** Ms to wait before re-opening a dropped co-edit SSE stream. */
+export const STREAM_RECONNECT_MS = 3000;

--- a/frontend/src/lib/editor/constants.ts
+++ b/frontend/src/lib/editor/constants.ts
@@ -28,8 +28,10 @@ export const AUTOSAVE_MAX_INTERVAL_MS = 30000;
 /** Ms of no local activity (edits, caret moves) before the editor auto-blurs.
  * Blurring routes through the normal focus-loss path, so the idle user's
  * caret clears for peers and their presence label drops to "viewing" —
- * an untouched tab can't hold an "editing" caret forever. */
-export const IDLE_UNFOCUS_MS = 5 * 60 * 1000;
+ * an untouched tab can't hold an "editing" caret forever. Generous enough
+ * that nobody actively working gets interrupted: a false blur costs the
+ * user a click back in, a stale "editing" label only costs peers confusion. */
+export const IDLE_UNFOCUS_MS = 10 * 60 * 1000;
 
 /** Ms to wait before re-opening a dropped co-edit SSE stream. */
 export const STREAM_RECONNECT_MS = 3000;

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -125,6 +125,14 @@ export function useCoeditSession(opts: {
   const flushFn = useRef<(() => Promise<void>) | null>(null);
   const setDocFn = useRef<((text: string) => void) | null>(null);
   const catchUpFn = useRef<(() => void) | null>(null);
+  // Ref mirror of `buffer` (the editor doc) for non-render reads.
+  const bufferRef = useRef("");
+  // Local doc carried across a forced re-join: when the session closed under
+  // us and the tail couldn't be delivered, the edits exist only in this tab —
+  // re-applied onto the fresh session instead of being silently replaced by
+  // the checkpointed version. Path-tagged so it can never leak onto another
+  // page.
+  const recoverDoc = useRef<{ path: string; doc: string } | null>(null);
   // Outbound cursor/typing throttle state.
   const cursorThrottle = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingCursor = useRef<{
@@ -215,6 +223,7 @@ export function useCoeditSession(opts: {
 
   const reportDoc = useCallback(
     (doc: string) => {
+      bufferRef.current = doc;
       setBuffer(doc);
       armAutosave();
     },
@@ -457,6 +466,7 @@ export function useCoeditSession(opts: {
     clientId.current = newClientId();
     let cancelled = false;
     // Mirror shows the committed body until the join resolves.
+    bufferRef.current = committedBody;
     setBuffer(committedBody);
     setJoinError(null);
 
@@ -479,6 +489,7 @@ export function useCoeditSession(opts: {
       }
       if (cancelled) return;
       sessionId.current = snap.session_id;
+      bufferRef.current = snap.buffer;
       setBuffer(snap.buffer);
       participantsRef.current = snap.participants;
       setParticipants(snap.participants);
@@ -515,7 +526,16 @@ export function useCoeditSession(opts: {
           if (e instanceof ApiError && e.status === 404) {
             // The session closed while we were gone (last participant left →
             // checkpoint + close). Streaming can't resurrect it — re-run the
-            // whole join to mint/adopt a fresh session.
+            // whole join to mint/adopt a fresh session. First try to deliver
+            // any local tail; if that fails too (ops bounce off the closed
+            // session), those edits exist only in this tab — carry the doc
+            // across the re-join so the fresh session's checkpointed buffer
+            // doesn't silently replace them (see the recovery effect below).
+            try {
+              await flushFn.current?.();
+            } catch {
+              recoverDoc.current = { path, doc: bufferRef.current };
+            }
             retryJoin();
             break;
           }
@@ -576,6 +596,20 @@ export function useCoeditSession(opts: {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, path, retryToken]);
+
+  // Re-apply a doc carried across a forced re-join (see the stream loop's
+  // 404 branch): once the fresh session's editor has mounted (child effects
+  // run before this one, so `setDoc` is registered), replace the buffer with
+  // the saved local doc as a normal local edit — it lands as an op on the
+  // new session instead of being lost to the checkpointed version.
+  useEffect(() => {
+    if (session === null || recoverDoc.current === null) return;
+    const saved = recoverDoc.current;
+    recoverDoc.current = null;
+    if (saved.path === path && saved.doc !== session.startDoc) {
+      setDoc(saved.doc);
+    }
+  }, [session, path, setDoc]);
 
   // Best-effort checkpoint when the tab is backgrounded/closed — `keepalive`
   // lets the request survive the page tearing down. Covers the gap between

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -39,6 +39,8 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { ApiError } from "@/lib/api";
+
 import type {
   CoeditFrame,
   CoeditParticipant,
@@ -57,6 +59,7 @@ import {
   AUTOSAVE_IDLE_MS,
   AUTOSAVE_MAX_INTERVAL_MS,
   CURSOR_THROTTLE_MS,
+  STREAM_RECONNECT_MS,
   TYPING_EXPIRY_MS,
   TYPING_IDLE_MS,
 } from "@/lib/editor/constants";
@@ -121,6 +124,7 @@ export function useCoeditSession(opts: {
   const serverFrame = useRef<((frame: CoeditFrame) => void) | null>(null);
   const flushFn = useRef<(() => Promise<void>) | null>(null);
   const setDocFn = useRef<((text: string) => void) | null>(null);
+  const catchUpFn = useRef<(() => void) | null>(null);
   // Outbound cursor/typing throttle state.
   const cursorThrottle = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingCursor = useRef<{
@@ -162,6 +166,9 @@ export function useCoeditSession(opts: {
   }, []);
   const registerSetDoc = useCallback((fn: ((text: string) => void) | null) => {
     setDocFn.current = fn;
+  }, []);
+  const registerCatchUp = useCallback((fn: (() => void) | null) => {
+    catchUpFn.current = fn;
   }, []);
   const setDoc = useCallback((text: string) => setDocFn.current?.(text), []);
 
@@ -483,22 +490,40 @@ export function useCoeditSession(opts: {
         startDoc: snap.buffer,
       });
       setActive(true);
-      try {
-        // Gate on `cancelled`: the stream outlives the effect during teardown
-        // (it's aborted only after the final flush/checkpoint/leave below), and
-        // a late frame from the old session must not leak into state a new
-        // session now owns.
-        await streamSession(
-          snap.session_id,
-          (frame) => {
-            if (!cancelled) onFrame(frame);
-          },
-          ctrl.signal,
-        );
-      } catch {
-        // Stream ended/dropped after a successful join (including our own
-        // cleanup's abort) — the session/doc are already usable, so this
-        // isn't a join failure and doesn't need to surface as one.
+      // The stream loop: reconnect when the connection drops (network blip,
+      // laptop sleep) instead of leaving a silently-stale editable doc — the
+      // server never pushes again on a dead stream, and without this loop the
+      // client would only heal on a full page reload. Re-opening the stream
+      // re-joins us as a participant; the catch-up pull replays ops missed
+      // while disconnected (anything landing in the crack re-pulls via the
+      // op-frame gap detection).
+      while (!cancelled) {
+        try {
+          // Gate on `cancelled`: the stream outlives the effect during
+          // teardown (it's aborted only after the final flush/checkpoint/
+          // leave below), and a late frame from the old session must not
+          // leak into state a new session now owns.
+          await streamSession(
+            snap.session_id,
+            (frame) => {
+              if (!cancelled) onFrame(frame);
+            },
+            ctrl.signal,
+          );
+        } catch (e) {
+          if (cancelled || ctrl.signal.aborted) break;
+          if (e instanceof ApiError && e.status === 404) {
+            // The session closed while we were gone (last participant left →
+            // checkpoint + close). Streaming can't resurrect it — re-run the
+            // whole join to mint/adopt a fresh session.
+            retryJoin();
+            break;
+          }
+        }
+        if (cancelled || ctrl.signal.aborted) break;
+        await new Promise((r) => setTimeout(r, STREAM_RECONNECT_MS));
+        if (cancelled || ctrl.signal.aborted) break;
+        catchUpFn.current?.();
       }
     })();
 
@@ -568,6 +593,11 @@ export function useCoeditSession(opts: {
       if (document.visibilityState === "hidden") {
         checkpointNow();
         reportCaretCleared();
+      } else {
+        // Coming back to the tab: pull anything missed while backgrounded —
+        // a slept machine's stream may be dead or healing, and the user must
+        // not resume on a stale doc (the reconnect loop is the other half).
+        catchUpFn.current?.();
       }
     };
     document.addEventListener("visibilitychange", onVisibilityChange);
@@ -592,6 +622,7 @@ export function useCoeditSession(opts: {
     reportDoc,
     registerFlush,
     registerSetDoc,
+    registerCatchUp,
     setDoc,
     reportSelection,
     reportCaretCleared,

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -129,6 +129,10 @@ export interface UseCoeditSession {
   registerFlush: (fn: (() => Promise<void>) | null) => void;
   /** Register the editor's "replace whole doc" fn (template pick / blank). */
   registerSetDoc: (fn: ((text: string) => void) | null) => void;
+  /** Register the editor's "pull missed ops" fn — called after an SSE
+   * reconnect and when the tab becomes visible, so a returning user catches
+   * up instead of resuming on a stale doc. */
+  registerCatchUp: (fn: (() => void) | null) => void;
   /** Replace the document (goes through the editor as an edit). No-op until
    * the editor has mounted. */
   setDoc: (text: string) => void;

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -919,6 +919,7 @@ export function FileView({ path }: FileViewProps) {
                   reportDoc={coedit.reportDoc}
                   registerFlush={coedit.registerFlush}
                   registerSetDoc={coedit.registerSetDoc}
+                  registerCatchUp={coedit.registerCatchUp}
                   readOnly={!canWrite}
                   commentHighlights={commentHighlights}
                   onSelectionForComment={handleSelectionForComment}


### PR DESCRIPTION
## Idle auto-unfocus — "after X min of no action, the user should be off focus"

The editor blurs itself after **10 minutes** (`IDLE_UNFOCUS_MS`; started at 5, widened so nobody actively working gets interrupted) with no local activity (edits, caret moves, focus changes reset the clock). Because the presence model is "the label is the rendered caret", the blur does all the rest through the existing focus-loss path: the caret clear is broadcast, peers drop the caret, and the label flips to "viewing". Reveal-on-focus (#458) also collapses the doc back to pure preview. Suspended timers fire on wake, so a slept laptop unfocuses right as the user returns.

## Reconnect + catch-up — "the user can't just insert cursor on an out-of-sync doc"

Root cause confirmed: `apiStream` never reconnects, so a dropped SSE stream (network blip, laptop sleep) left a **silently stale but editable** doc until a full page reload.

- The stream now reconnects in a loop (3s delay) while the session is enabled; each reconnect re-joins presence and pulls missed ops via a new `registerCatchUp` seam (same pattern as `registerFlush`; it calls the editor's existing `pull()`, which rebases through `@codemirror/collab` like any 409/gap).
- A 404 on reconnect means the session closed while we were gone (last participant left → checkpoint + close) — that re-runs the full join via `retryJoin` to adopt a fresh session.
- `visibilitychange → visible` also triggers a catch-up pull, so returning to a backgrounded tab refreshes the doc immediately even while the stream is still healing.

Ops that land in the crack between a pull and the stream re-opening are covered by the existing op-frame gap detection (a gap triggers another pull).

## Testing

- `bun run typecheck` clean.
- Not yet browser-verified; suggested manual pass: park a caret + wait past the idle window in a second browser (label should flip to "viewing" and the caret disappear); `docker pause`/network-toggle to kill the stream, edit from the other browser, un-pause → doc catches up without reload.
