### PR TITLE
feat(activities): friendly row for Auto Organize auto-applied cleanups

### DIFF
--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -71,6 +71,18 @@ function isAutoOrganizeEvent(event: AppEvent): boolean {
   return event.kind.startsWith("automanage.");
 }
 
+/** Chip location for an event. Auto Organize events point the chip at the
+ * *parent* folder: the acted-on path itself no longer exists (it was cleaned
+ * up), and the row's subject already names the item. */
+function eventScope(event: AppEvent): string {
+  const p = event.payload as ActivityPayload;
+  if (isAutoOrganizeEvent(event)) {
+    const path = p.source_paths?.[0] ?? event.target ?? "";
+    return path.split("/").slice(0, -1).join("/");
+  }
+  return p.doc_path ?? event.target ?? "";
+}
+
 function destinationName(type: string | undefined): string {
   if (type === "slack") return "Slack";
   if (type === "email") return "Email";
@@ -112,19 +124,19 @@ function eventTexts(event: AppEvent): {
     };
   }
   if (event.kind === "automanage.applied") {
-    const path = p.source_paths?.[0] ?? event.target ?? "a page";
-    if (p.op === "delete_empty_folder") {
-      return {
-        prefix: "Auto Organize removed empty folder",
-        subject: path,
-        body: "Applied automatically in an AI-managed scope. The folder was moved to Trash and can be restored.",
-      };
-    }
-    // Future ops (merge, move, …) render legibly before this list learns them.
+    // One glanceable line: the chip shows where, the Wiki AI avatar shows who,
+    // and the subject is just the item's name (a full path would render the
+    // chip's path twice and wrap). No body — deletes are restorable from
+    // Trash like any other delete.
+    const path = p.source_paths?.[0] ?? event.target ?? "";
+    const name = path.split("/").pop() || "a page";
     return {
-      prefix: "Auto Organize applied a cleanup on",
-      subject: path,
-      body: "Applied automatically in an AI-managed scope.",
+      prefix:
+        p.op === "delete_empty_folder"
+          ? "Removed empty folder"
+          : "Auto-organized",
+      subject: name,
+      body: null,
     };
   }
   // Unknown kinds stay legible instead of masquerading as trigger fires,
@@ -162,7 +174,7 @@ export function ActivityRow({
     <div className="flex w-full flex-col px-3 py-1">
       <div className="flex w-full items-center p-[2px]">
         <div className="flex min-w-0 flex-1 items-center gap-1 p-[2px]">
-          <ScopeChip scope={p.doc_path ?? event.target ?? ""} />
+          <ScopeChip scope={eventScope(event)} />
           <span className="flex size-4 items-center justify-center p-[2px]">
             {event.kind === "trigger.fire" ? (
               <SvgWorkflow className="size-3 text-(--text-03)" />

--- a/frontend/src/components/wiki/ActivitiesPanel.tsx
+++ b/frontend/src/components/wiki/ActivitiesPanel.tsx
@@ -14,6 +14,7 @@ import {
   SvgActivity,
   SvgChevronDown,
   SvgChevronUp,
+  SvgSparkle,
   SvgWorkflow,
   SvgX,
 } from "@onyx-ai/opal/icons";
@@ -41,6 +42,11 @@ interface ActivityPayload {
   count?: number;
   threshold?: number;
   cap?: number;
+  // automanage.applied (Auto Organize auto-applied cleanup)
+  op?: string;
+  source_paths?: string[];
+  target_paths?: string[];
+  applied_sha?: string;
 }
 
 // Searchable text for an event regardless of kind.
@@ -51,12 +57,18 @@ function eventHaystack(event: AppEvent): string {
     p.change_kind,
     p.reason,
     p.message,
+    ...(p.source_paths ?? []),
     event.target,
     event.kind,
   ]
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
+}
+
+/** Auto Organize events are acted by the AI system user, not the viewer. */
+function isAutoOrganizeEvent(event: AppEvent): boolean {
+  return event.kind.startsWith("automanage.");
 }
 
 function destinationName(type: string | undefined): string {
@@ -99,6 +111,22 @@ function eventTexts(event: AppEvent): {
       body: p.message || p.reason || null,
     };
   }
+  if (event.kind === "automanage.applied") {
+    const path = p.source_paths?.[0] ?? event.target ?? "a page";
+    if (p.op === "delete_empty_folder") {
+      return {
+        prefix: "Auto Organize removed empty folder",
+        subject: path,
+        body: "Applied automatically in an AI-managed scope. The folder was moved to Trash and can be restored.",
+      };
+    }
+    // Future ops (merge, move, …) render legibly before this list learns them.
+    return {
+      prefix: "Auto Organize applied a cleanup on",
+      subject: path,
+      body: "Applied automatically in an AI-managed scope.",
+    };
+  }
   // Unknown kinds stay legible instead of masquerading as trigger fires,
   // and their payload stays inspectable when it has no message/reason.
   const payloadKeys = Object.keys(event.payload ?? {});
@@ -138,12 +166,14 @@ export function ActivityRow({
           <span className="flex size-4 items-center justify-center p-[2px]">
             {event.kind === "trigger.fire" ? (
               <SvgWorkflow className="size-3 text-(--text-03)" />
+            ) : isAutoOrganizeEvent(event) ? (
+              <SvgSparkle className="size-3 text-(--text-03)" />
             ) : (
               <SvgActivity className="size-3 text-(--text-03)" />
             )}
           </span>
           <AvatarCluster
-            ownerName={ownerName}
+            ownerName={isAutoOrganizeEvent(event) ? "Wiki AI" : ownerName}
             destinationTypes={destinationTypes}
           />
         </div>


### PR DESCRIPTION
Frontend follow-up to #482 (task #6, Path-1 auto-applied visibility).

`automanage.applied` events fell through to the Activities panel's generic renderer — the row showed the raw kind and a JSON payload dump (screenshot-confirmed bad). This gives them a proper rendering:

- **"Auto Organize removed empty folder `<path>`"** with an expandable body noting it was applied automatically in an AI-managed scope and is restorable from Trash.
- **Sparkle icon** for `automanage.*` kinds (vs. the generic activity icon).
- **"Wiki AI" actor avatar** — the row previously showed the *viewer's* avatar, which misattributes an AI action to the person looking at the feed.
- Future automanage ops (merge/move) render a legible generic line ("Auto Organize applied a cleanup on …") instead of JSON until this list learns them.
- `source_paths` join the search haystack so the panel search finds these events by path.

Typecheck passes; verified rendering on the local stack against a real auto-applied event produced through the offline queue.
<img width="356" height="216" alt="Screenshot 2026-07-21 at 5 16 07 PM" src="https://github.com/user-attachments/assets/18d8d076-d0e3-4e6d-8d10-826296b115a1" />

