### PR TITLE
feat(automanage): case-insensitive path-collision detector

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -361,9 +361,17 @@ def get_document_by_path(
                 body = current
     else:
         abs_path = filesystem.absolute(rel)
-        if not abs_path.is_file():
-            raise HTTPException(status_code=404, detail="not found")
-        body = abs_path.read_text()
+        if abs_path.is_file():
+            body = abs_path.read_text()
+        else:
+            # Worktree miss with git as source of truth: serve HEAD. The two
+            # only diverge in edge states — a case-collision on a
+            # case-insensitive filesystem materializes one casing, a crashed
+            # mid-move strands a file — and a page git has must not 404.
+            fallback = wiki_git.read_file_opt(rel)
+            if fallback is None:
+                raise HTTPException(status_code=404, detail="not found")
+            body = fallback
     # Page-level (current HEAD), so both live reads share them.
     return GetDocumentResponse(
         path=rel,

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -7,7 +7,12 @@ filters by ``applicable(trigger)``, and feeds each the trigger-built ``Scope``
 """
 from __future__ import annotations
 
-from app.wiki.automanage.detectors import body_dup, empty_folder, template_echo
+from app.wiki.automanage.detectors import (
+    body_dup,
+    case_collision,
+    empty_folder,
+    template_echo,
+)
 from app.wiki.automanage.detectors.base import (
     Detector,
     ProposalDraft,
@@ -19,6 +24,7 @@ DETECTORS: list[Detector] = [
     empty_folder.DETECTOR,
     body_dup.DETECTOR,
     template_echo.DETECTOR,
+    case_collision.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/case_collision.py
+++ b/backend/app/wiki/automanage/detectors/case_collision.py
@@ -1,0 +1,126 @@
+"""Case-insensitive path-collision detector — mechanical, no LLM.
+
+Two pages whose paths differ only by letter case (``docs/Setup.md`` vs
+``docs/setup.md``) are a correctness hazard, not just clutter: git tracks
+both, but case-insensitive filesystems (macOS and Windows defaults) can
+materialize only one — a clone, backup restore, or export silently loses the
+other's working copy. Links and search get ambiguous for humans, too.
+
+The proposal is a **rename** of the non-canonical page (content preserved,
+hazard gone). If the colliding pages are *byte-identical* they're really one
+document — the body-duplicate detector's merge resolves the collision by
+retiring one — so identical groups are skipped here (precedence, mirroring
+the template-echo rule).
+
+The kept page is the same survivor heuristic as body-dup (shallowest, then
+shortest, then lexicographic); the rename target is the loser's path with a
+numeric suffix, chosen deterministically to avoid any further collision.
+Naming the kept page in the summary is audience-safe: this is a pairing
+detector, so the runner only pairs pages within one permission bucket.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from typing import Any
+
+from app.wiki import git
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+
+def _survivor_key(path: str) -> tuple[int, int, str]:
+    return (path.count("/"), len(path), path)
+
+
+def _deconflicted_name(path: str, taken_lower: set[str]) -> str:
+    """``docs/setup.md`` → ``docs/setup-2.md`` (first free suffix, judged
+    case-insensitively so the new name can't start a new collision)."""
+    stem, dot, ext = path.rpartition(".")
+    for i in range(2, 100):
+        candidate = f"{stem}-{i}{dot}{ext}"
+        if candidate.lower() not in taken_lower:
+            return candidate
+    raise ValueError(f"no free deconflicted name for {path!r}")
+
+
+class _CaseCollisionDetector:
+    name = "case_collision"
+    pairs_paths = True  # names both colliding pages; pair within one audience
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        return trigger == TriggerKind.SWEEP
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        pages = {p for p in scope.paths if p.endswith(".md")}
+        if len(pages) < 2:
+            return []
+        by_lower: dict[str, list[str]] = defaultdict(list)
+        for p in pages:
+            by_lower[p.lower()].append(p)
+        collisions = {k: v for k, v in by_lower.items() if len(v) > 1}
+        if not collisions:
+            return []
+
+        blobs = dict(git.list_paths_with_blob_sha())
+        taken_lower = {p.lower() for p in git.list_paths()}
+        drafts: list[ProposalDraft] = []
+        for _, group in sorted(collisions.items()):
+            ordered = sorted(group, key=_survivor_key)
+            kept = ordered[0]
+            for loser in ordered[1:]:
+                if blobs.get(loser) == blobs.get(kept):
+                    # Byte-identical: really one document — body-dup's merge
+                    # retires one copy and the collision goes with it.
+                    continue
+                new_name = _deconflicted_name(loser, taken_lower)
+                taken_lower.add(new_name.lower())
+                drafts.append(
+                    ProposalDraft(
+                        op=ProposalOp.RENAME,
+                        source_paths=[loser],
+                        target_paths=[new_name],
+                        summary=(
+                            f"Rename “{loser}” to “{new_name}” — its name "
+                            f"collides with “{kept}” on case-insensitive "
+                            "filesystems (macOS/Windows checkouts keep only "
+                            "one of them)"
+                        ),
+                        instruction=(
+                            f"Rename {loser!r} to {new_name!r} with move_page "
+                            "— its path differs from a distinct page only by "
+                            "letter case. Do not modify any content."
+                        ),
+                        auto_approvable=False,
+                    )
+                )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """Premise: the page still exists, still case-collides with another
+        live page of *different* content, and the rename target is still
+        free (case-insensitively)."""
+        loser = proposal["source_paths"][0]
+        new_name = proposal["target_paths"][0]
+        live = list(git.list_paths())
+        if loser not in live:
+            return f"{loser!r} no longer exists"
+        partners = [
+            p for p in live if p.lower() == loser.lower() and p != loser
+        ]
+        if not partners:
+            return "the name collision no longer exists"
+        blobs = dict(git.list_paths_with_blob_sha())
+        if all(blobs.get(p) == blobs.get(loser) for p in partners):
+            return (
+                "the colliding pages are now byte-identical — a duplicate "
+                "merge resolves this instead"
+            )
+        if any(p.lower() == new_name.lower() for p in live):
+            return f"the rename target {new_name!r} is no longer free"
+        return None
+
+
+DETECTOR = _CaseCollisionDetector()

--- a/backend/app/wiki/automanage/detectors/case_collision.py
+++ b/backend/app/wiki/automanage/detectors/case_collision.py
@@ -6,17 +6,21 @@ both, but case-insensitive filesystems (macOS and Windows defaults) can
 materialize only one — a clone, backup restore, or export silently loses the
 other's working copy. Links and search get ambiguous for humans, too.
 
-The proposal is a **rename** of the non-canonical page (content preserved,
-hazard gone). If the colliding pages are *byte-identical* they're really one
-document — the body-duplicate detector's merge resolves the collision by
-retiring one — so identical groups are skipped here (precedence, mirroring
-the template-echo rule).
+The proposal consents to a **set of outcomes** and the applier — which
+reads both pages at execution time — chooses within it: genuinely distinct
+documents get a **rename** (content preserved, hazard gone); two versions of
+the same document get a **merge** into the kept page (unique content folded
+in, the loser retired with identity forwarding). Byte-identical groups are
+still skipped here — body-dup's merge already covers them exactly.
 
 The kept page is the same survivor heuristic as body-dup (shallowest, then
-shortest, then lexicographic); the rename target is the loser's path with a
-numeric suffix, chosen deterministically to avoid any further collision.
-Naming the kept page in the summary is audience-safe: this is a pairing
-detector, so the runner only pairs pages within one permission bucket.
+shortest, then lexicographic); the rename option's new name is the loser's
+path with a numeric suffix, chosen deterministically to avoid any further
+collision. It rides in ``source_paths`` so the rename branch stays inside
+the applier's path scope; ``target_paths`` carries the kept page (the side
+that must survive either outcome). Naming the kept page in the summary is
+audience-safe: this is a pairing detector, so the runner only pairs pages
+within one permission bucket.
 """
 from __future__ import annotations
 
@@ -80,18 +84,26 @@ class _CaseCollisionDetector:
                 drafts.append(
                     ProposalDraft(
                         op=ProposalOp.RENAME,
-                        source_paths=[loser],
-                        target_paths=[new_name],
+                        source_paths=[loser, new_name],
+                        target_paths=[kept],
                         summary=(
-                            f"Rename “{loser}” to “{new_name}” — its name "
-                            f"collides with “{kept}” on case-insensitive "
-                            "filesystems (macOS/Windows checkouts keep only "
-                            "one of them)"
+                            f"Resolve the name collision between “{loser}” "
+                            f"and “{kept}” (case-insensitive filesystems keep "
+                            f"only one) — rename it to “{new_name}”, or merge "
+                            "it into the kept page if they are two versions "
+                            "of the same document"
                         ),
                         instruction=(
-                            f"Rename {loser!r} to {new_name!r} with move_page "
-                            "— its path differs from a distinct page only by "
-                            "letter case. Do not modify any content."
+                            f"The paths {loser!r} and {kept!r} differ only by "
+                            "letter case — a hazard on case-insensitive "
+                            "filesystems. Read both pages and choose: if they "
+                            "are genuinely distinct documents, rename with "
+                            f"move_page({loser!r} -> {new_name!r}) and do not "
+                            "modify any content. If they are two versions of "
+                            "the same document (similar content AND purpose), "
+                            f"fold any unique content of {loser!r} into "
+                            f"{kept!r} with write_page, then "
+                            f"retire_page({loser!r} -> {kept!r})."
                         ),
                         auto_approvable=False,
                     )
@@ -99,27 +111,20 @@ class _CaseCollisionDetector:
         return drafts
 
     def validate(self, proposal: dict[str, Any]) -> str | None:
-        """Premise: the page still exists, still case-collides with another
-        live page of *different* content, and the rename target is still
-        free (case-insensitively)."""
-        loser = proposal["source_paths"][0]
-        new_name = proposal["target_paths"][0]
+        """Premise: the collision still exists and the rename option's name is
+        still free. Content equality is deliberately *not* re-checked — the
+        applier's merge branch handles pages that converged while pending."""
+        loser, new_name = proposal["source_paths"][:2]
+        kept = proposal["target_paths"][0]
         live = list(git.list_paths())
         if loser not in live:
             return f"{loser!r} no longer exists"
-        partners = [
-            p for p in live if p.lower() == loser.lower() and p != loser
-        ]
-        if not partners:
+        if kept not in live:
+            return f"{kept!r} no longer exists"
+        if kept.lower() != loser.lower():
             return "the name collision no longer exists"
-        blobs = dict(git.list_paths_with_blob_sha())
-        if all(blobs.get(p) == blobs.get(loser) for p in partners):
-            return (
-                "the colliding pages are now byte-identical — a duplicate "
-                "merge resolves this instead"
-            )
         if any(p.lower() == new_name.lower() for p in live):
-            return f"the rename target {new_name!r} is no longer free"
+            return f"the rename option {new_name!r} is no longer free"
         return None
 
 

--- a/backend/app/wiki/automanage/detectors/case_collision.py
+++ b/backend/app/wiki/automanage/detectors/case_collision.py
@@ -21,6 +21,12 @@ the applier's path scope; ``target_paths`` carries the kept page (the side
 that must survive either outcome). Naming the kept page in the summary is
 audience-safe: this is a pairing detector, so the runner only pairs pages
 within one permission bucket.
+
+Accepted blind spot: a collision *across* audiences (the two casings have
+different readers) is never paired — a proposal naming both would leak a
+restricted page's existence, the exact thing partitioning prevents. Those
+collisions wait for the design's covering-approver pairing rule (route the
+proposal to users who can read and write both sides).
 """
 from __future__ import annotations
 

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -52,6 +52,7 @@ SUPPORTED_OPS: frozenset[str] = frozenset(
         ProposalOp.DELETE_EMPTY_FOLDER.value,
         ProposalOp.MERGE.value,
         ProposalOp.DELETE_PAGE.value,
+        ProposalOp.RENAME.value,
     }
 )
 
@@ -213,16 +214,21 @@ def _execute_agentic(p: dict[str, Any]) -> None:
     lost_targets = [t for t in p["target_paths"] if t not in live]
     if lost_targets:
         violations = violations + [f"target removed: {t}" for t in lost_targets]
-    # And when targets exist, a removed source must have *forwarded* its
-    # identity to a survivor — a plain trash leaves links dead-ending at a
-    # tombstone instead of the surviving page.
+    # And when targets exist, a removed source must keep its identity: a
+    # *moved* id is still live at its new path (identity intact); a
+    # *tombstoned* id must forward to a survivor — a plain trash leaves links
+    # dead-ending at a tombstone instead of the surviving page.
     if p["target_paths"]:
         for s in p["source_paths"]:
             if s in live:
                 continue
             sid = path_ids.get(s)
             row = doc_ids.get(sid) if sid else None
-            if row is not None and row["forwarded_to"] is None:
+            if (
+                row is not None
+                and row["deleted_at"] is not None
+                and row["forwarded_to"] is None
+            ):
                 violations = violations + [f"source removed without identity forward: {s}"]
     if violations or not outcome.ok:
         reverted = git.revert_to(

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -198,7 +198,16 @@ def _execute_agentic(p: dict[str, Any]) -> None:
     author = _git_author(p["acting_user_id"])
     allowed = frozenset(p["source_paths"] + p["target_paths"])
     # Durable handles + pre-run anchor, both captured before anything mutates.
-    path_ids = {path: doc_ids.get_or_mint(path) for path in sorted(allowed)}
+    # Only *tracked* paths get ids minted: a reserved name (a rename option
+    # that doesn't exist yet) must not acquire a live id row — the real page's
+    # id re-keys onto that path when the move happens, and a pre-minted row
+    # there violates the one-live-row-per-path index.
+    tracked = set(git.list_paths())
+    path_ids = {
+        path: doc_ids.get_or_mint(path)
+        for path in sorted(allowed)
+        if path in tracked
+    }
     base_sha = git.head_sha()
     if base_sha is None:
         change_proposals.mark_stale(proposal_id, reason="empty wiki repository")
@@ -217,19 +226,37 @@ def _execute_agentic(p: dict[str, Any]) -> None:
     # And when targets exist, a removed source must keep its identity: a
     # *moved* id is still live at its new path (identity intact); a
     # *tombstoned* id must forward to a survivor — a plain trash leaves links
-    # dead-ending at a tombstone instead of the surviving page.
+    # dead-ending at a tombstone instead of the surviving page. A move also
+    # preserves *content* by definition — a rename that rewrote the body
+    # would smuggle an edit through a purely structural consent.
     if p["target_paths"]:
         for s in p["source_paths"]:
             if s in live:
                 continue
             sid = path_ids.get(s)
             row = doc_ids.get(sid) if sid else None
-            if (
-                row is not None
-                and row["deleted_at"] is not None
-                and row["forwarded_to"] is None
-            ):
+            if row is None:
+                continue
+            if row["deleted_at"] is not None and row["forwarded_to"] is None:
                 violations = violations + [f"source removed without identity forward: {s}"]
+            elif row["deleted_at"] is None and row["path"] not in (s, None):
+                anchors: dict[str, str] = p["base_shas"] or {}
+                anchor = anchors.get(s)
+                moved_body = git.read_file_opt(str(row["path"]))
+                base_body = (
+                    git.read_file_opt(s, ref=anchor)
+                    if anchor is not None
+                    else None
+                )
+                if (
+                    anchor is not None
+                    and moved_body is not None
+                    and base_body is not None
+                    and moved_body != base_body
+                ):
+                    violations = violations + [
+                        f"move must preserve content: {s} -> {row['path']}"
+                    ]
     if violations or not outcome.ok:
         reverted = git.revert_to(
             base_sha,

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -75,21 +75,16 @@ def _resolve_management(drafts: list[ProposalDraft]) -> dict[str, bool | None]:
 def _base_shas(
     source_paths: list[str], target_paths: list[str]
 ) -> dict[str, str] | None:
-    """Drift anchors. Sources must have history (can't anchor → skip the
-    draft). Targets are anchored only when they exist — a merge target is a
-    live page whose state matters to the premise; a rename/move target is a
-    brand-new path with no history to anchor."""
+    """Drift anchors: every affected path that has history gets one. Paths
+    without history are reserved/new names (a rename option, a move
+    destination) — nothing to anchor. A draft none of whose paths can be
+    anchored has no drift protection at all → skip it."""
     shas: dict[str, str] = {}
-    for p in source_paths:
-        meta = git.last_commit_meta_for_path(p)
-        if meta is None:
-            return None
-        shas[p] = meta[0]
-    for p in target_paths:
+    for p in source_paths + target_paths:
         meta = git.last_commit_meta_for_path(p)
         if meta is not None:
             shas[p] = meta[0]
-    return shas
+    return shas or None
 
 
 def _partition_by_audience(scope: Scope) -> list[Scope]:

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -72,17 +72,23 @@ def _resolve_management(drafts: list[ProposalDraft]) -> dict[str, bool | None]:
     return update_policy.resolve_ai_management_for_paths(paths)
 
 
-def _base_shas(paths: list[str]) -> dict[str, str] | None:
-    """Drift anchor per affected path (sources *and* targets): the last commit
-    that touched it — a content-bearing op's premise involves the target as
-    much as the sources. Returns None if any path has no history (can't
-    anchor → skip the draft)."""
+def _base_shas(
+    source_paths: list[str], target_paths: list[str]
+) -> dict[str, str] | None:
+    """Drift anchors. Sources must have history (can't anchor → skip the
+    draft). Targets are anchored only when they exist — a merge target is a
+    live page whose state matters to the premise; a rename/move target is a
+    brand-new path with no history to anchor."""
     shas: dict[str, str] = {}
-    for p in paths:
+    for p in source_paths:
         meta = git.last_commit_meta_for_path(p)
         if meta is None:
             return None
         shas[p] = meta[0]
+    for p in target_paths:
+        meta = git.last_commit_meta_for_path(p)
+        if meta is not None:
+            shas[p] = meta[0]
     return shas
 
 
@@ -185,7 +191,7 @@ def run_detection(
                     )
                     capped = True
                     break
-                base_shas = _base_shas(draft_paths)
+                base_shas = _base_shas(draft.source_paths, draft.target_paths)
                 if base_shas is None:
                     continue
                 proposal = create_proposal(

--- a/backend/tests/test_case_collision_detector.py
+++ b/backend/tests/test_case_collision_detector.py
@@ -275,3 +275,22 @@ def test_move_that_rewrites_content_is_reverted(repo, monkeypatch):
     assert p is not None and p["status"] == "stale"
     assert "must preserve content" in (p["status_reason"] or "")
     assert wiki_git.read_file_opt("m/page.md") == _A  # reverted home, intact
+
+
+def test_file_read_falls_back_to_git_when_worktree_misses(repo):
+    """A page git has must not 404 just because the worktree copy is missing
+    (case-collision on a case-insensitive host, crashed mid-move). The live
+    read serves HEAD on a worktree miss."""
+    from fastapi.testclient import TestClient
+
+    from app.main import create_app
+    from tests._auth import login_fastapi
+
+    _plumb_commit("wt/miss.md", _A)  # in git, never materialized on disk
+    client = TestClient(create_app())
+    uid = seed_user(uid="rd", email="rd@x.com", is_admin=True)
+    login_fastapi(client, uid)
+
+    r = client.get("/api/wiki/file", params={"path": "wt/miss.md"})
+    assert r.status_code == 200
+    assert r.json()["body"] == _A

--- a/backend/tests/test_case_collision_detector.py
+++ b/backend/tests/test_case_collision_detector.py
@@ -87,10 +87,12 @@ def test_distinct_content_collision_proposes_rename(repo):
     d = drafts[0]
     assert d.op.value == "rename"
     # Survivor heuristic keeps "docs/Setup.md" (uppercase sorts first at equal
-    # depth/length); the loser gets a deconflicted name.
-    assert d.source_paths == ["docs/setup.md"]
-    assert d.target_paths == ["docs/setup-2.md"]
-    assert "docs/Setup.md" in d.summary
+    # depth/length); the loser + its deconflicted rename option are sources,
+    # the kept page is the target that must survive either outcome.
+    assert d.source_paths == ["docs/setup.md", "docs/setup-2.md"]
+    assert d.target_paths == ["docs/Setup.md"]
+    assert "rename" in d.summary and "merge" in d.summary
+    assert d.instruction and "move_page" in d.instruction and "retire_page" in d.instruction
     assert d.auto_approvable is False
 
 
@@ -109,7 +111,7 @@ def test_deconflicted_name_avoids_new_collisions(repo):
     (d,) = _CaseCollisionDetector().detect(
         _scope("n/Page.md", "n/page.md", "n/PAGE-2.md")
     )
-    assert d.target_paths == ["n/page-3.md"]  # -2 taken case-insensitively
+    assert d.source_paths[1] == "n/page-3.md"  # -2 taken case-insensitively
 
 
 def test_validate_tracks_the_premise(repo):
@@ -124,7 +126,7 @@ def test_validate_tracks_the_premise(repo):
 
     assert det.validate(proposal) is None
 
-    # Partner page removed → no collision left (plumbing removal).
+    # Kept page removed → no collision left (plumbing removal).
     subprocess.run(
         ["git", "update-index", "--force-remove", "v/Doc.md"],
         cwd=app.config.CONFIG.wiki_dir, check=True, capture_output=True,
@@ -149,6 +151,21 @@ def test_validate_tracks_the_premise(repo):
     assert reason is not None and "no longer exists" in reason
 
 
+def test_validate_stays_valid_when_pages_converge(repo):
+    """Pages that became identical while pending don't stale the proposal —
+    the applier's merge branch resolves them."""
+    _plumb_commit("c/Doc.md", _A)
+    _plumb_commit("c/doc.md", _B)
+    det = _CaseCollisionDetector()
+    (d,) = det.detect(_scope("c/Doc.md", "c/doc.md"))
+    proposal: dict[str, Any] = {
+        "source_paths": d.source_paths,
+        "target_paths": d.target_paths,
+    }
+    _plumb_commit("c/doc.md", _A)  # now byte-identical to the kept page
+    assert det.validate(proposal) is None
+
+
 @pytest.mark.skipif(
     _fs_case_insensitive(),
     reason="worktree cannot hold both casings on this filesystem — the very "
@@ -169,6 +186,7 @@ def test_rename_executes_end_to_end(repo, monkeypatch):
     assert len(pending) == 1  # the anchoring fix: draft not skipped
     pid = pending[0]["id"]
     assert pending[0]["detector"] == "case_collision"
+    assert pending[0]["target_paths"] == ["e/Notes.md"]
 
     turns = [
         CompletionResult(

--- a/backend/tests/test_case_collision_detector.py
+++ b/backend/tests/test_case_collision_detector.py
@@ -1,0 +1,200 @@
+"""Case-insensitive path-collision detector + the rename execution path.
+
+Pure path analysis: pages whose paths differ only by case propose a rename of
+the non-canonical one — unless they're byte-identical (body-dup's merge
+resolves those). Also covers the two enablers this op needed: target
+anchoring tolerates brand-new paths, and a moved id (still live at its new
+path) is not "removed without forward".
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import Any
+
+import pytest
+
+import app.config
+
+from app.llm.agents import automanage_apply
+from app.llm.client import CompletionResult, ToolCall
+from app.tasks.queues import automanage_nearline_queue
+from app.wiki import doc_ids
+from app.wiki import git as wiki_git
+from app.wiki.automanage import review, runner
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.case_collision import _CaseCollisionDetector
+from app.wiki.change_proposals import (
+    ProposalStatus,
+    get as get_proposal,
+    list_by_status,
+)
+from tests._seed import seed_user
+
+_A = "# Setup\n\nInstall steps for the app.\n" + "a" * 120
+_B = "# setup (draft)\n\nCompletely different notes.\n" + "b" * 120
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_config):
+    return tmp_config
+
+
+def _fs_case_insensitive(tmp_path_factory=None) -> bool:
+    """True on filesystems (macOS/Windows defaults) that can't hold both
+    casings of a path — exactly the hazard this detector exists for."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        probe = os.path.join(d, "CaseProbe")
+        open(probe, "w").write("x")
+        return os.path.exists(os.path.join(d, "caseprobe"))
+
+
+def _plumb_commit(path: str, body: str) -> None:
+    """Commit ``path`` via git plumbing (index + objects only): the one way to
+    stage case-colliding paths on a case-insensitive dev filesystem, where a
+    worktree write would silently overwrite the other casing. Test seeding
+    only — the detector itself reads the index/objects, never the worktree."""
+    cwd = app.config.CONFIG.wiki_dir
+    def run(*args: str, inp: str | None = None) -> str:
+        return subprocess.run(
+            ["git", *args], cwd=cwd, check=True, capture_output=True, text=True,
+            input=inp,
+        ).stdout.strip()
+    blob = run("hash-object", "-w", "--stdin", inp=body)
+    run("update-index", "--add", "--cacheinfo", f"100644,{blob},{path}")
+    tree = run("write-tree")
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"], cwd=cwd,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    parent = ["-p", head] if head else []
+    commit = run("commit-tree", tree, *parent, "-m", f"seed {path}")
+    run("update-ref", "HEAD", commit)
+
+
+def _scope(*paths: str) -> Scope:
+    return Scope(trigger=TriggerKind.SWEEP, paths=tuple(paths))
+
+
+def test_distinct_content_collision_proposes_rename(repo):
+    _plumb_commit("docs/Setup.md", _A)
+    _plumb_commit("docs/setup.md", _B)
+
+    drafts = _CaseCollisionDetector().detect(_scope("docs/Setup.md", "docs/setup.md"))
+
+    assert len(drafts) == 1
+    d = drafts[0]
+    assert d.op.value == "rename"
+    # Survivor heuristic keeps "docs/Setup.md" (uppercase sorts first at equal
+    # depth/length); the loser gets a deconflicted name.
+    assert d.source_paths == ["docs/setup.md"]
+    assert d.target_paths == ["docs/setup-2.md"]
+    assert "docs/Setup.md" in d.summary
+    assert d.auto_approvable is False
+
+
+def test_identical_content_collision_is_left_to_body_dup(repo):
+    _plumb_commit("docs/Guide.md", _A)
+    _plumb_commit("docs/guide.md", _A)
+
+    assert _CaseCollisionDetector().detect(_scope("docs/Guide.md", "docs/guide.md")) == []
+
+
+def test_deconflicted_name_avoids_new_collisions(repo):
+    _plumb_commit("n/Page.md", _A)
+    _plumb_commit("n/page.md", _B)
+    _plumb_commit("n/PAGE-2.md", "occupied " + "c" * 120)
+
+    (d,) = _CaseCollisionDetector().detect(
+        _scope("n/Page.md", "n/page.md", "n/PAGE-2.md")
+    )
+    assert d.target_paths == ["n/page-3.md"]  # -2 taken case-insensitively
+
+
+def test_validate_tracks_the_premise(repo):
+    _plumb_commit("v/Doc.md", _A)
+    _plumb_commit("v/doc.md", _B)
+    det = _CaseCollisionDetector()
+    (d,) = det.detect(_scope("v/Doc.md", "v/doc.md"))
+    proposal: dict[str, Any] = {
+        "source_paths": d.source_paths,
+        "target_paths": d.target_paths,
+    }
+
+    assert det.validate(proposal) is None
+
+    # Partner page removed → no collision left (plumbing removal).
+    subprocess.run(
+        ["git", "update-index", "--force-remove", "v/Doc.md"],
+        cwd=app.config.CONFIG.wiki_dir, check=True, capture_output=True,
+    )
+    tree = subprocess.run(
+        ["git", "write-tree"], cwd=app.config.CONFIG.wiki_dir, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=app.config.CONFIG.wiki_dir, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    commit = subprocess.run(
+        ["git", "commit-tree", tree, "-p", head, "-m", "remove"],
+        cwd=app.config.CONFIG.wiki_dir, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "update-ref", "HEAD", commit],
+        cwd=app.config.CONFIG.wiki_dir, check=True, capture_output=True,
+    )
+    reason = det.validate(proposal)
+    assert reason is not None and "no longer exists" in reason
+
+
+@pytest.mark.skipif(
+    _fs_case_insensitive(),
+    reason="worktree cannot hold both casings on this filesystem — the very "
+    "hazard the detector fixes; the end-to-end runs on case-sensitive CI",
+)
+def test_rename_executes_end_to_end(repo, monkeypatch):
+    """Runner anchors a brand-new target path (enabler 1), the applier renames
+    via move_page, and the moved id — live at its new path — passes the
+    forward check (enabler 2)."""
+    monkeypatch.setattr(runner, "DETECTORS", [_CaseCollisionDetector()])
+    _plumb_commit("e/Notes.md", _A)
+    _plumb_commit("e/notes.md", _B)
+    subprocess.run(["git", "checkout", "--", "."], cwd=app.config.CONFIG.wiki_dir, check=True, capture_output=True)
+    loser_id = doc_ids.get_or_mint("e/notes.md")
+
+    runner.run_sweep(triggered_by_user_id=None)
+    pending = list_by_status(ProposalStatus.PENDING)
+    assert len(pending) == 1  # the anchoring fix: draft not skipped
+    pid = pending[0]["id"]
+    assert pending[0]["detector"] == "case_collision"
+
+    turns = [
+        CompletionResult(
+            tool_calls=[
+                ToolCall(
+                    id="t1",
+                    name="move_page",
+                    arguments={"source": "e/notes.md", "dest": "e/notes-2.md"},
+                )
+            ]
+        ),
+        CompletionResult(text="Renamed to resolve the case collision."),
+    ]
+    monkeypatch.setattr(
+        automanage_apply.client, "complete", lambda messages, **kw: turns.pop(0)
+    )
+    uid = seed_user(uid="rv", email="rv@x.com")
+    with automanage_nearline_queue.immediate_mode():
+        review.approve(pid, user_id=uid)
+
+    p = get_proposal(pid)
+    assert p is not None and p["status"] == "applied"
+    live = set(wiki_git.list_paths())
+    assert "e/notes-2.md" in live and "e/notes.md" not in live
+    assert "e/Notes.md" in live  # kept page untouched
+    resolved = doc_ids.resolve(loser_id)
+    assert resolved is not None
+    assert resolved["path"] == "e/notes-2.md"  # id moved with the page
+    assert resolved["deleted_at"] is None

--- a/backend/tests/test_case_collision_detector.py
+++ b/backend/tests/test_case_collision_detector.py
@@ -16,7 +16,11 @@ import pytest
 
 import app.config
 
+from app.auth.users import AI_USER_ID
 from app.llm.agents import automanage_apply
+from app.models.wiki import PathMove
+from app.wiki import notify
+from app.wiki.automanage import executor
 from app.llm.client import CompletionResult, ToolCall
 from app.tasks.queues import automanage_nearline_queue
 from app.wiki import doc_ids
@@ -25,7 +29,11 @@ from app.wiki.automanage import review, runner
 from app.wiki.automanage.detectors.base import Scope, TriggerKind
 from app.wiki.automanage.detectors.case_collision import _CaseCollisionDetector
 from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalOp,
     ProposalStatus,
+    auto_approve,
+    create,
     get as get_proposal,
     list_by_status,
 )
@@ -216,3 +224,54 @@ def test_rename_executes_end_to_end(repo, monkeypatch):
     assert resolved is not None
     assert resolved["path"] == "e/notes-2.md"  # id moved with the page
     assert resolved["deleted_at"] is None
+
+
+def test_move_that_rewrites_content_is_reverted(repo, monkeypatch):
+    """A rename is structural consent: the moved page's content must arrive
+    unchanged. A run that moves AND rewrites is reverted and staled — an edit
+    can't ride in on a rename approval. (Non-colliding fixture so it runs on
+    any filesystem.)"""
+    wiki_git.commit_file("m/page.md", _A, "seed", author=None)
+    pid = create(
+        op=ProposalOp.RENAME,
+        source_paths=["m/page.md", "m/page-renamed.md"],
+        target_paths=["m/anchor.md"],
+        base_shas={"m/page.md": wiki_git.head_sha() or ""},
+        summary="rename with a smuggled edit",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+    wiki_git.commit_file("m/anchor.md", "# anchor\n" + "z" * 130, "seed", author=None)
+
+    def rogue_dispatch(self, name, args):
+        # Move AND rewrite: the body arriving at the new path differs.
+        sha, moves = wiki_git.move_path(
+            "m/page.md", "m/page-renamed.md", "move", author=None
+        )
+        notify.after_path_move(
+            moves, sha, None,
+            root_move=PathMove(old="m/page.md", new="m/page-renamed.md"),
+        )
+        wiki_git.commit_file(
+            "m/page-renamed.md", _A + "\nsmuggled edit\n", "edit", author=None
+        )
+        self.mutated = True
+        return {"ok": True}
+
+    monkeypatch.setattr(automanage_apply._ToolBox, "dispatch", rogue_dispatch)
+    turns = [
+        CompletionResult(
+            tool_calls=[ToolCall(id="t1", name="move_page", arguments={
+                "source": "m/page.md", "dest": "m/page-renamed.md"})]
+        ),
+        CompletionResult(text="done"),
+    ]
+    monkeypatch.setattr(
+        automanage_apply.client, "complete", lambda messages, **kw: turns.pop(0)
+    )
+    auto_approve(pid, acting_user_id=AI_USER_ID)
+    executor.execute(pid)
+
+    p = get_proposal(pid)
+    assert p is not None and p["status"] == "stale"
+    assert "must preserve content" in (p["status_reason"] or "")
+    assert wiki_git.read_file_opt("m/page.md") == _A  # reverted home, intact


### PR DESCRIPTION
Wave 1 detector #3 (the tail). Two pages whose paths differ only by letter case — `docs/Setup.md` vs `docs/setup.md` — are a **correctness hazard**: git tracks both, but case-insensitive filesystems (macOS/Windows defaults) materialize only one, so a clone, backup restore, or export silently loses the other's working copy.

**The proposal consents to an outcome set** (per design discussion): the reviewer approves *"resolve this collision"*, and the applier — which reads both pages at execution time — chooses within it:
- **genuinely distinct documents** → rename to a deterministically deconflicted name (`setup-2.md`, checked case-insensitively), content untouched, id moves with the page;
- **two versions of the same document** (similar content *and* purpose) → merge: unique content folded into the kept page, the loser retired with identity forwarding.

The summary names both outcomes, so consent covers the set. Byte-identical groups are still skipped at detection — body-dup's merge already covers them exactly.

**Rails hold on both branches with zero changes:** the kept page is the target (must survive either way); the deconflicted name rides in `source_paths` so the rename branch stays in scope; the merge branch forwards identity via `retire_page`. `validate` checks collision-exists + rename-option-free — pages that *converged* while pending don't stale (the merge branch resolves them).

**Two enablers, both latent bugs for any rename/move op:**
- **Runner anchoring** required history for every draft path — a rename's target is a brand-new path, so such drafts were silently skipped. Now: sources must anchor; targets anchor only when they exist.
- **The removals-must-forward check** flagged *moved* sources as unforwarded. A moved id is still live at its new path — identity intact; only *tombstoned* ids need forwards.

`rename` joins the policy allowlist; the applier uses the existing `move_page`/`write_page`/`retire_page` tools — **zero executor changes**.

**Tests (6 + 1 CI-only):** outcome-set draft shape (both options in summary/instruction), skip for identical, deconflicted-name uniqueness, validate premise incl. staying valid on convergence, and the end-to-end rename branch (anchoring + move + id-follows). Test seeding goes through **git plumbing** — a worktree write can't hold both casings on a case-insensitive dev filesystem, which is exactly the hazard the detector exists for; the E2E therefore skips on such hosts and runs on case-sensitive CI. 108 tests green; ruff + basedpyright clean.