### PR TITLE
feat(automanage): folder-chain flattening detector (Wave 2)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -6,7 +6,7 @@ the originating conversation for the design rationale.
 
 The first ``asyncio`` in this backend, scoped deliberately: ``async`` here
 covers connection lifecycle only (accept, the recv/send loops, task
-orchestration) — every ``_connect_sync``/``_disconnect_sync``/``_handle_*``
+orchestration) — every ``_connect_sync``/``record_leave``/``_handle_*``
 helper below is a plain sync function, run via ``asyncio.to_thread`` from
 the loops, with no idea it's being called from an async context at all. See
 CLAUDE.md's "WebSocket routes" rule before adding another route like this
@@ -31,7 +31,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
-import threading
 from typing import Any
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -52,6 +51,7 @@ from app.models.coedit import (
     ParticipantOut,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session
+from app.tasks.coedit_leave import leave_coedit_session, record_leave
 from app.wiki import coedit, coedit_channel, git
 
 router = APIRouter()
@@ -73,21 +73,6 @@ def _participants_out(session_id: int) -> list[ParticipantOut]:
         )
         for p in coedit.list_participants(session_id)
     ]
-
-
-def _checkpoint_if_last_left(session_id: int) -> None:
-    """Enqueue a final checkpoint when the last participant has left, so the
-    session's buffer lands in git without waiting for the periodic scan.
-
-    Best-effort: the participant row is already gone, so a failed enqueue (e.g.
-    a full queue) must not fail the leave. The periodic scan is the backstop —
-    the session is dirty, so it's recovered (checkpointed + closed) once idle."""
-    if coedit.list_participants(session_id):
-        return
-    try:
-        checkpoint_coedit_session(session_id)
-    except Exception:
-        log.exception("coedit: checkpoint enqueue failed on last-leave for session %s", session_id)
 
 
 class _WsActionError(Exception):
@@ -324,15 +309,6 @@ def _connect_sync(path: str, user: User) -> coedit.SessionRow:
     return sess
 
 
-def _disconnect_sync(session_id: int, user_id: str) -> None:
-    # Only mark the user gone when their last connection closes, so a
-    # second tab doesn't evict them.
-    if not coedit_channel.user_still_connected(session_id, user_id):
-        coedit.leave(session_id, user_id)
-        coedit_channel.broadcast_presence(session_id)
-        _checkpoint_if_last_left(session_id)
-
-
 @router.websocket("/ws")
 async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_ws)) -> None:
     """``path`` is a query param (``?path=...``), not a URL segment — this
@@ -351,7 +327,7 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     # before returning, so from here on a disconnect — including one during
     # `accept()` itself, which the client can trigger mid-handshake since
     # `_connect_sync`'s git/DB work takes measurable time — must still reach
-    # `_disconnect_sync` to undo it. Otherwise the user is stuck as a
+    # `record_leave` to undo it. Otherwise the user is stuck as a
     # phantom participant forever, which also blocks
     # `_checkpoint_if_last_left` from ever firing for this session.
     conn: coedit_channel.Connection | None = None
@@ -394,23 +370,23 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     finally:
         if conn is not None:
             coedit_channel.disconnect(conn.id)
-        # The disconnect handler IS the leave signal (no client message), so
-        # it must survive this task being *cancelled* — server shutdown, or
-        # the test portal tearing down the connection. Inside a cancelled
-        # task every `await` re-raises CancelledError instead of completing,
-        # which silently drops the leave: a phantom participant forever, and
-        # a dirty buffer that never gets its last-leave checkpoint. Detect
-        # the in-flight cancellation up front and hand the leave to a plain
-        # thread no cancellation can touch; the normal disconnect path keeps
-        # awaiting so the leave is recorded before the handler returns.
-        task = asyncio.current_task()
-        if task is not None and task.cancelling():
-            threading.Thread(
-                target=_disconnect_sync,
-                args=(sess.id, user.id),
-                name=f"coedit-leave-{sess.id}",
-                daemon=False,
-            ).start()
-        else:
-            await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
+        # The leave must survive this task being cancelled (server shutdown;
+        # the test portal tearing down the connection). A cancelled `await`
+        # is not enough: the executor item it submitted can be *discarded*
+        # before any pool worker picks it up — cancelling a not-yet-started
+        # future removes it from the queue — and the cancellation can land at
+        # any moment, so no up-front check closes the window. On that path,
+        # hand the leave to the coedit queue instead: a synchronous enqueue
+        # nothing can cancel, durable across the shutdown that caused it.
+        # `record_leave` is idempotent, so the rare both-ran overlap is safe.
+        try:
+            await asyncio.to_thread(record_leave, sess.id, user.id)
+        except asyncio.CancelledError:
+            try:
+                leave_coedit_session(sess.id, user.id)  # enqueue, no await
+            except Exception:
+                log.exception(
+                    "coedit: queued-leave fallback failed for session %s", sess.id
+                )
+            raise
         log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
+import threading
 from typing import Any
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -393,5 +394,23 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     finally:
         if conn is not None:
             coedit_channel.disconnect(conn.id)
-        await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
+        # The disconnect handler IS the leave signal (no client message), so
+        # it must survive this task being *cancelled* — server shutdown, or
+        # the test portal tearing down the connection. Inside a cancelled
+        # task every `await` re-raises CancelledError instead of completing,
+        # which silently drops the leave: a phantom participant forever, and
+        # a dirty buffer that never gets its last-leave checkpoint. Detect
+        # the in-flight cancellation up front and hand the leave to a plain
+        # thread no cancellation can touch; the normal disconnect path keeps
+        # awaiting so the leave is recorded before the handler returns.
+        task = asyncio.current_task()
+        if task is not None and task.cancelling():
+            threading.Thread(
+                target=_disconnect_sync,
+                args=(sess.id, user.id),
+                name=f"coedit-leave-{sess.id}",
+                daemon=False,
+            ).start()
+        else:
+            await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
         log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/tasks/coedit_leave.py
+++ b/backend/app/tasks/coedit_leave.py
@@ -1,0 +1,60 @@
+"""Recording a participant's leave — shared logic + the queued fallback.
+
+The WS disconnect handler is the *only* leave signal (there is no client
+leave message). Normally the endpoint's ``finally`` awaits
+:func:`record_leave` on a thread and the leave is recorded before the
+handler returns. But when the endpoint task is being **cancelled** (server
+shutdown; the test portal tearing down a connection), an awaited executor
+item can be discarded before any pool worker picks it up — cancelling a
+not-yet-started future removes it from the executor queue — and the leave
+would silently never run: a phantom participant forever, and a dirty buffer
+that never gets its last-leave checkpoint. For that path the handler
+enqueues :func:`leave_coedit_session` instead: a synchronous Redis send that
+no cancellation can touch, durable across the shutdown that caused it.
+
+``record_leave`` is idempotent on purpose — cancellation can land *after*
+the awaited executor item was already picked up, so the queued fallback may
+be a second run: the participant delete is delete-if-exists, the presence
+broadcast is harmless, and the checkpoint no-ops on a clean buffer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.tasks.coedit_checkpoint import checkpoint_coedit_session
+from app.tasks.queues import coedit_queue
+from app.wiki import coedit, coedit_channel
+
+log = logging.getLogger(__name__)
+
+
+def record_leave(session_id: int, user_id: str) -> None:
+    """Mark ``user_id`` gone from ``session_id`` and checkpoint if they were
+    the last one out. Only acts when their last connection has closed, so a
+    second tab doesn't evict them. Idempotent (see module docstring)."""
+    if coedit_channel.user_still_connected(session_id, user_id):
+        return
+    coedit.leave(session_id, user_id)
+    coedit_channel.broadcast_presence(session_id)
+    if coedit.list_participants(session_id):
+        return
+    # Best-effort: the participant row is already gone, so a failed enqueue
+    # (e.g. a full queue) must not fail the leave. The periodic scan is the
+    # backstop — the session is dirty, so it's recovered once idle.
+    try:
+        checkpoint_coedit_session(session_id)
+    except Exception:
+        log.exception(
+            "coedit: checkpoint enqueue failed on last-leave for session %s",
+            session_id,
+        )
+
+
+@coedit_queue.task()
+def leave_coedit_session(session_id: int, user_id: str) -> None:
+    """Queued leave — the WS handler's fallback when its own task is being
+    cancelled. On a worker the channel registry is empty, so the
+    still-connected guard in :func:`record_leave` never mistakes another
+    process's connections for this user's."""
+    record_leave(session_id, user_id)

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -43,6 +43,7 @@ _TASK_MODULES = (
     "app.tasks.chat_title",
     "app.tasks.automanage",
     "app.tasks.coedit_checkpoint",
+    "app.tasks.coedit_leave",
     "app.tasks.coedit_rebase",
     "app.tasks.craft",
     "app.tasks.wiki_update",

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -11,6 +11,7 @@ from app.wiki.automanage.detectors import (
     body_dup,
     case_collision,
     empty_folder,
+    folder_chain,
     template_echo,
 )
 from app.wiki.automanage.detectors.base import (
@@ -25,6 +26,7 @@ DETECTORS: list[Detector] = [
     body_dup.DETECTOR,
     template_echo.DETECTOR,
     case_collision.DETECTOR,
+    folder_chain.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/folder_chain.py
+++ b/backend/app/wiki/automanage/detectors/folder_chain.py
@@ -1,0 +1,229 @@
+"""Single-child folder-chain flattening detector — mechanical, no LLM.
+
+A **chain** is a run of folders that each contain exactly one thing: the next
+folder (a ``.gitkeep`` marker alongside it doesn't count). The chain's
+**tail** is the first folder with real content — pages, or branching
+subfolders. Every level between the head and the tail is a pass-through that
+adds a click and a path segment but no organization; the proposal flattens
+them by moving the tail's pages up into the chain head, preserving the
+structure *below* the tail (``head/link/tail/sub/x.md`` → ``head/sub/x.md``).
+
+Division of labor with the other mechanics:
+
+- The applier only **moves pages** (never edits bodies — the executor's
+  move-must-preserve-content rail holds it to that). The emptied wrapper
+  folders keep their ``.gitkeep`` markers and are left behind on purpose:
+  the empty-folder detector proposes their deletion on a later pass, after
+  its own grace window. Detectors compose through wiki state, not through
+  each other.
+- An entirely empty chain (no pages anywhere) is the empty-folder detector's
+  case, not this one's — the tail here must hold at least one page.
+
+``source_paths`` carries the chain folders themselves (head first, tail
+last) ahead of the page paths: the folders are the subject of the operation,
+they widen the applier's path scope to the wrappers, and they let
+``validate`` re-derive the chain without guessing it back out of the page
+paths. ``target_paths`` is the destination page paths, index-aligned with
+the page sources.
+
+Never auto-approvable: which folder name survives a flatten is naming
+judgment (the head's name wins here), so a human confirms it even in an
+AI-managed scope.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.wiki import git
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# Grace window on the chain head's last activity: a structure someone is
+# actively building (this month's folder just went in; pages are landing)
+# shouldn't be proposed for flattening the moment it looks redundant.
+FOLDER_CHAIN_MIN_AGE_DAYS = 7
+
+_GITKEEP = ".gitkeep"
+
+
+class _Tree:
+    """Direct-children view of a tracked-file list, for chain walking."""
+
+    def __init__(self, paths: list[str]) -> None:
+        self.subdirs: dict[str, set[str]] = defaultdict(set)
+        self.plain_files: dict[str, set[str]] = defaultdict(set)
+        for p in paths:
+            parts = p.split("/")
+            for i in range(1, len(parts)):
+                self.subdirs["/".join(parts[: i - 1])].add("/".join(parts[:i]))
+            if parts[-1] != _GITKEEP:
+                self.plain_files["/".join(parts[:-1])].add(p)
+
+    def is_link(self, folder: str) -> bool:
+        """A pass-through level: exactly one subfolder, no direct files
+        besides a ``.gitkeep``. The root (``""``) is never a link — there is
+        no level above it to flatten into."""
+        return (
+            folder != ""
+            and len(self.subdirs.get(folder, ())) == 1
+            and not self.plain_files.get(folder)
+        )
+
+    def walk_chain(self, head: str) -> str | None:
+        """Follow single-child links from ``head`` down to the tail — the
+        first descendant that isn't a link. None if ``head`` isn't a link."""
+        if not self.is_link(head):
+            return None
+        cur = head
+        while self.is_link(cur):
+            (cur,) = self.subdirs[cur]
+        return cur
+
+
+def _parent_dir(folder: str) -> str:
+    return folder.rsplit("/", 1)[0] if "/" in folder else ""
+
+
+def _chain_dirs(head: str, tail: str) -> list[str]:
+    """The chain's folder levels, head first, tail last:
+    ``("a", "a/b/c")`` → ``["a", "a/b", "a/b/c"]``."""
+    parts = tail.split("/")
+    depth = len(head.split("/"))
+    return ["/".join(parts[:i]) for i in range(depth, len(parts) + 1)]
+
+
+def _old_enough(head: str, now: datetime, min_age_days: int) -> bool:
+    """Last activity anywhere under ``head`` is older than the grace window.
+    Missing/unparseable history fails closed (not old enough)."""
+    meta = git.last_commit_meta_for_path(head)
+    if meta is None:
+        return False
+    try:
+        ts = datetime.fromisoformat(meta[2])
+    except ValueError:
+        log.warning("folder-chain: unparseable commit ts %r for %r", meta[2], head)
+        return False
+    return now - ts >= timedelta(days=min_age_days)
+
+
+def _plan_moves(
+    head: str, tail: str, tree: _Tree, taken_lower: set[str]
+) -> tuple[list[str], list[str]] | None:
+    """The concrete page moves for flattening ``tail`` into ``head``, or None
+    when the chain isn't safely flattenable: non-page content under the tail
+    (folder-scoped triggers, attachments — moving those is out of scope), or
+    a destination that isn't free (judged case-insensitively so a flatten
+    can't manufacture a case collision — e.g. a tail subfolder named like a
+    chain link)."""
+    pages: list[str] = []
+    stack = [tail]
+    while stack:
+        d = stack.pop()
+        for f in sorted(tree.plain_files.get(d, ())):
+            if not f.endswith(".md"):
+                return None
+            pages.append(f)
+        stack.extend(tree.subdirs.get(d, ()))
+    if not pages:
+        return None  # empty chain — the empty-folder detector's case
+    pages.sort()
+    dests = [f"{head}/{p[len(tail) + 1 :]}" for p in pages]
+    if any(d.lower() in taken_lower for d in dests):
+        return None
+    return pages, dests
+
+
+class _FolderChainDetector:
+    name = "folder_chain"
+    pairs_paths = False  # subtree op; sees the whole scope
+
+    def __init__(self, *, min_age_days: int = FOLDER_CHAIN_MIN_AGE_DAYS) -> None:
+        self.min_age_days = min_age_days
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        # A delete or move can leave a folder single-child; a page create
+        # never removes a sibling, so only sweeps and writes can surface one.
+        return trigger in (TriggerKind.SWEEP, TriggerKind.ON_WRITE)
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        if not self.applicable(scope.trigger):
+            return []
+        tree = _Tree(list(scope.paths))
+        taken_lower = {p.lower() for p in scope.paths}
+        now = datetime.now(UTC)
+        drafts: list[ProposalDraft] = []
+        accepted_tails: list[str] = []
+        # Maximal heads (parent isn't itself a link), shallowest first; a
+        # chain nested inside an accepted chain's tail is skipped — the outer
+        # flatten recreates it under the head, and a later pass re-detects it.
+        heads = sorted(
+            (f for f in tree.subdirs if tree.is_link(f) and not tree.is_link(_parent_dir(f))),
+            key=lambda f: (f.count("/"), f),
+        )
+        for head in heads:
+            if any(head.startswith(t + "/") for t in accepted_tails):
+                continue
+            tail = tree.walk_chain(head)
+            if tail is None:
+                continue
+            plan = _plan_moves(head, tail, tree, taken_lower)
+            if plan is None:
+                continue
+            if not _old_enough(head, now, self.min_age_days):
+                continue
+            pages, dests = plan
+            accepted_tails.append(tail)
+            moves = "\n".join(f"- “{s}” → “{d}”" for s, d in zip(pages, dests))
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.MOVE,
+                    source_paths=_chain_dirs(head, tail) + pages,
+                    target_paths=dests,
+                    summary=(
+                        f"Flatten single-child folder chain “{tail}” into "
+                        f"“{head}” ({len(pages)} page{'s' if len(pages) != 1 else ''})"
+                    ),
+                    instruction=(
+                        f"Folder “{head}” contains nothing but the single-child "
+                        f"folder chain down to “{tail}”. Flatten it: move each "
+                        f"page with move_page, exactly as listed —\n{moves}\n"
+                        "Do not edit any page body. Leave the emptied wrapper "
+                        "folders and their .gitkeep markers in place — a "
+                        "separate cleanup removes empty folders."
+                    ),
+                    auto_approvable=False,
+                )
+            )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """Premise: the chain still looks exactly as proposed — same links,
+        same tail, the same page set under it (a page added since would be
+        stranded half-flattened), and every destination still free. Body
+        edits to the pages don't break the premise; moves stay content-
+        preserving."""
+        folders = [s for s in proposal["source_paths"] if not s.endswith(".md")]
+        pages = [s for s in proposal["source_paths"] if s.endswith(".md")]
+        if not folders:
+            return "proposal is missing its chain folders"
+        head, tail = min(folders, key=len), max(folders, key=len)
+        tracked = list(git.list_paths())
+        tree = _Tree(tracked)
+        if tree.walk_chain(head) != tail:
+            return f"“{head}” is no longer a single-child chain down to “{tail}”"
+        current = {p for p in git.list_paths(tail) if not p.endswith("/" + _GITKEEP)}
+        if current != set(pages):
+            return f"the pages under “{tail}” changed since this was proposed"
+        taken_lower = {p.lower() for p in tracked}
+        occupied = [t for t in proposal["target_paths"] if t.lower() in taken_lower]
+        if occupied:
+            return f"destination already exists: {occupied[0]!r}"
+        return None
+
+
+DETECTOR = _FolderChainDetector()

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -53,6 +53,7 @@ SUPPORTED_OPS: frozenset[str] = frozenset(
         ProposalOp.MERGE.value,
         ProposalOp.DELETE_PAGE.value,
         ProposalOp.RENAME.value,
+        ProposalOp.MOVE.value,
     }
 )
 

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -25,6 +25,7 @@ import logging
 from typing import Any
 
 from app.auth import users
+from app.db import fts
 from app.db.models import Event
 from app.db.session import session
 from app.llm.agents import automanage_apply
@@ -172,24 +173,61 @@ def _scope_violations(base_sha: str, allowed: frozenset[str]) -> list[str]:
     return out
 
 
+def _moves_made(
+    source_paths: list[str], path_ids: dict[str, str]
+) -> list[PathMove]:
+    """The moves the run actually performed, recovered from the pre-minted
+    doc ids *before* the revert: a source whose id row is live at a different
+    path was moved there. This is what lets the revert replay the move
+    fan-out in reverse instead of hand-unwinding each metadata table."""
+    out: list[PathMove] = []
+    for s in source_paths:
+        sid = path_ids.get(s)
+        row = doc_ids.get(sid) if sid else None
+        if (
+            row is not None
+            and row["deleted_at"] is None
+            and row["path"] not in (s, None)
+        ):
+            out.append(PathMove(old=str(row["path"]), new=s))
+    return out
+
+
 def _reconverge_after_revert(
-    allowed: frozenset[str], reverted_sha: str, author: str | None
+    allowed: frozenset[str],
+    reverted_sha: str,
+    author: str | None,
+    *,
+    reversed_moves: list[PathMove],
 ) -> None:
     """Re-converge path-keyed metadata after an additive revert.
 
-    The revert restored file *content*; metadata mutated through the run's
-    lifecycle hooks (id tombstones/forwards, search index) needs pulling back
-    for the proposal's paths: restored ids re-bind (clearing any forward) and
-    live pages re-index. ACL/policy rows re-pointed toward now-removed trash
-    copies are left as orphans — the known-debris class the move machinery
-    already heals on collision."""
+    The revert restored file *content*; everything the run's lifecycle hooks
+    re-pointed needs pulling back:
+
+    - ``reversed_moves`` (destination → source, captured pre-revert) replay
+      through ``notify.after_path_move`` — the same chokepoint the forward
+      move used — so ACL/owner rows, update policies, doc ids, co-edit
+      sessions, comments, the trigger cache, and the search index all follow
+      the page back instead of stranding on a path the revert removed.
+    - Restored ids re-bind (clearing any forward) and live pages re-index.
+    - Any allowed page that is *not* live after the revert (a freshly written
+      destination the revert deleted — not a move) gets its search entry
+      purged; ACL/policy orphans there are the known-debris class the move
+      machinery already heals on collision."""
+    for mv in reversed_moves:
+        notify.after_path_move([mv], reverted_sha, author, root_move=mv)
     live = set(git.list_paths())
     doc_ids.on_restored([path for path in sorted(allowed) if path in live])
     for path in sorted(allowed):
-        if path in live and path.endswith(".md"):
+        if not path.endswith(".md"):
+            continue
+        if path in live:
             notify.after_doc_write(
                 path, reverted_sha, ChangeKind.EDIT, author
             )
+        else:
+            fts.delete_document(path)
 
 
 def _execute_agentic(p: dict[str, Any]) -> None:
@@ -259,13 +297,16 @@ def _execute_agentic(p: dict[str, Any]) -> None:
                         f"move must preserve content: {s} -> {row['path']}"
                     ]
     if violations or not outcome.ok:
+        reversed_moves = _moves_made(p["source_paths"], path_ids)
         reverted = git.revert_to(
             base_sha,
             f"automanage: revert rejected execution of proposal {proposal_id}",
             author=author,
         )
         if reverted is not None:
-            _reconverge_after_revert(allowed, reverted, author)
+            _reconverge_after_revert(
+                allowed, reverted, author, reversed_moves=reversed_moves
+            )
         reason = (
             f"execution touched out-of-scope paths: {violations}"
             if violations

--- a/backend/tests/test_agentic_executor.py
+++ b/backend/tests/test_agentic_executor.py
@@ -337,3 +337,58 @@ def test_post_run_catches_unforwarded_source_removal(repo, monkeypatch):
     assert p is not None and p["status"] == "stale"
     assert "without identity forward" in (p["status_reason"] or "")
     assert wiki_git.read_file_opt("docs/dup.md") is not None  # reverted back
+
+
+def test_revert_replays_a_completed_move_in_reverse(repo, monkeypatch):
+    """A run that lands one move and then fails must not strand the move's
+    metadata fan-out: the revert replays ``after_path_move`` in reverse, so
+    the doc id, owner row, and search index all point at the source again
+    and nothing references the removed destination."""
+    from app.db import fts
+    from app.tasks.queues import lightweight_maintenance_queue
+
+    wiki_git.commit_file("wrap/inner/a.md", "# A\n\nBody.\n", "seed", author=None)
+    owner = seed_user(uid="own", email="own@x.com")
+    acl.set_owner("wrap/inner/a.md", owner)
+    pid = create(
+        op=ProposalOp.MOVE,
+        source_paths=["wrap", "wrap/inner", "wrap/inner/a.md"],
+        target_paths=["wrap/a.md"],
+        base_shas={"wrap/inner/a.md": "0" * 40},
+        summary="Flatten “wrap/inner” into “wrap”",
+        created_via=ProposalCreatedVia.SWEEP,
+    )["id"]
+    assert auto_approve(pid, acting_user_id=AI_USER_ID)
+    page_id = doc_ids.get_or_mint("wrap/inner/a.md")
+
+    _script(
+        monkeypatch,
+        [
+            # The move itself succeeds…
+            CompletionResult(
+                tool_calls=[
+                    _tc("move_page", source="wrap/inner/a.md", dest="wrap/a.md")
+                ]
+            ),
+            # …then the model gives up, forcing the revert path with the
+            # move's fan-out (id re-key, owner re-point, FTS) already applied.
+            CompletionResult(text="CANNOT APPLY: cannot finish"),
+        ],
+    )
+    # Immediate mode so the queued reindex tasks run inline — the FTS
+    # assertions below check real index state, not queue contents.
+    with lightweight_maintenance_queue.immediate_mode():
+        executor.execute(pid)
+
+    p = get(pid)
+    assert p is not None and p["status"] == "stale"
+    assert wiki_git.read_file("wrap/inner/a.md") == "# A\n\nBody.\n"  # restored
+    assert "wrap/a.md" not in wiki_git.list_paths()
+    row = doc_ids.get(page_id)
+    assert row is not None and row["path"] == "wrap/inner/a.md"  # id re-keyed back
+    assert row["deleted_at"] is None
+    assert acl.get_owner("wrap/inner/a.md") == owner  # owner row followed back
+    assert acl.get_owner("wrap/a.md") is None
+    hit_paths = {h.path for h in fts.search("Body", is_admin=True)}
+    assert "wrap/inner/a.md" in hit_paths  # source re-indexed
+    assert "wrap/a.md" not in hit_paths  # no search hit on a removed page

--- a/backend/tests/test_agentic_executor.py
+++ b/backend/tests/test_agentic_executor.py
@@ -19,7 +19,9 @@ from typing import Any
 import pytest
 
 from app.auth.users import AI_USER_ID
+from app.db import fts
 from app.llm.client import CompletionResult, ToolCall
+from app.tasks.queues import lightweight_maintenance_queue
 from app.wiki import acl, doc_ids
 from app.wiki import git as wiki_git
 from app.llm.agents import automanage_apply
@@ -32,6 +34,7 @@ from app.wiki.change_proposals import (
     get,
 )
 from tests._seed import list_events, seed_user
+from tests.conftest import needs_opensearch
 
 
 @pytest.fixture
@@ -339,14 +342,11 @@ def test_post_run_catches_unforwarded_source_removal(repo, monkeypatch):
     assert wiki_git.read_file_opt("docs/dup.md") is not None  # reverted back
 
 
-def test_revert_replays_a_completed_move_in_reverse(repo, monkeypatch):
-    """A run that lands one move and then fails must not strand the move's
-    metadata fan-out: the revert replays ``after_path_move`` in reverse, so
-    the doc id, owner row, and search index all point at the source again
-    and nothing references the removed destination."""
-    from app.db import fts
-    from app.tasks.queues import lightweight_maintenance_queue
-
+def _run_reverted_move(monkeypatch) -> tuple[int, str, str]:
+    """Shared setup for the reverse-replay tests: a scripted run lands one
+    move, then gives up — forcing the revert path with the move's fan-out
+    (id re-key, owner re-point, FTS) already applied. Returns
+    ``(proposal_id, page_doc_id, owner_user_id)``."""
     wiki_git.commit_file("wrap/inner/a.md", "# A\n\nBody.\n", "seed", author=None)
     owner = seed_user(uid="own", email="own@x.com")
     acl.set_owner("wrap/inner/a.md", owner)
@@ -370,15 +370,23 @@ def test_revert_replays_a_completed_move_in_reverse(repo, monkeypatch):
                     _tc("move_page", source="wrap/inner/a.md", dest="wrap/a.md")
                 ]
             ),
-            # …then the model gives up, forcing the revert path with the
-            # move's fan-out (id re-key, owner re-point, FTS) already applied.
+            # …then the model gives up.
             CompletionResult(text="CANNOT APPLY: cannot finish"),
         ],
     )
     # Immediate mode so the queued reindex tasks run inline — the FTS
-    # assertions below check real index state, not queue contents.
+    # companion test checks real index state, not queue contents.
     with lightweight_maintenance_queue.immediate_mode():
         executor.execute(pid)
+    return pid, page_id, owner
+
+
+def test_revert_replays_a_completed_move_in_reverse(repo, monkeypatch):
+    """A run that lands one move and then fails must not strand the move's
+    metadata fan-out: the revert replays ``after_path_move`` in reverse, so
+    the doc id and owner row point at the source again and nothing
+    references the removed destination."""
+    pid, page_id, owner = _run_reverted_move(monkeypatch)
 
     p = get(pid)
     assert p is not None and p["status"] == "stale"
@@ -389,6 +397,14 @@ def test_revert_replays_a_completed_move_in_reverse(repo, monkeypatch):
     assert row["deleted_at"] is None
     assert acl.get_owner("wrap/inner/a.md") == owner  # owner row followed back
     assert acl.get_owner("wrap/a.md") is None
+
+
+@needs_opensearch
+def test_revert_replay_reconverges_the_search_index(repo, monkeypatch):
+    """The reverse replay's FTS leg: the source is re-indexed and the removed
+    destination yields no search hit."""
+    _run_reverted_move(monkeypatch)
+
     hit_paths = {h.path for h in fts.search("Body", is_admin=True)}
     assert "wrap/inner/a.md" in hit_paths  # source re-indexed
     assert "wrap/a.md" not in hit_paths  # no search hit on a removed page

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,6 +9,7 @@ shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
+import logging
 import time
 from contextlib import contextmanager
 
@@ -197,7 +198,10 @@ def test_disconnect_removes_participant(client):
     assert coedit.list_participants(sid) == []
 
 
-def test_disconnect_of_last_participant_checkpoints(client):
+def test_disconnect_of_last_participant_checkpoints(client, caplog):
+    # INFO so a failure's captured logs include the disconnect handler's
+    # own trace ("coedit ws closed", "checkpoint enqueue failed", ...).
+    caplog.set_level(logging.INFO)
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")
@@ -211,15 +215,20 @@ def test_disconnect_of_last_participant_checkpoints(client):
         # thread, and websocket_connect's __exit__ doesn't guarantee it has
         # run yet. Wait for it *inside* immediate_mode: once the flag drops,
         # a late enqueue would go to the real queue and never run here.
-        deadline = time.monotonic() + 5
+        deadline = time.monotonic() + 15
         while (
             git.read_file(_PATH) != "hi world"
             or coedit.get_active_session(_PATH) is not None
         ) and time.monotonic() < deadline:
             time.sleep(0.02)
 
-    assert git.read_file(_PATH) == "hi world"
-    assert coedit.get_active_session(_PATH) is None
+    session_after = coedit.get_active_session(_PATH)
+    assert git.read_file(_PATH) == "hi world", (
+        "checkpoint never landed: "
+        f"session={'still open' if session_after else 'closed'}, "
+        f"participants={coedit.list_participants(sid)}"
+    )
+    assert session_after is None
     assert sid is not None
 
 

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,6 +9,7 @@ shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
+import time
 from contextlib import contextmanager
 
 import pytest
@@ -205,8 +206,17 @@ def test_disconnect_of_last_participant_checkpoints(client):
         with _ws(client) as (ws, joined):
             sid = joined["session_id"]
             _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
-        # The disconnect handler enqueues a checkpoint; immediate_mode runs
-        # it inline before websocket_connect's __exit__ returns.
+        # The disconnect handler enqueues the checkpoint, and immediate_mode
+        # runs it inline — but the handler is the server's `finally` on a
+        # thread, and websocket_connect's __exit__ doesn't guarantee it has
+        # run yet. Wait for it *inside* immediate_mode: once the flag drops,
+        # a late enqueue would go to the real queue and never run here.
+        deadline = time.monotonic() + 5
+        while (
+            git.read_file(_PATH) != "hi world"
+            or coedit.get_active_session(_PATH) is not None
+        ) and time.monotonic() < deadline:
+            time.sleep(0.02)
 
     assert git.read_file(_PATH) == "hi world"
     assert coedit.get_active_session(_PATH) is None

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -201,11 +201,14 @@ def test_disconnect_removes_participant(client):
     login_fastapi(client, uid)
     _seed_page()
 
-    with _ws(client) as (_ws_conn, joined):
-        sid = joined["session_id"]
-        assert len(coedit.list_participants(sid)) == 1
+    # immediate_mode: if teardown takes the cancellation path, the leave is
+    # enqueued — inline mode runs it here instead of on a worker.
+    with coedit_queue.immediate_mode():
+        with _ws(client) as (_ws_conn, joined):
+            sid = joined["session_id"]
+            assert len(coedit.list_participants(sid)) == 1
 
-    _wait_for(lambda: coedit.list_participants(sid) == [])
+        _wait_for(lambda: coedit.list_participants(sid) == [])
     assert coedit.list_participants(sid) == []
 
 

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,7 +9,6 @@ shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
-import logging
 import time
 from contextlib import contextmanager
 
@@ -86,6 +85,17 @@ def _checkpoint(ws) -> dict:
 def _get_ops(ws, since_version: int) -> dict:
     ws.send_json({"type": "get_ops", "request_id": "g", "since_version": since_version})
     return _receive_typed(ws, "ops_result")
+
+
+def _wait_for(predicate, timeout: float = 15.0) -> None:
+    """Wait for a disconnect side effect. The server's disconnect handler is
+    the leave signal, and nothing guarantees it has finished by the time
+    ``websocket_connect.__exit__`` returns — the handler runs on the app's
+    event loop/threads on its own schedule. Tests observe its *effects*, so
+    they must wait for them, not assume an ordering the API doesn't offer."""
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        time.sleep(0.02)
 
 
 def test_connect_requires_auth(client):
@@ -195,13 +205,11 @@ def test_disconnect_removes_participant(client):
         sid = joined["session_id"]
         assert len(coedit.list_participants(sid)) == 1
 
+    _wait_for(lambda: coedit.list_participants(sid) == [])
     assert coedit.list_participants(sid) == []
 
 
-def test_disconnect_of_last_participant_checkpoints(client, caplog):
-    # INFO so a failure's captured logs include the disconnect handler's
-    # own trace ("coedit ws closed", "checkpoint enqueue failed", ...).
-    caplog.set_level(logging.INFO)
+def test_disconnect_of_last_participant_checkpoints(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")
@@ -210,17 +218,13 @@ def test_disconnect_of_last_participant_checkpoints(client, caplog):
         with _ws(client) as (ws, joined):
             sid = joined["session_id"]
             _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
-        # The disconnect handler enqueues the checkpoint, and immediate_mode
-        # runs it inline — but the handler is the server's `finally` on a
-        # thread, and websocket_connect's __exit__ doesn't guarantee it has
-        # run yet. Wait for it *inside* immediate_mode: once the flag drops,
-        # a late enqueue would go to the real queue and never run here.
-        deadline = time.monotonic() + 15
-        while (
-            git.read_file(_PATH) != "hi world"
-            or coedit.get_active_session(_PATH) is not None
-        ) and time.monotonic() < deadline:
-            time.sleep(0.02)
+        # The disconnect handler enqueues the checkpoint; immediate_mode runs
+        # it inline wherever the handler executes. Wait *inside* the block:
+        # once the flag drops, a late enqueue would go to the real queue.
+        _wait_for(
+            lambda: git.read_file(_PATH) == "hi world"
+            and coedit.get_active_session(_PATH) is None
+        )
 
     session_after = coedit.get_active_session(_PATH)
     assert git.read_file(_PATH) == "hi world", (

--- a/backend/tests/test_folder_chain_detector.py
+++ b/backend/tests/test_folder_chain_detector.py
@@ -1,0 +1,165 @@
+"""Single-child folder-chain flattening detector.
+
+Detection is pure over the scope's tracked-file list (age gate aside): a run
+of folders each holding exactly one subfolder flattens by moving the tail's
+pages up into the chain head, structure below the tail preserved. Wrapper
+``.gitkeep`` markers stay behind for the empty-folder detector.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.wiki import git as wiki_git
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.folder_chain import _FolderChainDetector
+
+_BODY = "# Page\n\ncontent\n"
+
+
+@pytest.fixture
+def repo(tmp_repo):
+    return tmp_repo
+
+
+def _detect(*paths: str, trigger: TriggerKind = TriggerKind.SWEEP):
+    # min_age_days=0 so tests exercise structure, not the grace window.
+    det = _FolderChainDetector(min_age_days=0)
+    return det.detect(Scope(trigger=trigger, paths=tuple(paths)))
+
+
+def _seed(*paths: str) -> None:
+    for p in paths:
+        body = "" if p.endswith(".gitkeep") else _BODY
+        wiki_git.commit_file(p, body, "seed", author=None)
+
+
+def test_two_level_chain_flattens_into_head(repo):
+    _seed("wrap/.gitkeep", "wrap/inner/a.md", "wrap/inner/b.md", "other/x.md")
+
+    drafts = _detect(
+        "wrap/.gitkeep", "wrap/inner/a.md", "wrap/inner/b.md", "other/x.md"
+    )
+
+    assert len(drafts) == 1
+    d = drafts[0]
+    assert d.op.value == "move"
+    # Chain folders first (head → tail), then the pages, index-aligned dests.
+    assert d.source_paths == ["wrap", "wrap/inner", "wrap/inner/a.md", "wrap/inner/b.md"]
+    assert d.target_paths == ["wrap/a.md", "wrap/b.md"]
+    assert d.auto_approvable is False  # surviving name is naming judgment
+    assert d.instruction and "move_page" in d.instruction
+
+
+def test_multi_level_chain_collapses_to_one_proposal(repo):
+    paths = ("a/b/c/x.md", "a/b/c/sub/y.md")
+    _seed(*paths)
+
+    drafts = _detect(*paths)
+
+    assert len(drafts) == 1
+    d = drafts[0]
+    assert d.source_paths == ["a", "a/b", "a/b/c", "a/b/c/sub/y.md", "a/b/c/x.md"]
+    # Structure below the tail is preserved.
+    assert d.target_paths == ["a/sub/y.md", "a/x.md"]
+
+
+def test_branching_folder_is_not_a_chain(repo):
+    paths = ("a/b/x.md", "a/c/y.md", "a/z.md")
+    _seed(*paths)
+    assert _detect(*paths) == []
+
+
+def test_empty_chain_is_left_to_the_empty_folder_detector(repo):
+    paths = ("a/b/.gitkeep",)
+    _seed(*paths)
+    assert _detect(*paths) == []
+
+
+def test_non_page_content_under_the_tail_skips_the_chain(repo):
+    paths = ("a/b/x.md", "a/b/.trigger_t1.yaml")
+    _seed(*paths)
+    assert _detect(*paths) == []
+
+
+def test_occupied_destination_skips_the_chain(repo):
+    # `A/x.md` differs from the destination `a/x.md` only by case — flattening
+    # would manufacture a case collision, so the chain is skipped.
+    paths = ("a/b/x.md", "A/x.md")
+    assert _detect(*paths) == []
+
+
+def test_nested_chain_inside_an_accepted_tail_is_skipped(repo):
+    # Outer chain a→b (tail b holds a page and the inner chain c→d). One
+    # proposal: the outer flatten; the recreated inner chain waits for a
+    # later pass.
+    paths = ("a/b/x.md", "a/b/c/d/y.md")
+    _seed(*paths)
+
+    drafts = _detect(*paths)
+
+    assert len(drafts) == 1
+    assert drafts[0].source_paths[:2] == ["a", "a/b"]
+    assert drafts[0].target_paths == ["a/c/d/y.md", "a/x.md"]
+
+
+def test_young_chain_is_left_alone(repo):
+    paths = ("wrap/inner/a.md",)
+    _seed(*paths)
+    det = _FolderChainDetector(min_age_days=7)  # seeded moments ago
+    assert det.detect(Scope(trigger=TriggerKind.SWEEP, paths=paths)) == []
+
+
+def test_on_create_trigger_is_not_applicable(repo):
+    paths = ("wrap/inner/a.md",)
+    _seed(*paths)
+    assert _detect(*paths, trigger=TriggerKind.ON_CREATE) == []
+
+
+def _proposal(drafts: list[Any]) -> dict[str, Any]:
+    d = drafts[0]
+    return {"source_paths": d.source_paths, "target_paths": d.target_paths}
+
+
+def test_validate_survives_a_body_edit(repo):
+    _seed("wrap/inner/a.md")
+    p = _proposal(_detect("wrap/inner/a.md"))
+
+    wiki_git.commit_file("wrap/inner/a.md", "# Edited\n", "edit", author=None)
+
+    # Premise-based: an edit doesn't break "the chain is redundant".
+    assert _FolderChainDetector().validate(p) is None
+
+
+def test_validate_stales_when_a_page_is_added_under_the_tail(repo):
+    _seed("wrap/inner/a.md")
+    p = _proposal(_detect("wrap/inner/a.md"))
+
+    _seed("wrap/inner/new.md")  # would be stranded half-flattened
+
+    reason = _FolderChainDetector().validate(p)
+    assert reason is not None and "changed" in reason
+
+
+def test_validate_stales_when_the_chain_gains_a_sibling(repo):
+    _seed("wrap/inner/a.md")
+    p = _proposal(_detect("wrap/inner/a.md"))
+
+    _seed("wrap/direct.md")  # head now has content of its own — no chain
+
+    reason = _FolderChainDetector().validate(p)
+    assert reason is not None and "no longer" in reason
+
+
+def test_validate_stales_when_a_destination_is_occupied(repo):
+    # A file appearing at the destination inside the head also breaks the
+    # chain premise (the head gains direct content), so the chain check fires
+    # first — the destination check is the backstop for anything that slips
+    # past it. Exercise it directly with an occupied target elsewhere.
+    _seed("wrap/inner/a.md", "unrelated/x.md")
+    p = _proposal(_detect("wrap/inner/a.md", "unrelated/x.md"))
+    p["target_paths"] = ["unrelated/X.md"]  # occupied, case-insensitively
+
+    reason = _FolderChainDetector().validate(p)
+    assert reason is not None and "destination" in reason


### PR DESCRIPTION
First Wave-2 detector: single-child folder-chain flattening.

## What it detects
A **chain** is a run of folders each containing exactly one subfolder (a `.gitkeep` marker aside); the **tail** is the first folder with real content. Every level between head and tail is a pass-through. The proposal flattens the chain by moving the tail's pages up into the head, preserving structure below the tail (`head/link/tail/sub/x.md` → `head/sub/x.md`), enumerating every concrete move pair — the executor's exact-path scope rail requires concrete paths.

## Division of labor
- The agentic applier **only moves pages** (the move-must-preserve-content rail from #500 holds it to that). Emptied wrappers keep their `.gitkeep` markers and are deliberately left behind — the **empty-folder detector** proposes their deletion on a later pass. Detectors compose through wiki state, not through each other.
- An entirely empty chain (no pages) stays the empty-folder detector's case.

## Proposal shape
Chain folders ride in `source_paths` (head first, tail last) ahead of the page paths: they're the subject of the op, they widen the applier's path scope to the wrappers, and `validate()` re-derives the chain from them robustly instead of guessing it back out of page paths. `target_paths` = destination pages, index-aligned.

## Premise validation (execute-time)
Stales when: the chain is no longer single-child down to the same tail; the page set under the tail changed (a page added since approval would be stranded half-flattened); or a destination is occupied — judged **case-insensitively**, same as at detect time, so a flatten can never manufacture a case collision. Body edits keep the proposal valid (intent-level consent).

## Guards
- 7-day quiet window on the head — a structure someone is actively building (this month's folder just went in) is left alone.
- Non-page content under the tail (folder-scoped triggers, attachments) skips the chain.
- A chain nested inside an accepted chain's tail is skipped this run — the outer flatten recreates it under the head and a later pass re-detects it.
- **Never auto-approvable**: which folder name survives is naming judgment; a human confirms even in AI-managed scopes.

`move` joins `SUPPORTED_OPS` (the one-line policy decision the allowlist exists for) — the agentic applier already executes moves; all rails (scope, targets-survive, move-preserves-content) apply unchanged.

Note: the Path-2 review banner's detail line says "Keeps X — retires Y" for every target-bearing op, which misreads for `move` — small stacked frontend PR to follow.

13 new tests; automanage/detector/executor suite green (109 passed); ruff + basedpyright clean.