### PR TITLE
feat(automanage): sweep singleton — one whole-space sweep at a time

### DIFF
--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -255,7 +255,17 @@ def run_detection(
 
 def run_sweep(*, triggered_by_user_id: str | None) -> dict[str, Any]:
     """Whole-space sweep — the admin-triggered trigger. Scope is every tracked
-    path so folder-subtree detectors (empty-folder) see complete subtrees."""
+    path so folder-subtree detectors (empty-folder) see complete subtrees.
+
+    **Singleton:** while a sweep is already running, another one is skipped —
+    two concurrent whole-space scans emit the same drafts into the same dedup
+    window and double every detector's cost for nothing. The manual trigger
+    stays available (this skips *overlap*, it doesn't rate-limit); a stuck
+    ``running`` corpse row stops blocking after ``STUCK_RUN_MAX_AGE_HOURS``.
+    """
+    if runs.running_sweep_exists():
+        log.info("sweep skipped — another sweep is already running")
+        return {"run_id": None, "paths_scanned": 0, "proposals_emitted": 0, "skipped": "sweep already running"}
     return run_detection(
         trigger=TriggerKind.SWEEP,
         triggered_by_user_id=triggered_by_user_id,

--- a/backend/app/wiki/automanage/runs.py
+++ b/backend/app/wiki/automanage/runs.py
@@ -11,7 +11,7 @@ plain dicts, like ``app/wiki/change_proposals.py``.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any
 
@@ -97,6 +97,29 @@ def mark_failed(run_id: str, *, error: str) -> None:
         )
     if not touched:
         raise ValueError(f"detection run {run_id!r} not found")
+
+
+# A ``running`` row older than this is a corpse (worker died mid-run without
+# marking failure) — it must not block sweeps forever.
+STUCK_RUN_MAX_AGE_HOURS = 2
+
+
+def running_sweep_exists() -> bool:
+    """True while a sweep run is genuinely in flight. Corpse rows — running
+    but older than ``STUCK_RUN_MAX_AGE_HOURS`` — don't count (and any real
+    sweep finishes in minutes, not hours)."""
+    cutoff = (
+        datetime.now(UTC) - timedelta(hours=STUCK_RUN_MAX_AGE_HOURS)
+    ).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        row = s.execute(
+            select(DetectionRun.id).where(
+                DetectionRun.trigger == TriggerKind.SWEEP.value,
+                DetectionRun.status == RunStatus.RUNNING.value,
+                DetectionRun.started_at >= cutoff,
+            )
+        ).first()
+        return row is not None
 
 
 def get(run_id: str) -> dict[str, Any] | None:

--- a/backend/tests/test_sweep_singleton.py
+++ b/backend/tests/test_sweep_singleton.py
@@ -1,0 +1,68 @@
+"""Sweep singleton — one whole-space sweep at a time.
+
+Two concurrent sweeps emit the same drafts into the same dedup window and
+double every detector's cost; the guard skips overlap without rate-limiting
+the manual trigger. A stuck ``running`` corpse row (worker died mid-run)
+stops blocking after the age cutoff.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.db.models import DetectionRun
+from app.db.session import session
+from app.wiki import git as wiki_git
+from app.wiki.automanage import runner, runs
+from app.wiki.automanage.detectors.empty_folder import _EmptyFolderDetector
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_config):
+    wiki_git.commit_file("team/plan.md", "# Plan\n", "seed", author=None)
+    wiki_git.commit_file("hollow/.gitkeep", "", "empty", author=None)
+    return tmp_config
+
+
+@pytest.fixture(autouse=True)
+def _eager_detector(monkeypatch):
+    monkeypatch.setattr(runner, "DETECTORS", [_EmptyFolderDetector(min_age_days=0)])
+
+
+def _plant_running_sweep(*, hours_old: float) -> None:
+    started = (datetime.now(UTC) - timedelta(hours=hours_old)).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
+    with session() as s:
+        s.add(
+            DetectionRun(
+                id=f"run_test_{hours_old}",
+                trigger="sweep",
+                status="running",
+                started_at=started,
+            )
+        )
+
+
+def test_second_sweep_is_skipped_while_one_runs(repo):
+    _plant_running_sweep(hours_old=0.1)
+    result = runner.run_sweep(triggered_by_user_id=None)
+    assert result["run_id"] is None
+    assert result["skipped"] == "sweep already running"
+    assert result["proposals_emitted"] == 0
+
+
+def test_stuck_corpse_run_does_not_block_forever(repo):
+    _plant_running_sweep(hours_old=runs.STUCK_RUN_MAX_AGE_HOURS + 1)
+    result = runner.run_sweep(triggered_by_user_id=None)
+    assert result["run_id"] is not None  # corpse ignored, sweep ran
+    assert result["proposals_emitted"] == 1
+
+
+def test_sequential_sweeps_are_not_rate_limited(repo):
+    first = runner.run_sweep(triggered_by_user_id=None)
+    assert first["run_id"] is not None
+    # The first completed; a manual re-trigger right after runs fine.
+    second = runner.run_sweep(triggered_by_user_id=None)
+    assert second["run_id"] is not None


### PR DESCRIPTION
The last Wave 1 item: two concurrent whole-space sweeps emit the same drafts into the same dedup window and double every detector's cost for nothing.

- `run_sweep` skips (with an explicit `skipped` marker in its result) while a sweep run is already in flight — an **overlap guard, not a rate limit**: the manual trigger stays usable and sequential sweeps run back-to-back.
- A stuck `running` corpse row — a worker that died mid-run without marking failure — stops blocking after `STUCK_RUN_MAX_AGE_HOURS` (2h; real sweeps finish in minutes).
- Guard sits at the `run_sweep` chokepoint, so the manual API trigger, both crons, and any future caller inherit it.

Tests: overlap skipped; corpse ignored after the cutoff; sequential sweeps not rate-limited. Suite green; ruff + basedpyright clean.