### PR TITLE
fix(db): re-chain doc_id_forwarding migration — main has two alembic heads

### DIFF
--- a/backend/app/db/migrations/versions/a7d31f92c8e4_doc_id_forwarding.py
+++ b/backend/app/db/migrations/versions/a7d31f92c8e4_doc_id_forwarding.py
@@ -1,7 +1,7 @@
 """wiki_doc_ids.forwarded_to — retired ids resolve to the surviving document
 
 Revision ID: a7d31f92c8e4
-Revises: 5c4a9e1b7d38
+Revises: a9e2c7f4b1d6
 Create Date: 2026-07-22
 """
 from __future__ import annotations
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision = "a7d31f92c8e4"
-down_revision = "5c4a9e1b7d38"
+down_revision = "a9e2c7f4b1d6"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/db/migrations/versions/a7d31f92c8e4_doc_id_forwarding.py
+++ b/backend/app/db/migrations/versions/a7d31f92c8e4_doc_id_forwarding.py
@@ -6,13 +6,15 @@ Create Date: 2026-07-22
 """
 from __future__ import annotations
 
+from typing import Sequence
+
 import sqlalchemy as sa
 from alembic import op
 
-revision = "a7d31f92c8e4"
-down_revision = "a9e2c7f4b1d6"
-branch_labels = None
-depends_on = None
+revision: str = "a7d31f92c8e4"
+down_revision: str | Sequence[str] | None = "a9e2c7f4b1d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:


### PR DESCRIPTION
#487 and #488 merged in parallel with migrations both chaining off `5c4a9e1b7d38`, leaving **two alembic heads on main** — `alembic upgrade head` fails on every fresh boot and CI run (same failure class as the #463 hotfix).

One-line fix: re-point the later-merged migration (`a7d31f92c8e4`, doc-id forwarding) onto the earlier one (`a9e2c7f4b1d6`, provenance source snippet). The re-pointed migration is an inspector-guarded add-column, so the ordering change is inert on existing databases.

Verified: `alembic heads` shows a single head; the per-test `upgrade head` path collects cleanly again.

**Merge this ahead of other backend work** — everything hitting a fresh schema is broken until it lands.