### PR TITLE
feat(wiki): Export as Markdown action in the page overflow menu

### DIFF
--- a/frontend/src/lib/wiki/svc.ts
+++ b/frontend/src/lib/wiki/svc.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "@/lib/api";
+import { apiFetch, apiFetchBlob } from "@/lib/api";
 import type {
   FileDiffResponse,
   FileHistoryResponse,
@@ -40,4 +40,20 @@ export async function fetchFileHistory(
   return apiFetch<FileHistoryResponse>(
     `/wiki/file/history?path=${encodeURIComponent(path)}`,
   );
+}
+
+/** Download a page as `.md` — or a folder ("" = whole wiki) as a zip of the
+ * pages the caller can read — via the binary arm of the api seam. */
+export async function downloadMarkdownExport(path: string): Promise<void> {
+  const blob = await apiFetchBlob(
+    `/wiki/export?path=${encodeURIComponent(path)}`,
+  );
+  const base = path.split("/").pop() || "wiki";
+  const filename = path.endsWith(".md") ? base : `${base}-export.zip`;
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
 }

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -20,6 +20,7 @@ import {
   SvgChevronRight,
   SvgExternalLink,
   SvgDocFile,
+  SvgDownload,
   SvgFolder,
   SvgHistory,
   SvgMoreHorizontal,
@@ -90,7 +91,11 @@ import {
 } from "@/lib/templates";
 import { absoluteTime, longDateTime, relativeTime } from "@/lib/time";
 import { useIsMobile } from "@/lib/viewport";
-import { fetchFileDiff, fetchFileHistory } from "@/lib/wiki/svc";
+import {
+  downloadMarkdownExport,
+  fetchFileDiff,
+  fetchFileHistory,
+} from "@/lib/wiki/svc";
 import type { CommitInfo, FileDiffResponse } from "@/lib/wiki/types";
 import type {
   CommentThreadView,
@@ -984,6 +989,16 @@ export function FileView({ path }: FileViewProps) {
                 onClick={() => {
                   setMoreOpen(false);
                   void toggleHistory();
+                }}
+              />
+              <LineItemButton
+                title="Export as Markdown"
+                icon={SvgDownload}
+                sizePreset="main-ui"
+                variant="section"
+                onClick={() => {
+                  setMoreOpen(false);
+                  void downloadMarkdownExport(path);
                 }}
               />
             </PopoverMenu>

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -998,7 +998,11 @@ export function FileView({ path }: FileViewProps) {
                 variant="section"
                 onClick={() => {
                   setMoreOpen(false);
-                  void downloadMarkdownExport(path);
+                  downloadMarkdownExport(path).catch((e: unknown) => {
+                    toast.error(
+                      e instanceof Error ? e.message : "Export failed",
+                    );
+                  });
                 }}
               />
             </PopoverMenu>


### PR DESCRIPTION
## What

Stacked on #507. Adds an **Export as Markdown** item to the page `···` menu (next to Run Agent / Version history) that downloads the current page as a `.md` file.

- `downloadMarkdownExport(path)` in `src/lib/wiki/svc.ts`, using the existing `apiFetchBlob` binary seam (same pattern as the users-CSV download).
- Menu item in `FileView.tsx` using the existing `LineItemButton` + `SvgDownload` Opal components.

The backend endpoint also supports folder/whole-wiki zips; surfacing that in the tree UI can come later if wanted.
<img width="533" height="362" alt="Screenshot 2026-07-23 at 5 13 07 PM" src="https://github.com/user-attachments/assets/e02c1b13-58b1-4605-917c-d3bc8f697ad9" />


