### PR TITLE
feat(automanage): exact body-duplicate detector + audience partitioning

### DIFF
--- a/backend/app/llm/agents/automanage_apply.py
+++ b/backend/app/llm/agents/automanage_apply.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -7,7 +7,7 @@ filters by ``applicable(trigger)``, and feeds each the trigger-built ``Scope``
 """
 from __future__ import annotations
 
-from app.wiki.automanage.detectors import empty_folder
+from app.wiki.automanage.detectors import body_dup, empty_folder
 from app.wiki.automanage.detectors.base import (
     Detector,
     ProposalDraft,
@@ -17,6 +17,7 @@ from app.wiki.automanage.detectors.base import (
 
 DETECTORS: list[Detector] = [
     empty_folder.DETECTOR,
+    body_dup.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/base.py
+++ b/backend/app/wiki/automanage/detectors/base.py
@@ -80,6 +80,7 @@ class ProposalDraft(BaseModel):
     source_paths: list[str]
     target_paths: list[str] = Field(default_factory=list)
     summary: str
+    instruction: str | None = None
     proposed_bodies: dict[str, str] | None = None
     auto_approvable: bool = True
 
@@ -100,6 +101,11 @@ class Detector(Protocol):
     """
 
     name: str
+    # Pairing detectors (True) compare pages against each other, so the runner
+    # feeds them one permission bucket at a time — pages with different
+    # audiences are never mentioned in one proposal. Single-path detectors
+    # leave the default (False) and see the whole scope.
+    pairs_paths: bool = False
 
     def applicable(self, trigger: TriggerKind) -> bool:
         """Which matrix cells this detector fills — whether it should run under

--- a/backend/app/wiki/automanage/detectors/body_dup.py
+++ b/backend/app/wiki/automanage/detectors/body_dup.py
@@ -1,0 +1,113 @@
+"""Exact body-duplicate detector — mechanical, no LLM.
+
+Groups the scope's pages by git blob sha: equal shas mean **byte-identical
+bodies**, the strongest duplicate evidence there is — zero false positives on
+the "same bytes" claim. Each group emits one ``merge`` proposal retiring the
+redundant copies into a survivor. The merged body is the shared content
+unchanged, so the proposal's preview is exact; the agentic applier's work is
+the identity half (retire + forward), not content.
+
+Byte-equality is deterministic, but *same bytes* ≠ *same document* when the
+content is trivial: two pages that both say ``# TODO`` are usually intentional
+placeholders for different future documents, not duplicates. Hence
+``MIN_BODY_BYTES`` — only substantial identical bodies are proposed; trivial
+stubs are the (LLM-judged) stub detector's territory.
+
+This is a **pairing** detector (``pairs_paths = True``): the runner feeds it
+one permission bucket at a time, so it never pairs pages across a visibility
+boundary — the proposal itself would leak a restricted page's existence.
+
+Survivor choice is a deterministic heuristic: the shallowest path (closer to
+the wiki root reads as the more canonical home), then the shortest, then
+lexicographic. The reviewer sees which page survives and can reject if the
+heuristic picked wrong.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from app.wiki import git
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# Identical bodies below this size are treated as placeholders, not duplicates.
+MIN_BODY_BYTES = 120
+
+
+def _survivor_key(path: str) -> tuple[int, int, str]:
+    return (path.count("/"), len(path), path)
+
+
+class _BodyDupDetector:
+    name = "body_dup"
+    pairs_paths = True  # runner partitions this detector's scope by audience
+
+    def __init__(self, min_body_bytes: int = MIN_BODY_BYTES):
+        self._min_bytes = min_body_bytes
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        return trigger == TriggerKind.SWEEP
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        in_scope = {p for p in scope.paths if p.endswith(".md")}
+        if len(in_scope) < 2:
+            return []
+        by_blob: dict[str, list[str]] = defaultdict(list)
+        for path, blob in git.list_paths_with_blob_sha():
+            if path in in_scope:
+                by_blob[blob].append(path)
+
+        drafts: list[ProposalDraft] = []
+        for blob, paths in sorted(by_blob.items()):
+            if len(paths) < 2:
+                continue
+            body = git.read_file_opt(paths[0])
+            if body is None or len(body.encode()) < self._min_bytes:
+                continue
+            ordered = sorted(paths, key=_survivor_key)
+            survivor, redundant = ordered[0], ordered[1:]
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.MERGE,
+                    source_paths=redundant,
+                    target_paths=[survivor],
+                    summary=(
+                        f"Merge {len(redundant)} byte-identical duplicate"
+                        f"{'s' if len(redundant) > 1 else ''} of "
+                        f"“{survivor}”: " + ", ".join(f"“{p}”" for p in redundant)
+                    ),
+                    instruction=(
+                        "These pages have byte-identical bodies. Keep "
+                        f"{survivor!r} unchanged and retire each duplicate "
+                        "into it (trash + identity forward). Do not rewrite "
+                        "any content."
+                    ),
+                    proposed_bodies={survivor: body},
+                    # Merges wait for a human until the agentic applier has
+                    # earned auto-apply with reliability data.
+                    auto_approvable=False,
+                )
+            )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """Premise: every affected page still exists and all bodies are still
+        byte-identical. An edit that keeps them identical (e.g. the same fix
+        applied to every copy) does not invalidate the proposal."""
+        paths = proposal["target_paths"] + proposal["source_paths"]
+        bodies: list[str] = []
+        for path in paths:
+            body = git.read_file_opt(path)
+            if body is None:
+                return f"{path!r} no longer exists"
+            bodies.append(body)
+        if any(b != bodies[0] for b in bodies[1:]):
+            return "the pages are no longer byte-identical"
+        return None
+
+
+DETECTOR = _BodyDupDetector()

--- a/backend/app/wiki/automanage/detectors/empty_folder.py
+++ b/backend/app/wiki/automanage/detectors/empty_folder.py
@@ -23,8 +23,8 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
 from typing import Any
-from datetime import datetime, timedelta, timezone
 
 from app.wiki import git
 from app.wiki.automanage.detectors.base import (
@@ -99,7 +99,7 @@ class _EmptyFolderDetector:
     def detect(self, scope: Scope) -> list[ProposalDraft]:
         if not self.applicable(scope.trigger):
             return []
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         drafts: list[ProposalDraft] = []
         for folder in _maximal_empty_folders(scope.paths):
             meta = git.last_commit_meta_for_path(folder)

--- a/backend/app/wiki/automanage/detectors/empty_folder.py
+++ b/backend/app/wiki/automanage/detectors/empty_folder.py
@@ -86,6 +86,7 @@ def _empty_long_enough(empty_since_iso: str, now: datetime, min_age_days: int) -
 
 class _EmptyFolderDetector:
     name = "empty_folder"
+    pairs_paths = False  # single-path op; sees the whole scope
 
     def __init__(self, *, min_age_days: int = EMPTY_FOLDER_MIN_AGE_DAYS) -> None:
         self.min_age_days = min_age_days

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -27,14 +27,14 @@ from typing import Any
 from app.auth import users
 from app.db.models import Event
 from app.db.session import session
-from app.models.wiki import ChangeKind, PathMove
-from app.wiki import change_proposals, doc_ids, git, notify, trash
 from app.llm.agents import automanage_apply
+from app.models.wiki import ChangeKind, PathMove
+from app.tracing import trace_flow
+from app.wiki import change_proposals, doc_ids, git, notify, trash
 from app.wiki.automanage import fingerprint, settings
 from app.wiki.automanage.detectors import DETECTORS_BY_NAME
 from app.wiki.change_proposals import ProposalOp, ProposalStatus
 from app.wiki.filesystem import TRASH_PREFIX
-from app.tracing import trace_flow
 
 log = logging.getLogger(__name__)
 

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -28,16 +28,17 @@ import logging
 from typing import Any
 
 from app.auth.users import AI_USER_ID
-from app.wiki import git
-from app.wiki import update_policy
+from app.wiki import git, update_policy
 from app.wiki.automanage import executor, fingerprint, review, runs, settings
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
     ProposalCreatedVia,
     ProposalStatus,
-    create as create_proposal,
     taken_dedupe_keys,
+)
+from app.wiki.change_proposals import (
+    create as create_proposal,
 )
 
 log = logging.getLogger(__name__)
@@ -217,10 +218,9 @@ def run_detection(
                     draft.auto_approvable
                     and draft_paths
                     and all(mgmt.get(p) is True for p in draft_paths)
+                ) and not review.auto_approve(
+                    proposal["id"], acting_user_id=AI_USER_ID
                 ):
-                    if not review.auto_approve(
-                        proposal["id"], acting_user_id=AI_USER_ID
-                    ):
                         # Shouldn't happen for a just-created proposal; if a race
                         # transitioned it out of pending, it stays pending (a
                         # human can still action it) — surface the anomaly loudly.

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -16,10 +16,11 @@ Guardrails applied to every draft:
 - **Per-run cap** — stop emitting past ``MAX_PROPOSALS_PER_RUN`` and log the
   truncation, so one run can't flood the queue.
 
-Permission-fingerprint partitioning (the pairing-time boundary in the design)
-is a duplicate/misplacement concern — the empty-folder detector proposes on a
-single path and never pairs across a visibility boundary, so it isn't exercised
-yet; the ACL fingerprint on the proposal is left null until that lands.
+Permission-fingerprint partitioning: detectors marked ``pairs_paths`` receive
+one same-audience bucket of pages at a time (``_partition_by_audience``), so
+pages with different audiences are never named together in one proposal.
+Single-path detectors (empty-folder) see the whole scope. Every emitted
+proposal is stamped with the combined audience fingerprint of its path-set.
 """
 from __future__ import annotations
 
@@ -84,6 +85,28 @@ def _base_shas(paths: list[str]) -> dict[str, str] | None:
     return shas
 
 
+def _partition_by_audience(scope: Scope) -> list[Scope]:
+    """Split a scope into same-audience sub-scopes for pairing detectors.
+
+    Only ``.md`` pages are fingerprinted and bucketed (pairing techniques
+    compare page content; markers like ``.gitkeep`` never pair). Buckets of a
+    single page are dropped — nothing to pair. Most wikis are default-public,
+    so this usually returns one big bucket and the partition costs one batched
+    fingerprint pass."""
+    pages = [p for p in scope.paths if p.endswith(".md")]
+    if not pages:
+        return []
+    fps = fingerprint.fingerprints_for_paths(pages)
+    by_fp: dict[str, list[str]] = {}
+    for path in pages:
+        by_fp.setdefault(fps[path], []).append(path)
+    return [
+        scope.model_copy(update={"paths": tuple(sorted(group))})
+        for _, group in sorted(by_fp.items())
+        if len(group) > 1
+    ]
+
+
 def run_detection(
     *, trigger: TriggerKind, triggered_by_user_id: str | None, paths: list[str]
 ) -> dict[str, Any]:
@@ -113,12 +136,23 @@ def run_detection(
         taken = taken_dedupe_keys(_BLOCKING_STATUSES)
         emitted = 0
         capped = False
+        # Pairing detectors compare pages against each other; feeding them one
+        # permission bucket at a time means pages with different audiences are
+        # never mentioned in one proposal (which alone would leak a restricted
+        # page's existence to whoever sees the review surface). Buckets are
+        # computed once per run and only when a pairing detector will run.
+        buckets: list[Scope] | None = None
         for detector in DETECTORS:
             if capped:
                 break
             if not detector.applicable(trigger):
                 continue
-            drafts = detector.detect(scope)
+            if getattr(detector, "pairs_paths", False):
+                if buckets is None:
+                    buckets = _partition_by_audience(scope)
+                drafts = [d for sub in buckets for d in detector.detect(sub)]
+            else:
+                drafts = detector.detect(scope)
             # One policy query per detector, not one per path per draft.
             mgmt = _resolve_management(drafts)
             for draft in drafts:
@@ -161,6 +195,7 @@ def run_detection(
                     summary=draft.summary,
                     created_via=created_via,
                     detector=detector.name,
+                    instruction=draft.instruction,
                     proposed_bodies=draft.proposed_bodies,
                     run_id=run_id,
                     # Audience snapshot at emit time — staleness re-checks can

--- a/backend/app/wiki/automanage/runs.py
+++ b/backend/app/wiki/automanage/runs.py
@@ -11,7 +11,7 @@ plain dicts, like ``app/wiki/change_proposals.py``.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -31,7 +31,7 @@ class RunStatus(str, Enum):
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _to_dict(row: DetectionRun) -> dict[str, Any]:

--- a/backend/app/wiki/automanage/settings.py
+++ b/backend/app/wiki/automanage/settings.py
@@ -11,7 +11,7 @@ where the per-page opt-ins left off.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict
 
@@ -33,7 +33,7 @@ class AIManagementSettings(BaseModel):
 
 
 def _now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def get() -> AIManagementSettings:

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -445,6 +445,23 @@ def revert_to(base_sha: str, message: str, author: str | None = None) -> str | N
     return sha
 
 
+def list_paths_with_blob_sha(prefix: str = "") -> list[tuple[str, str]]:
+    """``(path, blob_sha)`` for every tracked file under ``prefix`` at HEAD
+    (excluding the hidden ``.trash/``). The blob sha is git's content hash —
+    equal shas mean byte-identical file contents, which is what the exact
+    duplicate detector groups on."""
+    out = _run(
+        ["ls-tree", "-r", "HEAD", "--format=%(objectname) %(path)", prefix or "."],
+        check=False,
+    ).stdout
+    pairs: list[tuple[str, str]] = []
+    for line in out.splitlines():
+        sha, _, path = line.partition(" ")
+        if path and not path.startswith(TRASH_PREFIX):
+            pairs.append((path, sha))
+    return pairs
+
+
 def head_sha_for_path(rel_path: str) -> str | None:
     """SHA of the most recent commit that touched ``rel_path``, or None."""
     out = _run(["log", "-n1", "--pretty=format:%H", "--", rel_path], check=False).stdout.strip()

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -449,10 +449,15 @@ def list_paths_with_blob_sha(prefix: str = "") -> list[tuple[str, str]]:
     """``(path, blob_sha)`` for every tracked file under ``prefix`` at HEAD
     (excluding the hidden ``.trash/``). The blob sha is git's content hash —
     equal shas mean byte-identical file contents, which is what the exact
-    duplicate detector groups on."""
+    duplicate detector groups on.
+
+    An empty repo (no HEAD yet) legitimately has no tracked files; any other
+    ``ls-tree`` failure raises, so a sweep records a failed run instead of
+    silently reporting a duplicate-free wiki."""
+    if head_sha() is None:
+        return []
     out = _run(
         ["ls-tree", "-r", "HEAD", "--format=%(objectname) %(path)", prefix or "."],
-        check=False,
     ).stdout
     pairs: list[tuple[str, str]] = []
     for line in out.splitlines():

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -14,9 +14,9 @@ import re
 import subprocess
 import tempfile
 import time
-from contextlib import contextmanager
 from collections.abc import Generator
-from datetime import datetime, timedelta, timezone
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -114,12 +114,9 @@ def commit_lock() -> Generator[None]:
     """
     lock_path = Path(CONFIG.wiki_dir) / ".git" / "wiki-commit.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    f = open(lock_path, "a")
-    try:
+    with open(lock_path, "a") as f:  # closing the descriptor releases the flock
         fcntl.flock(f.fileno(), fcntl.LOCK_EX)
         yield
-    finally:
-        f.close()  # closing the descriptor releases the flock
 
 
 def commit_file(
@@ -534,7 +531,7 @@ def ingest_update_times_24h(rel_path: str) -> list[int]:
     out when an over-cap page drops back under the cap (the oldest updates age
     out of the 24h window)."""
     since = (
-        datetime.now(timezone.utc) - timedelta(hours=_INGEST_WINDOW_HOURS)
+        datetime.now(UTC) - timedelta(hours=_INGEST_WINDOW_HOURS)
     ).isoformat()
     out = _run(
         [
@@ -672,12 +669,12 @@ def paths_authored_by(author_email: str, limit: int = 50) -> list[tuple[str, str
     out = _run(
         [
             "log",
-            "--max-count=%d" % (limit * 20),
+            f"--max-count={limit * 20}",
             # --author is a regex; escape so metachars in an email (".", "+")
             # match literally and can't pull in or skip the wrong author.
-            "--author=%s" % re.escape(author_email),
+            f"--author={re.escape(author_email)}",
             "--name-only",
-            "--pretty=format:%s%%aI" % sep,
+            f"--pretty=format:{sep}%aI",
         ],
         check=False,
     ).stdout

--- a/backend/tests/test_body_dup_detector.py
+++ b/backend/tests/test_body_dup_detector.py
@@ -1,0 +1,208 @@
+"""Exact body-duplicate detector + the runner's audience partitioning.
+
+Detector: pure blob-sha grouping over the scope's pages — byte-identical
+substantial bodies emit one merge draft per group (deterministic survivor,
+human review required). Runner: pairing detectors see one same-audience
+bucket at a time, so duplicates with different audiences are never paired.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.wiki import acl, update_policy
+from app.wiki import git as wiki_git
+from app.llm.agents import automanage_apply
+from app.tasks.queues import automanage_nearline_queue
+from app.wiki.automanage import review, runner
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.body_dup import _BodyDupDetector
+from app.wiki.change_proposals import (
+    ProposalStatus,
+    get as get_proposal,
+    list_by_status,
+)
+from tests._seed import seed_user
+
+# Substantial enough to clear MIN_BODY_BYTES.
+_BODY = "# Setup Guide\n\n" + ("Run `make install` and configure the env.\n" * 4)
+
+
+@pytest.fixture
+def repo(tmp_repo):
+    return tmp_repo
+
+
+def _scope(*paths: str) -> Scope:
+    return Scope(trigger=TriggerKind.SWEEP, paths=tuple(paths))
+
+
+def _detect(*paths: str):
+    return _BodyDupDetector().detect(_scope(*paths))
+
+
+def test_identical_bodies_emit_one_merge_draft(repo):
+    wiki_git.commit_file("docs/setup.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("guides/old/setup-copy.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("docs/other.md", "# Other\n" + "x" * 200, "seed", author=None)
+
+    drafts = _detect("docs/setup.md", "guides/old/setup-copy.md", "docs/other.md")
+
+    assert len(drafts) == 1
+    d = drafts[0]
+    assert d.op.value == "merge"
+    assert d.target_paths == ["docs/setup.md"]  # shallower path survives
+    assert d.source_paths == ["guides/old/setup-copy.md"]
+    assert d.proposed_bodies == {"docs/setup.md": _BODY}
+    assert d.auto_approvable is False  # merges wait for a human for now
+    assert d.instruction and "byte-identical" in d.instruction
+
+
+def test_three_way_duplicates_collapse_to_one_draft(repo):
+    for p in ("a.md", "sub/b.md", "sub/deep/c.md"):
+        wiki_git.commit_file(p, _BODY, "seed", author=None)
+
+    drafts = _detect("a.md", "sub/b.md", "sub/deep/c.md")
+
+    assert len(drafts) == 1
+    assert drafts[0].target_paths == ["a.md"]
+    assert sorted(drafts[0].source_paths) == ["sub/b.md", "sub/deep/c.md"]
+
+
+def test_trivial_identical_bodies_are_not_duplicates(repo):
+    # Byte-identical but tiny — placeholders, not duplicates.
+    wiki_git.commit_file("a/todo.md", "# TODO\n", "seed", author=None)
+    wiki_git.commit_file("b/todo.md", "# TODO\n", "seed", author=None)
+
+    assert _detect("a/todo.md", "b/todo.md") == []
+
+
+def test_only_scope_paths_are_considered(repo):
+    wiki_git.commit_file("in/one.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("out/two.md", _BODY, "seed", author=None)
+
+    # The duplicate exists in the repo but not in the scope → no pairing.
+    assert _detect("in/one.md") == []
+
+
+def test_runner_pairs_only_within_one_audience(repo):
+    """Two identical pages with different audiences must not be paired — the
+    proposal itself would leak the restricted page's existence."""
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("pub/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("pub/b.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("private/c.md", _BODY, "seed", author=None)
+    # Restrict c.md: owner-only (drop nothing — owner row alone changes the
+    # audience fingerprint away from implicit-public).
+    acl.set_owner("private/c.md", uid)
+
+    runner.run_sweep(triggered_by_user_id=None)
+
+    pending = list_by_status(ProposalStatus.PENDING)
+    merges = [p for p in pending if p["op"] == "merge"]
+    assert len(merges) == 1
+    touched = set(merges[0]["source_paths"] + merges[0]["target_paths"])
+    assert touched == {"pub/a.md", "pub/b.md"}  # c.md never mentioned
+
+
+def test_runner_emits_merge_with_fingerprint_and_instruction(repo):
+    wiki_git.commit_file("x/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("x/b.md", _BODY, "seed", author=None)
+
+    runner.run_sweep(triggered_by_user_id=None)
+
+    merges = [
+        p for p in list_by_status(ProposalStatus.PENDING) if p["op"] == "merge"
+    ]
+    assert len(merges) == 1
+    p = merges[0]
+    assert p["acl_fingerprint_before"]
+    assert p["instruction"] and "retire" in p["instruction"]
+    assert p["proposed_bodies"] == {"x/a.md": _BODY}
+
+
+def test_merge_never_auto_applies_even_in_ai_scope(repo):
+    wiki_git.commit_file("ai/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("ai/b.md", _BODY, "seed", author=None)
+    update_policy.set_policy("ai", ai_management_allowed=True)
+
+    runner.run_sweep(triggered_by_user_id=None)
+
+    merges = [
+        p
+        for p in list_by_status(ProposalStatus.PENDING)
+        if p["op"] == "merge"
+    ]
+    assert len(merges) == 1  # pending — auto_approvable=False held even here
+    assert list_by_status(ProposalStatus.APPLIED) == []
+# --------------------------------------------------------------------------- #
+# Premise re-validation (Detector.validate)                                   #
+# --------------------------------------------------------------------------- #
+
+
+def _pending_merge():
+    merges = [
+        p for p in list_by_status(ProposalStatus.PENDING) if p["op"] == "merge"
+    ]
+    assert len(merges) == 1
+    return merges[0]
+
+
+def test_validate_holds_while_bodies_identical(repo):
+    wiki_git.commit_file("v/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("v/b.md", _BODY, "seed", author=None)
+    runner.run_sweep(triggered_by_user_id=None)
+    p = _pending_merge()
+
+    assert p["detector"] == "body_dup"  # runner stamped the author
+    assert _BodyDupDetector().validate(p) is None
+
+
+def test_validate_survives_an_edit_applied_to_both_copies(repo):
+    """Drift is not invalidity: the same fix landing on both copies keeps them
+    byte-identical, so the proposal's premise — duplicate — still holds."""
+    wiki_git.commit_file("v/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("v/b.md", _BODY, "seed", author=None)
+    runner.run_sweep(triggered_by_user_id=None)
+    p = _pending_merge()
+
+    fixed = _BODY.replace("configure the env", "configure the environment")
+    wiki_git.commit_file("v/a.md", fixed, "fix typo", author=None)
+    wiki_git.commit_file("v/b.md", fixed, "fix typo", author=None)
+
+    assert _BodyDupDetector().validate(p) is None  # still duplicates
+
+
+def test_validate_stales_when_the_survivor_diverges(repo):
+    wiki_git.commit_file("v/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("v/b.md", _BODY, "seed", author=None)
+    runner.run_sweep(triggered_by_user_id=None)
+    p = _pending_merge()
+
+    # The survivor (target) gains new content — the pages are distinct now.
+    wiki_git.commit_file("v/a.md", _BODY + "\nNew section.\n", "edit", author=None)
+
+    reason = _BodyDupDetector().validate(p)
+    assert reason is not None and "no longer byte-identical" in reason
+
+
+def test_executor_stales_a_diverged_merge_without_calling_the_llm(repo, monkeypatch):
+    wiki_git.commit_file("v/a.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("v/b.md", _BODY, "seed", author=None)
+    runner.run_sweep(triggered_by_user_id=None)
+    p = _pending_merge()
+
+    # Diverge after detection, then approve and execute.
+    wiki_git.commit_file("v/a.md", _BODY + "\nDrift.\n", "edit", author=None)
+
+    def must_not_run(*a, **k):
+        raise AssertionError("LLM must not run on an invalid premise")
+
+    monkeypatch.setattr(automanage_apply.client, "complete", must_not_run)
+    with automanage_nearline_queue.immediate_mode():
+        review.approve(p["id"], user_id=seed_user(uid="rv", email="rv@x.com"))
+
+    refreshed = get_proposal(p["id"])
+    assert refreshed is not None
+    assert refreshed["status"] == "stale"
+    assert "byte-identical" in (refreshed["status_reason"] or "")
+    assert "v/b.md" in wiki_git.list_paths()  # nothing retired

--- a/backend/tests/test_body_dup_detector.py
+++ b/backend/tests/test_body_dup_detector.py
@@ -9,17 +9,19 @@ from __future__ import annotations
 
 import pytest
 
-from app.wiki import acl, update_policy
-from app.wiki import git as wiki_git
 from app.llm.agents import automanage_apply
 from app.tasks.queues import automanage_nearline_queue
+from app.wiki import acl, update_policy
+from app.wiki import git as wiki_git
 from app.wiki.automanage import review, runner
 from app.wiki.automanage.detectors.base import Scope, TriggerKind
 from app.wiki.automanage.detectors.body_dup import _BodyDupDetector
 from app.wiki.change_proposals import (
     ProposalStatus,
-    get as get_proposal,
     list_by_status,
+)
+from app.wiki.change_proposals import (
+    get as get_proposal,
 )
 from tests._seed import seed_user
 

--- a/backend/tests/test_execute_validation.py
+++ b/backend/tests/test_execute_validation.py
@@ -21,8 +21,10 @@ from app.wiki.change_proposals import (
     ProposalOp,
     ProposalStatus,
     create,
-    get as get_proposal,
     list_by_status,
+)
+from app.wiki.change_proposals import (
+    get as get_proposal,
 )
 from tests._seed import seed_user
 


### PR DESCRIPTION
PR C of the execution series — **now stacked on #495** (execution-time validation seam); merge #495 first. This PR is the detector itself.

**Detector (`detectors/body_dup.py`).** Groups the scope's pages by **git blob sha** (new helper `git.list_paths_with_blob_sha`): equal shas = byte-identical bodies. Per group, **one merge proposal**: deterministic survivor (shallowest → shortest → lexicographic path), the shared body as the exact preview, an explicit `instruction` for the agentic applier. `MIN_BODY_BYTES` (120) keeps identical trivial placeholders (`# TODO`) from being called duplicates. `auto_approvable=False` — merges wait for a human until the applier earns auto-apply.

**Premise validation (implements #495's seam).** `validate`: every affected page still exists and all bodies are still byte-identical — re-checked at execution, so the review finding (survivor drift) stales instead of merging distinct documents. Deliberately premise-based: an edit applied identically to every copy keeps the proposal valid (there's a test for exactly that).

**Runner partitioning.** Detectors declare `pairs_paths`; pairing detectors get one same-audience bucket at a time (`_partition_by_audience`, one batched fingerprint pass) — two identical pages with different audiences are never named together in one proposal, since the proposal alone would leak the restricted page's existence.

**Tests (11):** grouping/survivor/trivial-skip/scope-confinement; cross-audience pairing refused; fingerprint + instruction stamped; no auto-apply even in AI-managed scopes; validate holds while identical, survives an identical edit to both copies, stales on divergence; executor stales a diverged merge **without calling the LLM**. 93 green across the suite; hooks/lint/types clean.