### PR TITLE
feat(automanage): permission-fingerprint substrate

### DIFF
--- a/backend/app/wiki/automanage/__init__.py
+++ b/backend/app/wiki/automanage/__init__.py
@@ -2,7 +2,6 @@
 
 Detection (this package's ``detectors/`` seam + the runner) finds duplicates,
 misplaced pages, and stale hierarchy and emits ``change_proposals``; a human
-(or an AI-managed scope) approves before anything touches the wiki. Design:
-``design/Wiki Auto Management — Engineering.md`` and its Detection sub-page.
+(or an AI-managed scope) approves before anything touches the wiki.
 """
 from __future__ import annotations

--- a/backend/app/wiki/automanage/detectors/base.py
+++ b/backend/app/wiki/automanage/detectors/base.py
@@ -1,8 +1,8 @@
 """The detector seam — the *technique* axis of Wiki Auto Management detection.
 
-Detection varies on two orthogonal axes (see the design page ``design/Wiki
-Auto Management — Detection.md``): a **trigger** decides *when* detection runs
-and over *what scope*; a **technique** decides *what pattern* to look for.
+Detection varies on two orthogonal axes: a **trigger** decides *when*
+detection runs and over *what scope*; a **technique** decides *what pattern*
+to look for.
 This module is the technique axis: a ``Detector`` is a pure function
 ``scope → proposals`` that a trigger-built ``Scope`` is fed through.
 

--- a/backend/app/wiki/automanage/fingerprint.py
+++ b/backend/app/wiki/automanage/fingerprint.py
@@ -1,0 +1,121 @@
+"""Permission fingerprints — the audience identity detection partitions on.
+
+Detection never pairs pages across a visibility boundary (see ``design/Wiki
+Auto Management — Detection.md`` § Permission boundary): the *proposal alone*
+would leak a restricted page's existence and title to whoever can see the
+review surface. The mechanism is a **fingerprint** — a hash of a path's full
+permission profile — computed here and used two ways:
+
+- the runner partitions candidate paths by fingerprint, so pairing detectors
+  (duplicate/merge) only ever compare pages with identical audiences;
+- emitted proposals store it (``acl_fingerprint_before``), so staleness
+  re-checks can notice "permissions changed since this was proposed".
+
+The profile is the **expanded audience**, not the grant rows: group grants are
+expanded to member user ids, so two pages restricted to the same people via
+different groups fingerprint equal — and a group-membership change drifts the
+fingerprint, which is exactly what staleness re-checks should notice. Write
+implies read (as in ``acl.effective``); the owner is folded into both sets;
+admins are excluded (a constant term in every profile). ``everyone`` grants
+use the ``"*"`` sentinel and absorb the rest of their set — an explicit grant
+adds nothing once everyone is in the audience.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+
+from pydantic import BaseModel, ConfigDict
+
+from app.auth import groups as groups_repo
+from app.wiki import acl
+
+# The `everyone` principal in an expanded audience set.
+EVERYONE = "*"
+
+
+class PermissionProfile(BaseModel):
+    """A path's expanded audience: who can read, who can write."""
+
+    model_config = ConfigDict(frozen=True)
+
+    read: frozenset[str]
+    write: frozenset[str]
+
+    def fingerprint(self) -> str:
+        payload = json.dumps(
+            {"r": sorted(self.read), "w": sorted(self.write)},
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def _normalize(principals: set[str]) -> frozenset[str]:
+    """``everyone`` absorbs explicit principals — the audience is the same."""
+    if EVERYONE in principals:
+        return frozenset({EVERYONE})
+    return frozenset(principals)
+
+
+def profile_for_path(
+    path: str, *, _group_members: dict[str, frozenset[str]] | None = None
+) -> PermissionProfile:
+    """The expanded audience for ``path``.
+
+    Mirrors ``acl.effective``'s resolution, audience-side: page rows +
+    ancestor-folder rows + owner, with the same implicit-public fallback (a
+    completely unconfigured path — no owner, no applicable rows — is readable
+    and writable by everyone). ``_group_members`` is a per-batch expansion
+    cache; callers use :func:`fingerprints_for_paths` rather than passing it.
+    """
+    cache = _group_members if _group_members is not None else {}
+    rows = acl.list_for_path(path)
+    owner = acl.get_owner(path)
+
+    if not rows and owner is None:
+        # Implicit-public: unmanaged until the first owner stamp or grant.
+        everyone = frozenset({EVERYONE})
+        return PermissionProfile(read=everyone, write=everyone)
+
+    read: set[str] = set()
+    write: set[str] = set()
+    for row in rows:
+        kind, pid = row["principal_kind"], row["principal_id"]
+        if kind == "everyone":
+            principals: frozenset[str] = frozenset({EVERYONE})
+        elif kind == "user":
+            principals = frozenset({pid})
+        else:  # group → expanded members
+            if pid not in cache:
+                cache[pid] = frozenset(groups_repo.member_ids(pid))
+            principals = cache[pid]
+        if row["permission"] == "write":
+            write |= principals
+        else:
+            read |= principals
+
+    if owner is not None:
+        write.add(owner)
+    read |= write  # write implies read
+    return PermissionProfile(read=_normalize(read), write=_normalize(write))
+
+
+def fingerprint_for_path(path: str) -> str:
+    return profile_for_path(path).fingerprint()
+
+
+def fingerprints_for_paths(paths: list[str]) -> dict[str, str]:
+    """Batch fingerprints with one group expansion per group across the batch."""
+    cache: dict[str, frozenset[str]] = {}
+    return {
+        p: profile_for_path(p, _group_members=cache).fingerprint() for p in paths
+    }
+
+
+def combined_fingerprint(paths: list[str]) -> str:
+    """One fingerprint over a proposal's whole path-set — what
+    ``acl_fingerprint_before`` stores. Deterministic in path order; equal iff
+    every path's own profile is equal."""
+    fps = fingerprints_for_paths(paths)
+    payload = "\n".join(f"{p}={fps[p]}" for p in sorted(fps))
+    return hashlib.sha256(payload.encode()).hexdigest()

--- a/backend/app/wiki/automanage/fingerprint.py
+++ b/backend/app/wiki/automanage/fingerprint.py
@@ -1,7 +1,6 @@
 """Permission fingerprints — the audience identity detection partitions on.
 
-Detection never pairs pages across a visibility boundary (see ``design/Wiki
-Auto Management — Detection.md`` § Permission boundary): the *proposal alone*
+Detection never pairs pages across a visibility boundary: the *proposal alone*
 would leak a restricted page's existence and title to whoever can see the
 review surface. The mechanism is a **fingerprint** — a hash of a path's full
 permission profile — computed here and used two ways:

--- a/backend/app/wiki/automanage/fingerprint.py
+++ b/backend/app/wiki/automanage/fingerprint.py
@@ -113,8 +113,8 @@ def fingerprints_for_paths(paths: list[str]) -> dict[str, str]:
 
 def combined_fingerprint(paths: list[str]) -> str:
     """One fingerprint over a proposal's whole path-set — what
-    ``acl_fingerprint_before`` stores. Deterministic in path order; equal iff
-    every path's own profile is equal."""
+    ``acl_fingerprint_before`` stores. Deterministic regardless of path order;
+    equal iff every path's own profile is equal."""
     fps = fingerprints_for_paths(paths)
     payload = "\n".join(f"{p}={fps[p]}" for p in sorted(fps))
     return hashlib.sha256(payload.encode()).hexdigest()

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -29,7 +29,7 @@ from typing import Any
 from app.auth.users import AI_USER_ID
 from app.wiki import git
 from app.wiki import update_policy
-from app.wiki.automanage import executor, review, runs, settings
+from app.wiki.automanage import executor, fingerprint, review, runs, settings
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
@@ -160,6 +160,12 @@ def run_detection(
                     created_via=created_via,
                     proposed_bodies=draft.proposed_bodies,
                     run_id=run_id,
+                    # Audience snapshot at emit time — staleness re-checks can
+                    # notice a permission change (e.g. group-membership drift)
+                    # between proposal and execution.
+                    acl_fingerprint_before=fingerprint.combined_fingerprint(
+                        draft_paths
+                    ),
                 )
                 taken.add(draft.dedupe_key)
                 emitted += 1

--- a/backend/tests/test_automanage_fingerprint.py
+++ b/backend/tests/test_automanage_fingerprint.py
@@ -1,0 +1,128 @@
+"""Permission fingerprints — the audience identity detection partitions on.
+
+The profile is the *expanded audience* (groups → member ids), so equal-audience
+paths fingerprint equal regardless of how the grants are spelled, and a
+group-membership change drifts the fingerprint.
+"""
+from __future__ import annotations
+
+from app.auth import groups as groups_repo
+from app.wiki import acl
+from app.wiki.automanage import fingerprint
+from app.wiki.automanage.fingerprint import EVERYONE, profile_for_path
+from tests._seed import seed_user
+
+
+def _grant(path: str, kind: str, pid: str | None, perm: str = "read") -> None:
+    acl.grant(
+        resource_kind="page" if path.endswith(".md") else "folder",
+        resource_path=path,
+        principal_kind=kind,
+        principal_id=pid,
+        permission=perm,
+        granted_by_user_id=None,
+    )
+
+
+def test_unmanaged_path_is_implicit_public(tmp_db):
+    p = profile_for_path("nowhere/unmanaged.md")
+    assert p.read == frozenset({EVERYONE})
+    assert p.write == frozenset({EVERYONE})
+    # Two unmanaged paths share one audience → equal fingerprints.
+    assert p.fingerprint() == profile_for_path("elsewhere/also.md").fingerprint()
+
+
+def test_owner_is_folded_into_both_sets(tmp_db):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    acl.set_owner("docs/spec.md", uid)
+    p = profile_for_path("docs/spec.md")
+    assert p.read == frozenset({uid})
+    assert p.write == frozenset({uid})
+
+
+def test_write_implies_read(tmp_db):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    other = seed_user(uid="u2", email="u2@x.com")
+    acl.set_owner("docs/spec.md", uid)
+    _grant("docs/spec.md", "user", other, perm="write")
+    p = profile_for_path("docs/spec.md")
+    assert other in p.read and other in p.write
+
+
+def test_everyone_absorbs_explicit_principals(tmp_db):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    reader = seed_user(uid="u2", email="u2@x.com")
+    acl.set_owner("docs/spec.md", uid)
+    _grant("docs/spec.md", "everyone", None)
+    _grant("docs/spec.md", "user", reader)  # redundant next to everyone-read
+    p = profile_for_path("docs/spec.md")
+    assert p.read == frozenset({EVERYONE})  # audience unchanged by the grant
+    assert p.write == frozenset({uid})
+
+
+def test_folder_grants_cascade_to_pages(tmp_db):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    reader = seed_user(uid="u2", email="u2@x.com")
+    acl.set_owner("team/notes.md", uid)
+    _grant("team", "user", reader)  # folder grant, inherited by the page
+    p = profile_for_path("team/notes.md")
+    assert reader in p.read
+
+
+def test_same_members_via_different_groups_fingerprint_equal(tmp_db):
+    """Audience identity, not grant spelling: two pages restricted to the same
+    people — one via a group, one via direct user grants — pair as equals."""
+    owner = seed_user(uid="own", email="o@x.com")
+    a = seed_user(uid="a", email="a@x.com")
+    b = seed_user(uid="b", email="b@x.com")
+    gid = groups_repo.create("team", None, owner)
+    groups_repo.add_member(gid, a)
+    groups_repo.add_member(gid, b)
+
+    acl.set_owner("one.md", owner)
+    _grant("one.md", "group", gid)
+    acl.set_owner("two.md", owner)
+    _grant("two.md", "user", a)
+    _grant("two.md", "user", b)
+
+    fps = fingerprint.fingerprints_for_paths(["one.md", "two.md"])
+    assert fps["one.md"] == fps["two.md"]
+
+
+def test_group_membership_change_drifts_the_fingerprint(tmp_db):
+    owner = seed_user(uid="own", email="o@x.com")
+    a = seed_user(uid="a", email="a@x.com")
+    late = seed_user(uid="late", email="l@x.com")
+    gid = groups_repo.create("team", None, owner)
+    groups_repo.add_member(gid, a)
+    acl.set_owner("one.md", owner)
+    _grant("one.md", "group", gid)
+
+    before = fingerprint.fingerprint_for_path("one.md")
+    groups_repo.add_member(gid, late)  # no ACL row changed — only membership
+    after = fingerprint.fingerprint_for_path("one.md")
+    assert before != after
+
+
+def test_different_audiences_fingerprint_differently(tmp_db):
+    u1 = seed_user(uid="u1", email="u1@x.com")
+    u2 = seed_user(uid="u2", email="u2@x.com")
+    acl.set_owner("a.md", u1)
+    acl.set_owner("b.md", u2)
+    assert (
+        fingerprint.fingerprint_for_path("a.md")
+        != fingerprint.fingerprint_for_path("b.md")
+    )
+
+
+def test_combined_fingerprint_covers_every_path(tmp_db):
+    uid = seed_user(uid="u1", email="u1@x.com")
+    acl.set_owner("a.md", uid)
+    combined_before = fingerprint.combined_fingerprint(["a.md", "b.md"])
+    # Managing the second path changes the set's combined fingerprint.
+    acl.set_owner("b.md", uid)
+    assert fingerprint.combined_fingerprint(["a.md", "b.md"]) != combined_before
+    # Order-insensitive.
+    assert fingerprint.combined_fingerprint(
+        ["b.md", "a.md"]
+    ) == fingerprint.combined_fingerprint(["a.md", "b.md"])

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -13,7 +13,7 @@ from app.auth.users import AI_USER_ID
 from app.tasks.queues import automanage_offline_queue
 from app.wiki import git as wiki_git
 from app.wiki import update_policy
-from app.wiki.automanage import runner, runs
+from app.wiki.automanage import fingerprint, runner, runs
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.automanage.detectors.empty_folder import _EmptyFolderDetector
 from app.wiki.change_proposals import (
@@ -178,3 +178,15 @@ def test_non_auto_approvable_draft_stays_pending_in_ai_scope(repo, monkeypatch):
     pending = list_by_status(ProposalStatus.PENDING)
     assert [p["source_paths"][0] for p in pending] == ["archive"]
     assert "archive/.gitkeep" in wiki_git.list_paths()  # untouched
+
+
+def test_emitted_proposal_carries_acl_fingerprint(repo):
+    """The runner stamps the audience snapshot at emit time, so staleness
+    re-checks can notice a permission change before execution."""
+    runner.run_sweep(triggered_by_user_id=None)
+
+    for p in list_by_status(ProposalStatus.PENDING):
+        expected = fingerprint.combined_fingerprint(
+            p["source_paths"] + p["target_paths"]
+        )
+        assert p["acl_fingerprint_before"] == expected


### PR DESCRIPTION
Second PR of the detection-roadmap waves (after #485). Pure substrate — no behavior change for the only live detector (empty-folder is single-path and never pairs); ships inert like #485 did.

**Why.** Pairing detectors (body-dup, fuzzy-dup, case-collision merges) compare pages against each other. Pairing a public page with a restricted one leaks the restricted page's existence/title through the proposal itself, so the visibility boundary must be enforced at pairing time. This PR lands the identity that boundary partitions on.

**What.**
- `app/wiki/automanage/fingerprint.py` — `profile_for_path` resolves a path's **expanded audience** (page rows + ancestor-folder grants + owner; groups expanded to member ids; write implies read; `everyone` → `"*"` sentinel absorbing explicit principals; admins excluded; implicit-public for unmanaged paths, mirroring `acl.effective`). `fingerprint_for_path` / batch `fingerprints_for_paths` (one member-expansion per group per batch) / `combined_fingerprint(paths)` for a proposal's whole path-set.
- Expanded-audience semantics: same people via different groups → **equal** fingerprints; a group-membership change → fingerprint **drifts** (what staleness re-checks should notice).
- Runner stamps `acl_fingerprint_before` on every emitted proposal — the column existed on `change_proposals` but was never filled.
- Docs cleanup: module docstrings no longer reference internal design-page paths (public repo).

**Next (separate PR):** runner partitioning by fingerprint, landing with the first pairing detector.

**Tests.** 9 fingerprint tests (implicit-public, owner folding, write-implies-read, everyone absorption, folder cascade, group-vs-direct equality, membership drift, distinct audiences, combined-set coverage + order-insensitivity) + a runner test asserting the stamp. 77 automanage/detection/proposal tests pass; ruff + basedpyright clean.