### PR TITLE
feat(automanage): template-echo detector — untouched template pages propose removal

### DIFF
--- a/backend/app/db/migrations/versions/c9d4e7f2a1b8_delete_page_op.py
+++ b/backend/app/db/migrations/versions/c9d4e7f2a1b8_delete_page_op.py
@@ -1,0 +1,36 @@
+"""widen change_proposals op CHECK with delete_page
+
+Revision ID: c9d4e7f2a1b8
+Revises: b3c8d4e5f6a7
+Create Date: 2026-07-23
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "c9d4e7f2a1b8"
+down_revision: str | Sequence[str] | None = "b3c8d4e5f6a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_OPS = "'move', 'rename', 'merge', 'split', 'create_folder', 'delete_empty_folder'"
+
+
+def upgrade() -> None:
+    # Drop-and-recreate is idempotent against the bootstrap create_all (which
+    # already materializes the widened constraint on fresh databases).
+    op.drop_constraint("change_proposals_op_check", "change_proposals", type_="check")
+    op.create_check_constraint(
+        "change_proposals_op_check",
+        "change_proposals",
+        f"op IN ({_OPS}, 'delete_page')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("change_proposals_op_check", "change_proposals", type_="check")
+    op.create_check_constraint(
+        "change_proposals_op_check", "change_proposals", f"op IN ({_OPS})"
+    )

--- a/backend/app/db/migrations/versions/c9d4e7f2a1b8_delete_page_op.py
+++ b/backend/app/db/migrations/versions/c9d4e7f2a1b8_delete_page_op.py
@@ -31,6 +31,11 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_constraint("change_proposals_op_check", "change_proposals", type_="check")
+    # Rows the narrower constraint can't represent must go first, or the
+    # constraint creation fails against its own table. A downgrade drops the
+    # op kind, so its proposals (a ledger of an op that no longer exists) go
+    # with it.
+    op.execute("DELETE FROM change_proposals WHERE op = 'delete_page'")
     op.create_check_constraint(
         "change_proposals_op_check", "change_proposals", f"op IN ({_OPS})"
     )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1400,7 +1400,7 @@ class ChangeProposal(Base):
     __table_args__ = (
         CheckConstraint(
             "op IN ('move', 'rename', 'merge', 'split', 'create_folder', "
-            "'delete_empty_folder')",
+            "'delete_empty_folder', 'delete_page')",
             name="change_proposals_op_check",
         ),
         CheckConstraint(

--- a/backend/app/llm/agents/automanage_apply.py
+++ b/backend/app/llm/agents/automanage_apply.py
@@ -125,15 +125,27 @@ def _render_proposal(p: dict[str, Any]) -> str:
 
 
 class _ToolBox:
-    """Bounded tool handlers, closed over the proposal's allowed paths."""
+    """Bounded tool handlers, closed over the proposal's paths.
 
-    def __init__(self, allowed: frozenset[str], author: str | None):
-        self._allowed = allowed
+    Two path rules, both from the proposal's own data: every touched path
+    must be one of the proposal's paths (scope), and **target paths must
+    survive** — targets are, by schema semantics, the surviving/receiving
+    side of any op (merge target, move destination), so the destructive
+    tools refuse them. The executor re-checks both after the run."""
+
+    def __init__(
+        self,
+        sources: frozenset[str],
+        targets: frozenset[str],
+        author: str | None,
+    ):
+        self._allowed = sources | targets
+        self._targets = targets
         self._author = author
         self.mutated = False
 
-    def _check(self, *paths: str) -> str | None:
-        for raw in paths:
+    def _check(self, *paths: str, consumes: tuple[str, ...] = ()) -> str | None:
+        for raw in (*paths, *consumes):
             try:
                 path = safe_rel_path(raw)
             except ValueError as e:
@@ -142,6 +154,13 @@ class _ToolBox:
                 return (
                     f"path {path!r} is outside this proposal's scope; allowed: "
                     f"{sorted(self._allowed)}"
+                )
+        for raw in consumes:
+            if safe_rel_path(raw) in self._targets:
+                return (
+                    f"path {raw!r} is one of the proposal's target paths — "
+                    "targets must survive the operation and cannot be "
+                    "trashed, retired, or moved away"
                 )
         return None
 
@@ -165,7 +184,7 @@ class _ToolBox:
         return {"path": path, "sha": sha}
 
     def move_page(self, args: dict[str, Any]) -> Any:
-        if err := self._check(args["source"], args["dest"]):
+        if err := self._check(args["dest"], consumes=(args["source"],)):
             return {"error": err}
         src, dst = args["source"], args["dest"]
         sha, moves = git.move_path(
@@ -178,7 +197,7 @@ class _ToolBox:
         return {"source": src, "dest": dst, "sha": sha}
 
     def trash_page(self, args: dict[str, Any]) -> Any:
-        if err := self._check(args["path"]):
+        if err := self._check(consumes=(args["path"],)):
             return {"error": err}
         path = args["path"]
         dest = trash.trash_location(trash.new_trash_id(), path)
@@ -192,7 +211,7 @@ class _ToolBox:
         return {"trashed": path, "sha": sha}
 
     def retire_page(self, args: dict[str, Any]) -> Any:
-        if err := self._check(args["source"], args["target"]):
+        if err := self._check(args["target"], consumes=(args["source"],)):
             return {"error": err}
         sha = retire.retire_page(
             args["source"], args["target"], author=self._author
@@ -214,10 +233,9 @@ class _ToolBox:
 def apply_proposal(p: dict[str, Any], *, author: str | None) -> ApplyOutcome:
     """Drive the LLM to apply an approved proposal. Pure orchestration — the
     executor owns the pre-gates and the post-run scope check/revert."""
-    allowed = frozenset(
-        safe_rel_path(x) for x in (p["source_paths"] + p["target_paths"])
-    )
-    box = _ToolBox(allowed, author)
+    sources = frozenset(safe_rel_path(x) for x in p["source_paths"])
+    targets = frozenset(safe_rel_path(x) for x in p["target_paths"])
+    box = _ToolBox(sources - targets, targets, author)
     messages: list[dict[str, Any]] = [
         {"role": "system", "content": _SYSTEM_PROMPT},
         {"role": "user", "content": _render_proposal(p)},

--- a/backend/app/llm/agents/automanage_apply.py
+++ b/backend/app/llm/agents/automanage_apply.py
@@ -197,6 +197,12 @@ class _ToolBox:
         return {"source": src, "dest": dst, "sha": sha}
 
     def trash_page(self, args: dict[str, Any]) -> Any:
+        if self._targets:
+            return {
+                "error": "this proposal has surviving target paths — a "
+                "removed page's identity must forward to the survivor; use "
+                "retire_page instead of trash_page"
+            }
         if err := self._check(consumes=(args["path"],)):
             return {"error": err}
         path = args["path"]

--- a/backend/app/llm/agents/automanage_apply.py
+++ b/backend/app/llm/agents/automanage_apply.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel, ConfigDict
 from app.llm import client
 from app.llm.prompts import load_prompt
 from app.models.wiki import ChangeKind, PathMove
-from app.wiki import git, notify, retire
+from app.wiki import git, notify, retire, trash
 from app.wiki.filesystem import safe_rel_path
 
 log = logging.getLogger(__name__)
@@ -84,6 +84,16 @@ def _tools() -> list[dict[str, Any]]:
                 "type": "object",
                 "properties": {"source": path_prop, "dest": path_prop},
                 "required": ["source", "dest"],
+            },
+        },
+        {
+            "name": "trash_page",
+            "description": "Remove one of the proposal's pages outright: "
+            "trash-move (restorable), no surviving page to forward to.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": path_prop},
+                "required": ["path"],
             },
         },
         {
@@ -166,6 +176,20 @@ class _ToolBox:
         )
         self.mutated = True
         return {"source": src, "dest": dst, "sha": sha}
+
+    def trash_page(self, args: dict[str, Any]) -> Any:
+        if err := self._check(args["path"]):
+            return {"error": err}
+        path = args["path"]
+        dest = trash.trash_location(trash.new_trash_id(), path)
+        sha, moves = git.move_path(
+            path, dest, trash.trash_commit_message(path), author=self._author
+        )
+        notify.after_doc_trashed(
+            moves, sha, self._author, root_move=PathMove(old=path, new=dest)
+        )
+        self.mutated = True
+        return {"trashed": path, "sha": sha}
 
     def retire_page(self, args: dict[str, Any]) -> Any:
         if err := self._check(args["source"], args["target"]):

--- a/backend/app/llm/prompts/automanage_apply.system.md
+++ b/backend/app/llm/prompts/automanage_apply.system.md
@@ -9,8 +9,9 @@ Rules:
   current content rather than blindly overwriting.
 - The proposed body (when present) is the reviewer-approved preview — stay
   faithful to it; deviate only to accommodate content that changed since.
-- Deletions happen only through retire_page (trash + identity forwarding),
-  never by writing empty bodies.
+- Deletions happen only through retire_page (when a surviving page exists —
+  trash + identity forwarding) or trash_page (when the proposal removes a
+  page outright), never by writing empty bodies.
 - When the change is fully applied, reply with a one-line summary and no
   tool calls. If the proposal cannot be applied safely, reply with a line
   starting with 'CANNOT APPLY:' and the reason, and no tool calls.

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -7,7 +7,7 @@ filters by ``applicable(trigger)``, and feeds each the trigger-built ``Scope``
 """
 from __future__ import annotations
 
-from app.wiki.automanage.detectors import body_dup, empty_folder
+from app.wiki.automanage.detectors import body_dup, empty_folder, template_echo
 from app.wiki.automanage.detectors.base import (
     Detector,
     ProposalDraft,
@@ -18,6 +18,7 @@ from app.wiki.automanage.detectors.base import (
 DETECTORS: list[Detector] = [
     empty_folder.DETECTOR,
     body_dup.DETECTOR,
+    template_echo.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/body_dup.py
+++ b/backend/app/wiki/automanage/detectors/body_dup.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from app.wiki import git
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.automanage.detectors.template_echo import template_body_blob_shas
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -61,9 +62,14 @@ class _BodyDupDetector:
             if path in in_scope:
                 by_blob[blob].append(path)
 
+        # Precedence: a duplicate group whose shared body is a template body
+        # is a group of untouched template instances — every member should be
+        # *removed* (template-echo's job), not merged into each other. Merging
+        # would consolidate onto a page with no unique content.
+        echo_blobs = set(template_body_blob_shas())
         drafts: list[ProposalDraft] = []
         for blob, paths in sorted(by_blob.items()):
-            if len(paths) < 2:
+            if len(paths) < 2 or blob in echo_blobs:
                 continue
             body = git.read_file_opt(paths[0])
             if body is None or len(body.encode()) < self._min_bytes:

--- a/backend/app/wiki/automanage/detectors/template_echo.py
+++ b/backend/app/wiki/automanage/detectors/template_echo.py
@@ -1,0 +1,124 @@
+"""Template-echo detector — mechanical, no LLM.
+
+A page whose body is still byte-identical to the template it was created from
+is a page nobody ever filled in. After a grace window (someone may be about
+to write), it proposes ``delete_page``: removal, not merge — an untouched
+template instance has no unique content worth consolidating.
+
+Matching is by git blob sha computed over the template bodies, so the sweep
+compares hashes against the tracked tree without reading page bodies. The
+grace window keys off the page's *last commit*: any edit both restarts the
+clock and (almost certainly) breaks the byte-equality anyway.
+
+This detector also gives the exact body-duplicate detector its precedence
+rule: duplicate groups whose shared body is a template body are *echo groups*
+— every member should be removed, not merged into each other — so body-dup
+skips them (see ``template_body_blob_shas``).
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.wiki import git, templates
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# The grace window before an untouched template instance is proposed for
+# removal — a fresh instantiation is usually someone about to write.
+TEMPLATE_ECHO_MIN_AGE_DAYS = 7
+
+
+def blob_sha(body: str) -> str:
+    """Git's content hash for ``body`` — comparable against ``ls-tree`` output
+    without writing the content anywhere."""
+    raw = body.encode()
+    return hashlib.sha1(b"blob %d\0" % len(raw) + raw).hexdigest()
+
+
+def template_body_blob_shas() -> dict[str, str]:
+    """``{blob_sha: template_name}`` over the current templates. Empty bodies
+    are skipped — an empty template matches nothing meaningfully."""
+    out: dict[str, str] = {}
+    for t in templates.list_all():
+        body = t.get("body") or ""
+        if body.strip():
+            out[blob_sha(body)] = t["name"]
+    return out
+
+
+def _old_enough(page: str, now: datetime, min_age_days: int) -> bool:
+    meta = git.last_commit_meta_for_path(page)
+    if meta is None:
+        return False
+    try:
+        touched = datetime.fromisoformat(meta[2])
+    except ValueError:
+        log.warning("template-echo: unparseable commit ts %r for %s", meta[2], page)
+        return False
+    return now - touched >= timedelta(days=min_age_days)
+
+
+class _TemplateEchoDetector:
+    name = "template_echo"
+    pairs_paths = False  # compares pages against templates, never against pages
+
+    def __init__(self, *, min_age_days: int = TEMPLATE_ECHO_MIN_AGE_DAYS) -> None:
+        self.min_age_days = min_age_days
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        return trigger == TriggerKind.SWEEP
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        echoes = template_body_blob_shas()
+        if not echoes:
+            return []
+        in_scope = {p for p in scope.paths if p.endswith(".md")}
+        if not in_scope:
+            return []
+        now = datetime.now(UTC)
+        drafts: list[ProposalDraft] = []
+        for path, blob in git.list_paths_with_blob_sha():
+            template_name = echoes.get(blob)
+            if template_name is None or path not in in_scope:
+                continue
+            if not _old_enough(path, now, self.min_age_days):
+                continue
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.DELETE_PAGE,
+                    source_paths=[path],
+                    summary=(
+                        f"Remove “{path}” — still identical to the "
+                        f"“{template_name}” template after "
+                        f"{self.min_age_days}+ days (never filled in)"
+                    ),
+                    instruction=(
+                        f"The page {path!r} is an untouched instance of the "
+                        f"{template_name!r} template. Remove it with "
+                        "trash_page (restorable). Do not write any content."
+                    ),
+                    auto_approvable=False,
+                )
+            )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """Premise: the page still byte-matches a *current* template body.
+        One edit by anyone — to the page — breaks equality and invalidates;
+        template edits/deletions invalidate too (the page is no longer an
+        echo of anything that exists)."""
+        path = proposal["source_paths"][0]
+        body = git.read_file_opt(path)
+        if body is None:
+            return f"{path!r} no longer exists"
+        if blob_sha(body) not in template_body_blob_shas():
+            return "the page no longer matches any template body"
+        return None
+
+
+DETECTOR = _TemplateEchoDetector()

--- a/backend/app/wiki/automanage/detectors/template_echo.py
+++ b/backend/app/wiki/automanage/detectors/template_echo.py
@@ -1,7 +1,11 @@
 """Template-echo detector — mechanical, no LLM.
 
 A page whose body is still byte-identical to the template it was created from
-is a page nobody ever filled in. After a grace window (someone may be about
+is a page nobody ever filled in. Equality implies provenance here because the
+product's creation flows are template-driven (the new-doc picker and
+write_doc(template_id) both instantiate a template, Blank included); the
+one template-free path — ingestion — writes connector content that never
+matches a template skeleton. After a grace window (someone may be about
 to write), it proposes ``delete_page``: removal, not merge — an untouched
 template instance has no unique content worth consolidating.
 

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -213,6 +213,17 @@ def _execute_agentic(p: dict[str, Any]) -> None:
     lost_targets = [t for t in p["target_paths"] if t not in live]
     if lost_targets:
         violations = violations + [f"target removed: {t}" for t in lost_targets]
+    # And when targets exist, a removed source must have *forwarded* its
+    # identity to a survivor — a plain trash leaves links dead-ending at a
+    # tombstone instead of the surviving page.
+    if p["target_paths"]:
+        for s in p["source_paths"]:
+            if s in live:
+                continue
+            sid = path_ids.get(s)
+            row = doc_ids.get(sid) if sid else None
+            if row is not None and row["forwarded_to"] is None:
+                violations = violations + [f"source removed without identity forward: {s}"]
     if violations or not outcome.ok:
         reverted = git.revert_to(
             base_sha,

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -48,7 +48,11 @@ EVENT_AUTOMANAGE_APPLIED = "automanage.applied"
 # gate on which proposals we let exist). The emit/approve layers check it, so
 # widening it is a deliberate one-line decision per op.
 SUPPORTED_OPS: frozenset[str] = frozenset(
-    {ProposalOp.DELETE_EMPTY_FOLDER.value, ProposalOp.MERGE.value}
+    {
+        ProposalOp.DELETE_EMPTY_FOLDER.value,
+        ProposalOp.MERGE.value,
+        ProposalOp.DELETE_PAGE.value,
+    }
 )
 
 

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -207,6 +207,12 @@ def _execute_agentic(p: dict[str, Any]) -> None:
         outcome = automanage_apply.apply_proposal(p, author=author)
 
     violations = _scope_violations(base_sha, allowed)
+    # Targets are the surviving side of any op by schema semantics — a run
+    # that removed one (however it managed to) is invalid regardless of op.
+    live = set(git.list_paths())
+    lost_targets = [t for t in p["target_paths"] if t not in live]
+    if lost_targets:
+        violations = violations + [f"target removed: {t}" for t in lost_targets]
     if violations or not outcome.ok:
         reverted = git.revert_to(
             base_sha,

--- a/backend/app/wiki/change_proposals.py
+++ b/backend/app/wiki/change_proposals.py
@@ -14,7 +14,7 @@ row and returns ``False``).
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -34,6 +34,7 @@ class ProposalOp(str, Enum):
     SPLIT = "split"
     CREATE_FOLDER = "create_folder"
     DELETE_EMPTY_FOLDER = "delete_empty_folder"
+    DELETE_PAGE = "delete_page"
 
 
 class ProposalStatus(str, Enum):
@@ -60,7 +61,7 @@ class ProposalCreatedVia(str, Enum):
 
 def _now() -> str:
     """UTC timestamp matching the ``YYYY-MM-DD HH:MM:SS`` column format."""
-    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _to_dict(row: ChangeProposal) -> dict[str, Any]:
@@ -119,7 +120,10 @@ def create(
     """
     if not source_paths and op is not ProposalOp.CREATE_FOLDER:
         raise ValueError(f"source_paths required for op {op.value!r}")
-    if not target_paths and op is not ProposalOp.DELETE_EMPTY_FOLDER:
+    if not target_paths and op not in (
+        ProposalOp.DELETE_EMPTY_FOLDER,
+        ProposalOp.DELETE_PAGE,
+    ):
         raise ValueError(f"target_paths required for op {op.value!r}")
     now = _now()
     with session() as s:

--- a/backend/tests/test_agentic_executor.py
+++ b/backend/tests/test_agentic_executor.py
@@ -204,3 +204,64 @@ def test_finishing_without_changes_is_not_applied(repo, monkeypatch):
 
     p = get(pid)
     assert p is not None and p["status"] == "stale"  # no silent no-op applies
+
+
+def test_destructive_tools_refuse_target_paths(repo, monkeypatch):
+    """Targets are the surviving side by schema semantics: the model cannot
+    trash or retire a target path, whatever the op."""
+    pid = _merge_proposal()
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)
+
+    _script(
+        monkeypatch,
+        [
+            CompletionResult(
+                tool_calls=[
+                    _tc("trash_page", path="docs/kept.md"),  # the survivor!
+                ]
+            ),
+            CompletionResult(text="CANNOT APPLY: refused"),
+        ],
+    )
+    executor.execute(pid)
+
+    assert wiki_git.read_file("docs/kept.md")  # survivor untouched
+    p = get(pid)
+    assert p is not None and p["status"] == "stale"
+
+
+def test_post_run_check_catches_a_removed_target(repo, monkeypatch):
+    """Defense in depth: a bypassed mutation that removes a target path is
+    reverted by the executor's targets-survive check."""
+    from app.models.wiki import PathMove
+    from app.wiki import notify, trash as wiki_trash
+
+    pid = _merge_proposal()
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)
+
+    def rogue_dispatch(self, name, args):
+        # Bypass the tool rails and trash the survivor directly.
+        dest = wiki_trash.trash_location(wiki_trash.new_trash_id(), "docs/kept.md")
+        sha, moves = wiki_git.move_path(
+            "docs/kept.md", dest, "rogue", author=None
+        )
+        notify.after_doc_trashed(
+            moves, sha, None, root_move=PathMove(old="docs/kept.md", new=dest)
+        )
+        self.mutated = True
+        return {"ok": True}
+
+    monkeypatch.setattr(automanage_apply._ToolBox, "dispatch", rogue_dispatch)
+    _script(
+        monkeypatch,
+        [
+            CompletionResult(tool_calls=[_tc("write_page", path="docs/kept.md", body="x")]),
+            CompletionResult(text="done"),
+        ],
+    )
+    executor.execute(pid)
+
+    p = get(pid)
+    assert p is not None and p["status"] == "stale"
+    assert "target removed" in (p["status_reason"] or "")
+    assert wiki_git.read_file_opt("docs/kept.md") is not None  # reverted back

--- a/backend/tests/test_agentic_executor.py
+++ b/backend/tests/test_agentic_executor.py
@@ -265,3 +265,75 @@ def test_post_run_check_catches_a_removed_target(repo, monkeypatch):
     assert p is not None and p["status"] == "stale"
     assert "target removed" in (p["status_reason"] or "")
     assert wiki_git.read_file_opt("docs/kept.md") is not None  # reverted back
+
+
+def test_trash_page_refused_when_a_survivor_exists(repo, monkeypatch):
+    """With target paths present, removals must forward identity — the model
+    is steered to retire_page instead of a plain trash."""
+    pid = _merge_proposal()
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)
+
+    _script(
+        monkeypatch,
+        [
+            CompletionResult(
+                tool_calls=[_tc("trash_page", path="docs/dup.md")]  # source, but no forward
+            ),
+            # The refusal steers the model to the right tool.
+            CompletionResult(
+                tool_calls=[
+                    _tc("retire_page", source="docs/dup.md", target="docs/kept.md")
+                ]
+            ),
+            CompletionResult(text="Retired with forwarding."),
+        ],
+    )
+    executor.execute(pid)
+
+    p = get(pid)
+    assert p is not None and p["status"] == "applied"
+    dup_id = None
+    from app.db.session import session
+    from sqlalchemy import text as _text
+    with session() as s:
+        dup_id = s.execute(
+            _text(
+                "select forwarded_to from wiki_doc_ids where path like '%docs/dup%' "
+                "and deleted_at is not null order by created_at desc limit 1"
+            )
+        ).scalar()
+    assert dup_id  # identity forwarded, not a dead tombstone
+
+
+def test_post_run_catches_unforwarded_source_removal(repo, monkeypatch):
+    """Bypass rail: a source that leaves the tree without a forward (while a
+    survivor exists) is a violation — reverted and staled."""
+    from app.models.wiki import PathMove
+    from app.wiki import notify, trash as wiki_trash
+
+    pid = _merge_proposal()
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)
+
+    def rogue_dispatch(self, name, args):
+        dest = wiki_trash.trash_location(wiki_trash.new_trash_id(), "docs/dup.md")
+        sha, moves = wiki_git.move_path("docs/dup.md", dest, "rogue", author=None)
+        notify.after_doc_trashed(
+            moves, sha, None, root_move=PathMove(old="docs/dup.md", new=dest)
+        )
+        self.mutated = True
+        return {"ok": True}
+
+    monkeypatch.setattr(automanage_apply._ToolBox, "dispatch", rogue_dispatch)
+    _script(
+        monkeypatch,
+        [
+            CompletionResult(tool_calls=[_tc("write_page", path="docs/kept.md", body="x")]),
+            CompletionResult(text="done"),
+        ],
+    )
+    executor.execute(pid)
+
+    p = get(pid)
+    assert p is not None and p["status"] == "stale"
+    assert "without identity forward" in (p["status_reason"] or "")
+    assert wiki_git.read_file_opt("docs/dup.md") is not None  # reverted back

--- a/backend/tests/test_template_echo_detector.py
+++ b/backend/tests/test_template_echo_detector.py
@@ -1,0 +1,131 @@
+"""Template-echo detector — untouched template instances propose removal.
+
+Pure blob-sha matching against the current template bodies, an age grace
+window, a validate premise (still matches *some* current template), and the
+precedence rule: body-dup skips duplicate groups that are template echoes.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.llm.agents import automanage_apply
+from app.llm.client import CompletionResult, ToolCall
+from app.tasks.queues import automanage_nearline_queue
+from app.wiki import git as wiki_git
+from app.wiki import templates
+from app.wiki.automanage import review, runner
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.body_dup import _BodyDupDetector
+from app.wiki.automanage.detectors.template_echo import _TemplateEchoDetector
+from app.wiki.change_proposals import (
+    ProposalStatus,
+    list_by_status,
+)
+from app.wiki.change_proposals import (
+    get as get_proposal,
+)
+from tests._seed import seed_user
+
+_TPL = "# Weekly Notes\n\n## Highlights\n\n## Blockers\n\n## Next week\n" + "x" * 100
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_config):
+    templates.create(
+        name="Weekly Notes",
+        body=_TPL,
+        description=None,
+        system_prompt=None,
+        created_by_user_id=None,
+    )
+    return tmp_config
+
+
+def _scope(*paths: str) -> Scope:
+    return Scope(trigger=TriggerKind.SWEEP, paths=tuple(paths))
+
+
+def test_untouched_template_instance_is_proposed_for_removal(repo):
+    wiki_git.commit_file("notes/week-30.md", _TPL, "from template", author=None)
+
+    drafts = _TemplateEchoDetector(min_age_days=0).detect(_scope("notes/week-30.md"))
+
+    assert len(drafts) == 1
+    d = drafts[0]
+    assert d.op.value == "delete_page"
+    assert d.source_paths == ["notes/week-30.md"]
+    assert d.target_paths == []
+    assert "Weekly Notes" in d.summary
+    assert d.auto_approvable is False
+    assert d.instruction and "trash_page" in d.instruction
+
+
+def test_fresh_instantiation_is_left_alone(repo):
+    # Same echo, but inside the grace window (default 7 days).
+    wiki_git.commit_file("notes/week-31.md", _TPL, "from template", author=None)
+    assert _TemplateEchoDetector().detect(_scope("notes/week-31.md")) == []
+
+
+def test_filled_in_page_is_not_an_echo(repo):
+    wiki_git.commit_file(
+        "notes/week-32.md", _TPL + "\nActual content this week.\n", "filled", author=None
+    )
+    assert _TemplateEchoDetector(min_age_days=0).detect(_scope("notes/week-32.md")) == []
+
+
+def test_validate_tracks_the_premise(repo):
+    wiki_git.commit_file("notes/week-33.md", _TPL, "from template", author=None)
+    det = _TemplateEchoDetector(min_age_days=0)
+    (draft,) = det.detect(_scope("notes/week-33.md"))
+    proposal: dict[str, Any] = {"source_paths": draft.source_paths}
+
+    assert det.validate(proposal) is None  # still an echo
+
+    wiki_git.commit_file("notes/week-33.md", _TPL + "\nEdited.\n", "edit", author=None)
+    reason = det.validate(proposal)
+    assert reason is not None and "no longer matches" in reason
+
+
+def test_body_dup_skips_echo_groups(repo):
+    # Two untouched instances of the same template: byte-identical, but they
+    # are echoes — removal territory, not merge territory.
+    wiki_git.commit_file("a/notes.md", _TPL, "t", author=None)
+    wiki_git.commit_file("b/notes.md", _TPL, "t", author=None)
+
+    assert _BodyDupDetector().detect(_scope("a/notes.md", "b/notes.md")) == []
+
+
+def test_executes_end_to_end_with_trash_page(repo, monkeypatch):
+    monkeypatch.setattr(
+        runner, "DETECTORS", [_TemplateEchoDetector(min_age_days=0)]
+    )
+    wiki_git.commit_file("notes/week-34.md", _TPL, "from template", author=None)
+    runner.run_sweep(triggered_by_user_id=None)
+    pending = list_by_status(ProposalStatus.PENDING)
+    assert len(pending) == 1
+    pid = pending[0]["id"]
+    assert pending[0]["detector"] == "template_echo"
+
+    turns = [
+        CompletionResult(
+            tool_calls=[
+                ToolCall(id="t1", name="trash_page", arguments={"path": "notes/week-34.md"})
+            ]
+        ),
+        CompletionResult(text="Removed the untouched template page."),
+    ]
+    monkeypatch.setattr(
+        automanage_apply.client, "complete", lambda messages, **kw: turns.pop(0)
+    )
+    uid = seed_user(uid="rv", email="rv@x.com")
+    with automanage_nearline_queue.immediate_mode():
+        review.approve(pid, user_id=uid)
+
+    p = get_proposal(pid)
+    assert p is not None and p["status"] == "applied"
+    assert "notes/week-34.md" not in wiki_git.list_paths()  # in trash
+    assert any(
+        t.endswith("/notes/week-34.md") for t in wiki_git.list_trash_files()
+    )


### PR DESCRIPTION
Wave 1 detector #2, from live-testing #494: a "duplicate" pair the sweep found turned out to be two never-edited template instances — the right cleanup was **removal, not merge** (an untouched instance has no unique content worth consolidating into).

**Detector (`detectors/template_echo.py`).** A page whose body is still **byte-identical to a template body** after a grace window (7 days, keyed off the page's last commit) proposes `delete_page`. Matching computes git's blob sha over the `document_templates` bodies in Python and compares against `ls-tree` output — no page reads, no LLM, zero false positives on the equality claim. `validate` re-checks the premise at execution: the page must still match a *current* template body (an edit to the page, or the template being changed/deleted, stales it). `auto_approvable=False` like every new detector.

**Precedence rule.** Body-dup now **skips** duplicate groups whose shared body is a template body: echo groups are removal territory — merging two untouched instances would consolidate onto a page with no unique content (exactly the live case that motivated this).

**Enablers in the same PR:**
- `ProposalOp.DELETE_PAGE` + CHECK-widening migration (drop-and-recreate, idempotent against the bootstrap) + policy-allowlist entry + no-target arity.
- `trash_page` applier tool — trash-move, restorable, **no identity forward** (there is no survivor to point at); the apply prompt distinguishes retire (survivor exists) from trash (outright removal).

**Tests (6):** echo detected past the grace window; fresh instantiation left alone; filled-in page not an echo; validate tracks the premise both ways; body-dup skips echo groups; end-to-end through the runner → approve → agentic applier with `trash_page` (scripted model), page lands in Trash. 99 tests green across the automanage suite; ruff (PR files) + basedpyright clean.