### PR TITLE
fix(automanage): scope proposal listing downward only

### DIFF
--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -50,18 +50,20 @@ def _can_act(user: User, proposal: dict[str, Any]) -> bool:
     return all(acl.can(user.id, user.is_admin, "write", p) for p in paths)
 
 
-def _paths_overlap(a: str, b: str) -> bool:
-    """True if two wiki paths are the same or one is an ancestor of the other."""
-    return a == b or a.startswith(b + "/") or b.startswith(a + "/")
+def _within_scope(path: str, scope: str) -> bool:
+    """True if ``path`` sits at or below ``scope`` — equal to it, or nested inside
+    it. Directional: an ancestor ``path`` is *not* within a descendant ``scope``."""
+    return path == scope or path.startswith(scope + "/")
 
 
 def _touches(proposal: dict[str, Any], scope: str) -> bool:
-    """True if the proposal acts within ``scope`` — any of its paths equals
-    ``scope`` or is an ancestor/descendant of it. So a page surfaces proposals on
-    itself (or an enclosing folder), and a folder surfaces proposals anywhere in
-    its subtree."""
+    """True if the proposal acts at or below ``scope`` — any of its paths equals
+    ``scope`` or is nested inside it. So a folder surfaces every proposal in its
+    subtree, and a page surfaces only proposals scoped to that page — an enclosing
+    folder's proposal (e.g. delete-this-folder) does *not* leak onto the pages
+    inside it, which would otherwise nag on every descendant page."""
     paths = list(proposal["source_paths"]) + list(proposal["target_paths"])
-    return any(_paths_overlap(p, scope) for p in paths)
+    return any(_within_scope(p, scope) for p in paths)
 
 
 @router.get("/settings", response_model=DetectionSettingsView)

--- a/backend/tests/test_detection_proposals_api.py
+++ b/backend/tests/test_detection_proposals_api.py
@@ -134,8 +134,18 @@ def test_path_filter_scopes_to_subtree(client):
     assert folders("docs/old") == {"docs/old"}  # exact
     assert folders("archive") == {"archive"}
     assert folders("nope") == set()  # no overlap
+    # Downward-only: a page inside a folder does NOT surface that folder's
+    # proposal — otherwise a delete-this-folder suggestion would nag on every
+    # descendant page. Scoping matches proposals at or below the viewed path.
+    assert folders("docs/old/page.md") == set()
     # Query path is normalized like other wiki paths (surrounding slashes /
     # root are tolerated), so a banner request isn't silently empty.
     assert folders("/docs") == {"docs/old"}
     assert folders("docs/") == {"docs/old"}
     assert folders("/") == {"docs/old", "archive"}  # root → no filter
+
+    # A page-scoped proposal still surfaces on that page itself and on any
+    # enclosing folder (the folder view sees everything in its subtree).
+    _mk("docs/notes.md")
+    assert folders("docs/notes.md") == {"docs/notes.md"}  # the page itself
+    assert folders("docs") == {"docs/old", "docs/notes.md"}  # ancestor folder


### PR DESCRIPTION
Follow-up to #475 / #478. The `?path=` filter on the proposal listing used a **symmetric** overlap (`a == b or a.startswith(b+"/") or b.startswith(a+"/")`), so a folder-scoped proposal surfaced on the Path-2 review banner of *every page inside that folder*.

Concretely: with a `delete_empty_folder` proposal on `review-demo/stale-me`, opening the page `review-demo/stale-me/note.md` showed a banner suggesting its own containing folder be deleted — which would then go stale precisely because that page exists. In a real folder of N pages, the same suggestion would nag on all N.

**Fix:** make containment directional — a proposal surfaces on a scope only when it sits **at or below** that scope:

```python
def _within_scope(path: str, scope: str) -> bool:
    return path == scope or path.startswith(scope + "/")
```

- Folder view → still sees every proposal in its subtree ✓
- Page view → sees only proposals scoped to that page (a future `delete_page` / `merge_pages` / `move_page`), not its enclosing folder ✓

Tradeoff: a page swept up in an *ancestor folder move* no longer warns on the page itself, only on the folder — the folder is the proposal's natural home.

Test `test_path_filter_scopes_to_subtree` extended with the leak guard (`docs/old/page.md` → empty) and a positive page-scoped case. 55 automanage/detection/proposal tests pass locally.