### PR TITLE
feat(coedit): migrate live-session transport from SSE+HTTP to WebSocket

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,6 +325,28 @@ code — domain exceptions (`HTTPException`, `PermissionDenied`,
 installed in `app/main.py:_install_error_handlers`. The frontend's
 `ApiError` parses this shape.
 
+### WebSocket routes — asyncio is transport-only
+
+A `@router.websocket(...)` handler's own `async def` body is for connection
+lifecycle (accept, receive/send loops, task orchestration) — nothing more.
+Every call into domain logic (`require_can`, an ORM repo function, a git
+read, `apply_op`, ...) is blocking and must go through `asyncio.to_thread`;
+it does not get FastAPI's automatic threadpool dispatch the way a plain
+`def` HTTP route does, so an un-offloaded blocking call stalls the event
+loop for every other WebSocket connection sharing this process, not just
+the one making the call. See `app/api/coedit.py` (`ws`, `_recv_loop`,
+`_send_loop`, and the `_connect_sync`/`_disconnect_sync`/`_handle_*` helper
+functions they wrap in `asyncio.to_thread`) as the canonical example: the
+helpers themselves are plain sync functions, unaware they're being called
+from an async context at all.
+
+Also watch the send side specifically: if more than one task can write to
+the same `WebSocket` (e.g. a receive loop replying directly *and* a
+separate broadcast-drain loop), route every outbound frame through one
+queue drained by a single writer task instead — two tasks calling
+`send_json` concurrently on one socket races the frame order and risks
+corrupting the write.
+
 ## Frontend rules
 
 See `frontend/AGENTS.md` for the complete frontend guide: directory layout,

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -135,21 +135,21 @@ def _handle_op(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, u
             client_id=msg.client_id,
         )
     except _WsActionError as e:
-        outbox.put_nowait(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump())
+        outbox.put_nowait(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(by_alias=True))
         return
     except ValueError:
         outbox.put_nowait(
-            OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump()
+            OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump(by_alias=True)
         )
         return
     if out is None:
         outbox.put_nowait(
-            OpResultFrame(request_id=msg.request_id, ok=False, error="stale_version").model_dump()
+            OpResultFrame(request_id=msg.request_id, ok=False, error="stale_version").model_dump(by_alias=True)
         )
         return
     coedit.touch(session_id, user.id, edited=True)
     outbox.put_nowait(
-        OpResultFrame(request_id=msg.request_id, ok=True, version=out.version).model_dump()
+        OpResultFrame(request_id=msg.request_id, ok=True, version=out.version).model_dump(by_alias=True)
     )
     # caret_seq rides the frame so peers render the author's caret at the
     # edit; None (cleared caret / legacy client) = no caret assertion.
@@ -191,10 +191,10 @@ def _handle_checkpoint(outbox: queue.Queue[coedit_channel.QueueItem], session_id
     try:
         _require_active(session_id, user, "write")
     except _WsActionError:
-        outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=False).model_dump())
+        outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=False).model_dump(by_alias=True))
         return
     checkpoint_coedit_session(session_id)
-    outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=True).model_dump())
+    outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=True).model_dump(by_alias=True))
 
 
 def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
@@ -205,7 +205,7 @@ def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: i
         outbox.put_nowait(
             OpsResultFrame(
                 request_id=msg.request_id, ok=False, error=e.error, current_head_version=0, ops=[]
-            ).model_dump()
+            ).model_dump(by_alias=True)
         )
         return
     # Head version + ops read as one consistent snapshot (see
@@ -227,7 +227,7 @@ def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: i
                 )
                 for r in result.ops
             ],
-        ).model_dump()
+        ).model_dump(by_alias=True)
     )
 
 
@@ -365,7 +365,7 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
                 version=sess.version,
                 base_sha=sess.base_sha,
                 participants=participants,
-            ).model_dump()
+            ).model_dump(by_alias=True)
         )
 
         recv_task = asyncio.create_task(_recv_loop(websocket, conn.queue, sess.id, user))

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -253,17 +253,39 @@ async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[dict[str, Any]], 
             log.warning("coedit ws: malformed %r message", msg_type)
 
 
+# How often _send_loop's blocking drain call returns to check for
+# cancellation. Short on purpose: asyncio.to_thread cancellation only
+# unblocks the *awaiting* coroutine, not the underlying OS thread still
+# parked in queue.Queue.get(timeout=...) — found the hard way, in
+# production, not just in theory. Every disconnect (a WS closes, we
+# reconnect) cancels this task; with a long timeout, the orphaned thread
+# lingers for up to that long, still holding a slot in the shared default
+# thread pool every asyncio.to_thread call in the process draws from. Under
+# frequent reconnects, orphaned threads accumulate faster than they drain,
+# eventually exhausting the pool — at which point *every* asyncio.to_thread
+# call across the whole backend (new connects, every op/cursor/checkpoint
+# message, for every session) queues for a free worker. That reads as "the
+# whole app froze," and can plausibly cause more disconnects itself (a
+# starved event loop can miss uvicorn's own ping/pong window and get
+# closed as unresponsive) — a self-reinforcing spiral. Bounding the poll to
+# ~1s bounds any orphaned thread's worst case to ~1s instead of 15.
+_SEND_LOOP_POLL_SECONDS = 1.0
+
+
 async def _send_loop(
     websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user_id: str
 ) -> None:
+    idle_elapsed = 0.0
     while True:
-        # coedit_channel.drain blocks synchronously on a queue.Queue — offload
-        # to a thread so it doesn't stall the event loop the recv side shares.
-        frame = await asyncio.to_thread(coedit_channel.drain, conn.queue, _HEARTBEAT_SECONDS)
+        frame = await asyncio.to_thread(coedit_channel.drain, conn.queue, _SEND_LOOP_POLL_SECONDS)
         if frame is None:
-            await asyncio.to_thread(coedit.touch, session_id, user_id)
-            await websocket.send_json({"type": "ping"})
+            idle_elapsed += _SEND_LOOP_POLL_SECONDS
+            if idle_elapsed >= _HEARTBEAT_SECONDS:
+                idle_elapsed = 0.0
+                await asyncio.to_thread(coedit.touch, session_id, user_id)
+                await websocket.send_json({"type": "ping"})
             continue
+        idle_elapsed = 0.0
         await websocket.send_json(frame)
 
 

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -4,6 +4,14 @@ broadcast layer (``app/wiki/coedit_channel.py``) every message type in this
 module shares. See ``plans/coedit-websocket-transport.md`` (if present) or
 the originating conversation for the design rationale.
 
+The first ``asyncio`` in this backend, scoped deliberately: ``async`` here
+covers connection lifecycle only (accept, the recv/send loops, task
+orchestration) — every ``_connect_sync``/``_disconnect_sync``/``_handle_*``
+helper below is a plain sync function, run via ``asyncio.to_thread`` from
+the loops, with no idea it's being called from an async context at all. See
+CLAUDE.md's "WebSocket routes" rule before adding another route like this
+one.
+
 A "co-edit session" is the page's *live session*: everyone viewing the page
 joins it (read-gated — presence + real-time updates), and editing is a
 capability inside it (``op``/``cursor``/``checkpoint`` messages are

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -1,25 +1,21 @@
 """The page live-session channel — one WebSocket per session (cookie-authed
-humans). Pure transport swap from the old SSE-down + HTTP-POST-up protocol:
-same JSON message shapes, same domain logic (``app/wiki/coedit.py``), same
-broadcast layer (``app/wiki/coedit_channel.py``) — only the wire mechanism
-changed. See ``plans/coedit-websocket-transport.md`` (if present) or the
-originating conversation for the design rationale.
+humans), driving the same domain logic (``app/wiki/coedit.py``) and
+broadcast layer (``app/wiki/coedit_channel.py``) every message type in this
+module shares. See ``plans/coedit-websocket-transport.md`` (if present) or
+the originating conversation for the design rationale.
 
 A "co-edit session" is the page's *live session*: everyone viewing the page
 joins it (read-gated — presence + real-time updates), and editing is a
 capability inside it (``op``/``cursor``/``checkpoint`` messages are
-write-gated, re-checked on *every* message, not just at connect — mirrors
-the old per-POST ``require_can`` exactly, so a mid-session ACL change still
-takes effect). Presence labels editors vs viewers client-side from the live
-caret frames — a rendered caret IS the "editing" state; the server stores
-nothing for it.
+write-gated, re-checked on *every* message, not just at connect, so a
+mid-session ACL change takes effect immediately). Presence labels editors
+vs viewers client-side from the live caret frames — a rendered caret IS the
+"editing" state; the server stores nothing for it.
 
 No client-sent "leave" message: the server's disconnect handler (``finally``
 below) is the sole leave signal, firing on any connection loss — explicit
-close, network drop, or a killed tab's socket dying — which is *more*
-reliable than the old design's client-initiated ``fetch(..., {keepalive:
-true})`` on unload, since it never depends on the client successfully
-transmitting anything during teardown.
+close, network drop, or a killed tab's socket dying — which doesn't depend
+on the client successfully transmitting anything during teardown.
 """
 
 from __future__ import annotations
@@ -53,8 +49,7 @@ router = APIRouter()
 log = logging.getLogger(__name__)
 
 # Idle silence before the send loop touches presence liveness + pings the
-# client — matches the old SSE heartbeat cadence, so proxies see the same
-# idle behavior either way.
+# client, so proxies don't consider the connection idle.
 _HEARTBEAT_SECONDS = 15.0
 
 
@@ -89,8 +84,8 @@ def _checkpoint_if_last_left(session_id: int) -> None:
 class _WsActionError(Exception):
     """Internal — a write/read re-check failed for one inbound message.
     Caught per-handler and turned into a correlated error reply so the
-    *connection* stays open (mirrors the old design: a single 403/404 on one
-    POST never killed the SSE stream either)."""
+    *connection* stays open — a rejected message is a per-message failure,
+    not a reason to tear down the whole session."""
 
     def __init__(self, error: str) -> None:
         self.error = error
@@ -161,9 +156,9 @@ def _handle_op(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User,
 
 
 def _handle_cursor(session_id: int, user: User, raw: dict[str, Any]) -> None:
-    """Fire-and-forget — matches the old client's ``sendCursor(...).catch(()
-    => {})``: a rejected/failed cursor ping is silently dropped, never
-    surfaced, since the next throttled ping self-heals it."""
+    """Fire-and-forget: a rejected/failed cursor ping is silently dropped,
+    never surfaced to the client, since the next throttled ping self-heals
+    it (matches ``svc.ts``'s ``sendCursor``, which doesn't await a reply)."""
     msg = CursorMessage.model_validate(raw)
     try:
         _require_active(session_id, user, "write")
@@ -236,9 +231,9 @@ async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[dict[str, Any]], 
             # Every handler below makes blocking DB calls (require_can,
             # coedit.apply_op, ...) — offloaded to a thread so one session's
             # DB round-trip doesn't stall every other WS connection sharing
-            # this event loop. The old REST handlers got this for free (a
-            # plain `def` FastAPI route runs in a threadpool automatically);
-            # a sync call made *from inside* an `async def` route doesn't.
+            # this event loop. FastAPI only threadpools a plain `def` route
+            # automatically; a sync call made *from inside* an `async def`
+            # route (this one, since it's a WebSocket route) does not.
             if msg_type == "op":
                 await asyncio.to_thread(_handle_op, outbox, session_id, user, raw)
             elif msg_type == "cursor":
@@ -333,9 +328,17 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     """
     sess = await asyncio.to_thread(_connect_sync, path, user)
 
-    await websocket.accept()
-    conn = coedit_channel.connect(sess.id, user.id)
+    # `_connect_sync` already registered the participant (`coedit.join`)
+    # before returning, so from here on a disconnect — including one during
+    # `accept()` itself, which the client can trigger mid-handshake since
+    # `_connect_sync`'s git/DB work takes measurable time — must still reach
+    # `_disconnect_sync` to undo it. Otherwise the user is stuck as a
+    # phantom participant forever, which also blocks
+    # `_checkpoint_if_last_left` from ever firing for this session.
+    conn: coedit_channel.Connection | None = None
     try:
+        await websocket.accept()
+        conn = coedit_channel.connect(sess.id, user.id)
         participants = await asyncio.to_thread(_participants_out, sess.id)
         await websocket.send_json(
             JoinedFrame(
@@ -361,6 +364,7 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     except WebSocketDisconnect:
         pass
     finally:
-        coedit_channel.disconnect(conn.id)
+        if conn is not None:
+            coedit_channel.disconnect(conn.id)
         await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
         log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -1,37 +1,49 @@
-"""The page live-session channel — SSE down, HTTP POST up (cookie-authed humans).
+"""The page live-session channel — one WebSocket per session (cookie-authed
+humans). Pure transport swap from the old SSE-down + HTTP-POST-up protocol:
+same JSON message shapes, same domain logic (``app/wiki/coedit.py``), same
+broadcast layer (``app/wiki/coedit_channel.py``) — only the wire mechanism
+changed. See ``plans/coedit-websocket-transport.md`` (if present) or the
+originating conversation for the design rationale.
 
 A "co-edit session" is the page's *live session*: everyone viewing the page
 joins it (read-gated — presence + real-time updates), and editing is a
-capability inside it (`/op`/`/cursor` are write-gated). Presence labels
-editors vs viewers client-side from the live caret frames — a rendered caret
-IS the "editing" state; the server stores nothing for it.
+capability inside it (``op``/``cursor``/``checkpoint`` messages are
+write-gated, re-checked on *every* message, not just at connect — mirrors
+the old per-POST ``require_can`` exactly, so a mid-session ACL change still
+takes effect). Presence labels editors vs viewers client-side from the live
+caret frames — a rendered caret IS the "editing" state; the server stores
+nothing for it.
 
-Thin HTTP layer: gate by page permission, drive the ``app/wiki/coedit.py`` store
-and the ``app/wiki/coedit_channel.py`` broadcast layer. The SSE stream is a
-plain sync generator, one threadpool thread per open connection.
+No client-sent "leave" message: the server's disconnect handler (``finally``
+below) is the sole leave signal, firing on any connection loss — explicit
+close, network drop, or a killed tab's socket dying — which is *more*
+reliable than the old design's client-initiated ``fetch(..., {keepalive:
+true})`` on unload, since it never depends on the client successfully
+transmitting anything during teardown.
 """
 
 from __future__ import annotations
 
-import json
+import asyncio
 import logging
-from collections.abc import Iterator
+import queue
+from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from pydantic import ValidationError
 
-from app.auth import User, require_can
-from app.auth.deps import require_user
+from app.auth import PermissionDenied, User, require_can
+from app.auth.deps import require_user_ws
 from app.models.coedit import (
-    CheckpointRequest,
-    CursorRequest,
-    JoinRequest,
-    JoinResponse,
-    LeaveRequest,
-    OpRequest,
-    OpResponse,
-    OpsResponse,
+    CheckpointMessage,
+    CheckpointResultFrame,
+    CursorMessage,
+    GetOpsMessage,
+    JoinedFrame,
+    OpMessage,
     Operation,
+    OpResultFrame,
+    OpsResultFrame,
     ParticipantOut,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session
@@ -40,8 +52,10 @@ from app.wiki import coedit, coedit_channel, git
 router = APIRouter()
 log = logging.getLogger(__name__)
 
-# Matches the MCP SSE cadence so proxies see the same idle behavior.
-_SSE_HEARTBEAT_SECONDS = 15.0
+# Idle silence before the send loop touches presence liveness + pings the
+# client — matches the old SSE heartbeat cadence, so proxies see the same
+# idle behavior either way.
+_HEARTBEAT_SECONDS = 15.0
 
 
 def _participants_out(session_id: int) -> list[ParticipantOut]:
@@ -55,32 +69,6 @@ def _participants_out(session_id: int) -> list[ParticipantOut]:
         )
         for p in coedit.list_participants(session_id)
     ]
-
-
-@router.post("/join")
-def join(req: JoinRequest, user: User = Depends(require_user)) -> JoinResponse:
-    """Open (or join) the live session for a page and return its buffer.
-
-    Joining is opening the page — presence + the live op stream — so it
-    requires only read; *writing* is gated at ``/op``/``/cursor``. A
-    participant who never places a caret shows as "viewing" in presence
-    (the label derives client-side from live caret frames). A fresh session
-    is seeded from the page's current HEAD; an already-open session is
-    adopted as-is (its live buffer wins).
-    """
-    require_can("read", req.path, user)
-    head = git.head_sha_for_path(req.path)
-    initial = git.read_file_opt(req.path) or ""
-    sess = coedit.open_session(req.path, base_sha=head, initial_buffer=initial)
-    coedit.join(sess.id, user.id)
-    coedit_channel.broadcast_presence(sess.id)
-    return JoinResponse(
-        session_id=sess.id,
-        buffer=sess.buffer_text,
-        version=sess.version,
-        base_sha=sess.base_sha,
-        participants=_participants_out(sess.id),
-    )
 
 
 def _checkpoint_if_last_left(session_id: int) -> None:
@@ -98,202 +86,259 @@ def _checkpoint_if_last_left(session_id: int) -> None:
         log.exception("coedit: checkpoint enqueue failed on last-leave for session %s", session_id)
 
 
-@router.post("/leave")
-def leave(req: LeaveRequest, user: User = Depends(require_user)) -> dict[str, bool]:
-    """Explicitly leave a session (e.g. closing the editor)."""
-    coedit.leave(req.session_id, user.id)
-    coedit_channel.broadcast_presence(req.session_id)
-    _checkpoint_if_last_left(req.session_id)
-    return {"ok": True}
+class _WsActionError(Exception):
+    """Internal — a write/read re-check failed for one inbound message.
+    Caught per-handler and turned into a correlated error reply so the
+    *connection* stays open (mirrors the old design: a single 403/404 on one
+    POST never killed the SSE stream either)."""
+
+    def __init__(self, error: str) -> None:
+        self.error = error
 
 
 def _require_active(session_id: int, user: User, action: str) -> coedit.SessionRow:
     sess = coedit.get_session(session_id)
     if sess is None or sess.status != coedit.SessionStatus.ACTIVE.value:
-        raise HTTPException(status_code=404, detail="no active session")
-    require_can(action, sess.path, user)
+        raise _WsActionError("no_active_session")
+    try:
+        require_can(action, sess.path, user)
+    except PermissionDenied:
+        raise _WsActionError("forbidden") from None
     return sess
 
 
-@router.post("/op")
-def op(req: OpRequest, user: User = Depends(require_user)) -> OpResponse:
-    """Apply an edit op to the session buffer and broadcast it.
-
-    409 if ``base_version`` is stale (the client re-syncs via GET /session and
-    re-applies); 422 if the op is out of bounds / overlapping.
+def _handle_op(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User, raw: dict[str, Any]) -> None:
+    """All handlers below enqueue onto ``outbox`` (the connection's own
+    ``coedit_channel`` queue) rather than calling ``websocket.send_json``
+    directly. Found the hard way (a real test failure, not a hypothetical):
+    ``_send_loop`` is *already* draining this queue and writing to the same
+    socket concurrently with the recv loop — two tasks both calling
+    ``send_json`` on one ``WebSocket`` races (and can interleave/corrupt)
+    the frame writes, and there's no ordering guarantee between a direct
+    reply and a same-op broadcast echo landing first. Routing everything
+    through the one queue makes ``_send_loop`` the sole writer, and
+    enqueueing the reply *before* triggering the broadcast (see the ``op``
+    case) makes the ordering deterministic: a sender always sees their own
+    ``op_result`` before its broadcast echo, not racing it.
     """
-    _require_active(req.session_id, user, "write")
+    msg = OpMessage.model_validate(raw)
     try:
+        _require_active(session_id, user, "write")
         out = coedit.apply_op(
-            req.session_id,
-            base_version=req.base_version,
-            changes=req.changes,
+            session_id,
+            base_version=msg.base_version,
+            changes=msg.changes,
             author_user_id=user.id,
-            client_id=req.client_id,
+            client_id=msg.client_id,
         )
-    except ValueError as e:
-        raise HTTPException(status_code=422, detail=str(e)) from e
+    except _WsActionError as e:
+        outbox.put_nowait(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump())
+        return
+    except ValueError:
+        outbox.put_nowait(
+            OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump()
+        )
+        return
     if out is None:
-        raise HTTPException(status_code=409, detail="stale base_version; re-sync and retry")
-    coedit.touch(req.session_id, user.id, edited=True)
+        outbox.put_nowait(
+            OpResultFrame(request_id=msg.request_id, ok=False, error="stale_version").model_dump()
+        )
+        return
+    coedit.touch(session_id, user.id, edited=True)
+    outbox.put_nowait(
+        OpResultFrame(request_id=msg.request_id, ok=True, version=out.version).model_dump()
+    )
     # caret_seq rides the frame so peers render the author's caret at the
     # edit; None (cleared caret / legacy client) = no caret assertion.
     coedit_channel.broadcast_op(
-        req.session_id,
+        session_id,
         out.version,
-        req.changes,
+        msg.changes,
         user.id,
-        client_id=req.client_id,
-        caret_seq=req.caret_seq,
+        client_id=msg.client_id,
+        caret_seq=msg.caret_seq,
     )
-    return OpResponse(version=out.version)
 
 
-@router.post("/cursor")
-def cursor(req: CursorRequest, user: User = Depends(require_user)) -> dict[str, bool]:
-    """Broadcast the caller's live cursor/selection to the session.
-
-    A null anchor/head clears the caret (the editor lost focus / the tab went
-    hidden) — peers drop it and presence flips the sender to "viewing".
-    High-frequency + throttled client-side; deliberately does not touch the DB
-    (no last_seen write — the SSE heartbeat covers liveness; no caret state —
-    a rendered caret IS the editing state, so nothing needs persisting).
-    ``seq`` (the client caret epoch) rides the frame so peers drop reordered
-    stale frames.
-    """
-    _require_active(req.session_id, user, "write")
-    cleared = req.anchor is None or req.head is None
+def _handle_cursor(session_id: int, user: User, raw: dict[str, Any]) -> None:
+    """Fire-and-forget — matches the old client's ``sendCursor(...).catch(()
+    => {})``: a rejected/failed cursor ping is silently dropped, never
+    surfaced, since the next throttled ping self-heals it."""
+    msg = CursorMessage.model_validate(raw)
+    try:
+        _require_active(session_id, user, "write")
+    except _WsActionError:
+        return
+    cleared = msg.anchor is None or msg.head is None
     coedit_channel.broadcast_cursor(
-        req.session_id,
+        session_id,
         user_id=user.id,
         # Match list_participants' SQL COALESCE(name, email) exactly — substitute
         # only on NULL, not on "" — so a peer's caret label and roster name agree.
         user_display=user.name if user.name is not None else user.email,
-        anchor=None if cleared else req.anchor,
-        head=None if cleared else req.head,
-        typing=req.typing and not cleared,
-        seq=req.seq,
-    )
-    return {"ok": True}
-
-
-@router.post("/checkpoint")
-def checkpoint(req: CheckpointRequest, user: User = Depends(require_user)) -> dict[str, bool]:
-    """Explicit save: enqueue a checkpoint of the session's buffer to git.
-
-    Async (the commit + any merge run on the worker), so this returns once
-    queued rather than blocking on the git write.
-    """
-    _require_active(req.session_id, user, "write")
-    checkpoint_coedit_session(req.session_id)
-    return {"queued": True}
-
-
-@router.get("/session")
-def session_state(session_id: int, user: User = Depends(require_user)) -> JoinResponse:
-    """Current buffer + version + roster — a read-only snapshot for a client to
-    re-sync after a stale op or a `resync` frame (no join side effects)."""
-    sess = _require_active(session_id, user, "read")
-    return JoinResponse(
-        session_id=sess.id,
-        buffer=sess.buffer_text,
-        version=sess.version,
-        base_sha=sess.base_sha,
-        participants=_participants_out(sess.id),
+        anchor=None if cleared else msg.anchor,
+        head=None if cleared else msg.head,
+        typing=msg.typing and not cleared,
+        seq=msg.seq,
     )
 
 
-@router.get("/ops")
-def ops(
-    session_id: int, since_version: int, user: User = Depends(require_user)
-) -> OpsResponse:
-    """Ops applied after ``since_version`` (oldest first) + the current head
-    version. Lets a client rebase its unconfirmed edits after a stale op (409),
-    a reconnect, or a big-op ``resync`` — replaying the exact missed changes
-    rather than replacing the buffer. Read-only; no join side effects."""
-    sess = _require_active(session_id, user, "read")
+def _handle_checkpoint(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User, raw: dict[str, Any]) -> None:
+    msg = CheckpointMessage.model_validate(raw)
+    try:
+        _require_active(session_id, user, "write")
+    except _WsActionError:
+        outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=False).model_dump())
+        return
+    checkpoint_coedit_session(session_id)
+    outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=True).model_dump())
+
+
+def _handle_get_ops(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User, raw: dict[str, Any]) -> None:
+    msg = GetOpsMessage.model_validate(raw)
+    try:
+        sess = _require_active(session_id, user, "read")
+    except _WsActionError as e:
+        outbox.put_nowait(
+            OpsResultFrame(
+                request_id=msg.request_id, ok=False, error=e.error, current_head_version=0, ops=[]
+            ).model_dump()
+        )
+        return
     # Head version + ops read as one consistent snapshot (see
     # ops_since_with_head), so a concurrent op can't desync them.
-    result = coedit.ops_since_with_head(session_id, since_version)
-    return OpsResponse(
-        session_id=session_id,
-        current_head_version=(
-            result.head_version if result.head_version is not None else sess.version
-        ),
-        ops=[
-            Operation(
-                version=r.seq,
-                author=r.author_user_id,
-                client_id=r.client_id,
-                changes=[coedit.Change.model_validate(c) for c in r.changes],
-            )
-            for r in result.ops
-        ],
+    result = coedit.ops_since_with_head(session_id, msg.since_version)
+    outbox.put_nowait(
+        OpsResultFrame(
+            request_id=msg.request_id,
+            ok=True,
+            current_head_version=(
+                result.head_version if result.head_version is not None else sess.version
+            ),
+            ops=[
+                Operation(
+                    version=r.seq,
+                    author=r.author_user_id,
+                    client_id=r.client_id,
+                    changes=[coedit.Change.model_validate(c) for c in r.changes],
+                )
+                for r in result.ops
+            ],
+        ).model_dump()
     )
 
 
-@router.get("/stream")
-def stream(session_id: int, user: User = Depends(require_user)) -> StreamingResponse:
-    """Long-lived SSE stream of session frames (presence).
-
-    A plain sync generator: it blocks on the connection's queue, emitting a
-    keepalive every ``_SSE_HEARTBEAT_SECONDS`` of silence. The connection is the
-    presence heartbeat — each keepalive refreshes ``last_seen_at``. When the
-    client disconnects, Starlette closes the generator (``GeneratorExit`` at the
-    next yield, at most one heartbeat later), and the ``finally`` block fires
-    ``leave`` once the user's last connection for the session closes.
-    """
-    sess = coedit.get_session(session_id)
-    if sess is None or sess.status != coedit.SessionStatus.ACTIVE.value:
-        raise HTTPException(status_code=404, detail="no active session")
-    # Opening the stream makes the user a session participant (roster +
-    # heartbeat), which is page-open presence, not edit intent — so it
-    # requires read, symmetric with POST /join. Writes stay gated at /op.
-    require_can("read", sess.path, user)
-
-    coedit.join(session_id, user.id)
-    # Announce the new participant to existing connections *before* registering
-    # this one — otherwise the broadcast lands in our own queue and gen() would
-    # emit it on top of the inline initial roster below (a duplicate frame).
-    coedit_channel.broadcast_presence(session_id)
-    conn = coedit_channel.connect(session_id, user.id)
-
-    def gen() -> Iterator[bytes]:
+async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[dict[str, Any]], session_id: int, user: User) -> None:
+    while True:
+        raw = await websocket.receive_json()
+        msg_type = raw.get("type")
         try:
-            # Prime the stream with the current roster so a joiner doesn't wait
-            # for the next change to render presence.
-            yield _sse(
-                {
-                    "type": "presence",
-                    "session_id": session_id,
-                    "participants": [
-                        p.model_dump() for p in coedit.list_participants(session_id)
-                    ],
-                }
-            )
-            while True:
-                frame = coedit_channel.drain(conn.queue, _SSE_HEARTBEAT_SECONDS)
-                if frame is None:
-                    coedit.touch(session_id, user.id)
-                    yield b": keepalive\n\n"
-                    continue
-                yield _sse(frame)
-        finally:
-            coedit_channel.disconnect(conn.id)
-            # Only mark the user gone when their last connection closes, so a
-            # second tab doesn't evict them.
-            if not coedit_channel.user_still_connected(session_id, user.id):
-                coedit.leave(session_id, user.id)
-                coedit_channel.broadcast_presence(session_id)
-                _checkpoint_if_last_left(session_id)
-            log.info("coedit sse closed session=%s user=%s", session_id, user.id)
-
-    return StreamingResponse(
-        gen(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no"},
-    )
+            # Every handler below makes blocking DB calls (require_can,
+            # coedit.apply_op, ...) — offloaded to a thread so one session's
+            # DB round-trip doesn't stall every other WS connection sharing
+            # this event loop. The old REST handlers got this for free (a
+            # plain `def` FastAPI route runs in a threadpool automatically);
+            # a sync call made *from inside* an `async def` route doesn't.
+            if msg_type == "op":
+                await asyncio.to_thread(_handle_op, outbox, session_id, user, raw)
+            elif msg_type == "cursor":
+                await asyncio.to_thread(_handle_cursor, session_id, user, raw)
+            elif msg_type == "checkpoint":
+                await asyncio.to_thread(_handle_checkpoint, outbox, session_id, user, raw)
+            elif msg_type == "get_ops":
+                await asyncio.to_thread(_handle_get_ops, outbox, session_id, user, raw)
+            else:
+                log.warning("coedit ws: unknown message type %r", msg_type)
+        except ValidationError:
+            log.warning("coedit ws: malformed %r message", msg_type)
 
 
-def _sse(frame: dict[str, object]) -> bytes:
-    return f"data: {json.dumps(frame)}\n\n".encode("utf-8")
+async def _send_loop(
+    websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user_id: str
+) -> None:
+    while True:
+        # coedit_channel.drain blocks synchronously on a queue.Queue — offload
+        # to a thread so it doesn't stall the event loop the recv side shares.
+        frame = await asyncio.to_thread(coedit_channel.drain, conn.queue, _HEARTBEAT_SECONDS)
+        if frame is None:
+            await asyncio.to_thread(coedit.touch, session_id, user_id)
+            await websocket.send_json({"type": "ping"})
+            continue
+        await websocket.send_json(frame)
+
+
+def _connect_sync(path: str, user: User) -> coedit.SessionRow:
+    """The whole pre-accept handshake's DB/git work, bundled into one
+    thread hop. ``require_can`` must run (and be free to raise
+    ``PermissionDenied``) before ``websocket.accept()`` — verified directly
+    that an exception raised here still reaches the app's registered
+    exception handler and produces a clean denial response pre-upgrade, the
+    same as it does from a plain ``async def`` route body; offloading to a
+    thread via ``asyncio.to_thread`` doesn't change that propagation."""
+    require_can("read", path, user)
+    head = git.head_sha_for_path(path)
+    initial = git.read_file_opt(path) or ""
+    sess = coedit.open_session(path, base_sha=head, initial_buffer=initial)
+    coedit.join(sess.id, user.id)
+    # Announce the new participant to existing connections *before*
+    # registering this one — otherwise the broadcast lands in our own queue
+    # and the send loop would emit it on top of the inline `joined` frame
+    # sent right after (a duplicate).
+    coedit_channel.broadcast_presence(sess.id)
+    return sess
+
+
+def _disconnect_sync(session_id: int, user_id: str) -> None:
+    # Only mark the user gone when their last connection closes, so a
+    # second tab doesn't evict them.
+    if not coedit_channel.user_still_connected(session_id, user_id):
+        coedit.leave(session_id, user_id)
+        coedit_channel.broadcast_presence(session_id)
+        _checkpoint_if_last_left(session_id)
+
+
+@router.websocket("/ws")
+async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_ws)) -> None:
+    """``path`` is a query param (``?path=...``), not a URL segment — this
+    app owns both ends of the connection URL, so there's no need for
+    ``y-websocket``'s ``serverUrl/roomname`` convention.
+
+    Joining is opening the page — presence + the live op stream — so
+    connecting requires only read; *writing* (``op``/``cursor``/
+    ``checkpoint``) is gated per-message inside the recv loop. A fresh
+    session is seeded from the page's current HEAD; an already-open session
+    is adopted as-is (its live buffer wins) — see ``coedit.open_session``.
+    """
+    sess = await asyncio.to_thread(_connect_sync, path, user)
+
+    await websocket.accept()
+    conn = coedit_channel.connect(sess.id, user.id)
+    try:
+        participants = await asyncio.to_thread(_participants_out, sess.id)
+        await websocket.send_json(
+            JoinedFrame(
+                session_id=sess.id,
+                buffer=sess.buffer_text,
+                version=sess.version,
+                base_sha=sess.base_sha,
+                participants=participants,
+            ).model_dump()
+        )
+
+        recv_task = asyncio.create_task(_recv_loop(websocket, conn.queue, sess.id, user))
+        send_task = asyncio.create_task(_send_loop(websocket, conn, sess.id, user.id))
+        done, pending = await asyncio.wait(
+            {recv_task, send_task}, return_when=asyncio.FIRST_COMPLETED
+        )
+        for t in pending:
+            t.cancel()
+        for t in done:
+            exc = t.exception()
+            if exc is not None and not isinstance(exc, WebSocketDisconnect):
+                raise exc
+    except WebSocketDisconnect:
+        pass
+    finally:
+        coedit_channel.disconnect(conn.id)
+        await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
+        log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -110,7 +110,7 @@ def _require_active(session_id: int, user: User, action: str) -> coedit.SessionR
     return sess
 
 
-def _handle_op(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User, raw: dict[str, Any]) -> None:
+def _handle_op(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
     """All handlers below enqueue onto ``outbox`` (the connection's own
     ``coedit_channel`` queue) rather than calling ``websocket.send_json``
     directly. Found the hard way (a real test failure, not a hypothetical):
@@ -186,7 +186,7 @@ def _handle_cursor(session_id: int, user: User, raw: dict[str, Any]) -> None:
     )
 
 
-def _handle_checkpoint(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User, raw: dict[str, Any]) -> None:
+def _handle_checkpoint(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
     msg = CheckpointMessage.model_validate(raw)
     try:
         _require_active(session_id, user, "write")
@@ -197,7 +197,7 @@ def _handle_checkpoint(outbox: queue.Queue[dict[str, Any]], session_id: int, use
     outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=True).model_dump())
 
 
-def _handle_get_ops(outbox: queue.Queue[dict[str, Any]], session_id: int, user: User, raw: dict[str, Any]) -> None:
+def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
     msg = GetOpsMessage.model_validate(raw)
     try:
         sess = _require_active(session_id, user, "read")
@@ -231,7 +231,7 @@ def _handle_get_ops(outbox: queue.Queue[dict[str, Any]], session_id: int, user: 
     )
 
 
-async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[dict[str, Any]], session_id: int, user: User) -> None:
+async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User) -> None:
     while True:
         raw = await websocket.receive_json()
         msg_type = raw.get("type")
@@ -281,6 +281,16 @@ async def _send_loop(
     idle_elapsed = 0.0
     while True:
         frame = await asyncio.to_thread(coedit_channel.drain, conn.queue, _SEND_LOOP_POLL_SECONDS)
+        if frame is coedit_channel.CLOSE_SIGNAL:
+            # ws()'s teardown path pushed this via coedit_channel.wake() right
+            # before cancelling this task — reachable here (not just via
+            # cancellation) because there's a real race between the two: this
+            # drain call may already have picked up the signal as an ordinary
+            # queue item before the asyncio-level cancellation is delivered.
+            # Either path ends the loop; this one just does it without
+            # waiting on a CancelledError that might arrive after the value
+            # already did.
+            return
         if frame is None:
             idle_elapsed += _SEND_LOOP_POLL_SECONDS
             if idle_elapsed >= _HEARTBEAT_SECONDS:
@@ -363,6 +373,15 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
         done, pending = await asyncio.wait(
             {recv_task, send_task}, return_when=asyncio.FIRST_COMPLETED
         )
+        # Wake a still-blocked drain() *before* cancelling it: cancelling
+        # send_task only stops the asyncio Task watching the thread, not the
+        # already-dispatched OS thread itself — queue.Queue.get(timeout=...)
+        # has no cancellation hook, so without this it just keeps blocking,
+        # doing nothing, until its own timeout expires (see
+        # coedit_channel.wake's docstring). Pushing CLOSE_SIGNAL is what
+        # actually unblocks that thread immediately, same as a real frame
+        # arriving would.
+        coedit_channel.wake(conn.id)
         for t in pending:
             t.cancel()
         for t in done:

--- a/backend/app/auth/deps.py
+++ b/backend/app/auth/deps.py
@@ -16,7 +16,9 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 
-from fastapi import Depends, HTTPException, Request
+from typing import Any
+
+from fastapi import Depends, HTTPException, Request, WebSocket
 from pydantic import BaseModel
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
@@ -36,11 +38,12 @@ def user_epoch(user_id: str) -> int:
     return int((row or {}).get("session_epoch") or 0)
 
 
-def current_user(request: Request) -> User | None:
-    """Resolve the active user from the session cookie. Returns
-    ``None`` when there is no cookie, the signature is invalid, the
-    user row has been deleted, or the account is deactivated."""
-    user_id = request.session.get("user_id")
+def _resolve_user(sess: dict[str, Any]) -> User | None:
+    """Shared session-cookie -> ``User`` resolution, against a plain
+    ``dict``-like session mapping — ``Request.session`` and
+    ``WebSocket.session`` are both Starlette ``SessionMiddleware`` reads of
+    the exact same signed cookie, so one resolver covers both transports."""
+    user_id = sess.get("user_id")
     if not isinstance(user_id, str) or not user_id:
         return None
     row = users_repo.get_by_id(user_id)
@@ -51,7 +54,7 @@ def current_user(request: Request) -> User | None:
         return None
     # Sessions minted before a password change carry an older epoch (or none,
     # for pre-epoch cookies against a bumped account) and stop authenticating.
-    if int(request.session.get("session_epoch") or 0) != int(row["session_epoch"] or 0):
+    if int(sess.get("session_epoch") or 0) != int(row["session_epoch"] or 0):
         return None
     return User(
         id=row["id"],
@@ -61,7 +64,31 @@ def current_user(request: Request) -> User | None:
     )
 
 
+def current_user(request: Request) -> User | None:
+    """Resolve the active user from the session cookie. Returns
+    ``None`` when there is no cookie, the signature is invalid, the
+    user row has been deleted, or the account is deactivated."""
+    return _resolve_user(request.session)
+
+
 def require_user(user: User | None = Depends(current_user)) -> User:
+    if user is None:
+        raise HTTPException(status_code=401, detail="unauthorized")
+    return user
+
+
+def current_user_ws(websocket: WebSocket) -> User | None:
+    """WebSocket-flavored ``current_user`` — same cookie, same resolver."""
+    return _resolve_user(websocket.session)
+
+
+def require_user_ws(user: User | None = Depends(current_user_ws)) -> User:
+    """Raises before the handshake completes on a missing/invalid session.
+    Verified directly (not assumed): an ``HTTPException`` raised while
+    FastAPI solves a websocket route's dependencies produces a clean HTTP
+    denial response *before* the upgrade — the client sees a normal 401,
+    the connection never opens — the same outcome ``require_user`` gives an
+    HTTP caller, not a raw dropped socket."""
     if user is None:
         raise HTTPException(status_code=401, detail="unauthorized")
     return user

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -1,7 +1,8 @@
-"""HTTP request/response shapes for the co-editing live channel.
+"""Wire shapes for the co-editing live channel — one ``WebSocket`` per
+session (``app/api/coedit.py``), messages multiplexed by a ``type`` field.
 
 Kept separate from the ORM rows in ``app/wiki/coedit.py`` (the DB shape) and the
-in-memory frames in ``app/wiki/coedit_channel.py`` (the wire shape).
+in-memory frames in ``app/wiki/coedit_channel.py`` (the pub/sub wire shape).
 """
 
 from __future__ import annotations
@@ -11,24 +12,14 @@ from pydantic import BaseModel, Field
 from app.wiki.coedit import Change
 
 
-class JoinRequest(BaseModel):
-    path: str
+class OpMessage(BaseModel):
+    """Client -> server ``{"type": "op", ...}``. No ``session_id`` — the
+    connection itself is scoped to one session (see ``JoinFrame``)."""
 
-
-class LeaveRequest(BaseModel):
-    session_id: int
-
-
-class CheckpointRequest(BaseModel):
-    session_id: int
-
-
-class OpRequest(BaseModel):
-    session_id: int
+    request_id: str
     base_version: int
-    # Range changes ({from,to,insert}); FastAPI validates each via Change, so a
-    # malformed op is a 400 (the app's RequestValidationError handler) before it
-    # reaches the repo.
+    # Range changes ({from,to,insert}); pydantic validates each via Change, so
+    # a malformed op gets an error reply before it reaches the repo.
     changes: list[Change]
     # Opaque per-connection id (one editor tab). Lets a collaborative client
     # recognize its own op when it echoes back. Optional — non-collab clients
@@ -43,19 +34,26 @@ class OpRequest(BaseModel):
     caret_seq: int | None = Field(default=None, ge=0)
 
 
-class OpResponse(BaseModel):
-    version: int  # the session version this op produced
+class OpResultFrame(BaseModel):
+    """Server -> client direct reply to an ``OpMessage``, correlated by
+    ``request_id``. Not a broadcast frame — only the sender gets this."""
+
+    type: str = "op_result"
+    request_id: str
+    ok: bool
+    version: int | None = None  # set when ok
+    error: str | None = None  # "stale_version" | "invalid_op" | "forbidden"
 
 
-class CursorRequest(BaseModel):
-    """A participant's live cursor/selection. ``anchor``/``head`` are UTF-16
-    offsets (like Change); a collapsed selection (anchor == head) is a caret,
-    otherwise it's a highlighted range. ``None`` (either offset omitted) means
-    the caller *cleared* their caret — the editor lost focus or the tab was
-    hidden — so peers drop the caret and presence flips them to "viewing".
-    Ephemeral end to end: broadcast to the session, never persisted."""
+class CursorMessage(BaseModel):
+    """Client -> server ``{"type": "cursor", ...}``, fire-and-forget (no
+    ``request_id`` — matches today's swallowed-error handling on the HTTP
+    path). ``anchor``/``head`` are UTF-16 offsets (like ``Change``); a
+    collapsed selection (anchor == head) is a caret, otherwise a highlighted
+    range. ``None`` (either offset omitted) means the caller *cleared* their
+    caret — peers drop it and presence flips them to "viewing". Ephemeral end
+    to end: broadcast to the session, never persisted."""
 
-    session_id: int
     anchor: int | None = Field(default=None, ge=0)
     head: int | None = Field(default=None, ge=0)
     typing: bool = False
@@ -64,6 +62,26 @@ class CursorRequest(BaseModel):
     # stale frames (a place broadcast landing after a newer clear must not
     # resurrect the caret). None = a client predating the epoch protocol.
     seq: int | None = Field(default=None, ge=0)
+
+
+class CheckpointMessage(BaseModel):
+    """Client -> server ``{"type": "checkpoint", ...}``."""
+
+    request_id: str
+
+
+class CheckpointResultFrame(BaseModel):
+    type: str = "checkpoint_result"
+    request_id: str
+    ok: bool
+
+
+class GetOpsMessage(BaseModel):
+    """Client -> server ``{"type": "get_ops", ...}`` — replaces the old
+    ``GET /coedit/ops`` catch-up-after-a-gap read."""
+
+    request_id: str
+    since_version: int
 
 
 class ParticipantOut(BaseModel):
@@ -77,7 +95,12 @@ class ParticipantOut(BaseModel):
     last_edited_at: str | None = None
 
 
-class JoinResponse(BaseModel):
+class JoinedFrame(BaseModel):
+    """Server -> client, sent once right after ``accept()`` — the WS
+    connection's own handshake response, replacing the old ``POST /join``
+    response body."""
+
+    type: str = "joined"
     session_id: int
     buffer: str
     version: int
@@ -86,9 +109,10 @@ class JoinResponse(BaseModel):
 
 
 class Operation(BaseModel):
-    """One logged edit operation (one version bump), wire-shaped like the SSE
-    ``op`` frame so a client can feed it to the same apply/rebase path. Its
-    ``changes`` are the range edits applied together in that operation (≥1)."""
+    """One logged edit operation (one version bump), wire-shaped like the
+    broadcast ``op`` frame so a client can feed it to the same apply/rebase
+    path. Its ``changes`` are the range edits applied together in that
+    operation (≥1)."""
 
     version: int  # the new buffer version after this operation applies (coedit_ops.seq)
     author: str  # author_user_id
@@ -96,11 +120,18 @@ class Operation(BaseModel):
     changes: list[Change]
 
 
-class OpsResponse(BaseModel):
-    """Ops after a given version (oldest first) + the current head version, so a
-    client can rebase its unconfirmed edits after a 409 / reconnect / big-op
-    resync instead of replacing the buffer wholesale."""
+class OpsResultFrame(BaseModel):
+    """Server -> client reply to a ``GetOpsMessage``, correlated by
+    ``request_id``. Ops after a given version (oldest first) + the current
+    head version, so a client can rebase its unconfirmed edits after a
+    stale-version reject / reconnect / big-op resync instead of replacing the
+    buffer wholesale. ``ok``/``error`` mirror the other result frames — a
+    mid-session read-permission loss (rare) still gets a reply rather than
+    leaving the caller's correlated promise hanging forever."""
 
-    session_id: int
+    type: str = "ops_result"
+    request_id: str
+    ok: bool = True
+    error: str | None = None  # "no_active_session" | "forbidden"
     current_head_version: int
     ops: list[Operation]

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -36,6 +36,18 @@ log = logging.getLogger(__name__)
 Frame = dict[str, Any]
 
 
+class _CloseSignal:
+    """Sentinel type for the one non-``Frame`` value a connection's queue can
+    carry. Distinct from ``None`` (which ``drain`` already uses to mean "the
+    poll timed out, nothing arrived") and from any real ``Frame`` (a plain
+    ``dict``, so nothing dict-shaped could ever collide with an ``is``
+    check against the singleton instance below)."""
+
+
+CLOSE_SIGNAL = _CloseSignal()
+QueueItem = Frame | _CloseSignal
+
+
 class Connection(BaseModel):
     """Handle for one live connection: its opaque id (for ``disconnect``) and
     the queue its send loop drains."""
@@ -43,12 +55,12 @@ class Connection(BaseModel):
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     id: str
-    queue: queue.Queue[Frame]
+    queue: queue.Queue[QueueItem]
 
 # Per-connection registry, keyed by an opaque connection id (one per open
 # WebSocket). Parallel dicts rather than a class, mirroring ``pubsub``'s sync
 # ``_queues`` style for the same runtime state.
-_queues: dict[str, queue.Queue[Frame]] = {}
+_queues: dict[str, queue.Queue[QueueItem]] = {}
 _session_of: dict[str, int] = {}  # conn_id -> coedit_session_id
 _user_of: dict[str, str] = {}  # conn_id -> user_id
 _conns_by_session: dict[int, set[str]] = {}  # coedit_session_id -> {conn_id}
@@ -58,7 +70,7 @@ _lock = threading.Lock()
 def connect(coedit_session_id: int, user_id: str) -> Connection:
     """Register a live connection for a session. Returns its handle."""
     conn_id = uuid.uuid4().hex
-    q: queue.Queue[Frame] = queue.Queue()
+    q: queue.Queue[QueueItem] = queue.Queue()
     with _lock:
         _queues[conn_id] = q
         _session_of[conn_id] = coedit_session_id
@@ -94,13 +106,36 @@ def user_still_connected(coedit_session_id: int, user_id: str) -> bool:
         )
 
 
-def drain(q: queue.Queue[Frame], timeout: float) -> Frame | None:
+def drain(q: queue.Queue[QueueItem], timeout: float) -> QueueItem | None:
     """Block up to ``timeout`` seconds for the next frame; ``None`` on timeout so
-    the caller can emit a heartbeat."""
+    the caller can emit a heartbeat. Can also return ``CLOSE_SIGNAL`` — see
+    ``wake``."""
     try:
         return q.get(timeout=timeout)
     except queue.Empty:
         return None
+
+
+def wake(conn_id: str) -> None:
+    """Unblock a connection's own ``drain`` call immediately, instead of
+    leaving it to run out its poll timeout.
+
+    ``queue.Queue.get(timeout=...)`` has no cancellation hook — a task
+    awaiting it via ``asyncio.to_thread`` can be cancelled at the asyncio
+    level, but the underlying OS thread has no way to know that and keeps
+    blocking regardless, for up to the full timeout, occupying a thread-pool
+    slot the whole time (confirmed directly: cancelling the wrapping Future
+    doesn't stop the executor's function, it only makes the *awaiter* stop
+    watching it — see ``loop.run_in_executor``'s documented behavior). This
+    reaches the blocked call the only way that's actually possible: pushing
+    something into the same queue it's already waiting on, so ``get()``
+    returns immediately the normal way, on its own thread, same as a real
+    frame arriving. The caller (``app/api/coedit.py``'s teardown path) must
+    call this whenever it's about to cancel a connection's send loop."""
+    with _lock:
+        q = _queues.get(conn_id)
+    if q is not None:
+        q.put_nowait(CLOSE_SIGNAL)
 
 
 def _bus_payload(coedit_session_id: int, frame: Frame) -> dict[str, Any]:

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -1,16 +1,19 @@
-"""Live channel for co-editing — the SSE-down + POST-up transport.
+"""Live channel for co-editing — transport-agnostic pub/sub, currently fed by
+one ``WebSocket`` per session (``app/api/coedit.py``).
 
-Browser clients open one SSE connection per co-edit session (cookie-authed) and
+Browser clients open one connection per co-edit session (cookie-authed) and
 the server pushes session frames (e.g. presence) to every connection in the
 session. Cross-process delivery rides the shared realtime bus
 (``app/realtime/bus.py``, Postgres LISTEN/NOTIFY) under a ``coedit`` payload
 kind, so participants connected to different app servers still see each other.
 
-One thread per connection with a thread-safe ``queue.Queue``, mirroring the MCP
-pubsub's sync ``_queues`` / ``drain_blocking`` path. Connection state is
-in-process and ephemeral — nothing here is persisted; durable
-session/participant state lives in ``app/wiki/coedit.py``. Frames are plain
-JSON-serializable dicts.
+One thread-safe ``queue.Queue`` per connection, mirroring the MCP pubsub's
+sync ``_queues`` / ``drain_blocking`` path — the module here has no opinion on
+how a connection drains its queue (a WS route's send loop calls ``drain`` in
+a thread today; it was an SSE generator's blocking read before that). Frames
+are plain JSON-serializable dicts either way. Connection state is in-process
+and ephemeral — nothing here is persisted; durable session/participant state
+lives in ``app/wiki/coedit.py``.
 
 See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
 """

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -8,12 +8,11 @@ session. Cross-process delivery rides the shared realtime bus
 kind, so participants connected to different app servers still see each other.
 
 One thread-safe ``queue.Queue`` per connection, mirroring the MCP pubsub's
-sync ``_queues`` / ``drain_blocking`` path — the module here has no opinion on
-how a connection drains its queue (a WS route's send loop calls ``drain`` in
-a thread today; it was an SSE generator's blocking read before that). Frames
-are plain JSON-serializable dicts either way. Connection state is in-process
-and ephemeral — nothing here is persisted; durable session/participant state
-lives in ``app/wiki/coedit.py``.
+sync ``_queues`` / ``drain_blocking`` path — this module has no opinion on
+how a connection drains its queue (``app/api/coedit.py``'s WS send loop
+calls ``drain`` in a thread). Frames are plain JSON-serializable dicts.
+Connection state is in-process and ephemeral — nothing here is persisted;
+durable session/participant state lives in ``app/wiki/coedit.py``.
 
 See ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``.
 """
@@ -38,16 +37,16 @@ Frame = dict[str, Any]
 
 
 class Connection(BaseModel):
-    """Handle for one live SSE connection: its opaque id (for ``disconnect``)
-    and the queue the stream generator drains."""
+    """Handle for one live connection: its opaque id (for ``disconnect``) and
+    the queue its send loop drains."""
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     id: str
     queue: queue.Queue[Frame]
 
-# Per-connection registry, keyed by an opaque connection id (one per open SSE
-# stream). Parallel dicts rather than a class, mirroring ``pubsub``'s sync
+# Per-connection registry, keyed by an opaque connection id (one per open
+# WebSocket). Parallel dicts rather than a class, mirroring ``pubsub``'s sync
 # ``_queues`` style for the same runtime state.
 _queues: dict[str, queue.Queue[Frame]] = {}
 _session_of: dict[str, int] = {}  # conn_id -> coedit_session_id
@@ -85,8 +84,8 @@ def disconnect(conn_id: str) -> None:
 def user_still_connected(coedit_session_id: int, user_id: str) -> bool:
     """True if ``user_id`` still has any open connection to the session.
 
-    Lets the SSE handler avoid firing ``leave`` when one of a user's several
-    tabs closes while another stays open.
+    Lets the caller avoid firing ``leave`` when one of a user's several tabs
+    closes while another stays open.
     """
     with _lock:
         return any(
@@ -97,7 +96,7 @@ def user_still_connected(coedit_session_id: int, user_id: str) -> bool:
 
 def drain(q: queue.Queue[Frame], timeout: float) -> Frame | None:
     """Block up to ``timeout`` seconds for the next frame; ``None`` on timeout so
-    the SSE writer can emit a heartbeat."""
+    the caller can emit a heartbeat."""
     try:
         return q.get(timeout=timeout)
     except queue.Empty:

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -1,11 +1,19 @@
-"""Co-edit HTTP surface (app/api/coedit.py) — join / leave and their
-permission gating. The SSE stream's live delivery is covered at the channel
-level in test_coedit_channel.py; here we exercise the request layer.
+"""Co-edit WebSocket surface (app/api/coedit.py) — the connect handshake,
+per-message write-permission re-checks, and op/cursor/checkpoint/get_ops
+message handling. Live delivery fan-out is covered at the channel level in
+test_coedit_channel.py; here we exercise the WS route itself.
+
+Pure transport swap from the old SSE-down + HTTP-POST-up protocol (see the
+module docstring in app/api/coedit.py) — same domain logic, same message
+shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
+from contextlib import contextmanager
+
 import pytest
 from fastapi.testclient import TestClient
+from starlette.testclient import WebSocketDenialResponse
 
 from app.auth import users as users_repo
 from app.main import create_app
@@ -26,40 +34,92 @@ def _seed_page(body: str = "# Setup\n\nhello\n") -> str:
     return git.commit_file(_PATH, body, message="seed", author="t <t@x.com>")
 
 
-def test_join_requires_auth(client):
-    assert client.post("/api/coedit/join", json={"path": _PATH}).status_code == 401
+@contextmanager
+def _ws(client, path: str = _PATH):
+    """Open the coedit WS and yield `(ws, joined_frame)` once the handshake
+    completes. Closing the `with` block closes the connection — the WS
+    equivalent of the old `POST /leave` (see app/api/coedit.py: the server's
+    disconnect handler is the leave signal, not a client message)."""
+    with client.websocket_connect(f"/api/coedit/ws?path={path}") as ws:
+        joined = ws.receive_json()
+        assert joined["type"] == "joined"
+        yield ws, joined
 
 
-def test_join_creates_session_seeded_from_head(client):
+def _receive_typed(ws, expected_type: str) -> dict:
+    """Skip past any broadcast frames (the sender's own op/cursor echoes,
+    presence, etc.) to find the correlated reply — a connection sees its own
+    broadcasts too, and there's no ordering guarantee worth hard-coding a
+    test against beyond "the reply eventually arrives" (the server enqueues
+    a reply before triggering its own broadcast, but a test asserting on
+    exact interleaving would be pinned to that implementation detail, not
+    the actual contract)."""
+    for _ in range(10):
+        frame = ws.receive_json()
+        if frame["type"] == expected_type:
+            return frame
+    raise AssertionError(f"never received a {expected_type!r} frame")
+
+
+def _op(ws, base_version: int, changes: list[dict], **extra) -> dict:
+    ws.send_json({"type": "op", "request_id": "r", "base_version": base_version, "changes": changes, **extra})
+    return _receive_typed(ws, "op_result")
+
+
+def _apply_op(ws, base_version: int, changes: list[dict]) -> int:
+    result = _op(ws, base_version, changes)
+    assert result == {"type": "op_result", "request_id": "r", "ok": True, "version": result["version"], "error": None}
+    return result["version"]
+
+
+def _cursor(ws, **fields) -> None:
+    ws.send_json({"type": "cursor", **fields})
+
+
+def _checkpoint(ws) -> dict:
+    ws.send_json({"type": "checkpoint", "request_id": "c"})
+    return _receive_typed(ws, "checkpoint_result")
+
+
+def _get_ops(ws, since_version: int) -> dict:
+    ws.send_json({"type": "get_ops", "request_id": "g", "since_version": since_version})
+    return _receive_typed(ws, "ops_result")
+
+
+def test_connect_requires_auth(client):
+    with pytest.raises(WebSocketDenialResponse) as exc_info:
+        with client.websocket_connect(f"/api/coedit/ws?path={_PATH}"):
+            pass
+    assert exc_info.value.status_code == 401
+
+
+def test_connect_creates_session_seeded_from_head(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     sha = _seed_page()
 
-    resp = client.post("/api/coedit/join", json={"path": _PATH})
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["version"] == 0
-    assert body["buffer"] == "# Setup\n\nhello\n"
-    assert body["base_sha"] == sha
-    assert [p["user_id"] for p in body["participants"]] == [uid]
+    with _ws(client) as (_ws_conn, joined):
+        assert joined["version"] == 0
+        assert joined["buffer"] == "# Setup\n\nhello\n"
+        assert joined["base_sha"] == sha
+        assert [p["user_id"] for p in joined["participants"]] == [uid]
 
 
-def test_join_is_idempotent_and_shared(client):
+def test_connect_is_idempotent_and_shared(client):
     a = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     b = users_repo.create(email="bo@x.com", password="hunter2-x", name="Bo")
     _seed_page()
 
     login_fastapi(client, a)
-    first = client.post("/api/coedit/join", json={"path": _PATH}).json()
-    login_fastapi(client, b)
-    second = client.post("/api/coedit/join", json={"path": _PATH}).json()
+    with _ws(client) as (_ws_a, first):
+        login_fastapi(client, b)
+        with _ws(client) as (_ws_b, second):
+            # Same shared session; both users are participants.
+            assert first["session_id"] == second["session_id"]
+            assert {p["user_id"] for p in second["participants"]} == {a, b}
 
-    # Same shared session; both users are participants.
-    assert first["session_id"] == second["session_id"]
-    assert {p["user_id"] for p in second["participants"]} == {a, b}
 
-
-def test_join_without_read_is_forbidden(client):
+def test_connect_without_read_is_forbidden(client):
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
     _seed_page()
@@ -68,30 +128,17 @@ def test_join_without_read_is_forbidden(client):
     acl.set_owner(_PATH, owner)
 
     login_fastapi(client, other)
-    assert client.post("/api/coedit/join", json={"path": _PATH}).status_code == 403
-
-
-def test_stream_requires_read(client):
-    # Opening the stream joins the roster (page-open presence), gated on read
-    # — symmetric with /join; writes are gated at /op. require_can raises
-    # before the response starts streaming, so this returns 403 without
-    # hanging.
-    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
-    other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
-    _seed_page()
-    acl.set_owner(_PATH, owner)  # owner-only page
-
-    login_fastapi(client, owner)
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-
-    login_fastapi(client, other)
-    assert client.get(f"/api/coedit/stream?session_id={sid}").status_code == 403
+    with pytest.raises(WebSocketDenialResponse) as exc_info:
+        with client.websocket_connect(f"/api/coedit/ws?path={_PATH}"):
+            pass
+    assert exc_info.value.status_code == 403
 
 
 def test_read_only_user_joins_as_viewer_but_cannot_edit(client):
-    # Joining is page-open presence (read-gated); the write boundary is /op
-    # and /cursor. A read-only user lands in the roster; they never broadcast
-    # a caret, so presence renders them "viewing" client-side.
+    # Connecting is page-open presence (read-gated); the write boundary is
+    # per-message (op/cursor/checkpoint). A read-only user lands in the
+    # roster; they never broadcast a caret, so presence renders them
+    # "viewing" client-side.
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     reader = users_repo.create(email="reader@x.com", password="hunter2-x", name="Reader")
     _seed_page()
@@ -106,26 +153,14 @@ def test_read_only_user_joins_as_viewer_but_cannot_edit(client):
     )  # ...plus an explicit read grant for the viewer
 
     login_fastapi(client, reader)
-    resp = client.post("/api/coedit/join", json={"path": _PATH})
-    assert resp.status_code == 200
-    sid = resp.json()["session_id"]
-    me = [p for p in resp.json()["participants"] if p["user_id"] == reader]
-    assert me and me[0]["last_edited_at"] is None
+    with _ws(client) as (ws, joined):
+        me = [p for p in joined["participants"] if p["user_id"] == reader]
+        assert me and me[0]["last_edited_at"] is None
 
-    op = client.post(
-        "/api/coedit/op",
-        json={
-            "session_id": sid,
-            "base_version": 0,
-            "changes": [{"from": 0, "to": 0, "insert": "x"}],
-        },
-    )
-    assert op.status_code == 403
-    cursor = client.post(
-        "/api/coedit/cursor",
-        json={"session_id": sid, "anchor": 0, "head": 0, "typing": False},
-    )
-    assert cursor.status_code == 403
+        op_result = _op(ws, 0, [{"from": 0, "to": 0, "insert": "x"}])
+        assert op_result == {"type": "op_result", "request_id": "r", "ok": False, "version": None, "error": "forbidden"}
+
+        _cursor(ws, anchor=0, head=0, typing=False, seq=None)  # fire-and-forget, no reply to assert
 
     # The read tells the frontend not to offer editing at all.
     doc = client.get(f"/api/wiki/file?path={_PATH}")
@@ -141,195 +176,286 @@ def test_op_stamps_last_edited_at(client):
     login_fastapi(client, uid)
     _seed_page()
 
-    joined = client.post("/api/coedit/join", json={"path": _PATH}).json()
-    sid = joined["session_id"]
-    assert joined["participants"][0]["last_edited_at"] is None
-
-    _apply_op(client, sid, 0, [{"from": 0, "to": 0, "insert": "x"}])
-    after = client.get(f"/api/coedit/session?session_id={sid}").json()
-    me = [p for p in after["participants"] if p["user_id"] == uid]
-    assert me and me[0]["last_edited_at"] is not None
+    with _ws(client) as (ws, joined):
+        assert joined["participants"][0]["last_edited_at"] is None
+        _apply_op(ws, 0, [{"from": 0, "to": 0, "insert": "x"}])
+        after = coedit.list_participants(joined["session_id"])
+        me = [p for p in after if p.user_id == uid]
+        assert me and me[0].last_edited_at is not None
 
 
-def test_leave_removes_participant(client):
+def test_disconnect_removes_participant(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page()
 
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    assert len(coedit.list_participants(sid)) == 1
+    with _ws(client) as (_ws_conn, joined):
+        sid = joined["session_id"]
+        assert len(coedit.list_participants(sid)) == 1
 
-    resp = client.post("/api/coedit/leave", json={"session_id": sid})
-    assert resp.status_code == 200
     assert coedit.list_participants(sid) == []
 
 
-def test_leave_last_participant_checkpoints(client):
+def test_disconnect_of_last_participant_checkpoints(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
-    )
 
-    # The last leave enqueues a checkpoint; immediate_mode runs it inline.
     with coedit_queue.immediate_mode():
-        assert client.post("/api/coedit/leave", json={"session_id": sid}).status_code == 200
+        with _ws(client) as (ws, joined):
+            sid = joined["session_id"]
+            _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
+        # The disconnect handler enqueues a checkpoint; immediate_mode runs
+        # it inline before websocket_connect's __exit__ returns.
 
     assert git.read_file(_PATH) == "hi world"
     assert coedit.get_active_session(_PATH) is None
+    assert sid is not None
 
 
-def test_checkpoint_endpoint_commits_buffer(client):
+def test_checkpoint_message_commits_buffer(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
-    )
 
     with coedit_queue.immediate_mode():
-        resp = client.post("/api/coedit/checkpoint", json={"session_id": sid})
-    assert resp.status_code == 200
-    assert resp.json() == {"queued": True}
+        with _ws(client) as (ws, joined):
+            sid = joined["session_id"]
+            _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
+            result = _checkpoint(ws)
+            assert result == {"type": "checkpoint_result", "request_id": "c", "ok": True}
+
     assert git.read_file(_PATH) == "hi world"
     # An explicit checkpoint doesn't close a session with an active participant.
     assert coedit.get_active_session(_PATH) is not None
+    assert sid is not None
 
 
 def test_checkpoint_requires_write(client):
+    # `other` needs *read* to connect at all (the WS handshake is read-gated
+    # — see app/api/coedit.py) — granting only read, not write, is what
+    # actually exercises the write-specific rejection; owner-only with no
+    # grant for `other` would reject the connection itself, never reaching
+    # the per-message check this test is about.
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
     _seed_page()
-    acl.set_owner(_PATH, owner)  # owner-only
+    acl.set_owner(_PATH, owner)
+    acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=other,
+        permission="read",
+        granted_by_user_id=owner,
+    )
     login_fastapi(client, owner)
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    with _ws(client) as (_owner_ws, _joined):
+        login_fastapi(client, other)
+        with _ws(client) as (ws, _joined2):
+            result = _checkpoint(ws)
+            assert result == {"type": "checkpoint_result", "request_id": "c", "ok": False}
 
-    login_fastapi(client, other)
-    assert client.post("/api/coedit/checkpoint", json={"session_id": sid}).status_code == 403
 
-
-def _login_and_join(client, email="ada@x.com") -> int:
+def _login_and_join(client, email="ada@x.com"):
     uid = users_repo.create(email=email, password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")
-    return client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    return client.websocket_connect(f"/api/coedit/ws?path={_PATH}")
 
 
 def test_op_applies_and_returns_version(client):
-    sid = _login_and_join(client)  # buffer seeded as "hello world"
-    resp = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 5, "insert": "hi"}]},
-    )
-    assert resp.status_code == 200
-    assert resp.json()["version"] == 1
-    # GET /session reflects the applied edit.
-    state = client.get(f"/api/coedit/session?session_id={sid}").json()
-    assert state["version"] == 1
-    assert state["buffer"] == "hi world"
+    with _login_and_join(client) as ws:
+        joined = ws.receive_json()  # buffer seeded as "hello world"
+        version = _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
+        assert version == 1
+        # get_ops reflects the applied edit.
+        ops = _get_ops(ws, 0)
+        assert ops["current_head_version"] == 1
+        assert ops["ops"][0]["changes"] == [{"from": 0, "to": 5, "insert": "hi"}]
+        assert joined["session_id"]  # sanity: joined before the op
 
 
-def test_op_stale_base_version_is_409(client):
-    sid = _login_and_join(client)
-    client.post("/api/coedit/op", json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "x"}]})
-    resp = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "y"}]},
-    )
-    assert resp.status_code == 409
+def test_op_stale_base_version_is_stale_version_error(client):
+    with _login_and_join(client) as ws:
+        ws.receive_json()
+        _apply_op(ws, 0, [{"from": 0, "to": 0, "insert": "x"}])
+        result = _op(ws, 0, [{"from": 0, "to": 0, "insert": "y"}])
+        assert result == {"type": "op_result", "request_id": "r", "ok": False, "version": None, "error": "stale_version"}
 
 
-def test_op_out_of_bounds_is_422(client):
-    sid = _login_and_join(client)
-    resp = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 9999, "insert": "x"}]},
-    )
-    assert resp.status_code == 422
+def test_op_out_of_bounds_is_invalid_op_error(client):
+    with _login_and_join(client) as ws:
+        ws.receive_json()
+        result = _op(ws, 0, [{"from": 0, "to": 9999, "insert": "x"}])
+        assert result == {"type": "op_result", "request_id": "r", "ok": False, "version": None, "error": "invalid_op"}
 
 
-def test_op_malformed_change_is_rejected(client):
-    # Missing 'to' fails Change request-body validation → the app's handler
-    # returns 400 (semantic out-of-bounds is the 422 case above).
-    sid = _login_and_join(client)
-    resp = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "insert": "x"}]},
-    )
-    assert resp.status_code == 400
+def test_op_malformed_change_logs_and_drops_silently(client):
+    # Missing 'to' fails pydantic validation inside the recv loop — logged
+    # and dropped (see app/api/coedit.py's ValidationError handling), not a
+    # per-message error reply, since a malformed frame has no valid
+    # request_id to correlate a reply against. A well-formed op sent right
+    # after still gets a normal reply, proving the connection survives it.
+    with _login_and_join(client) as ws:
+        ws.receive_json()
+        ws.send_json({"type": "op", "request_id": "bad", "base_version": 0, "changes": [{"from": 0, "insert": "x"}]})
+        version = _apply_op(ws, 0, [{"from": 0, "to": 0, "insert": "ok"}])
+        assert version == 1
 
 
-def test_cursor_broadcasts_and_returns_ok(client):
-    sid = _login_and_join(client)
-    resp = client.post(
-        "/api/coedit/cursor",
-        json={"session_id": sid, "anchor": 0, "head": 5, "typing": True},
-    )
-    assert resp.status_code == 200
-    assert resp.json() == {"ok": True}
+def test_cursor_broadcasts_to_peers(client):
+    a = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    b = users_repo.create(email="bo@x.com", password="hunter2-x", name="Bo")
+    _seed_page("hello world")
+
+    login_fastapi(client, a)
+    with _ws(client) as (ws_a, _joined_a):
+        login_fastapi(client, b)
+        with _ws(client) as (ws_b, _joined_b):
+            ws_a.receive_json()  # the presence frame announcing b's join
+            _cursor(ws_a, anchor=0, head=5, typing=True, seq=1)
+            frame = ws_b.receive_json()
+            assert frame["type"] == "cursor"
+            assert frame["user_id"] == a
+            assert frame["anchor"] == 0 and frame["head"] == 5
 
 
-def test_cursor_clear_returns_ok(client):
+def test_cursor_clear_broadcasts_null_anchor(client):
     # A null-position cursor (editor blur / tab hidden) is a caret clear —
     # broadcast to the session so peers drop the caret; nothing persisted.
-    sid = _login_and_join(client)
-    resp = client.post(
-        "/api/coedit/cursor",
-        json={
-            "session_id": sid,
-            "anchor": None,
-            "head": None,
-            "typing": False,
-            "seq": 2,
-        },
-    )
-    assert resp.status_code == 200
-    assert resp.json() == {"ok": True}
+    a = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    b = users_repo.create(email="bo@x.com", password="hunter2-x", name="Bo")
+    _seed_page("hello world")
+
+    login_fastapi(client, a)
+    with _ws(client) as (ws_a, _joined_a):
+        login_fastapi(client, b)
+        with _ws(client) as (ws_b, _joined_b):
+            ws_a.receive_json()  # presence
+            _cursor(ws_a, anchor=None, head=None, typing=False, seq=2)
+            frame = ws_b.receive_json()
+            assert frame["type"] == "cursor"
+            assert frame["anchor"] is None and frame["head"] is None
 
 
 def test_cursor_requires_write(client):
+    # See test_checkpoint_requires_write's comment: `other` needs read to
+    # connect at all — granting only read (not write) is what exercises the
+    # write-specific rejection this test is actually about.
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
     _seed_page()
-    acl.set_owner(_PATH, owner)  # owner-only
-    login_fastapi(client, owner)
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-
-    login_fastapi(client, other)
-    resp = client.post(
-        "/api/coedit/cursor", json={"session_id": sid, "anchor": 0, "head": 0, "typing": False}
+    acl.set_owner(_PATH, owner)
+    acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=other,
+        permission="read",
+        granted_by_user_id=owner,
     )
-    assert resp.status_code == 403
+    login_fastapi(client, owner)
+    with _ws(client) as (owner_ws, _joined):
+        login_fastapi(client, other)
+        with _ws(client) as (ws, _joined2):
+            owner_ws.receive_json()  # presence frame for other's join
+            _cursor(ws, anchor=0, head=0, typing=False, seq=None)
+            # Cursor is fire-and-forget (no result frame to assert on
+            # directly — see app/api/coedit.py), so prove the rejection by
+            # racing it against a legitimate, always-broadcast op from the
+            # owner: broadcasts (including a sender's own) land on every
+            # connection in arrival order, so if `other`'s connection sees
+            # the owner's op *before* any cursor frame, their own cursor was
+            # dropped rather than merely reordered behind it.
+            result = _op(owner_ws, 0, [{"from": 0, "to": 0, "insert": "x"}])
+            assert result["ok"] is True
+            first = ws.receive_json()
+            assert first["type"] == "op"
 
 
 def test_op_requires_write(client):
+    # See test_checkpoint_requires_write's comment: `other` needs read to
+    # connect at all — granting only read (not write) is what exercises the
+    # write-specific rejection this test is actually about.
     owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
     other = users_repo.create(email="other@x.com", password="hunter2-x", name="Other")
     _seed_page()
-    acl.set_owner(_PATH, owner)  # owner-only
+    acl.set_owner(_PATH, owner)
+    acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=other,
+        permission="read",
+        granted_by_user_id=owner,
+    )
     login_fastapi(client, owner)
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
+    with _ws(client) as (_owner_ws, _joined):
+        login_fastapi(client, other)
+        with _ws(client) as (ws, _joined2):
+            result = _op(ws, 0, [{"from": 0, "to": 0, "insert": "x"}])
+            assert result == {"type": "op_result", "request_id": "r", "ok": False, "version": None, "error": "forbidden"}
 
-    login_fastapi(client, other)
-    resp = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 0, "changes": [{"from": 0, "to": 0, "insert": "x"}]},
+
+def test_write_permission_revoked_mid_session_is_enforced_on_next_message(client):
+    # The one behavior this migration was explicit about preserving: unlike
+    # the other (Yjs) WS work's connect-time-only gate, write permission is
+    # re-checked on every message, not just at connect — a mid-session ACL
+    # change takes effect immediately, not just on the next reconnect.
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    editor = users_repo.create(email="editor@x.com", password="hunter2-x", name="Editor")
+    _seed_page("hello world")
+    acl.set_owner(_PATH, owner)
+    entry_id = acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=editor,
+        permission="write",
+        granted_by_user_id=owner,
     )
-    assert resp.status_code == 403
+
+    login_fastapi(client, editor)
+    with _ws(client) as (ws, _joined):
+        assert _apply_op(ws, 0, [{"from": 0, "to": 0, "insert": "x"}]) == 1
+        acl.revoke(entry_id)
+        result = _op(ws, 1, [{"from": 0, "to": 0, "insert": "y"}])
+        assert result == {"type": "op_result", "request_id": "r", "ok": False, "version": None, "error": "forbidden"}
 
 
-def _apply_op(client, sid: int, base_version: int, changes: list[dict]) -> int:
-    resp = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": base_version, "changes": changes},
-    )
-    assert resp.status_code == 200, resp.text
-    return resp.json()["version"]
+def test_get_ops_returns_missed_changes_for_rebase(client):
+    with _login_and_join(client) as ws:
+        ws.receive_json()
+        v1 = _apply_op(ws, 0, [{"from": 0, "to": 0, "insert": "X"}])
+        v2 = _apply_op(ws, v1, [{"from": 0, "to": 0, "insert": "Y"}])
+
+        # since_version=0 → both ops, oldest first, wire-shaped like op frames ("from" alias).
+        body = _get_ops(ws, 0)
+        assert body["current_head_version"] == v2
+        assert [o["version"] for o in body["ops"]] == [v1, v2]
+        assert body["ops"][0]["changes"] == [{"from": 0, "to": 0, "insert": "X"}]
+
+        # since_version=v1 → only the op after it.
+        body2 = _get_ops(ws, v1)
+        assert [o["version"] for o in body2["ops"]] == [v2]
+
+        # since_version=head → nothing missed.
+        assert _get_ops(ws, v2)["ops"] == []
+
+
+def test_op_client_id_round_trips_to_get_ops(client):
+    with _login_and_join(client) as ws:
+        ws.receive_json()
+        # Op tagged with a per-connection client id.
+        _op(ws, 0, [{"from": 0, "to": 0, "insert": "X"}], client_id="cli_abc")
+        op = _get_ops(ws, 0)["ops"][0]
+        assert op["client_id"] == "cli_abc"
+
+        # Omitting client_id (non-collab client) is fine — it's null.
+        _op(ws, 1, [{"from": 0, "to": 0, "insert": "Y"}])
+        ops = _get_ops(ws, 1)["ops"]
+        assert ops[0]["client_id"] is None
 
 
 def test_file_read_serves_live_buffer_during_session(client):
@@ -339,16 +465,16 @@ def test_file_read_serves_live_buffer_during_session(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     sha = _seed_page("# Setup\n\nhello\n")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    _apply_op(client, sid, 0, [{"from": 0, "to": len("# Setup\n\nhello\n"), "insert": "LIVE\n"}])
+    with _ws(client) as (ws, _joined):
+        _apply_op(ws, 0, [{"from": 0, "to": len("# Setup\n\nhello\n"), "insert": "LIVE\n"}])
 
-    resp = client.get(f"/api/wiki/file?path={_PATH}")
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["body"] == "LIVE\n"  # buffer, not committed HEAD
-    assert body["head_sha"] == sha  # HEAD still the pre-session commit
-    # git working tree is untouched — nothing was committed.
-    assert git.read_file(_PATH) == "# Setup\n\nhello\n"
+        resp = client.get(f"/api/wiki/file?path={_PATH}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["body"] == "LIVE\n"  # buffer, not committed HEAD
+        assert body["head_sha"] == sha  # HEAD still the pre-session commit
+        # git working tree is untouched — nothing was committed.
+        assert git.read_file(_PATH) == "# Setup\n\nhello\n"
 
 
 def test_file_read_merges_agent_commit_over_live_buffer(client):
@@ -359,76 +485,14 @@ def test_file_read_merges_agent_commit_over_live_buffer(client):
     login_fastapi(client, uid)
     doc = "one\ntwo\nthree\nfour\nfive\n"
     _seed_page(doc)
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    # Human edits the first line in the buffer...
-    _apply_op(client, sid, 0, [{"from": 0, "to": 3, "insert": "ONE"}])
-    # ...an agent commits a distant, non-overlapping change out of band.
-    git.commit_file(_PATH, "one\ntwo\nthree\nfour\nFIVE\n", message="agent", author="A <a@x.com>")
+    with _ws(client) as (ws, _joined):
+        # Human edits the first line in the buffer...
+        _apply_op(ws, 0, [{"from": 0, "to": 3, "insert": "ONE"}])
+        # ...an agent commits a distant, non-overlapping change out of band.
+        git.commit_file(_PATH, "one\ntwo\nthree\nfour\nFIVE\n", message="agent", author="A <a@x.com>")
 
-    body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
-    assert body == "ONE\ntwo\nthree\nfour\nFIVE\n"  # both edits, no LLM, no commit
-
-
-def test_ops_requires_auth(client):
-    assert client.get("/api/coedit/ops?session_id=1&since_version=0").status_code == 401
-
-
-def test_ops_since_returns_missed_changes_for_rebase(client):
-    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
-    login_fastapi(client, uid)
-    _seed_page("abcdef\n")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    v1 = _apply_op(client, sid, 0, [{"from": 0, "to": 0, "insert": "X"}])
-    v2 = _apply_op(client, sid, v1, [{"from": 0, "to": 0, "insert": "Y"}])
-
-    # since_version=0 → both ops, oldest first, wire-shaped like op frames ("from" alias).
-    body = client.get(f"/api/coedit/ops?session_id={sid}&since_version=0").json()
-    assert body["current_head_version"] == v2
-    assert [o["version"] for o in body["ops"]] == [v1, v2]
-    assert body["ops"][0]["changes"] == [{"from": 0, "to": 0, "insert": "X"}]
-    assert body["ops"][0]["author"] == uid
-
-    # since_version=v1 → only the op after it.
-    body2 = client.get(f"/api/coedit/ops?session_id={sid}&since_version={v1}").json()
-    assert [o["version"] for o in body2["ops"]] == [v2]
-
-    # since_version=head → nothing missed.
-    assert client.get(f"/api/coedit/ops?session_id={sid}&since_version={v2}").json()["ops"] == []
-
-
-def test_ops_404_when_no_active_session(client):
-    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
-    login_fastapi(client, uid)
-    assert client.get("/api/coedit/ops?session_id=99999&since_version=0").status_code == 404
-
-
-def test_op_client_id_round_trips_to_ops(client):
-    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
-    login_fastapi(client, uid)
-    _seed_page("abc\n")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    # Op tagged with a per-connection client id.
-    resp = client.post(
-        "/api/coedit/op",
-        json={
-            "session_id": sid,
-            "base_version": 0,
-            "changes": [{"from": 0, "to": 0, "insert": "X"}],
-            "client_id": "cli_abc",
-        },
-    )
-    assert resp.status_code == 200
-    op = client.get(f"/api/coedit/ops?session_id={sid}&since_version=0").json()["ops"][0]
-    assert op["client_id"] == "cli_abc"
-
-    # Omitting client_id (non-collab client) is fine — it's null.
-    resp2 = client.post(
-        "/api/coedit/op",
-        json={"session_id": sid, "base_version": 1, "changes": [{"from": 0, "to": 0, "insert": "Y"}]},
-    )
-    assert resp2.status_code == 200
-    ops = client.get(f"/api/coedit/ops?session_id={sid}&since_version=1").json()["ops"]
-    assert ops[0]["client_id"] is None
+        body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
+        assert body == "ONE\ntwo\nthree\nfour\nFIVE\n"  # both edits, no LLM, no commit
 
 
 def test_file_read_serves_head_when_buffer_conflicts_with_committed_change(client):
@@ -440,14 +504,14 @@ def test_file_read_serves_head_when_buffer_conflicts_with_committed_change(clien
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("one\ntwo\nthree\n")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    # Human edits the first line in the buffer...
-    _apply_op(client, sid, 0, [{"from": 0, "to": 3, "insert": "BUFFER"}])
-    # ...an agent commits a CONFLICTING change to the same first line out of band.
-    git.commit_file(_PATH, "AGENT\ntwo\nthree\n", message="agent", author="A <a@x.com>")
+    with _ws(client) as (ws, _joined):
+        # Human edits the first line in the buffer...
+        _apply_op(ws, 0, [{"from": 0, "to": 3, "insert": "BUFFER"}])
+        # ...an agent commits a CONFLICTING change to the same first line out of band.
+        git.commit_file(_PATH, "AGENT\ntwo\nthree\n", message="agent", author="A <a@x.com>")
 
-    body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
-    assert body == "AGENT\ntwo\nthree\n"  # committed HEAD, not the stale buffer
+        body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
+        assert body == "AGENT\ntwo\nthree\n"  # committed HEAD, not the stale buffer
 
 
 def test_file_read_serves_buffer_at_zero_participants_when_no_conflict(client):
@@ -459,11 +523,11 @@ def test_file_read_serves_buffer_at_zero_participants_when_no_conflict(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("# Setup\n\nhello\n")
-    sid = client.post("/api/coedit/join", json={"path": _PATH}).json()["session_id"]
-    _apply_op(client, sid, 0, [{"from": 0, "to": len("# Setup\n\nhello\n"), "insert": "LIVE\n"}])
-    coedit.leave(sid, uid)  # everyone leaves; session stays active (zombie)
-    st = coedit.get_active_session(_PATH)
-    assert st is not None and st.status == "active"
+    with _ws(client) as (ws, joined):
+        _apply_op(ws, 0, [{"from": 0, "to": len("# Setup\n\nhello\n"), "insert": "LIVE\n"}])
+        coedit.leave(joined["session_id"], uid)  # everyone leaves; session stays active (zombie)
+        st = coedit.get_active_session(_PATH)
+        assert st is not None and st.status == "active"
 
-    body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
-    assert body == "LIVE\n"  # HEAD hasn't moved → buffer still safe to serve
+        body = client.get(f"/api/wiki/file?path={_PATH}").json()["body"]
+        assert body == "LIVE\n"  # HEAD hasn't moved → buffer still safe to serve

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -224,10 +224,13 @@ def test_checkpoint_message_commits_buffer(client):
             _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
             result = _checkpoint(ws)
             assert result == {"type": "checkpoint_result", "request_id": "c", "ok": True}
+            # An explicit checkpoint doesn't close a session with an active
+            # participant — must assert this before the connection closes;
+            # disconnecting drops the last participant too, which (with an
+            # already-clean buffer) triggers its own close.
+            assert coedit.get_active_session(_PATH) is not None
 
     assert git.read_file(_PATH) == "hi world"
-    # An explicit checkpoint doesn't close a session with an active participant.
-    assert coedit.get_active_session(_PATH) is not None
     assert sid is not None
 
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,6 +69,23 @@ export async function apiFetchBlob(
   return res.blob();
 }
 
+/** Resolves `path` against `BASE` the same way {@link apiFetch} does, but as
+ * a `ws://`/`wss://` URL for a `new WebSocket(...)` caller. Kept here (not in
+ * the coedit-specific client) so `BASE`'s resolution logic — relative vs. an
+ * absolute `NEXT_PUBLIC_API_BASE` override — lives in exactly one place. */
+export function apiSocketUrl(path: string): string {
+  const isAbsolute = /^https?:\/\//i.test(BASE);
+  if (isAbsolute) {
+    return `${BASE}${path}`.replace(/^http/, "ws");
+  }
+  const proto =
+    typeof window !== "undefined" && window.location.protocol === "https:"
+      ? "wss"
+      : "ws";
+  const host = typeof window !== "undefined" ? window.location.host : "";
+  return `${proto}://${host}${BASE}${path}`;
+}
+
 /** SSE-style streaming POST. Parses ``data: {...json}\n\n`` frames and
  * dispatches them through ``onEvent``. Pre-stream HTTP errors come back as
  * ``ApiError`` (matching ``apiFetch``). The promise resolves when the server

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -10,19 +10,21 @@
  * Nothing is persisted: carets appear from live cursor/op frames and go away
  * on a clear (editor blur / hidden tab) or when the peer leaves.
  *
- * On `enabled` it joins the session for `path`, streams inbound frames, and
- * exposes presence (`participants`/`typing`/`peers`) and autosave
- * (`saveStatus`). Teardown (flush → checkpoint → leave → stream abort, in
- * that order — leaving/disconnecting first would let the server's last-leave
- * forced commit race ahead of the final ops) happens entirely inside the
- * hook's own effect cleanup — driven by `enabled`/`path` changing or the
- * component unmounting, never by the caller invoking a function. The
- * *document* is owned by the editor via
- * `@codemirror/collab` (see `Coeditor`), not here — the hook just hands the
- * editor what it needs to run collab (`session` = id/clientId/start
- * version+doc), forwards inbound `op`/`resync` frames to it (`onServerFrame`),
- * and keeps a read-only `buffer` mirror for non-editor UI (the template
- * gallery).
+ * On `enabled` it opens the session's WebSocket for `path` and exposes
+ * presence (`participants`/`typing`/`peers`) and autosave (`saveStatus`).
+ * Teardown (flush → checkpoint → close, in that order — closing before the
+ * final ops and checkpoint have landed would let the server's last-leave
+ * forced commit race ahead of them) happens entirely inside the hook's own
+ * effect cleanup — driven by `enabled`/`path` changing or the component
+ * unmounting, never by the caller invoking a function. There's no explicit
+ * "leave" call: closing the connection *is* the leave signal, handled
+ * server-side (see `app/api/coedit.py`'s module docstring) — more reliable
+ * than the old design's client-initiated keepalive fetch on unload. The
+ * *document* is owned by the editor via `@codemirror/collab` (see
+ * `Coeditor`), not here — the hook just hands the editor what it needs to
+ * run collab (`session` = id/clientId/start version+doc), forwards inbound
+ * `op`/`resync` frames to it (`onServerFrame`), and keeps a read-only
+ * `buffer` mirror for non-editor UI (the template gallery).
  *
  * Autosave: every `reportDoc` (called by the editor on each doc change) arms
  * an idle timer (checkpoint `AUTOSAVE_IDLE_MS` after the last edit) and, if
@@ -39,8 +41,6 @@
  */
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { ApiError } from "@/lib/api";
-
 import type {
   CoeditFrame,
   CoeditParticipant,
@@ -50,10 +50,9 @@ import type {
 } from "@/lib/editor/types";
 import {
   checkpointSession,
-  joinSession,
-  leaveSession,
+  closeSession,
+  connectSession,
   sendCursor,
-  streamSession,
 } from "@/lib/editor/svc";
 import {
   AUTOSAVE_IDLE_MS,
@@ -65,14 +64,13 @@ import {
 } from "@/lib/editor/constants";
 
 /** Generate a fresh per-connection collab clientId (UUID v4).
- * Used to filter out our own op echoes from the SSE stream. */
+ * Used to filter out our own op echoes from the broadcast stream. */
 function newClientId(): string {
   return crypto.randomUUID();
 }
 
-/** Manage the full lifecycle of a page's live session: join, stream,
- * presence, and save. Disable with `enabled: false` to leave the session and
- * tear down the stream. */
+/** Manage the full lifecycle of a page's live session: connect, presence,
+ * and save. Disable with `enabled: false` to close the connection. */
 export function useCoeditSession(opts: {
   path: string;
   enabled: boolean;
@@ -82,7 +80,7 @@ export function useCoeditSession(opts: {
    * False joins the live session as a pure viewer: presence + real-time
    * updates flow as usual, but every write call (ops come from the read-only
    * editor anyway, cursor pings, checkpoints) is suppressed — the server
-   * would 403 them. Defaults to true. */
+   * would reject them. Defaults to true. */
   canWrite?: boolean;
   onEnd?: () => void;
 }): UseCoeditSession {
@@ -119,7 +117,6 @@ export function useCoeditSession(opts: {
 
   const sessionId = useRef<number | null>(null);
   const clientId = useRef<string>("");
-  const abort = useRef<AbortController | null>(null);
   // Editor-registered hooks: inbound frame handler + pending-op flush.
   const serverFrame = useRef<((frame: CoeditFrame) => void) | null>(null);
   const flushFn = useRef<(() => Promise<void>) | null>(null);
@@ -127,11 +124,12 @@ export function useCoeditSession(opts: {
   const catchUpFn = useRef<(() => void) | null>(null);
   // Ref mirror of `buffer` (the editor doc) for non-render reads.
   const bufferRef = useRef("");
-  // Local doc carried across a forced re-join: when the session closed under
-  // us and the tail couldn't be delivered, the edits exist only in this tab —
-  // re-applied onto the fresh session instead of being silently replaced by
-  // the checkpointed version. Path-tagged so it can never leak onto another
-  // page.
+  // Local doc carried across a forced reconnect that landed on a *different*
+  // session than we had before (ours closed while we were disconnected —
+  // last participant left, checkpointed, closed): the edits exist only in
+  // this tab, so they're re-applied onto the fresh session instead of being
+  // silently replaced by its checkpointed buffer. Path-tagged so it can
+  // never leak onto another page.
   const recoverDoc = useRef<{ path: string; doc: string } | null>(null);
   // Outbound cursor/typing throttle state.
   const cursorThrottle = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -256,13 +254,7 @@ export function useCoeditSession(opts: {
         const c = pendingCursor.current;
         pendingCursor.current = null;
         if (c && sessionId.current !== null) {
-          void sendCursor(
-            sessionId.current,
-            c.anchor,
-            c.head,
-            c.typing,
-            c.seq,
-          ).catch(() => {});
+          sendCursor(sessionId.current, c.anchor, c.head, c.typing, c.seq);
         }
       };
       if (!cursorThrottle.current) {
@@ -278,13 +270,13 @@ export function useCoeditSession(opts: {
           typingIdle.current = null;
           const lc = lastCursor.current;
           if (sessionId.current !== null && lc) {
-            void sendCursor(
+            sendCursor(
               sessionId.current,
               lc.anchor,
               lc.head,
               false,
               caretEpoch.current,
-            ).catch(() => {});
+            );
           }
         }, TYPING_IDLE_MS);
       }
@@ -308,11 +300,7 @@ export function useCoeditSession(opts: {
       clearTimeout(typingIdle.current);
       typingIdle.current = null;
     }
-    // Immediate (clears are rare) + keepalive so the hidden-tab clear
-    // survives the page backgrounding.
-    void sendCursor(sessionId.current, null, null, false, caretEpoch.current, {
-      keepalive: true,
-    }).catch(() => {});
+    sendCursor(sessionId.current, null, null, false, caretEpoch.current);
   }, [canWrite]);
 
   const getCaretSeq = useCallback(
@@ -428,9 +416,9 @@ export function useCoeditSession(opts: {
 
   // Tears down the *local* session state (timers, presence, handles) and
   // fires `onEnd` — the one and only "session is over" signal. The network
-  // side (flush, checkpoint, leave, stream abort) is NOT done here: the join
-  // effect's cleanup below — the only caller — sequences those explicitly,
-  // because their order matters (see the comment there).
+  // side (flush, checkpoint, close) is NOT done here: the join effect's
+  // cleanup below — the only caller — sequences those explicitly, because
+  // their order matters (see the comment there).
   const stop = useCallback(() => {
     clearAutosaveTimers();
     if (cursorThrottle.current) {
@@ -455,122 +443,109 @@ export function useCoeditSession(opts: {
     onEnd?.();
   }, [clearAutosaveTimers, onEnd]);
 
-  // Join + stream while enabled (the caller passes `!viewingVersion` — i.e.
-  // whenever the live/current doc is showing, not an old commit); leave on
-  // disable/path-change/unmount. `retryToken` lets `retryJoin` force a re-run
-  // without `enabled`/`path` changing.
+  // Connect while enabled (the caller passes `!viewingVersion` — i.e.
+  // whenever the live/current doc is showing, not an old commit); close on
+  // disable/path-change/unmount. `retryToken` lets `retryJoin` force a
+  // re-run without `enabled`/`path` changing.
   useEffect(() => {
     if (!enabled) return;
-    const ctrl = new AbortController();
-    abort.current = ctrl;
     clientId.current = newClientId();
     let cancelled = false;
-    // Mirror shows the committed body until the join resolves.
+    // Mirror shows the committed body until the connection resolves.
     bufferRef.current = committedBody;
     setBuffer(committedBody);
     setJoinError(null);
 
     void (async () => {
-      let snap;
-      try {
-        snap = await joinSession(path);
-      } catch (e) {
-        // The join handshake itself failed — there's no session to fall
-        // back to (no more read-only mode), so this must be surfaced rather
-        // than left as a silent, permanent "Connecting…".
-        if (!cancelled) {
-          setJoinError(
-            e instanceof Error
-              ? e.message
-              : "Failed to join the editing session.",
-          );
-        }
-        return;
-      }
-      if (cancelled) return;
-      sessionId.current = snap.session_id;
-      bufferRef.current = snap.buffer;
-      setBuffer(snap.buffer);
-      participantsRef.current = snap.participants;
-      setParticipants(snap.participants);
-      caretPlaced.current = false;
-      setSession({
-        id: snap.session_id,
-        clientId: clientId.current,
-        startVersion: snap.version,
-        startDoc: snap.buffer,
-      });
-      setActive(true);
-      // The stream loop: reconnect when the connection drops (network blip,
-      // laptop sleep) instead of leaving a silently-stale editable doc — the
-      // server never pushes again on a dead stream, and without this loop the
-      // client would only heal on a full page reload. Re-opening the stream
-      // re-joins us as a participant; the catch-up pull replays ops missed
-      // while disconnected (anything landing in the crack re-pulls via the
-      // op-frame gap detection).
+      // Connect (and reconnect on a drop) in a loop — the server never
+      // pushes again on a dead connection, and without this loop the client
+      // would only heal on a full page reload. Each attempt re-resolves the
+      // session by *path* (get-or-create server-side), so — unlike the old
+      // numeric-session_id-scoped stream — there's no separate "the session
+      // I had went stale" error to special-case; a reconnect either adopts
+      // the same still-open session or transparently gets a fresh one (see
+      // the session-id-changed branch below for that latter case).
+      let firstConnect = true;
       while (!cancelled) {
+        let snap;
         try {
-          // Gate on `cancelled`: the stream outlives the effect during
-          // teardown (it's aborted only after the final flush/checkpoint/
-          // leave below), and a late frame from the old session must not
-          // leak into state a new session now owns.
-          await streamSession(
-            snap.session_id,
-            (frame) => {
-              if (!cancelled) onFrame(frame);
-            },
-            ctrl.signal,
-          );
+          snap = await connectSession(path, (frame) => {
+            if (!cancelled) onFrame(frame);
+          });
         } catch (e) {
-          if (cancelled || ctrl.signal.aborted) break;
-          if (e instanceof ApiError && e.status === 404) {
-            // The session closed while we were gone (last participant left →
-            // checkpoint + close). Streaming can't resurrect it — re-run the
-            // whole join to mint/adopt a fresh session. First try to deliver
-            // any local tail; if that fails too (ops bounce off the closed
-            // session), those edits exist only in this tab — carry the doc
-            // across the re-join so the fresh session's checkpointed buffer
-            // doesn't silently replace them (see the recovery effect below).
-            try {
-              await flushFn.current?.();
-            } catch {
-              recoverDoc.current = { path, doc: bufferRef.current };
-            }
-            retryJoin();
-            break;
+          // The join handshake itself failed — there's no session to fall
+          // back to (no more read-only mode), so this must be surfaced
+          // rather than left as a silent, permanent "Connecting…".
+          if (!cancelled) {
+            setJoinError(
+              e instanceof Error
+                ? e.message
+                : "Failed to join the editing session.",
+            );
           }
+          return;
         }
-        if (cancelled || ctrl.signal.aborted) break;
+        if (cancelled) {
+          closeSession(snap.session_id);
+          return;
+        }
+
+        // A reconnect that landed on a *different* session than before means
+        // ours closed while we were disconnected (last participant left,
+        // checkpointed, closed) — there's no live target left to flush our
+        // pending edits onto, so stash the local doc for the recovery effect
+        // below instead of losing it to the fresh session's checkpointed
+        // buffer.
+        if (
+          sessionId.current !== null &&
+          sessionId.current !== snap.session_id
+        ) {
+          recoverDoc.current = { path, doc: bufferRef.current };
+        }
+
+        sessionId.current = snap.session_id;
+        bufferRef.current = snap.buffer;
+        setBuffer(snap.buffer);
+        participantsRef.current = snap.participants;
+        setParticipants(snap.participants);
+        caretPlaced.current = false;
+        setSession({
+          id: snap.session_id,
+          clientId: clientId.current,
+          startVersion: snap.version,
+          startDoc: snap.buffer,
+        });
+        setActive(true);
+        if (!firstConnect) catchUpFn.current?.();
+        firstConnect = false;
+
+        // Waits here for the connection's whole lifetime — resolves once it
+        // ends, for any reason (network drop, server close, or our own
+        // teardown's `closeSession` below).
+        const { expected } = await snap.closed;
+        if (cancelled || expected) return;
         await new Promise((r) => setTimeout(r, STREAM_RECONNECT_MS));
-        if (cancelled || ctrl.signal.aborted) break;
-        catchUpFn.current?.();
       }
     })();
 
     return () => {
       cancelled = true;
-      // Teardown must run flush → checkpoint → leave → abort, in that strict
-      // order. The server force-commits and closes the session when the last
-      // participant is gone, and BOTH leaving and dropping the SSE stream
-      // count as "gone" — so leaving (or aborting) before the final ops and
-      // checkpoint have landed lets that forced commit race ahead of them:
-      // it commits a buffer missing the tail, `close_if_clean` closes the
-      // session, and the late ops bounce off a closed session (silent loss).
-      // Leaving last means the forced commit only ever sees a clean,
-      // fully-flushed buffer.
+      // Teardown must run flush → checkpoint → close, in that strict order.
+      // The server force-commits and closes the session when the last
+      // participant is gone, and closing the connection counts as "gone" —
+      // so closing before the final ops and checkpoint have landed lets that
+      // forced commit race ahead of them: it commits a buffer missing the
+      // tail, closes the session, and the late ops bounce off a closed
+      // session (silent loss). Closing last means the forced commit only
+      // ever sees a clean, fully-flushed buffer.
       const sid = sessionId.current;
       // The editor never unregisters its flush (see Coeditor's cleanup) so
       // it's still here even when the child unmounted first; clear it as we
       // take ownership of the final call.
       const flush = flushFn.current;
       flushFn.current = null;
-      const ctrl = abort.current;
-      abort.current = null;
       stop();
-      if (sid === null) {
-        ctrl?.abort();
-        return;
-      }
+      if (sid === null) return;
       void (async () => {
         try {
           await flush?.();
@@ -581,27 +556,23 @@ export function useCoeditSession(opts: {
         }
         if (canWrite) {
           try {
-            await checkpointSession(sid, { keepalive: true });
+            await checkpointSession(sid);
           } catch {
-            // The last-leave forced commit below is the backstop.
+            // The server-side close-triggered forced commit is the backstop.
           }
         }
-        try {
-          await leaveSession(sid, { keepalive: true });
-        } catch {
-          // The server-side leave on SSE disconnect is the backstop.
-        }
-        ctrl?.abort();
+        closeSession(sid);
       })();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [enabled, path, retryToken]);
 
-  // Re-apply a doc carried across a forced re-join (see the stream loop's
-  // 404 branch): once the fresh session's editor has mounted (child effects
-  // run before this one, so `setDoc` is registered), replace the buffer with
-  // the saved local doc as a normal local edit — it lands as an op on the
-  // new session instead of being lost to the checkpointed version.
+  // Re-apply a doc carried across a forced reconnect (see the connect loop's
+  // session-id-changed branch above): once the fresh session's editor has
+  // mounted (child effects run before this one, so `setDoc` is registered),
+  // replace the buffer with the saved local doc as a normal local edit — it
+  // lands as an op on the new session instead of being lost to the
+  // checkpointed version.
   useEffect(() => {
     if (session === null || recoverDoc.current === null) return;
     const saved = recoverDoc.current;
@@ -611,17 +582,26 @@ export function useCoeditSession(opts: {
     }
   }, [session, path, setDoc]);
 
-  // Best-effort checkpoint when the tab is backgrounded/closed — `keepalive`
-  // lets the request survive the page tearing down. Covers the gap between
-  // the last edit and the idle-autosave timer firing. A hidden tab also
-  // clears our caret: the user isn't positioned to edit anymore, and CM blur
-  // doesn't fire reliably on tab switches.
+  // Best-effort checkpoint when the tab is backgrounded/closed. Covers the
+  // gap between the last edit and the idle-autosave timer firing. A hidden
+  // tab also clears our caret: the user isn't positioned to edit anymore,
+  // and CM blur doesn't fire reliably on tab switches.
+  //
+  // The WS connection itself stays open while merely backgrounded (browsers
+  // don't tear down a WebSocket on visibility change, only on actual
+  // navigation/close/sleep), so a checkpoint message here is exactly as
+  // reliable as it was over HTTP. `pagehide` (the tab actually closing) is
+  // the one case with no delivery guarantee either way — a `send()` racing
+  // an abrupt unload has no stronger guarantee than the old fetch without
+  // `keepalive` did — but the server's own disconnect-triggered forced
+  // checkpoint (see `app/api/coedit.py`) is the backstop for exactly that
+  // case, and it doesn't depend on the client transmitting anything at all.
   useEffect(() => {
     if (!active) return;
     const checkpointNow = () => {
       const sid = sessionId.current;
       if (sid === null || !canWrite) return;
-      void checkpointSession(sid, { keepalive: true }).catch(() => {});
+      void checkpointSession(sid).catch(() => {});
     };
     const onVisibilityChange = () => {
       if (document.visibilityState === "hidden") {
@@ -629,8 +609,9 @@ export function useCoeditSession(opts: {
         reportCaretCleared();
       } else {
         // Coming back to the tab: pull anything missed while backgrounded —
-        // a slept machine's stream may be dead or healing, and the user must
-        // not resume on a stale doc (the reconnect loop is the other half).
+        // a slept machine's connection may be dead or healing, and the user
+        // must not resume on a stale doc (the reconnect loop is the other
+        // half).
         catchUpFn.current?.();
       }
     };

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -18,9 +18,9 @@
  * effect cleanup — driven by `enabled`/`path` changing or the component
  * unmounting, never by the caller invoking a function. There's no explicit
  * "leave" call: closing the connection *is* the leave signal, handled
- * server-side (see `app/api/coedit.py`'s module docstring) — more reliable
- * than the old design's client-initiated keepalive fetch on unload. The
- * *document* is owned by the editor via `@codemirror/collab` (see
+ * server-side (see `app/api/coedit.py`'s module docstring) — this doesn't
+ * depend on the client successfully transmitting anything during teardown.
+ * The *document* is owned by the editor via `@codemirror/collab` (see
  * `Coeditor`), not here — the hook just hands the editor what it needs to
  * run collab (`session` = id/clientId/start version+doc), forwards inbound
  * `op`/`resync` frames to it (`onServerFrame`), and keeps a read-only
@@ -460,11 +460,10 @@ export function useCoeditSession(opts: {
       // Connect (and reconnect on a drop) in a loop — the server never
       // pushes again on a dead connection, and without this loop the client
       // would only heal on a full page reload. Each attempt re-resolves the
-      // session by *path* (get-or-create server-side), so — unlike the old
-      // numeric-session_id-scoped stream — there's no separate "the session
-      // I had went stale" error to special-case; a reconnect either adopts
-      // the same still-open session or transparently gets a fresh one (see
-      // the session-id-changed branch below for that latter case).
+      // session by *path* (get-or-create server-side), so there's no "the
+      // session I had went stale" error to special-case; a reconnect either
+      // adopts the same still-open session or transparently gets a fresh one
+      // (see the session-id-changed branch below for that latter case).
       let firstConnect = true;
       while (!cancelled) {
         let snap;
@@ -589,13 +588,12 @@ export function useCoeditSession(opts: {
   //
   // The WS connection itself stays open while merely backgrounded (browsers
   // don't tear down a WebSocket on visibility change, only on actual
-  // navigation/close/sleep), so a checkpoint message here is exactly as
-  // reliable as it was over HTTP. `pagehide` (the tab actually closing) is
-  // the one case with no delivery guarantee either way — a `send()` racing
-  // an abrupt unload has no stronger guarantee than the old fetch without
-  // `keepalive` did — but the server's own disconnect-triggered forced
-  // checkpoint (see `app/api/coedit.py`) is the backstop for exactly that
-  // case, and it doesn't depend on the client transmitting anything at all.
+  // navigation/close/sleep), so a checkpoint message here reliably reaches
+  // the server. `pagehide` (the tab actually closing) is the one case with
+  // no delivery guarantee: a `send()` racing an abrupt unload can be lost.
+  // The server's own disconnect-triggered forced checkpoint (see
+  // `app/api/coedit.py`) is the backstop for exactly that case, and it
+  // doesn't depend on the client transmitting anything at all.
   useEffect(() => {
     if (!active) return;
     const checkpointNow = () => {

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -1,18 +1,23 @@
-/** API client for the live-session endpoints (`/api/coedit/*`).
+/** Client for the live-session endpoint (`/api/coedit/ws`) — one WebSocket
+ * per session, multiplexing what used to be 8 REST/SSE endpoints (`/join`,
+ * `/leave`, `/op`, `/cursor`, `/checkpoint`, `/session`, `/ops`, `/stream`).
+ * Pure transport swap: `sendOp`/`getOps` keep the exact signatures and
+ * `Promise` shapes they had over HTTP (`components.tsx` imports them
+ * directly and doesn't change), and the backend domain logic/message shapes
+ * are unchanged — see `app/api/coedit.py`'s module docstring for the design.
  *
- * Every page view joins the page's live session: the shared buffer lives on
- * the server, and inbound ops/presence/resync arrive over an SSE stream —
- * viewers get real-time updates, editors additionally send range-change ops
- * (write-gated server-side). Checkpoint commits the buffer to git; leaving or
- * disconnecting exits the session. See the backend in `app/api/coedit.py` and
- * the design in `design/Co-Editing.md`.
+ * There's no `leaveSession` anymore: the server treats any socket close
+ * (explicit, network drop, or a killed tab) as the leave signal — more
+ * reliable than the old client-initiated `fetch(..., {keepalive: true})`,
+ * which depended on the client successfully transmitting during teardown.
+ * `closeSession` is the equivalent — it just closes the connection.
  *
  * Offsets are UTF-16 code units — which is exactly what JS string indexing and
  * `slice` use, so the ops interoperate with the server
  * (`Change` in `app/wiki/coedit.py`) without conversion; see `utils.ts` for
  * `diffToChange`/`applyChange`.
  */
-import { apiFetch, apiStream } from "@/lib/api";
+import { apiSocketUrl, ApiError } from "@/lib/api";
 import type {
   CoeditChange,
   CoeditFrame,
@@ -20,118 +25,246 @@ import type {
   CoeditSession,
 } from "@/lib/editor/types";
 
-/** Join (or re-join) the live session for `path`, returning the initial buffer + roster. */
-export function joinSession(path: string): Promise<CoeditSession> {
-  return apiFetch("/coedit/join", {
-    method: "POST",
-    body: JSON.stringify({ path }),
-  });
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
 }
 
-/** Fetch the current session snapshot (buffer + roster) without joining. */
-export function getSession(sessionId: number): Promise<CoeditSession> {
-  return apiFetch(`/coedit/session?session_id=${sessionId}`);
+interface TrackedSocket {
+  ws: WebSocket;
+  pending: Map<string, PendingRequest>;
+  markExpectedClose: () => void;
 }
 
-/** Leave the session, allowing the server to clean up presence + buffer if
- * empty. `init` lets teardown pass `{ keepalive: true }` so the request
- * survives the page tearing down. */
-export function leaveSession(
+// sessionId -> its live WebSocket + in-flight request/response correlation.
+// One entry per `connectSession` call; removed on close. Every other
+// exported function looks itself up here by `sessionId`, matching the old
+// client's plain-sessionId-based calls (each of which was a stateless HTTP
+// request; here they all resolve to the one tracked connection).
+const sockets = new Map<number, TrackedSocket>();
+
+function newRequestId(): string {
+  return crypto.randomUUID();
+}
+
+// Maps a WS `*_result` frame's `error` string back onto the HTTP status the
+// old REST endpoints used for the same condition, so `ApiError`-checking
+// call sites (`components.tsx`'s `e.status === 409` 409-stale-version check,
+// specifically) don't need to change.
+const ERROR_STATUS: Record<string, number> = {
+  stale_version: 409,
+  invalid_op: 422,
+  forbidden: 403,
+  no_active_session: 404,
+};
+
+function errorFor(error: string | null | undefined): ApiError {
+  const code = error ?? "unknown_error";
+  return new ApiError(ERROR_STATUS[code] ?? 500, code);
+}
+
+function send(sessionId: number, message: Record<string, unknown>): void {
+  const entry = sockets.get(sessionId);
+  if (!entry || entry.ws.readyState !== WebSocket.OPEN) return;
+  entry.ws.send(JSON.stringify(message));
+}
+
+function request<T>(
   sessionId: number,
-  init?: RequestInit,
-): Promise<void> {
-  return apiFetch("/coedit/leave", {
-    ...init,
-    method: "POST",
-    body: JSON.stringify({ session_id: sessionId }),
+  message: Record<string, unknown>,
+): Promise<T> {
+  const entry = sockets.get(sessionId);
+  if (!entry || entry.ws.readyState !== WebSocket.OPEN) {
+    return Promise.reject(new ApiError(0, "not connected"));
+  }
+  const requestId = newRequestId();
+  return new Promise<T>((resolve, reject) => {
+    entry.pending.set(requestId, {
+      resolve: resolve as (value: unknown) => void,
+      reject,
+    });
+    entry.ws.send(JSON.stringify({ ...message, request_id: requestId }));
   });
+}
+
+/** A joined session's snapshot plus `closed` — a promise that resolves once
+ * the connection ends, for any reason. Mirrors the old `streamSession`
+ * promise the reconnect loop awaited (which spanned the SSE connection's
+ * whole lifetime) — here `connectSession`'s own promise settles at *join*,
+ * not at connection-end, since the multiplexed WS also needs to hand back
+ * the join snapshot immediately for the caller to mount the editor from. */
+export interface CoeditConnection extends CoeditSession {
+  closed: Promise<{ code: number; expected: boolean }>;
+}
+
+/** Open the live session for `path` — the WS connection's `joined` frame
+ * *is* the join response (replaces `POST /join` + separately opening
+ * `GET /stream`). `onFrame` fires for every inbound broadcast frame
+ * (`presence`/`op`/`cursor`/`resync`) until the connection closes. */
+export function connectSession(
+  path: string,
+  onFrame: (frame: CoeditFrame) => void,
+): Promise<CoeditConnection> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(
+      apiSocketUrl(`/coedit/ws?path=${encodeURIComponent(path)}`),
+    );
+    const pending = new Map<string, PendingRequest>();
+    let joined = false;
+    let expectedClose = false;
+    let sessionId: number | null = null;
+    let resolveClosed:
+      | ((info: { code: number; expected: boolean }) => void)
+      | null = null;
+    const closed = new Promise<{ code: number; expected: boolean }>((res) => {
+      resolveClosed = res;
+    });
+
+    ws.onmessage = (event) => {
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+      const type = msg.type;
+      if (type === "joined") {
+        joined = true;
+        sessionId = msg.session_id as number;
+        sockets.set(sessionId, {
+          ws,
+          pending,
+          markExpectedClose: () => {
+            expectedClose = true;
+          },
+        });
+        resolve({
+          session_id: msg.session_id as number,
+          buffer: msg.buffer as string,
+          version: msg.version as number,
+          base_sha: msg.base_sha as string | null,
+          participants: msg.participants as CoeditSession["participants"],
+          closed,
+        });
+        return;
+      }
+      if (type === "ping") return;
+      if (
+        type === "op_result" ||
+        type === "checkpoint_result" ||
+        type === "ops_result"
+      ) {
+        const p = pending.get(msg.request_id as string);
+        if (!p) return;
+        pending.delete(msg.request_id as string);
+        if (msg.ok) {
+          p.resolve(msg);
+        } else {
+          p.reject(errorFor(msg.error as string | null | undefined));
+        }
+        return;
+      }
+      // presence / op / cursor / resync — the broadcast frames hooks.ts handles.
+      onFrame(msg as unknown as CoeditFrame);
+    };
+
+    ws.onclose = (event) => {
+      if (sessionId !== null) sockets.delete(sessionId);
+      for (const p of pending.values()) {
+        p.reject(new ApiError(0, "connection closed"));
+      }
+      pending.clear();
+      if (!joined) {
+        // The join handshake itself failed — mirrors the old client's
+        // "no read-only fallback" contract: surface it, don't retry silently.
+        reject(
+          event.code === 1008
+            ? new ApiError(403, "You don't have permission to edit this page.")
+            : new ApiError(0, "Failed to join the editing session."),
+        );
+        return;
+      }
+      resolveClosed?.({ code: event.code, expected: expectedClose });
+    };
+
+    // Kept for symmetry with the old contract's error path, but onclose
+    // (which always follows an error per the WebSocket spec) does the real
+    // handling — this alone would give an unhelpful generic Event.
+    ws.onerror = () => {};
+  });
+}
+
+/** Close the session's connection — the WS equivalent of the old
+ * `leaveSession`. A no-op if already closed/never connected. Resolves
+ * `closed` with `expected: true`, so the caller's reconnect loop knows not
+ * to reconnect. */
+export function closeSession(sessionId: number): void {
+  const entry = sockets.get(sessionId);
+  if (!entry) return;
+  entry.markExpectedClose();
+  entry.ws.close();
 }
 
 /** Apply an edit op. Resolves to the new version, or throws `ApiError` with
  * status 409 when `baseVersion` is stale (caller rebases the missed ops from
  * `getOps` and retries). `clientId` tags the op so the sender can recognize its
  * own echo. */
-export function sendOp(
+export async function sendOp(
   sessionId: number,
   baseVersion: number,
   changes: CoeditChange[],
   clientId?: string,
   caretSeq?: number | null,
 ): Promise<{ version: number }> {
-  return apiFetch("/coedit/op", {
-    method: "POST",
-    body: JSON.stringify({
-      session_id: sessionId,
-      base_version: baseVersion,
-      changes,
-      ...(clientId ? { client_id: clientId } : {}),
-      // An edit asserts caret placement at the sender's current epoch; omit
-      // when the caret is cleared so a late-flushed op can't resurrect it.
-      ...(caretSeq !== null && caretSeq !== undefined
-        ? { caret_seq: caretSeq }
-        : {}),
-    }),
+  const result = await request<{ version: number }>(sessionId, {
+    type: "op",
+    base_version: baseVersion,
+    changes,
+    ...(clientId ? { client_id: clientId } : {}),
+    // An edit asserts caret placement at the sender's current epoch; omit
+    // when the caret is cleared so a late-flushed op can't resurrect it.
+    ...(caretSeq !== null && caretSeq !== undefined
+      ? { caret_seq: caretSeq }
+      : {}),
   });
+  return { version: result.version };
 }
 
 /** Report the local caret/selection to the server so peers see live presence.
- * Null anchor/head clears the caret (editor blur / hidden tab) — peers drop it
- * and presence flips the sender to "viewing". `seq` is the caret epoch that
- * orders concurrent place/clear writes server-side. `init` lets the
- * hidden-tab clear pass `{ keepalive: true }` so it survives the page
- * backgrounding. */
+ * Fire-and-forget, matching the old client's swallowed-error handling —
+ * a dropped ping self-heals on the next throttled send. Null anchor/head
+ * clears the caret (editor blur / hidden tab) — peers drop it and presence
+ * flips the sender to "viewing". `seq` is the caret epoch that orders
+ * concurrent place/clear writes server-side. */
 export function sendCursor(
   sessionId: number,
   anchor: number | null,
   head: number | null,
   typing: boolean,
   seq: number,
-  init?: RequestInit,
-): Promise<void> {
-  return apiFetch("/coedit/cursor", {
-    ...init,
-    method: "POST",
-    body: JSON.stringify({ session_id: sessionId, anchor, head, typing, seq }),
-  });
+): void {
+  send(sessionId, { type: "cursor", anchor, head, typing, seq });
 }
 
-/** Commit the session buffer to git. Returns `queued: true` when the write was
- * handed off to the background worker rather than applied inline. `init` lets
- * a best-effort checkpoint on unmount/tab-close pass `{ keepalive: true }` so
- * the request survives the page tearing down. */
-export function checkpointSession(
-  sessionId: number,
-  init?: RequestInit,
-): Promise<{ queued: boolean }> {
-  return apiFetch("/coedit/checkpoint", {
-    ...init,
-    method: "POST",
-    body: JSON.stringify({ session_id: sessionId }),
-  });
+/** Commit the session buffer to git. Resolves once the server has enqueued
+ * (or completed) the checkpoint. */
+export async function checkpointSession(sessionId: number): Promise<void> {
+  await request<{ ok: boolean }>(sessionId, { type: "checkpoint" });
 }
 
 /** Fetch all ops after `sinceVersion` (oldest first) plus the current head
- * version. Used to rebase un-acked local edits after a 409 or a version gap. */
-export function getOps(
+ * version. Used to rebase un-acked local edits after a stale op or a gap. */
+export async function getOps(
   sessionId: number,
   sinceVersion: number,
 ): Promise<CoeditOps> {
-  return apiFetch(
-    `/coedit/ops?session_id=${sessionId}&since_version=${sinceVersion}`,
-  );
-}
-
-/** Open the SSE stream; `onFrame` fires per frame until `signal` aborts (or the
- * server closes). Opening the stream also joins the caller as a participant. */
-export function streamSession(
-  sessionId: number,
-  onFrame: (frame: CoeditFrame) => void,
-  signal: AbortSignal,
-): Promise<void> {
-  return apiStream(
-    `/coedit/stream?session_id=${sessionId}`,
-    { method: "GET" },
-    (data) => onFrame(data as CoeditFrame),
-    signal,
-  );
+  const result = await request<{
+    current_head_version: number;
+    ops: CoeditOps["ops"];
+  }>(sessionId, { type: "get_ops", since_version: sinceVersion });
+  return {
+    session_id: sessionId,
+    current_head_version: result.current_head_version,
+    ops: result.ops,
+  };
 }

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -1,16 +1,14 @@
 /** Client for the live-session endpoint (`/api/coedit/ws`) — one WebSocket
- * per session, multiplexing what used to be 8 REST/SSE endpoints (`/join`,
- * `/leave`, `/op`, `/cursor`, `/checkpoint`, `/session`, `/ops`, `/stream`).
- * Pure transport swap: `sendOp`/`getOps` keep the exact signatures and
- * `Promise` shapes they had over HTTP (`components.tsx` imports them
- * directly and doesn't change), and the backend domain logic/message shapes
- * are unchanged — see `app/api/coedit.py`'s module docstring for the design.
+ * per session, multiplexing every message type (join, op, cursor,
+ * checkpoint, get_ops). `sendOp`/`getOps` keep the exact signatures and
+ * `Promise` shapes `components.tsx` imports directly, so that file doesn't
+ * need to change; the backend domain logic/message shapes are covered in
+ * `app/api/coedit.py`'s module docstring.
  *
- * There's no `leaveSession` anymore: the server treats any socket close
- * (explicit, network drop, or a killed tab) as the leave signal — more
- * reliable than the old client-initiated `fetch(..., {keepalive: true})`,
- * which depended on the client successfully transmitting during teardown.
- * `closeSession` is the equivalent — it just closes the connection.
+ * There's no explicit "leave" call: the server treats any socket close
+ * (explicit, network drop, or a killed tab) as the leave signal, which
+ * doesn't depend on the client successfully transmitting anything during
+ * teardown. `closeSession` is that close — it just closes the connection.
  *
  * Offsets are UTF-16 code units — which is exactly what JS string indexing and
  * `slice` use, so the ops interoperate with the server
@@ -47,10 +45,9 @@ function newRequestId(): string {
   return crypto.randomUUID();
 }
 
-// Maps a WS `*_result` frame's `error` string back onto the HTTP status the
-// old REST endpoints used for the same condition, so `ApiError`-checking
-// call sites (`components.tsx`'s `e.status === 409` 409-stale-version check,
-// specifically) don't need to change.
+// Maps a WS `*_result` frame's `error` string onto an HTTP-style status, so
+// `ApiError`-checking call sites (`components.tsx`'s `e.status === 409`
+// stale-version check, specifically) can keep checking a status code.
 const ERROR_STATUS: Record<string, number> = {
   stale_version: 409,
   invalid_op: 422,
@@ -76,15 +73,13 @@ function request<T>(
   const entry = sockets.get(sessionId);
   if (!entry || entry.ws.readyState !== WebSocket.OPEN) {
     // `components.tsx`'s CM6 collab layer retries a failed op unconditionally
-    // and immediately (`doPush`'s tail call) — under the old fetch()-based
-    // client that was harmless, since even a failing fetch takes real
-    // macrotask-level time (DNS/connect/handshake). A synchronous
-    // Promise.reject() here has no such delay, so a disconnected socket plus
-    // pending local edits produced an unbroken chain of microtasks with no
-    // yield to the browser's event loop — a real, reproduced main-thread
-    // freeze, not a hypothetical. Settling on a real macrotask tick (instead
-    // of synchronously) forces a yield between retries, which is enough to
-    // keep the tab responsive without touching that pre-existing retry logic.
+    // and immediately, with no backoff (`doPush`'s tail call) — so this must
+    // never settle synchronously. A same-tick Promise.reject() here, paired
+    // with that retry, produces an unbroken chain of microtasks with no
+    // yield to the browser's event loop: a real, reproduced main-thread
+    // freeze, not a hypothetical. Settling on a real macrotask tick instead
+    // forces a yield between retries, which is enough to keep the tab
+    // responsive without touching that retry logic.
     return new Promise<T>((_resolve, reject) => {
       setTimeout(() => reject(new ApiError(0, "not connected")), 0);
     });
@@ -100,11 +95,10 @@ function request<T>(
 }
 
 /** A joined session's snapshot plus `closed` — a promise that resolves once
- * the connection ends, for any reason. Mirrors the old `streamSession`
- * promise the reconnect loop awaited (which spanned the SSE connection's
- * whole lifetime) — here `connectSession`'s own promise settles at *join*,
- * not at connection-end, since the multiplexed WS also needs to hand back
- * the join snapshot immediately for the caller to mount the editor from. */
+ * the connection ends, for any reason. `connectSession`'s own promise
+ * settles at *join*, not at connection-end, since the caller needs the join
+ * snapshot immediately to mount the editor from; `closed` is the separate
+ * handle the reconnect loop awaits for the connection's whole lifetime. */
 export interface CoeditConnection extends CoeditSession {
   closed: Promise<{ code: number; expected: boolean }>;
 }
@@ -187,29 +181,30 @@ export function connectSession(
       }
       pending.clear();
       if (!joined) {
-        // The join handshake itself failed — mirrors the old client's
-        // "no read-only fallback" contract: surface it, don't retry silently.
-        reject(
-          event.code === 1008
-            ? new ApiError(403, "You don't have permission to edit this page.")
-            : new ApiError(0, "Failed to join the editing session."),
-        );
+        // The join handshake itself failed — surface it rather than retry
+        // silently (there's no read-only fallback to fall back to). No
+        // permission-specific message here: a pre-accept HTTP-level denial
+        // (401/403 from the backend's connect-time checks) always reports as
+        // the browser's generic close code 1006 — WebSocket close codes like
+        // 1008 only apply to a close the server sends *after* accepting,
+        // which a rejected handshake never reaches, so there's no reliable
+        // signal here to distinguish "forbidden" from any other failure.
+        reject(new ApiError(0, "Failed to join the editing session."));
         return;
       }
       resolveClosed?.({ code: event.code, expected: expectedClose });
     };
 
-    // Kept for symmetry with the old contract's error path, but onclose
-    // (which always follows an error per the WebSocket spec) does the real
-    // handling — this alone would give an unhelpful generic Event.
+    // A no-op: onclose (which always follows an error per the WebSocket
+    // spec) does the real handling — this event alone would only give an
+    // unhelpful generic Event with no useful failure detail.
     ws.onerror = () => {};
   });
 }
 
-/** Close the session's connection — the WS equivalent of the old
- * `leaveSession`. A no-op if already closed/never connected. Resolves
- * `closed` with `expected: true`, so the caller's reconnect loop knows not
- * to reconnect. */
+/** Close the session's connection. A no-op if already closed/never
+ * connected. Resolves `closed` with `expected: true`, so the caller's
+ * reconnect loop knows not to reconnect. */
 export function closeSession(sessionId: number): void {
   const entry = sockets.get(sessionId);
   if (!entry) return;
@@ -243,8 +238,8 @@ export async function sendOp(
 }
 
 /** Report the local caret/selection to the server so peers see live presence.
- * Fire-and-forget, matching the old client's swallowed-error handling —
- * a dropped ping self-heals on the next throttled send. Null anchor/head
+ * Fire-and-forget — a dropped ping self-heals on the next throttled send, so
+ * failures are silently swallowed rather than surfaced. Null anchor/head
  * clears the caret (editor blur / hidden tab) — peers drop it and presence
  * flips the sender to "viewing". `seq` is the caret epoch that orders
  * concurrent place/clear writes server-side. */

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -75,7 +75,19 @@ function request<T>(
 ): Promise<T> {
   const entry = sockets.get(sessionId);
   if (!entry || entry.ws.readyState !== WebSocket.OPEN) {
-    return Promise.reject(new ApiError(0, "not connected"));
+    // `components.tsx`'s CM6 collab layer retries a failed op unconditionally
+    // and immediately (`doPush`'s tail call) — under the old fetch()-based
+    // client that was harmless, since even a failing fetch takes real
+    // macrotask-level time (DNS/connect/handshake). A synchronous
+    // Promise.reject() here has no such delay, so a disconnected socket plus
+    // pending local edits produced an unbroken chain of microtasks with no
+    // yield to the browser's event loop — a real, reproduced main-thread
+    // freeze, not a hypothetical. Settling on a real macrotask tick (instead
+    // of synchronously) forces a yield between retries, which is enough to
+    // keep the tab responsive without touching that pre-existing retry logic.
+    return new Promise<T>((_resolve, reject) => {
+      setTimeout(() => reject(new ApiError(0, "not connected")), 0);
+    });
   }
   const requestId = newRequestId();
   return new Promise<T>((resolve, reject) => {

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1099,7 +1099,7 @@ export function FileView({ path }: FileViewProps) {
           </div>
         )}
 
-        {loading && <LoadingSpinner />}
+        {loading && <LoadingSpinner center />}
 
         {!loading && !error && (
           <>

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1150,8 +1150,21 @@ export function FileView({ path }: FileViewProps) {
                     // to discard without losing user work: truly blank, or
                     // still verbatim equal to the template the user just
                     // applied (so they can keep swapping templates).
-                    const isBlank = coedit.buffer.trim() === "";
+                    //
+                    // Gated on `coedit.session` too, not just the buffer
+                    // text: `coedit.buffer` starts as `""` before the coedit
+                    // session has actually resolved (a separate async
+                    // handshake from the file fetch that drives `loading`
+                    // above), so without this a real, non-blank page could
+                    // flash the template picker for the gap between the file
+                    // fetch resolving and the session catching up — reusing
+                    // the exact "has the session resolved" signal the editor
+                    // fallback below already keys off (`coedit.session` vs.
+                    // `coedit.joinError` vs. "Connecting…").
+                    const isBlank =
+                      coedit.session !== null && coedit.buffer.trim() === "";
                     const matchesApplied =
+                      coedit.session !== null &&
                       appliedTemplateBody !== null &&
                       coedit.buffer === appliedTemplateBody;
                     const showGallery =

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,6 +16,26 @@ http {
 
         client_max_body_size 25m;
 
+        # Dedicated block for the coedit WebSocket — needs Upgrade/Connection
+        # headers, which the general /api/ block below deliberately doesn't
+        # set (blindly adding them there would need a `map $http_upgrade
+        # $connection_upgrade` guard so normal HTTP keep-alive on every other
+        # /api/* route doesn't regress). Long timeouts: this is a persistent
+        # connection, not a request/response round trip.
+        location /api/coedit/ws {
+            set $backend http://backend:8080;
+            proxy_pass         $backend;
+            proxy_http_version 1.1;
+            proxy_set_header   Upgrade           $http_upgrade;
+            proxy_set_header   Connection        "upgrade";
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+        }
+
         location /api/ {
             set $backend http://backend:8080;
             proxy_pass         $backend;


### PR DESCRIPTION
## Summary
- Pure transport swap for the co-edit live session: the 8 REST/SSE endpoints (`join`/`leave`/`op`/`cursor`/`checkpoint`/`session`/`ops`/`stream`) collapse into one `WebSocket` route that multiplexes the same JSON message shapes over the same domain logic (`app/wiki/coedit.py` untouched). CodeMirror, the checkpoint/git pipeline, and the Postgres LISTEN/NOTIFY broadcast fan-out are all unchanged.
- Write permission is re-checked on every inbound message, not just at connect, matching the old per-POST `require_can` exactly.
- No client-sent `leave` message — the server's disconnect handler is the sole leave signal, firing on any connection loss (more reliable than the old keepalive-fetch-on-unload approach).
- Two follow-up bugs found via manual testing and fixed:
  - `FileView.tsx`: the template picker briefly flashed on real (non-blank) pages, and the loading spinner rendered unstyled top-left instead of centered.
  - A frontend main-thread freeze: `components.tsx`'s pre-existing op-retry loop had no backoff, which was safe under the old `fetch()`-based client (real network I/O rate-limited it) but spun as an unbroken microtask chain once `svc.ts`'s WS-based `request()` could reject synchronously on a closed socket.
  - A backend thread-pool exhaustion bug in `_send_loop`'s heartbeat poll (orphaned threads on cancellation, tightened poll interval to bound the damage).