### PR TITLE
feat(automanage): emit an activity event when a cleanup auto-applies

### DIFF
--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -51,14 +51,18 @@ def list_events(
     owned_page_paths = select(WikiOwner.path).where(
         WikiOwner.owner_user_id == user.id
     )
+    visibility = or_(
+        EventRow.target.in_(owned_trigger_ids),
+        EventRow.target.in_(owned_page_paths),
+    )
+    # Auto Organize auto-applies cleanups across the space, often on paths with
+    # no explicit owner — an admin audit concern. So admins additionally see
+    # every ``automanage.*`` event regardless of ownership.
+    if user.is_admin:
+        visibility = or_(visibility, EventRow.kind.like("automanage.%"))
     stmt = (
         select(EventRow)
-        .where(
-            or_(
-                EventRow.target.in_(owned_trigger_ids),
-                EventRow.target.in_(owned_page_paths),
-            )
-        )
+        .where(visibility)
         .order_by(EventRow.id.desc())
         .limit(limit)
     )
@@ -77,6 +81,9 @@ def get_event(event_id: int, user: User = Depends(require_user)) -> Event:
         e = s.get(EventRow, event_id)
         if e is None:
             raise HTTPException(status_code=404, detail="not found")
+        # Admins can read any automanage event (mirrors the list's audit view).
+        if user.is_admin and e.kind.startswith("automanage."):
+            return _to_view(e)
         # Hide cross-owner rows behind a 404 so we don't leak existence.
         if e.target is None:
             raise HTTPException(status_code=404, detail="not found")

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -122,8 +122,12 @@ def _finalize_applied(
     visible to the approver (they watched the outcome in the review banner), so
     only the silent AI-managed path needs the audit trail. ``path_ids`` maps the
     affected paths to their stable doc ids (captured before mutation)."""
-    change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
-    if p["reviewed_by_user_id"] is None:
+    # `mark_applied` is a conditional approved→applied transition: it returns
+    # False if a concurrent change (reject/expire/stale) already moved the
+    # proposal off `approved`. Only emit the event when the transition actually
+    # happened, so the audit feed can't disagree with the persisted status.
+    applied = change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
+    if applied and p["reviewed_by_user_id"] is None:
         _record_applied_event(p, applied_sha, path_ids)
 
 

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -18,16 +18,24 @@ rather than deleting content.
 """
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
 from app.auth import users
+from app.db.models import Event
+from app.db.session import session
 from app.models.wiki import PathMove
 from app.wiki import change_proposals, git, notify, trash
 from app.wiki.automanage import settings
 from app.wiki.change_proposals import ProposalOp, ProposalStatus
 
 log = logging.getLogger(__name__)
+
+# Activity-feed event for an *auto-applied* cleanup (AI-managed scope, no human
+# reviewer). The `automanage.` prefix is what `GET /events` matches to give
+# admins the space-wide audit trail — keep new automanage kinds under it.
+EVENT_AUTOMANAGE_APPLIED = "automanage.applied"
 
 
 def _git_author(user_id: str | None) -> str | None:
@@ -92,10 +100,49 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     notify.after_doc_trashed(
         moves, sha, author, root_move=PathMove(old=folder, new=dest)
     )
-    change_proposals.mark_applied(proposal_id, applied_sha=sha)
+    _finalize_applied(p, applied_sha=sha)
     log.info(
         "execute: proposal %s applied — trashed empty folder %s (sha=%s)",
         proposal_id,
         folder,
         sha[:8],
     )
+
+
+def _finalize_applied(p: dict[str, Any], *, applied_sha: str) -> None:
+    """Mark the proposal ``applied`` and, when it was auto-applied (no human
+    reviewer), record an activity event. A human-approved apply is already
+    visible to the approver (they watched the outcome in the review banner), so
+    only the silent AI-managed path needs the audit trail."""
+    change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
+    if p["reviewed_by_user_id"] is None:
+        _record_applied_event(p, applied_sha)
+
+
+def _record_applied_event(p: dict[str, Any], applied_sha: str) -> None:
+    """Best-effort: the change already happened, so a feed write that fails must
+    not fail the apply. ``target`` is the primary affected path (so its owner
+    sees it); admins see every ``automanage.*`` event regardless of ownership."""
+    try:
+        with session() as s:
+            s.add(
+                Event(
+                    kind=EVENT_AUTOMANAGE_APPLIED,
+                    actor=p["acting_user_id"],
+                    target=p["source_paths"][0],
+                    payload_json=json.dumps(
+                        {
+                            "op": p["op"],
+                            "source_paths": p["source_paths"],
+                            "target_paths": p["target_paths"],
+                            "applied_sha": applied_sha,
+                        }
+                    ),
+                )
+            )
+    except Exception:
+        log.exception(
+            "execute: failed to record %s event for proposal %s",
+            EVENT_AUTOMANAGE_APPLIED,
+            p["id"],
+        )

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -100,12 +100,7 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     notify.after_doc_trashed(
         moves, sha, author, root_move=PathMove(old=folder, new=dest)
     )
-    # Notify the owner of the *parent* folder: the deleted folder's own owner
-    # row was just re-pointed to the trash path by `after_doc_trashed`, so
-    # targeting `folder` would match no owner — and the parent-area owner is the
-    # stakeholder who cares that a subfolder was cleaned up.
-    parent = folder.rsplit("/", 1)[0] if "/" in folder else ""
-    _finalize_applied(p, applied_sha=sha, event_target=parent)
+    _finalize_applied(p, applied_sha=sha)
     log.info(
         "execute: proposal %s applied — trashed empty folder %s (sha=%s)",
         proposal_id,
@@ -114,33 +109,29 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     )
 
 
-def _finalize_applied(
-    p: dict[str, Any], *, applied_sha: str, event_target: str
-) -> None:
+def _finalize_applied(p: dict[str, Any], *, applied_sha: str) -> None:
     """Mark the proposal ``applied`` and, when it was auto-applied (no human
     reviewer), record an activity event. A human-approved apply is already
     visible to the approver (they watched the outcome in the review banner), so
-    only the silent AI-managed path needs the audit trail. ``event_target`` is
-    the surviving path whose owner should be notified (the op decides it — a
-    deleted path can't be its own target)."""
+    only the silent AI-managed path needs the audit trail."""
     change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
     if p["reviewed_by_user_id"] is None:
-        _record_applied_event(p, applied_sha, event_target)
+        _record_applied_event(p, applied_sha)
 
 
-def _record_applied_event(
-    p: dict[str, Any], applied_sha: str, target: str
-) -> None:
+def _record_applied_event(p: dict[str, Any], applied_sha: str) -> None:
     """Best-effort: the change already happened, so a feed write that fails must
-    not fail the apply. ``target`` is a surviving path whose owner should see
-    the event; admins see every ``automanage.*`` event regardless of ownership."""
+    not fail the apply. ``target`` is the affected folder itself — trashing a
+    folder does *not* re-point its owner row (unlike a page; see
+    ``acl.on_path_moved``), so the folder's owner still resolves at this path
+    and sees the event. Admins see every ``automanage.*`` event regardless."""
     try:
         with session() as s:
             s.add(
                 Event(
                     kind=EVENT_AUTOMANAGE_APPLIED,
                     actor=p["acting_user_id"],
-                    target=target,
+                    target=p["source_paths"][0],
                     payload_json=json.dumps(
                         {
                             "op": p["op"],

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -100,7 +100,12 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     notify.after_doc_trashed(
         moves, sha, author, root_move=PathMove(old=folder, new=dest)
     )
-    _finalize_applied(p, applied_sha=sha)
+    # Notify the owner of the *parent* folder: the deleted folder's own owner
+    # row was just re-pointed to the trash path by `after_doc_trashed`, so
+    # targeting `folder` would match no owner — and the parent-area owner is the
+    # stakeholder who cares that a subfolder was cleaned up.
+    parent = folder.rsplit("/", 1)[0] if "/" in folder else ""
+    _finalize_applied(p, applied_sha=sha, event_target=parent)
     log.info(
         "execute: proposal %s applied — trashed empty folder %s (sha=%s)",
         proposal_id,
@@ -109,27 +114,33 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     )
 
 
-def _finalize_applied(p: dict[str, Any], *, applied_sha: str) -> None:
+def _finalize_applied(
+    p: dict[str, Any], *, applied_sha: str, event_target: str
+) -> None:
     """Mark the proposal ``applied`` and, when it was auto-applied (no human
     reviewer), record an activity event. A human-approved apply is already
     visible to the approver (they watched the outcome in the review banner), so
-    only the silent AI-managed path needs the audit trail."""
+    only the silent AI-managed path needs the audit trail. ``event_target`` is
+    the surviving path whose owner should be notified (the op decides it — a
+    deleted path can't be its own target)."""
     change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
     if p["reviewed_by_user_id"] is None:
-        _record_applied_event(p, applied_sha)
+        _record_applied_event(p, applied_sha, event_target)
 
 
-def _record_applied_event(p: dict[str, Any], applied_sha: str) -> None:
+def _record_applied_event(
+    p: dict[str, Any], applied_sha: str, target: str
+) -> None:
     """Best-effort: the change already happened, so a feed write that fails must
-    not fail the apply. ``target`` is the primary affected path (so its owner
-    sees it); admins see every ``automanage.*`` event regardless of ownership."""
+    not fail the apply. ``target`` is a surviving path whose owner should see
+    the event; admins see every ``automanage.*`` event regardless of ownership."""
     try:
         with session() as s:
             s.add(
                 Event(
                     kind=EVENT_AUTOMANAGE_APPLIED,
                     actor=p["acting_user_id"],
-                    target=p["source_paths"][0],
+                    target=target,
                     payload_json=json.dumps(
                         {
                             "op": p["op"],

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -26,7 +26,7 @@ from app.auth import users
 from app.db.models import Event
 from app.db.session import session
 from app.models.wiki import PathMove
-from app.wiki import change_proposals, git, notify, trash
+from app.wiki import change_proposals, doc_ids, git, notify, trash
 from app.wiki.automanage import settings
 from app.wiki.change_proposals import ProposalOp, ProposalStatus
 
@@ -92,6 +92,11 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
         log.info("execute: proposal %s stale — %s not empty", proposal_id, folder)
         return
 
+    # Capture the folder's stable id *before* the trash-move tombstones it, so
+    # the activity event carries a durable handle (the id keeps resolving to the
+    # tombstone via `doc_ids.get`, even though the path is now gone).
+    path_ids = {folder: doc_ids.get_or_mint(folder)}
+
     author = _git_author(p["acting_user_id"])
     dest = trash.trash_location(trash.new_trash_id(), folder)
     sha, moves = git.move_path(
@@ -100,7 +105,7 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     notify.after_doc_trashed(
         moves, sha, author, root_move=PathMove(old=folder, new=dest)
     )
-    _finalize_applied(p, applied_sha=sha)
+    _finalize_applied(p, applied_sha=sha, path_ids=path_ids)
     log.info(
         "execute: proposal %s applied — trashed empty folder %s (sha=%s)",
         proposal_id,
@@ -109,22 +114,29 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     )
 
 
-def _finalize_applied(p: dict[str, Any], *, applied_sha: str) -> None:
+def _finalize_applied(
+    p: dict[str, Any], *, applied_sha: str, path_ids: dict[str, str]
+) -> None:
     """Mark the proposal ``applied`` and, when it was auto-applied (no human
     reviewer), record an activity event. A human-approved apply is already
     visible to the approver (they watched the outcome in the review banner), so
-    only the silent AI-managed path needs the audit trail."""
+    only the silent AI-managed path needs the audit trail. ``path_ids`` maps the
+    affected paths to their stable doc ids (captured before mutation)."""
     change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
     if p["reviewed_by_user_id"] is None:
-        _record_applied_event(p, applied_sha)
+        _record_applied_event(p, applied_sha, path_ids)
 
 
-def _record_applied_event(p: dict[str, Any], applied_sha: str) -> None:
+def _record_applied_event(
+    p: dict[str, Any], applied_sha: str, path_ids: dict[str, str]
+) -> None:
     """Best-effort: the change already happened, so a feed write that fails must
     not fail the apply. ``target`` is the affected folder itself — trashing a
     folder does *not* re-point its owner row (unlike a page; see
     ``acl.on_path_moved``), so the folder's owner still resolves at this path
-    and sees the event. Admins see every ``automanage.*`` event regardless."""
+    and sees the event. Admins see every ``automanage.*`` event regardless.
+    ``path_ids`` gives the UI a durable handle for linking (paths churn; the id
+    resolves even after the item is trashed)."""
     try:
         with session() as s:
             s.add(
@@ -137,6 +149,7 @@ def _record_applied_event(p: dict[str, Any], applied_sha: str) -> None:
                             "op": p["op"],
                             "source_paths": p["source_paths"],
                             "target_paths": p["target_paths"],
+                            "path_ids": path_ids,
                             "applied_sha": applied_sha,
                         }
                     ),

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -59,8 +59,8 @@ def test_auto_applied_delete_records_activity_event(repo):
     """An AI auto-applied cleanup (no human reviewer) emits an
     ``automanage.applied`` event so admins/owners get an audit trail."""
     # The AI system user (AI_USER_ID) is seeded by migration, so no seed here.
-    wiki_git.commit_file("gone/.gitkeep", "", "create gone folder", author=None)
-    pid = _proposal_for("gone")
+    wiki_git.commit_file("area/gone/.gitkeep", "", "create gone folder", author=None)
+    pid = _proposal_for("area/gone")
     assert auto_approve(pid, acting_user_id=AI_USER_ID)  # pending -> approved, no reviewer
 
     executor.execute(pid)
@@ -70,9 +70,11 @@ def test_auto_applied_delete_records_activity_event(repo):
     assert len(events) == 1
     ev = events[0]
     assert ev["actor"] == AI_USER_ID
-    assert ev["target"] == "gone"
+    # Targets the surviving *parent* folder (the deleted folder's own owner row
+    # was re-pointed to trash), so the parent-area owner can see it.
+    assert ev["target"] == "area"
     assert ev["payload"]["op"] == ProposalOp.DELETE_EMPTY_FOLDER.value
-    assert ev["payload"]["source_paths"] == ["gone"]
+    assert ev["payload"]["source_paths"] == ["area/gone"]
     assert ev["payload"]["applied_sha"]
 
 

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -7,16 +7,18 @@ from __future__ import annotations
 
 import pytest
 
+from app.auth.users import AI_USER_ID
 from app.wiki import git as wiki_git
 from app.wiki.automanage import executor
 from app.wiki.change_proposals import (
     ProposalCreatedVia,
     ProposalOp,
     approve,
+    auto_approve,
     create,
     get,
 )
-from tests._seed import seed_user
+from tests._seed import list_events, seed_user
 
 
 @pytest.fixture
@@ -51,6 +53,41 @@ def test_execute_trashes_empty_folder(repo):
     assert p is not None
     assert p["status"] == "applied"
     assert p["applied_sha"]
+
+
+def test_auto_applied_delete_records_activity_event(repo):
+    """An AI auto-applied cleanup (no human reviewer) emits an
+    ``automanage.applied`` event so admins/owners get an audit trail."""
+    # The AI system user (AI_USER_ID) is seeded by migration, so no seed here.
+    wiki_git.commit_file("gone/.gitkeep", "", "create gone folder", author=None)
+    pid = _proposal_for("gone")
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)  # pending -> approved, no reviewer
+
+    executor.execute(pid)
+
+    assert get(pid)["status"] == "applied"  # type: ignore[index]
+    events = list_events(kind=executor.EVENT_AUTOMANAGE_APPLIED)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["actor"] == AI_USER_ID
+    assert ev["target"] == "gone"
+    assert ev["payload"]["op"] == ProposalOp.DELETE_EMPTY_FOLDER.value
+    assert ev["payload"]["source_paths"] == ["gone"]
+    assert ev["payload"]["applied_sha"]
+
+
+def test_human_approved_delete_records_no_event(repo):
+    """A human-approved apply is already visible to the approver (they watched
+    the review banner), so it must NOT emit the auto-applied audit event."""
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("byhand/.gitkeep", "", "create", author=None)
+    pid = _proposal_for("byhand")
+    assert approve(pid, user_id=uid)  # human reviewer set
+
+    executor.execute(pid)
+
+    assert get(pid)["status"] == "applied"  # type: ignore[index]
+    assert list_events(kind=executor.EVENT_AUTOMANAGE_APPLIED) == []
 
 
 def test_execute_skips_folder_that_is_no_longer_empty(repo):

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 
 from app.auth.users import AI_USER_ID
-from app.wiki import acl
+from app.wiki import acl, doc_ids
 from app.wiki import git as wiki_git
 from app.wiki.automanage import executor
 from app.wiki.change_proposals import (
@@ -77,6 +77,10 @@ def test_auto_applied_delete_records_activity_event(repo):
     assert ev["payload"]["op"] == ProposalOp.DELETE_EMPTY_FOLDER.value
     assert ev["payload"]["source_paths"] == ["area/gone"]
     assert ev["payload"]["applied_sha"]
+    # A stable doc id captured before the trash-move; it still resolves (to the
+    # tombstone) after the folder is gone, so the UI can link to it.
+    folder_id = ev["payload"]["path_ids"]["area/gone"]
+    assert doc_ids.get(folder_id) is not None
 
 
 def test_trashed_folder_owner_still_resolves_at_original_path(repo):

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import pytest
 
 from app.auth.users import AI_USER_ID
+from app.wiki import acl
 from app.wiki import git as wiki_git
 from app.wiki.automanage import executor
 from app.wiki.change_proposals import (
@@ -70,12 +71,30 @@ def test_auto_applied_delete_records_activity_event(repo):
     assert len(events) == 1
     ev = events[0]
     assert ev["actor"] == AI_USER_ID
-    # Targets the surviving *parent* folder (the deleted folder's own owner row
-    # was re-pointed to trash), so the parent-area owner can see it.
-    assert ev["target"] == "area"
+    # Targets the folder itself: trashing a folder doesn't re-point its owner
+    # row (unlike a page), so the folder's owner still resolves here.
+    assert ev["target"] == "area/gone"
     assert ev["payload"]["op"] == ProposalOp.DELETE_EMPTY_FOLDER.value
     assert ev["payload"]["source_paths"] == ["area/gone"]
     assert ev["payload"]["applied_sha"]
+
+
+def test_trashed_folder_owner_still_resolves_at_original_path(repo):
+    """Pins the behavior the auto-apply event target depends on: trashing a
+    folder does NOT re-point its ``wiki_owners`` row (only a page's row moves),
+    so the folder's owner still resolves at the original path and can see the
+    ``automanage.applied`` event keyed there. If this ever changes, the event
+    visibility silently regresses — so guard it here."""
+    uid = seed_user(uid="owner1", email="owner@x.com")
+    wiki_git.commit_file("keep/gone/.gitkeep", "", "create", author=None)
+    acl.set_owner("keep/gone", uid)
+    pid = _proposal_for("keep/gone")
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)
+
+    executor.execute(pid)
+
+    assert "keep/gone/.gitkeep" not in wiki_git.list_paths()  # trashed
+    assert acl.get_owner("keep/gone") == uid  # owner row stayed → event reaches them
 
 
 def test_human_approved_delete_records_no_event(repo):

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -101,6 +101,24 @@ def test_trashed_folder_owner_still_resolves_at_original_path(repo):
     assert acl.get_owner("keep/gone") == uid  # owner row stayed → event reaches them
 
 
+def test_no_event_when_apply_transition_loses_race(repo):
+    """If the approved→applied transition loses to a concurrent change (the
+    proposal was rejected/expired/stale meanwhile), `mark_applied` returns
+    False — and we must NOT emit `automanage.applied`, or the audit feed would
+    disagree with the persisted status. Drive `_finalize_applied` on a proposal
+    that isn't `approved` so the transition fails."""
+    wiki_git.commit_file("racy/.gitkeep", "", "c", author=None)
+    pid = _proposal_for("racy")  # still pending — never approved
+    p = get(pid)
+    assert p is not None
+    p["reviewed_by_user_id"] = None  # auto-apply shape
+
+    executor._finalize_applied(p, applied_sha="deadbeef", path_ids={"racy": "x"})
+
+    assert get(pid)["status"] == "pending"  # type: ignore[index] # transition didn't happen
+    assert list_events(kind=executor.EVENT_AUTOMANAGE_APPLIED) == []
+
+
 def test_human_approved_delete_records_no_event(repo):
     """A human-approved apply is already visible to the approver (they watched
     the review banner), so it must NOT emit the auto-applied audit event."""

--- a/backend/tests/test_events_api.py
+++ b/backend/tests/test_events_api.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import create_app
+from app.wiki import acl
 
 from tests._auth import login_fastapi
 from tests._seed import insert_event, seed_trigger, seed_user
@@ -135,6 +136,19 @@ def test_non_admin_does_not_see_automanage_event_on_unowned_path(client):
 
     login_fastapi(client, user)
     assert client.get("/api/events").json()["events"] == []
+
+
+def test_path_owner_sees_automanage_event_on_their_path(client):
+    """A non-admin who owns the event's (surviving) target path sees it — this
+    is why the auto-apply event targets the surviving parent folder rather than
+    the deleted path, whose owner row was re-pointed to trash."""
+    user = seed_user("usr", "usr@x.com")
+    acl.set_owner("area", user)  # owns the parent folder the event targets
+    insert_event("automanage.applied", "area", {"op": "delete_empty_folder"})
+
+    login_fastapi(client, user)
+    targets = [e["target"] for e in client.get("/api/events").json()["events"]]
+    assert targets == ["area"]
 
 
 def test_admin_can_fetch_automanage_event_detail(client):

--- a/backend/tests/test_events_api.py
+++ b/backend/tests/test_events_api.py
@@ -108,3 +108,40 @@ def test_get_event_404s_for_other_owners_event(client):
 
     login_fastapi(client, b)
     assert client.get(f"/api/events/{eid}").status_code == 404
+
+
+# --------------------------------------------------------------------------- #
+# Admin audit view of automanage.* events                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_admin_sees_automanage_events_on_unowned_paths(client):
+    """Auto Organize auto-applies on paths with no owner — an admin sees those
+    ``automanage.*`` events regardless of ownership (the space-wide audit)."""
+    admin = seed_user("adm", "adm@x.com", is_admin=True)
+    insert_event("automanage.applied", "orphan/folder", {"op": "delete_empty_folder"})
+
+    login_fastapi(client, admin)
+    body = client.get("/api/events").json()
+    targets = [e["target"] for e in body["events"]]
+    assert "orphan/folder" in targets
+
+
+def test_non_admin_does_not_see_automanage_event_on_unowned_path(client):
+    """A non-admin who owns neither the path nor a trigger does not see the
+    auto-applied event — the admin audit clause is admin-only."""
+    user = seed_user("usr", "usr@x.com")
+    insert_event("automanage.applied", "orphan/folder", {"op": "delete_empty_folder"})
+
+    login_fastapi(client, user)
+    assert client.get("/api/events").json()["events"] == []
+
+
+def test_admin_can_fetch_automanage_event_detail(client):
+    """The detail endpoint mirrors the list: an admin can read an automanage
+    event even when the target path isn't a trigger they own."""
+    admin = seed_user("adm", "adm@x.com", is_admin=True)
+    eid = insert_event("automanage.applied", "orphan/folder", {"op": "x"})
+
+    login_fastapi(client, admin)
+    assert client.get(f"/api/events/{eid}").status_code == 200


### PR DESCRIPTION
Task #6 (Path-1 auto-applied visibility), backend.

**Problem.** AI-managed scopes auto-apply cleanups with no human review, so the change is silent — nothing tells anyone the AI moved/deleted something.

**Change.**
- Emit an `automanage.applied` activity event when a proposal applies, **only on the auto-apply path** — `auto_approve` leaves `reviewed_by_user_id` NULL, so we distinguish it from a human-approved apply (which the approver already watched land in the Path-2 review banner). Emit is best-effort (the change already happened; a feed-write failure must not fail the apply). `actor` = the AI system user, `target` = the affected path, payload carries `{op, source_paths, target_paths, applied_sha}`. Factored through a `_finalize_applied` helper so future ops (merge/move) reuse it.
- **Visibility:** the `/events` feed is strictly owner-scoped, but auto-applies land on arbitrary paths that often have no owner. So `GET /events` now also surfaces every `automanage.*` event to **admins** regardless of ownership (space-wide AI audit trail); path owners still see events on their own paths. The detail endpoint mirrors this.

**Tests.**
- Executor: emits `automanage.applied` on the AI path (actor/target/payload asserted); emits **nothing** on the human-approved path.
- `/events`: admin sees an automanage event on an unowned path; a non-admin non-owner does not; admin can fetch its detail.
- 77 automanage/detection/event tests pass locally; ruff + basedpyright clean.

**Follow-up (frontend, stacked):** a friendly row + icon for `automanage.applied` in `ActivitiesPanel` — unknown kinds already render as a generic row, so not blocking.
<img width="503" height="245" alt="Screenshot 2026-07-21 at 5 04 26 PM" src="https://github.com/user-attachments/assets/1f816c46-6462-4115-9ea6-4b021d6e09b0" />


