### PR TITLE
feat(wiki): overview tick rail for commented and attributed regions

### DIFF
--- a/frontend/src/components/wiki/AnnotationTickRail.tsx
+++ b/frontend/src/components/wiki/AnnotationTickRail.tsx
@@ -17,6 +17,9 @@ const TICK_SLOT = 12;
 interface Tick {
   kind: "comment" | "source";
   id: string;
+  /** Occurrence index among this id's surviving spans, a source cited in
+   * several regions gets a tick per region. */
+  nth: number;
   /** Content fraction of the doc, 0..1. */
   fraction: number;
 }
@@ -46,7 +49,8 @@ export function AnnotationTickRail({
   activeCommentIds?: string[];
   activeSourceIds?: string[];
   onPickComment?: (id: string) => void;
-  onPickSource?: (key: string) => void;
+  /** nth picks the clicked region among the source's spans. */
+  onPickSource?: (key: string, nth: number) => void;
 }) {
   const [ticks, setTicks] = useState<Tick[]>([]);
   const [trackH, setTrackH] = useState(0);
@@ -70,23 +74,26 @@ export function AnnotationTickRail({
     if (!editor) return;
     const sh = editor.scrollHeight();
     if (sh <= 0) return;
-    // First surviving span per id, from the live-mapped fields so ticks
-    // ride edits like the highlights do.
+    // Every surviving span from the live-mapped fields, so ticks ride
+    // edits like the highlights do.
     const next: Tick[] = [];
-    const seen = new Set<string>();
+    const occurrences = new Map<string, number>();
     const collect = (
       targets: AnchoredHighlightTarget[],
       kind: Tick["kind"],
     ) => {
       for (const t of targets) {
+        if (!t.id || t.startOffset >= t.endOffset) continue;
+        // nth counts surviving spans, mirroring scrollToSource's filter.
         const key = `${kind}:${t.id}`;
-        if (!t.id || t.startOffset >= t.endOffset || seen.has(key)) continue;
+        const nth = occurrences.get(key) ?? 0;
+        occurrences.set(key, nth + 1);
         const line = editor.anchorLine(t.startOffset);
         if (!line) continue;
-        seen.add(key);
         next.push({
           kind,
           id: t.id,
+          nth,
           fraction: Math.min(1, Math.max(0, line.top / sh)),
         });
       }
@@ -150,13 +157,15 @@ export function AnnotationTickRail({
       {shown.map((t) => (
         // raw-ok: no Opal control renders a 2px proportional minimap tick
         <button
-          key={`${t.kind}:${t.id}`}
+          key={`${t.kind}:${t.id}:${t.nth}`}
           type="button"
           aria-label={t.kind === "comment" ? "Comment" : "Source"}
           className="pointer-events-auto absolute inset-x-[2px] flex h-2 cursor-pointer items-center"
           style={{ top: `calc(${t.fraction * 100}% - 4px)` }}
           onClick={() =>
-            t.kind === "comment" ? onPickComment?.(t.id) : onPickSource?.(t.id)
+            t.kind === "comment"
+              ? onPickComment?.(t.id)
+              : onPickSource?.(t.id, t.nth)
           }
         >
           <span

--- a/frontend/src/components/wiki/AnnotationTickRail.tsx
+++ b/frontend/src/components/wiki/AnnotationTickRail.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+
+import type { CoeditorHandle } from "@/lib/editor/components";
+import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
+
+// A tick per annotated region, deduped when two regions land within one
+// slot of each other on the strip.
+const TICK_SLOT = 12;
+
+interface Tick {
+  kind: "comment" | "source";
+  id: string;
+  offset: number;
+  /** Content fraction of the doc, 0..1. */
+  fraction: number;
+}
+
+/**
+ * Overview tick strip at the doc's right margin (mock 1855:281488): one
+ * line per commented or source-attributed region at its proportional doc
+ * position, the active region's tick heavier (Weight/Bar/Medium,
+ * Border/05) than the rest (Weight/Bar/Small, Border/02). Clicking a tick
+ * scrolls to and activates its region. Reads whichever highlight field is
+ * populated, which the tabs keep mutually exclusive.
+ */
+export function AnnotationTickRail({
+  editorRef,
+  commentTargets,
+  sourceTargets,
+  activeCommentIds,
+  activeSourceIds,
+  onPickComment,
+  onPickSource,
+}: {
+  editorRef: RefObject<CoeditorHandle | null>;
+  /** The page's current targets, retriggering layout when they change.
+   * Tick positions read the editor's live-mapped copies. */
+  commentTargets: AnchoredHighlightTarget[];
+  sourceTargets: AnchoredHighlightTarget[];
+  activeCommentIds?: string[];
+  activeSourceIds?: string[];
+  onPickComment?: (id: string) => void;
+  onPickSource?: (key: string) => void;
+}) {
+  const [ticks, setTicks] = useState<Tick[]>([]);
+  const [trackH, setTrackH] = useState(0);
+  const trackRef = useRef<HTMLDivElement | null>(null);
+  const rafId = useRef(0);
+
+  // The slot collapse needs the strip's real height, measured after mount
+  // and on resize (reading it during render sees 0 on the first
+  // tick-bearing pass, before the strip exists).
+  const trackObserver = useRef<ResizeObserver | null>(null);
+  const measureTrack = useCallback((el: HTMLDivElement | null) => {
+    trackObserver.current?.disconnect();
+    trackObserver.current = null;
+    trackRef.current = el;
+    if (!el) return;
+    setTrackH(el.clientHeight);
+    const ro = new ResizeObserver(() => setTrackH(el.clientHeight));
+    ro.observe(el);
+    trackObserver.current = ro;
+  }, []);
+
+  const relayout = useCallback(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const sh = editor.scrollHeight();
+    if (sh <= 0) return;
+    // First surviving span per id, from the live-mapped fields so ticks
+    // ride edits like the highlights do.
+    const next: Tick[] = [];
+    const seen = new Set<string>();
+    const collect = (
+      targets: AnchoredHighlightTarget[],
+      kind: Tick["kind"],
+    ) => {
+      for (const t of targets) {
+        const key = `${kind}:${t.id}`;
+        if (!t.id || t.startOffset >= t.endOffset || seen.has(key)) continue;
+        const line = editor.anchorLine(t.startOffset);
+        if (!line) continue;
+        seen.add(key);
+        next.push({
+          kind,
+          id: t.id,
+          offset: t.startOffset,
+          fraction: Math.min(1, Math.max(0, line.top / sh)),
+        });
+      }
+    };
+    collect(editor.commentTargets(), "comment");
+    collect(editor.sourceTargets(), "source");
+    next.sort((a, b) => a.fraction - b.fraction);
+    setTicks(next);
+  }, [editorRef]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const scheduled = () => {
+      cancelAnimationFrame(rafId.current);
+      rafId.current = requestAnimationFrame(relayout);
+    };
+    // Synchronous first pass, rAF is throttled in occluded tabs. Ticks are
+    // content-fraction positioned, so plain scrolling never moves them.
+    relayout();
+    const unsub = editor.subscribeLayout((kind) => {
+      if (kind === "geometry") scheduled();
+    });
+    return () => {
+      unsub();
+      cancelAnimationFrame(rafId.current);
+    };
+  }, [relayout, editorRef]);
+
+  // Retrigger on target-set changes that reach the editor via effects,
+  // which produce no geometry notification of their own.
+  useEffect(relayout, [relayout, commentTargets, sourceTargets]);
+
+  if (ticks.length === 0) return null;
+
+  const isActive = (t: Tick) =>
+    t.kind === "comment"
+      ? !!activeCommentIds?.includes(t.id)
+      : !!activeSourceIds?.includes(t.id);
+
+  // Collapse ticks that share a slot, keeping an active one visible.
+  const shown: Tick[] = [];
+  for (const t of ticks) {
+    const prev = shown[shown.length - 1];
+    if (
+      prev &&
+      trackH > 0 &&
+      (t.fraction - prev.fraction) * trackH < TICK_SLOT &&
+      !isActive(t)
+    )
+      continue;
+    shown.push(t);
+  }
+
+  return (
+    <div
+      ref={measureTrack}
+      className="pointer-events-none absolute inset-y-2 right-5 z-10 w-5"
+    >
+      {shown.map((t) => (
+        // raw-ok: no Opal control renders a 2px proportional minimap tick
+        <button
+          key={`${t.kind}:${t.id}`}
+          type="button"
+          aria-label={t.kind === "comment" ? "Comment" : "Source"}
+          className="pointer-events-auto absolute inset-x-[2px] flex h-2 cursor-pointer items-center"
+          style={{ top: `calc(${t.fraction * 100}% - 4px)` }}
+          onClick={() =>
+            t.kind === "comment" ? onPickComment?.(t.id) : onPickSource?.(t.id)
+          }
+        >
+          <span
+            className={
+              isActive(t)
+                ? "h-[4px] w-full rounded-full bg-(--border-05)"
+                : "h-[2px] w-full rounded-full bg-(--border-02)"
+            }
+          />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/AnnotationTickRail.tsx
+++ b/frontend/src/components/wiki/AnnotationTickRail.tsx
@@ -11,14 +11,12 @@ import {
 import type { CoeditorHandle } from "@/lib/editor/components";
 import type { AnchoredHighlightTarget } from "@/lib/editor/highlights";
 
-// A tick per annotated region, deduped when two regions land within one
-// slot of each other on the strip.
+// Min px between shown ticks, closer regions collapse into one.
 const TICK_SLOT = 12;
 
 interface Tick {
   kind: "comment" | "source";
   id: string;
-  offset: number;
   /** Content fraction of the doc, 0..1. */
   fraction: number;
 }
@@ -28,8 +26,8 @@ interface Tick {
  * line per commented or source-attributed region at its proportional doc
  * position, the active region's tick heavier (Weight/Bar/Medium,
  * Border/05) than the rest (Weight/Bar/Small, Border/02). Clicking a tick
- * scrolls to and activates its region. Reads whichever highlight field is
- * populated, which the tabs keep mutually exclusive.
+ * scrolls to and activates its region. Reads both live-mapped highlight
+ * fields and shows a tick for every populated target.
  */
 export function AnnotationTickRail({
   editorRef,
@@ -52,17 +50,14 @@ export function AnnotationTickRail({
 }) {
   const [ticks, setTicks] = useState<Tick[]>([]);
   const [trackH, setTrackH] = useState(0);
-  const trackRef = useRef<HTMLDivElement | null>(null);
   const rafId = useRef(0);
 
-  // The slot collapse needs the strip's real height, measured after mount
-  // and on resize (reading it during render sees 0 on the first
-  // tick-bearing pass, before the strip exists).
+  // The slot collapse needs the strip's real px height, which only exists
+  // after the first tick-bearing render (measured on mount and resize).
   const trackObserver = useRef<ResizeObserver | null>(null);
   const measureTrack = useCallback((el: HTMLDivElement | null) => {
     trackObserver.current?.disconnect();
     trackObserver.current = null;
-    trackRef.current = el;
     if (!el) return;
     setTrackH(el.clientHeight);
     const ro = new ResizeObserver(() => setTrackH(el.clientHeight));
@@ -92,7 +87,6 @@ export function AnnotationTickRail({
         next.push({
           kind,
           id: t.id,
-          offset: t.startOffset,
           fraction: Math.min(1, Math.max(0, line.top / sh)),
         });
       }
@@ -110,9 +104,10 @@ export function AnnotationTickRail({
       cancelAnimationFrame(rafId.current);
       rafId.current = requestAnimationFrame(relayout);
     };
-    // Synchronous first pass, rAF is throttled in occluded tabs. Ticks are
-    // content-fraction positioned, so plain scrolling never moves them.
+    // Synchronous first pass, rAF is throttled in occluded tabs.
     relayout();
+    // Ticks are content-fraction positioned, so plain scrolling never
+    // moves them and only geometry changes matter.
     const unsub = editor.subscribeLayout((kind) => {
       if (kind === "geometry") scheduled();
     });

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -402,6 +402,9 @@ export interface CoeditorHandle {
    * anchor UI to span positions (collapsed spans included, callers skip
    * them). */
   sourceTargets: () => AnchoredHighlightTarget[];
+  /** The comment highlight field's live-mapped targets, same contract as
+   * `sourceTargets`. */
+  commentTargets: () => AnchoredHighlightTarget[];
   /** Doc-space top and height (px from the document's start) of the line
    * block holding a character offset. Stable for off-screen positions
    * (line-block geometry, not rendered coordinates). */
@@ -514,6 +517,10 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         sourceTargets: () => {
           const v = view.current;
           return v ? v.state.field(sourceHighlightsExt.field).targets : [];
+        },
+        commentTargets: () => {
+          const v = view.current;
+          return v ? v.state.field(commentsField).targets : [];
         },
         scrollToSource: (id: string) => {
           const v = view.current;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -395,9 +395,10 @@ interface CoeditorProps {
  * links). */
 export interface CoeditorHandle {
   scrollToOffset: (offset: number) => void;
-  /** Scroll to a source's first attributed span, read from the highlight
-   * field's live-mapped offsets so edits since the fetch are honored. */
-  scrollToSource: (id: string) => void;
+  /** Scroll to the nth attributed span of a source (default the first),
+   * read from the highlight field's live-mapped offsets so edits since
+   * the fetch are honored. */
+  scrollToSource: (id: string, nth?: number) => void;
   /** The source highlight field's live-mapped targets, for hosts that
    * anchor UI to span positions (collapsed spans included, callers skip
    * them). */
@@ -522,14 +523,17 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
           const v = view.current;
           return v ? v.state.field(commentsField).targets : [];
         },
-        scrollToSource: (id: string) => {
+        scrollToSource: (id: string, nth = 0) => {
           const v = view.current;
           if (!v) return;
           // An edit can collapse a span to zero width, and a collapsed
           // target paints nothing, so it can't be the scroll destination.
-          const target = v.state
+          const spans = v.state
             .field(sourceHighlightsExt.field)
-            .targets.find((t) => t.id === id && t.startOffset < t.endOffset);
+            .targets.filter((t) => t.id === id && t.startOffset < t.endOffset);
+          // A span collapsing can strand a caller's nth, land on the last
+          // surviving span rather than dead-clicking.
+          const target = spans[Math.min(nth, spans.length - 1)];
           if (!target) return;
           v.dispatch({
             effects: EditorView.scrollIntoView(

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -334,8 +334,8 @@ export function FileView({ path }: FileViewProps) {
   }, [sourcesTabOpen, sourceSpans]);
   // Scrolls via the editor's live-mapped span, not the raw server offset,
   // so a click after local edits lands on the moved text.
-  const activateSource = useCallback((key: string) => {
-    coeditorRef.current?.scrollToSource(key);
+  const activateSource = useCallback((key: string, nth?: number) => {
+    coeditorRef.current?.scrollToSource(key, nth);
   }, []);
   // Attribution runs both ways: hovering a card lights only that source's
   // spans, and a caret inside a span lights its card (the editor reports

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/wiki/VersionHistoryList";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
+import { AnnotationTickRail } from "@/components/wiki/AnnotationTickRail";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
 import { EditorEdgeScrollbar } from "@/components/wiki/EditorEdgeScrollbar";
 import { sourceKey } from "@/components/wiki/sources";
@@ -1329,6 +1330,17 @@ export function FileView({ path }: FileViewProps) {
             run={runMargin}
             onSubmitDraft={(body) => void submitMarginDraft(body)}
             onCancelDraft={() => setCommentDraft(null)}
+          />
+        )}
+        {panelScrollDocked && (
+          <AnnotationTickRail
+            editorRef={coeditorRef}
+            commentTargets={commentHighlights}
+            sourceTargets={sourceHighlights}
+            activeCommentIds={activeCommentIds}
+            activeSourceIds={activeSourceIds}
+            onPickComment={activateComment}
+            onPickSource={activateSource}
           />
         )}
       </div>


### PR DESCRIPTION
## Description

Adds the overview tick strip from mock 1855:281488, the last piece of the anchored comments/sources experience (#493).

- A tick renders at the doc's right margin for every commented or source-attributed region, at its proportional doc position. Active regions get the heavier 4px `--border-05` bar, the rest the 2px `--border-02` bar.
- Clicking a tick scrolls to the region and activates it (focuses the thread or source card), reusing the existing activation paths.
- Ticks read the live-mapped highlight fields so they ride edits, collapse when they land within one slot of each other, and never move on plain scrolling since they are content-fraction positioned.
- Shown under the same gate as the docked scrollbar, so no rail on mobile, closed panels, or old-version views.

Built on `nikg/source-line-highlights`, cherry-picked onto main after #493 merged.

## How Has This Been Tested?

Live on dev1 (test_poem): two comment ticks at distinct positions, three co-located sources collapse to one tick, clicking a tick activates exactly that region and expands its thread. tsc clean.