### PR TITLE
feat(automanage): emit safety — SUPPORTED_OPS gate + ProposalDraft.auto_approvable

### DIFF
--- a/backend/app/wiki/automanage/detectors/base.py
+++ b/backend/app/wiki/automanage/detectors/base.py
@@ -67,6 +67,13 @@ class ProposalDraft(BaseModel):
     merge/split carry ``proposed_bodies``). ``dedupe_key`` lets the runner's
     do-not-re-propose guard match this draft against rejected history without
     re-deriving the op's identity.
+
+    ``auto_approvable`` is the detector's own consent to skip the human queue:
+    the runner auto-applies a draft only when the scope allows AI management
+    **and** the detector marked it auto-approvable. Deterministic detectors
+    (empty folder, byte-identical duplicates) default True; a detector whose
+    judgment is probabilistic (LLM-confirmed merges, misplacement) should emit
+    False until its precision has earned auto-apply.
     """
 
     op: ProposalOp
@@ -74,6 +81,7 @@ class ProposalDraft(BaseModel):
     target_paths: list[str] = Field(default_factory=list)
     summary: str
     proposed_bodies: dict[str, str] | None = None
+    auto_approvable: bool = True
 
     @property
     def dedupe_key(self) -> str:

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -37,6 +37,13 @@ log = logging.getLogger(__name__)
 # admins the space-wide audit trail — keep new automanage kinds under it.
 EVENT_AUTOMANAGE_APPLIED = "automanage.applied"
 
+# The ops this executor can actually apply. The emit/approve layers gate on
+# this set (runner refuses to persist a draft, review refuses to approve), so
+# a detector landing ahead of its executor degrades to a loud skip instead of
+# an approved-but-unexecutable proposal. Grow it in the same PR as each new
+# `_execute_*` branch.
+SUPPORTED_OPS: frozenset[str] = frozenset({ProposalOp.DELETE_EMPTY_FOLDER.value})
+
 
 def _git_author(user_id: str | None) -> str | None:
     """`name <email>` for commit attribution, or None for the default identity."""

--- a/backend/app/wiki/automanage/review.py
+++ b/backend/app/wiki/automanage/review.py
@@ -18,9 +18,31 @@ import time (tasks import automanage, not the reverse).
 """
 from __future__ import annotations
 
+import logging
+
 from app.wiki import change_proposals
-from app.wiki.automanage import settings
+from app.wiki.automanage import executor, settings
 from app.wiki.change_proposals import ProposalStatus
+
+log = logging.getLogger(__name__)
+
+
+def _executable(proposal_id: int) -> bool:
+    """Refuse to approve what the executor can't apply. A detector shipping
+    ahead of its op's executor (or a bad manual insert) must dead-end here —
+    an approved-but-unexecutable proposal would either crash the execute task
+    or, on the AI path, auto-approve something that can never run."""
+    p = change_proposals.get(proposal_id)
+    if p is None:
+        return False
+    if p["op"] not in executor.SUPPORTED_OPS:
+        log.error(
+            "review: proposal %s has op %r with no executor — refusing approval",
+            proposal_id,
+            p["op"],
+        )
+        return False
+    return True
 
 
 def _dispatch_human_execution(proposal_id: int) -> None:
@@ -60,6 +82,8 @@ def approve(proposal_id: int, *, user_id: str) -> bool:
     if Auto Organize is disabled (proposals are frozen while off)."""
     if not settings.is_enabled():
         return False
+    if not _executable(proposal_id):
+        return False
     transitioned = change_proposals.approve(proposal_id, user_id=user_id)
     if not _actionable_after(proposal_id, transitioned):
         return False
@@ -74,6 +98,8 @@ def auto_approve(proposal_id: int, *, acting_user_id: str) -> bool:
     already-approved proposal. Returns False if missing or terminal, or if Auto
     Organize is disabled."""
     if not settings.is_enabled():
+        return False
+    if not _executable(proposal_id):
         return False
     transitioned = change_proposals.auto_approve(
         proposal_id, acting_user_id=acting_user_id

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -29,7 +29,7 @@ from typing import Any
 from app.auth.users import AI_USER_ID
 from app.wiki import git
 from app.wiki import update_policy
-from app.wiki.automanage import review, runs, settings
+from app.wiki.automanage import executor, review, runs, settings
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
@@ -121,6 +121,20 @@ def run_detection(
             mgmt = _resolve_management(drafts)
             for draft in drafts:
                 draft_paths = draft.source_paths + draft.target_paths
+                # Emit safety: never persist a draft the executor can't apply —
+                # a detector landing ahead of its op's executor degrades to this
+                # loud skip instead of filling the queue with proposals that
+                # dead-end at approval (review re-checks the same set).
+                if draft.op.value not in executor.SUPPORTED_OPS:
+                    log.error(
+                        "detection run %s: detector %s emitted op %r with no "
+                        "executor — draft skipped (%s)",
+                        run_id,
+                        detector.name,
+                        draft.op.value,
+                        draft.dedupe_key,
+                    )
+                    continue
                 if draft.dedupe_key in taken:
                     continue
                 if any(mgmt.get(p) is False for p in draft_paths):
@@ -151,8 +165,15 @@ def run_detection(
                 emitted += 1
                 # Whole operation inside an AI-managed scope → auto-apply as the
                 # AI system user (no human queue). Otherwise it waits for a
-                # human in the pending-cleanups queue.
-                if draft_paths and all(mgmt.get(p) is True for p in draft_paths):
+                # human in the pending-cleanups queue. The detector must also
+                # consent (`auto_approvable`) — probabilistic detectors emit
+                # False so their proposals always get a human even in
+                # AI-managed scopes.
+                if (
+                    draft.auto_approvable
+                    and draft_paths
+                    and all(mgmt.get(p) is True for p in draft_paths)
+                ):
                     if not review.auto_approve(
                         proposal["id"], acting_user_id=AI_USER_ID
                     ):

--- a/backend/tests/test_detection_review.py
+++ b/backend/tests/test_detection_review.py
@@ -102,3 +102,38 @@ def test_approve_recovers_stuck_approved(repo):
     with automanage_nearline_queue.immediate_mode():
         assert review.approve(pid, user_id=uid) is True  # re-dispatches
     assert _get(pid)["status"] == "applied"
+
+
+def _mk_unsupported(path: str) -> int:
+    """A proposal whose op has no executor yet (merge is a valid ledger op)."""
+    return create_proposal(
+        op=ProposalOp.MERGE,
+        source_paths=[path],
+        target_paths=["kept.md"],
+        base_shas={path: "0" * 40},
+        summary=f"Merge “{path}” into “kept.md”",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+
+
+def test_approve_refuses_op_without_executor(repo):
+    """Emit safety: an op the executor can't apply must dead-end at approval —
+    approving it would crash the execute task (or silently freeze)."""
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("dup.md", "# Dup\n", "create", author=None)
+    pid = _mk_unsupported("dup.md")
+
+    with automanage_nearline_queue.immediate_mode():
+        assert review.approve(pid, user_id=uid) is False
+
+    assert _get(pid)["status"] == "pending"  # untouched, no execution attempted
+
+
+def test_auto_approve_refuses_op_without_executor(repo):
+    wiki_git.commit_file("dup2.md", "# Dup\n", "create", author=None)
+    pid = _mk_unsupported("dup2.md")
+
+    with automanage_offline_queue.immediate_mode():
+        assert review.auto_approve(pid, acting_user_id=AI_USER_ID) is False
+
+    assert _get(pid)["status"] == "pending"

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -14,8 +14,14 @@ from app.tasks.queues import automanage_offline_queue
 from app.wiki import git as wiki_git
 from app.wiki import update_policy
 from app.wiki.automanage import runner, runs
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.automanage.detectors.empty_folder import _EmptyFolderDetector
-from app.wiki.change_proposals import ProposalStatus, list_by_status, reject
+from app.wiki.change_proposals import (
+    ProposalOp,
+    ProposalStatus,
+    list_by_status,
+    reject,
+)
 from tests._seed import seed_user
 
 
@@ -121,22 +127,19 @@ class _StubDetector:
 
     name = "stub"
 
-    def __init__(self, drafts):
+    def __init__(self, drafts: list[ProposalDraft]) -> None:
         self._drafts = drafts
 
-    def applicable(self, trigger):
+    def applicable(self, trigger: TriggerKind) -> bool:
         return True
 
-    def detect(self, scope):
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
         return list(self._drafts)
 
 
 def test_unsupported_op_draft_is_skipped_not_persisted(repo, monkeypatch):
     """Emit safety: a detector landing ahead of its op's executor degrades to a
     loud skip — the draft never becomes a proposal row."""
-    from app.wiki.automanage.detectors.base import ProposalDraft
-    from app.wiki.change_proposals import ProposalOp
-
     draft = ProposalDraft(
         op=ProposalOp.MERGE,  # valid ledger op, but no executor yet
         source_paths=["team/plan.md"],
@@ -157,9 +160,6 @@ def test_unsupported_op_draft_is_skipped_not_persisted(repo, monkeypatch):
 def test_non_auto_approvable_draft_stays_pending_in_ai_scope(repo, monkeypatch):
     """A detector that hasn't earned auto-apply (auto_approvable=False) gets a
     human even when the whole scope is AI-managed."""
-    from app.wiki.automanage.detectors.base import ProposalDraft
-    from app.wiki.change_proposals import ProposalOp
-
     update_policy.set_policy("archive", ai_management_allowed=True)
     draft = ProposalDraft(
         op=ProposalOp.DELETE_EMPTY_FOLDER,

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -114,3 +114,67 @@ def test_unset_scope_stays_pending(repo):
     assert list_by_status(ProposalStatus.APPLIED) == []
     pending = {p["source_paths"][0] for p in list_by_status(ProposalStatus.PENDING)}
     assert pending == {"archive", "old"}
+
+
+class _StubDetector:
+    """Emits fixed drafts — for exercising runner gates without a real detector."""
+
+    name = "stub"
+
+    def __init__(self, drafts):
+        self._drafts = drafts
+
+    def applicable(self, trigger):
+        return True
+
+    def detect(self, scope):
+        return list(self._drafts)
+
+
+def test_unsupported_op_draft_is_skipped_not_persisted(repo, monkeypatch):
+    """Emit safety: a detector landing ahead of its op's executor degrades to a
+    loud skip — the draft never becomes a proposal row."""
+    from app.wiki.automanage.detectors.base import ProposalDraft
+    from app.wiki.change_proposals import ProposalOp
+
+    draft = ProposalDraft(
+        op=ProposalOp.MERGE,  # valid ledger op, but no executor yet
+        source_paths=["team/plan.md"],
+        target_paths=["old/notes.md"],
+        summary="Merge plan into notes",
+    )
+    monkeypatch.setattr(runner, "DETECTORS", [_StubDetector([draft])])
+
+    result = runner.run_sweep(triggered_by_user_id=None)
+
+    assert result["proposals_emitted"] == 0
+    assert list_by_status(ProposalStatus.PENDING) == []
+    run = runs.get(result["run_id"])
+    assert run is not None
+    assert run["status"] == "completed"  # skip, not a run failure
+
+
+def test_non_auto_approvable_draft_stays_pending_in_ai_scope(repo, monkeypatch):
+    """A detector that hasn't earned auto-apply (auto_approvable=False) gets a
+    human even when the whole scope is AI-managed."""
+    from app.wiki.automanage.detectors.base import ProposalDraft
+    from app.wiki.change_proposals import ProposalOp
+
+    update_policy.set_policy("archive", ai_management_allowed=True)
+    draft = ProposalDraft(
+        op=ProposalOp.DELETE_EMPTY_FOLDER,
+        source_paths=["archive"],
+        target_paths=[],
+        summary="Delete empty folder “archive”",
+        auto_approvable=False,
+    )
+    monkeypatch.setattr(runner, "DETECTORS", [_StubDetector([draft])])
+
+    with automanage_offline_queue.immediate_mode():
+        result = runner.run_sweep(triggered_by_user_id=None)
+
+    assert result["proposals_emitted"] == 1
+    assert list_by_status(ProposalStatus.APPLIED) == []  # no auto-apply
+    pending = list_by_status(ProposalStatus.PENDING)
+    assert [p["source_paths"][0] for p in pending] == ["archive"]
+    assert "archive/.gitkeep" in wiki_git.list_paths()  # untouched


### PR DESCRIPTION
First PR of the detection-roadmap waves (the keystone — everything detector-shaped stacks on this).

**Problem.** The `change_proposals` ledger accepts six op kinds and the runner auto-approves anything in an AI-managed scope, but the executor can only apply `delete_empty_folder` (it raises on everything else). A detector shipping ahead of its op's executor would fill the pending queue with proposals that crash the execute task — or, on the AI path, **auto-approve changes that can never run**.

**Change — three defensive layers:**
- `executor.SUPPORTED_OPS` — the set of ops the executor can actually apply. Contract: grow it in the same PR as each new `_execute_*` branch.
- **Runner emit gate** — a draft whose op isn't supported is skipped with a loud `log.error` and never persisted; the pending queue only ever holds actionable proposals. The run completes (skip ≠ failure).
- **Review gate** — `approve`/`auto_approve` refuse (return False → the API's 409) on an unsupported op, covering rows that predate the emit gate or arrive outside the runner.

**Plus `ProposalDraft.auto_approvable` (default True)** — the detector's own consent to skip the human queue. Auto-apply now requires the scope to be AI-managed **and** the draft to be auto-approvable, so future probabilistic detectors (LLM-judged fuzzy-dup, misplacement) can emit `False` and always route to a human until their precision earns auto-apply. Deterministic detectors keep the default.

**Tests.** Review: approve/auto_approve refuse a `merge` proposal (valid ledger op, no executor), row stays pending. Runner: unsupported-op draft skipped and not persisted (run still completes); `auto_approvable=False` draft in a fully AI-managed scope stays pending and nothing executes. 96 automanage/detection/proposal/event tests pass; ruff + basedpyright clean.

The wave ordering (deterministic detectors first, each op's executor before the detectors that emit it) is documented in the internal design docs.
