### PR TITLE
fix(coedit): don't lose the leave when the WS task is cancelled

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
-import threading
 from typing import Any
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -327,10 +326,13 @@ def _connect_sync(path: str, user: User) -> coedit.SessionRow:
 def _disconnect_sync(session_id: int, user_id: str) -> None:
     # Only mark the user gone when their last connection closes, so a
     # second tab doesn't evict them.
-    if not coedit_channel.user_still_connected(session_id, user_id):
+    still = coedit_channel.user_still_connected(session_id, user_id)
+    log.info("coedit leave session=%s user=%s still_connected=%s", session_id, user_id, still)
+    if not still:
         coedit.leave(session_id, user_id)
         coedit_channel.broadcast_presence(session_id)
         _checkpoint_if_last_left(session_id)
+        log.info("coedit leave done session=%s", session_id)
 
 
 @router.websocket("/ws")
@@ -374,6 +376,11 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
         done, pending = await asyncio.wait(
             {recv_task, send_task}, return_when=asyncio.FIRST_COMPLETED
         )
+        log.info(
+            "coedit ws wait returned session=%s done=%s",
+            sess.id,
+            [("recv" if t is recv_task else "send") for t in done],
+        )
         # Wake a still-blocked drain() *before* cancelling it: cancelling
         # send_task only stops the asyncio Task watching the thread, not the
         # already-dispatched OS thread itself — queue.Queue.get(timeout=...)
@@ -394,23 +401,11 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     finally:
         if conn is not None:
             coedit_channel.disconnect(conn.id)
-        # The disconnect handler IS the leave signal (no client message), so
-        # it must survive this task being *cancelled* — server shutdown, or
-        # the test portal tearing down the connection. Inside a cancelled
-        # task every `await` re-raises CancelledError instead of completing,
-        # which silently drops the leave: a phantom participant forever, and
-        # a dirty buffer that never gets its last-leave checkpoint. Detect
-        # the in-flight cancellation up front and hand the leave to a plain
-        # thread no cancellation can touch; the normal disconnect path keeps
-        # awaiting so the leave is recorded before the handler returns.
         task = asyncio.current_task()
-        if task is not None and task.cancelling():
-            threading.Thread(
-                target=_disconnect_sync,
-                args=(sess.id, user.id),
-                name=f"coedit-leave-{sess.id}",
-                daemon=False,
-            ).start()
-        else:
-            await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
+        log.info(
+            "coedit ws finally session=%s cancelling=%s",
+            sess.id,
+            task.cancelling() if task is not None else "?",
+        )
+        await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
         log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -6,7 +6,7 @@ the originating conversation for the design rationale.
 
 The first ``asyncio`` in this backend, scoped deliberately: ``async`` here
 covers connection lifecycle only (accept, the recv/send loops, task
-orchestration) — every ``_connect_sync``/``_disconnect_sync``/``_handle_*``
+orchestration) — every ``_connect_sync``/``record_leave``/``_handle_*``
 helper below is a plain sync function, run via ``asyncio.to_thread`` from
 the loops, with no idea it's being called from an async context at all. See
 CLAUDE.md's "WebSocket routes" rule before adding another route like this
@@ -51,6 +51,7 @@ from app.models.coedit import (
     ParticipantOut,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session
+from app.tasks.coedit_leave import leave_coedit_session, record_leave
 from app.wiki import coedit, coedit_channel, git
 
 router = APIRouter()
@@ -72,21 +73,6 @@ def _participants_out(session_id: int) -> list[ParticipantOut]:
         )
         for p in coedit.list_participants(session_id)
     ]
-
-
-def _checkpoint_if_last_left(session_id: int) -> None:
-    """Enqueue a final checkpoint when the last participant has left, so the
-    session's buffer lands in git without waiting for the periodic scan.
-
-    Best-effort: the participant row is already gone, so a failed enqueue (e.g.
-    a full queue) must not fail the leave. The periodic scan is the backstop —
-    the session is dirty, so it's recovered (checkpointed + closed) once idle."""
-    if coedit.list_participants(session_id):
-        return
-    try:
-        checkpoint_coedit_session(session_id)
-    except Exception:
-        log.exception("coedit: checkpoint enqueue failed on last-leave for session %s", session_id)
 
 
 class _WsActionError(Exception):
@@ -323,18 +309,6 @@ def _connect_sync(path: str, user: User) -> coedit.SessionRow:
     return sess
 
 
-def _disconnect_sync(session_id: int, user_id: str) -> None:
-    # Only mark the user gone when their last connection closes, so a
-    # second tab doesn't evict them.
-    still = coedit_channel.user_still_connected(session_id, user_id)
-    log.info("coedit leave session=%s user=%s still_connected=%s", session_id, user_id, still)
-    if not still:
-        coedit.leave(session_id, user_id)
-        coedit_channel.broadcast_presence(session_id)
-        _checkpoint_if_last_left(session_id)
-        log.info("coedit leave done session=%s", session_id)
-
-
 @router.websocket("/ws")
 async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_ws)) -> None:
     """``path`` is a query param (``?path=...``), not a URL segment — this
@@ -353,7 +327,7 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     # before returning, so from here on a disconnect — including one during
     # `accept()` itself, which the client can trigger mid-handshake since
     # `_connect_sync`'s git/DB work takes measurable time — must still reach
-    # `_disconnect_sync` to undo it. Otherwise the user is stuck as a
+    # `record_leave` to undo it. Otherwise the user is stuck as a
     # phantom participant forever, which also blocks
     # `_checkpoint_if_last_left` from ever firing for this session.
     conn: coedit_channel.Connection | None = None
@@ -376,11 +350,6 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
         done, pending = await asyncio.wait(
             {recv_task, send_task}, return_when=asyncio.FIRST_COMPLETED
         )
-        log.info(
-            "coedit ws wait returned session=%s done=%s",
-            sess.id,
-            [("recv" if t is recv_task else "send") for t in done],
-        )
         # Wake a still-blocked drain() *before* cancelling it: cancelling
         # send_task only stops the asyncio Task watching the thread, not the
         # already-dispatched OS thread itself — queue.Queue.get(timeout=...)
@@ -401,11 +370,23 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     finally:
         if conn is not None:
             coedit_channel.disconnect(conn.id)
-        task = asyncio.current_task()
-        log.info(
-            "coedit ws finally session=%s cancelling=%s",
-            sess.id,
-            task.cancelling() if task is not None else "?",
-        )
-        await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
+        # The leave must survive this task being cancelled (server shutdown;
+        # the test portal tearing down the connection). A cancelled `await`
+        # is not enough: the executor item it submitted can be *discarded*
+        # before any pool worker picks it up — cancelling a not-yet-started
+        # future removes it from the queue — and the cancellation can land at
+        # any moment, so no up-front check closes the window. On that path,
+        # hand the leave to the coedit queue instead: a synchronous enqueue
+        # nothing can cancel, durable across the shutdown that caused it.
+        # `record_leave` is idempotent, so the rare both-ran overlap is safe.
+        try:
+            await asyncio.to_thread(record_leave, sess.id, user.id)
+        except asyncio.CancelledError:
+            try:
+                leave_coedit_session(sess.id, user.id)  # enqueue, no await
+            except Exception:
+                log.exception(
+                    "coedit: queued-leave fallback failed for session %s", sess.id
+                )
+            raise
         log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
+import threading
 from typing import Any
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -393,5 +394,23 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     finally:
         if conn is not None:
             coedit_channel.disconnect(conn.id)
-        await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
+        # The disconnect handler IS the leave signal (no client message), so
+        # it must survive this task being *cancelled* — server shutdown, or
+        # the test portal tearing down the connection. Inside a cancelled
+        # task every `await` re-raises CancelledError instead of completing,
+        # which silently drops the leave: a phantom participant forever, and
+        # a dirty buffer that never gets its last-leave checkpoint. Detect
+        # the in-flight cancellation up front and hand the leave to a plain
+        # thread no cancellation can touch; the normal disconnect path keeps
+        # awaiting so the leave is recorded before the handler returns.
+        task = asyncio.current_task()
+        if task is not None and task.cancelling():
+            threading.Thread(
+                target=_disconnect_sync,
+                args=(sess.id, user.id),
+                name=f"coedit-leave-{sess.id}",
+                daemon=False,
+            ).start()
+        else:
+            await asyncio.to_thread(_disconnect_sync, sess.id, user.id)
         log.info("coedit ws closed session=%s user=%s", sess.id, user.id)

--- a/backend/app/tasks/coedit_leave.py
+++ b/backend/app/tasks/coedit_leave.py
@@ -1,0 +1,60 @@
+"""Recording a participant's leave — shared logic + the queued fallback.
+
+The WS disconnect handler is the *only* leave signal (there is no client
+leave message). Normally the endpoint's ``finally`` awaits
+:func:`record_leave` on a thread and the leave is recorded before the
+handler returns. But when the endpoint task is being **cancelled** (server
+shutdown; the test portal tearing down a connection), an awaited executor
+item can be discarded before any pool worker picks it up — cancelling a
+not-yet-started future removes it from the executor queue — and the leave
+would silently never run: a phantom participant forever, and a dirty buffer
+that never gets its last-leave checkpoint. For that path the handler
+enqueues :func:`leave_coedit_session` instead: a synchronous Redis send that
+no cancellation can touch, durable across the shutdown that caused it.
+
+``record_leave`` is idempotent on purpose — cancellation can land *after*
+the awaited executor item was already picked up, so the queued fallback may
+be a second run: the participant delete is delete-if-exists, the presence
+broadcast is harmless, and the checkpoint no-ops on a clean buffer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.tasks.coedit_checkpoint import checkpoint_coedit_session
+from app.tasks.queues import coedit_queue
+from app.wiki import coedit, coedit_channel
+
+log = logging.getLogger(__name__)
+
+
+def record_leave(session_id: int, user_id: str) -> None:
+    """Mark ``user_id`` gone from ``session_id`` and checkpoint if they were
+    the last one out. Only acts when their last connection has closed, so a
+    second tab doesn't evict them. Idempotent (see module docstring)."""
+    if coedit_channel.user_still_connected(session_id, user_id):
+        return
+    coedit.leave(session_id, user_id)
+    coedit_channel.broadcast_presence(session_id)
+    if coedit.list_participants(session_id):
+        return
+    # Best-effort: the participant row is already gone, so a failed enqueue
+    # (e.g. a full queue) must not fail the leave. The periodic scan is the
+    # backstop — the session is dirty, so it's recovered once idle.
+    try:
+        checkpoint_coedit_session(session_id)
+    except Exception:
+        log.exception(
+            "coedit: checkpoint enqueue failed on last-leave for session %s",
+            session_id,
+        )
+
+
+@coedit_queue.task()
+def leave_coedit_session(session_id: int, user_id: str) -> None:
+    """Queued leave — the WS handler's fallback when its own task is being
+    cancelled. On a worker the channel registry is empty, so the
+    still-connected guard in :func:`record_leave` never mistakes another
+    process's connections for this user's."""
+    record_leave(session_id, user_id)

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -43,6 +43,7 @@ _TASK_MODULES = (
     "app.tasks.chat_title",
     "app.tasks.automanage",
     "app.tasks.coedit_checkpoint",
+    "app.tasks.coedit_leave",
     "app.tasks.coedit_rebase",
     "app.tasks.craft",
     "app.tasks.wiki_update",

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,6 +9,7 @@ shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
+import time
 from contextlib import contextmanager
 
 import pytest
@@ -84,6 +85,17 @@ def _checkpoint(ws) -> dict:
 def _get_ops(ws, since_version: int) -> dict:
     ws.send_json({"type": "get_ops", "request_id": "g", "since_version": since_version})
     return _receive_typed(ws, "ops_result")
+
+
+def _wait_for(predicate, timeout: float = 15.0) -> None:
+    """Wait for a disconnect side effect. The server's disconnect handler is
+    the leave signal, and nothing guarantees it has finished by the time
+    ``websocket_connect.__exit__`` returns — the handler runs on the app's
+    event loop/threads on its own schedule. Tests observe its *effects*, so
+    they must wait for them, not assume an ordering the API doesn't offer."""
+    deadline = time.monotonic() + timeout
+    while not predicate() and time.monotonic() < deadline:
+        time.sleep(0.02)
 
 
 def test_connect_requires_auth(client):
@@ -193,6 +205,7 @@ def test_disconnect_removes_participant(client):
         sid = joined["session_id"]
         assert len(coedit.list_participants(sid)) == 1
 
+    _wait_for(lambda: coedit.list_participants(sid) == [])
     assert coedit.list_participants(sid) == []
 
 
@@ -205,11 +218,21 @@ def test_disconnect_of_last_participant_checkpoints(client):
         with _ws(client) as (ws, joined):
             sid = joined["session_id"]
             _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
-        # The disconnect handler enqueues a checkpoint; immediate_mode runs
-        # it inline before websocket_connect's __exit__ returns.
+        # The disconnect handler enqueues the checkpoint; immediate_mode runs
+        # it inline wherever the handler executes. Wait *inside* the block:
+        # once the flag drops, a late enqueue would go to the real queue.
+        _wait_for(
+            lambda: git.read_file(_PATH) == "hi world"
+            and coedit.get_active_session(_PATH) is None
+        )
 
-    assert git.read_file(_PATH) == "hi world"
-    assert coedit.get_active_session(_PATH) is None
+    session_after = coedit.get_active_session(_PATH)
+    assert git.read_file(_PATH) == "hi world", (
+        "checkpoint never landed: "
+        f"session={'still open' if session_after else 'closed'}, "
+        f"participants={coedit.list_participants(sid)}"
+    )
+    assert session_after is None
     assert sid is not None
 
 

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,7 +9,6 @@ shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
-import logging
 import time
 from contextlib import contextmanager
 
@@ -197,22 +196,23 @@ def test_op_stamps_last_edited_at(client):
         assert me and me[0].last_edited_at is not None
 
 
-def test_disconnect_removes_participant(client, caplog):
-    caplog.set_level(logging.INFO)
+def test_disconnect_removes_participant(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page()
 
-    with _ws(client) as (_ws_conn, joined):
-        sid = joined["session_id"]
-        assert len(coedit.list_participants(sid)) == 1
+    # immediate_mode: if teardown takes the cancellation path, the leave is
+    # enqueued — inline mode runs it here instead of on a worker.
+    with coedit_queue.immediate_mode():
+        with _ws(client) as (_ws_conn, joined):
+            sid = joined["session_id"]
+            assert len(coedit.list_participants(sid)) == 1
 
-    _wait_for(lambda: coedit.list_participants(sid) == [])
+        _wait_for(lambda: coedit.list_participants(sid) == [])
     assert coedit.list_participants(sid) == []
 
 
-def test_disconnect_of_last_participant_checkpoints(client, caplog):
-    caplog.set_level(logging.INFO)
+def test_disconnect_of_last_participant_checkpoints(client):
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -9,6 +9,7 @@ shapes, one WebSocket instead of eight endpoints.
 """
 from __future__ import annotations
 
+import logging
 import time
 from contextlib import contextmanager
 
@@ -196,7 +197,8 @@ def test_op_stamps_last_edited_at(client):
         assert me and me[0].last_edited_at is not None
 
 
-def test_disconnect_removes_participant(client):
+def test_disconnect_removes_participant(client, caplog):
+    caplog.set_level(logging.INFO)
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page()
@@ -209,7 +211,8 @@ def test_disconnect_removes_participant(client):
     assert coedit.list_participants(sid) == []
 
 
-def test_disconnect_of_last_participant_checkpoints(client):
+def test_disconnect_of_last_participant_checkpoints(client, caplog):
+    caplog.set_level(logging.INFO)
     uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
     login_fastapi(client, uid)
     _seed_page("hello world")


### PR DESCRIPTION
Fixes the CI failures hitting unrelated PRs (#502, #504) since the WS transport migration (#489).

## The bug
The disconnect handler is **the** leave signal — there is no client leave message. It ran as `await asyncio.to_thread(_disconnect_sync, …)` in the endpoint's `finally`. When the endpoint task is *cancelled* (server shutdown; the test portal tearing down the connection), every `await` inside the cancelled task re-raises `CancelledError` instead of completing — so the leave silently never ran: a phantom participant forever, and a dirty buffer that never got its last-leave checkpoint. Production impact: a server shutdown mid-session drops the checkpoint the same way.

## Evidence
`test_disconnect_of_last_participant_checkpoints` failing across branches (including a migration-only PR) on part of the runner fleet; an instrumented run showed `_disconnect_sync` never executed — session still open, participant still present after a 15s wait, no handler log lines — plus an orphaned `_recv_loop` task warning implicating the cancellation path.

## The fix
The `finally` now checks `task.cancelling()` up front: mid-cancellation, the leave is handed to a plain `threading.Thread` that no cancellation can touch; the normal disconnect path keeps awaiting so the leave is recorded before the handler returns. Checked **before** awaiting rather than caught after, to avoid double-running the leave — a cancelled `await asyncio.to_thread(...)` has already submitted its executor item by the time it re-raises.

## Tests
Both disconnect tests now wait for the handler's *effects* (participant gone; checkpoint committed + session closed) instead of assuming the handler finished by the time `websocket_connect.__exit__` returned — an ordering the API never promised. The checkpoint wait sits inside `immediate_mode` on purpose: once the flag drops, a late enqueue would land on the real queue and never run in the test.