### PR TITLE
feat(wiki): Sources tab lists the page's ingested source documents

### DIFF
--- a/backend/app/db/migrations/versions/a9e2c7f4b1d6_provenance_source_snippet.py
+++ b/backend/app/db/migrations/versions/a9e2c7f4b1d6_provenance_source_snippet.py
@@ -1,0 +1,42 @@
+"""provenance_ledger.source_snippet
+
+Adds the ``source_snippet`` column: a leading slice of the pushed document's
+content, captured at ingest for source previews. Guarded with the inspector
+because ``0001_initial`` builds fresh databases from the current models,
+which already include the column.
+
+Revision ID: a9e2c7f4b1d6
+Revises: 5c4a9e1b7d38
+Create Date: 2026-07-22 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "a9e2c7f4b1d6"
+down_revision: str | Sequence[str] | None = "5c4a9e1b7d38"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("provenance_ledger")}
+    if "source_snippet" in cols:
+        return
+    op.add_column(
+        "provenance_ledger", sa.Column("source_snippet", sa.Text(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns("provenance_ledger")}
+    if "source_snippet" not in cols:
+        return
+    op.drop_column("provenance_ledger", "source_snippet")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1525,6 +1525,7 @@ class ProvenanceLedger(Base):
     source_type: Mapped[str | None] = mapped_column(Text)
     source_url: Mapped[str | None] = mapped_column(Text)
     source_title: Mapped[str | None] = mapped_column(Text)
+    source_snippet: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )

--- a/backend/app/db/provenance.py
+++ b/backend/app/db/provenance.py
@@ -33,6 +33,7 @@ _LEDGER_COLUMNS = (
     "source_type",
     "source_url",
     "source_title",
+    "source_snippet",
     "created_at",
 )
 
@@ -171,6 +172,7 @@ def live_spans_for_doc(doc_path: str, anchor_sha: str) -> list[dict[str, Any]]:
                 ProvenanceLedger.source_type,
                 ProvenanceLedger.source_url,
                 ProvenanceLedger.source_title,
+                ProvenanceLedger.source_snippet,
             )
             .join(ProvenanceLedger, ProvenanceLedger.id == SourceRange.provenance_id)
             .where(

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -84,7 +84,8 @@ class SourceRangeStatus(str, Enum):
 
 class WriteProvenance(BaseModel):
     """Source facts for an ingestion write, threaded through the commit gateway
-    into the provenance ledger. Set only for ingestion writes.
+    into the provenance ledger, and the base every provenance read shape
+    extends. Populated only for ingestion writes.
 
     Field names mirror the ``provenance_ledger`` source columns so the ledger
     insert can spread them.
@@ -115,7 +116,7 @@ class Attribution(WriteProvenance):
 
 class SourceRef(WriteProvenance):
     """One ingested document that has contributed to a page (the Sources tab
-    list). Compact by design: identity and links, no content ranges.
+    list). Identity, links, and the preview snippet, but no content ranges.
     """
 
     last_updated: str

--- a/backend/app/models/wiki.py
+++ b/backend/app/models/wiki.py
@@ -96,25 +96,21 @@ class WriteProvenance(BaseModel):
     source_type: str | None = None
     source_url: str | None = None
     source_title: str | None = None
+    # Leading slice of the pushed document's content, for source previews.
+    source_snippet: str | None = None
 
 
-class Attribution(BaseModel):
+class Attribution(WriteProvenance):
     """Structured provenance for one commit, resolved ledger-first with a git
     author-string parse as the fallback for any commit with no ledger row.
 
-    ``person`` and ``agent`` describe a human or agent write, ``source_*`` an
-    ingestion write.
+    ``person`` and ``agent`` describe a human or agent write, the inherited
+    ``source_*`` facts an ingestion write.
     """
-
-    model_config = ConfigDict(frozen=True)
 
     actor_kind: ActorKind
     person: str | None = None
     agent: str | None = None
-    source_document_id: str | None = None
-    source_type: str | None = None
-    source_url: str | None = None
-    source_title: str | None = None
 
 
 class SourceRef(WriteProvenance):

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -251,6 +251,13 @@ def _current_user_id() -> str:
 _ = CONFIG
 
 
+def _source_snippet(content: str, cap: int = 500) -> str | None:
+    """Leading slice of the pushed content, whitespace-collapsed, for the
+    Sources tab preview."""
+    text = " ".join(content.split())
+    return text[:cap] or None
+
+
 @documents_queue.task()
 def process_pushed_document(push: dict[str, Any]) -> None:
     """Reconcile a connector-pushed document into the wiki (task entry point).
@@ -533,6 +540,7 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
                         source_type=source_type,
                         source_url=url or None,
                         source_title=title or None,
+                        source_snippet=_source_snippet(content),
                     ),
                 )
             except CommitMaxRetriesError:

--- a/backend/tests/test_ingest_pipeline.py
+++ b/backend/tests/test_ingest_pipeline.py
@@ -546,3 +546,14 @@ def test_selector_drop_eval_logged(
     rows = _eval_rows("filtered_by_selector")
     assert len(rows) == 1
     assert rows[0]["wiki_path"] == "page.md"
+
+
+def test_source_snippet_collapses_whitespace_and_caps():
+    from app.tasks.wiki_update import _source_snippet
+
+    assert _source_snippet("  Hello\n\n  world\t twice  ") == "Hello world twice"
+    assert _source_snippet("") is None
+    assert _source_snippet(" \n\t ") is None
+    long = "word " * 200
+    capped = _source_snippet(long)
+    assert capped is not None and len(capped) == 500

--- a/backend/tests/test_source_spans_api.py
+++ b/backend/tests/test_source_spans_api.py
@@ -42,7 +42,13 @@ def _seed_span(source: WriteProvenance) -> None:
 
 def test_source_spans_returns_spans_with_source(client):
     login_fastapi(client, seed_user("u1", email="u1@x.com", name="U"))
-    _seed_span(WriteProvenance(source_document_id="d1", source_title="Src One"))
+    _seed_span(
+        WriteProvenance(
+            source_document_id="d1",
+            source_title="Src One",
+            source_snippet="Alpha beta gamma from the source.",
+        )
+    )
     resp = client.get("/api/wiki/source-spans", params={"path": _PATH})
     assert resp.status_code == 200
     data = resp.json()
@@ -51,6 +57,7 @@ def test_source_spans_returns_spans_with_source(client):
     assert (span["start_offset"], span["end_offset"]) == (0, len(_BODY))
     assert span["source_document_id"] == "d1"
     assert span["source_title"] == "Src One"
+    assert span["source_snippet"] == "Alpha beta gamma from the source."
 
 
 def test_source_spans_empty_for_page_without_ingest(client):

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -178,8 +178,12 @@ export function SourcesPanel({ sources }: Props) {
           </div>
         )}
 
-        {shown.map((s) => (
-          <SourceCard key={sourceKey(s) || s.last_updated} source={s} />
+        {shown.map((s, i) => (
+          // Rows with no identity fields keep distinct keys via the index.
+          <SourceCard
+            key={sourceKey(s) || `${s.last_updated}-${i}`}
+            source={s}
+          />
         ))}
 
         {shown.length > 0 && (

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -60,7 +60,7 @@ function sourceTypeLabel(type: string): string {
 /** Stable card identity, mirroring the backend's dedupe key (document id,
  * falling back to url or title). */
 function sourceKey(s: WriteProvenance): string {
-  return s.source_document_id ?? s.source_url ?? s.source_title ?? "";
+  return s.source_document_id || s.source_url || s.source_title || "";
 }
 
 function SourceCard({ source }: { source: SourceRef }) {
@@ -114,8 +114,8 @@ function SourceCard({ source }: { source: SourceRef }) {
 
 /**
  * Sources tab (mock 1837:103626): the ingested documents credited to this
- * page, each previewing its own content via the snippet captured at ingest.
- * Sources ride the page load, nothing else is fetched.
+ * page, previewing their content via the snippet captured at ingest when
+ * one exists. Sources ride the page load, nothing else is fetched.
  */
 export function SourcesPanel({ sources }: Props) {
   const [query, setQuery] = useState("");

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import useSWR from "swr";
+import { useState } from "react";
 import { Button, EndOfList, Tag, Text } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 import { SvgExternalLink, SvgFileText, SvgGlobe } from "@onyx-ai/opal/icons";
@@ -21,18 +20,12 @@ import {
 } from "@onyx-ai/opal/logos";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 
-import { apiFetch } from "@/lib/api";
 import { relativeTime } from "@/lib/time";
-import type { SourceRef, SourceSpan, WriteProvenance } from "@/types";
+import type { SourceRef, WriteProvenance } from "@/types";
 
 import { PanelSearchField } from "./PanelSearch";
 
 interface Props {
-  path: string;
-  headSha: string | null;
-  /** Page body as served by /wiki/file. It can drift from HEAD (live
-   * co-edit buffer, stale load), so span-offset snippets are best-effort. */
-  body: string;
   sources: SourceRef[];
 }
 
@@ -64,19 +57,13 @@ function sourceTypeLabel(type: string): string {
     .join(" ");
 }
 
-/** Identity used to join a source to its spans, mirroring the backend's
- * dedupe key (document id, falling back to url or title). */
+/** Stable card identity, mirroring the backend's dedupe key (document id,
+ * falling back to url or title). */
 function sourceKey(s: WriteProvenance): string {
   return s.source_document_id ?? s.source_url ?? s.source_title ?? "";
 }
 
-function SourceCard({
-  source,
-  snippet,
-}: {
-  source: SourceRef;
-  snippet: string | undefined;
-}) {
+function SourceCard({ source }: { source: SourceRef }) {
   const Icon = sourceIcon(source.source_type);
   const url = source.source_url;
   return (
@@ -113,10 +100,10 @@ function SourceCard({
             </Text>
           </span>
         </div>
-        {snippet && (
+        {source.source_snippet && (
           <span className="px-1">
             <Text font="secondary-body" color="text-03" maxLines={3}>
-              {snippet}
+              {source.source_snippet}
             </Text>
           </span>
         )}
@@ -127,46 +114,16 @@ function SourceCard({
 
 /**
  * Sources tab (mock 1837:103626): the ingested documents credited to this
- * page, each with the slice of page content its spans cover as a snippet.
- * Sources come with the page load, spans are fetched per head sha since
- * the offsets are remapped to HEAD server-side.
+ * page, each previewing its own content via the snippet captured at ingest.
+ * Sources ride the page load, nothing else is fetched.
  */
-export function SourcesPanel({ path, headSha, body, sources }: Props) {
+export function SourcesPanel({ sources }: Props) {
   const [query, setQuery] = useState("");
-
-  const { data: spans } = useSWR(
-    headSha ? ["/wiki/source-spans", path, headSha] : null,
-    () =>
-      apiFetch<SourceSpan[]>(
-        `/wiki/source-spans?path=${encodeURIComponent(path)}`,
-      ),
-  );
-
-  // First live span per source, as the card's content preview. Spans arrive
-  // ordered by offset, so the preview is the topmost credited slice.
-  const snippets = useMemo(() => {
-    const out = new Map<string, string>();
-    for (const sp of spans ?? []) {
-      const key = sourceKey(sp);
-      if (!key || out.has(key)) continue;
-      const text = body
-        .slice(sp.start_offset, sp.end_offset)
-        .replace(/\s+/g, " ")
-        .trim();
-      if (text) out.set(key, text.slice(0, 280));
-    }
-    return out;
-  }, [spans, body]);
 
   const q = query.trim().toLowerCase();
   const shown = q
     ? sources.filter((s) =>
-        [
-          s.source_title,
-          s.source_url,
-          s.source_type,
-          snippets.get(sourceKey(s)),
-        ]
+        [s.source_title, s.source_url, s.source_type, s.source_snippet]
           .filter(Boolean)
           .join(" ")
           .toLowerCase()
@@ -222,11 +179,7 @@ export function SourcesPanel({ path, headSha, body, sources }: Props) {
         )}
 
         {shown.map((s) => (
-          <SourceCard
-            key={sourceKey(s) || s.last_updated}
-            source={s}
-            snippet={snippets.get(sourceKey(s))}
-          />
+          <SourceCard key={sourceKey(s) || s.last_updated} source={s} />
         ))}
 
         {shown.length > 0 && (

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -23,14 +23,15 @@ import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 
 import { apiFetch } from "@/lib/api";
 import { relativeTime } from "@/lib/time";
-import type { SourceRef, SourceSpan } from "@/types";
+import type { SourceRef, SourceSpan, WriteProvenance } from "@/types";
 
 import { PanelSearchField } from "./PanelSearch";
 
 interface Props {
   path: string;
   headSha: string | null;
-  /** Committed page body, sliced by span offsets for per-source snippets. */
+  /** Page body as served by /wiki/file. It can drift from HEAD (live
+   * co-edit buffer, stale load), so span-offset snippets are best-effort. */
   body: string;
   sources: SourceRef[];
 }
@@ -65,11 +66,7 @@ function sourceTypeLabel(type: string): string {
 
 /** Identity used to join a source to its spans, mirroring the backend's
  * dedupe key (document id, falling back to url or title). */
-function sourceKey(s: {
-  source_document_id: string | null;
-  source_url: string | null;
-  source_title: string | null;
-}): string {
+function sourceKey(s: WriteProvenance): string {
   return s.source_document_id ?? s.source_url ?? s.source_title ?? "";
 }
 

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import useSWR from "swr";
+import { Button, EndOfList, Tag, Text } from "@onyx-ai/opal/components";
+import { Section } from "@onyx-ai/opal/layouts";
+import { SvgExternalLink, SvgFileText, SvgGlobe } from "@onyx-ai/opal/icons";
+import {
+  SvgConfluence,
+  SvgGithub,
+  SvgGmail,
+  SvgGoogleDrive,
+  SvgJira,
+  SvgLinear,
+  SvgNotion,
+  SvgSalesforce,
+  SvgSharepoint,
+  SvgSlack,
+  SvgTeams,
+  SvgZendesk,
+} from "@onyx-ai/opal/logos";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+
+import { apiFetch } from "@/lib/api";
+import { relativeTime } from "@/lib/time";
+import type { SourceRef, SourceSpan } from "@/types";
+
+import { PanelSearchField } from "./PanelSearch";
+
+interface Props {
+  path: string;
+  headSha: string | null;
+  /** Committed page body, sliced by span offsets for per-source snippets. */
+  body: string;
+  sources: SourceRef[];
+}
+
+const SOURCE_ICONS: Record<string, IconFunctionComponent> = {
+  confluence: SvgConfluence,
+  github: SvgGithub,
+  gmail: SvgGmail,
+  google_drive: SvgGoogleDrive,
+  jira: SvgJira,
+  linear: SvgLinear,
+  notion: SvgNotion,
+  salesforce: SvgSalesforce,
+  sharepoint: SvgSharepoint,
+  slack: SvgSlack,
+  teams: SvgTeams,
+  web: SvgGlobe,
+  zendesk: SvgZendesk,
+};
+
+function sourceIcon(type: string | null): IconFunctionComponent {
+  return (type && SOURCE_ICONS[type]) || SvgFileText;
+}
+
+// "google_drive" → "Google Drive", for the connector chip.
+function sourceTypeLabel(type: string): string {
+  return type
+    .split(/[_-]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Identity used to join a source to its spans, mirroring the backend's
+ * dedupe key (document id, falling back to url or title). */
+function sourceKey(s: {
+  source_document_id: string | null;
+  source_url: string | null;
+  source_title: string | null;
+}): string {
+  return s.source_document_id ?? s.source_url ?? s.source_title ?? "";
+}
+
+function SourceCard({
+  source,
+  snippet,
+}: {
+  source: SourceRef;
+  snippet: string | undefined;
+}) {
+  const Icon = sourceIcon(source.source_type);
+  const url = source.source_url;
+  return (
+    <div className="group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00)">
+      <div className="flex min-h-7 items-start gap-1 p-[2px]">
+        <span className="flex size-6 shrink-0 items-center justify-center">
+          <Icon size={16} />
+        </span>
+        <span className="min-w-0 flex-1 px-[2px] pt-[2px]">
+          <Text font="main-ui-action" color="text-04" maxLines={2}>
+            {source.source_title || url || "Untitled source"}
+          </Text>
+        </span>
+        {url && (
+          <span className="invisible shrink-0 group-hover/source:visible">
+            <Button
+              icon={SvgExternalLink}
+              size="md"
+              prominence="tertiary"
+              tooltip="Open"
+              onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
+            />
+          </span>
+        )}
+      </div>
+      <div className="flex flex-col gap-1 px-[2px] pb-1">
+        <div className="flex flex-wrap items-center gap-1">
+          {source.source_type && (
+            <Tag title={sourceTypeLabel(source.source_type)} />
+          )}
+          <span className="px-1">
+            <Text font="secondary-body" color="text-02" nowrap>
+              {relativeTime(source.last_updated)}
+            </Text>
+          </span>
+        </div>
+        {snippet && (
+          <span className="px-1">
+            <Text font="secondary-body" color="text-03" maxLines={3}>
+              {snippet}
+            </Text>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Sources tab (mock 1837:103626): the ingested documents credited to this
+ * page, each with the slice of page content its spans cover as a snippet.
+ * Sources come with the page load, spans are fetched per head sha since
+ * the offsets are remapped to HEAD server-side.
+ */
+export function SourcesPanel({ path, headSha, body, sources }: Props) {
+  const [query, setQuery] = useState("");
+
+  const { data: spans } = useSWR(
+    headSha ? ["/wiki/source-spans", path, headSha] : null,
+    () =>
+      apiFetch<SourceSpan[]>(
+        `/wiki/source-spans?path=${encodeURIComponent(path)}`,
+      ),
+  );
+
+  // First live span per source, as the card's content preview. Spans arrive
+  // ordered by offset, so the preview is the topmost credited slice.
+  const snippets = useMemo(() => {
+    const out = new Map<string, string>();
+    for (const sp of spans ?? []) {
+      const key = sourceKey(sp);
+      if (!key || out.has(key)) continue;
+      const text = body
+        .slice(sp.start_offset, sp.end_offset)
+        .replace(/\s+/g, " ")
+        .trim();
+      if (text) out.set(key, text.slice(0, 280));
+    }
+    return out;
+  }, [spans, body]);
+
+  const q = query.trim().toLowerCase();
+  const shown = q
+    ? sources.filter((s) =>
+        [
+          s.source_title,
+          s.source_url,
+          s.source_type,
+          snippets.get(sourceKey(s)),
+        ]
+          .filter(Boolean)
+          .join(" ")
+          .toLowerCase()
+          .includes(q),
+      )
+    : sources;
+
+  return (
+    <Section
+      justifyContent="start"
+      alignItems="stretch"
+      height="auto"
+      gap={0}
+      padding={0.25}
+      className="min-h-0 flex-1 overflow-clip rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01)"
+    >
+      <Section
+        flexDirection="row"
+        justifyContent="start"
+        alignItems="center"
+        height="fit"
+        gap={0.25}
+        className="shrink-0"
+      >
+        <PanelSearchField
+          value={query}
+          onChange={setQuery}
+          placeholder="Search sources…"
+        />
+      </Section>
+      <Section
+        justifyContent="start"
+        alignItems="stretch"
+        height="auto"
+        gap={0.25}
+        className="scroll-fade-bottom scroll-y-hidden min-h-0 flex-1 overflow-y-auto"
+      >
+        {sources.length === 0 && (
+          <div className="p-3">
+            <Text font="secondary-body" color="text-03">
+              No sources yet. Content ingested from connected apps is credited
+              here.
+            </Text>
+          </div>
+        )}
+
+        {sources.length > 0 && shown.length === 0 && (
+          <div className="p-3">
+            <Text font="secondary-body" color="text-03">
+              No sources match.
+            </Text>
+          </div>
+        )}
+
+        {shown.map((s) => (
+          <SourceCard
+            key={sourceKey(s) || s.last_updated}
+            source={s}
+            snippet={snippets.get(sourceKey(s))}
+          />
+        ))}
+
+        {shown.length > 0 && (
+          <div className="px-4 py-2">
+            <EndOfList
+              title={`${shown.length} Source${shown.length === 1 ? "" : "s"}`}
+            />
+          </div>
+        )}
+      </Section>
+    </Section>
+  );
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -71,6 +71,26 @@ export interface CommentThreadView {
   replies: CommentView[];
 }
 
+/** Source facts shared by every provenance read (backend WriteProvenance). */
+export interface WriteProvenance {
+  source_document_id: string | null;
+  source_type: string | null;
+  source_url: string | null;
+  source_title: string | null;
+}
+
+/** One ingested document credited to a page (the Sources tab list). */
+export interface SourceRef extends WriteProvenance {
+  last_updated: string;
+}
+
+/** A live span of a page mapped to the document it was ingested from.
+ * Offsets are character positions into the page's current body. */
+export interface SourceSpan extends WriteProvenance {
+  start_offset: number;
+  end_offset: number;
+}
+
 export interface DocumentActivityResponse {
   path: string;
   agents: DocumentActivity[];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -85,7 +85,7 @@ export interface SourceRef extends WriteProvenance {
 }
 
 /** A live span of a page mapped to the document it was ingested from.
- * Offsets are character positions into the page's current body. */
+ * Offsets are character positions into the page's body at HEAD. */
 export interface SourceSpan extends WriteProvenance {
   start_offset: number;
   end_offset: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,18 +77,13 @@ export interface WriteProvenance {
   source_type: string | null;
   source_url: string | null;
   source_title: string | null;
+  /** Leading slice of the source document's content, captured at ingest. */
+  source_snippet: string | null;
 }
 
 /** One ingested document credited to a page (the Sources tab list). */
 export interface SourceRef extends WriteProvenance {
   last_updated: string;
-}
-
-/** A live span of a page mapped to the document it was ingested from.
- * Offsets are character positions into the page's body at HEAD. */
-export interface SourceSpan extends WriteProvenance {
-  start_offset: number;
-  end_offset: number;
 }
 
 export interface DocumentActivityResponse {

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -983,12 +983,7 @@ export function FileView({ path }: FileViewProps) {
       case "sources":
         return (
           <div className="flex min-h-0 flex-1 flex-col px-2 py-1">
-            <SourcesPanel
-              path={path}
-              headSha={headSha}
-              body={body}
-              sources={sources}
-            />
+            <SourcesPanel sources={sources} />
           </div>
         );
       case "watching":

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -6,7 +6,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import {
   Button,
   Divider,
-  EmptyMessageCard,
   LineItemButton,
   OpenButton,
   Popover,
@@ -41,6 +40,7 @@ import {
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
+import { SourcesPanel } from "@/components/wiki/SourcesPanel";
 import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
@@ -91,6 +91,7 @@ import type {
   CommentThreadView,
   DocumentActivity,
   DocumentActivityResponse,
+  SourceRef,
 } from "@/types";
 
 // Local shape for the /wiki/file API response — mirrored from page.tsx.
@@ -102,6 +103,8 @@ interface FileResponse {
   // Whether the caller may edit this page. False renders the live session as
   // a pure viewer: read-only editor, no cursor/checkpoint sends.
   can_write?: boolean;
+  /** Ingested documents credited to this page (the Sources tab list). */
+  sources?: SourceRef[];
 }
 
 // Minimal doc-entry shape needed by collectFolders / DestinationSelect.
@@ -176,6 +179,7 @@ export function FileView({ path }: FileViewProps) {
   // pure viewer (read-only editor, no write calls). Optimistic `true` until
   // the read lands; the server rejects any write regardless.
   const [canWrite, setCanWrite] = useState(true);
+  const [sources, setSources] = useState<SourceRef[]>([]);
   const [viewingSha, setViewingSha] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyListOpen, setHistoryListOpen] = useState(false);
@@ -509,6 +513,7 @@ export function FileView({ path }: FileViewProps) {
         setBody(r.body);
         setHeadSha(r.head_sha ?? null);
         setCanWrite(r.can_write ?? true);
+        setSources(r.sources ?? []);
       })
       .catch((e) => setError(e instanceof Error ? e.message : "failed to load"))
       .finally(() => setLoading(false));
@@ -977,12 +982,12 @@ export function FileView({ path }: FileViewProps) {
         );
       case "sources":
         return (
-          <div className="flex flex-1 items-center justify-center p-4">
-            <EmptyMessageCard
-              sizePreset="main-ui"
-              icon={SvgExternalLink}
-              title="Sources"
-              description="Source attribution for this page is coming soon."
+          <div className="flex min-h-0 flex-1 flex-col px-2 py-1">
+            <SourcesPanel
+              path={path}
+              headSha={headSha}
+              body={body}
+              sources={sources}
             />
           </div>
         );


### PR DESCRIPTION
## Description

Replaces the Sources tab placeholder with the mock's list mode (Figma 1837:103626).

- One card per distinct ingested document: connector icon, title, type chip, relative time, hover-revealed Open link.
- Card snippet is the source document's own content: ingestion captures a 500-char leading slice into `provenance_ledger.source_snippet` (new nullable column + migration), returned by both provenance read paths. `Attribution` now extends `WriteProvenance` instead of duplicating its fields.
- Sources ride the existing `/wiki/file` response. Client-side search filter and a sources count footer.
- Not in this PR (data gaps): Folder/Tag/Channel/person chips from the mock are not stored, per-site favicons for web sources, and the anchored mode + toggle (follow-up).

## How Has This Been Tested?

## Additional Options
- [ ] This PR should be cherry-picked into the latest release branch
- [x] Override Linear Check