### PR TITLE
docs: define the Agent Wiki Markdown Standard

### DIFF
--- a/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
+++ b/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
@@ -11,8 +11,8 @@ this document are to be interpreted as in RFC 2119.
 
 | Standard | Reference | Adherence |
 |---|---|---|
-| CommonMark | [spec.commonmark.org](https://spec.commonmark.org), latest release | Full. Every construct defined by the CommonMark spec MUST be supported. |
-| GitHub Flavored Markdown (GFM) | [github.github.com/gfm](https://github.github.com/gfm) | Full. GFM extends CommonMark with exactly five constructs; all five are adopted below. |
+| CommonMark | [spec.commonmark.org](https://spec.commonmark.org), latest release | Full, with one deliberate exception — §5. |
+| GitHub Flavored Markdown (GFM) | [github.github.com/gfm](https://github.github.com/gfm) | GFM extends CommonMark with five constructs; four are adopted below, the fifth is superseded by §5. |
 | Agent Wiki Extensions | This document, §4 | Deliberate, non-standard additions adopted where CommonMark and GFM both fall short of a high-value editor feature. |
 
 No other markdown dialect, flavor, or informal convention is in scope.
@@ -35,7 +35,7 @@ The following CM constructs MUST be supported:
 12. Reference-style links (including link reference definitions)
 13. Autolinks (angle-bracket form, e.g. `<https://example.com>`)
 14. Hard line breaks (trailing double-space or backslash)
-15. Raw HTML passthrough (block and inline)
+15. Images (`![alt](src)`)
 
 ## 3. GFM — Adopted Extensions
 
@@ -45,10 +45,10 @@ The following GFM constructs MUST be supported:
 2. Strikethrough (`~~text~~`)
 3. Task list items (`- [ ]` / `- [x]`)
 4. Extended autolinks (bare URLs and email addresses, no delimiters required)
-5. Disallowed Raw HTML ("tagfilter") — `script`, `style`, `xmp`, `iframe`,
-   `noembed`, `noframes`, `title`, `textarea`, and `plaintext` tags MUST be
-   escaped rather than passed through raw (§2 item 15), regardless of
-   CommonMark's general raw-HTML-passthrough rule.
+
+GFM's fifth construct, Disallowed Raw HTML ("tagfilter"), modifies raw-HTML-
+passthrough behavior. It is not adopted as such — §5 excludes raw HTML
+passthrough entirely, which supersedes it.
 
 ## 4. Agent Wiki Extensions (Beyond CommonMark and GFM)
 
@@ -60,10 +60,12 @@ referenced standards:
    no separate support — CommonMark text content is Unicode, so a literal
    emoji character is already ordinary text.
 
-## 5. Deferred
+## 5. Explicitly Excluded
 
-1. Images (`![alt](src)`). Support is deferred, not rejected. Resolution
-   requires distinguishing external image links from internally-stored
-   wiki image links, the latter of which is unresolved pending design work
-   with Nik. Until resolved, image syntax MAY parse but MUST NOT be assumed
-   reliable, and MUST NOT be advertised as supported.
+The following constructs MUST NOT be supported:
+
+1. Raw HTML passthrough (block and inline). Any literal `<...>` sequence in
+   source text MUST be treated as ordinary text — MUST NOT be parsed as an
+   HTML tag, and MUST NOT be rendered as a live element. This is a
+   deliberate divergence from CommonMark, which mandates raw HTML
+   passthrough.

--- a/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
+++ b/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
@@ -65,8 +65,14 @@ referenced standards:
 
 The following constructs MUST NOT be supported:
 
-1. Raw HTML passthrough (block and inline). Any literal `<...>` sequence in
-   source text MUST be treated as ordinary text — MUST NOT be parsed as an
-   HTML tag, and MUST NOT be rendered as a live element. This is a
+1. Raw HTML tags (block and inline), as defined by CommonMark's raw-HTML
+   grammar — open tags, closing tags, comments, processing instructions,
+   declarations, CDATA sections. MUST be treated as ordinary text, MUST NOT
+   be parsed as a tag, and MUST NOT be rendered as a live element. This is a
    deliberate divergence from CommonMark, which mandates raw HTML
    passthrough.
+
+   Autolinks (§2 item 13, e.g. `<https://example.com>`) are a distinct
+   CommonMark construct — matched by a URI/email pattern, not the tag-name
+   grammar above — and are unaffected by this exclusion; they MUST still
+   render as links.

--- a/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
+++ b/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
@@ -1,0 +1,69 @@
+# Agent Wiki Markdown Standard
+
+Version 1.0. Governs the markdown dialect supported by `AgentWikiEditor` and
+by every backend component that parses or serializes wiki page content
+(`backend/app/wiki/markdown_blocks.py`, `backend/app/wiki/markdown_yjs.py`).
+
+The key words **MUST**, **MUST NOT**, **SHALL**, **SHALL NOT**, and **MAY** in
+this document are to be interpreted as in RFC 2119.
+
+## 1. Standards
+
+| Standard | Reference | Adherence |
+|---|---|---|
+| CommonMark | [spec.commonmark.org](https://spec.commonmark.org), latest release | Full. Every construct defined by the CommonMark spec MUST be supported. |
+| GitHub Flavored Markdown (GFM) | [github.github.com/gfm](https://github.github.com/gfm) | Full. GFM extends CommonMark with exactly five constructs; all five are adopted below. |
+| Agent Wiki Extensions | This document, §4 | Deliberate, non-standard additions adopted where CommonMark and GFM both fall short of a high-value editor feature. |
+
+No other markdown dialect, flavor, or informal convention is in scope.
+
+## 2. CommonMark — Full Compliance (Mandatory)
+
+The following CM constructs MUST be supported:
+
+1. ATX headings (levels 1–6, `#` through `######`)
+2. Setext headings (`===`/`---` underline form)
+3. Thematic breaks (`---`, `***`, `___`)
+4. Emphasis and strong emphasis (`*`/`_`, `**`/`__`)
+5. List items — ordered and unordered
+6. Nested list items via indentation
+7. Code spans (single-backtick inline code)
+8. Indented code blocks
+9. Fenced code blocks (backtick or tilde fenced, with optional info string)
+10. Block quotes (`>`)
+11. Inline links
+12. Reference-style links (including link reference definitions)
+13. Autolinks (angle-bracket form, e.g. `<https://example.com>`)
+14. Hard line breaks (trailing double-space or backslash)
+15. Raw HTML passthrough (block and inline)
+
+## 3. GFM — Adopted Extensions
+
+The following GFM constructs MUST be supported:
+
+1. Tables
+2. Strikethrough (`~~text~~`)
+3. Task list items (`- [ ]` / `- [x]`)
+4. Extended autolinks (bare URLs and email addresses, no delimiters required)
+5. Disallowed Raw HTML ("tagfilter") — `script`, `style`, `xmp`, `iframe`,
+   `noembed`, `noframes`, `title`, `textarea`, and `plaintext` tags MUST be
+   escaped rather than passed through raw (§2 item 15), regardless of
+   CommonMark's general raw-HTML-passthrough rule.
+
+## 4. Agent Wiki Extensions (Beyond CommonMark and GFM)
+
+The following constructs MUST be supported despite being absent from both
+referenced standards:
+
+1. Footnotes (`[^label]` reference + `[^label]: text` definition)
+2. Emoji shortcodes (`:emoji-name:`). Literal Unicode emoji characters require
+   no separate support — CommonMark text content is Unicode, so a literal
+   emoji character is already ordinary text.
+
+## 5. Deferred
+
+1. Images (`![alt](src)`). Support is deferred, not rejected. Resolution
+   requires distinguishing external image links from internally-stored
+   wiki image links, the latter of which is unresolved pending design work
+   with Nik. Until resolved, image syntax MAY parse but MUST NOT be assumed
+   reliable, and MUST NOT be advertised as supported.

--- a/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
+++ b/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
@@ -12,14 +12,15 @@ this document are to be interpreted as in RFC 2119.
 | Standard | Reference | Adherence |
 |---|---|---|
 | CommonMark | [spec.commonmark.org](https://spec.commonmark.org), latest release | Full, with one deliberate exception — §5. |
-| GitHub Flavored Markdown (GFM) | [github.github.com/gfm](https://github.github.com/gfm) | GFM extends CommonMark with five constructs; four are adopted below, the fifth is superseded by §5. |
+| GitHub Flavored Markdown (GFM) | [github.github.com/gfm](https://github.github.com/gfm) | Full, except tagfilter — superseded by §5. |
 | Agent Wiki Extensions | This document, §4 | Deliberate, non-standard additions adopted where CommonMark and GFM both fall short of a high-value editor feature. |
 
 No other markdown dialect, flavor, or informal convention is in scope.
 
-## 2. CommonMark — Full Compliance (Mandatory)
+## 2. CommonMark — Full Compliance (Mandatory; One Exception — §5)
 
-The following CM constructs MUST be supported:
+The following CM constructs MUST be supported. (Raw HTML passthrough is
+also core CommonMark, but is excluded — see §5.)
 
 1. ATX headings (levels 1–6, `#` through `######`)
 2. Setext headings (`===`/`---` underline form)


### PR DESCRIPTION
## Summary
- Adds `docs/AGENT_WIKI_MARKDOWN_STANDARD.md`, a formal spec (RFC-2119 style) for the markdown dialect the prospective `AgentWikiEditor` and the backend markdown codec (`markdown_blocks.py`/`markdown_yjs.py`) must support.
- Full CommonMark compliance (mandatory).
- Full GFM compliance — tables, strikethrough, task lists, extended autolinks, and the tagfilter/"Disallowed Raw HTML" extension (closes a real XSS gap since we mandate CommonMark's raw-HTML-passthrough rule).
- Two deliberate extensions beyond both specs: footnotes, emoji shortcodes.
- Images explicitly deferred pending internal-vs-external image link design work with Nik.