### PR TITLE
feat(admin): sweep outcome + run history on the Auto Organize page

### DIFF
--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -176,31 +176,31 @@ const runColumns = (() => {
   return [
     tc.column("started_at", {
       header: "Started",
-      weight: 30,
+      weight: 32,
       enableSorting: false,
       cell: startedCell,
     }),
     tc.column("triggered_by_user_id", {
       header: "Trigger",
-      weight: 15,
+      weight: 16,
       enableSorting: false,
       cell: triggerCell,
     }),
     tc.column("proposals_emitted", {
       header: "Proposals",
-      weight: 20,
+      weight: 22,
       enableSorting: false,
       cell: proposalsCell,
     }),
     tc.column("paths_scanned", {
       header: "Scanned",
-      weight: 15,
+      weight: 18,
       enableSorting: false,
       cell: scannedCell,
     }),
     tc.column("status", {
       header: "Status",
-      weight: 20,
+      weight: 12,
       enableSorting: false,
       cell: statusCell,
     }),

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -120,7 +120,15 @@ function runTime(ts: string): string {
 function startedCell(_value: string, row: DetectionRun) {
   return (
     <Text font="main-ui-body" color="text-04">
-      {`${runTime(row.started_at)} · ${row.triggered_by_user_id === null ? "system" : "manual"}`}
+      {runTime(row.started_at)}
+    </Text>
+  );
+}
+
+function triggerCell(_value: string | null, row: DetectionRun) {
+  return (
+    <Text font="main-ui-body" color="text-03">
+      {row.triggered_by_user_id === null ? "Scheduled" : "Manual"}
     </Text>
   );
 }
@@ -168,9 +176,15 @@ const runColumns = (() => {
   return [
     tc.column("started_at", {
       header: "Started",
-      weight: 22,
+      weight: 18,
       enableSorting: false,
       cell: startedCell,
+    }),
+    tc.column("triggered_by_user_id", {
+      header: "Trigger",
+      weight: 12,
+      enableSorting: false,
+      cell: triggerCell,
     }),
     tc.column("proposals_emitted", {
       header: "Proposals",

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -2,9 +2,21 @@
 
 import { useEffect, useState } from "react";
 
-import { Button, Card, Switch, Text } from "@onyx-ai/opal/components";
-import { SvgSliders } from "@onyx-ai/opal/icons";
-import { ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
+import {
+  Button,
+  Card,
+  Switch,
+  Table,
+  Text,
+  createTableColumns,
+} from "@onyx-ai/opal/components";
+import {
+  SvgAlertCircle,
+  SvgCheckCircle,
+  SvgClock,
+  SvgSliders,
+} from "@onyx-ai/opal/icons";
+import { Content, ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 
 import {
   type AutoOrganizeSchedule,
@@ -97,48 +109,102 @@ export function AutoOrganize() {
   );
 }
 
-/** UTC second-granular DB text ("YYYY-MM-DD HH:MM:SS") → local display. */
+/** UTC second-granular DB text ("YYYY-MM-DD HH:MM:SS") → local display,
+ * short form ("Jul 24, 9:25 AM"). */
 function runTime(ts: string): string {
   const d = new Date(ts.replace(" ", "T") + "Z");
-  return Number.isNaN(d.getTime()) ? ts : d.toLocaleString();
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
 }
 
-const RUN_STATUS_LABEL: Record<string, string> = {
-  running: "Running…",
-  completed: "Completed",
-  failed: "Failed",
-};
+const RUN_STATUS_ICON = {
+  completed: SvgCheckCircle,
+  failed: SvgAlertCircle,
+} as const;
+
+function startedCell(_value: string, row: DetectionRun) {
+  return (
+    <Content
+      sizePreset="main-ui"
+      variant="section"
+      title={runTime(row.started_at)}
+      description={row.triggered_by_user_id === null ? "System" : "Manual"}
+    />
+  );
+}
+
+function resultCell(_value: number, row: DetectionRun) {
+  if (row.status === "running") {
+    return (
+      <Text font="main-ui-body" color="text-03">
+        Running…
+      </Text>
+    );
+  }
+  if (row.status === "failed") {
+    return (
+      <Text font="main-ui-body" color="status-error-05">
+        {row.error ?? "Failed"}
+      </Text>
+    );
+  }
+  return (
+    <Content
+      sizePreset="main-ui"
+      variant="section"
+      title={`${row.proposals_emitted} proposal${row.proposals_emitted === 1 ? "" : "s"}`}
+      description={`${row.paths_scanned} pages scanned`}
+    />
+  );
+}
+
+const runColumns = (() => {
+  const tc = createTableColumns<DetectionRun>();
+  return [
+    tc.qualifier({
+      content: "icon",
+      getContent: (row) =>
+        RUN_STATUS_ICON[row.status as "completed" | "failed"] ?? SvgClock,
+    }),
+    tc.column("started_at", {
+      header: "Started",
+      weight: 20,
+      enableSorting: false,
+      cell: startedCell,
+    }),
+    tc.column("proposals_emitted", {
+      header: "Result",
+      weight: 30,
+      enableSorting: false,
+      cell: resultCell,
+    }),
+  ];
+})();
 
 function RunHistory() {
   const { runs } = useDetectionRuns(false);
   if (runs.length === 0) return null;
 
   return (
-    <Card padding="xs" rounding="md" border="solid" background="heavy">
-      <div className="flex w-full flex-col gap-1 p-1">
-        <Text font="main-content-emphasis" color="text-04">
-          Recent sweeps
-        </Text>
-        {runs.slice(0, 8).map((r) => (
-          <div
-            key={r.id}
-            className="flex w-full items-baseline justify-between gap-2"
-          >
-            <Text font="secondary-body" color="text-03">
-              {`${runTime(r.started_at)} · ${r.triggered_by_user_id === null ? "scheduled" : "manual"}`}
-            </Text>
-            <Text
-              font="secondary-body"
-              color={r.status === "failed" ? "status-error-05" : "text-04"}
-            >
-              {r.status === "completed"
-                ? `${r.proposals_emitted} proposal${r.proposals_emitted === 1 ? "" : "s"} · ${r.paths_scanned} paths`
-                : (RUN_STATUS_LABEL[r.status] ?? r.status)}
-            </Text>
-          </div>
-        ))}
-      </div>
-    </Card>
+    <div className="flex w-full flex-col gap-2">
+      <ContentAction
+        sizePreset="main-ui"
+        variant="section"
+        icon={SvgClock}
+        title="Recent sweeps"
+        description="What the last detection runs scanned and proposed."
+      />
+      <Table
+        data={runs.slice(0, 10)}
+        columns={runColumns}
+        getRowId={(r) => r.id}
+      />
+    </div>
   );
 }
 

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Button, Card, Switch, Text } from "@onyx-ai/opal/components";
 import { SvgSliders } from "@onyx-ai/opal/icons";
@@ -8,9 +8,11 @@ import { ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 
 import {
   type AutoOrganizeSchedule,
+  type DetectionRun,
   triggerSweep,
   updateAutoOrganizeSettings,
   useAutoOrganizeSettings,
+  useDetectionRuns,
 } from "@/lib/autoOrganize";
 
 export function AutoOrganize() {
@@ -89,7 +91,54 @@ export function AutoOrganize() {
       </Card>
 
       <SweepControl disabled={!enabled} />
+
+      <RunHistory />
     </div>
+  );
+}
+
+/** UTC second-granular DB text ("YYYY-MM-DD HH:MM:SS") → local display. */
+function runTime(ts: string): string {
+  const d = new Date(ts.replace(" ", "T") + "Z");
+  return Number.isNaN(d.getTime()) ? ts : d.toLocaleString();
+}
+
+const RUN_STATUS_LABEL: Record<string, string> = {
+  running: "Running…",
+  completed: "Completed",
+  failed: "Failed",
+};
+
+function RunHistory() {
+  const { runs } = useDetectionRuns(false);
+  if (runs.length === 0) return null;
+
+  return (
+    <Card padding="xs" rounding="md" border="solid" background="heavy">
+      <div className="flex w-full flex-col gap-1 p-1">
+        <Text font="main-content-emphasis" color="text-04">
+          Recent sweeps
+        </Text>
+        {runs.slice(0, 8).map((r) => (
+          <div
+            key={r.id}
+            className="flex w-full items-baseline justify-between gap-2"
+          >
+            <Text font="secondary-body" color="text-03">
+              {`${runTime(r.started_at)} · ${r.triggered_by_user_id === null ? "scheduled" : "manual"}`}
+            </Text>
+            <Text
+              font="secondary-body"
+              color={r.status === "failed" ? "status-error-05" : "text-04"}
+            >
+              {r.status === "completed"
+                ? `${r.proposals_emitted} proposal${r.proposals_emitted === 1 ? "" : "s"} · ${r.paths_scanned} paths`
+                : (RUN_STATUS_LABEL[r.status] ?? r.status)}
+            </Text>
+          </div>
+        ))}
+      </div>
+    </Card>
   );
 }
 
@@ -130,22 +179,55 @@ function ScheduleSelector({
 
 function SweepControl({ disabled }: { disabled: boolean }) {
   const [busy, setBusy] = useState(false);
-  const [note, setNote] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // The run id at the top of the history when the sweep was requested — the
+  // request only *enqueues*, so the new run appears (and finishes) on its own
+  // schedule; we watch the history until a different id lands and completes.
+  const [watchFrom, setWatchFrom] = useState<string | null>(null);
+  const watching = watchFrom !== null;
+  const { runs, refresh } = useDetectionRuns(watching);
+
+  const latest = runs[0];
+  const newRun =
+    watching && latest && latest.id !== watchFrom ? latest : undefined;
+  const [lastFinished, setLastFinished] = useState<DetectionRun | null>(null);
+  useEffect(() => {
+    // Terminal state on the watched run — capture the outcome, stop polling.
+    if (newRun && newRun.status !== "running") {
+      setLastFinished(newRun);
+      setWatchFrom(null);
+    }
+  }, [newRun]);
 
   async function run() {
     setBusy(true);
     setError(null);
-    setNote(null);
+    setLastFinished(null);
     try {
+      // Snapshot the current top-of-history *before* enqueueing so the new
+      // run is recognized by id, not by racy timestamp comparison.
+      setWatchFrom(runs[0]?.id ?? "");
       await triggerSweep();
-      setNote("Sweep started.");
+      void refresh();
     } catch (e) {
+      setWatchFrom(null);
       setError(e instanceof Error ? e.message : "failed to start sweep");
     } finally {
       setBusy(false);
     }
   }
+
+  const note = watching
+    ? newRun
+      ? "Sweep running…"
+      : "Sweep queued…"
+    : lastFinished
+      ? lastFinished.status === "completed"
+        ? `Sweep finished — ${lastFinished.proposals_emitted} proposal${
+            lastFinished.proposals_emitted === 1 ? "" : "s"
+          } from ${lastFinished.paths_scanned} paths.`
+        : `Sweep failed${lastFinished.error ? `: ${lastFinished.error}` : "."}`
+      : null;
 
   return (
     <Card padding="xs" rounding="md" border="solid" background="heavy">

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -10,13 +10,8 @@ import {
   Text,
   createTableColumns,
 } from "@onyx-ai/opal/components";
-import {
-  SvgAlertCircle,
-  SvgCheckCircle,
-  SvgClock,
-  SvgSliders,
-} from "@onyx-ai/opal/icons";
-import { Content, ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
+import { SvgClock, SvgSliders } from "@onyx-ai/opal/icons";
+import { ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 
 import {
   type AutoOrganizeSchedule,
@@ -122,30 +117,38 @@ function runTime(ts: string): string {
   });
 }
 
-const RUN_STATUS_ICON = {
-  completed: SvgCheckCircle,
-  failed: SvgAlertCircle,
-} as const;
-
 function startedCell(_value: string, row: DetectionRun) {
   return (
-    <Content
-      sizePreset="main-ui"
-      variant="section"
-      title={runTime(row.started_at)}
-      description={row.triggered_by_user_id === null ? "System" : "Manual"}
-    />
+    <Text font="main-ui-body" color="text-04">
+      {`${runTime(row.started_at)} · ${row.triggered_by_user_id === null ? "system" : "manual"}`}
+    </Text>
   );
 }
 
-function resultCell(_value: number, row: DetectionRun) {
-  if (row.status === "running") {
+function proposalsCell(_value: number, row: DetectionRun) {
+  if (row.status !== "completed") {
     return (
-      <Text font="main-ui-body" color="text-03">
-        Running…
+      <Text font="main-ui-body" color="text-02">
+        —
       </Text>
     );
   }
+  return (
+    <Text font="main-ui-body" color="text-04">
+      {`${row.proposals_emitted} proposal${row.proposals_emitted === 1 ? "" : "s"}`}
+    </Text>
+  );
+}
+
+function scannedCell(_value: number, row: DetectionRun) {
+  return (
+    <Text font="main-ui-body" color="text-03">
+      {row.status === "completed" ? `${row.paths_scanned} pages` : "—"}
+    </Text>
+  );
+}
+
+function statusCell(_value: string, row: DetectionRun) {
   if (row.status === "failed") {
     return (
       <Text font="main-ui-body" color="status-error-05">
@@ -154,34 +157,38 @@ function resultCell(_value: number, row: DetectionRun) {
     );
   }
   return (
-    <Content
-      sizePreset="main-ui"
-      variant="section"
-      title={`${row.proposals_emitted} proposal${row.proposals_emitted === 1 ? "" : "s"}`}
-      description={`${row.paths_scanned} pages scanned`}
-    />
+    <Text font="main-ui-body" color="text-03">
+      {row.status === "running" ? "Running…" : "Completed"}
+    </Text>
   );
 }
 
 const runColumns = (() => {
   const tc = createTableColumns<DetectionRun>();
   return [
-    tc.qualifier({
-      content: "icon",
-      getContent: (row) =>
-        RUN_STATUS_ICON[row.status as "completed" | "failed"] ?? SvgClock,
-    }),
     tc.column("started_at", {
       header: "Started",
-      weight: 20,
+      weight: 22,
       enableSorting: false,
       cell: startedCell,
     }),
     tc.column("proposals_emitted", {
-      header: "Result",
-      weight: 30,
+      header: "Proposals",
+      weight: 14,
       enableSorting: false,
-      cell: resultCell,
+      cell: proposalsCell,
+    }),
+    tc.column("paths_scanned", {
+      header: "Scanned",
+      weight: 14,
+      enableSorting: false,
+      cell: scannedCell,
+    }),
+    tc.column("status", {
+      header: "Status",
+      weight: 20,
+      enableSorting: false,
+      cell: statusCell,
     }),
   ];
 })();
@@ -200,9 +207,11 @@ function RunHistory() {
         description="What the last detection runs scanned and proposed."
       />
       <Table
-        data={runs.slice(0, 10)}
+        data={runs.slice(0, 20)}
         columns={runColumns}
         getRowId={(r) => r.id}
+        variant="rows"
+        size="md"
       />
     </div>
   );

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -213,22 +213,24 @@ function RunHistory() {
   if (sweeps.length === 0) return null;
 
   return (
-    <div className="flex w-full flex-col gap-2">
-      <ContentAction
-        sizePreset="main-ui"
-        variant="section"
-        icon={SvgClock}
-        title="Recent sweeps"
-        description="What the last detection runs scanned and proposed."
-      />
-      <Table
-        data={sweeps.slice(0, 20)}
-        columns={runColumns}
-        getRowId={(r) => r.id}
-        variant="rows"
-        size="md"
-      />
-    </div>
+    <Card rounding="lg" padding="sm">
+      <div className="flex w-full flex-col gap-2">
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          icon={SvgClock}
+          title="Recent sweeps"
+          description="What the last detection runs scanned and proposed."
+        />
+        <Table
+          data={sweeps.slice(0, 20)}
+          columns={runColumns}
+          getRowId={(r) => r.id}
+          variant="rows"
+          size="md"
+        />
+      </div>
+    </Card>
   );
 }
 

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -209,7 +209,13 @@ const runColumns = (() => {
 
 function RunHistory() {
   const { runs } = useDetectionRuns(false);
-  if (runs.length === 0) return null;
+  // This card is the *sweep* history. Every run is a sweep today, but the
+  // runs API is trigger-agnostic — once on-create/on-write triggers exist,
+  // their per-page runs must not flood this table. (Server-side filtering
+  // belongs with that work: a client filter over a limited fetch would skew
+  // the page size.)
+  const sweeps = runs.filter((r) => r.trigger === "sweep");
+  if (sweeps.length === 0) return null;
 
   return (
     <div className="flex w-full flex-col gap-2">
@@ -221,7 +227,7 @@ function RunHistory() {
         description="What the last detection runs scanned and proposed."
       />
       <Table
-        data={runs.slice(0, 20)}
+        data={sweeps.slice(0, 20)}
         columns={runColumns}
         getRowId={(r) => r.id}
         variant="rows"

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -176,25 +176,25 @@ const runColumns = (() => {
   return [
     tc.column("started_at", {
       header: "Started",
-      weight: 18,
+      weight: 30,
       enableSorting: false,
       cell: startedCell,
     }),
     tc.column("triggered_by_user_id", {
       header: "Trigger",
-      weight: 12,
+      weight: 15,
       enableSorting: false,
       cell: triggerCell,
     }),
     tc.column("proposals_emitted", {
       header: "Proposals",
-      weight: 14,
+      weight: 20,
       enableSorting: false,
       cell: proposalsCell,
     }),
     tc.column("paths_scanned", {
       header: "Scanned",
-      weight: 14,
+      weight: 15,
       enableSorting: false,
       cell: scannedCell,
     }),

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -208,13 +208,7 @@ const runColumns = (() => {
 })();
 
 function RunHistory() {
-  const { runs } = useDetectionRuns(false);
-  // This card is the *sweep* history. Every run is a sweep today, but the
-  // runs API is trigger-agnostic — once on-create/on-write triggers exist,
-  // their per-page runs must not flood this table. (Server-side filtering
-  // belongs with that work: a client filter over a limited fetch would skew
-  // the page size.)
-  const sweeps = runs.filter((r) => r.trigger === "sweep");
+  const { sweeps } = useDetectionRuns(false);
   if (sweeps.length === 0) return null;
 
   return (
@@ -280,9 +274,9 @@ function SweepControl({ disabled }: { disabled: boolean }) {
   // schedule; we watch the history until a different id lands and completes.
   const [watchFrom, setWatchFrom] = useState<string | null>(null);
   const watching = watchFrom !== null;
-  const { runs, refresh } = useDetectionRuns(watching);
+  const { sweeps, refresh } = useDetectionRuns(watching);
 
-  const latest = runs[0];
+  const latest = sweeps[0];
   const newRun =
     watching && latest && latest.id !== watchFrom ? latest : undefined;
   const [lastFinished, setLastFinished] = useState<DetectionRun | null>(null);
@@ -301,7 +295,7 @@ function SweepControl({ disabled }: { disabled: boolean }) {
     try {
       // Snapshot the current top-of-history *before* enqueueing so the new
       // run is recognized by id, not by racy timestamp comparison.
-      setWatchFrom(runs[0]?.id ?? "");
+      setWatchFrom(sweeps[0]?.id ?? "");
       await triggerSweep();
       void refresh();
     } catch (e) {

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -177,25 +177,25 @@ const runColumns = (() => {
   return [
     tc.column("started_at", {
       header: "Started",
-      weight: 32,
+      weight: 20,
       enableSorting: false,
       cell: startedCell,
     }),
     tc.column("triggered_by_user_id", {
       header: "Trigger",
-      weight: 16,
+      weight: 14,
       enableSorting: false,
       cell: triggerCell,
     }),
     tc.column("proposals_emitted", {
       header: "Proposals",
-      weight: 22,
+      weight: 18,
       enableSorting: false,
       cell: proposalsCell,
     }),
     tc.column("paths_scanned", {
       header: "Scanned",
-      weight: 18,
+      weight: 16,
       enableSorting: false,
       cell: scannedCell,
     }),

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -16,6 +16,7 @@ import { ContentAction, InputErrorText } from "@onyx-ai/opal/layouts";
 import {
   type AutoOrganizeSchedule,
   type DetectionRun,
+  sweepRuns,
   triggerSweep,
   updateAutoOrganizeSettings,
   useAutoOrganizeSettings,
@@ -293,9 +294,14 @@ function SweepControl({ disabled }: { disabled: boolean }) {
     setError(null);
     setLastFinished(null);
     try {
-      // Snapshot the current top-of-history *before* enqueueing so the new
-      // run is recognized by id, not by racy timestamp comparison.
-      setWatchFrom(sweeps[0]?.id ?? "");
+      // Snapshot the top-of-history from an *awaited authoritative fetch*
+      // before enqueueing, so the new run is recognized by id. Reading the
+      // possibly-unloaded cache instead would snapshot "" while history
+      // exists — and the first pre-existing terminal run to arrive would
+      // masquerade as the new sweep. After this await, "" can only mean
+      // the history is verifiably empty (any sweep row IS the new one).
+      const fresh = await refresh();
+      setWatchFrom(sweepRuns(fresh?.runs ?? [])[0]?.id ?? "");
       await triggerSweep();
       void refresh();
     } catch (e) {

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -41,6 +41,31 @@ export function updateAutoOrganizeSettings(patch: {
   });
 }
 
+/** One detection run — the sweep history. Mirrors
+ * `app/models/automanage.py:DetectionRunView`. */
+export interface DetectionRun {
+  id: string;
+  trigger: string;
+  status: "running" | "completed" | "failed" | string;
+  triggered_by_user_id: string | null;
+  paths_scanned: number;
+  proposals_emitted: number;
+  error: string | null;
+  started_at: string;
+  finished_at: string | null;
+}
+
+/** Recent detection runs, newest first (admin only server-side). `poll` turns
+ * on a short refresh interval — used while a sweep the admin just started is
+ * still enqueued/running, so the outcome shows up without a reload. */
+export function useDetectionRuns(poll: boolean) {
+  const { data, error, isLoading, mutate } = useSWR<{ runs: DetectionRun[] }>(
+    SWR_KEYS.automanageRuns,
+    { refreshInterval: poll ? 2000 : 0 },
+  );
+  return { runs: data?.runs ?? [], error, isLoading, refresh: mutate };
+}
+
 /** One Auto Organize change proposal (a pending AI-initiated cleanup awaiting
  * human review). Mirrors `app/models/automanage.py:ProposalView`. */
 export interface Proposal {

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -58,6 +58,12 @@ export interface DetectionRun {
 /** Recent detection runs, newest first (admin only server-side). `poll` turns
  * on a short refresh interval — used while a sweep the admin just started is
  * still enqueued/running, so the outcome shows up without a reload. */
+/** The sweep rows of a runs payload — the one definition of "is a sweep"
+ * shared by the hook and the snapshot-before-trigger path. */
+export function sweepRuns(runs: DetectionRun[]): DetectionRun[] {
+  return runs.filter((r) => r.trigger === "sweep");
+}
+
 export function useDetectionRuns(poll: boolean) {
   const { data, error, isLoading, mutate } = useSWR<{ runs: DetectionRun[] }>(
     SWR_KEYS.automanageRuns,
@@ -69,7 +75,7 @@ export function useDetectionRuns(poll: boolean) {
   // rows), so expose the filtered view once — a future on_create/on_write
   // run completing mid-watch must never masquerade as the sweep outcome.
   // Server-side filtering belongs with the focused-trigger work.
-  const sweeps = runs.filter((r) => r.trigger === "sweep");
+  const sweeps = sweepRuns(runs);
   return { sweeps, error, isLoading, refresh: mutate };
 }
 

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -63,7 +63,14 @@ export function useDetectionRuns(poll: boolean) {
     SWR_KEYS.automanageRuns,
     { refreshInterval: poll ? 2000 : 0 },
   );
-  return { runs: data?.runs ?? [], error, isLoading, refresh: mutate };
+  const runs = data?.runs ?? [];
+  // The runs API is trigger-agnostic. Every admin surface here is about
+  // *sweeps* (the outcome watcher and the history table both key off sweep
+  // rows), so expose the filtered view once — a future on_create/on_write
+  // run completing mid-watch must never masquerade as the sweep outcome.
+  // Server-side filtering belongs with the focused-trigger work.
+  const sweeps = runs.filter((r) => r.trigger === "sweep");
+  return { sweeps, error, isLoading, refresh: mutate };
 }
 
 /** One Auto Organize change proposal (a pending AI-initiated cleanup awaiting

--- a/frontend/src/lib/swr-keys.ts
+++ b/frontend/src/lib/swr-keys.ts
@@ -45,6 +45,7 @@ export const SWR_KEYS = {
 
   // ── Auto Organize ─────────────────────────────────────────────────────
   autoOrganizeSettings: "/automanage/settings",
+  automanageRuns: "/automanage/runs",
   automanageProposals: (path: string) =>
     `/automanage/proposals?path=${encodeURIComponent(path)}`,
 


### PR DESCRIPTION
"Run a sweep" previously said **"Sweep started."** and nothing else — the run-history endpoint (`GET /api/automanage/runs`, from #426) existed but nothing in the UI called it, so the admin who pressed the button never learned whether the sweep found 0 proposals or 15 (or failed) without curling the API or stumbling onto a page banner.

Frontend-only:

- **Sweep outcome**: the button watches the run history (2s SWR poll only while a triggered run is queued/running; the new run is recognized **by id against a pre-trigger snapshot** — the request only enqueues, so timestamp comparison against client time would be racy) and reports "Sweep finished — N proposals from M paths" or the failure error inline.
- **Recent sweeps card** under the controls: last runs with local time, manual/scheduled (from `triggered_by_user_id`), proposal + path counts, and status (failed runs show in the error color).

`lib/autoOrganize.ts` gains the `DetectionRun` type + `useDetectionRuns(poll)` hook via `SWR_KEYS.automanageRuns` per the swr-keys convention. Opal components throughout; typecheck clean.

First slice of the proposal-visibility work — the owner-notification design (dedup + impression discounting) remains the follow-up.
<img width="758" height="896" alt="Screenshot 2026-07-24 at 10 52 49 AM" src="https://github.com/user-attachments/assets/9acad28c-0bba-4056-833b-d61a302e509e" />

