### PR TITLE
fix(acl): re-point a folder's own wiki_owners row on move/trash

### DIFF
--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -774,6 +774,25 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                     )
                 )
             )
+            # Owner rows for the renamed folder and folders nested under it.
+            # Page owner rows were already re-keyed by the per-file loop, so
+            # the prefix match only finds folder rows (a page row still at an
+            # old path would be an orphan the rewrite also heals).
+            s.execute(
+                update(WikiOwner)
+                .where(WikiOwner.path == old_prefix)
+                .values(path=new_prefix)
+            )
+            s.execute(
+                update(WikiOwner)
+                .where(WikiOwner.path.like(old_prefix + "/%"))
+                .values(
+                    path=func.concat(
+                        new_prefix,
+                        func.substr(WikiOwner.path, len(old_prefix) + 1),
+                    )
+                )
+            )
 
 
 # Re-export for type-stability of ``Document`` import — keeps pyright happy

--- a/backend/app/wiki/acl.py
+++ b/backend/app/wiki/acl.py
@@ -40,6 +40,7 @@ from sqlalchemy import (
     select,
     update,
 )
+from sqlalchemy.orm import Session
 
 from app.auth import groups as groups_repo
 from app.db.models import AclEntry, WikiOwner
@@ -732,9 +733,7 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                     )
                     .values(resource_path=new_p)
                 )
-                s.execute(
-                    update(WikiOwner).where(WikiOwner.path == old_p).values(path=new_p)
-                )
+                _repoint_owner(s, old_p, new_p)
 
         # The folder-level prefix swap. A `.md`-page root is a single page
         # move: the per-file loop above re-keys it and there is no folder to
@@ -760,12 +759,16 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                 )
                 .values(resource_path=new_prefix)
             )
-            # Folder ACLs nested under the renamed folder.
+            # Folder ACLs nested under the renamed folder. `startswith` with
+            # autoescape treats `_`/`%` in the prefix as literals — a bare
+            # LIKE would let `my_project/%` also match `myXproject/...`.
             s.execute(
                 update(AclEntry)
                 .where(
                     AclEntry.resource_kind == PageKind.FOLDER,
-                    AclEntry.resource_path.like(old_prefix + "/%"),
+                    AclEntry.resource_path.startswith(
+                        old_prefix + "/", autoescape=True
+                    ),
                 )
                 .values(
                     resource_path=func.concat(
@@ -777,22 +780,33 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
             # Owner rows for the renamed folder and folders nested under it.
             # Page owner rows were already re-keyed by the per-file loop, so
             # the prefix match only finds folder rows (a page row still at an
-            # old path would be an orphan the rewrite also heals).
-            s.execute(
-                update(WikiOwner)
-                .where(WikiOwner.path == old_prefix)
-                .values(path=new_prefix)
-            )
-            s.execute(
-                update(WikiOwner)
-                .where(WikiOwner.path.like(old_prefix + "/%"))
-                .values(
-                    path=func.concat(
-                        new_prefix,
-                        func.substr(WikiOwner.path, len(old_prefix) + 1),
+            # old path would be an orphan the rewrite also heals). Row-by-row
+            # so a stale destination row can't abort the move on the path PK.
+            owner_paths = s.scalars(
+                select(WikiOwner.path).where(
+                    or_(
+                        WikiOwner.path == old_prefix,
+                        WikiOwner.path.startswith(old_prefix + "/", autoescape=True),
                     )
                 )
-            )
+            ).all()
+            for p_old in owner_paths:
+                _repoint_owner(s, p_old, new_prefix + p_old[len(old_prefix) :])
+
+
+def _repoint_owner(s: Session, old_path: str, new_path: str) -> None:
+    """Re-key one ``WikiOwner`` row. ``path`` is the primary key, so a row
+    already sitting at the destination would abort the whole move; it can only
+    be a stale orphan (move validation keeps destinations free of live
+    content), so the moving row wins and the orphan is dropped."""
+    row = s.get(WikiOwner, old_path)
+    if row is None:
+        return
+    existing = s.get(WikiOwner, new_path)
+    if existing is not None:
+        s.delete(existing)
+        s.flush()
+    row.path = new_path
 
 
 # Re-export for type-stability of ``Document`` import — keeps pyright happy

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -105,7 +105,11 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
     notify.after_doc_trashed(
         moves, sha, author, root_move=PathMove(old=folder, new=dest)
     )
-    _finalize_applied(p, applied_sha=sha, path_ids=path_ids)
+    # The event targets the trash destination: `after_doc_trashed` just
+    # re-pointed the folder's owner row there, and `/events` matches owners by
+    # exact target path — so the deleted folder's owner sees the event. The
+    # payload keeps the original path for display.
+    _finalize_applied(p, applied_sha=sha, path_ids=path_ids, event_target=dest)
     log.info(
         "execute: proposal %s applied — trashed empty folder %s (sha=%s)",
         proposal_id,
@@ -115,39 +119,47 @@ def _execute_delete_empty_folder(p: dict[str, Any]) -> None:
 
 
 def _finalize_applied(
-    p: dict[str, Any], *, applied_sha: str, path_ids: dict[str, str]
+    p: dict[str, Any],
+    *,
+    applied_sha: str,
+    path_ids: dict[str, str],
+    event_target: str,
 ) -> None:
     """Mark the proposal ``applied`` and, when it was auto-applied (no human
     reviewer), record an activity event. A human-approved apply is already
     visible to the approver (they watched the outcome in the review banner), so
     only the silent AI-managed path needs the audit trail. ``path_ids`` maps the
-    affected paths to their stable doc ids (captured before mutation)."""
+    affected paths to their stable doc ids (captured before mutation);
+    ``event_target`` is the path whose *current* owner row should match (the op
+    decides — for a trash-move that's the trash destination, where the owner
+    row now lives)."""
     # `mark_applied` is a conditional approved→applied transition: it returns
     # False if a concurrent change (reject/expire/stale) already moved the
     # proposal off `approved`. Only emit the event when the transition actually
     # happened, so the audit feed can't disagree with the persisted status.
     applied = change_proposals.mark_applied(p["id"], applied_sha=applied_sha)
     if applied and p["reviewed_by_user_id"] is None:
-        _record_applied_event(p, applied_sha, path_ids)
+        _record_applied_event(p, applied_sha, path_ids, event_target)
 
 
 def _record_applied_event(
-    p: dict[str, Any], applied_sha: str, path_ids: dict[str, str]
+    p: dict[str, Any], applied_sha: str, path_ids: dict[str, str], target: str
 ) -> None:
     """Best-effort: the change already happened, so a feed write that fails must
-    not fail the apply. ``target`` is the affected folder itself — trashing a
-    folder does *not* re-point its owner row (unlike a page; see
-    ``acl.on_path_moved``), so the folder's owner still resolves at this path
-    and sees the event. Admins see every ``automanage.*`` event regardless.
-    ``path_ids`` gives the UI a durable handle for linking (paths churn; the id
-    resolves even after the item is trashed)."""
+    not fail the apply. ``/events`` matches owners by exact ``target`` path at
+    query time, so ``target`` must be where the affected item's owner row lives
+    *after* the op — the trash destination for a delete. The item's owner sees
+    the event; admins see every ``automanage.*`` event regardless. ``path_ids``
+    gives the UI a durable handle for linking (paths churn; the id resolves
+    even after the item is trashed); display paths come from ``source_paths``,
+    never from ``target``."""
     try:
         with session() as s:
             s.add(
                 Event(
                     kind=EVENT_AUTOMANAGE_APPLIED,
                     actor=p["acting_user_id"],
-                    target=p["source_paths"][0],
+                    target=target,
                     payload_json=json.dumps(
                         {
                             "op": p["op"],

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -232,10 +232,12 @@ def on_path_moved(moves: list[PathMove], root_move: PathMove | None = None) -> N
                 .where(UpdatePolicy.path == old_prefix)
                 .values(path=new_prefix)
             )
-            # Policy rows nested under the renamed folder.
+            # Policy rows nested under the renamed folder. `startswith` with
+            # autoescape treats `_`/`%` in the prefix as literals — a bare
+            # LIKE would let `my_project/%` also match `myXproject/...`.
             s.execute(
                 update(UpdatePolicy)
-                .where(UpdatePolicy.path.like(old_prefix + "/%"))
+                .where(UpdatePolicy.path.startswith(old_prefix + "/", autoescape=True))
                 .values(
                     path=func.concat(
                         new_prefix,

--- a/backend/tests/test_detection_executor.py
+++ b/backend/tests/test_detection_executor.py
@@ -71,9 +71,11 @@ def test_auto_applied_delete_records_activity_event(repo):
     assert len(events) == 1
     ev = events[0]
     assert ev["actor"] == AI_USER_ID
-    # Targets the folder itself: trashing a folder doesn't re-point its owner
-    # row (unlike a page), so the folder's owner still resolves here.
-    assert ev["target"] == "area/gone"
+    # Targets the trash destination — where `after_doc_trashed` re-pointed the
+    # folder's owner row — so the feed's exact-path owner match reaches the
+    # deleted folder's owner. Display paths come from the payload, not target.
+    assert ev["target"].startswith(".trash/")
+    assert ev["target"].endswith("/area/gone")
     assert ev["payload"]["op"] == ProposalOp.DELETE_EMPTY_FOLDER.value
     assert ev["payload"]["source_paths"] == ["area/gone"]
     assert ev["payload"]["applied_sha"]
@@ -83,12 +85,12 @@ def test_auto_applied_delete_records_activity_event(repo):
     assert doc_ids.get(folder_id) is not None
 
 
-def test_trashed_folder_owner_still_resolves_at_original_path(repo):
-    """Pins the behavior the auto-apply event target depends on: trashing a
-    folder does NOT re-point its ``wiki_owners`` row (only a page's row moves),
-    so the folder's owner still resolves at the original path and can see the
-    ``automanage.applied`` event keyed there. If this ever changes, the event
-    visibility silently regresses — so guard it here."""
+def test_deleted_folder_owner_matches_event_target(repo):
+    """Pins the chain the event's owner visibility depends on: trashing a
+    folder re-points its ``wiki_owners`` row to the trash destination
+    (``acl.on_path_moved``), and the event targets that same destination — so
+    the deleted folder's owner matches the feed's exact-path owner check. If
+    either side drifts, owner visibility silently regresses — guard it here."""
     uid = seed_user(uid="owner1", email="owner@x.com")
     wiki_git.commit_file("keep/gone/.gitkeep", "", "create", author=None)
     acl.set_owner("keep/gone", uid)
@@ -98,7 +100,9 @@ def test_trashed_folder_owner_still_resolves_at_original_path(repo):
     executor.execute(pid)
 
     assert "keep/gone/.gitkeep" not in wiki_git.list_paths()  # trashed
-    assert acl.get_owner("keep/gone") == uid  # owner row stayed → event reaches them
+    assert acl.get_owner("keep/gone") is None  # owner row followed into trash
+    (ev,) = list_events(kind=executor.EVENT_AUTOMANAGE_APPLIED)
+    assert acl.get_owner(ev["target"]) == uid  # …and the event points at it
 
 
 def test_no_event_when_apply_transition_loses_race(repo):
@@ -113,7 +117,9 @@ def test_no_event_when_apply_transition_loses_race(repo):
     assert p is not None
     p["reviewed_by_user_id"] = None  # auto-apply shape
 
-    executor._finalize_applied(p, applied_sha="deadbeef", path_ids={"racy": "x"})
+    executor._finalize_applied(
+        p, applied_sha="deadbeef", path_ids={"racy": "x"}, event_target="racy"
+    )
 
     assert get(pid)["status"] == "pending"  # type: ignore[index] # transition didn't happen
     assert list_events(kind=executor.EVENT_AUTOMANAGE_APPLIED) == []

--- a/backend/tests/test_folder_acl_repoint.py
+++ b/backend/tests/test_folder_acl_repoint.py
@@ -129,6 +129,62 @@ def test_page_move_between_folders_leaves_folder_owner_untouched(tmp_db):
     assert acl.get_owner("dest") == u2
 
 
+def test_prefix_rewrite_escapes_like_wildcards(tmp_db):
+    # `_` is a LIKE single-char wildcard: moving `my_project` must not drag
+    # rows under the unrelated sibling `myXproject` (which `my_project/%`
+    # would match unescaped) — across owner, folder-ACL, and policy rows.
+    u1 = seed_user(uid="u1", email="u1@x.com")
+    u2 = seed_user(uid="u2", email="u2@x.com")
+    acl.set_owner("my_project/sub", u1)
+    acl.set_owner("myXproject/sub", u2)
+    acl.grant(
+        resource_kind="folder",
+        resource_path="myXproject/sub",
+        principal_kind="everyone",
+        principal_id=None,
+        permission="read",
+        granted_by_user_id=None,
+    )
+    update_policy.set_policy("myXproject/sub", ingestion_auto_update_disabled=True)
+
+    root = PathMove(old="my_project", new="moved_project")
+    acl.on_path_moved(
+        [PathMove(old="my_project/sub/a.md", new="moved_project/sub/a.md")],
+        root_move=root,
+    )
+    update_policy.on_path_moved(
+        [PathMove(old="my_project/sub/a.md", new="moved_project/sub/a.md")],
+        root_move=root,
+    )
+
+    assert acl.get_owner("moved_project/sub") == u1  # moved
+    assert acl.get_owner("myXproject/sub") == u2  # untouched
+    assert "myXproject/sub" in _folder_paths("myXproject/sub/b.md")
+    assert update_policy.get("myXproject/sub") is not None
+
+
+def test_stale_destination_owner_row_loses_to_the_move(tmp_db):
+    # `wiki_owners.path` is the primary key: a stale orphan row already at the
+    # destination must not abort the move — the moving row wins. Covers both
+    # the folder-prefix path and the per-file page path.
+    u_live = seed_user(uid="u_live", email="live@x.com")
+    u_stale = seed_user(uid="u_stale", email="stale@x.com")
+    acl.set_owner("src", u_live)
+    acl.set_owner("src/page.md", u_live)
+    acl.set_owner("dst", u_stale)  # stale orphans at the destination
+    acl.set_owner("dst/page.md", u_stale)
+
+    acl.on_path_moved(
+        [PathMove(old="src/page.md", new="dst/page.md")],
+        root_move=PathMove(old="src", new="dst"),
+    )
+
+    assert acl.get_owner("dst") == u_live
+    assert acl.get_owner("dst/page.md") == u_live
+    assert acl.get_owner("src") is None
+    assert acl.get_owner("src/page.md") is None
+
+
 def test_update_policy_folder_repoints_with_root_move(tmp_db):
     update_policy.set_policy("proj", ingestion_auto_update_disabled=True)
     # A nested-folder row exercises the LIKE "proj/%" branch of the rewrite.

--- a/backend/tests/test_folder_acl_repoint.py
+++ b/backend/tests/test_folder_acl_repoint.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from app.models.wiki import PathMove
 from app.wiki import acl, update_policy
+from tests._seed import seed_user
 
 
 def _folder_paths(path: str) -> set[str]:
@@ -90,6 +91,42 @@ def test_page_move_between_folders_leaves_policy_rows_untouched(tmp_db):
     )
     assert update_policy.get("scratch") is not None
     assert update_policy.get("dest") is not None
+
+
+def test_folder_owner_repoints_with_root_move(tmp_db):
+    # Owner rows on the folder itself and a nested folder follow the rename,
+    # matching the ACL/policy behavior (previously only *page* owner rows
+    # moved, stranding folder owners at the old path).
+    u1 = seed_user(uid="u1", email="u1@x.com")
+    u2 = seed_user(uid="u2", email="u2@x.com")
+    u3 = seed_user(uid="u3", email="u3@x.com")
+    acl.set_owner("proj", u1)
+    acl.set_owner("proj/sub", u2)
+    acl.set_owner("proj/sub/a.md", u3)
+    acl.on_path_moved(
+        [PathMove(old="proj/sub/a.md", new="proj2/sub/a.md")],
+        root_move=PathMove(old="proj", new="proj2"),
+    )
+    assert acl.get_owner("proj2") == u1
+    assert acl.get_owner("proj") is None
+    assert acl.get_owner("proj2/sub") == u2
+    assert acl.get_owner("proj/sub") is None
+    assert acl.get_owner("proj2/sub/a.md") == u3  # page row, per-file loop
+
+
+def test_page_move_between_folders_leaves_folder_owner_untouched(tmp_db):
+    # A single page move must not drag the source folder's owner row onto the
+    # destination — the page root_move suppresses the folder-prefix swap.
+    u1 = seed_user(uid="u1", email="u1@x.com")
+    u2 = seed_user(uid="u2", email="u2@x.com")
+    acl.set_owner("scratch", u1)
+    acl.set_owner("dest", u2)
+    acl.on_path_moved(
+        [PathMove(old="scratch/xrep.md", new="dest/xrep.md")],
+        root_move=PathMove(old="scratch/xrep.md", new="dest/xrep.md"),
+    )
+    assert acl.get_owner("scratch") == u1
+    assert acl.get_owner("dest") == u2
 
 
 def test_update_policy_folder_repoints_with_root_move(tmp_db):


### PR DESCRIPTION
**Bug.** `acl.on_path_moved` re-keys *page* owner rows in the per-file loop and rewrites folder **ACL grants** in the prefix swap — but never touches `wiki_owners` rows for the moved folder itself or folders nested under it. A folder rename/trash stranded the folder's owner row at the old path, contradicting `after_doc_trashed`'s "re-points … owner" contract (verified empirically on a live stack during the #482 review discussion).

**Fix.** Two `WikiOwner` rewrites in the folder-prefix block, exactly mirroring the `AclEntry` ones (exact match on the renamed folder + prefix rewrite for nested rows). Page rows are already re-keyed by the per-file loop by then, so the prefix match only finds folder rows.

**Automanage event routing (the coupled decision).** The #482 auto-apply event targeted the deleted folder's original path — which only reached the owner *because* of the stranded row. With the fix, the owner row follows into `.trash/`, so the event now targets the **trash destination**: `/events` matches owners by exact target path at query time, so the deleted folder's owner keeps seeing the event, plus all admins via the `automanage.*` clause. Display is unaffected — the Activities row renders from `payload.source_paths`, never `target`.

**Tests.**
- `test_folder_owner_repoints_with_root_move` (folder + nested folder + page rows all follow), `test_page_move_between_folders_leaves_folder_owner_untouched` (single-page move doesn't drag folder owners).
- Executor tripwire updated: `test_deleted_folder_owner_matches_event_target` pins the new chain (owner row gone from the original path, present at the event's target).
- 65 tests across acl/executor/events/repoint pass; a wide `-k "trash or move or …"` slice shows the same 34 pre-existing environment failures on unmodified main (empty-repo HEAD errors), none introduced here. ruff + basedpyright clean.