### PR TITLE
feat(automanage): stub/placeholder-page detector

### DIFF
--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -12,6 +12,7 @@ from app.wiki.automanage.detectors import (
     case_collision,
     empty_folder,
     folder_chain,
+    stub_page,
     template_echo,
 )
 from app.wiki.automanage.detectors.base import (
@@ -27,6 +28,7 @@ DETECTORS: list[Detector] = [
     template_echo.DETECTOR,
     case_collision.DETECTOR,
     folder_chain.DETECTOR,
+    stub_page.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/stub_page.py
+++ b/backend/app/wiki/automanage/detectors/stub_page.py
@@ -1,0 +1,147 @@
+"""Stub/placeholder-page detector — mechanical, no LLM.
+
+A page that never grew past a title is clutter that pollutes search and
+listings: someone created it meaning to write, and didn't. After a grace
+window this proposes ``delete_page`` — removal, not merge — for pages whose
+body carries essentially no content once scaffolding is stripped.
+
+**Content**, for this detector, is what remains after dropping heading
+lines, horizontal rules, and blank lines, with whitespace runs collapsed.
+A title-only page measures zero; ``# Notes\\n\\nTODO`` measures four bytes; a
+single real sentence clears the floor. The floor is deliberately low
+(``STUB_MAX_CONTENT_BYTES``) — this detector exists for pages that are
+*obviously* placeholders, not for judging whether short pages are worth
+keeping. A skeleton instantiated from a template and partially filled in
+(placeholder tokens, a couple of real fields) is *not* a stub — telling
+"barely started" from "abandoned scaffold" takes judgment, which is the
+future fuzzy detectors' job, not a byte count's.
+
+Division of labor: a page byte-identical to a current template body is the
+template-echo detector's case and is skipped here — its proposal names the
+template, which is a better review story than "this page is small".
+
+Never auto-approvable: smallness is evidence, not proof — a terse page can
+be exactly as long as it needs to be, so a human confirms every removal.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from app.wiki import git
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.automanage.detectors.template_echo import (
+    blob_sha,
+    template_body_blob_shas,
+)
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# A page whose stripped body is at or below this many bytes is a stub. Sized
+# to catch "TODO", "Coming soon.", "fill me in later" — and to stay well
+# below one meaningful sentence (a short real sentence runs ~35+ bytes).
+STUB_MAX_CONTENT_BYTES = 24
+
+# The grace window off the page's last commit: a small page someone touched
+# recently may be about to grow. Any edit restarts the clock.
+STUB_MIN_AGE_DAYS = 7
+
+_SCAFFOLDING_LINE = re.compile(r"^\s*(#{1,6}\s.*|#{1,6}|-{3,}|_{3,}|\*{3,})\s*$")
+
+
+def content_bytes(body: str) -> int:
+    """Byte size of ``body`` once scaffolding is stripped: heading lines,
+    horizontal rules, and blank lines dropped; whitespace runs collapsed to
+    one space. What's left is prose, links, list items, code — anything a
+    reader actually came for."""
+    kept = [
+        line for line in body.splitlines() if not _SCAFFOLDING_LINE.match(line)
+    ]
+    return len(re.sub(r"\s+", " ", " ".join(kept)).strip().encode())
+
+
+def _old_enough(page: str, now: datetime, min_age_days: int) -> bool:
+    meta = git.last_commit_meta_for_path(page)
+    if meta is None:
+        return False
+    try:
+        touched = datetime.fromisoformat(meta[2])
+    except ValueError:
+        log.warning("stub-page: unparseable commit ts %r for %s", meta[2], page)
+        return False
+    return now - touched >= timedelta(days=min_age_days)
+
+
+class _StubPageDetector:
+    name = "stub_page"
+    pairs_paths = False  # judges each page alone; sees the whole scope
+
+    def __init__(
+        self,
+        *,
+        max_content_bytes: int = STUB_MAX_CONTENT_BYTES,
+        min_age_days: int = STUB_MIN_AGE_DAYS,
+    ) -> None:
+        self.max_content_bytes = max_content_bytes
+        self.min_age_days = min_age_days
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        # Sweep-only: the age gate means a page can't qualify at write time.
+        return trigger == TriggerKind.SWEEP
+
+    def _is_stub(self, body: str) -> bool:
+        return content_bytes(body) <= self.max_content_bytes
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        if not self.applicable(scope.trigger):
+            return []
+        pages = sorted(p for p in scope.paths if p.endswith(".md"))
+        if not pages:
+            return []
+        echoes = template_body_blob_shas()
+        now = datetime.now(UTC)
+        drafts: list[ProposalDraft] = []
+        for path in pages:
+            body = git.read_file_opt(path)
+            if body is None or not self._is_stub(body):
+                continue
+            if blob_sha(body) in echoes:
+                continue  # template-echo's case — better review story there
+            if not _old_enough(path, now, self.min_age_days):
+                continue
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.DELETE_PAGE,
+                    source_paths=[path],
+                    summary=(
+                        f"Remove stub page “{path}” — no real content after "
+                        f"{self.min_age_days}+ days"
+                    ),
+                    instruction=(
+                        f"The page {path!r} is a placeholder that never got "
+                        "content (nothing beyond a title/scaffolding). Remove "
+                        "it with trash_page (restorable). Do not write any "
+                        "content."
+                    ),
+                    auto_approvable=False,
+                )
+            )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """Premise: the page still has no real content. Someone writing even
+        a sentence since approval clears the floor and stales the proposal;
+        scaffolding-only shuffles keep it valid."""
+        path = proposal["source_paths"][0]
+        body = git.read_file_opt(path)
+        if body is None:
+            return f"{path!r} no longer exists"
+        if not self._is_stub(body):
+            return f"“{path}” has content now — no longer a stub"
+        return None
+
+
+DETECTOR = _StubPageDetector()

--- a/backend/app/wiki/automanage/detectors/stub_page.py
+++ b/backend/app/wiki/automanage/detectors/stub_page.py
@@ -140,15 +140,19 @@ class _StubPageDetector:
         return drafts
 
     def validate(self, proposal: dict[str, Any]) -> str | None:
-        """Premise: the page still has no real content. Someone writing even
-        a sentence since approval clears the floor and stales the proposal;
-        scaffolding-only shuffles keep it valid."""
+        """Premise: the page still has no real content **and** is still
+        quiet. Someone writing even a sentence since approval clears the
+        floor; an edit that stays tiny still restarts the quiet window —
+        activity is activity, and the detector re-proposes once the page
+        has settled again."""
         path = proposal["source_paths"][0]
         body = git.read_file_opt(path)
         if body is None:
             return f"{path!r} no longer exists"
         if not self._is_stub(body):
             return f"“{path}” has content now — no longer a stub"
+        if not _old_enough(path, datetime.now(UTC), self.min_age_days):
+            return f"“{path}” was edited recently — the quiet window restarted"
         return None
 
 

--- a/backend/app/wiki/automanage/detectors/stub_page.py
+++ b/backend/app/wiki/automanage/detectors/stub_page.py
@@ -120,10 +120,18 @@ class _StubPageDetector:
                         f"Remove stub page “{path}” — no real content after "
                         f"{self.min_age_days}+ days"
                     ),
+                    # State the premise exactly: "at most a few words",
+                    # not "title/scaffolding only" — a tiny page whose bytes
+                    # are all body text is still a stub, and the applier
+                    # shouldn't re-litigate the reviewer's judgment over a
+                    # wording mismatch (premise drift is validate()'s job,
+                    # re-checked before the applier ever runs).
                     instruction=(
-                        f"The page {path!r} is a placeholder that never got "
-                        "content (nothing beyond a title/scaffolding). Remove "
-                        "it with trash_page (restorable). Do not write any "
+                        f"The page {path!r} is a stub: at most a few words "
+                        "of content, unchanged long enough to be abandoned. "
+                        "A reviewer approved its removal and a validation "
+                        "step has re-confirmed it is still a stub. Remove it "
+                        "with trash_page (restorable). Do not write any "
                         "content."
                     ),
                     auto_approvable=False,

--- a/backend/tests/test_stub_page_detector.py
+++ b/backend/tests/test_stub_page_detector.py
@@ -114,7 +114,12 @@ def test_validate_holds_across_scaffolding_shuffles(repo):
 
     _seed("proj/notes.md", "## Notes\n\n---\n\n### Later\n")  # still no content
 
-    assert _StubPageDetector().validate(p) is None
+    # Still a stub, but the edit restarted the quiet window — an
+    # age-agnostic validator would trash a page someone touched today.
+    reason = _StubPageDetector().validate(p)
+    assert reason is not None and "quiet window" in reason
+    # With the window elapsed (age gate disabled), the premise holds.
+    assert _StubPageDetector(min_age_days=0).validate(p) is None
 
 
 def test_validate_stales_when_the_page_is_gone(repo):

--- a/backend/tests/test_stub_page_detector.py
+++ b/backend/tests/test_stub_page_detector.py
@@ -1,0 +1,127 @@
+"""Stub/placeholder-page detector.
+
+Content measurement is pure (scaffolding stripped, whitespace collapsed);
+detection adds the template-echo precedence skip and the quiet-window age
+gate; validate re-checks the still-a-stub premise at execution time.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.wiki import git as wiki_git
+from app.wiki import templates
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.stub_page import (
+    _StubPageDetector,
+    content_bytes,
+)
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_db):
+    return tmp_repo
+
+
+def _detect(*paths: str, trigger: TriggerKind = TriggerKind.SWEEP):
+    det = _StubPageDetector(min_age_days=0)
+    return det.detect(Scope(trigger=trigger, paths=tuple(paths)))
+
+
+def _seed(path: str, body: str) -> None:
+    wiki_git.commit_file(path, body, "seed", author=None)
+
+
+def test_content_bytes_strips_scaffolding():
+    assert content_bytes("# Title\n") == 0
+    assert content_bytes("# Title\n\n---\n\n## Section\n") == 0
+    assert content_bytes("# Notes\n\nTODO\n") == len(b"TODO")
+    # Whitespace runs collapse; real prose counts byte-for-byte.
+    assert content_bytes("hello   world") == len(b"hello world")
+
+
+def test_title_only_page_emits_removal(repo):
+    _seed("proj/notes.md", "# Notes\n")
+    drafts = _detect("proj/notes.md")
+
+    assert len(drafts) == 1
+    d = drafts[0]
+    assert d.op.value == "delete_page"
+    assert d.source_paths == ["proj/notes.md"]
+    assert d.target_paths == []
+    assert d.auto_approvable is False  # smallness is evidence, not proof
+    assert "trash_page" in (d.instruction or "")
+
+
+def test_placeholder_text_below_floor_emits(repo):
+    _seed("proj/soon.md", "# Roadmap\n\nComing soon.\n")
+    assert len(_detect("proj/soon.md")) == 1
+
+
+def test_one_real_sentence_clears_the_floor(repo):
+    _seed(
+        "proj/real.md",
+        "# Decision\n\nWe picked Postgres over DynamoDB for the queue store.\n",
+    )
+    assert _detect("proj/real.md") == []
+
+
+def test_template_identical_page_is_left_to_template_echo(repo):
+    body = "# <Project name>\n\n**Owner:** <name>\n"
+    templates.create(
+        name="Project",
+        body=body,
+        description=None,
+        system_prompt=None,
+        created_by_user_id=None,
+    )
+    _seed("proj/skeleton.md", body)
+    # Small enough to be a stub, but byte-identical to a template — the
+    # template-echo detector owns it (its proposal names the template).
+    assert _detect("proj/skeleton.md") == []
+
+
+def test_recent_stub_is_left_alone(repo):
+    _seed("proj/new.md", "# New\n")
+    det = _StubPageDetector(min_age_days=7)  # seeded moments ago
+    assert det.detect(Scope(trigger=TriggerKind.SWEEP, paths=("proj/new.md",))) == []
+
+
+def test_only_sweep_trigger_applies(repo):
+    _seed("proj/notes.md", "# Notes\n")
+    assert _detect("proj/notes.md", trigger=TriggerKind.ON_WRITE) == []
+    assert _detect("proj/notes.md", trigger=TriggerKind.ON_CREATE) == []
+
+
+def _proposal(drafts: list[Any]) -> dict[str, Any]:
+    return {"source_paths": drafts[0].source_paths}
+
+
+def test_validate_stales_once_content_lands(repo):
+    _seed("proj/notes.md", "# Notes\n")
+    p = _proposal(_detect("proj/notes.md"))
+
+    _seed("proj/notes.md", "# Notes\n\nReal decisions live here now, in detail.\n")
+
+    reason = _StubPageDetector().validate(p)
+    assert reason is not None and "content" in reason
+
+
+def test_validate_holds_across_scaffolding_shuffles(repo):
+    _seed("proj/notes.md", "# Notes\n")
+    p = _proposal(_detect("proj/notes.md"))
+
+    _seed("proj/notes.md", "## Notes\n\n---\n\n### Later\n")  # still no content
+
+    assert _StubPageDetector().validate(p) is None
+
+
+def test_validate_stales_when_the_page_is_gone(repo):
+    _seed("proj/notes.md", "# Notes\n")
+    p = _proposal(_detect("proj/notes.md"))
+
+    wiki_git.delete_path("proj/notes.md", "removed", author=None)
+
+    reason = _StubPageDetector().validate(p)
+    assert reason is not None and "exists" in reason


### PR DESCRIPTION
The last mechanical detection technique — closes out the deterministic wave entirely.

## What it detects
A page that never grew past its title. **Content bytes** = the body with heading lines, horizontal rules, and blank lines stripped, whitespace collapsed; at or under a deliberately low floor (24 bytes — catches "TODO" / "Coming soon.", stays well under one meaningful sentence) → `delete_page` proposal, once the page has been quiet for 7 days (any edit restarts the clock).

## Boundaries, on purpose
- **Byte-identical to a current template body → skipped**: template-echo owns that case, and its proposal names the template — a better review story than "this page is small".
- **Partially-filled template skeletons are NOT stubs**: telling "barely started" from "abandoned scaffold" takes judgment — that's the future fuzzy detectors' job, not a byte count's. The floor exists for pages that are *obviously* placeholders.
- **Never auto-approvable**: smallness is evidence, not proof; a terse page can be exactly as long as it needs to be.

## Execution
Zero executor changes — `delete_page` and the `trash_page` applier tool have existed since template-echo. `validate()` re-checks the premise at execute time: real content written since approval stales the proposal; scaffolding-only shuffles keep it valid.

10 new tests (content measurement, floor calibration against a real short sentence, template-echo precedence, quiet window, trigger gating, all three validate outcomes); automanage suite green (121 passed); ruff + basedpyright clean.