### PR TITLE
feat(wiki): markdown export endpoint for pages, folders, and the whole wiki

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import logging
+import posixpath
 import re
 import subprocess
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
 from app.auth import PermissionDenied, User, require_can
 from app.auth.deps import require_user
@@ -66,6 +67,7 @@ from app.wiki import (
     diff as wiki_diff,
     doc_ids,
     drafts as wiki_drafts,
+    export as wiki_export,
     filesystem,
     git as wiki_git,
     notify as wiki_notify,
@@ -390,6 +392,48 @@ def get_source_spans(
         raise HTTPException(status_code=400, detail=str(e)) from e
     require_can("read", rel, user)
     return provenance.content_spans_for_path(rel)
+
+
+@router.get("/export")
+def export_markdown(
+    user: User = Depends(require_user),
+    path: str = "",
+) -> Response:
+    """Download markdown: one page as a ``.md`` attachment, or a folder
+    (``""`` for the whole wiki) as a zip of the pages the caller can read.
+
+    Internal ``/app/wiki/`` links are rewritten to relative paths so the
+    exported files cross-link on disk. Permission rows are Postgres-only
+    and never part of an export — whatever is downloaded carries no ACLs.
+    """
+    try:
+        rel = filesystem.safe_rel_path(path) if path else ""
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    if rel.endswith(".md"):
+        require_can("read", rel, user)
+        body = wiki_export.export_page(rel)
+        if body is None:
+            raise HTTPException(status_code=404, detail="not found")
+        filename = posixpath.basename(rel)
+        return Response(
+            content=body,
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": wiki_export.content_disposition(filename)},
+        )
+
+    visible = wiki_export.visible_md_paths(user, rel)
+    if not visible:
+        raise HTTPException(status_code=404, detail="nothing to export")
+    base = posixpath.basename(rel) if rel else "wiki"
+    return Response(
+        content=wiki_export.build_zip(visible),
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": wiki_export.content_disposition(f"{base}-export.zip")
+        },
+    )
 
 
 @router.put("/file", response_model=PutDocumentResponse)

--- a/backend/app/wiki/export.py
+++ b/backend/app/wiki/export.py
@@ -30,9 +30,19 @@ _APP_ROUTE_PREFIX = "/app/wiki/"
 _LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(([^)]+)\)")
 
 
+def _is_dot_metadata(path: str) -> bool:
+    """Any dot-prefixed component marks app metadata, never a wiki page —
+    even with a ``.md`` suffix (e.g. ``.metadata.md``, ``.meta/state.md``)."""
+    return any(part.startswith(".") for part in path.split("/"))
+
+
 def visible_md_paths(user: User, prefix: str = "") -> list[str]:
     """Tracked ``.md`` pages under ``prefix`` that ``user`` can read."""
-    md = [p for p in wiki_git.list_paths(prefix) if p.endswith(".md")]
+    md = [
+        p
+        for p in wiki_git.list_paths(prefix)
+        if p.endswith(".md") and not _is_dot_metadata(p)
+    ]
     return acl.filter_paths_in_python(user.id, user.is_admin, md)
 
 

--- a/backend/app/wiki/export.py
+++ b/backend/app/wiki/export.py
@@ -1,0 +1,107 @@
+"""Markdown export — single pages and folder subtrees as downloadable files.
+
+Bodies are exported verbatim except for internal links: absolute app links
+(``/app/wiki/<path>``) are rewritten to paths relative to the containing
+document, so cross-links resolve inside the extracted tree instead of
+pointing back at the app. Zip entries keep their full wiki-relative paths
+for the same reason.
+
+Only ``.md`` pages are exported. Postgres-only state (ACLs, comments,
+provenance, update policies) is not part of an export — exported content
+carries no permissions.
+"""
+from __future__ import annotations
+
+import io
+import posixpath
+import re
+import zipfile
+from urllib.parse import quote, unquote
+
+from app.auth import User
+from app.wiki import acl, filesystem
+from app.wiki import git as wiki_git
+
+_APP_ROUTE_PREFIX = "/app/wiki/"
+
+# Match ``[text](target)`` not preceded by ``!`` (image syntax). Unlike the
+# broken-link checker's pattern, the target may contain spaces — internal
+# links in the corpus are written unencoded.
+_LINK_RE = re.compile(r"(?<!!)\[([^\]]*)\]\(([^)]+)\)")
+
+
+def visible_md_paths(user: User, prefix: str = "") -> list[str]:
+    """Tracked ``.md`` pages under ``prefix`` that ``user`` can read."""
+    md = [p for p in wiki_git.list_paths(prefix) if p.endswith(".md")]
+    return acl.filter_paths_in_python(user.id, user.is_admin, md)
+
+
+def rewrite_links(body: str, doc_path: str) -> str:
+    """Rewrite absolute app links to paths relative to ``doc_path``.
+
+    ``[B](/app/wiki/docs/b.md)`` inside ``docs/a.md`` becomes ``[B](b.md)``.
+    Percent-encoded targets are decoded to the corpus's unencoded style;
+    anchors are preserved. Relative and external links pass through as-is.
+    """
+    doc_dir = posixpath.dirname(doc_path)
+
+    def _sub(match: re.Match[str]) -> str:
+        text, target = match.group(1), match.group(2)
+        relativized = _relativize(target, doc_dir)
+        if relativized is None:
+            return match.group(0)
+        return f"[{text}]({relativized})"
+
+    return _LINK_RE.sub(_sub, body)
+
+
+def _relativize(target: str, doc_dir: str) -> str | None:
+    """Relative form of an ``/app/wiki/`` target, or None to leave it alone."""
+    path_part, sep, anchor = target.strip().partition("#")
+    decoded = unquote(path_part)
+    if not decoded.startswith(_APP_ROUTE_PREFIX):
+        return None
+    rel = decoded[len(_APP_ROUTE_PREFIX) :]
+    if not rel:
+        return None
+    return posixpath.relpath(rel, start=doc_dir or ".") + (sep + anchor)
+
+
+def export_page(rel_path: str) -> str | None:
+    """Body of one page with links rewritten; None if it isn't on disk."""
+    abs_path = filesystem.absolute(rel_path)
+    if not abs_path.is_file():
+        return None
+    return rewrite_links(abs_path.read_text(), rel_path)
+
+
+def build_zip(rel_paths: list[str]) -> bytes:
+    """Zip of the given pages, entries keyed by wiki-relative path.
+
+    Built in memory: exports are read-only, occasional, and bounded by the
+    visible page set, so a buffer beats plumbing a streaming response
+    through the router. Revisit if wikis outgrow this.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for rel in rel_paths:
+            body = export_page(rel)
+            if body is not None:
+                zf.writestr(rel, body)
+    return buf.getvalue()
+
+
+def content_disposition(filename: str) -> str:
+    """``Content-Disposition`` attachment header value for ``filename``.
+
+    Wiki paths are routinely non-ASCII, so emit both the plain ``filename``
+    fallback (ASCII-squashed) and the RFC 5987 ``filename*`` form.
+    """
+    ascii_name = (
+        filename.encode("ascii", "ignore").decode().replace('"', "").replace("\\", "")
+        or "export"
+    )
+    return (
+        f'attachment; filename="{ascii_name}"; '
+        f"filename*=UTF-8''{quote(filename)}"
+    )

--- a/backend/tests/test_wiki_export.py
+++ b/backend/tests/test_wiki_export.py
@@ -1,0 +1,160 @@
+"""Markdown export: single-page download, folder/whole-wiki zips, link
+rewriting, and ACL filtering (``app.wiki.export`` + ``GET /api/wiki/export``).
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import acl
+from app.wiki.export import content_disposition, rewrite_links
+
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def _client(user_id: str) -> TestClient:
+    client = TestClient(create_app())
+    login_fastapi(client, user_id)
+    return client
+
+
+def _zip_names(resp) -> set[str]:
+    return set(zipfile.ZipFile(io.BytesIO(resp.content)).namelist())
+
+
+def _make_private(path: str) -> None:
+    """Strip the default-public grants a page got on create; the owner row
+    stays, so the page is managed and readable only by owner/admin."""
+    for entry in acl.list_for_path(path):
+        acl.revoke(entry["id"])
+
+
+# --------------------------------------------------------------------------- #
+# Link rewriting (pure)                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_rewrite_absolute_app_links_to_relative():
+    body = (
+        "[sibling](/app/wiki/docs/sub b.md) and "
+        "[cousin](/app/wiki/c.md#sec) and "
+        "[encoded](/app/wiki/My%20Page.md)"
+    )
+    out = rewrite_links(body, "docs/a.md")
+    assert "[sibling](sub b.md)" in out
+    assert "[cousin](../c.md#sec)" in out
+    assert "[encoded](../My Page.md)" in out
+
+
+def test_rewrite_leaves_external_relative_and_image_links_alone():
+    body = (
+        "[ext](https://example.com/x) [rel](sub/b.md) [anchor](#top) "
+        "![img](/app/wiki/pic.png)"
+    )
+    assert rewrite_links(body, "docs/a.md") == body
+
+
+def test_rewrite_from_root_document():
+    assert rewrite_links("[b](/app/wiki/docs/b.md)", "a.md") == "[b](docs/b.md)"
+
+
+def test_content_disposition_non_ascii_filename():
+    value = content_disposition("Zusammenfassung — Тест.md")
+    assert value.startswith("attachment; ")
+    assert 'filename="Zusammenfassung  .md"' in value
+    assert "filename*=UTF-8''" in value
+
+
+# --------------------------------------------------------------------------- #
+# Endpoint                                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_export_single_page(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put(
+        "/api/wiki/file",
+        json={"path": "docs/a.md", "body": "# A\n[b](/app/wiki/docs/b.md)\n"},
+    )
+
+    resp = client.get("/api/wiki/export", params={"path": "docs/a.md"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/markdown")
+    assert 'filename="a.md"' in resp.headers["content-disposition"]
+    assert resp.text == "# A\n[b](b.md)\n"
+
+
+def test_export_folder_zip_scopes_to_prefix(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "team/x.md", "body": "# X\n"})
+    client.put("/api/wiki/file", json={"path": "team/sub/y.md", "body": "# Y\n"})
+    client.put("/api/wiki/file", json={"path": "other/z.md", "body": "# Z\n"})
+
+    resp = client.get("/api/wiki/export", params={"path": "team"})
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    assert 'filename="team-export.zip"' in resp.headers["content-disposition"]
+    assert _zip_names(resp) == {"team/x.md", "team/sub/y.md"}
+
+
+def test_export_whole_wiki_zip(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "a.md", "body": "# A\n"})
+    client.put("/api/wiki/file", json={"path": "deep/b.md", "body": "# B\n"})
+
+    resp = client.get("/api/wiki/export")
+    assert resp.status_code == 200
+    assert 'filename="wiki-export.zip"' in resp.headers["content-disposition"]
+    assert {"a.md", "deep/b.md"} <= _zip_names(resp)
+
+
+def test_export_zip_drops_unreadable_pages(tmp_repo):
+    owner = seed_user(uid="u_owner", email="owner@x.com")
+    other = seed_user(uid="u_other", email="other@x.com")
+    owner_client = _client(owner)
+    owner_client.put("/api/wiki/file", json={"path": "team/open.md", "body": "# O\n"})
+    owner_client.put(
+        "/api/wiki/file", json={"path": "team/secret.md", "body": "# S\n"}
+    )
+    _make_private("team/secret.md")
+
+    names = _zip_names(_client(other).get("/api/wiki/export", params={"path": "team"}))
+    assert names == {"team/open.md"}
+    owner_names = _zip_names(
+        owner_client.get("/api/wiki/export", params={"path": "team"})
+    )
+    assert owner_names == {"team/open.md", "team/secret.md"}
+
+
+def test_export_single_page_forbidden(tmp_repo):
+    owner = seed_user(uid="u_owner", email="owner@x.com")
+    other = seed_user(uid="u_other", email="other@x.com")
+    _client(owner).put(
+        "/api/wiki/file", json={"path": "team/secret.md", "body": "# S\n"}
+    )
+    _make_private("team/secret.md")
+
+    resp = _client(other).get("/api/wiki/export", params={"path": "team/secret.md"})
+    assert resp.status_code == 403
+
+
+def test_export_rejects_traversal_and_missing(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    assert (
+        client.get("/api/wiki/export", params={"path": "../etc"}).status_code == 400
+    )
+    assert (
+        client.get("/api/wiki/export", params={"path": "nope/void"}).status_code == 404
+    )
+    assert (
+        client.get("/api/wiki/export", params={"path": "nope/void.md"}).status_code
+        == 404
+    )

--- a/backend/tests/test_wiki_export.py
+++ b/backend/tests/test_wiki_export.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from app.main import create_app
 from app.wiki import acl
+from app.wiki import git as wiki_git
 from app.wiki.export import content_disposition, rewrite_links
 
 from tests._auth import login_fastapi
@@ -113,6 +114,18 @@ def test_export_whole_wiki_zip(tmp_repo):
     assert resp.status_code == 200
     assert 'filename="wiki-export.zip"' in resp.headers["content-disposition"]
     assert {"a.md", "deep/b.md"} <= _zip_names(resp)
+
+
+def test_export_zip_excludes_dot_metadata_pages(tmp_repo):
+    user = seed_user()
+    client = _client(user)
+    client.put("/api/wiki/file", json={"path": "team/x.md", "body": "# X\n"})
+    # Dot paths bypass the page-write API; commit them like app metadata does.
+    wiki_git.commit_file("team/.metadata.md", "meta\n", "seed metadata")
+    wiki_git.commit_file("team/.meta/state.md", "state\n", "seed state")
+
+    resp = client.get("/api/wiki/export", params={"path": "team"})
+    assert _zip_names(resp) == {"team/x.md"}
 
 
 def test_export_zip_drops_unreadable_pages(tmp_repo):


### PR DESCRIPTION
## What

Adds `GET /api/wiki/export` — downloads one page as a `.md` attachment, or a folder (empty `path` = whole wiki) as a zip of the pages the caller can read.

- New domain module `app/wiki/export.py`: visible-page listing (ACL-filtered via `acl.filter_paths_in_python`), internal-link rewriting, zip building, and `Content-Disposition` encoding (RFC 5987 for non-ASCII page names).
- Internal `/app/wiki/` links are rewritten to paths relative to the containing document, so exported files cross-link on disk instead of pointing back at the app. Zip entries keep full wiki-relative paths so those links resolve inside the extracted tree.
- Only `.md` pages are exported; `.trash/` and dot-metadata files are excluded (single-page export of an unreadable page 403s; unreadable pages are dropped from zips).

## Notes

- Permission rows are Postgres-only and never part of an export — anything downloaded carries no ACLs.
- Zip is built in memory: exports are read-only, occasional, and bounded by the visible page set. Can move to a streaming response if wikis outgrow it.

## Tests

`tests/test_wiki_export.py` — link rewriting (absolute→relative, anchors, percent-encoded, external/relative/image passthrough), single-page download, folder scoping, whole-wiki zip, ACL filtering, 403/404/400 paths.