### PR TITLE
feat(wiki): retire_page — trash-move a page while forwarding its identity

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -192,11 +192,16 @@ def resolve_doc_id(
 ) -> ResolveDocIdResponse:
     """Resolve a stable doc id to its current binding — the id-URL entry point.
 
+    A retired id (page merged into a survivor) forwards: resolution lands on
+    the surviving document, so old links keep working. Otherwise
     ``deleted_at`` set means the page/folder was trashed; ``path`` is where it
     lived, for the tombstone/restore surfaces. 404 for an unknown id."""
-    row = doc_ids.get(doc_id)
+    row = doc_ids.resolve(doc_id)
     if row is None:
         raise HTTPException(status_code=404, detail="unknown id")
+    # A forward landed us on the survivor — respond with *its* id so the
+    # client canonicalizes its URL to the live document.
+    doc_id = str(row["id"])
     # Stored paths are app-generated from validated values, but re-validate
     # before the ACL check so this endpoint matches every other read path.
     try:

--- a/backend/app/db/migrations/versions/a7d31f92c8e4_doc_id_forwarding.py
+++ b/backend/app/db/migrations/versions/a7d31f92c8e4_doc_id_forwarding.py
@@ -1,0 +1,31 @@
+"""wiki_doc_ids.forwarded_to — retired ids resolve to the surviving document
+
+Revision ID: a7d31f92c8e4
+Revises: 5c4a9e1b7d38
+Create Date: 2026-07-22
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a7d31f92c8e4"
+down_revision = "5c4a9e1b7d38"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The bootstrap migration materializes current models via create_all, so a
+    # fresh database already has this column — only pre-existing deployments
+    # need the ALTER.
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("wiki_doc_ids")}
+    if "forwarded_to" not in cols:
+        op.add_column(
+            "wiki_doc_ids", sa.Column("forwarded_to", sa.Text(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("wiki_doc_ids", "forwarded_to")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1298,6 +1298,10 @@ class WikiDocId(Base):
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
     deleted_at: Mapped[str | None] = mapped_column(Text)
+    # When a page is retired into a surviving page (merge), its tombstone row
+    # points at the survivor's id: the retired id keeps resolving — forwarded
+    # to the surviving document instead of dead-ending at a tombstone.
+    forwarded_to: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -72,11 +72,15 @@ def set_forward(source_id: str, target_id: str) -> None:
     Called by the retire flow after the source page was trash-moved (its row
     is already a tombstone). The row keeps resolving — via :func:`resolve` —
     to the survivor instead of dead-ending at the tombstone. No-op if the
-    source row is missing; self-forwarding is refused.
+    source row is missing; self-forwarding and an unknown target are refused
+    (a dangling forward would silently defeat the retirement — the id would
+    resolve to the tombstone instead of the survivor).
     """
     if source_id == target_id:
         raise ValueError("a document cannot forward to itself")
     with session() as s:
+        if s.get(WikiDocId, target_id) is None:
+            raise ValueError(f"unknown forward target id: {target_id!r}")
         row = s.get(WikiDocId, source_id)
         if row is None:
             log.warning("set_forward: unknown source id %s", source_id)
@@ -91,20 +95,24 @@ def resolve(doc_id: str) -> dict[str, str | None] | None:
     A retired into B then B into C resolves to C). Unknown id → ``None``; a
     dangling or cyclic forward stops at the last reachable row.
     """
-    row = get(doc_id)
-    if row is None:
-        return None
-    seen = {doc_id}
-    for _ in range(_MAX_FORWARD_HOPS):
-        fwd = row["forwarded_to"]
-        if fwd is None or fwd in seen:
-            return row
-        nxt = get(fwd)
-        if nxt is None:
-            return row  # dangling forward — the tombstone is the best answer
-        seen.add(fwd)
-        row = nxt
-    return row
+    # One session for the whole walk — a chain must not cost a connection
+    # checkout per hop.
+    with session() as s:
+        row = s.get(WikiDocId, doc_id)
+        if row is None:
+            return None
+        seen = {doc_id}
+        for _ in range(_MAX_FORWARD_HOPS):
+            fwd = row.forwarded_to
+            if fwd is None or fwd in seen:
+                return _row_dict(row)
+            nxt = s.get(WikiDocId, fwd)
+            if nxt is None:
+                # Dangling forward — the tombstone is the best answer.
+                return _row_dict(row)
+            seen.add(fwd)
+            row = nxt
+        return _row_dict(row)
 
 
 def id_for_path(path: str) -> str | None:

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -49,6 +49,7 @@ def _row_dict(row: WikiDocId) -> dict[str, str | None]:
         "kind": row.kind,
         "created_at": row.created_at,
         "deleted_at": row.deleted_at,
+        "forwarded_to": row.forwarded_to,
     }
 
 
@@ -57,6 +58,53 @@ def get(doc_id: str) -> dict[str, str | None] | None:
     with session() as s:
         row = s.get(WikiDocId, doc_id)
         return _row_dict(row) if row else None
+
+
+# Forward chains are one hop per retire; a long chain means repeated merges.
+# The cap only bounds pathological data (a cycle written by hand) — followers
+# stop and treat the last row reached as terminal.
+_MAX_FORWARD_HOPS = 10
+
+
+def set_forward(source_id: str, target_id: str) -> None:
+    """Point a retired id at the surviving document's id.
+
+    Called by the retire flow after the source page was trash-moved (its row
+    is already a tombstone). The row keeps resolving — via :func:`resolve` —
+    to the survivor instead of dead-ending at the tombstone. No-op if the
+    source row is missing; self-forwarding is refused.
+    """
+    if source_id == target_id:
+        raise ValueError("a document cannot forward to itself")
+    with session() as s:
+        row = s.get(WikiDocId, source_id)
+        if row is None:
+            log.warning("set_forward: unknown source id %s", source_id)
+            return
+        row.forwarded_to = target_id
+
+
+def resolve(doc_id: str) -> dict[str, str | None] | None:
+    """The row for ``doc_id`` with forwards followed to the terminal document.
+
+    A retired id resolves to the survivor it was merged into (transitively —
+    A retired into B then B into C resolves to C). Unknown id → ``None``; a
+    dangling or cyclic forward stops at the last reachable row.
+    """
+    row = get(doc_id)
+    if row is None:
+        return None
+    seen = {doc_id}
+    for _ in range(_MAX_FORWARD_HOPS):
+        fwd = row["forwarded_to"]
+        if fwd is None or fwd in seen:
+            return row
+        nxt = get(fwd)
+        if nxt is None:
+            return row  # dangling forward — the tombstone is the best answer
+        seen.add(fwd)
+        row = nxt
+    return row
 
 
 def id_for_path(path: str) -> str | None:
@@ -243,3 +291,5 @@ def on_restored(paths: list[str]) -> None:
             ).scalar_one_or_none()
             if row is not None:
                 row.deleted_at = None
+                # A restored document is live again; it no longer forwards.
+                row.forwarded_to = None

--- a/backend/app/wiki/retire.py
+++ b/backend/app/wiki/retire.py
@@ -4,19 +4,23 @@ Retiring is what distinguishes "these two paths are the same document,
 consolidate them" from a plain delete: the source page is trash-moved (so the
 retire stays losslessly restorable, like every delete), but its *identity*
 survives — the stable doc id forwards to the surviving page, so old links and
-bookmarks resolve to the survivor instead of a tombstone, and its comment
-threads re-anchor to the survivor instead of riding into the trash.
+bookmarks resolve to the survivor instead of a tombstone.
 
 Content is out of scope here: whoever calls this has already decided what the
-surviving page's body should be (and written it, if it changed). This module
-only retires the redundant path and forwards its references.
+surviving page's body should be (and written it, if it changed). Comments are
+also out of scope — they follow the standard trash lifecycle with the page.
+Re-anchoring them onto the survivor is only sound when the two bodies are
+identical (inline anchors are character offsets into a specific body), so a
+caller in that position may re-anchor explicitly via
+``comments.reassign_doc_path``; anything smarter is a semantic re-anchor and
+belongs to the LLM-assisted merge flow.
 """
 from __future__ import annotations
 
 import logging
 
 from app.models.wiki import PathMove
-from app.wiki import comments, doc_ids, git, notify, trash
+from app.wiki import doc_ids, git, notify, trash
 from app.wiki.filesystem import safe_rel_path
 
 log = logging.getLogger(__name__)
@@ -26,16 +30,11 @@ def retire_page(source: str, target: str, *, author: str | None = None) -> str:
     """Trash-move ``source`` and forward its identity to ``target``.
 
     Both must be tracked ``.md`` pages. Returns the commit SHA of the
-    trash-move. Side effects beyond the standard trash lifecycle
-    (``after_doc_trashed``: ACL/policy re-point to trash, search/live drop):
-
-    - the source's doc id forwards to the target's id — ``doc_ids.resolve``
-      (and the id-URL endpoint) lands on the survivor;
-    - the source's comment threads re-anchor to the target path.
-
-    Restoring the source from Trash undoes the forward (the id re-binds to
-    the restored page); re-anchored comments deliberately stay with the
-    survivor — they were conversations about content that now lives there.
+    trash-move. Beyond the standard trash lifecycle (``after_doc_trashed``:
+    ACL/policy/comments re-point to trash, search/live drop), the source's doc
+    id forwards to the target's id — ``doc_ids.resolve`` (and the id-URL
+    endpoint) lands on the survivor. Restoring the source from Trash undoes
+    the forward (the id re-binds to the restored page).
     """
     src = safe_rel_path(source)
     tgt = safe_rel_path(target)
@@ -61,15 +60,8 @@ def retire_page(source: str, target: str, *, author: str | None = None) -> str:
     notify.after_doc_trashed(
         moves, sha, author, root_move=PathMove(old=src, new=dest)
     )
-    # The standard trash lifecycle carried the comments to the trash path and
-    # tombstoned the id; the retire deltas redirect both at the survivor.
-    moved = comments.reassign_doc_path(dest, tgt)
+    # The standard trash lifecycle tombstoned the id; the retire delta points
+    # it at the survivor.
     doc_ids.set_forward(source_id, target_id)
-    log.info(
-        "retire: %s -> %s (sha=%s, comments re-anchored=%d)",
-        src,
-        tgt,
-        sha[:8],
-        moved,
-    )
+    log.info("retire: %s -> %s (sha=%s)", src, tgt, sha[:8])
     return sha

--- a/backend/app/wiki/retire.py
+++ b/backend/app/wiki/retire.py
@@ -35,6 +35,13 @@ def retire_page(source: str, target: str, *, author: str | None = None) -> str:
     id forwards to the target's id — ``doc_ids.resolve`` (and the id-URL
     endpoint) lands on the survivor. Restoring the source from Trash undoes
     the forward (the id re-binds to the restored page).
+
+    Not transactional across the git commit and the two DB effects: a crash
+    after the trash-move but before ``set_forward`` leaves an ordinary
+    tombstone (old links get the tombstone instead of the survivor — degraded,
+    not corrupt), restorable from Trash like any delete. A retry of the whole
+    retire fails validation (the source is no longer tracked); recovery is
+    restore-then-retire or a manual ``set_forward``.
     """
     src = safe_rel_path(source)
     tgt = safe_rel_path(target)

--- a/backend/app/wiki/retire.py
+++ b/backend/app/wiki/retire.py
@@ -1,0 +1,75 @@
+"""Retire a page into a surviving page — the identity-forwarding half of a merge.
+
+Retiring is what distinguishes "these two paths are the same document,
+consolidate them" from a plain delete: the source page is trash-moved (so the
+retire stays losslessly restorable, like every delete), but its *identity*
+survives — the stable doc id forwards to the surviving page, so old links and
+bookmarks resolve to the survivor instead of a tombstone, and its comment
+threads re-anchor to the survivor instead of riding into the trash.
+
+Content is out of scope here: whoever calls this has already decided what the
+surviving page's body should be (and written it, if it changed). This module
+only retires the redundant path and forwards its references.
+"""
+from __future__ import annotations
+
+import logging
+
+from app.models.wiki import PathMove
+from app.wiki import comments, doc_ids, git, notify, trash
+from app.wiki.filesystem import safe_rel_path
+
+log = logging.getLogger(__name__)
+
+
+def retire_page(source: str, target: str, *, author: str | None = None) -> str:
+    """Trash-move ``source`` and forward its identity to ``target``.
+
+    Both must be tracked ``.md`` pages. Returns the commit SHA of the
+    trash-move. Side effects beyond the standard trash lifecycle
+    (``after_doc_trashed``: ACL/policy re-point to trash, search/live drop):
+
+    - the source's doc id forwards to the target's id — ``doc_ids.resolve``
+      (and the id-URL endpoint) lands on the survivor;
+    - the source's comment threads re-anchor to the target path.
+
+    Restoring the source from Trash undoes the forward (the id re-binds to
+    the restored page); re-anchored comments deliberately stay with the
+    survivor — they were conversations about content that now lives there.
+    """
+    src = safe_rel_path(source)
+    tgt = safe_rel_path(target)
+    if src == tgt:
+        raise ValueError("source and target are the same page")
+    if not src.endswith(".md") or not tgt.endswith(".md"):
+        raise ValueError("retire_page operates on .md pages")
+    tracked = set(git.list_paths())
+    if src not in tracked:
+        raise ValueError(f"source page not found: {src!r}")
+    if tgt not in tracked:
+        raise ValueError(f"target page not found: {tgt!r}")
+
+    # Capture both ids while the source is still live — the trash-move
+    # tombstones its row, and a tombstone can't be minted for.
+    source_id = doc_ids.get_or_mint(src)
+    target_id = doc_ids.get_or_mint(tgt)
+
+    dest = trash.trash_location(trash.new_trash_id(), src)
+    sha, moves = git.move_path(
+        src, dest, f"Retire {src} into {tgt}", author=author
+    )
+    notify.after_doc_trashed(
+        moves, sha, author, root_move=PathMove(old=src, new=dest)
+    )
+    # The standard trash lifecycle carried the comments to the trash path and
+    # tombstoned the id; the retire deltas redirect both at the survivor.
+    moved = comments.reassign_doc_path(dest, tgt)
+    doc_ids.set_forward(source_id, target_id)
+    log.info(
+        "retire: %s -> %s (sha=%s, comments re-anchored=%d)",
+        src,
+        tgt,
+        sha[:8],
+        moved,
+    )
+    return sha

--- a/backend/tests/test_retire_page.py
+++ b/backend/tests/test_retire_page.py
@@ -1,17 +1,16 @@
 """Retire a page into a survivor — trash-move + identity forwarding.
 
 The retire keeps the standard trash lifecycle (restorable, drops from
-search/live) but redirects the page's *references* at the survivor: the doc
-id forwards and comment threads re-anchor.
+search/live, comments ride to trash with the page) and adds one delta: the
+doc id forwards to the survivor.
 """
 from __future__ import annotations
 
 import pytest
 
 from app.models.wiki import PathMove
-from app.wiki import comments, doc_ids, notify, retire, trash
+from app.wiki import doc_ids, notify, retire, trash
 from app.wiki import git as wiki_git
-from tests._seed import seed_user
 
 
 @pytest.fixture
@@ -74,27 +73,6 @@ def test_forward_cycle_stops_instead_of_looping(repo):
     resolved = doc_ids.resolve(a)
     assert resolved is not None
     assert resolved["id"] in {a, b}
-
-
-def test_comments_reanchor_to_the_survivor(repo):
-    uid = seed_user(uid="u1", email="u@x.com")
-    comments.create_thread(
-        doc_path="docs/dup.md",
-        body="does this apply to v2?",
-        author_user_id=uid,
-        anchor_sha=None,
-        start_offset=None,
-        end_offset=None,
-        quoted_text=None,
-        scope="page",
-    )
-
-    retire.retire_page("docs/dup.md", "docs/kept.md")
-
-    assert comments.list_for_doc("docs/dup.md") == []
-    moved = comments.list_for_doc("docs/kept.md")
-    assert len(moved) == 1
-    assert moved[0]["body"] == "does this apply to v2?"
 
 
 def test_restore_from_trash_clears_the_forward(repo):

--- a/backend/tests/test_retire_page.py
+++ b/backend/tests/test_retire_page.py
@@ -1,0 +1,137 @@
+"""Retire a page into a survivor — trash-move + identity forwarding.
+
+The retire keeps the standard trash lifecycle (restorable, drops from
+search/live) but redirects the page's *references* at the survivor: the doc
+id forwards and comment threads re-anchor.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.models.wiki import PathMove
+from app.wiki import comments, doc_ids, notify, retire, trash
+from app.wiki import git as wiki_git
+from tests._seed import seed_user
+
+
+@pytest.fixture
+def repo(tmp_repo):
+    wiki_git.commit_file("docs/kept.md", "# Kept\n", "seed", author=None)
+    wiki_git.commit_file("docs/dup.md", "# Dup\n", "seed", author=None)
+    return tmp_repo
+
+
+def test_retire_trashes_source_and_keeps_target(repo):
+    sha = retire.retire_page("docs/dup.md", "docs/kept.md")
+
+    assert sha
+    paths = list(wiki_git.list_paths())
+    assert "docs/dup.md" not in paths
+    assert "docs/kept.md" in paths
+    # The source rode into the (list_paths-hidden) trash tree, restorable.
+    assert any(
+        p.endswith("/docs/dup.md") for p in wiki_git.list_trash_files()
+    )
+
+
+def test_retired_id_resolves_to_the_survivor(repo):
+    dup_id = doc_ids.get_or_mint("docs/dup.md")
+    kept_id = doc_ids.get_or_mint("docs/kept.md")
+
+    retire.retire_page("docs/dup.md", "docs/kept.md")
+
+    resolved = doc_ids.resolve(dup_id)
+    assert resolved is not None
+    assert resolved["id"] == kept_id
+    assert resolved["path"] == "docs/kept.md"
+    assert resolved["deleted_at"] is None  # landed on a live document
+    # The raw row is still the tombstone — resolve is what follows the forward.
+    raw = doc_ids.get(dup_id)
+    assert raw is not None and raw["deleted_at"] is not None
+    assert raw["forwarded_to"] == kept_id
+
+
+def test_forward_chain_resolves_transitively(repo):
+    wiki_git.commit_file("docs/final.md", "# Final\n", "seed", author=None)
+    a = doc_ids.get_or_mint("docs/dup.md")
+    final_id = doc_ids.get_or_mint("docs/final.md")
+
+    retire.retire_page("docs/dup.md", "docs/kept.md")  # A -> B
+    retire.retire_page("docs/kept.md", "docs/final.md")  # B -> C
+
+    resolved = doc_ids.resolve(a)
+    assert resolved is not None
+    assert resolved["id"] == final_id  # A follows through B to C
+
+
+def test_forward_cycle_stops_instead_of_looping(repo):
+    a = doc_ids.get_or_mint("docs/dup.md")
+    b = doc_ids.get_or_mint("docs/kept.md")
+    # Hand-corrupted state: a cycle. resolve must terminate.
+    doc_ids.set_forward(a, b)
+    doc_ids.set_forward(b, a)
+
+    resolved = doc_ids.resolve(a)
+    assert resolved is not None
+    assert resolved["id"] in {a, b}
+
+
+def test_comments_reanchor_to_the_survivor(repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    comments.create_thread(
+        doc_path="docs/dup.md",
+        body="does this apply to v2?",
+        author_user_id=uid,
+        anchor_sha=None,
+        start_offset=None,
+        end_offset=None,
+        quoted_text=None,
+        scope="page",
+    )
+
+    retire.retire_page("docs/dup.md", "docs/kept.md")
+
+    assert comments.list_for_doc("docs/dup.md") == []
+    moved = comments.list_for_doc("docs/kept.md")
+    assert len(moved) == 1
+    assert moved[0]["body"] == "does this apply to v2?"
+
+
+def test_restore_from_trash_clears_the_forward(repo):
+    dup_id = doc_ids.get_or_mint("docs/dup.md")
+    retire.retire_page("docs/dup.md", "docs/kept.md")
+
+    # Restore exactly as the API route does: git move back, re-point
+    # metadata, re-bind the tombstoned ids.
+    entry = next(
+        e for e in trash.list_entries() if e.original_path == "docs/dup.md"
+    )
+    sha, moves = wiki_git.restore_from_trash(entry.trash_id, "restore", author=None)
+    notify.after_path_move(
+        moves,
+        sha,
+        None,
+        root_move=PathMove(
+            old=trash.trash_location(entry.trash_id, entry.original_path),
+            new=entry.original_path,
+        ),
+    )
+    doc_ids.on_restored([mv.new for mv in moves])
+
+    assert "docs/dup.md" in wiki_git.list_paths()  # back from trash
+    resolved = doc_ids.resolve(dup_id)
+    assert resolved is not None
+    assert resolved["id"] == dup_id  # live again, no forward followed
+    assert resolved["path"] == "docs/dup.md"
+    assert resolved["forwarded_to"] is None
+
+
+def test_retire_validations(repo):
+    with pytest.raises(ValueError, match="same page"):
+        retire.retire_page("docs/dup.md", "docs/dup.md")
+    with pytest.raises(ValueError, match="not found"):
+        retire.retire_page("docs/missing.md", "docs/kept.md")
+    with pytest.raises(ValueError, match="not found"):
+        retire.retire_page("docs/dup.md", "docs/missing.md")
+    with pytest.raises(ValueError, match=r"\.md"):
+        retire.retire_page("docs", "docs/kept.md")

--- a/backend/tests/test_retire_page.py
+++ b/backend/tests/test_retire_page.py
@@ -104,6 +104,14 @@ def test_restore_from_trash_clears_the_forward(repo):
     assert resolved["forwarded_to"] is None
 
 
+def test_set_forward_refuses_unknown_target(repo):
+    # A dangling forward would silently defeat the retirement (the id would
+    # resolve to the tombstone, not the survivor) — refused up front.
+    a = doc_ids.get_or_mint("docs/dup.md")
+    with pytest.raises(ValueError, match="unknown forward target"):
+        doc_ids.set_forward(a, "no-such-id")
+
+
 def test_retire_validations(repo):
     with pytest.raises(ValueError, match="same page"):
         retire.retire_page("docs/dup.md", "docs/dup.md")


### PR DESCRIPTION
PR A of the execution work: the one genuinely new mechanical capability the agentic executor needs, shipped standalone and inert (no callers yet).

**What it is.** `retire_page(source, target)` retires a redundant page into a survivor — the identity-forwarding half of a merge, distinct from a plain delete:

- **Standard trash lifecycle** — source is trash-moved (losslessly restorable), ACL/policy/comments re-point to trash, dropped from search/live.
- **Doc-id forwarding (the new capability)** — `wiki_doc_ids` gains a nullable `forwarded_to`; the retired id keeps resolving, *to the survivor*: `doc_ids.resolve()` follows forward chains (transitive across repeated merges, hop-capped so hand-corrupted cycles terminate), and `GET /wiki/id/{id}` returns the surviving document (with its canonical id, so clients re-canonicalize their URL). Old links/bookmarks to the retired page keep working instead of dead-ending at a tombstone.
- **Restore undoes the forward** — restoring the source from Trash re-binds its id (clears `forwarded_to`).

**Deliberately out of scope:** content (the caller decides the surviving body) and **comment re-anchoring** — moving threads onto the survivor is only sound when the two bodies are byte-identical (inline anchors are offsets into a specific body), so comments follow the standard trash lifecycle; an identical-bodies caller can re-anchor explicitly via `comments.reassign_doc_path`, and anything smarter is a semantic re-anchor for the LLM-assisted merge flow.

First consumer is the upcoming agentic execution of merge proposals (next PR).

**Migration** is inspector-guarded (the bootstrap migration's `create_all` already materializes the column on fresh databases).

**Tests** (6): trash + survivor intact, retired id resolves to survivor (raw row stays a tombstone), transitive chain A→B→C, cycle termination, restore clears the forward, validation errors. Regressions: doc-ids (19), trash (26), comments repo+API (29) green; ruff + basedpyright clean.