### PR TITLE
fix(automanage): make sweep-slot acquisition atomic

### DIFF
--- a/backend/app/db/migrations/versions/d5e8a1c4f7b2_sweep_singleton_index.py
+++ b/backend/app/db/migrations/versions/d5e8a1c4f7b2_sweep_singleton_index.py
@@ -22,6 +22,30 @@ depends_on: str | None = None
 
 
 def upgrade() -> None:
+    # Databases from the check-then-insert era can hold several ``running``
+    # sweep rows (crashed workers never marked failure) — the unique index
+    # can't be created over them. Reconcile first: keep the newest, fail the
+    # rest, mirroring the runtime corpse failover. If the survivor is a live
+    # sweep, its own completion overwrites the status later; if it's a
+    # corpse, try_start_sweep's age cutoff clears it on the next sweep.
+    op.execute(
+        sa.text(
+            """
+            UPDATE detection_runs
+            SET status = 'failed',
+                error = 'superseded — duplicate running sweep reconciled by migration',
+                finished_at = to_char(now() AT TIME ZONE 'utc', 'YYYY-MM-DD HH24:MI:SS')
+            WHERE trigger = 'sweep'
+              AND status = 'running'
+              AND id <> (
+                    SELECT id FROM detection_runs
+                    WHERE trigger = 'sweep' AND status = 'running'
+                    ORDER BY started_at DESC, id DESC
+                    LIMIT 1
+              )
+            """
+        )
+    )
     op.create_index(
         "uq_detection_runs_single_running_sweep",
         "detection_runs",

--- a/backend/app/db/migrations/versions/d5e8a1c4f7b2_sweep_singleton_index.py
+++ b/backend/app/db/migrations/versions/d5e8a1c4f7b2_sweep_singleton_index.py
@@ -1,0 +1,40 @@
+"""at most one running sweep — partial unique index on detection_runs.
+
+Revision ID: d5e8a1c4f7b2
+Revises: c9d4e7f2a1b8
+
+Backs atomic sweep-slot acquisition (``automanage/runs.py:try_start_sweep``):
+the ``running`` sweep row is the slot, so a guarded INSERT either takes it or
+conflicts — no check-then-insert window. ``if_not_exists`` because
+``0001_initial`` materializes the whole model metadata (index included) on
+fresh databases.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e8a1c4f7b2"
+down_revision: str | None = "c9d4e7f2a1b8"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "uq_detection_runs_single_running_sweep",
+        "detection_runs",
+        ["trigger"],
+        unique=True,
+        postgresql_where=sa.text("status = 'running' AND trigger = 'sweep'"),
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_detection_runs_single_running_sweep",
+        table_name="detection_runs",
+        if_exists=True,
+    )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1461,6 +1461,15 @@ class DetectionRun(Base):
             name="detection_runs_status_check",
         ),
         Index("idx_detection_runs_status", "status", "started_at"),
+        # At most one live sweep row — what makes sweep-slot acquisition an
+        # atomic guarded INSERT instead of check-then-insert (see
+        # ``automanage/runs.py:try_start_sweep``).
+        Index(
+            "uq_detection_runs_single_running_sweep",
+            "trigger",
+            unique=True,
+            postgresql_where=text("status = 'running' AND trigger = 'sweep'"),
+        ),
     )
 
 

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -132,7 +132,24 @@ def run_detection(
         log.info("detection: Auto Organize disabled — %s run skipped", trigger.value)
         return {"run_id": None, "paths_scanned": 0, "proposals_emitted": 0}
 
-    run_id = runs.start(trigger=trigger, triggered_by_user_id=triggered_by_user_id)
+    # Sweeps are singleton: the run row doubles as the slot (a partial unique
+    # index allows at most one running sweep), so acquisition is atomic — no
+    # check-then-insert window even for direct callers or multiple consumers.
+    if trigger is TriggerKind.SWEEP:
+        acquired = runs.try_start_sweep(triggered_by_user_id=triggered_by_user_id)
+        if acquired is None:
+            log.info("detection: sweep already running — skipped")
+            return {
+                "run_id": None,
+                "paths_scanned": 0,
+                "proposals_emitted": 0,
+                "skipped": "sweep already running",
+            }
+        run_id = acquired
+    else:
+        run_id = runs.start(
+            trigger=trigger, triggered_by_user_id=triggered_by_user_id
+        )
     try:
         scope = Scope(trigger=trigger, paths=tuple(paths), run_id=run_id)
         taken = taken_dedupe_keys(_BLOCKING_STATUSES)
@@ -259,13 +276,12 @@ def run_sweep(*, triggered_by_user_id: str | None) -> dict[str, Any]:
 
     **Singleton:** while a sweep is already running, another one is skipped —
     two concurrent whole-space scans emit the same drafts into the same dedup
-    window and double every detector's cost for nothing. The manual trigger
-    stays available (this skips *overlap*, it doesn't rate-limit); a stuck
-    ``running`` corpse row stops blocking after ``STUCK_RUN_MAX_AGE_HOURS``.
+    window and double every detector's cost for nothing. The slot is acquired
+    atomically inside ``run_detection`` (``runs.try_start_sweep``); the manual
+    trigger stays available (it skips *overlap*, it doesn't rate-limit), and a
+    stuck ``running`` corpse row stops blocking after
+    ``STUCK_RUN_MAX_AGE_HOURS``.
     """
-    if runs.running_sweep_exists():
-        log.info("sweep skipped — another sweep is already running")
-        return {"run_id": None, "paths_scanned": 0, "proposals_emitted": 0, "skipped": "sweep already running"}
     return run_detection(
         trigger=TriggerKind.SWEEP,
         triggered_by_user_id=triggered_by_user_id,

--- a/backend/app/wiki/automanage/runs.py
+++ b/backend/app/wiki/automanage/runs.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Any
 
 from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.db.models import DetectionRun
 from app.db.session import execute_dml, session
@@ -104,22 +105,54 @@ def mark_failed(run_id: str, *, error: str) -> None:
 STUCK_RUN_MAX_AGE_HOURS = 2
 
 
-def running_sweep_exists() -> bool:
-    """True while a sweep run is genuinely in flight. Corpse rows — running
-    but older than ``STUCK_RUN_MAX_AGE_HOURS`` — don't count (and any real
-    sweep finishes in minutes, not hours)."""
+def try_start_sweep(*, triggered_by_user_id: str | None) -> str | None:
+    """Atomically acquire the sweep slot: insert the ``running`` row, or
+    return None while a sweep is already in flight.
+
+    The slot is the partial unique index ``uq_detection_runs_single_running_
+    sweep`` (at most one ``running`` sweep row), so acquisition is a single
+    guarded INSERT — no check-then-insert window, safe for direct callers
+    and multi-consumer deployments alike, not just the serialized queue.
+    Corpse rows — ``running`` but older than ``STUCK_RUN_MAX_AGE_HOURS``
+    (a worker died mid-run; any real sweep finishes in minutes) — are failed
+    over first so they never hold the slot forever."""
     cutoff = (
         datetime.now(UTC) - timedelta(hours=STUCK_RUN_MAX_AGE_HOURS)
     ).strftime("%Y-%m-%d %H:%M:%S")
+    run_id = uuid.uuid4().hex
     with session() as s:
-        row = s.execute(
-            select(DetectionRun.id).where(
+        execute_dml(
+            s,
+            update(DetectionRun)
+            .where(
                 DetectionRun.trigger == TriggerKind.SWEEP.value,
                 DetectionRun.status == RunStatus.RUNNING.value,
-                DetectionRun.started_at >= cutoff,
+                DetectionRun.started_at < cutoff,
             )
+            .values(
+                status=RunStatus.FAILED.value,
+                error="timed out — assumed dead (worker exited mid-run?)",
+                finished_at=_now(),
+            ),
+        )
+        # Targetless DO NOTHING: the only realistic conflict is the partial
+        # unique index (a live sweep holds the slot); the uuid4 PK doesn't
+        # collide in practice. RETURNING reports the outcome — the id comes
+        # back only when this insert won the slot (rowcount is unreliable
+        # for INSERT … ON CONFLICT under implicit returning).
+        won = s.execute(
+            pg_insert(DetectionRun)
+            .values(
+                id=run_id,
+                trigger=TriggerKind.SWEEP.value,
+                status=RunStatus.RUNNING.value,
+                triggered_by_user_id=triggered_by_user_id,
+                started_at=_now(),
+            )
+            .on_conflict_do_nothing()
+            .returning(DetectionRun.id)
         ).first()
-        return row is not None
+    return run_id if won is not None else None
 
 
 def get(run_id: str) -> dict[str, Any] | None:

--- a/backend/tests/test_detection_runs.py
+++ b/backend/tests/test_detection_runs.py
@@ -47,9 +47,25 @@ def test_list_recent_newest_first(tmp_db):
     from app.db.models import DetectionRun
     from app.db.session import session
 
+    # `completed` status: two simultaneous *running* sweep rows are outlawed
+    # by the partial unique index backing atomic sweep-slot acquisition.
     with session() as s:
-        s.add(DetectionRun(id="older", trigger="sweep", started_at="2026-07-16 10:00:00"))
-        s.add(DetectionRun(id="newer", trigger="sweep", started_at="2026-07-16 11:00:00"))
+        s.add(
+            DetectionRun(
+                id="older",
+                trigger="sweep",
+                status="completed",
+                started_at="2026-07-16 10:00:00",
+            )
+        )
+        s.add(
+            DetectionRun(
+                id="newer",
+                trigger="sweep",
+                status="completed",
+                started_at="2026-07-16 11:00:00",
+            )
+        )
     ids = [r["id"] for r in runs.list_recent()]
     assert ids.index("newer") < ids.index("older")
 

--- a/backend/tests/test_sweep_singleton.py
+++ b/backend/tests/test_sweep_singleton.py
@@ -2,14 +2,18 @@
 
 Two concurrent sweeps emit the same drafts into the same dedup window and
 double every detector's cost; the guard skips overlap without rate-limiting
-the manual trigger. A stuck ``running`` corpse row (worker died mid-run)
-stops blocking after the age cutoff.
+the manual trigger. The slot is the partial unique index on the ``running``
+sweep row, so acquisition is one atomic guarded INSERT — safe beyond the
+serialized queue consumer. A stuck ``running`` corpse row (worker died
+mid-run) stops blocking after the age cutoff.
 """
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 
 import pytest
+
+from sqlalchemy import select
 
 from app.db.models import DetectionRun
 from app.db.session import session
@@ -56,8 +60,25 @@ def test_second_sweep_is_skipped_while_one_runs(repo):
 def test_stuck_corpse_run_does_not_block_forever(repo):
     _plant_running_sweep(hours_old=runs.STUCK_RUN_MAX_AGE_HOURS + 1)
     result = runner.run_sweep(triggered_by_user_id=None)
-    assert result["run_id"] is not None  # corpse ignored, sweep ran
+    assert result["run_id"] is not None  # corpse failed over, sweep ran
     assert result["proposals_emitted"] == 1
+    # The corpse was closed, not ignored — it no longer holds the slot.
+    with session() as s:
+        corpse = s.scalars(
+            select(DetectionRun).where(DetectionRun.id.like("run_test_%"))
+        ).one()
+        assert corpse.status == "failed"
+        assert corpse.error is not None
+
+
+def test_slot_acquisition_is_first_wins(repo):
+    """The slot is a guarded INSERT against the partial unique index — the
+    second acquisition loses atomically, with no exists-check window."""
+    first = runs.try_start_sweep(triggered_by_user_id=None)
+    assert first is not None
+    assert runs.try_start_sweep(triggered_by_user_id=None) is None
+    runs.mark_completed(first, paths_scanned=0, proposals_emitted=0)
+    assert runs.try_start_sweep(triggered_by_user_id=None) is not None
 
 
 def test_sequential_sweeps_are_not_rate_limited(repo):


### PR DESCRIPTION
Follow-up to #501, resolving the review comment: the guard was check-then-insert (`running_sweep_exists()` in one transaction, the run-row insert in another), so the singleton held only because the queue has a single consumer — direct callers or a multi-consumer deployment could still double-scan.

- **The running sweep row is now the slot.** A partial unique index — `detection_runs(trigger) WHERE status = 'running' AND trigger = 'sweep'` — allows at most one, so acquisition is a single guarded `INSERT … ON CONFLICT DO NOTHING RETURNING id`. The id comes back only when the insert won; no exists-check window at any concurrency. (`RETURNING` rather than rowcount — rowcount is unreliable for `ON CONFLICT` inserts under implicit returning; a test caught it returning truthy for a losing insert.)
- **Corpses are failed over, not ignored.** A `running` row older than `STUCK_RUN_MAX_AGE_HOURS` is marked `failed` (with an explanatory error) in the same transaction before the insert, so it can't hold the slot forever and the run history shows what happened.
- **Acquisition sits inside `run_detection`,** after the kill-switch check — a disabled run never leaks a `running` row, and every sweep caller (manual API trigger, crons, direct calls) inherits the guard rather than only the `run_sweep` wrapper.

Migration `d5e8a1c4f7b2` adds the index (`if_not_exists`, since `0001_initial` materializes model metadata on fresh installs).

Tests: overlap skipped; first-wins acquisition asserted directly at the repo layer; corpse failover verified to close the row; sequential sweeps unaffected. Suite green; ruff + basedpyright clean.