### PR TITLE
fix(automanage): use info variant for the Path-2 review banner

### DIFF
--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -39,7 +39,7 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
   return (
     <div className="mb-3">
       <MessageCard
-        variant="warning"
+        variant="info"
         title={`Auto Organize suggests ${n} cleanup${n === 1 ? "" : "s"} here`}
         description="Approve a change to apply it, or reject to dismiss it (rejection is durable — it won't be suggested again)."
         bottomChildren={


### PR DESCRIPTION
Follow-up to #478. The Path-2 review banner used the amber `warning` MessageCard variant, which reads as "something is wrong". A cleanup *suggestion* is informational, not an alert — switch to the `info` variant (informational blue).

One-line change; typecheck passes.