### PR TITLE
feat(wiki): highlight source-attributed lines while the Sources tab is open

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -420,10 +420,10 @@ body {
 /* Anchored comments panel: the editor's native scrollbar would sit at the
    doc/panel boundary, so it hides in favor of the panel's viewport-edge
    scrollbar (EditorEdgeScrollbar). */
-.comments-anchored .cm-scroller {
+.panel-anchored .cm-scroller {
   scrollbar-width: none;
 }
-.comments-anchored .cm-scroller::-webkit-scrollbar {
+.panel-anchored .cm-scroller::-webkit-scrollbar {
   display: none;
 }
 

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -204,7 +204,7 @@ export function CommentsPanel({
 
   if (!listMode) {
     // Anchored mode (mock 1855). The doc's scrollbar renders at the
-    // viewport edge, the page hides the native one (comments-anchored).
+    // viewport edge, the page hides the native one (panel-anchored).
     return (
       <Section
         justifyContent="start"

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -18,7 +18,6 @@ import type { CommentThreadView } from "@/types";
 
 import { CommentMarginRail } from "./CommentMarginRail";
 import { SvgListLines } from "./icons";
-import { EditorEdgeScrollbar } from "./EditorEdgeScrollbar";
 import { PanelSearchField } from "./PanelSearch";
 import { NewCommentComposer, ThreadCard } from "./commentCards";
 
@@ -238,7 +237,6 @@ export function CommentsPanel({
           onSubmitDraft={(body) => void submitDraft(body)}
           onCancelDraft={onDraftConsumed}
         />
-        <EditorEdgeScrollbar editorRef={editorRef!} />
       </Section>
     );
   }

--- a/frontend/src/components/wiki/SourceAnchorRail.tsx
+++ b/frontend/src/components/wiki/SourceAnchorRail.tsx
@@ -11,8 +11,9 @@ import { Button, Tag, Text } from "@onyx-ai/opal/components";
 import { SvgExternalLink } from "@onyx-ai/opal/icons";
 
 import type { CoeditorHandle } from "@/lib/editor/components";
+import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
 import { relativeTime } from "@/lib/time";
-import type { SourceRef, SourceSpan } from "@/types";
+import type { SourceRef } from "@/types";
 
 import { sourceIcon, sourceKey, sourceTypeLabel } from "./sources";
 
@@ -189,7 +190,7 @@ function MoreChip({
  */
 export function SourceAnchorRail({
   sources,
-  spans,
+  targets,
   editorRef,
   activeKeys,
   onHoverSource,
@@ -197,7 +198,9 @@ export function SourceAnchorRail({
   onShowAll,
 }: {
   sources: SourceRef[];
-  spans: SourceSpan[];
+  /** The page's current highlight targets. Anchoring reads the editor's
+   * live-mapped copies, this prop retriggers layout when they land. */
+  targets: AnchoredHighlightTarget[];
   editorRef: RefObject<CoeditorHandle | null>;
   /** Source keys whose chips render dark (the caret sits in their spans). */
   activeKeys?: string[];
@@ -226,12 +229,13 @@ export function SourceAnchorRail({
   const relayout = useCallback(() => {
     const editor = editorRef.current;
     if (!editor) return;
-    // First span per source is its anchor, spans arrive ordered by offset.
+    // Anchors come from the editor's live-mapped targets so chips ride
+    // local and remote edits like the highlights do. First surviving
+    // target per source wins, targets arrive ordered by offset.
     const anchorOffsets = new Map<string, number>();
-    for (const sp of spans) {
-      const key = sourceKey(sp);
-      if (key && !anchorOffsets.has(key))
-        anchorOffsets.set(key, sp.start_offset);
+    for (const t of editor.sourceTargets()) {
+      if (t.id && t.startOffset < t.endOffset && !anchorOffsets.has(t.id))
+        anchorOffsets.set(t.id, t.startOffset);
     }
     const anchored: { rail: RailSource; want: number }[] = [];
     for (const s of sources) {
@@ -264,7 +268,7 @@ export function SourceAnchorRail({
     const railTop = rootRef.current?.getBoundingClientRect().top ?? 0;
     originStatic.current = editor.scrollerTop() - railTop;
     syncScroll();
-  }, [sources, spans, editorRef, syncScroll]);
+  }, [sources, targets, editorRef, syncScroll]);
 
   useEffect(() => {
     const editor = editorRef.current;

--- a/frontend/src/components/wiki/SourceAnchorRail.tsx
+++ b/frontend/src/components/wiki/SourceAnchorRail.tsx
@@ -14,7 +14,7 @@ import type { CoeditorHandle } from "@/lib/editor/components";
 import { relativeTime } from "@/lib/time";
 import type { SourceRef, SourceSpan } from "@/types";
 
-import { sourceIcon, sourceKey, sourceTypeLabel } from "./SourcesPanel";
+import { sourceIcon, sourceKey, sourceTypeLabel } from "./sources";
 
 const ROW_HEIGHT = 32;
 const ROW_GAP = 4;
@@ -29,6 +29,11 @@ const MAX_CHIPS = 2;
 interface RailSource {
   key: string;
   source: SourceRef;
+}
+
+interface ChipRow {
+  top: number;
+  items: RailSource[];
 }
 
 /** One source's chip: connector icon in a white box plus the title, dark
@@ -201,7 +206,7 @@ export function SourceAnchorRail({
   /** Overflow chips hand off to the list view. */
   onShowAll?: () => void;
 }) {
-  const [rows, setRows] = useState<{ top: number; items: RailSource[] }[]>([]);
+  const [rows, setRows] = useState<ChipRow[]>([]);
   const [pinnedKey, setPinnedKey] = useState<string | null>(null);
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -243,7 +248,7 @@ export function SourceAnchorRail({
     anchored.sort((a, b) => a.want - b.want);
     // Sources within a row height of the cluster's start share its row,
     // later rows push down on collision.
-    const next: { top: number; items: RailSource[] }[] = [];
+    const next: ChipRow[] = [];
     let cursor = 0;
     for (const { rail, want } of anchored) {
       const last = next[next.length - 1];
@@ -297,6 +302,7 @@ export function SourceAnchorRail({
     setHoveredKey(key);
     onHoverSource?.(key);
   };
+  const isOpen = (key: string) => key === pinnedKey || key === hoveredKey;
 
   return (
     <div
@@ -312,9 +318,7 @@ export function SourceAnchorRail({
         {rows.map((row) => {
           const shown = row.items.slice(0, MAX_CHIPS);
           const hidden = row.items.slice(MAX_CHIPS);
-          const rowLit = row.items.some(
-            (it) => it.key === hoveredKey || it.key === pinnedKey,
-          );
+          const rowLit = row.items.some((it) => isOpen(it.key));
           return (
             <div
               key={row.items[0]!.key}
@@ -324,7 +328,7 @@ export function SourceAnchorRail({
               style={{ top: row.top }}
             >
               {shown.map(({ key, source }, i) => {
-                const open = key === pinnedKey || key === hoveredKey;
+                const open = isOpen(key);
                 return (
                   <span
                     key={key}

--- a/frontend/src/components/wiki/SourceAnchorRail.tsx
+++ b/frontend/src/components/wiki/SourceAnchorRail.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import { Button, Tag, Text } from "@onyx-ai/opal/components";
+import { SvgExternalLink } from "@onyx-ai/opal/icons";
+
+import type { CoeditorHandle } from "@/lib/editor/components";
+import { relativeTime } from "@/lib/time";
+import type { SourceRef, SourceSpan } from "@/types";
+
+import { sourceIcon, sourceKey, sourceTypeLabel } from "./SourcesPanel";
+
+const ROW_HEIGHT = 32;
+const ROW_GAP = 4;
+// Chip rows center their 24px chip on the anchor line's center.
+const CHIP_ROW_CENTER = 12;
+// Sources anchored within one row height share a chip row.
+const CLUSTER_SPAN = 28;
+// Chips shown before the rest collapse into the "+N more" chip (mock
+// 1832:82929 shows two).
+const MAX_CHIPS = 2;
+
+interface RailSource {
+  key: string;
+  source: SourceRef;
+}
+
+/** One source's chip: connector icon in a white box plus the title, dark
+ * inverted while hovered, pinned, or caret-active (mock hover state). */
+function SourceChip({
+  source,
+  lit,
+  onClick,
+}: {
+  source: SourceRef;
+  lit: boolean;
+  onClick: () => void;
+}) {
+  const Icon = sourceIcon(source.source_type);
+  return (
+    // raw-ok: Opal's Tag has no onClick, no inverted color, no icon-box slot
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex cursor-pointer items-center gap-1 overflow-clip rounded-(--radius-08) p-[4px] ${
+        lit ? "bg-(--background-tint-inverted-03)" : "bg-(--background-tint-02)"
+      }`}
+    >
+      <span
+        className={`flex size-4 items-center justify-center rounded-(--radius-04) border bg-(--background-tint-00) ${
+          lit
+            ? "border-(--background-tint-inverted-03)"
+            : "border-(--background-tint-02)"
+        }`}
+      >
+        <Icon size={12} />
+      </span>
+      <span
+        className={`max-w-[120px] truncate px-[2px] text-xs leading-4 ${
+          lit ? "text-(--text-inverted-05)" : "text-(--text-04)"
+        }`}
+      >
+        {source.source_title || source.source_url || "Untitled source"}
+      </span>
+    </button>
+  );
+}
+
+/** The chip's hover/pinned card (mock Details): popover chrome hanging
+ * below the chip with the contextual-menu width and the soft shadow pair.
+ * Cards for chips deeper in a row hang right-aligned so the 280px width
+ * stays inside the panel column. */
+function SourceHoverCard({
+  source,
+  alignRight,
+}: {
+  source: SourceRef;
+  alignRight?: boolean;
+}) {
+  const Icon = sourceIcon(source.source_type);
+  const url = source.source_url;
+  return (
+    <div
+      className={`absolute top-[28px] z-20 w-(--block-width-contextual-menu-medium-large) overflow-clip rounded-(--radius-12) border border-(--border-01) bg-(--background-neutral-00) shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)] ${
+        alignRight ? "right-[-6px]" : "left-[-6px]"
+      }`}
+    >
+      <div className="flex w-full flex-col p-1">
+        <div className="flex min-h-7 w-full items-start gap-1 p-[2px]">
+          <span className="flex size-5 shrink-0 items-center justify-center p-[2px]">
+            <Icon size={16} />
+          </span>
+          <span className="min-w-0 flex-1 px-[2px]">
+            <Text font="main-ui-action" color="text-04" maxLines={2}>
+              {source.source_title || url || "Untitled source"}
+            </Text>
+          </span>
+          {url && (
+            <span className="shrink-0">
+              <Button
+                icon={SvgExternalLink}
+                size="md"
+                prominence="tertiary"
+                tooltip="Open"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  window.open(url, "_blank", "noopener,noreferrer");
+                }}
+              />
+            </span>
+          )}
+        </div>
+        <div className="flex w-full flex-col gap-1 px-[2px] pb-1">
+          <div className="flex flex-wrap items-center gap-1">
+            {source.source_type && (
+              <Tag title={sourceTypeLabel(source.source_type)} />
+            )}
+            <span className="px-1">
+              <Text font="secondary-body" color="text-02" nowrap>
+                {relativeTime(source.last_updated)}
+              </Text>
+            </span>
+          </div>
+          {source.source_snippet && (
+            <span className="px-1">
+              <Text font="secondary-body" color="text-03" maxLines={4}>
+                {source.source_snippet}
+              </Text>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Overflow chip: the hidden sources' icons stacked plus "+N more" (mock
+ * 1853:241106). Clicking hands off to the list view. */
+function MoreChip({
+  hidden,
+  onClick,
+}: {
+  hidden: SourceRef[];
+  onClick?: () => void;
+}) {
+  return (
+    // raw-ok: same clickable-tag gap as SourceChip, plus the stacked icon boxes
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex cursor-pointer items-center gap-1 overflow-clip rounded-(--radius-08) bg-(--background-tint-02) p-[4px]"
+    >
+      <span className="flex items-center px-[2px]">
+        {hidden.slice(0, 3).map((s, i) => {
+          const Icon = sourceIcon(s.source_type);
+          return (
+            <span
+              key={sourceKey(s) || i}
+              className="-mr-1 flex size-4 items-center justify-center rounded-(--radius-04) border border-(--background-tint-02) bg-(--background-tint-00) last:mr-0"
+            >
+              <Icon size={12} />
+            </span>
+          );
+        })}
+      </span>
+      <span className="px-[2px] text-xs leading-4 whitespace-nowrap text-(--text-04)">
+        +{hidden.length} more
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Anchored source chips for the Sources tab (mock 1832:81274): chip rows
+ * track the doc position of each source's first attributed span, sources
+ * anchored close together share a row, and overflow collapses into a
+ * "+N more" chip. Hovering a chip reveals its card, clicking pins it.
+ */
+export function SourceAnchorRail({
+  sources,
+  spans,
+  editorRef,
+  activeKeys,
+  onHoverSource,
+  onActivateSource,
+  onShowAll,
+}: {
+  sources: SourceRef[];
+  spans: SourceSpan[];
+  editorRef: RefObject<CoeditorHandle | null>;
+  /** Source keys whose chips render dark (the caret sits in their spans). */
+  activeKeys?: string[];
+  onHoverSource?: (key: string | null) => void;
+  onActivateSource?: (key: string) => void;
+  /** Overflow chips hand off to the list view. */
+  onShowAll?: () => void;
+}) {
+  const [rows, setRows] = useState<{ top: number; items: RailSource[] }[]>([]);
+  const [pinnedKey, setPinnedKey] = useState<string | null>(null);
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  // The layer translates via a direct style write inside the scroll event
+  // so chips repaint in the same frame as the text (comment rail pattern).
+  const layerRef = useRef<HTMLDivElement | null>(null);
+  const originStatic = useRef(0);
+  const rafId = useRef(0);
+
+  const syncScroll = useCallback(() => {
+    const editor = editorRef.current;
+    const layer = layerRef.current;
+    if (!editor || !layer) return;
+    layer.style.transform = `translateY(${originStatic.current - editor.scrollTop()}px)`;
+  }, [editorRef]);
+
+  const relayout = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    // First span per source is its anchor, spans arrive ordered by offset.
+    const anchorOffsets = new Map<string, number>();
+    for (const sp of spans) {
+      const key = sourceKey(sp);
+      if (key && !anchorOffsets.has(key))
+        anchorOffsets.set(key, sp.start_offset);
+    }
+    const anchored: { rail: RailSource; want: number }[] = [];
+    for (const s of sources) {
+      const key = sourceKey(s);
+      const offset = key ? anchorOffsets.get(key) : undefined;
+      if (offset === undefined) continue;
+      const line = editor.anchorLine(offset);
+      if (!line) continue;
+      anchored.push({
+        rail: { key, source: s },
+        want: line.top + line.height / 2 - CHIP_ROW_CENTER,
+      });
+    }
+    anchored.sort((a, b) => a.want - b.want);
+    // Sources within a row height of the cluster's start share its row,
+    // later rows push down on collision.
+    const next: { top: number; items: RailSource[] }[] = [];
+    let cursor = 0;
+    for (const { rail, want } of anchored) {
+      const last = next[next.length - 1];
+      if (last && want - last.top < CLUSTER_SPAN) {
+        last.items.push(rail);
+        continue;
+      }
+      const top = Math.max(want, cursor);
+      next.push({ top, items: [rail] });
+      cursor = top + ROW_HEIGHT + ROW_GAP;
+    }
+    setRows(next);
+    const railTop = rootRef.current?.getBoundingClientRect().top ?? 0;
+    originStatic.current = editor.scrollerTop() - railTop;
+    syncScroll();
+  }, [sources, spans, editorRef, syncScroll]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const scheduled = () => {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(relayout);
+    };
+    // Synchronous first pass, rAF is throttled in occluded tabs.
+    relayout();
+    const unsub = editor.subscribeLayout((kind) => {
+      if (kind === "scroll") syncScroll();
+      else scheduled();
+    });
+    return () => {
+      unsub();
+      cancelAnimationFrame(rafId.current);
+    };
+  }, [relayout, syncScroll, editorRef]);
+
+  // A pointer landing outside any chip row unpins the open card. Capture
+  // phase, the editor stops pointer events from bubbling.
+  useEffect(() => {
+    if (!pinnedKey) return;
+    const onDown = (e: PointerEvent) => {
+      const t = e.target as Element | null;
+      if (t && rootRef.current?.contains(t)) return;
+      setPinnedKey(null);
+    };
+    document.addEventListener("pointerdown", onDown, true);
+    return () => document.removeEventListener("pointerdown", onDown, true);
+  }, [pinnedKey]);
+
+  const hover = (key: string | null) => {
+    setHoveredKey(key);
+    onHoverSource?.(key);
+  };
+
+  return (
+    <div
+      ref={rootRef}
+      className="pointer-events-none relative min-h-0 min-w-0 flex-1 overflow-clip"
+      // Chips live outside the editor's scroll container, wheel input over
+      // them forwards to the doc (deltaMode 1 is line-based deltas).
+      onWheel={(e) => {
+        editorRef.current?.scrollBy(e.deltaY * (e.deltaMode === 1 ? 16 : 1));
+      }}
+    >
+      <div ref={layerRef} className="absolute inset-0 will-change-transform">
+        {rows.map((row) => {
+          const shown = row.items.slice(0, MAX_CHIPS);
+          const hidden = row.items.slice(MAX_CHIPS);
+          const rowLit = row.items.some(
+            (it) => it.key === hoveredKey || it.key === pinnedKey,
+          );
+          return (
+            <div
+              key={row.items[0]!.key}
+              className={`pointer-events-auto absolute inset-x-2 flex flex-wrap items-start gap-1 py-1 ${
+                rowLit ? "z-10" : ""
+              }`}
+              style={{ top: row.top }}
+            >
+              {shown.map(({ key, source }, i) => {
+                const open = key === pinnedKey || key === hoveredKey;
+                return (
+                  <span
+                    key={key}
+                    className="relative"
+                    onMouseEnter={() => hover(key)}
+                    onMouseLeave={() => hover(null)}
+                  >
+                    <SourceChip
+                      source={source}
+                      lit={open || !!activeKeys?.includes(key)}
+                      onClick={() => {
+                        setPinnedKey(pinnedKey === key ? null : key);
+                        onActivateSource?.(key);
+                      }}
+                    />
+                    {open && (
+                      <SourceHoverCard source={source} alignRight={i > 0} />
+                    )}
+                  </span>
+                );
+              })}
+              {hidden.length > 0 && (
+                <MoreChip
+                  hidden={hidden.map((h) => h.source)}
+                  onClick={onShowAll}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -12,9 +12,10 @@ import { Section } from "@onyx-ai/opal/layouts";
 import { SvgExternalLink } from "@onyx-ai/opal/icons";
 
 import type { CoeditorHandle } from "@/lib/editor/components";
+import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
 import { relativeTime } from "@/lib/time";
 import { useIsMobile } from "@/lib/viewport";
-import type { SourceRef, SourceSpan } from "@/types";
+import type { SourceRef } from "@/types";
 
 import { SvgListLines } from "./icons";
 import { PanelSearchField } from "./PanelSearch";
@@ -23,8 +24,9 @@ import { sourceIcon, sourceKey, sourceTypeLabel } from "./sources";
 
 interface Props {
   sources: SourceRef[];
-  /** Attributed spans, anchoring the chips in anchored mode. */
-  spans?: SourceSpan[];
+  /** The page's highlight targets, retriggering chip layout in anchored
+   * mode when spans land or change. */
+  targets?: AnchoredHighlightTarget[];
   /** The live editor, required by anchored mode to track doc positions. */
   editorRef?: RefObject<CoeditorHandle | null>;
   /** Anchored/list mode is page-owned: the page hides the editor's native
@@ -127,7 +129,7 @@ function SourceCard({
  */
 export function SourcesPanel({
   sources,
-  spans,
+  targets,
   editorRef,
   listView,
   onListViewChange,
@@ -200,7 +202,7 @@ export function SourcesPanel({
         </div>
         <SourceAnchorRail
           sources={shown}
-          spans={spans ?? []}
+          targets={targets ?? []}
           editorRef={editorRef!}
           activeKeys={activeKeys}
           onHoverSource={onHoverSource}

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Button, EndOfList, Tag, Text } from "@onyx-ai/opal/components";
+import { useEffect, useState, type RefObject } from "react";
+import {
+  Button,
+  EndOfList,
+  SelectButton,
+  Tag,
+  Text,
+} from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 import { SvgExternalLink, SvgFileText, SvgGlobe } from "@onyx-ai/opal/icons";
 import {
@@ -22,13 +28,26 @@ import {
 } from "@onyx-ai/opal/logos";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 
+import type { CoeditorHandle } from "@/lib/editor/components";
 import { relativeTime } from "@/lib/time";
-import type { SourceRef, WriteProvenance } from "@/types";
+import { useIsMobile } from "@/lib/viewport";
+import type { SourceRef, SourceSpan, WriteProvenance } from "@/types";
 
+import { EditorEdgeScrollbar } from "./EditorEdgeScrollbar";
+import { SvgListLines } from "./icons";
 import { PanelSearchField } from "./PanelSearch";
+import { SourceAnchorRail } from "./SourceAnchorRail";
 
 interface Props {
   sources: SourceRef[];
+  /** Attributed spans, anchoring the chips in anchored mode. */
+  spans?: SourceSpan[];
+  /** The live editor, required by anchored mode to track doc positions. */
+  editorRef?: RefObject<CoeditorHandle | null>;
+  /** Anchored/list mode is page-owned: the page hides the editor's native
+   * scrollbar while anchored mode shows the viewport-edge one. */
+  listView: boolean;
+  onListViewChange: (v: boolean) => void;
   /** Source keys whose cards light up (the caret sits in their spans). */
   activeKeys?: string[];
   /** Called with a card's source key to scroll the doc to that source's
@@ -57,12 +76,12 @@ const SOURCE_ICONS: Record<string, IconFunctionComponent> = {
   zendesk: SvgZendesk,
 };
 
-function sourceIcon(type: string | null): IconFunctionComponent {
+export function sourceIcon(type: string | null): IconFunctionComponent {
   return (type && SOURCE_ICONS[type]) || SvgFileText;
 }
 
 // "google_drive" → "Google Drive", for the connector chip.
-function sourceTypeLabel(type: string): string {
+export function sourceTypeLabel(type: string): string {
   return type
     .split(/[_-]/)
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
@@ -161,20 +180,26 @@ function SourceCard({
  */
 export function SourcesPanel({
   sources,
+  spans,
+  editorRef,
+  listView,
+  onListViewChange,
   activeKeys,
   onActivateSource,
   onHoverSource,
 }: Props) {
+  const isMobile = useIsMobile();
   const [query, setQuery] = useState("");
+  const listMode = listView || isMobile || !editorRef;
 
-  // A caret landing in a span brings its card into view.
+  // A caret landing in a span brings its card into view (list mode).
   const firstActive = activeKeys?.[0];
   useEffect(() => {
-    if (!firstActive) return;
+    if (!firstActive || !listMode) return;
     document
       .querySelector(`[data-source-key="${CSS.escape(firstActive)}"]`)
       ?.scrollIntoView({ block: "nearest" });
-  }, [firstActive]);
+  }, [firstActive, listMode]);
 
   const q = query.trim().toLowerCase();
   const shown = q
@@ -187,6 +212,59 @@ export function SourcesPanel({
       )
     : sources;
 
+  const searchRow = (
+    <Section
+      flexDirection="row"
+      justifyContent="start"
+      alignItems="center"
+      height="fit"
+      gap={0.25}
+      className="shrink-0"
+    >
+      <PanelSearchField
+        value={query}
+        onChange={setQuery}
+        placeholder="Search sources…"
+      />
+      {!isMobile && editorRef && (
+        <SelectButton
+          icon={SvgListLines}
+          state={listView ? "selected" : "empty"}
+          tooltip={listView ? "Anchored view" : "List view"}
+          onClick={() => onListViewChange(!listView)}
+        />
+      )}
+    </Section>
+  );
+
+  if (!listMode) {
+    // Anchored mode (mock 1832:81274): only the search row is chromed,
+    // chips float on the page background tracking their doc spans.
+    return (
+      <Section
+        justifyContent="start"
+        alignItems="stretch"
+        height="auto"
+        gap={0.25}
+        className="relative min-h-0 flex-1"
+      >
+        <div className="shrink-0 rounded-(--radius-12) border border-(--border-01) p-1">
+          {searchRow}
+        </div>
+        <SourceAnchorRail
+          sources={shown}
+          spans={spans ?? []}
+          editorRef={editorRef!}
+          activeKeys={activeKeys}
+          onHoverSource={onHoverSource}
+          onActivateSource={onActivateSource}
+          onShowAll={() => onListViewChange(true)}
+        />
+        <EditorEdgeScrollbar editorRef={editorRef!} />
+      </Section>
+    );
+  }
+
   return (
     <Section
       justifyContent="start"
@@ -196,20 +274,7 @@ export function SourcesPanel({
       padding={0.25}
       className="min-h-0 flex-1 overflow-clip rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01)"
     >
-      <Section
-        flexDirection="row"
-        justifyContent="start"
-        alignItems="center"
-        height="fit"
-        gap={0.25}
-        className="shrink-0"
-      >
-        <PanelSearchField
-          value={query}
-          onChange={setQuery}
-          placeholder="Search sources…"
-        />
-      </Section>
+      {searchRow}
       <Section
         justifyContent="start"
         alignItems="stretch"

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -96,8 +96,12 @@ function SourceCard({
   return (
     <div
       data-source-key={sourceKey(source) || undefined}
-      className={`group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00) ${
-        active ? "bg-(--background-tint-00)" : ""
+      // Same chrome as comment cards: rested tint with the flat shadow,
+      // hover and the caret-active state lift to white and the raised one.
+      className={`group/source w-full shrink-0 cursor-pointer rounded-(--radius-12) p-1 ${
+        active
+          ? "bg-(--background-tint-00) shadow-(--shadow-box-01)"
+          : "bg-(--background-tint-01) shadow-(--shadow-box-00) hover:bg-(--background-tint-00) hover:shadow-(--shadow-box-01)"
       }`}
       onClick={onActivate}
       onMouseEnter={() => onHoverChange?.(true)}

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -29,7 +29,8 @@ import { PanelSearchField } from "./PanelSearch";
 
 interface Props {
   sources: SourceRef[];
-  /** Called with a card's source key to scroll the doc to its spans. */
+  /** Called with a card's source key to scroll the doc to that source's
+   * first span. */
   onActivateSource?: (key: string) => void;
 }
 
@@ -69,14 +70,13 @@ export function sourceKey(s: WriteProvenance): string {
   return s.source_document_id || s.source_url || s.source_title || "";
 }
 
-function SourceCard({
-  source,
-  onActivate,
-}: {
+interface SourceCardProps {
   source: SourceRef;
   /** Scrolls the doc to this source's first attributed span. */
   onActivate?: () => void;
-}) {
+}
+
+function SourceCard({ source, onActivate }: SourceCardProps) {
   const Icon = sourceIcon(source.source_type);
   const url = source.source_url;
   return (
@@ -134,7 +134,7 @@ function SourceCard({
 /**
  * Sources tab (mock 1837:103626): the ingested documents credited to this
  * page, previewing their content via the snippet captured at ingest when
- * one exists. Sources ride the page load, nothing else is fetched.
+ * one exists. Sources ride the page load, the panel itself fetches nothing.
  */
 export function SourcesPanel({ sources, onActivateSource }: Props) {
   const [query, setQuery] = useState("");

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -16,7 +16,6 @@ import { relativeTime } from "@/lib/time";
 import { useIsMobile } from "@/lib/viewport";
 import type { SourceRef, SourceSpan } from "@/types";
 
-import { EditorEdgeScrollbar } from "./EditorEdgeScrollbar";
 import { SvgListLines } from "./icons";
 import { PanelSearchField } from "./PanelSearch";
 import { SourceAnchorRail } from "./SourceAnchorRail";
@@ -208,7 +207,6 @@ export function SourcesPanel({
           onActivateSource={onActivateSource}
           onShowAll={() => onListViewChange(true)}
         />
-        <EditorEdgeScrollbar editorRef={editorRef!} />
       </Section>
     );
   }

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, EndOfList, Tag, Text } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 import { SvgExternalLink, SvgFileText, SvgGlobe } from "@onyx-ai/opal/icons";
@@ -29,6 +29,8 @@ import { PanelSearchField } from "./PanelSearch";
 
 interface Props {
   sources: SourceRef[];
+  /** Source keys whose cards light up (the caret sits in their spans). */
+  activeKeys?: string[];
   /** Called with a card's source key to scroll the doc to that source's
    * first span. */
   onActivateSource?: (key: string) => void;
@@ -75,18 +77,28 @@ export function sourceKey(s: WriteProvenance): string {
 
 interface SourceCardProps {
   source: SourceRef;
+  /** Lights the card while the caret sits in one of its spans. */
+  active?: boolean;
   /** Scrolls the doc to this source's first attributed span. */
   onActivate?: () => void;
   /** Hover state, so the page can light this source's doc spans. */
   onHoverChange?: (hovered: boolean) => void;
 }
 
-function SourceCard({ source, onActivate, onHoverChange }: SourceCardProps) {
+function SourceCard({
+  source,
+  active,
+  onActivate,
+  onHoverChange,
+}: SourceCardProps) {
   const Icon = sourceIcon(source.source_type);
   const url = source.source_url;
   return (
     <div
-      className="group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00)"
+      data-source-key={sourceKey(source) || undefined}
+      className={`group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00) ${
+        active ? "bg-(--background-tint-00)" : ""
+      }`}
       onClick={onActivate}
       onMouseEnter={() => onHoverChange?.(true)}
       onMouseLeave={() => onHoverChange?.(false)}
@@ -145,10 +157,20 @@ function SourceCard({ source, onActivate, onHoverChange }: SourceCardProps) {
  */
 export function SourcesPanel({
   sources,
+  activeKeys,
   onActivateSource,
   onHoverSource,
 }: Props) {
   const [query, setQuery] = useState("");
+
+  // A caret landing in a span brings its card into view.
+  const firstActive = activeKeys?.[0];
+  useEffect(() => {
+    if (!firstActive) return;
+    document
+      .querySelector(`[data-source-key="${CSS.escape(firstActive)}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [firstActive]);
 
   const q = query.trim().toLowerCase();
   const shown = q
@@ -215,6 +237,7 @@ export function SourcesPanel({
             <SourceCard
               key={key || `${s.last_updated}-${i}`}
               source={s}
+              active={!!key && !!activeKeys?.includes(key)}
               onActivate={
                 key && onActivateSource
                   ? () => onActivateSource(key)

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -29,6 +29,8 @@ import { PanelSearchField } from "./PanelSearch";
 
 interface Props {
   sources: SourceRef[];
+  /** Called with a card's source key to scroll the doc to its spans. */
+  onActivateSource?: (key: string) => void;
 }
 
 const SOURCE_ICONS: Record<string, IconFunctionComponent> = {
@@ -62,16 +64,26 @@ function sourceTypeLabel(type: string): string {
 }
 
 /** Stable card identity, mirroring the backend's dedupe key (document id,
- * falling back to url or title). */
-function sourceKey(s: WriteProvenance): string {
+ * falling back to url or title). Also joins a card to its doc spans. */
+export function sourceKey(s: WriteProvenance): string {
   return s.source_document_id || s.source_url || s.source_title || "";
 }
 
-function SourceCard({ source }: { source: SourceRef }) {
+function SourceCard({
+  source,
+  onActivate,
+}: {
+  source: SourceRef;
+  /** Scrolls the doc to this source's first attributed span. */
+  onActivate?: () => void;
+}) {
   const Icon = sourceIcon(source.source_type);
   const url = source.source_url;
   return (
-    <div className="group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00)">
+    <div
+      className="group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00)"
+      onClick={onActivate}
+    >
       <div className="flex min-h-7 items-start gap-1 p-[2px]">
         <span className="flex size-6 shrink-0 items-center justify-center">
           <Icon size={16} />
@@ -82,7 +94,10 @@ function SourceCard({ source }: { source: SourceRef }) {
           </Text>
         </span>
         {url && (
-          <span className="invisible shrink-0 group-hover/source:visible">
+          <span
+            className="invisible shrink-0 group-hover/source:visible"
+            onClick={(e) => e.stopPropagation()}
+          >
             <Button
               icon={SvgExternalLink}
               size="md"
@@ -121,7 +136,7 @@ function SourceCard({ source }: { source: SourceRef }) {
  * page, previewing their content via the snippet captured at ingest when
  * one exists. Sources ride the page load, nothing else is fetched.
  */
-export function SourcesPanel({ sources }: Props) {
+export function SourcesPanel({ sources, onActivateSource }: Props) {
   const [query, setQuery] = useState("");
 
   const q = query.trim().toLowerCase();
@@ -182,13 +197,21 @@ export function SourcesPanel({ sources }: Props) {
           </div>
         )}
 
-        {shown.map((s, i) => (
-          // Rows with no identity fields keep distinct keys via the index.
-          <SourceCard
-            key={sourceKey(s) || `${s.last_updated}-${i}`}
-            source={s}
-          />
-        ))}
+        {shown.map((s, i) => {
+          const key = sourceKey(s);
+          return (
+            // Rows with no identity fields keep distinct keys via the index.
+            <SourceCard
+              key={key || `${s.last_updated}-${i}`}
+              source={s}
+              onActivate={
+                key && onActivateSource
+                  ? () => onActivateSource(key)
+                  : undefined
+              }
+            />
+          );
+        })}
 
         {shown.length > 0 && (
           <div className="px-4 py-2">

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -32,6 +32,9 @@ interface Props {
   /** Called with a card's source key to scroll the doc to that source's
    * first span. */
   onActivateSource?: (key: string) => void;
+  /** Fires with the hovered card's source key (null on leave), so the
+   * page can light that source's doc spans. */
+  onHoverSource?: (key: string | null) => void;
 }
 
 const SOURCE_ICONS: Record<string, IconFunctionComponent> = {
@@ -74,15 +77,19 @@ interface SourceCardProps {
   source: SourceRef;
   /** Scrolls the doc to this source's first attributed span. */
   onActivate?: () => void;
+  /** Hover state, so the page can light this source's doc spans. */
+  onHoverChange?: (hovered: boolean) => void;
 }
 
-function SourceCard({ source, onActivate }: SourceCardProps) {
+function SourceCard({ source, onActivate, onHoverChange }: SourceCardProps) {
   const Icon = sourceIcon(source.source_type);
   const url = source.source_url;
   return (
     <div
       className="group/source w-full shrink-0 rounded-(--radius-12) p-1 hover:bg-(--background-tint-00)"
       onClick={onActivate}
+      onMouseEnter={() => onHoverChange?.(true)}
+      onMouseLeave={() => onHoverChange?.(false)}
     >
       <div className="flex min-h-7 items-start gap-1 p-[2px]">
         <span className="flex size-6 shrink-0 items-center justify-center">
@@ -136,7 +143,11 @@ function SourceCard({ source, onActivate }: SourceCardProps) {
  * page, previewing their content via the snippet captured at ingest when
  * one exists. Sources ride the page load, the panel itself fetches nothing.
  */
-export function SourcesPanel({ sources, onActivateSource }: Props) {
+export function SourcesPanel({
+  sources,
+  onActivateSource,
+  onHoverSource,
+}: Props) {
   const [query, setQuery] = useState("");
 
   const q = query.trim().toLowerCase();
@@ -207,6 +218,11 @@ export function SourcesPanel({ sources, onActivateSource }: Props) {
               onActivate={
                 key && onActivateSource
                   ? () => onActivateSource(key)
+                  : undefined
+              }
+              onHoverChange={
+                key && onHoverSource
+                  ? (h) => onHoverSource(h ? key : null)
                   : undefined
               }
             />

--- a/frontend/src/components/wiki/SourcesPanel.tsx
+++ b/frontend/src/components/wiki/SourcesPanel.tsx
@@ -9,34 +9,18 @@ import {
   Text,
 } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
-import { SvgExternalLink, SvgFileText, SvgGlobe } from "@onyx-ai/opal/icons";
-import {
-  SvgBraintrust,
-  SvgConfluence,
-  SvgGithub,
-  SvgGmail,
-  SvgGoogleDrive,
-  SvgHubspot,
-  SvgJira,
-  SvgLinear,
-  SvgNotion,
-  SvgSalesforce,
-  SvgSharepoint,
-  SvgSlack,
-  SvgTeams,
-  SvgZendesk,
-} from "@onyx-ai/opal/logos";
-import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+import { SvgExternalLink } from "@onyx-ai/opal/icons";
 
 import type { CoeditorHandle } from "@/lib/editor/components";
 import { relativeTime } from "@/lib/time";
 import { useIsMobile } from "@/lib/viewport";
-import type { SourceRef, SourceSpan, WriteProvenance } from "@/types";
+import type { SourceRef, SourceSpan } from "@/types";
 
 import { EditorEdgeScrollbar } from "./EditorEdgeScrollbar";
 import { SvgListLines } from "./icons";
 import { PanelSearchField } from "./PanelSearch";
 import { SourceAnchorRail } from "./SourceAnchorRail";
+import { sourceIcon, sourceKey, sourceTypeLabel } from "./sources";
 
 interface Props {
   sources: SourceRef[];
@@ -56,42 +40,6 @@ interface Props {
   /** Fires with the hovered card's source key (null on leave), so the
    * page can light that source's doc spans. */
   onHoverSource?: (key: string | null) => void;
-}
-
-const SOURCE_ICONS: Record<string, IconFunctionComponent> = {
-  braintrust: SvgBraintrust,
-  confluence: SvgConfluence,
-  github: SvgGithub,
-  gmail: SvgGmail,
-  google_drive: SvgGoogleDrive,
-  hubspot: SvgHubspot,
-  jira: SvgJira,
-  linear: SvgLinear,
-  notion: SvgNotion,
-  salesforce: SvgSalesforce,
-  sharepoint: SvgSharepoint,
-  slack: SvgSlack,
-  teams: SvgTeams,
-  web: SvgGlobe,
-  zendesk: SvgZendesk,
-};
-
-export function sourceIcon(type: string | null): IconFunctionComponent {
-  return (type && SOURCE_ICONS[type]) || SvgFileText;
-}
-
-// "google_drive" → "Google Drive", for the connector chip.
-export function sourceTypeLabel(type: string): string {
-  return type
-    .split(/[_-]/)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-}
-
-/** Stable card identity, mirroring the backend's dedupe key (document id,
- * falling back to url or title). Also joins a card to its doc spans. */
-export function sourceKey(s: WriteProvenance): string {
-  return s.source_document_id || s.source_url || s.source_title || "";
 }
 
 interface SourceCardProps {

--- a/frontend/src/components/wiki/sources.ts
+++ b/frontend/src/components/wiki/sources.ts
@@ -1,0 +1,59 @@
+/** Shared source-attribution helpers for the Sources tab surfaces (panel
+ * list, anchored rail, FileView wiring), a leaf module so the panel and the
+ * rail never import each other. */
+import { SvgFileText, SvgGlobe } from "@onyx-ai/opal/icons";
+import {
+  SvgBraintrust,
+  SvgConfluence,
+  SvgGithub,
+  SvgGmail,
+  SvgGoogleDrive,
+  SvgHubspot,
+  SvgJira,
+  SvgLinear,
+  SvgNotion,
+  SvgSalesforce,
+  SvgSharepoint,
+  SvgSlack,
+  SvgTeams,
+  SvgZendesk,
+} from "@onyx-ai/opal/logos";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+
+import type { WriteProvenance } from "@/types";
+
+const SOURCE_ICONS: Record<string, IconFunctionComponent> = {
+  braintrust: SvgBraintrust,
+  confluence: SvgConfluence,
+  github: SvgGithub,
+  gmail: SvgGmail,
+  google_drive: SvgGoogleDrive,
+  hubspot: SvgHubspot,
+  jira: SvgJira,
+  linear: SvgLinear,
+  notion: SvgNotion,
+  salesforce: SvgSalesforce,
+  sharepoint: SvgSharepoint,
+  slack: SvgSlack,
+  teams: SvgTeams,
+  web: SvgGlobe,
+  zendesk: SvgZendesk,
+};
+
+export function sourceIcon(type: string | null): IconFunctionComponent {
+  return (type && SOURCE_ICONS[type]) || SvgFileText;
+}
+
+// "google_drive" → "Google Drive", for the connector chip.
+export function sourceTypeLabel(type: string): string {
+  return type
+    .split(/[_-]/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+/** Stable card identity, mirroring the backend's dedupe key (document id,
+ * falling back to url or title). Also joins a card to its doc spans. */
+export function sourceKey(s: WriteProvenance): string {
+  return s.source_document_id || s.source_url || s.source_title || "";
+}

--- a/frontend/src/lib/editor/comments.ts
+++ b/frontend/src/lib/editor/comments.ts
@@ -2,10 +2,13 @@
  *
  * CodeMirror's doc *is* the raw markdown string, so a comment's anchor is
  * just a `[from, to)` offset pair into it — no DOM-alignment bridge needed.
+ * The highlight field itself is the comments instantiation of the shared
+ * anchored-highlight machinery in `highlights.ts`.
  */
-import type { EditorState, Range } from "@codemirror/state";
-import { StateEffect, StateField } from "@codemirror/state";
-import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
+import type { EditorState } from "@codemirror/state";
+
+import { commentHighlights } from "@/lib/editor/highlights";
+import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
 
 export interface CommentDraft {
   startOffset: number;
@@ -25,76 +28,8 @@ export function selectionToDraft(state: EditorState): CommentDraft | null {
   };
 }
 
-export interface CommentHighlightTarget {
-  /** Thread root comment id, matched against the active-id effect. */
-  id: string;
-  startOffset: number;
-  endOffset: number;
-}
+export type CommentHighlightTarget = AnchoredHighlightTarget;
 
-/** Dispatched to update the highlighted comment spans in `commentsField`. */
-export const setCommentHighlightsEffect =
-  StateEffect.define<CommentHighlightTarget[]>();
-
-/** Dispatched when the selected/hovered threads change, giving those ids the
- * stronger (orange) highlight. Separate from the spans effect so hover and
- * selection flips never re-send offsets over a locally edited doc. */
-export const setActiveCommentHighlightsEffect = StateEffect.define<string[]>();
-
-function buildCommentDecorations(
-  targets: CommentHighlightTarget[],
-  activeIds: string[],
-  docLen: number,
-): DecorationSet {
-  const ranges: Range<Decoration>[] = [];
-  for (const t of targets) {
-    const from = Math.max(0, Math.min(t.startOffset, docLen));
-    const to = Math.max(from, Math.min(t.endOffset, docLen));
-    if (from === to) continue;
-    ranges.push(
-      Decoration.mark({
-        class: activeIds.includes(t.id)
-          ? "cm-comment-highlight-active"
-          : "cm-comment-highlight",
-      }).range(from, to),
-    );
-  }
-  return Decoration.set(ranges, true);
-}
-
-/** Holds the comment highlight targets, the active thread ids, and their
- * decorations. Doc changes map the held offsets through the edit so a
- * highlight stays on the text it was anchored to. Fresh server offsets and
- * active ids only arrive via their effects. */
-export const commentsField = StateField.define<{
-  targets: CommentHighlightTarget[];
-  activeIds: string[];
-  deco: DecorationSet;
-}>({
-  create: () => ({ targets: [], activeIds: [], deco: Decoration.none }),
-  update(value, tr) {
-    let targets = value.targets;
-    let activeIds = value.activeIds;
-    if (tr.docChanged) {
-      // Boundary-typed text stays outside the range (start maps after an
-      // insertion at the start, end maps before one at the end).
-      targets = targets.map((t) => ({
-        ...t,
-        startOffset: tr.changes.mapPos(t.startOffset, 1),
-        endOffset: tr.changes.mapPos(t.endOffset, -1),
-      }));
-    }
-    for (const e of tr.effects) {
-      if (e.is(setCommentHighlightsEffect)) targets = e.value;
-      if (e.is(setActiveCommentHighlightsEffect)) activeIds = e.value;
-    }
-    if (targets === value.targets && activeIds === value.activeIds)
-      return value;
-    return {
-      targets,
-      activeIds,
-      deco: buildCommentDecorations(targets, activeIds, tr.state.doc.length),
-    };
-  },
-  provide: (f) => EditorView.decorations.from(f, (v) => v.deco),
-});
+export const commentsField = commentHighlights.field;
+export const setCommentHighlightsEffect = commentHighlights.setTargets;
+export const setActiveCommentHighlightsEffect = commentHighlights.setActive;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -484,9 +484,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         scrollToSource: (id: string) => {
           const v = view.current;
           if (!v) return;
+          // An edit can collapse a span to zero width, and a collapsed
+          // target paints nothing, so it can't be the scroll destination.
           const target = v.state
             .field(sourceHighlightsExt.field)
-            .targets.find((t) => t.id === id);
+            .targets.find((t) => t.id === id && t.startOffset < t.endOffset);
           if (!target) return;
           v.dispatch({
             effects: EditorView.scrollIntoView(

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -84,6 +84,24 @@ class CaretWidget extends WidgetType {
 /** Dispatched to update the peer list in `peersField`. */
 const setPeersEffect = StateEffect.define<CoeditPeer[]>();
 
+/** Highlight ids whose spans contain a collapsed caret or intersect a
+ * selection, half-open at span ends so a caret just past a span misses. */
+function caretHitIds(
+  targets: AnchoredHighlightTarget[],
+  from: number,
+  to: number,
+): string[] {
+  const ids: string[] = [];
+  for (const t of targets) {
+    const hit =
+      from === to
+        ? from >= t.startOffset && from < t.endOffset
+        : from < t.endOffset && to > t.startOffset;
+    if (hit && !ids.includes(t.id)) ids.push(t.id);
+  }
+  return ids;
+}
+
 /** Build a `DecorationSet` from the current peer list: one selection highlight
  * per non-collapsed selection and one `CaretWidget` per peer head position.
  * Offsets are clamped to `docLen` so a stale frame never lands out of range. */
@@ -353,6 +371,9 @@ interface CoeditorProps {
   commentHighlights?: CommentHighlightTarget[];
   /** Thread ids whose spans get the stronger (active) highlight. */
   activeCommentIds?: string[];
+  /** Fires with the thread ids whose spans contain the caret (or intersect
+   * the selection), deduped against the last report. */
+  onCommentCaret?: (ids: string[]) => void;
   /** Source-attributed spans to highlight while the Sources tab is open. */
   sourceHighlights?: AnchoredHighlightTarget[];
   /** Source keys whose spans get the stronger (active) highlight. */
@@ -431,6 +452,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       readOnly,
       commentHighlights,
       activeCommentIds,
+      onCommentCaret,
       sourceHighlights,
       activeSourceIds,
       onSourceCaret,
@@ -453,8 +475,11 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     const reportDocRef = useRef(reportDoc);
     const onSelectionForCommentRef = useRef(onSelectionForComment);
     const onSourceCaretRef = useRef(onSourceCaret);
-    // Last caret-source report, so selection churn inside one span is quiet.
+    const onCommentCaretRef = useRef(onCommentCaret);
+    // Last caret reports per field, so selection churn inside one span is
+    // quiet.
     const lastCaretIds = useRef("");
+    const lastCommentCaretIds = useRef("");
     const peersRef = useRef(peers);
     const commentHighlightsRef = useRef(commentHighlights);
     const activeCommentIdsRef = useRef(activeCommentIds);
@@ -466,6 +491,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     reportDocRef.current = reportDoc;
     onSelectionForCommentRef.current = onSelectionForComment;
     onSourceCaretRef.current = onSourceCaret;
+    onCommentCaretRef.current = onCommentCaret;
     peersRef.current = peers;
     commentHighlightsRef.current = commentHighlights;
     activeCommentIdsRef.current = activeCommentIds;
@@ -703,32 +729,42 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           void doPush();
         }
         if (u.geometryChanged || u.docChanged) notifyLayout("geometry");
-        // Caret-to-source attribution against the field's live-mapped spans.
-        // Runs above the remote-op return and also on field-value changes,
-        // since remote edits and effect-only target swaps move or clear the
-        // spans under a parked caret.
-        const sourceField = sourceHighlightsExt.field;
-        if (
-          (u.selectionSet ||
-            u.docChanged ||
-            u.startState.field(sourceField) !== u.state.field(sourceField)) &&
-          onSourceCaretRef.current
-        ) {
+        // Caret attribution against each highlight field's live-mapped
+        // spans. Runs above the remote-op return and also on field-value
+        // changes, since remote edits and effect-only target swaps move or
+        // clear the spans under a parked caret.
+        const reportCaret = (
+          field: typeof sourceHighlightsExt.field | typeof commentsField,
+          cb: ((ids: string[]) => void) | undefined,
+          last: { current: string },
+        ) => {
+          if (
+            !cb ||
+            !(
+              u.selectionSet ||
+              u.docChanged ||
+              u.startState.field(field) !== u.state.field(field)
+            )
+          )
+            return;
           const { from, to } = u.state.selection.main;
-          const ids: string[] = [];
-          for (const t of u.state.field(sourceField).targets) {
-            const hit =
-              from === to
-                ? from >= t.startOffset && from < t.endOffset
-                : from < t.endOffset && to > t.startOffset;
-            if (hit && !ids.includes(t.id)) ids.push(t.id);
-          }
+          const ids = caretHitIds(u.state.field(field).targets, from, to);
           const key = ids.join("\n");
-          if (key !== lastCaretIds.current) {
-            lastCaretIds.current = key;
-            onSourceCaretRef.current(ids);
+          if (key !== last.current) {
+            last.current = key;
+            cb(ids);
           }
-        }
+        };
+        reportCaret(
+          sourceHighlightsExt.field,
+          onSourceCaretRef.current,
+          lastCaretIds,
+        );
+        reportCaret(
+          commentsField,
+          onCommentCaretRef.current,
+          lastCommentCaretIds,
+        );
         // Remote-applied transactions aren't local input — don't report them as
         // our caret/typing.
         if (applyingRemote.current) return;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -822,6 +822,10 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       });
       v = new EditorView({ state, parent: host.current });
       view.current = v;
+      // A sentinel no ids-join can produce, so the fresh editor's first
+      // caret report always fires and clears any prior page's attribution.
+      lastCaretIds.current = "\0";
+      lastCommentCaretIds.current = "\0";
       // A fresh state starts with empty peer/highlight fields, and the
       // prop-tracking effects below only fire on identity change. Seed both.
       v.dispatch({

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -377,6 +377,10 @@ export interface CoeditorHandle {
   /** Scroll to a source's first attributed span, read from the highlight
    * field's live-mapped offsets so edits since the fetch are honored. */
   scrollToSource: (id: string) => void;
+  /** The source highlight field's live-mapped targets, for hosts that
+   * anchor UI to span positions (collapsed spans included, callers skip
+   * them). */
+  sourceTargets: () => AnchoredHighlightTarget[];
   /** Doc-space top and height (px from the document's start) of the line
    * block holding a character offset. Stable for off-screen positions
    * (line-block geometry, not rendered coordinates). */
@@ -480,6 +484,10 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
               { y: "center" },
             ),
           });
+        },
+        sourceTargets: () => {
+          const v = view.current;
+          return v ? v.state.field(sourceHighlightsExt.field).targets : [];
         },
         scrollToSource: (id: string) => {
           const v = view.current;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -163,7 +163,7 @@ const peersField = StateField.define<{
  * uses a slim scrollbar with a transparent track. */
 // Every anchored-highlight mark class, for selectors that must match all.
 const ANCHOR_HIGHLIGHT =
-  ":is(.cm-comment-highlight, .cm-comment-highlight-active, .cm-source-highlight)";
+  ":is(.cm-comment-highlight, .cm-comment-highlight-active, .cm-source-highlight, .cm-source-highlight-active)";
 
 const baseTheme = EditorView.theme({
   "&": {
@@ -270,19 +270,24 @@ const baseTheme = EditorView.theme({
   ".cm-comment-highlight-active": {
     backgroundColor: "var(--highlight-active)",
   },
-  // Source-attributed spans paint at Highlight/Active (mock 1832:81274).
+  // Source-attributed spans idle at the light amber, and the hovered
+  // card's spans jump to Highlight/Active (mock 1832:81274) so a reader
+  // can tell which highlight belongs to which source.
   ".cm-source-highlight": {
+    backgroundColor: "var(--neon-amber-a30)",
+  },
+  ".cm-source-highlight-active": {
     backgroundColor: "var(--highlight-active)",
   },
   // Code marks nest inside highlight marks with an opaque tint that would
   // occlude the wrapping span's amber, so they repaint the highlight color
   // over their own background.
-  ".cm-comment-highlight .cm-md-code-block, .cm-comment-highlight .cm-md-code-inline":
+  ".cm-comment-highlight .cm-md-code-block, .cm-comment-highlight .cm-md-code-inline, .cm-source-highlight .cm-md-code-block, .cm-source-highlight .cm-md-code-inline":
     {
       backgroundImage:
         "linear-gradient(var(--neon-amber-a30), var(--neon-amber-a30))",
     },
-  ".cm-comment-highlight-active .cm-md-code-block, .cm-comment-highlight-active .cm-md-code-inline, .cm-source-highlight .cm-md-code-block, .cm-source-highlight .cm-md-code-inline":
+  ".cm-comment-highlight-active .cm-md-code-block, .cm-comment-highlight-active .cm-md-code-inline, .cm-source-highlight-active .cm-md-code-block, .cm-source-highlight-active .cm-md-code-inline":
     {
       backgroundImage:
         "linear-gradient(var(--highlight-active), var(--highlight-active))",
@@ -350,6 +355,8 @@ interface CoeditorProps {
   activeCommentIds?: string[];
   /** Source-attributed spans to highlight while the Sources tab is open. */
   sourceHighlights?: AnchoredHighlightTarget[];
+  /** Source keys whose spans get the stronger (active) highlight. */
+  activeSourceIds?: string[];
   /** Fires on every selection change with the current selection as a comment
    * draft (null if collapsed) plus its on-screen coordinates, for the caller
    * to position a floating "Comment" affordance. */
@@ -415,6 +422,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       commentHighlights,
       activeCommentIds,
       sourceHighlights,
+      activeSourceIds,
       onSelectionForComment,
     },
     ref,
@@ -437,6 +445,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     const commentHighlightsRef = useRef(commentHighlights);
     const activeCommentIdsRef = useRef(activeCommentIds);
     const sourceHighlightsRef = useRef(sourceHighlights);
+    const activeSourceIdsRef = useRef(activeSourceIds);
     onSelRef.current = onSelectionChange;
     onCaretClearedRef.current = onCaretCleared;
     getCaretSeqRef.current = getCaretSeq;
@@ -446,6 +455,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     commentHighlightsRef.current = commentHighlights;
     activeCommentIdsRef.current = activeCommentIds;
     sourceHighlightsRef.current = sourceHighlights;
+    activeSourceIdsRef.current = activeSourceIds;
 
     useImperativeHandle(
       ref,
@@ -725,6 +735,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
             activeCommentIdsRef.current ?? [],
           ),
           sourceHighlightsExt.setTargets.of(sourceHighlightsRef.current ?? []),
+          sourceHighlightsExt.setActive.of(activeSourceIdsRef.current ?? []),
         ],
       });
       const onScroll = () => notifyLayout("scroll");
@@ -849,6 +860,13 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         effects: sourceHighlightsExt.setTargets.of(sourceHighlights ?? []),
       });
     }, [sourceHighlights]);
+
+    // Hovered source keys ride their own effect, like comment actives.
+    useEffect(() => {
+      view.current?.dispatch({
+        effects: sourceHighlightsExt.setActive.of(activeSourceIds ?? []),
+      });
+    }, [activeSourceIds]);
 
     // Reconfigure the read-only facets when the prop changes — they're baked
     // into the state at create time otherwise, and a `can_write` correction

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -48,6 +48,10 @@ import {
   type CommentDraft,
   type CommentHighlightTarget,
 } from "@/lib/editor/comments";
+import {
+  sourceHighlights as sourceHighlightsExt,
+  type AnchoredHighlightTarget,
+} from "@/lib/editor/highlights";
 
 /** A remote peer's caret: a thin colored bar with a small name label above it. */
 class CaretWidget extends WidgetType {
@@ -157,9 +161,9 @@ const peersField = StateField.define<{
  * `--cm-gutter` custom property that the surrounding column sets (so the text
  * gutter tracks the page's responsive padding at every breakpoint), and it
  * uses a slim scrollbar with a transparent track. */
-// Either comment-highlight mark class, for selectors that must match both.
-const COMMENT_HIGHLIGHT =
-  ":is(.cm-comment-highlight, .cm-comment-highlight-active)";
+// Every anchored-highlight mark class, for selectors that must match all.
+const ANCHOR_HIGHLIGHT =
+  ":is(.cm-comment-highlight, .cm-comment-highlight-active, .cm-source-highlight)";
 
 const baseTheme = EditorView.theme({
   "&": {
@@ -266,6 +270,10 @@ const baseTheme = EditorView.theme({
   ".cm-comment-highlight-active": {
     backgroundColor: "var(--highlight-active)",
   },
+  // Source-attributed spans paint at Highlight/Active (mock 1832:81274).
+  ".cm-source-highlight": {
+    backgroundColor: "var(--highlight-active)",
+  },
   // Code marks nest inside highlight marks with an opaque tint that would
   // occlude the wrapping span's amber, so they repaint the highlight color
   // over their own background.
@@ -274,16 +282,16 @@ const baseTheme = EditorView.theme({
       backgroundImage:
         "linear-gradient(var(--neon-amber-a30), var(--neon-amber-a30))",
     },
-  ".cm-comment-highlight-active .cm-md-code-block, .cm-comment-highlight-active .cm-md-code-inline":
+  ".cm-comment-highlight-active .cm-md-code-block, .cm-comment-highlight-active .cm-md-code-inline, .cm-source-highlight .cm-md-code-block, .cm-source-highlight .cm-md-code-inline":
     {
       backgroundImage:
         "linear-gradient(var(--highlight-active), var(--highlight-active))",
     },
   // A highlight mark splits the line's block-display code span, and each
-  // piece being a block would break the line at the comment's boundaries.
+  // piece being a block would break the line at the highlight's boundaries.
   // Inline pieces keep the line whole and the amber hugging the text, the
   // same as highlights on plain content.
-  [`.cm-line:has(${COMMENT_HIGHLIGHT}) .cm-md-code-block`]: {
+  [`.cm-line:has(${ANCHOR_HIGHLIGHT}) .cm-md-code-block`]: {
     display: "inline",
     borderRadius: "0",
   },
@@ -340,6 +348,8 @@ interface CoeditorProps {
   commentHighlights?: CommentHighlightTarget[];
   /** Thread ids whose spans get the stronger (active) highlight. */
   activeCommentIds?: string[];
+  /** Source-attributed spans to highlight while the Sources tab is open. */
+  sourceHighlights?: AnchoredHighlightTarget[];
   /** Fires on every selection change with the current selection as a comment
    * draft (null if collapsed) plus its on-screen coordinates, for the caller
    * to position a floating "Comment" affordance. */
@@ -404,6 +414,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       readOnly,
       commentHighlights,
       activeCommentIds,
+      sourceHighlights,
       onSelectionForComment,
     },
     ref,
@@ -425,6 +436,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     const peersRef = useRef(peers);
     const commentHighlightsRef = useRef(commentHighlights);
     const activeCommentIdsRef = useRef(activeCommentIds);
+    const sourceHighlightsRef = useRef(sourceHighlights);
     onSelRef.current = onSelectionChange;
     onCaretClearedRef.current = onCaretCleared;
     getCaretSeqRef.current = getCaretSeq;
@@ -433,6 +445,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     peersRef.current = peers;
     commentHighlightsRef.current = commentHighlights;
     activeCommentIdsRef.current = activeCommentIds;
+    sourceHighlightsRef.current = sourceHighlights;
 
     useImperativeHandle(
       ref,
@@ -695,6 +708,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           placeholderExt(placeholder ?? ""),
           peersField,
           commentsField,
+          sourceHighlightsExt.field,
           baseTheme,
           updateListener,
         ],
@@ -710,6 +724,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           setActiveCommentHighlightsEffect.of(
             activeCommentIdsRef.current ?? [],
           ),
+          sourceHighlightsExt.setTargets.of(sourceHighlightsRef.current ?? []),
         ],
       });
       const onScroll = () => notifyLayout("scroll");
@@ -827,6 +842,13 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         effects: setActiveCommentHighlightsEffect.of(activeCommentIds ?? []),
       });
     }, [activeCommentIds]);
+
+    // Push source-attributed spans into the editor state.
+    useEffect(() => {
+      view.current?.dispatch({
+        effects: sourceHighlightsExt.setTargets.of(sourceHighlights ?? []),
+      });
+    }, [sourceHighlights]);
 
     // Reconfigure the read-only facets when the prop changes — they're baked
     // into the state at create time otherwise, and a `can_write` correction

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -374,6 +374,9 @@ interface CoeditorProps {
  * links). */
 export interface CoeditorHandle {
   scrollToOffset: (offset: number) => void;
+  /** Scroll to a source's first attributed span, read from the highlight
+   * field's live-mapped offsets so edits since the fetch are honored. */
+  scrollToSource: (id: string) => void;
   /** Doc-space top and height (px from the document's start) of the line
    * block holding a character offset. Stable for off-screen positions
    * (line-block geometry, not rendered coordinates). */
@@ -474,6 +477,20 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           v.dispatch({
             effects: EditorView.scrollIntoView(
               Math.max(0, Math.min(offset, v.state.doc.length)),
+              { y: "center" },
+            ),
+          });
+        },
+        scrollToSource: (id: string) => {
+          const v = view.current;
+          if (!v) return;
+          const target = v.state
+            .field(sourceHighlightsExt.field)
+            .targets.find((t) => t.id === id);
+          if (!target) return;
+          v.dispatch({
+            effects: EditorView.scrollIntoView(
+              Math.max(0, Math.min(target.startOffset, v.state.doc.length)),
               { y: "center" },
             ),
           });
@@ -676,6 +693,32 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           void doPush();
         }
         if (u.geometryChanged || u.docChanged) notifyLayout("geometry");
+        // Caret-to-source attribution against the field's live-mapped spans.
+        // Runs above the remote-op return and also on field-value changes,
+        // since remote edits and effect-only target swaps move or clear the
+        // spans under a parked caret.
+        const sourceField = sourceHighlightsExt.field;
+        if (
+          (u.selectionSet ||
+            u.docChanged ||
+            u.startState.field(sourceField) !== u.state.field(sourceField)) &&
+          onSourceCaretRef.current
+        ) {
+          const { from, to } = u.state.selection.main;
+          const ids: string[] = [];
+          for (const t of u.state.field(sourceField).targets) {
+            const hit =
+              from === to
+                ? from >= t.startOffset && from < t.endOffset
+                : from < t.endOffset && to > t.startOffset;
+            if (hit && !ids.includes(t.id)) ids.push(t.id);
+          }
+          const key = ids.join("\n");
+          if (key !== lastCaretIds.current) {
+            lastCaretIds.current = key;
+            onSourceCaretRef.current(ids);
+          }
+        }
         // Remote-applied transactions aren't local input — don't report them as
         // our caret/typing.
         if (applyingRemote.current) return;
@@ -701,24 +744,6 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
             draft,
             coords ? { x: coords.left, y: coords.top } : null,
           );
-        }
-        // Caret-to-source attribution against the field's live-mapped spans
-        // (empty unless the page is feeding source targets).
-        if ((u.selectionSet || u.docChanged) && onSourceCaretRef.current) {
-          const { from, to } = sel;
-          const ids: string[] = [];
-          for (const t of u.state.field(sourceHighlightsExt.field).targets) {
-            const hit =
-              from === to
-                ? from >= t.startOffset && from < t.endOffset
-                : from < t.endOffset && to > t.startOffset;
-            if (hit && !ids.includes(t.id)) ids.push(t.id);
-          }
-          const key = ids.join("\n");
-          if (key !== lastCaretIds.current) {
-            lastCaretIds.current = key;
-            onSourceCaretRef.current(ids);
-          }
         }
       });
 

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -357,6 +357,9 @@ interface CoeditorProps {
   sourceHighlights?: AnchoredHighlightTarget[];
   /** Source keys whose spans get the stronger (active) highlight. */
   activeSourceIds?: string[];
+  /** Fires with the source ids whose spans contain the caret (or intersect
+   * the selection), deduped against the last report. */
+  onSourceCaret?: (ids: string[]) => void;
   /** Fires on every selection change with the current selection as a comment
    * draft (null if collapsed) plus its on-screen coordinates, for the caller
    * to position a floating "Comment" affordance. */
@@ -423,6 +426,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       activeCommentIds,
       sourceHighlights,
       activeSourceIds,
+      onSourceCaret,
       onSelectionForComment,
     },
     ref,
@@ -441,6 +445,9 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     const getCaretSeqRef = useRef(getCaretSeq);
     const reportDocRef = useRef(reportDoc);
     const onSelectionForCommentRef = useRef(onSelectionForComment);
+    const onSourceCaretRef = useRef(onSourceCaret);
+    // Last caret-source report, so selection churn inside one span is quiet.
+    const lastCaretIds = useRef("");
     const peersRef = useRef(peers);
     const commentHighlightsRef = useRef(commentHighlights);
     const activeCommentIdsRef = useRef(activeCommentIds);
@@ -451,6 +458,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
     getCaretSeqRef.current = getCaretSeq;
     reportDocRef.current = reportDoc;
     onSelectionForCommentRef.current = onSelectionForComment;
+    onSourceCaretRef.current = onSourceCaret;
     peersRef.current = peers;
     commentHighlightsRef.current = commentHighlights;
     activeCommentIdsRef.current = activeCommentIds;
@@ -693,6 +701,24 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
             draft,
             coords ? { x: coords.left, y: coords.top } : null,
           );
+        }
+        // Caret-to-source attribution against the field's live-mapped spans
+        // (empty unless the page is feeding source targets).
+        if ((u.selectionSet || u.docChanged) && onSourceCaretRef.current) {
+          const { from, to } = sel;
+          const ids: string[] = [];
+          for (const t of u.state.field(sourceHighlightsExt.field).targets) {
+            const hit =
+              from === to
+                ? from >= t.startOffset && from < t.endOffset
+                : from < t.endOffset && to > t.startOffset;
+            if (hit && !ids.includes(t.id)) ids.push(t.id);
+          }
+          const key = ids.join("\n");
+          if (key !== lastCaretIds.current) {
+            lastCaretIds.current = key;
+            onSourceCaretRef.current(ids);
+          }
         }
       });
 

--- a/frontend/src/lib/editor/highlights.ts
+++ b/frontend/src/lib/editor/highlights.ts
@@ -90,9 +90,7 @@ export const commentHighlights = anchoredHighlightField({
   active: "cm-comment-highlight-active",
 });
 
-// The sources view paints every attributed span at Highlight/Active (mock
-// 1832:81274), so the active class never differs from idle.
 export const sourceHighlights = anchoredHighlightField({
   idle: "cm-source-highlight",
-  active: "cm-source-highlight",
+  active: "cm-source-highlight-active",
 });

--- a/frontend/src/lib/editor/highlights.ts
+++ b/frontend/src/lib/editor/highlights.ts
@@ -1,0 +1,98 @@
+/** Anchored highlight fields: `[from, to)` offset ranges decorated into the
+ * doc, held in editor state so local edits map them onto the text they were
+ * anchored to. Comments and source attribution are the two instantiations,
+ * differing only in mark classes. */
+import type { Range } from "@codemirror/state";
+import { StateEffect, StateField } from "@codemirror/state";
+import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
+
+export interface AnchoredHighlightTarget {
+  /** Owner id (comment thread root or source dedupe key), matched against
+   * the active-id effect. Several targets may share one id. */
+  id: string;
+  startOffset: number;
+  endOffset: number;
+}
+
+interface HighlightClasses {
+  idle: string;
+  active: string;
+}
+
+function buildDecorations(
+  targets: AnchoredHighlightTarget[],
+  activeIds: string[],
+  classes: HighlightClasses,
+  docLen: number,
+): DecorationSet {
+  const ranges: Range<Decoration>[] = [];
+  for (const t of targets) {
+    const from = Math.max(0, Math.min(t.startOffset, docLen));
+    const to = Math.max(from, Math.min(t.endOffset, docLen));
+    if (from === to) continue;
+    ranges.push(
+      Decoration.mark({
+        class: activeIds.includes(t.id) ? classes.active : classes.idle,
+      }).range(from, to),
+    );
+  }
+  return Decoration.set(ranges, true);
+}
+
+/** Build a highlight field plus its two effects. Doc changes map the held
+ * offsets through the edit so a highlight stays on the text it was anchored
+ * to. Fresh server offsets and active ids only arrive via the effects. */
+export function anchoredHighlightField(classes: HighlightClasses) {
+  const setTargets = StateEffect.define<AnchoredHighlightTarget[]>();
+  const setActive = StateEffect.define<string[]>();
+  const field = StateField.define<{
+    targets: AnchoredHighlightTarget[];
+    activeIds: string[];
+    deco: DecorationSet;
+  }>({
+    create: () => ({ targets: [], activeIds: [], deco: Decoration.none }),
+    update(value, tr) {
+      let targets = value.targets;
+      let activeIds = value.activeIds;
+      if (tr.docChanged) {
+        // Boundary-typed text stays outside the range (start maps after an
+        // insertion at the start, end maps before one at the end).
+        targets = targets.map((t) => ({
+          ...t,
+          startOffset: tr.changes.mapPos(t.startOffset, 1),
+          endOffset: tr.changes.mapPos(t.endOffset, -1),
+        }));
+      }
+      for (const e of tr.effects) {
+        if (e.is(setTargets)) targets = e.value;
+        if (e.is(setActive)) activeIds = e.value;
+      }
+      if (targets === value.targets && activeIds === value.activeIds)
+        return value;
+      return {
+        targets,
+        activeIds,
+        deco: buildDecorations(
+          targets,
+          activeIds,
+          classes,
+          tr.state.doc.length,
+        ),
+      };
+    },
+    provide: (f) => EditorView.decorations.from(f, (v) => v.deco),
+  });
+  return { field, setTargets, setActive };
+}
+
+export const commentHighlights = anchoredHighlightField({
+  idle: "cm-comment-highlight",
+  active: "cm-comment-highlight-active",
+});
+
+// The sources view paints every attributed span at Highlight/Active (mock
+// 1832:81274), so the active class never differs from idle.
+export const sourceHighlights = anchoredHighlightField({
+  idle: "cm-source-highlight",
+  active: "cm-source-highlight",
+});

--- a/frontend/src/lib/swr-keys.ts
+++ b/frontend/src/lib/swr-keys.ts
@@ -17,6 +17,10 @@ export const SWR_KEYS = {
     `/wiki/update-health?path=${encodeURIComponent(path)}`,
   documentActivity: (path: string) =>
     `/wiki/file/activity?path=${encodeURIComponent(path)}`,
+  /** Tuple key: the head sha busts the cache on new commits even though the
+   * request URL only carries the path (the server always reads at HEAD). */
+  sourceSpans: (path: string, headSha: string) =>
+    ["/wiki/source-spans", path, headSha] as const,
   pageAcl: (path: string) => `/wiki/acl?path=${encodeURIComponent(path)}`,
   /** `usePathToId`'s cache key is a `[tag, path]` tuple — `tag` namespaces two
    * call sites resolving different concerns off the same `resolveIds`

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -86,6 +86,13 @@ export interface SourceRef extends WriteProvenance {
   last_updated: string;
 }
 
+/** A live span of a page mapped to the document it was ingested from.
+ * Offsets are character positions into the page's body at HEAD. */
+export interface SourceSpan extends WriteProvenance {
+  start_offset: number;
+  end_offset: number;
+}
+
 export interface DocumentActivityResponse {
   path: string;
   agents: DocumentActivity[];

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -266,15 +266,18 @@ export function FileView({ path }: FileViewProps) {
     void refreshComments();
   }, [refreshComments]);
 
+  const sourcesTabOpen = panelTab === "sources";
+
   // Comment thread spans to highlight in the editor. Cleared while viewing
-  // an old commit (DiffView, no live editor). The active/hovered ids ride a
-  // separate prop: the editor maps these offsets through local edits, and a
-  // hover or selection flip must not re-send the unmapped ones.
+  // an old commit (DiffView, no live editor) and while the Sources tab has
+  // the doc, so the two highlight families never mix. The active/hovered
+  // ids ride a separate prop: the editor maps these offsets through local
+  // edits, and a hover or selection flip must not re-send the unmapped ones.
   // Hovering a card lights its doc highlight like selection does (mock
   // 1855 annotation: "Hover highlight - match the hovered comment").
   const [hoveredCommentId, setHoveredCommentId] = useState<string | null>(null);
   const commentHighlights = useMemo<CommentHighlightTarget[]>(() => {
-    if (viewingVersion) return [];
+    if (viewingVersion || sourcesTabOpen) return [];
     return commentThreads
       .map((t) => t.root)
       .filter(
@@ -291,7 +294,7 @@ export function FileView({ path }: FileViewProps) {
         startOffset: r.start_offset as number,
         endOffset: r.end_offset as number,
       }));
-  }, [commentThreads, viewingVersion]);
+  }, [commentThreads, viewingVersion, sourcesTabOpen]);
   const activeCommentIds = useMemo(
     () =>
       [activeCommentId, hoveredCommentId].filter((id): id is string => !!id),
@@ -301,7 +304,6 @@ export function FileView({ path }: FileViewProps) {
   // Source-attributed spans light up in the doc while the Sources tab is
   // open (mock 1832:81274). Fetched lazily per head sha since the server
   // remaps offsets to HEAD, so an old version never fetches.
-  const sourcesTabOpen = panelTab === "sources";
   const { data: sourceSpans } = useSWR(
     sourcesTabOpen && headSha && !viewingVersion
       ? SWR_KEYS.sourceSpans(path, headSha)
@@ -329,12 +331,17 @@ export function FileView({ path }: FileViewProps) {
     },
     [sourceSpans],
   );
-  // Hovering a card lights only that source's spans, attributing each
-  // highlight to its card.
+  // Attribution runs both ways: hovering a card lights only that source's
+  // spans, and a caret inside a span lights its card (the editor reports
+  // caret-source ids against its live-mapped offsets).
   const [hoveredSourceKey, setHoveredSourceKey] = useState<string | null>(null);
+  const [caretSourceKeys, setCaretSourceKeys] = useState<string[]>([]);
   const activeSourceIds = useMemo(
-    () => (hoveredSourceKey ? [hoveredSourceKey] : []),
-    [hoveredSourceKey],
+    () =>
+      hoveredSourceKey && !caretSourceKeys.includes(hoveredSourceKey)
+        ? [hoveredSourceKey, ...caretSourceKeys]
+        : caretSourceKeys,
+    [hoveredSourceKey, caretSourceKeys],
   );
 
   // The doc area hosting the lane, measured at interaction time so the
@@ -1028,6 +1035,7 @@ export function FileView({ path }: FileViewProps) {
           <div className="flex min-h-0 flex-1 flex-col px-2 py-1">
             <SourcesPanel
               sources={sources}
+              activeKeys={caretSourceKeys}
               onActivateSource={viewingVersion ? undefined : activateSource}
               onHoverSource={viewingVersion ? undefined : setHoveredSourceKey}
             />
@@ -1238,6 +1246,7 @@ export function FileView({ path }: FileViewProps) {
                       activeCommentIds={activeCommentIds}
                       sourceHighlights={sourceHighlights}
                       activeSourceIds={activeSourceIds}
+                      onSourceCaret={setCaretSourceKeys}
                       onSelectionForComment={handleSelectionForComment}
                       placeholder="Start typing, or pick a template above…"
                     />

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -43,6 +43,7 @@ import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { sourceKey, SourcesPanel } from "@/components/wiki/SourcesPanel";
 import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
@@ -303,12 +304,15 @@ export function FileView({ path }: FileViewProps) {
   const sourcesTabOpen = panelTab === "sources";
   const { data: sourceSpans } = useSWR(
     sourcesTabOpen && headSha && !viewingVersion
-      ? ["/wiki/source-spans", path, headSha]
+      ? SWR_KEYS.sourceSpans(path, headSha)
       : null,
     () =>
       apiFetch<SourceSpan[]>(
         `/wiki/source-spans?path=${encodeURIComponent(path)}`,
       ),
+    // Offsets are only valid for the doc revision they were fetched for, so
+    // a path or head change must blank the highlights, never reuse them.
+    { keepPreviousData: false },
   );
   const sourceHighlights = useMemo<AnchoredHighlightTarget[]>(() => {
     if (!sourcesTabOpen) return [];

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -41,7 +41,8 @@ import {
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
-import { sourceKey, SourcesPanel } from "@/components/wiki/SourcesPanel";
+import { sourceKey } from "@/components/wiki/sources";
+import { SourcesPanel } from "@/components/wiki/SourcesPanel";
 import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
@@ -1136,7 +1137,7 @@ export function FileView({ path }: FileViewProps) {
         ref={docRowRef}
         className={`@container relative flex min-h-0 min-w-0 flex-1 flex-col ${
           railActive ? "rail-reserved" : ""
-        } ${anchoredPanelActive ? "comments-anchored" : ""}`}
+        } ${anchoredPanelActive ? "panel-anchored" : ""}`}
       >
         <DocTitle
           path={path}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1037,7 +1037,7 @@ export function FileView({ path }: FileViewProps) {
           <div className="flex min-h-0 flex-1 flex-col px-2 py-1">
             <SourcesPanel
               sources={sources}
-              spans={sourceSpans}
+              targets={sourceHighlights}
               editorRef={viewingVersion ? undefined : coeditorRef}
               listView={sourcesListView}
               onListViewChange={setSourcesListView}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -303,7 +303,10 @@ export function FileView({ path }: FileViewProps) {
 
   // Source-attributed spans light up in the doc while the Sources tab is
   // open (mock 1832:81274). Fetched lazily per head sha since the server
-  // remaps offsets to HEAD, so an old version never fetches.
+  // remaps offsets to HEAD, so an old version never fetches. The server
+  // always reads at its current HEAD, which can be ahead of this key:
+  // offsets apply best-effort, and the live session converges the local
+  // doc toward the state the server read, like comment offsets.
   const { data: sourceSpans } = useSWR(
     sourcesTabOpen && headSha && !viewingVersion
       ? SWR_KEYS.sourceSpans(path, headSha)

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -429,6 +429,14 @@ export function FileView({ path }: FileViewProps) {
   const panelScrollDocked =
     !!coedit.session && !viewingVersion && !isMobile && panelTab !== null;
 
+  // A caret inside a commented span focuses its thread in the panel (the
+  // panel's activeId effect scrolls the card into view), without the doc
+  // scroll a card click performs. Leaving every span clears the focus,
+  // matching the click-off collapse.
+  const handleCommentCaret = useCallback((ids: string[]) => {
+    setActiveCommentId(ids[0] ?? null);
+  }, []);
+
   // Select a thread (its span gets the orange highlight) and scroll the
   // editor to bring that span into view. Only an explicit click runs this —
   // keying a scroll off `activeCommentId` alone would also re-scroll on
@@ -1250,6 +1258,7 @@ export function FileView({ path }: FileViewProps) {
                       readOnly={!canWrite}
                       commentHighlights={commentHighlights}
                       activeCommentIds={activeCommentIds}
+                      onCommentCaret={handleCommentCaret}
                       sourceHighlights={sourceHighlights}
                       activeSourceIds={activeSourceIds}
                       onSourceCaret={setCaretSourceKeys}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -41,6 +41,7 @@ import {
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
+import { EditorEdgeScrollbar } from "@/components/wiki/EditorEdgeScrollbar";
 import { sourceKey } from "@/components/wiki/sources";
 import { SourcesPanel } from "@/components/wiki/SourcesPanel";
 import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
@@ -422,14 +423,11 @@ export function FileView({ path }: FileViewProps) {
     !isMobile &&
     (marginThreadCount > 0 || commentDraft !== null);
 
-  // Anchored panel mode hides the editor's native scrollbar (it would sit
-  // at the doc/panel boundary) in favor of the panel's viewport-edge one.
-  const anchoredPanelActive =
-    !!coedit.session &&
-    !viewingVersion &&
-    !isMobile &&
-    ((panelTab === "comments" && !commentsListView) ||
-      (panelTab === "sources" && !sourcesListView));
+  // With any panel open on the live doc, the doc's scrollbar docks at the
+  // viewport edge (EditorEdgeScrollbar) and the native one hides, so tab
+  // switches never toggle the native bar's width inside the scroller.
+  const panelScrollDocked =
+    !!coedit.session && !viewingVersion && !isMobile && panelTab !== null;
 
   // Select a thread (its span gets the orange highlight) and scroll the
   // editor to bring that span into view. Only an explicit click runs this —
@@ -1137,7 +1135,7 @@ export function FileView({ path }: FileViewProps) {
         ref={docRowRef}
         className={`@container relative flex min-h-0 min-w-0 flex-1 flex-col ${
           railActive ? "rail-reserved" : ""
-        } ${anchoredPanelActive ? "panel-anchored" : ""}`}
+        } ${panelScrollDocked ? "panel-anchored" : ""}`}
       >
         <DocTitle
           path={path}
@@ -1293,7 +1291,14 @@ export function FileView({ path }: FileViewProps) {
               rightHost?.el &&
               createPortal(
                 <DocPanel tab={panelTab} onTabChange={setPanelTab}>
-                  {panelBody}
+                  <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
+                    {panelBody}
+                    {/* One docked doc scrollbar for every tab, so switching
+                        tabs never toggles the native bar's width. */}
+                    {panelScrollDocked && (
+                      <EditorEdgeScrollbar editorRef={coeditorRef} />
+                    )}
+                  </div>
                 </DocPanel>,
                 rightHost.el,
               )}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -299,7 +299,7 @@ export function FileView({ path }: FileViewProps) {
 
   // Source-attributed spans light up in the doc while the Sources tab is
   // open (mock 1832:81274). Fetched lazily per head sha since the server
-  // remaps offsets to HEAD.
+  // remaps offsets to HEAD, so an old version never fetches.
   const sourcesTabOpen = panelTab === "sources";
   const { data: sourceSpans } = useSWR(
     sourcesTabOpen && headSha && !viewingVersion

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useRouter, useSearchParams } from "next/navigation";
+import useSWR from "swr";
 import {
   Button,
   Divider,
@@ -40,7 +41,8 @@ import {
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
-import { SourcesPanel } from "@/components/wiki/SourcesPanel";
+import { sourceKey, SourcesPanel } from "@/components/wiki/SourcesPanel";
+import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
 import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
@@ -92,6 +94,7 @@ import type {
   DocumentActivity,
   DocumentActivityResponse,
   SourceRef,
+  SourceSpan,
 } from "@/types";
 
 // Local shape for the /wiki/file API response — mirrored from page.tsx.
@@ -292,6 +295,35 @@ export function FileView({ path }: FileViewProps) {
     () =>
       [activeCommentId, hoveredCommentId].filter((id): id is string => !!id),
     [activeCommentId, hoveredCommentId],
+  );
+
+  // Source-attributed spans light up in the doc while the Sources tab is
+  // open (mock 1832:81274). Fetched lazily per head sha since the server
+  // remaps offsets to HEAD.
+  const sourcesTabOpen = panelTab === "sources";
+  const { data: sourceSpans } = useSWR(
+    sourcesTabOpen && headSha && !viewingVersion
+      ? ["/wiki/source-spans", path, headSha]
+      : null,
+    () =>
+      apiFetch<SourceSpan[]>(
+        `/wiki/source-spans?path=${encodeURIComponent(path)}`,
+      ),
+  );
+  const sourceHighlights = useMemo<AnchoredHighlightTarget[]>(() => {
+    if (!sourcesTabOpen) return [];
+    return (sourceSpans ?? []).map((sp) => ({
+      id: sourceKey(sp),
+      startOffset: sp.start_offset,
+      endOffset: sp.end_offset,
+    }));
+  }, [sourcesTabOpen, sourceSpans]);
+  const activateSource = useCallback(
+    (key: string) => {
+      const span = (sourceSpans ?? []).find((sp) => sourceKey(sp) === key);
+      if (span) coeditorRef.current?.scrollToOffset(span.start_offset);
+    },
+    [sourceSpans],
   );
 
   // The doc area hosting the lane, measured at interaction time so the
@@ -983,7 +1015,10 @@ export function FileView({ path }: FileViewProps) {
       case "sources":
         return (
           <div className="flex min-h-0 flex-1 flex-col px-2 py-1">
-            <SourcesPanel sources={sources} />
+            <SourcesPanel
+              sources={sources}
+              onActivateSource={viewingVersion ? undefined : activateSource}
+            />
           </div>
         );
       case "watching":
@@ -1189,6 +1224,7 @@ export function FileView({ path }: FileViewProps) {
                       readOnly={!canWrite}
                       commentHighlights={commentHighlights}
                       activeCommentIds={activeCommentIds}
+                      sourceHighlights={sourceHighlights}
                       onSelectionForComment={handleSelectionForComment}
                       placeholder="Start typing, or pick a template above…"
                     />

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -329,6 +329,13 @@ export function FileView({ path }: FileViewProps) {
     },
     [sourceSpans],
   );
+  // Hovering a card lights only that source's spans, attributing each
+  // highlight to its card.
+  const [hoveredSourceKey, setHoveredSourceKey] = useState<string | null>(null);
+  const activeSourceIds = useMemo(
+    () => (hoveredSourceKey ? [hoveredSourceKey] : []),
+    [hoveredSourceKey],
+  );
 
   // The doc area hosting the lane, measured at interaction time so the
   // panel fallback keys off the same width as the lane's container query.
@@ -1022,6 +1029,7 @@ export function FileView({ path }: FileViewProps) {
             <SourcesPanel
               sources={sources}
               onActivateSource={viewingVersion ? undefined : activateSource}
+              onHoverSource={viewingVersion ? undefined : setHoveredSourceKey}
             />
           </div>
         );
@@ -1229,6 +1237,7 @@ export function FileView({ path }: FileViewProps) {
                       commentHighlights={commentHighlights}
                       activeCommentIds={activeCommentIds}
                       sourceHighlights={sourceHighlights}
+                      activeSourceIds={activeSourceIds}
                       onSelectionForComment={handleSelectionForComment}
                       placeholder="Start typing, or pick a template above…"
                     />

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -200,6 +200,8 @@ export function FileView({ path }: FileViewProps) {
   // also swaps the editor's native scrollbar for the viewport-edge one.
   const [commentDraft, setCommentDraft] = useState<CommentDraft | null>(null);
   const [commentsListView, setCommentsListView] = useState(false);
+  // Same page-owned split for the Sources tab's anchored/list modes.
+  const [sourcesListView, setSourcesListView] = useState(false);
   const [commentThreads, setCommentThreads] = useState<CommentThreadView[]>([]);
   const [activeCommentId, setActiveCommentId] = useState<string | null>(null);
   const [selTool, setSelTool] = useState<{
@@ -424,9 +426,9 @@ export function FileView({ path }: FileViewProps) {
   const anchoredPanelActive =
     !!coedit.session &&
     !viewingVersion &&
-    panelTab === "comments" &&
-    !commentsListView &&
-    !isMobile;
+    !isMobile &&
+    ((panelTab === "comments" && !commentsListView) ||
+      (panelTab === "sources" && !sourcesListView));
 
   // Select a thread (its span gets the orange highlight) and scroll the
   // editor to bring that span into view. Only an explicit click runs this —
@@ -1036,6 +1038,10 @@ export function FileView({ path }: FileViewProps) {
           <div className="flex min-h-0 flex-1 flex-col px-2 py-1">
             <SourcesPanel
               sources={sources}
+              spans={sourceSpans}
+              editorRef={viewingVersion ? undefined : coeditorRef}
+              listView={sourcesListView}
+              onListViewChange={setSourcesListView}
               activeKeys={caretSourceKeys}
               onActivateSource={viewingVersion ? undefined : activateSource}
               onHoverSource={viewingVersion ? undefined : setHoveredSourceKey}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -327,13 +327,11 @@ export function FileView({ path }: FileViewProps) {
       endOffset: sp.end_offset,
     }));
   }, [sourcesTabOpen, sourceSpans]);
-  const activateSource = useCallback(
-    (key: string) => {
-      const span = (sourceSpans ?? []).find((sp) => sourceKey(sp) === key);
-      if (span) coeditorRef.current?.scrollToOffset(span.start_offset);
-    },
-    [sourceSpans],
-  );
+  // Scrolls via the editor's live-mapped span, not the raw server offset,
+  // so a click after local edits lands on the moved text.
+  const activateSource = useCallback((key: string) => {
+    coeditorRef.current?.scrollToSource(key);
+  }, []);
   // Attribution runs both ways: hovering a card lights only that source's
   // spans, and a caret inside a span lights its card (the editor reports
   // caret-source ids against its live-mapped offsets).


### PR DESCRIPTION
## Description

Task-3 slices on top of #487, all against mock 1832:81274.

- Source-attributed spans highlight at `Highlight/Active` while the Sources tab is open, with the offsets living in a shared `anchoredHighlightField` factory that comments and sources both instantiate.
- The Sources tab defaults to the anchored mode: connector chips track each source's first span, cluster by proximity with a `+N more` overflow, invert on hover, and reveal a details card with the mock's shadow pair. Click pins the card, click-off unpins, clicking a chip or list card scrolls to the source's live-mapped span. List view stays behind the toggle.
- Attribution runs both ways: hovering a chip/card lights its doc spans, and a caret inside a span lights its chip/card.
- The doc scrollbar docks at the viewport edge whenever any panel tab is open (one `EditorEdgeScrollbar` for all tabs), ending the tab-switch reflow from toggling the native bar. Closed panels, mobile, and old-version views keep the native bar.
- `sources.ts` leaf module carries the shared helpers plus the hubspot/braintrust icons, superseding #490.

## How Has This Been Tested?

## Additional Options
- [ ] This PR should be cherry-picked into the latest release branch
- [x] Override Linear Check