### PR TITLE
fix(automanage): review banner spells out the full merge operation

### DIFF
--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -72,6 +72,16 @@ const STATUS_LABEL: Record<string, string> = {
   applying: "Applying…",
 };
 
+/** The full operation, spelled out: which paths go away, which survives.
+ * The summary alone truncates on long paths — a reviewer deciding a merge
+ * must see both sides, so ops with a target always render this detail. */
+function operationDetail(p: Proposal): string | undefined {
+  if (p.target_paths.length === 0) return undefined;
+  const retire = p.source_paths.map((s) => `“${s}”`).join(", ");
+  const keep = p.target_paths.map((t) => `“${t}”`).join(", ");
+  return `Keeps ${keep} — retires ${retire} (restorable from Trash; links to it will point at the surviving page).`;
+}
+
 function ProposalRow({
   proposal,
   onActioned,
@@ -148,9 +158,11 @@ function ProposalRow({
       sizePreset="main-ui"
       variant="section"
       title={proposal.summary}
-      titleMaxLines={1}
+      titleMaxLines={2}
       auxIcon={outcome === "error" ? "error" : undefined}
-      description={outcome === "error" ? (error ?? undefined) : undefined}
+      description={
+        outcome === "error" ? (error ?? undefined) : operationDetail(proposal)
+      }
       rightChildren={
         TERMINAL.includes(outcome) ? (
           <Text


### PR DESCRIPTION
Small frontend follow-up from live-testing #494: the review banner's one-line summary truncated exactly where a merge decision needs information — the reviewer could not see which page goes away and which survives.

- Rows for target-bearing ops always render an **operation detail** line: *Keeps "X" — retires "Y" (restorable from Trash; links to it will point at the surviving page).* Built from the proposal's `source_paths`/`target_paths`, so it never truncates the decision-relevant halves.
- The title wraps to two lines (`titleMaxLines={2}`) instead of truncating at one.
- Error text still takes the description slot when a row errors.

Typecheck + prettier clean; verified on the local stack against real merge proposals.