### PR TITLE
feat(backend): `markdown <-> Yjs` codec

### DIFF
--- a/backend/app/wiki/markdown_blocks.py
+++ b/backend/app/wiki/markdown_blocks.py
@@ -1,0 +1,180 @@
+"""Top-level markdown block/row boundary parsing — pure text, no CRDT.
+
+This is the shared foundation for the targeted-splice checkpoint engine
+(``markdown_splice.py``) and the markdown<->Yjs codec (``markdown_yjs.py``).
+It only answers "where do the top-level blocks (and, for tables, rows) sit in
+this markdown string" — parsing is done once per body via ``markdown-it-py``.
+
+Offsets are Unicode code-point indices (Python ``str`` indices already are
+code-points) — nothing here should leak UTF-16 units.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from markdown_it import MarkdownIt
+from pydantic import BaseModel, ConfigDict
+
+
+class BlockKind(str, Enum):
+    HEADING = "heading"
+    PARAGRAPH = "paragraph"
+    LIST = "list"
+    BLOCKQUOTE = "blockquote"
+    CODE_BLOCK = "code_block"
+    TABLE = "table"
+    THEMATIC_BREAK = "thematic_break"
+    HTML_BLOCK = "html_block"
+    # Anything markdown-it-py emits at level 0 that we don't have a specific
+    # kind for. Range-tracking still works for an OTHER block; the markdown
+    # <-> Yjs codec is the layer that must fail loud (NotImplementedError)
+    # rather than silently mis-serialize one.
+    OTHER = "other"
+
+
+_KIND_BY_TOKEN_TYPE: dict[str, BlockKind] = {
+    "heading_open": BlockKind.HEADING,
+    "paragraph_open": BlockKind.PARAGRAPH,
+    "bullet_list_open": BlockKind.LIST,
+    "ordered_list_open": BlockKind.LIST,
+    "blockquote_open": BlockKind.BLOCKQUOTE,
+    "table_open": BlockKind.TABLE,
+    "hr": BlockKind.THEMATIC_BREAK,
+    "fence": BlockKind.CODE_BLOCK,
+    "code_block": BlockKind.CODE_BLOCK,
+    "html_block": BlockKind.HTML_BLOCK,
+}
+
+
+def gfm_parser() -> MarkdownIt:
+    """The one GFM config used everywhere a wiki page's markdown gets parsed
+    for structure. ``html: False`` matches
+    ``docs/AGENT_WIKI_MARKDOWN_STANDARD.md`` §5 — raw HTML tags are never
+    parsed as tags, so ``html_block``/``html_inline`` tokens never appear;
+    ``BlockKind.HTML_BLOCK`` above is unreachable in practice, kept only
+    because ``markdown-it-py`` still exposes the token type name."""
+    return MarkdownIt("commonmark", {"html": False}).enable("table")
+
+
+class RowRange(BaseModel):
+    """A table row's character span within its page body. ``row_id`` is
+    positional within its table (``<block_id>:r<index>``), same determinism
+    contract as ``BlockRange.block_id`` below."""
+
+    model_config = ConfigDict(frozen=True)
+
+    row_id: str
+    start: int
+    end: int
+
+
+class BlockRange(BaseModel):
+    """A top-level block's character span within its page body.
+
+    ``block_id`` is deterministic and purely positional (``b0``, ``b1``, ...
+    in document order) — never content-hashed or random. The checkpoint
+    worker recomputes identical ids from ``base_body`` alone with no
+    persisted id-mapping, so two parses of the same text must always agree.
+
+    ``separator`` (tables only) is the span between the header row and the
+    first body row (or the block end, if there is no body) — the GFM
+    delimiter line (``| --- | --- |``). It is not a ``tr_open`` token, so it
+    is invisible to ``rows``; without capturing it separately, reconstructing
+    a table purely by concatenating row text would silently drop it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    block_id: str
+    kind: BlockKind
+    start: int
+    end: int
+    rows: tuple[RowRange, ...] = ()
+    separator: RowRange | None = None
+
+
+def _line_offsets(body: str) -> list[int]:
+    """``offsets[i]`` = the character offset where line ``i`` (0-indexed)
+    starts. ``markdown-it-py`` token ``.map`` values are ``[start_line,
+    end_line)`` line ranges; this converts those to character offsets."""
+    offsets = [0]
+    for line in body.splitlines(keepends=True):
+        offsets.append(offsets[-1] + len(line))
+    return offsets
+
+
+def _trim_trailing_blank_lines(body: str, start: int, end: int) -> int:
+    """Some container tokens' ``.map`` (verified: ``bullet_list_open``/
+    ``ordered_list_open``) includes the blank line(s) *after* the
+    construct; ``paragraph_open``/``heading_open`` never do. Trimming
+    uniformly here means every block's span carries the same meaning —
+    "just this block's own text," with any blank-line gap always belonging
+    to whatever comes after (or the trailing tail) — which is the
+    invariant both the markdown<->Yjs codec's block-boundary NL handling
+    and the checkpoint splice engine's gap-ownership model depend on
+    (``markdown_yjs.py``, ``markdown_splice.py``). Keeps at least one line
+    so a block never collapses to nothing.
+    """
+    lines = body[start:end].splitlines(keepends=True)
+    while len(lines) > 1 and lines[-1].strip() == "":
+        lines.pop()
+    return start + sum(len(line) for line in lines)
+
+
+def top_level_block_ranges(body: str) -> list[BlockRange]:
+    """Top-level block boundaries of ``body``, in document order.
+
+    A top-level block is any token markdown-it-py emits at nesting level 0
+    that carries a line ``.map`` (an ``*_open`` token, or a self-closing one
+    like ``hr``/``fence``) — nested content (list items, table cells, inline
+    marks) all sit at level > 0 and is naturally excluded by that filter, no
+    manual open/close tracking needed. Table blocks additionally carry
+    per-row ``RowRange``s (matching ``tr_open`` tokens carry ``.map`` too,
+    confirmed against the installed markdown-it-py).
+    """
+    if not body.strip():
+        return []
+    tokens = gfm_parser().parse(body)
+    offsets = _line_offsets(body)
+    blocks: list[BlockRange] = []
+    for idx, token in enumerate(tokens):
+        if token.level != 0 or token.map is None:
+            continue
+        start_line, end_line = token.map
+        start, end = offsets[start_line], offsets[end_line]
+        end = _trim_trailing_blank_lines(body, start, end)
+        kind = _KIND_BY_TOKEN_TYPE.get(token.type, BlockKind.OTHER)
+        block_id = f"b{len(blocks)}"
+
+        rows: tuple[RowRange, ...] = ()
+        separator: RowRange | None = None
+        if kind is BlockKind.TABLE:
+            # The matching table_close is the next level-0 token; every
+            # tr_open strictly between the two is a row of this table.
+            end_idx = next(
+                (j for j in range(idx + 1, len(tokens)) if tokens[j].level == 0),
+                len(tokens),
+            )
+            row_ranges: list[RowRange] = []
+            for t in tokens[idx + 1 : end_idx]:
+                if t.type == "tr_open" and t.map is not None:
+                    r_start, r_end = offsets[t.map[0]], offsets[t.map[1]]
+                    row_ranges.append(
+                        RowRange(
+                            row_id=f"{block_id}:r{len(row_ranges)}", start=r_start, end=r_end
+                        )
+                    )
+            rows = tuple(row_ranges)
+            if rows:
+                sep_start = rows[0].end
+                sep_end = rows[1].start if len(rows) > 1 else end
+                if sep_end > sep_start:
+                    separator = RowRange(row_id=f"{block_id}:sep", start=sep_start, end=sep_end)
+
+        blocks.append(
+            BlockRange(
+                block_id=block_id, kind=kind, start=start, end=end, rows=rows, separator=separator
+            )
+        )
+    return blocks

--- a/backend/app/wiki/markdown_splice.py
+++ b/backend/app/wiki/markdown_splice.py
@@ -1,0 +1,207 @@
+"""Targeted-splice checkpoint engine — turn a live ``pycrdt`` Yjs doc back
+into markdown text while leaving every byte outside an actually-touched
+region identical to the markdown body the session started from.
+
+This is the highest-risk piece of the whole live-doc design: re-serializing
+untouched content through the codec risks reformatting it in a way that
+silently orphans comment/provenance anchors (``app/wiki/comment_anchor.py``
+et al. re-anchor via a textual diff against the *previous* committed body —
+a serializer that isn't byte-identical for regions nobody touched reads as
+"everything changed" to that diff). See
+``Engineering Projects/Agent Wiki Project/design/Co-Editing.md`` for the
+full design rationale.
+
+Two pieces:
+
+- ``TouchedTracker`` subscribes to a session's ``Doc`` for its lifetime and
+  records, at whatever granularity a change actually occurred, which
+  top-level blocks (``markdown_yjs.BLOCK_ID_ATTR``) or table rows
+  (``ROW_ID_ATTR``) were mutated — via ``observe_deep``, so it sees every
+  mutation regardless of origin (a local edit, or a remote peer's raw Yjs
+  update applied by ``pycrdt-websocket``), not just ones that flowed through
+  our own code.
+- ``checkpoint_body`` walks the live doc's current top-level children once,
+  in document order, choosing per block: a byte-verbatim slice of
+  ``base_body`` for anything untouched-and-still-present, or a fresh
+  ``markdown_yjs.serialize_block``/``serialize_row`` for anything touched,
+  new, or (for a table) structurally changed. A block whose id has no match
+  in ``base_body`` (created during this session) is always serialized; a
+  block present in ``base_body`` but no longer in the live doc is simply
+  never emitted — deletion needs no special-casing.
+"""
+
+from __future__ import annotations
+
+from pycrdt import Doc, Subscription, XmlElement, XmlFragment
+
+from app.wiki.markdown_blocks import BlockRange, top_level_block_ranges
+from app.wiki.markdown_yjs import (
+    BLOCK_ID_ATTR,
+    ROOT_XML_KEY,
+    ROW_ID_ATTR,
+    serialize_block,
+    serialize_row,
+)
+
+_ROW_TAGS = ("tableRow", "tableSeparator")
+
+# Synthesized separator inserted before a touched/new block when no original
+# gap is available to reuse verbatim (see checkpoint_body) — one blank line,
+# matching CommonMark's block-separator convention. Each block's own
+# serialized text already carries its own trailing newline (BlockRange.end
+# is inclusive of it), so this is the *additional* blank-line character, not
+# two. Not required to match the source body's exact blank-line count — only
+# untouched regions carry a byte-stability guarantee (see module docstring /
+# design doc).
+_SYNTHESIZED_GAP = "\n"
+
+
+class TouchedTracker:
+    """Tracks which blocks/rows of a session's live doc have been mutated
+    since the tracker was created (or last ``reset``).
+
+    One tracker per active co-edit session, created alongside the session's
+    ``Doc`` and reset after each successful checkpoint — so "touched" always
+    means "touched since the ``base_body`` a pending checkpoint will diff
+    against."
+    """
+
+    def __init__(self, doc: Doc) -> None:
+        self._root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+        self.touched_block_ids: set[str] = set()
+        self.touched_row_ids: dict[str, set[str]] = {}
+        self._subscription: Subscription = self._root.observe_deep(self._on_events)
+
+    def _on_events(self, events: list[object]) -> None:
+        for event in events:
+            self._record(event.target)  # type: ignore[attr-defined]
+
+    def _record(self, node: object) -> None:
+        block_id, row_id = _classify_target(node)
+        if block_id is None:
+            # A structural change targeting the root fragment itself (a
+            # whole top-level block inserted/deleted) — checkpoint_body
+            # handles new/gone blocks by diffing ids against base_body, no
+            # tracking needed.
+            return
+        if row_id is not None:
+            self.touched_row_ids.setdefault(block_id, set()).add(row_id)
+        else:
+            self.touched_block_ids.add(block_id)
+
+    def reset(self) -> None:
+        """Clear touched state after a successful checkpoint commits."""
+        self.touched_block_ids.clear()
+        self.touched_row_ids.clear()
+
+    def mark_all_touched(self) -> None:
+        """Mark every current top-level block as touched — the safe fallback
+        when a doc was reconstructed from a persisted snapshot rather than
+        continuously tracked in memory (e.g. a process restart mid-session:
+        replaying ``ydoc_snapshot`` + the update log restores the *content*
+        correctly, but this fresh tracker has no record of which regions
+        changed since the last checkpoint's ``base_body``). Forces the next
+        checkpoint to re-serialize everything rather than risk treating an
+        actually-changed region as untouched — correct but not
+        byte-stability-optimal for that one checkpoint; normal incremental
+        tracking resumes after it."""
+        for child in self._root.children:
+            if isinstance(child, XmlElement):
+                block_id = dict(child.attributes).get(BLOCK_ID_ATTR)
+                if block_id is not None:
+                    self.touched_block_ids.add(block_id)
+
+    def stop(self) -> None:
+        """Unsubscribe when the session ends (its ``Doc`` is being dropped)."""
+        self._root.unobserve(self._subscription)
+
+
+def _classify_target(node: object) -> tuple[str | None, str | None]:
+    """Walk up from a changed node to the top-level block that contains it.
+
+    Returns ``(block_id, row_id)`` — ``row_id`` set only when the change is
+    scoped to a single table row/separator, so the caller can splice just
+    that row rather than re-serializing the whole table. ``(None, None)``
+    when ``node`` has no parent (the root fragment itself — a whole-block
+    insert/delete, tracked implicitly, not explicitly). Works unchanged for
+    a change inside a ``hardBreak`` leaf — it's just another node to walk up
+    from, no different from any other inline child.
+    """
+    current = node
+    row_id: str | None = None
+    while True:
+        parent = current.parent  # type: ignore[attr-defined]
+        if parent is None:
+            return None, None
+        if isinstance(parent, XmlFragment):
+            if not isinstance(current, XmlElement):
+                return None, None
+            return dict(current.attributes).get(BLOCK_ID_ATTR), row_id
+        if isinstance(current, XmlElement) and current.tag in _ROW_TAGS:
+            row_id = dict(current.attributes).get(ROW_ID_ATTR)
+        current = parent
+
+
+def checkpoint_body(base_body: str, doc: Doc, tracker: TouchedTracker) -> str:
+    """Reconstruct the markdown body to commit at checkpoint time.
+
+    ``base_body`` is the body the live doc was seeded from (session start,
+    or the body as of the last checkpoint after a ``tracker.reset()``).
+    """
+    orig_blocks = top_level_block_ranges(base_body)
+    orig_by_id = {b.block_id: b for b in orig_blocks}
+    leading_gap_start: dict[str, int] = {}
+    prev_end = 0
+    for b in orig_blocks:
+        leading_gap_start[b.block_id] = prev_end
+        prev_end = b.end
+    tail_start = prev_end
+
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    parts: list[str] = []
+    for child in root.children:
+        if not isinstance(child, XmlElement):
+            raise NotImplementedError(f"unexpected top-level child: {type(child)!r}")
+        block_id = dict(child.attributes).get(BLOCK_ID_ATTR)
+        orig = orig_by_id.get(block_id) if block_id else None
+
+        if orig is not None and child.tag == "table" and block_id not in tracker.touched_block_ids:
+            gap = base_body[leading_gap_start[block_id] : orig.start]
+            parts.append(gap + _splice_table(base_body, orig, child, tracker.touched_row_ids.get(block_id, set())))
+            continue
+
+        touched = (
+            orig is None
+            or block_id in tracker.touched_block_ids
+            or block_id in tracker.touched_row_ids
+        )
+        if not touched:
+            assert orig is not None and block_id is not None
+            parts.append(base_body[leading_gap_start[block_id] : orig.end])
+            continue
+
+        gap = _SYNTHESIZED_GAP if parts else ""
+        parts.append(gap + serialize_block(child))
+
+    parts.append(base_body[tail_start:])
+    return "".join(parts)
+
+
+def _splice_table(
+    base_body: str, orig: BlockRange, table_el: XmlElement, touched_row_ids: set[str]
+) -> str:
+    """Row-level splice for an untouched-at-the-structure table: rows not in
+    ``touched_row_ids`` are sliced verbatim from ``base_body``; touched rows
+    (and the header separator, if touched) are re-serialized."""
+    orig_rows = {r.row_id: r for r in orig.rows}
+    if orig.separator is not None:
+        orig_rows[orig.separator.row_id] = orig.separator
+    parts: list[str] = []
+    for row_el in table_el.children:
+        row_id = dict(row_el.attributes).get(ROW_ID_ATTR)
+        orig_row = orig_rows.get(row_id) if row_id else None
+        if orig_row is None or row_id in touched_row_ids:
+            parts.append(serialize_row(row_el))
+        else:
+            parts.append(base_body[orig_row.start : orig_row.end])
+    return "".join(parts)

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -620,6 +620,37 @@ _ORDERED_MARKER_RE = re.compile(r"^\d{1,9}[.)](\s|$)")
 # position.
 _THEMATIC_BREAK_DASH_RE = re.compile(r"^-(?:[ \t]*-){2,}[ \t]*(?:\n|$)")
 
+# A setext heading underline: one or more *contiguous* "=" (level 1) or "-"
+# (level 2), only trailing space/tab, nothing else — a different threshold
+# from a thematic break (which needs 3+ dashes, and tolerates spaces
+# *between* them): a setext underline needs only one dash/equals, but no
+# internal spaces. It only ever reactivates a *preceding* line (there's no
+# rule for a bare "-\n" as a heading without a paragraph line above it),
+# which is exactly the per-line position this module already escapes at.
+_SETEXT_UNDERLINE_RE = re.compile(r"^(?:-+|=+)[ \t]*$")
+
+# A GFM table delimiter row: 1+ cells of optional ":", 1+ "-", optional
+# ":", separated by "|", with optional leading/trailing "|" and whitespace
+# around each cell. A paragraph whose *first* line contains "|" followed by
+# a line matching this shape reactivates as a table header on the next
+# parse — confirmed against the forward parse (not assumed): a plain
+# paragraph typed as "a | b" + soft break + "---|---" is indistinguishable
+# from real table source once serialized, since neither "|" nor a bare
+# dash run were escaped by anything else in this module.
+_TABLE_DELIMITER_ROW_RE = re.compile(
+    r"^[ \t]*\|?[ \t]*:?-+:?[ \t]*(?:\|[ \t]*:?-+:?[ \t]*)*\|?[ \t]*$"
+)
+
+# A fence opener: 3+ backticks or 3+ tildes at the start of the line — unlike
+# a thematic break/setext underline/table row, a fence opener is *not*
+# whole-line-only: trailing content (the info string, e.g. "```python") is
+# valid and still opens the fence (confirmed against the forward parse: 2
+# backticks doesn't, 3+ does, with or without trailing text). Reactivating
+# one is the most severe case in this module — a fenced code block swallows
+# everything up to the *next* matching fence (or EOF) as raw content, not
+# just misclassifying the one paragraph.
+_FENCE_OPENER_RE = re.compile(r"^(?:`{3,}|~{3,})")
+
 
 def _escape_block_start_ambiguity(text: str) -> str:
     """A paragraph's serialized text starting with a character or pattern
@@ -649,6 +680,8 @@ def _escape_line_start(line: str) -> str:
         return line
     if line[0] == "#":
         return "\\" + line
+    if line[0] in "-=" and _SETEXT_UNDERLINE_RE.match(line):
+        return "\\" + line
     if line[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(line):
         return "\\" + line
     if line[0] in "-+" and (len(line) == 1 or line[1].isspace()):
@@ -656,6 +689,10 @@ def _escape_line_start(line: str) -> str:
     if line[0] == ">":
         return "\\" + line
     if _ORDERED_MARKER_RE.match(line):
+        return "\\" + line
+    if _TABLE_DELIMITER_ROW_RE.match(line):
+        return "\\" + line
+    if _FENCE_OPENER_RE.match(line):
         return "\\" + line
     return line
 

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -141,7 +141,25 @@ def _inline_runs(inline_token: Any) -> list[_Segment]:
     return segments
 
 
+def _escape_inline_text(text: str) -> str:
+    """Escape characters markdown-it consumes at parse time — `\\*x\\*`
+    parses to the *text* `*x*` with no italic mark (correctly, since it was
+    escaped), but re-serializing that text verbatim hands back active
+    syntax on the next parse (`*x*` now reads as real emphasis). Same
+    failure mode for `` \\` ``, `\\_`, `\\[`, `\\]`. Backslash itself goes
+    first, so escaping the other characters doesn't get double-escaped."""
+    for ch in "\\`*_[]":
+        text = text.replace(ch, "\\" + ch)
+    return text
+
+
 def _wrap_run(text: str, attrs: dict[str, Any] | None) -> str:
+    attrs = attrs or {}
+    # Inline code spans are verbatim — CommonMark never processes escapes
+    # inside them, so escaping here would corrupt the code's actual text
+    # (a literal backslash would become part of the visible content).
+    if "code" not in attrs:
+        text = _escape_inline_text(text)
     if not attrs:
         return text
     result = text
@@ -383,15 +401,27 @@ def _build_code_block(raw: str, attrs: dict[str, str]) -> XmlElement:
     )
 
 
-def _heading_level_and_line(raw: str) -> tuple[int, str]:
-    line = raw.rstrip("\n")
-    hashes = 0
-    while hashes < len(line) and line[hashes] == "#":
-        hashes += 1
-    rest = line[hashes:]
-    if rest.startswith(" "):
-        rest = rest[1:]
-    return hashes, rest
+def _build_heading(raw: str, attrs: dict[str, str]) -> tuple[XmlElement, list[Any]]:
+    """Parses ``raw`` through the real tokenizer rather than hand-stripping
+    a leading ``#`` run — a setext heading (``Title\\n=====\\n``) has no
+    leading hashes at all, and a hand-rolled ATX-only strip both mis-levels
+    it (falls through to ``level=0``, which then serializes with no ``#``
+    marker at all — silently demoting the heading to a paragraph) and
+    leaves the underline line embedded in the parsed title text. The
+    tokenizer's own ``heading_open.tag`` (``"h1"``..``"h6"``) is correct for
+    both styles, and its ``inline`` token's content already excludes
+    whichever prefix/underline syntax produced it — including the
+    empty-title case (``"# "`` with nothing after it still yields an
+    ``inline`` token with empty content when parsing the *unstripped* raw
+    block, unlike parsing a manually-stripped empty string standalone,
+    which yields no inline token at all)."""
+    tokens = gfm_parser().parse(raw)
+    open_idx = next(i for i, t in enumerate(tokens) if t.type == "heading_open")
+    level = int(tokens[open_idx].tag[1:])
+    inline_token = tokens[open_idx + 1]
+    return _element_from_segments(
+        "heading", {**attrs, "level": str(level)}, _inline_runs(inline_token)
+    )
 
 
 def _build_block_element(body: str, block: BlockRange) -> tuple[XmlElement, list[Any]]:
@@ -403,10 +433,7 @@ def _build_block_element(body: str, block: BlockRange) -> tuple[XmlElement, list
     nl_attr = "1" if trailing_nl else "0"
 
     if block.kind is BlockKind.HEADING:
-        level, line = _heading_level_and_line(raw)
-        return _make_inline_element(
-            "heading", {BLOCK_ID_ATTR: block.block_id, "level": str(level), _NL_ATTR: nl_attr}, line
-        )
+        return _build_heading(raw, {BLOCK_ID_ATTR: block.block_id, _NL_ATTR: nl_attr})
 
     if block.kind is BlockKind.PARAGRAPH:
         line = raw[:-1] if trailing_nl else raw
@@ -579,6 +606,13 @@ def serialize_block(node: XmlElement) -> str:
         return "#" * level + " " + text + ("\n" if trailing else "")
     if node.tag == "paragraph":
         text = _serialize_inline_children(list(node.children))
+        # A literal leading "#" (e.g. from escaped `\# not a heading` source
+        # text) must stay escaped on the way back out too — `_wrap_run`
+        # only escapes mark-delimiter characters, but "#" is only special
+        # as a block-start marker, which is exactly the position this text
+        # is about to occupy.
+        if text.startswith("#"):
+            text = "\\" + text
         return text + ("\n" if trailing else "")
     if node.tag in ("bulletList", "orderedList", "taskList"):
         text = _serialize_list(node)

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -24,9 +24,7 @@ only reflows its own row, not the whole table) but each row's *content* is
 still stored as opaque verbatim text, not decomposed into cells —
 deliberately simpler than per-cell reconstruction with recomputed column
 padding, and still achieves the byte-stability goal for every row that isn't
-touched. Real per-cell table editing, images, footnotes, and emoji
-shortcodes are explicitly out of scope for this pass (see
-``docs/AGENT_WIKI_MARKDOWN_STANDARD.md``'s deferred items); thematic break
+touched — cells aren't decomposed or individually editable. Thematic break
 and html block stay opaque verbatim, tagged ``_raw="1"``.
 
 Unrecognized inline constructs (an image, GFM strikethrough — anything this
@@ -607,8 +605,15 @@ def _serialize_code_block(node: XmlElement) -> str:
 # matches CommonMark's own marker grammar (see the list-building side,
 # `_build_list`, which reads `open_tok.attrs["start"]` rather than
 # re-deriving this pattern; this is the inverse direction, detecting the
-# pattern in already-serialized plain text).
-_ORDERED_MARKER_RE = re.compile(r"^\d{1,9}[.)](\s|$)")
+# pattern in already-serialized plain text). Digits captured in their own
+# group — unlike every other marker character this module escapes, a digit
+# is not ASCII punctuation, so a backslash placed before it is never
+# consumed as an escape on the next parse (confirmed against the forward
+# parse: `\1. item` keeps its backslash as a literal character instead of
+# protecting the marker). The delimiter (`.`/`)`) immediately after the
+# digits *is* punctuation, so that's the character that actually needs the
+# backslash — see the escape call site below.
+_ORDERED_MARKER_RE = re.compile(r"^(\d{1,9})([.)])(\s|$)")
 
 # A thematic break is a *whole line* of 3+ "-" (optionally space/tab
 # separated) and nothing else — "---" alone reactivates, but "--- and more
@@ -681,14 +686,19 @@ def _escape_block_start_ambiguity(text: str) -> str:
     breaks). ``*`` as a bullet marker doesn't need a case here — it's
     already escaped unconditionally by ``_wrap_run`` for the emphasis
     reason, which covers every line's start position too as a side
-    effect. The first line additionally gets the indented-code-block check
-    (``_INDENTED_CODE_FIRST_LINE_RE``), since that ambiguity only exists on
-    a block's first line, not on every line the way the marker checks do."""
+    effect.
+
+    The first line additionally gets the indented-code-block check
+    (``_INDENTED_CODE_FIRST_LINE_RE``) first, since that ambiguity only
+    exists on a block's first line, not on every line the way the marker
+    checks do — its leading whitespace run is stripped *before*
+    ``_escape_line_start`` runs on that line, so whatever's left (e.g. a
+    literal ``#`` that was hiding behind 4 leading spaces) still gets
+    marker-escaped by the same pass, rather than being left live."""
     lines = text.split("\n")
-    escaped = [_escape_line_start(line) for line in lines]
     if lines[0] and _INDENTED_CODE_FIRST_LINE_RE.match(lines[0]):
-        escaped[0] = "\\" + lines[0]
-    return "\n".join(escaped)
+        lines[0] = lines[0].lstrip(" \t")
+    return "\n".join(_escape_line_start(line) for line in lines)
 
 
 def _escape_line_start(line: str) -> str:
@@ -703,26 +713,44 @@ def _escape_line_start(line: str) -> str:
     # instead — a different, narrower case handled separately by
     # _INDENTED_CODE_FIRST_LINE_RE, so a line whose leading run is that long
     # is left alone here.
+    #
+    # The escape backslash below is placed immediately before the marker
+    # character (``rest``), not before the dropped indentation (``line``) —
+    # CommonMark's backslash escape applies only to punctuation, never to
+    # whitespace, so a backslash placed before a space is never consumed on
+    # the next parse; it would survive as a literal extra character instead
+    # of protecting anything. Escaping the marker in its own escapable
+    # position is the only construct that round-trips, at the documented
+    # cost of the leading whitespace itself not surviving (see
+    # AGENT_WIKI_MARKDOWN_STANDARD.md §6) — CommonMark strips that
+    # insignificant indentation on reparse regardless of whether this
+    # function keeps or drops it from the emitted text.
     indent_len = min(3, len(line) - len(line.lstrip(" ")))
     rest = line[indent_len:]
     if not rest or rest[0] in " \t":
         return line
     if rest[0] == "#":
-        return "\\" + line
+        return "\\" + rest
     if rest[0] in "-=" and _SETEXT_UNDERLINE_RE.match(rest):
-        return "\\" + line
+        return "\\" + rest
     if rest[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(rest):
-        return "\\" + line
+        return "\\" + rest
     if rest[0] in "-+" and (len(rest) == 1 or rest[1].isspace()):
-        return "\\" + line
+        return "\\" + rest
     if rest[0] == ">":
-        return "\\" + line
-    if _ORDERED_MARKER_RE.match(rest):
-        return "\\" + line
-    if _TABLE_DELIMITER_ROW_RE.match(line):
-        return "\\" + line
+        return "\\" + rest
+    ordered_match = _ORDERED_MARKER_RE.match(rest)
+    if ordered_match:
+        # Backslash goes after the digits, before the delimiter — see
+        # _ORDERED_MARKER_RE's comment for why escaping the digits
+        # themselves (as every other call site here escapes its marker
+        # character) doesn't work for this one construct.
+        digits = ordered_match.group(1)
+        return digits + "\\" + rest[len(digits) :]
+    if _TABLE_DELIMITER_ROW_RE.match(rest):
+        return "\\" + rest
     if _FENCE_OPENER_RE.match(rest):
-        return "\\" + line
+        return "\\" + rest
     return line
 
 

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -603,22 +603,35 @@ def _serialize_code_block(node: XmlElement) -> str:
 # pattern in already-serialized plain text).
 _ORDERED_MARKER_RE = re.compile(r"^\d{1,9}[.)](\s|$)")
 
+# A thematic break is a *whole line* of 3+ "-" (optionally space/tab
+# separated) and nothing else — "---" alone reactivates, but "--- and more
+# text" doesn't (confirmed against the forward parse, not assumed: a
+# trailing non-marker character on the line makes it an ordinary
+# paragraph). "*"/"_" thematic breaks ("***", "_ _ _") need no matching
+# case — every "*"/"_" is already escaped unconditionally by `_wrap_run`
+# for the emphasis/italic reason, which breaks the run regardless of
+# position.
+_THEMATIC_BREAK_DASH_RE = re.compile(r"^-(?:[ \t]*-){2,}[ \t]*(?:\n|$)")
+
 
 def _escape_block_start_ambiguity(text: str) -> str:
     """A paragraph's serialized text starting with a character or pattern
     that's only special as a *block*-start marker (heading ``#``, bullet
-    ``-``/``+``, blockquote ``>``, ordered-list ``1.``) must stay escaped,
-    or the next parse reinterprets this paragraph as a different block
-    type entirely. Unlike ``_wrap_run``'s mark-delimiter escaping (position-
-    independent — a ``*``/``_``/`` ` ``/``[``/``]`` is ambiguous anywhere in
-    the text, already handled there), these are only ambiguous at the very
-    start of the block, which is exactly the one position this function
-    runs at. ``*`` as a bullet marker doesn't need a case here — it's
-    already escaped unconditionally by ``_wrap_run`` for the emphasis
-    reason, which covers this position too as a side effect."""
+    ``-``/``+``, thematic break ``---``, blockquote ``>``, ordered-list
+    ``1.``) must stay escaped, or the next parse reinterprets this
+    paragraph as a different block type entirely. Unlike ``_wrap_run``'s
+    mark-delimiter escaping (position-independent — a ``*``/``_``/`` ` ``/
+    ``[``/``]`` is ambiguous anywhere in the text, already handled there),
+    these are only ambiguous at the very start of the block, which is
+    exactly the one position this function runs at. ``*`` as a bullet
+    marker doesn't need a case here — it's already escaped unconditionally
+    by ``_wrap_run`` for the emphasis reason, which covers this position
+    too as a side effect."""
     if not text:
         return text
     if text[0] == "#":
+        return "\\" + text
+    if text[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(text):
         return "\\" + text
     if text[0] in "-+" and (len(text) == 1 or text[1].isspace()):
         return "\\" + text

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -596,6 +596,39 @@ def _serialize_code_block(node: XmlElement) -> str:
     return f"{fence}{language}\n{content}{fence}\n"
 
 
+# Ordered-list marker: 1-9 digits + "." or ")" + a space or end of line —
+# matches CommonMark's own marker grammar (see the list-building side,
+# `_build_list`, which reads `open_tok.attrs["start"]` rather than
+# re-deriving this pattern; this is the inverse direction, detecting the
+# pattern in already-serialized plain text).
+_ORDERED_MARKER_RE = re.compile(r"^\d{1,9}[.)](\s|$)")
+
+
+def _escape_block_start_ambiguity(text: str) -> str:
+    """A paragraph's serialized text starting with a character or pattern
+    that's only special as a *block*-start marker (heading ``#``, bullet
+    ``-``/``+``, blockquote ``>``, ordered-list ``1.``) must stay escaped,
+    or the next parse reinterprets this paragraph as a different block
+    type entirely. Unlike ``_wrap_run``'s mark-delimiter escaping (position-
+    independent — a ``*``/``_``/`` ` ``/``[``/``]`` is ambiguous anywhere in
+    the text, already handled there), these are only ambiguous at the very
+    start of the block, which is exactly the one position this function
+    runs at. ``*`` as a bullet marker doesn't need a case here — it's
+    already escaped unconditionally by ``_wrap_run`` for the emphasis
+    reason, which covers this position too as a side effect."""
+    if not text:
+        return text
+    if text[0] == "#":
+        return "\\" + text
+    if text[0] in "-+" and (len(text) == 1 or text[1].isspace()):
+        return "\\" + text
+    if text[0] == ">":
+        return "\\" + text
+    if _ORDERED_MARKER_RE.match(text):
+        return "\\" + text
+    return text
+
+
 def serialize_block(node: XmlElement) -> str:
     attrs = dict(node.attributes)
     trailing = attrs.get(_NL_ATTR) == "1"
@@ -605,14 +638,7 @@ def serialize_block(node: XmlElement) -> str:
         text = _serialize_inline_children(list(node.children))
         return "#" * level + " " + text + ("\n" if trailing else "")
     if node.tag == "paragraph":
-        text = _serialize_inline_children(list(node.children))
-        # A literal leading "#" (e.g. from escaped `\# not a heading` source
-        # text) must stay escaped on the way back out too — `_wrap_run`
-        # only escapes mark-delimiter characters, but "#" is only special
-        # as a block-start marker, which is exactly the position this text
-        # is about to occupy.
-        if text.startswith("#"):
-            text = "\\" + text
+        text = _escape_block_start_ambiguity(_serialize_inline_children(list(node.children)))
         return text + ("\n" if trailing else "")
     if node.tag in ("bulletList", "orderedList", "taskList"):
         text = _serialize_list(node)

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -1,0 +1,660 @@
+"""Markdown <-> Yjs codec: the live document representation for co-editing.
+
+Every top-level block (``markdown_blocks.top_level_block_ranges``) becomes an
+``XmlElement`` in a ``pycrdt`` doc's root ``XmlFragment``, tagged with a
+stable, positional ``_blockId`` attribute. Structural treatment (real
+ProseMirror-shaped nodes, editable node-by-node, not opaque text) covers:
+``heading``, ``paragraph`` (inline content — text runs + bold/italic/code/
+link marks, represented via a ``pycrdt.XmlText``'s ``.format()`` runs, plus
+an explicit ``hardBreak`` leaf element interspersed as a sibling wherever a
+hard line break occurs — y-prosemirror maps a PM leaf/atom node to an empty
+sibling ``XmlElement``, not to a text mark, since a break is a node boundary,
+not formatting), ``bulletList``/``orderedList``/``listItem`` (arbitrarily
+nested — CommonMark's own grammar is already recursive here, so supporting
+depth costs about the same as supporting one level), ``taskList``/
+``taskItem`` (a GFM checkbox list — a plain bullet list whose items *all*
+start with a ``[ ]``/``[x]`` marker; a mixed list stays a regular
+``bulletList`` since a taskList's children must be uniformly taskItems — see
+``_build_list``), ``blockquote`` (a sequence of paragraph/list/blockquote
+children, so multi-paragraph quotes and quotes containing lists work), and
+``codeBlock`` (a ``language`` attribute + plain text content, fence syntax
+stripped — not stored as opaque markup). Tables get row-level structure
+(each row is its own ``XmlElement`` tagged ``_rowId``, so a single-cell edit
+only reflows its own row, not the whole table) but each row's *content* is
+still stored as opaque verbatim text, not decomposed into cells —
+deliberately simpler than per-cell reconstruction with recomputed column
+padding, and still achieves the byte-stability goal for every row that isn't
+touched. Real per-cell table editing, images, footnotes, and emoji
+shortcodes are explicitly out of scope for this pass (see
+``docs/AGENT_WIKI_MARKDOWN_STANDARD.md``'s deferred items); thematic break
+and html block stay opaque verbatim, tagged ``_raw="1"``.
+
+Unrecognized inline constructs (an image, GFM strikethrough — anything this
+module doesn't have an explicit encoder for) raise ``NotImplementedError``
+rather than silently drop or mis-serialize content — the byte-stability
+requirement this whole engine exists for is only meaningful if failures are
+loud, never silent. Same for a list item that isn't a clean sequence of
+paragraph/list/blockquote children (e.g. a list item containing a table) —
+unsupported, raises rather than mis-encodes.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Literal
+
+from pycrdt import Doc, XmlElement, XmlFragment, XmlText
+from pydantic import BaseModel, ConfigDict
+
+from app.wiki.markdown_blocks import BlockKind, BlockRange, gfm_parser, top_level_block_ranges
+
+# Root-fragment key. Must match the frontend PM schema's y-prosemirror
+# `field` config exactly (see frontend/src/lib/editor/schema.ts).
+ROOT_XML_KEY = "prosemirror"
+
+_NL_ATTR = "_nl"  # "1" if this block's raw text ends with a trailing newline
+_RAW_ATTR = "_raw"  # "1" for an opaque verbatim-text block
+BLOCK_ID_ATTR = "_blockId"
+ROW_ID_ATTR = "_rowId"
+
+_KNOWN_INLINE_TYPES = {
+    "text",
+    "softbreak",
+    "hardbreak",
+    "strong_open",
+    "strong_close",
+    "em_open",
+    "em_close",
+    "code_inline",
+    "link_open",
+    "link_close",
+}
+
+# Applied innermost-first when wrapping a diff run back into markdown syntax
+# (i.e. iterated in reverse of this tuple) — outer to inner: link, bold,
+# italic, code. Handles arbitrary combinations deterministically; not every
+# combination is meaningfully round-trippable in CommonMark (e.g. code spans
+# can't semantically nest other marks), but this never raises — an
+# unsupported *combination* degrades to best-effort markup, only a fully
+# unrecognized inline *construct* (see _KNOWN_INLINE_TYPES) raises.
+_MARK_WRAP_ORDER = ("link", "bold", "italic", "code")
+
+# A text segment ("text", plain_text, mark_runs) or a hard-break leaf
+# ("hardbreak", None, None) — see module docstring for why a hard break is a
+# sibling element, not foldable into a text run's marks.
+_Segment = tuple[Literal["text", "hardbreak"], str | None, list[tuple[int, int, dict[str, Any]]] | None]
+
+
+def _inline_runs(inline_token: Any) -> list[_Segment]:
+    """Walk a markdown-it ``inline`` token's children into ordered segments —
+    text runs (with their mark spans) interspersed with hard-break leaves."""
+    segments: list[_Segment] = []
+    parts: list[str] = []
+    pos = 0
+    runs: list[tuple[int, int, dict[str, Any]]] = []
+    active: dict[str, Any] = {}
+
+    def _flush_text() -> None:
+        nonlocal parts, pos, runs
+        if parts:
+            segments.append(("text", "".join(parts), runs))
+        parts, pos, runs = [], 0, []
+
+    def _emit(content: str, attrs: dict[str, Any]) -> None:
+        nonlocal pos
+        if content and attrs:
+            runs.append((pos, pos + len(content), dict(attrs)))
+        parts.append(content)
+        pos += len(content)
+
+    for child in inline_token.children or []:
+        if child.type not in _KNOWN_INLINE_TYPES:
+            raise NotImplementedError(f"unrecognized inline construct: {child.type!r}")
+        if child.type == "hardbreak":
+            _flush_text()
+            segments.append(("hardbreak", None, None))
+        elif child.type == "text":
+            _emit(child.content, active)
+        elif child.type == "softbreak":
+            _emit("\n", active)
+        elif child.type == "strong_open":
+            active = {**active, "bold": True}
+        elif child.type == "strong_close":
+            active = {k: v for k, v in active.items() if k != "bold"}
+        elif child.type == "em_open":
+            active = {**active, "italic": True}
+        elif child.type == "em_close":
+            active = {k: v for k, v in active.items() if k != "italic"}
+        elif child.type == "code_inline":
+            _emit(child.content, {**active, "code": True})
+        elif child.type == "link_open":
+            # y-prosemirror treats a mark's XmlText-format value as that
+            # mark's *attrs object* — verified directly against the real
+            # library. A bare href string decodes as an attrs object with
+            # every string index as a key, silently producing an empty
+            # href. Must be `{href: ...}`.
+            active = {**active, "link": {"href": child.attrs.get("href", "")}}
+        elif child.type == "link_close":
+            active = {k: v for k, v in active.items() if k != "link"}
+
+    _flush_text()
+    return segments
+
+
+def _wrap_run(text: str, attrs: dict[str, Any] | None) -> str:
+    if not attrs:
+        return text
+    result = text
+    for mark in reversed(_MARK_WRAP_ORDER):
+        if mark not in attrs:
+            continue
+        if mark == "code":
+            result = f"`{result}`"
+        elif mark == "italic":
+            result = f"*{result}*"
+        elif mark == "bold":
+            result = f"**{result}**"
+        elif mark == "link":
+            # attrs["link"] is {"href": ...} (matching y-prosemirror's
+            # mark-attrs convention) — but also accept a bare string
+            # defensively in case something upstream ever writes the old
+            # shape.
+            link_attrs = attrs["link"]
+            href = link_attrs["href"] if isinstance(link_attrs, dict) else link_attrs
+            result = f"[{result}]({href})"
+    return result
+
+
+def _serialize_inline_text(xt: XmlText) -> str:
+    return "".join(_wrap_run(text, attrs) for text, attrs in xt.diff())
+
+
+def _serialize_inline_children(children: list[Any]) -> str:
+    """Inverse of ``_element_from_segments``: walks a paragraph/heading's
+    ``contents`` list, which may interleave ``XmlText`` runs with
+    ``hardBreak`` leaf elements."""
+    parts: list[str] = []
+    for child in children:
+        if isinstance(child, XmlText):
+            parts.append(_serialize_inline_text(child))
+        elif isinstance(child, XmlElement) and child.tag == "hardBreak":
+            # Canonical form regardless of whether the source used trailing
+            # double-space or backslash syntax — same "correct, not
+            # necessarily byte-identical" tradeoff already accepted
+            # elsewhere in this module for touched blocks.
+            parts.append("  \n")
+        else:
+            raise NotImplementedError(f"unrecognized inline child: {child!r}")
+    return "".join(parts)
+
+
+def _element_from_segments(
+    tag: str, attrs: dict[str, str], segments: list[_Segment]
+) -> tuple[XmlElement, list[Any]]:
+    """Build a heading/paragraph element from ``_inline_runs`` segments.
+    Marks are applied via ``.format()`` once each text node is integrated
+    (pycrdt requires integration before ``.insert``/``.format``), so this
+    returns finisher callbacks to run post-integration, same pattern as the
+    rest of this module."""
+    contents: list[Any] = []
+    finishers: list[Any] = []
+    for kind, text, runs in segments:
+        if kind == "hardbreak":
+            contents.append(XmlElement("hardBreak", {}))
+        else:
+            xt = XmlText(text or "")
+            contents.append(xt)
+            if runs:
+                finishers.append(lambda xt=xt, runs=runs: _apply_runs(xt, runs))
+    if not contents:
+        contents = [XmlText("")]
+    return XmlElement(tag, attrs, contents=contents), finishers
+
+
+def _make_inline_element(
+    tag: str, attrs: dict[str, str], line: str
+) -> tuple[XmlElement, list[Any]]:
+    """Build a heading/paragraph element: parse ``line`` standalone to get
+    its inline token, then delegate to ``_element_from_segments``.
+
+    ``line`` can be empty — e.g. a heading block whose text was stripped
+    down to nothing (``"# "`` with no title after it, a real state while
+    editing, not a hypothetical). Parsing an empty string standalone
+    produces zero tokens at all (no ``inline`` token, unlike parsing the
+    unstripped ``"# "`` line, which still gets one with empty content) —
+    confirmed directly. A block with genuinely empty inline content is
+    just an empty text node with no mark runs, not an error."""
+    mini_tokens = gfm_parser().parse(line)
+    inline_token = next((t for t in mini_tokens if t.type == "inline"), None)
+    if inline_token is None:
+        return XmlElement(tag, attrs, contents=[XmlText("")]), []
+    return _element_from_segments(tag, attrs, _inline_runs(inline_token))
+
+
+def _apply_runs(xt: XmlText, runs: list[tuple[int, int, dict[str, Any]]]) -> None:
+    for start, end, attrs in runs:
+        if start < end:
+            xt.format(start, end, attrs)
+
+
+def _matching_close(tokens: list[Any], open_idx: int, close_type: str) -> int:
+    """Index of the token that closes ``tokens[open_idx]`` — the next token
+    of ``close_type`` at the same nesting level."""
+    level = tokens[open_idx].level
+    j = open_idx + 1
+    while not (tokens[j].type == close_type and tokens[j].level == level):
+        j += 1
+    return j
+
+
+def _build_paragraph_from_inline(inline_token: Any) -> tuple[XmlElement, list[Any]]:
+    return _element_from_segments("paragraph", {}, _inline_runs(inline_token))
+
+
+def _build_block_sequence(tokens: list[Any], start: int, end: int) -> tuple[list[XmlElement], list[Any]]:
+    """Build a sequence of paragraph/list/blockquote child elements from a
+    flat markdown-it token range ``[start, end)`` — used for list-item and
+    blockquote content, recursing into ``_build_list``/``_build_blockquote``
+    for nested containers. This is what lets a list item contain multiple
+    paragraphs or a nested list, and a blockquote contain multiple
+    paragraphs or a list, with the same code path either way."""
+    children: list[XmlElement] = []
+    finishers: list[Any] = []
+    i = start
+    while i < end:
+        t = tokens[i]
+        if t.type == "paragraph_open":
+            el, para_finishers = _build_paragraph_from_inline(tokens[i + 1])
+            children.append(el)
+            finishers.extend(para_finishers)
+            i += 3  # paragraph_open, inline, paragraph_close
+            continue
+        if t.type in ("bullet_list_open", "ordered_list_open"):
+            close_idx = _matching_close(tokens, i, t.type.replace("_open", "_close"))
+            el, list_finishers = _build_list(tokens, i, close_idx + 1)
+            children.append(el)
+            finishers.extend(list_finishers)
+            i = close_idx + 1
+            continue
+        if t.type == "blockquote_open":
+            close_idx = _matching_close(tokens, i, "blockquote_close")
+            el, bq_finishers = _build_blockquote(tokens, i, close_idx + 1)
+            children.append(el)
+            finishers.extend(bq_finishers)
+            i = close_idx + 1
+            continue
+        raise NotImplementedError(f"unsupported nested block construct: {t.type!r}")
+    return children, finishers
+
+
+# GFM task-list marker: "[ ] "/"[x] "/"[X] " at the very start of a list
+# item's first paragraph. No dedicated task-list plugin is enabled on
+# `gfm_parser()` (see markdown_blocks.py), so this is recognized as plain
+# inline text and matched by hand rather than via a token type.
+_TASK_MARKER_RE = re.compile(r"^\[([ xX])\](?:\s+|$)")
+
+
+def _list_item_task_marker(tokens: list[Any], item_start: int, item_end: int) -> re.Match[str] | None:
+    """If a list item's first block is a paragraph beginning with a
+    checkbox marker, the match against that paragraph's leading text run;
+    else ``None``. ``item_start``/``item_end`` bracket the item's own
+    content tokens (i.e. *excluding* its `list_item_open`/`_close`)."""
+    if item_end - item_start < 3 or tokens[item_start].type != "paragraph_open":
+        return None
+    inline = tokens[item_start + 1]
+    if inline.type != "inline" or not inline.children:
+        return None
+    first_child = inline.children[0]
+    if first_child.type != "text":
+        return None
+    return _TASK_MARKER_RE.match(first_child.content)
+
+
+def _build_list(
+    tokens: list[Any], start: int, end: int, *, extra_attrs: dict[str, str] | None = None
+) -> tuple[XmlElement, list[Any]]:
+    open_tok = tokens[start]
+    ordered = open_tok.type == "ordered_list_open"
+
+    item_ranges: list[tuple[int, int]] = []
+    i = start + 1
+    while i < end - 1:  # exclude the outer list's own close token
+        t = tokens[i]
+        if t.type == "list_item_open":
+            close_idx = _matching_close(tokens, i, "list_item_close")
+            item_ranges.append((i + 1, close_idx))
+            i = close_idx + 1
+            continue
+        raise NotImplementedError(f"unexpected token inside list: {t.type!r}")
+
+    # A bullet list becomes a task list only when *every* item carries a
+    # checkbox marker — a taskList schema requires uniform taskItem
+    # children, so a mixed list (some items marked, some not) can't become
+    # one; it stays a plain bulletList with the literal "[ ] "/"[x] " text
+    # visible.
+    task_matches = (
+        None if ordered else [_list_item_task_marker(tokens, s, e) for s, e in item_ranges]
+    )
+    is_task_list = bool(item_ranges) and task_matches is not None and all(task_matches)
+
+    attrs = dict(extra_attrs or {})
+    if is_task_list:
+        tag = "taskList"
+    else:
+        tag = "orderedList" if ordered else "bulletList"
+        if ordered:
+            attrs["start"] = str(open_tok.attrs.get("start", 1))
+
+    items: list[XmlElement] = []
+    finishers: list[Any] = []
+    for idx, (item_start, item_end) in enumerate(item_ranges):
+        if is_task_list:
+            match = task_matches[idx]  # type: ignore[index]
+            assert match is not None
+            checked = match.group(1).lower() == "x"
+            first_text = tokens[item_start + 1].children[0]
+            first_text.content = first_text.content[match.end() :]
+            item_children, item_finishers = _build_block_sequence(tokens, item_start, item_end)
+            items.append(
+                XmlElement(
+                    "taskItem", {"checked": "true" if checked else "false"}, contents=item_children
+                )
+            )
+        else:
+            item_children, item_finishers = _build_block_sequence(tokens, item_start, item_end)
+            items.append(XmlElement("listItem", {}, contents=item_children))
+        finishers.extend(item_finishers)
+
+    return XmlElement(tag, attrs, contents=items), finishers
+
+
+def _build_blockquote(
+    tokens: list[Any], start: int, end: int, *, extra_attrs: dict[str, str] | None = None
+) -> tuple[XmlElement, list[Any]]:
+    children, finishers = _build_block_sequence(tokens, start + 1, end - 1)
+    return XmlElement("blockquote", dict(extra_attrs or {}), contents=children), finishers
+
+
+def _build_code_block(raw: str, attrs: dict[str, str]) -> XmlElement:
+    tok = next(t for t in gfm_parser().parse(raw) if t.type in ("fence", "code_block"))
+    language = tok.info.strip() if tok.type == "fence" else ""
+    return XmlElement(
+        "codeBlock", {**attrs, "language": language}, contents=[XmlText(tok.content)]
+    )
+
+
+def _heading_level_and_line(raw: str) -> tuple[int, str]:
+    line = raw.rstrip("\n")
+    hashes = 0
+    while hashes < len(line) and line[hashes] == "#":
+        hashes += 1
+    rest = line[hashes:]
+    if rest.startswith(" "):
+        rest = rest[1:]
+    return hashes, rest
+
+
+def _build_block_element(body: str, block: BlockRange) -> tuple[XmlElement, list[Any]]:
+    """Returns the (prelim) element plus a list of "finish" callbacks to run
+    once the element is integrated into a doc (mark ``.format()`` calls need
+    an already-integrated ``XmlText``)."""
+    raw = body[block.start : block.end]
+    trailing_nl = raw.endswith("\n")
+    nl_attr = "1" if trailing_nl else "0"
+
+    if block.kind is BlockKind.HEADING:
+        level, line = _heading_level_and_line(raw)
+        return _make_inline_element(
+            "heading", {BLOCK_ID_ATTR: block.block_id, "level": str(level), _NL_ATTR: nl_attr}, line
+        )
+
+    if block.kind is BlockKind.PARAGRAPH:
+        line = raw[:-1] if trailing_nl else raw
+        return _make_inline_element(
+            "paragraph", {BLOCK_ID_ATTR: block.block_id, _NL_ATTR: nl_attr}, line
+        )
+
+    if block.kind is BlockKind.LIST:
+        tokens = gfm_parser().parse(raw)
+        el, finishers = _build_list(
+            tokens, 0, len(tokens), extra_attrs={BLOCK_ID_ATTR: block.block_id, _NL_ATTR: nl_attr}
+        )
+        return el, finishers
+
+    if block.kind is BlockKind.BLOCKQUOTE:
+        tokens = gfm_parser().parse(raw)
+        el, finishers = _build_blockquote(
+            tokens, 0, len(tokens), extra_attrs={BLOCK_ID_ATTR: block.block_id, _NL_ATTR: nl_attr}
+        )
+        return el, finishers
+
+    if block.kind is BlockKind.CODE_BLOCK:
+        el = _build_code_block(raw, {BLOCK_ID_ATTR: block.block_id, _NL_ATTR: nl_attr})
+        return el, []
+
+    if block.kind is BlockKind.TABLE:
+        row_children: list[XmlElement] = []
+        for row in block.rows:
+            row_children.append(
+                XmlElement(
+                    "tableRow",
+                    {ROW_ID_ATTR: row.row_id},
+                    contents=[XmlText(body[row.start : row.end])],
+                )
+            )
+            if block.separator is not None and row.row_id == block.rows[0].row_id:
+                row_children.append(
+                    XmlElement(
+                        "tableSeparator",
+                        {ROW_ID_ATTR: block.separator.row_id},
+                        contents=[XmlText(body[block.separator.start : block.separator.end])],
+                    )
+                )
+        el = XmlElement("table", {BLOCK_ID_ATTR: block.block_id}, contents=row_children)
+        return el, []
+
+    # Opaque verbatim passthrough: thematic_break, html_block, other.
+    el = XmlElement(
+        block.kind.value,
+        {BLOCK_ID_ATTR: block.block_id, _RAW_ATTR: "1"},
+        contents=[XmlText(raw)],
+    )
+    return el, []
+
+
+def seed_doc_from_markdown(body: str) -> Doc:
+    """Build a fresh ``pycrdt.Doc`` whose root ``XmlFragment`` represents
+    every top-level block of ``body``, in document order."""
+    doc = Doc()
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    blocks = top_level_block_ranges(body)
+    with doc.transaction():
+        for block in blocks:
+            el, finishers = _build_block_element(body, block)
+            root.children.append(el)
+            for finish in finishers:
+                finish()
+    return doc
+
+
+def find_by_block_id(doc: Doc, block_id: str) -> XmlElement | None:
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    for child in root.children:
+        if isinstance(child, XmlElement) and dict(child.attributes).get(BLOCK_ID_ATTR) == block_id:
+            return child
+    return None
+
+
+def find_by_row_id(doc: Doc, row_id: str) -> XmlElement | None:
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    for child in root.children:
+        if not isinstance(child, XmlElement) or child.tag != "table":
+            continue
+        for row in child.children:
+            if dict(row.attributes).get(ROW_ID_ATTR) == row_id:
+                return row
+    return None
+
+
+def serialize_row(row: XmlElement) -> str:
+    return row.children[0].to_py()  # type: ignore[return-value]
+
+
+def _serialize_block_sequence(children: list[XmlElement], indent: str) -> str:
+    """Inverse of ``_build_block_sequence``: paragraph/list/blockquote
+    children joined by blank lines, with every line after the very first
+    indented by ``indent`` so continuation lines / nested constructs align
+    under the parent marker or blockquote ``>``."""
+    parts: list[str] = []
+    for child in children:
+        if child.tag == "paragraph":
+            parts.append(_serialize_inline_children(list(child.children)))
+        elif child.tag in ("bulletList", "orderedList", "taskList"):
+            parts.append(_serialize_list(child).rstrip("\n"))
+        elif child.tag == "blockquote":
+            parts.append(_serialize_blockquote(child).rstrip("\n"))
+        else:
+            raise NotImplementedError(f"unsupported nested block in sequence: tag={child.tag!r}")
+    combined = "\n\n".join(parts)
+    lines = combined.split("\n")
+    indented = [lines[0]] + [(indent + line if line else line) for line in lines[1:]]
+    return "\n".join(indented)
+
+
+def _serialize_list(node: XmlElement) -> str:
+    """Serializes every list as CommonMark "loose" style (blank line between
+    items), even if the source was "tight" (no blank lines) — tight vs.
+    loose is purely an HTML-rendering distinction (whether item content gets
+    wrapped in ``<p>``); the item *text* is identical either way, so this
+    never changes a page's actual content. Not byte-identical for a touched
+    list, same accepted tradeoff as ordered-list renumbering — only
+    untouched blocks carry the byte-stability guarantee
+    (``markdown_splice.py``), which never calls this serializer at all.
+    """
+    ordered = node.tag == "orderedList"
+    is_task = node.tag == "taskList"
+    attrs = dict(node.attributes)
+    start = int(attrs.get("start", "1")) if ordered else 1
+    lines: list[str] = []
+    for idx, item in enumerate(node.children):
+        if is_task:
+            checked = dict(item.attributes).get("checked") == "true"
+            marker = f"- [{'x' if checked else ' '}] "
+        elif ordered:
+            marker = f"{start + idx}. "
+        else:
+            marker = "- "
+        body = _serialize_block_sequence(list(item.children), " " * len(marker))  # type: ignore[arg-type]
+        lines.append(marker + body)
+    return "\n\n".join(lines) + "\n"
+
+
+def _serialize_blockquote(node: XmlElement) -> str:
+    body = _serialize_block_sequence(list(node.children), "")  # type: ignore[arg-type]
+    lines = body.split("\n")
+    return "\n".join(("> " + line if line else ">") for line in lines) + "\n"
+
+
+def _serialize_code_block(node: XmlElement) -> str:
+    """Always emits fenced syntax, even if the source was an indented code
+    block — semantically identical, and simpler/more robust than
+    reconstructing 4-space indentation. Same non-byte-identical-but-correct
+    tradeoff as ``_serialize_list``."""
+    attrs = dict(node.attributes)
+    language = attrs.get("language", "")
+    content = node.children[0].to_py()  # type: ignore[union-attr]
+    fence = "```"
+    while fence in content:
+        fence += "`"
+    return f"{fence}{language}\n{content}{fence}\n"
+
+
+def serialize_block(node: XmlElement) -> str:
+    attrs = dict(node.attributes)
+    trailing = attrs.get(_NL_ATTR) == "1"
+
+    if node.tag == "heading":
+        level = int(attrs["level"])
+        text = _serialize_inline_children(list(node.children))
+        return "#" * level + " " + text + ("\n" if trailing else "")
+    if node.tag == "paragraph":
+        text = _serialize_inline_children(list(node.children))
+        return text + ("\n" if trailing else "")
+    if node.tag in ("bulletList", "orderedList", "taskList"):
+        text = _serialize_list(node)
+        return text if trailing else text.rstrip("\n")
+    if node.tag == "blockquote":
+        text = _serialize_blockquote(node)
+        return text if trailing else text.rstrip("\n")
+    if node.tag == "codeBlock":
+        text = _serialize_code_block(node)
+        return text if trailing else text.rstrip("\n")
+    if node.tag == "table":
+        return "".join(serialize_row(row) for row in node.children)
+    if attrs.get(_RAW_ATTR) == "1":
+        return serialize_row(node)
+
+    raise NotImplementedError(f"unrecognized block construct: tag={node.tag!r}")
+
+
+class BlockSpan(BaseModel):
+    """One top-level block's character span within a
+    ``reconstruct_body``-style reserialize, keyed by its stable
+    ``_blockId``. Lets a caller translate a flat offset into that
+    reserialized text back into ``{block_id, offset_within_block}`` against
+    the *same* live tree the text was just serialized from — critical for
+    comment/source anchor resolution, where matching block ids computed
+    from two independently-parsed document versions would not correspond to
+    the same block (see
+    ``Engineering Projects/Agent Wiki Project/design/Co-Editing.md``)."""
+
+    model_config = ConfigDict(frozen=True)
+
+    block_id: str
+    start: int
+    end: int
+
+
+def reconstruct_body(doc: Doc) -> str:
+    """Full whole-document reserialize — a last-resort fallback. Never used
+    by the normal targeted-splice checkpoint path (see
+    ``markdown_splice.py``), since a whole-doc reserialize doesn't guarantee
+    byte-stability for untouched regions if any block's serializer doesn't
+    exactly reproduce its source (safe-but-lossy: correct output, not
+    necessarily byte-identical).
+    """
+    return reconstruct_body_with_block_map(doc)[0]
+
+
+def reconstruct_body_with_block_map(doc: Doc) -> tuple[str, list[BlockSpan]]:
+    """Like ``reconstruct_body``, but also returns each top-level block's
+    character span within the returned text. See ``BlockSpan``.
+
+    Each block's own serialized text already carries its own trailing
+    newline (``BlockRange.end`` is inclusive of it, per
+    ``markdown_blocks.py``) — bare concatenation would silently merge
+    adjacent blocks (e.g. two paragraphs collapse into one) rather than just
+    losing exact spacing, so a blank-line separator is inserted between
+    blocks whose own text doesn't already end in one (a raw/opaque block's
+    captured span sometimes already includes its trailing blank line;
+    headings/paragraphs never do, per ``_build_block_element``). A table's
+    span covers its whole reserialized text (every row concatenated) — rows
+    aren't tracked individually, matching this codec's row-level (not
+    per-cell) granularity everywhere else.
+    """
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    parts: list[str] = []
+    spans: list[BlockSpan] = []
+    pos = 0
+    for child in root.children:
+        if parts and not parts[-1].endswith("\n\n"):
+            parts.append("\n")
+            pos += 1
+        text = serialize_block(child)  # type: ignore[arg-type]
+        block_id = dict(child.attributes).get(BLOCK_ID_ATTR)  # type: ignore[union-attr]
+        start = pos
+        parts.append(text)
+        pos += len(text)
+        if block_id is not None:
+            spans.append(BlockSpan(block_id=block_id, start=start, end=pos))
+    return "".join(parts), spans

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -629,24 +629,35 @@ def _escape_block_start_ambiguity(text: str) -> str:
     paragraph as a different block type entirely. Unlike ``_wrap_run``'s
     mark-delimiter escaping (position-independent — a ``*``/``_``/`` ` ``/
     ``[``/``]`` is ambiguous anywhere in the text, already handled there),
-    these are only ambiguous at the very start of the block, which is
-    exactly the one position this function runs at. ``*`` as a bullet
-    marker doesn't need a case here — it's already escaped unconditionally
-    by ``_wrap_run`` for the emphasis reason, which covers this position
-    too as a side effect."""
-    if not text:
-        return text
-    if text[0] == "#":
-        return "\\" + text
-    if text[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(text):
-        return "\\" + text
-    if text[0] in "-+" and (len(text) == 1 or text[1].isspace()):
-        return "\\" + text
-    if text[0] == ">":
-        return "\\" + text
-    if _ORDERED_MARKER_RE.match(text):
-        return "\\" + text
-    return text
+    these are only ambiguous at the very start of *a line*, which is why
+    this checks every line a soft break produces, not just ``text[0]`` —
+    a multi-line paragraph's second line becomes just as much a fresh
+    block-start position once it's re-emitted, whether that's the plain
+    top level, prefixed with a list item's continuation indent (which
+    CommonMark still parses as a block start through up to 3 spaces), or
+    with a blockquote's repeated ``> `` (``_serialize_blockquote`` adds
+    that per line unconditionally, including a paragraph's internal soft
+    breaks). ``*`` as a bullet marker doesn't need a case here — it's
+    already escaped unconditionally by ``_wrap_run`` for the emphasis
+    reason, which covers every line's start position too as a side
+    effect."""
+    return "\n".join(_escape_line_start(line) for line in text.split("\n"))
+
+
+def _escape_line_start(line: str) -> str:
+    if not line:
+        return line
+    if line[0] == "#":
+        return "\\" + line
+    if line[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(line):
+        return "\\" + line
+    if line[0] in "-+" and (len(line) == 1 or line[1].isspace()):
+        return "\\" + line
+    if line[0] == ">":
+        return "\\" + line
+    if _ORDERED_MARKER_RE.match(line):
+        return "\\" + line
+    return line
 
 
 def serialize_block(node: XmlElement) -> str:

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -535,7 +535,14 @@ def _serialize_block_sequence(children: list[XmlElement], indent: str) -> str:
     parts: list[str] = []
     for child in children:
         if child.tag == "paragraph":
-            parts.append(_serialize_inline_children(list(child.children)))
+            # Same block-start ambiguity as a top-level paragraph
+            # (serialize_block) — a list item or blockquote's own first
+            # line is just as much a fresh block-start position as the
+            # top of the document, so a literal leading "-"/">"/"#"/"---"
+            # needs the same escaping, not just the top-level case.
+            parts.append(
+                _escape_block_start_ambiguity(_serialize_inline_children(list(child.children)))
+            )
         elif child.tag in ("bulletList", "orderedList", "taskList"):
             parts.append(_serialize_list(child).rstrip("\n"))
         elif child.tag == "blockquote":

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -651,6 +651,16 @@ _TABLE_DELIMITER_ROW_RE = re.compile(
 # just misclassifying the one paragraph.
 _FENCE_OPENER_RE = re.compile(r"^(?:`{3,}|~{3,})")
 
+# An indented code block: 4+ columns of leading indentation (4 spaces, or
+# fewer spaces then a tab — a tab always reaches the next 4-column stop, so
+# 0-3 spaces followed by one is equivalent to 4 bare spaces; confirmed
+# against the forward parse). Unlike every check above, this only matters on
+# a block's *first* line: an indented code block can't interrupt an
+# already-started paragraph (confirmed: a later soft-break line with 4+
+# leading spaces stays part of the same paragraph), so continuation lines
+# are already safe without any escaping.
+_INDENTED_CODE_FIRST_LINE_RE = re.compile(r"^(?: {4}| {0,3}\t)")
+
 
 def _escape_block_start_ambiguity(text: str) -> str:
     """A paragraph's serialized text starting with a character or pattern
@@ -671,28 +681,47 @@ def _escape_block_start_ambiguity(text: str) -> str:
     breaks). ``*`` as a bullet marker doesn't need a case here — it's
     already escaped unconditionally by ``_wrap_run`` for the emphasis
     reason, which covers every line's start position too as a side
-    effect."""
-    return "\n".join(_escape_line_start(line) for line in text.split("\n"))
+    effect. The first line additionally gets the indented-code-block check
+    (``_INDENTED_CODE_FIRST_LINE_RE``), since that ambiguity only exists on
+    a block's first line, not on every line the way the marker checks do."""
+    lines = text.split("\n")
+    escaped = [_escape_line_start(line) for line in lines]
+    if lines[0] and _INDENTED_CODE_FIRST_LINE_RE.match(lines[0]):
+        escaped[0] = "\\" + lines[0]
+    return "\n".join(escaped)
 
 
 def _escape_line_start(line: str) -> str:
     if not line:
         return line
-    if line[0] == "#":
+    # Up to 3 leading spaces are insignificant to CommonMark — "  # Heading"
+    # is still an ATX heading, "   - item" is still a bullet (confirmed
+    # against the forward parse: every marker below reactivates through 1-3
+    # leading spaces the same as at column 0) — so the checks below look
+    # past them, not just at column 0. A 4th leading space (or a tab, which
+    # advances to the next 4-column stop) tips into indented-code territory
+    # instead — a different, narrower case handled separately by
+    # _INDENTED_CODE_FIRST_LINE_RE, so a line whose leading run is that long
+    # is left alone here.
+    indent_len = min(3, len(line) - len(line.lstrip(" ")))
+    rest = line[indent_len:]
+    if not rest or rest[0] in " \t":
+        return line
+    if rest[0] == "#":
         return "\\" + line
-    if line[0] in "-=" and _SETEXT_UNDERLINE_RE.match(line):
+    if rest[0] in "-=" and _SETEXT_UNDERLINE_RE.match(rest):
         return "\\" + line
-    if line[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(line):
+    if rest[0] == "-" and _THEMATIC_BREAK_DASH_RE.match(rest):
         return "\\" + line
-    if line[0] in "-+" and (len(line) == 1 or line[1].isspace()):
+    if rest[0] in "-+" and (len(rest) == 1 or rest[1].isspace()):
         return "\\" + line
-    if line[0] == ">":
+    if rest[0] == ">":
         return "\\" + line
-    if _ORDERED_MARKER_RE.match(line):
+    if _ORDERED_MARKER_RE.match(rest):
         return "\\" + line
     if _TABLE_DELIMITER_ROW_RE.match(line):
         return "\\" + line
-    if _FENCE_OPENER_RE.match(line):
+    if _FENCE_OPENER_RE.match(rest):
         return "\\" + line
     return line
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "uvicorn[standard]>=0.27",  # ASGI server — production entry via Dockerfile CMD
     "itsdangerous>=2.1", # Starlette SessionMiddleware signs the session cookie
     "onnxruntime>=1.17", # in-process relevance scoring (two-tower ONNX); no torch
+    "markdown-it-py>=3.0", # markdown <-> Yjs codec block parsing (app/wiki/markdown_blocks.py)
+    "pycrdt>=0.14",         # Python Yjs CRDT implementation — coedit live doc
 ]
 
 [project.optional-dependencies]
@@ -47,7 +49,6 @@ dev = [
     "ruff>=0.15,<0.16",
     "basedpyright>=1.18",
     "httpx>=0.27",            # fastapi.testclient.TestClient transport
-    "markdown-it-py>=3.0",    # eval scorer: structural markdown validity
 ]
 
 [tool.setuptools.packages.find]
@@ -109,6 +110,48 @@ reportMissingTypeArgument = "none"
 reportUntypedFunctionDecorator = "none"
 reportPrivateUsage = "none"
 reportUnusedFunction = "none"
+# pycrdt's `.attributes` stub is bytes-keyed but str-keyed at runtime (see
+# the executionEnvironments below) — test_markdown_yjs.py hits the same
+# mismatch dict()-ing an XmlElement's attributes.
+reportArgumentType = "none"
+reportCallIssue = "none"
+
+# pycrdt's bundled stubs are loosely typed under strict mode: `Doc` is
+# generic with no usable neutral type argument, `.attributes`/`.children`
+# are declared with types (bytes-keyed dicts, unions including XmlFragment)
+# that don't match verified runtime behavior (str-keyed, always XmlElement
+# for our own tree shape). Relaxed here, per-file, same pattern as the
+# `tests` override above, rather than scattering `# type: ignore` at every
+# call site across the modules that talk to pycrdt directly.
+[[tool.basedpyright.executionEnvironments]]
+root = "app/wiki/markdown_yjs.py"
+reportUnknownParameterType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"
+reportUnknownMemberType = "none"
+reportUnknownLambdaType = "none"
+reportMissingTypeArgument = "none"
+reportArgumentType = "none"
+reportCallIssue = "none"
+reportAttributeAccessIssue = "none"
+reportReturnType = "none"
+reportUnnecessaryComparison = "none"
+reportOperatorIssue = "none"
+
+[[tool.basedpyright.executionEnvironments]]
+root = "app/wiki/markdown_splice.py"
+reportUnknownParameterType = "none"
+reportUnknownArgumentType = "none"
+reportUnknownVariableType = "none"
+reportUnknownMemberType = "none"
+reportMissingTypeArgument = "none"
+reportArgumentType = "none"
+reportCallIssue = "none"
+reportAttributeAccessIssue = "none"
+reportReturnType = "none"
+reportAssignmentType = "none"
+reportUnnecessaryComparison = "none"
+reportUnnecessaryContains = "none"
 
 [tool.uv]
 # Some transitive deps (e.g. greenlet) publish releases missing Linux wheels;

--- a/backend/tests/test_markdown_blocks.py
+++ b/backend/tests/test_markdown_blocks.py
@@ -1,0 +1,114 @@
+"""Pure unit tests for app/wiki/markdown_blocks.py — no DB/git fixtures."""
+
+from __future__ import annotations
+
+from app.wiki.markdown_blocks import BlockKind, top_level_block_ranges
+
+_SAMPLE = """# Heading
+
+Paragraph one has some **bold** text.
+
+- item one
+- item two
+
+| a | b |
+| --- | --- |
+| 1 | 2 |
+| 3 | 4 |
+
+Final paragraph.
+"""
+
+
+def test_top_level_block_ranges_reconstructs_body_verbatim() -> None:
+    blocks = top_level_block_ranges(_SAMPLE)
+    # Blocks are in document order and non-overlapping; concatenating the
+    # slices they cover plus the gaps between them must reconstruct the
+    # original body exactly. This is the hard invariant the splicer depends
+    # on: if this drifts, offsets are wrong and splicing corrupts content.
+    assert blocks[0].start == 0
+    assert blocks[-1].end <= len(_SAMPLE)
+    for prev, nxt in zip(blocks, blocks[1:]):
+        assert prev.end <= nxt.start
+
+
+def test_block_kinds_classified_correctly() -> None:
+    blocks = top_level_block_ranges(_SAMPLE)
+    kinds = [b.kind for b in blocks]
+    assert kinds == [
+        BlockKind.HEADING,
+        BlockKind.PARAGRAPH,
+        BlockKind.LIST,
+        BlockKind.TABLE,
+        BlockKind.PARAGRAPH,
+    ]
+
+
+def test_block_ids_are_positional_and_deterministic() -> None:
+    blocks_a = top_level_block_ranges(_SAMPLE)
+    blocks_b = top_level_block_ranges(_SAMPLE)
+    assert [b.block_id for b in blocks_a] == [b.block_id for b in blocks_b]
+    assert [b.block_id for b in blocks_a] == ["b0", "b1", "b2", "b3", "b4"]
+
+
+def test_table_block_has_row_ranges() -> None:
+    blocks = top_level_block_ranges(_SAMPLE)
+    table = next(b for b in blocks if b.kind is BlockKind.TABLE)
+    assert len(table.rows) == 3  # header + 2 body rows
+    assert [r.row_id for r in table.rows] == ["b3:r0", "b3:r1", "b3:r2"]
+    for row in table.rows:
+        assert table.start <= row.start < row.end <= table.end
+    # Each row's text is a distinct slice of the table's text.
+    row_texts = [_SAMPLE[r.start : r.end] for r in table.rows]
+    assert row_texts[0] != row_texts[1] != row_texts[2]
+
+
+def test_block_text_slices_match_expected_content() -> None:
+    blocks = top_level_block_ranges(_SAMPLE)
+    heading = blocks[0]
+    assert _SAMPLE[heading.start : heading.end].strip() == "# Heading"
+    final_paragraph = blocks[-1]
+    assert "Final paragraph." in _SAMPLE[final_paragraph.start : final_paragraph.end]
+
+
+def test_empty_body_has_no_blocks() -> None:
+    assert top_level_block_ranges("") == []
+    assert top_level_block_ranges("   \n\n  ") == []
+
+
+def test_single_paragraph() -> None:
+    body = "Just one paragraph.\n"
+    blocks = top_level_block_ranges(body)
+    assert len(blocks) == 1
+    assert blocks[0].kind is BlockKind.PARAGRAPH
+    assert body[blocks[0].start : blocks[0].end] == body
+
+
+def test_code_block_kind() -> None:
+    body = "Intro.\n\n```python\nx = 1\n```\n\nOutro.\n"
+    blocks = top_level_block_ranges(body)
+    kinds = [b.kind for b in blocks]
+    assert kinds == [BlockKind.PARAGRAPH, BlockKind.CODE_BLOCK, BlockKind.PARAGRAPH]
+
+
+def test_thematic_break_and_blockquote_kinds() -> None:
+    body = "Para.\n\n---\n\n> quoted line\n"
+    blocks = top_level_block_ranges(body)
+    kinds = [b.kind for b in blocks]
+    assert kinds == [BlockKind.PARAGRAPH, BlockKind.THEMATIC_BREAK, BlockKind.BLOCKQUOTE]
+
+
+def test_list_block_span_excludes_trailing_blank_line() -> None:
+    """markdown-it-py's bullet_list_open/ordered_list_open `.map` swallows
+    the blank line after the list into the token's own span; paragraph/
+    heading never do. A block's span must mean the same thing regardless of
+    kind — "just this block's own text" — since markdown_yjs.py and
+    markdown_splice.py's gap-ownership model both depend on that
+    uniformity (see _trim_trailing_blank_lines)."""
+    body = "- item one\n- item two\n\nNext paragraph.\n"
+    blocks = top_level_block_ranges(body)
+    list_block = blocks[0]
+    assert body[list_block.start : list_block.end] == "- item one\n- item two\n"
+    # The blank line belongs to nobody's span — it's the gap before the
+    # next block, same as a heading/paragraph pair.
+    assert body[list_block.end : blocks[1].start] == "\n"

--- a/backend/tests/test_markdown_splice.py
+++ b/backend/tests/test_markdown_splice.py
@@ -1,0 +1,248 @@
+"""Tests for app/wiki/markdown_splice.py — the targeted-splice checkpoint
+engine. The byte-stability assertions here are the riskiest piece of the
+AgentWikiEditor design (see the Co-Editing design doc): checkpointing a
+session where only one region changed must leave every other byte of the
+committed body identical to pre-session HEAD.
+"""
+
+from __future__ import annotations
+
+from pycrdt import XmlElement, XmlFragment
+
+from app.wiki.markdown_splice import TouchedTracker, checkpoint_body
+from app.wiki.markdown_yjs import ROOT_XML_KEY, seed_doc_from_markdown
+
+_SAMPLE = """# Heading
+
+Paragraph one has some **bold** text.
+
+- item one
+- item two
+
+| a | b |
+| --- | --- |
+| 1 | 2 |
+| 3 | 4 |
+
+Final paragraph.
+"""
+
+
+def _root(doc):
+    return doc.get(ROOT_XML_KEY, type=XmlFragment)
+
+
+def test_no_edits_round_trips_byte_identical() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    assert checkpoint_body(_SAMPLE, doc, tracker) == _SAMPLE
+
+
+def test_editing_one_paragraph_leaves_every_other_byte_identical() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    para = root.children[1]  # "Paragraph one has some **bold** text."
+    with doc.transaction():
+        para.children[0].insert(0, "EDITED: ")
+
+    new_body = checkpoint_body(_SAMPLE, doc, tracker)
+
+    assert "EDITED: Paragraph one" in new_body
+    # Every block except the edited paragraph is untouched — byte-identical
+    # to the source, including the surrounding heading/list/table/paragraph
+    # and the blank-line gaps between them.
+    heading_and_gap = "# Heading\n\n"
+    assert new_body.startswith(heading_and_gap)
+    tail = _SAMPLE[_SAMPLE.index("- item one") :]
+    assert new_body.endswith(tail)
+
+
+def test_editing_table_cell_only_touches_that_row() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    table = next(c for c in root.children if c.tag == "table")
+    row0 = table.children[0]  # header row "| a | b |"
+    with doc.transaction():
+        row0.children[0].insert(0, "EDITED ")
+
+    new_body = checkpoint_body(_SAMPLE, doc, tracker)
+
+    assert "EDITED | a | b |" in new_body
+    # The rest of the table (separator + both body rows) is untouched.
+    assert "| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n" in new_body
+    # Everything before and after the table is untouched too.
+    before_table = _SAMPLE[: _SAMPLE.index("| a | b |")]
+    assert new_body.startswith(before_table)
+    after_table = _SAMPLE[_SAMPLE.index("Final paragraph.") :]
+    assert new_body.endswith(after_table)
+
+
+def test_editing_two_separate_blocks_leaves_middle_untouched() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    heading = root.children[0]
+    final_para = list(root.children)[-1]
+    with doc.transaction():
+        heading.children[0].insert(0, "NEW ")
+    with doc.transaction():
+        final_para.children[0].insert(0, "NEW ")
+
+    new_body = checkpoint_body(_SAMPLE, doc, tracker)
+
+    middle = _SAMPLE[_SAMPLE.index("Paragraph one") : _SAMPLE.index("Final paragraph.")]
+    assert middle in new_body
+    assert "NEW Heading" in new_body
+    assert "NEW Final paragraph." in new_body
+
+
+def test_inserting_a_new_top_level_block_leaves_existing_blocks_untouched() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    new_para = XmlElement("paragraph", {"_blockId": "new0", "_nl": "1"}, contents=[])
+    with doc.transaction():
+        root.children.append(new_para)
+    from pycrdt import XmlText
+
+    with doc.transaction():
+        new_para.children.append(XmlText("Brand new paragraph."))
+
+    new_body = checkpoint_body(_SAMPLE, doc, tracker)
+
+    assert new_body.startswith(_SAMPLE.rstrip("\n"))
+    assert "Brand new paragraph." in new_body
+
+
+def test_deleting_a_top_level_block_omits_it_and_leaves_rest_untouched() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    list_block = next(c for c in root.children if c.tag == "bulletList")
+    with doc.transaction():
+        idx = list(root.children).index(list_block)
+        del root.children[idx]
+
+    new_body = checkpoint_body(_SAMPLE, doc, tracker)
+
+    assert "item one" not in new_body
+    assert "# Heading" in new_body
+    assert "| a | b |" in new_body
+    assert "Final paragraph." in new_body
+
+
+def test_reset_clears_touched_state_for_next_checkpoint() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    para = root.children[1]
+    with doc.transaction():
+        para.children[0].insert(0, "FIRST: ")
+    first_checkpoint = checkpoint_body(_SAMPLE, doc, tracker)
+    tracker.reset()
+
+    # No further edits — the second checkpoint against the new base should be
+    # byte-identical (nothing touched since reset).
+    second_checkpoint = checkpoint_body(first_checkpoint, doc, tracker)
+    assert second_checkpoint == first_checkpoint
+
+
+def test_concurrent_editing_convergence_via_update_apply() -> None:
+    """Two peers editing the same doc via raw Yjs updates (the actual
+    pycrdt-websocket wire path, not our own API) converge, and the
+    tracker on the receiving end still sees the touch — proving touched
+    tracking works for updates applied from bytes, not just local edits."""
+    from pycrdt import Doc
+
+    doc_a = seed_doc_from_markdown(_SAMPLE)
+    doc_b = Doc()
+    doc_b.apply_update(doc_a.get_update())
+
+    tracker_b = TouchedTracker(doc_b)
+    root_a = _root(doc_a)
+    para_a = root_a.children[1]
+    with doc_a.transaction():
+        para_a.children[0].insert(0, "FROM PEER A: ")
+
+    update = doc_a.get_update()
+    doc_b.apply_update(update)
+
+    new_body = checkpoint_body(_SAMPLE, doc_b, tracker_b)
+    assert "FROM PEER A: Paragraph one" in new_body
+    assert new_body.startswith("# Heading\n\n")
+
+
+_NESTED_SAMPLE = """# Heading
+
+Paragraph one.
+
+- item one
+- item two
+- item three
+
+> A quote paragraph.
+
+```python
+x = 1
+```
+
+Final paragraph.
+"""
+
+
+def test_editing_deep_inside_a_list_item_touches_only_the_whole_list() -> None:
+    """Block-level granularity for containers (per the splice-granularity
+    decision — table rows are the one exception): an edit anywhere inside a
+    list, however deeply nested, marks the whole top-level list touched,
+    everything else stays untouched."""
+    doc = seed_doc_from_markdown(_NESTED_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+    list_block = next(c for c in root.children if c.tag == "bulletList")
+    item2_para = list_block.children[1].children[0]
+    assert item2_para.tag == "paragraph"
+    with doc.transaction():
+        item2_para.children[0].insert(0, "EDITED ")
+
+    new_body = checkpoint_body(_NESTED_SAMPLE, doc, tracker)
+    assert "EDITED item two" in new_body
+    before_list = _NESTED_SAMPLE[: _NESTED_SAMPLE.index("- item one")]
+    assert new_body.startswith(before_list)
+    after_list = _NESTED_SAMPLE[_NESTED_SAMPLE.index("> A quote") :]
+    assert new_body.endswith(after_list)
+
+
+def test_editing_inside_blockquote_leaves_everything_before_it_untouched() -> None:
+    doc = seed_doc_from_markdown(_NESTED_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+    bq = next(c for c in root.children if c.tag == "blockquote")
+    bq_para = bq.children[0]
+    with doc.transaction():
+        bq_para.children[0].insert(0, "EDITED ")
+
+    new_body = checkpoint_body(_NESTED_SAMPLE, doc, tracker)
+    assert "EDITED A quote" in new_body
+    before_bq = _NESTED_SAMPLE[: _NESTED_SAMPLE.index("> A quote")]
+    assert new_body.startswith(before_bq)
+
+
+def test_editing_inside_code_block_leaves_everything_before_it_untouched() -> None:
+    doc = seed_doc_from_markdown(_NESTED_SAMPLE)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+    code = next(c for c in root.children if c.tag == "codeBlock")
+    with doc.transaction():
+        code.children[0].insert(0, "y = 2\n")
+
+    new_body = checkpoint_body(_NESTED_SAMPLE, doc, tracker)
+    assert "y = 2\nx = 1" in new_body
+    assert new_body.startswith(_NESTED_SAMPLE[: _NESTED_SAMPLE.index("```python")])

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -332,6 +332,45 @@ def test_mid_text_block_marker_characters_are_left_alone() -> None:
         assert reconstruct_body(seed_doc_from_markdown(raw)) == raw
 
 
+def test_escaped_thematic_break_dash_run_stays_a_paragraph() -> None:
+    # A paragraph whose whole text is an escaped dash run ("\---") is the
+    # sharpest case: an unescaped "---" alone on a line isn't just
+    # misclassified like the bullet/blockquote cases, it's a thematic
+    # break — content-free — so reactivating it doesn't just change the
+    # block type, it silently discards the paragraph's text entirely.
+    # "***"/"_ _ _" thematic breaks need no dedicated case: every "*"/"_"
+    # is already escaped unconditionally by _wrap_run for the emphasis
+    # reason, which breaks the run regardless of position.
+    for raw in ("\\---\n", "\\- - -\n"):
+        doc = seed_doc_from_markdown(raw)
+        root = _root(doc)
+        assert root.children[0].tag == "paragraph"
+        once = reconstruct_body(doc)
+        assert once == raw
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
+def test_dash_run_with_trailing_content_does_not_need_escaping() -> None:
+    # CommonMark requires a thematic break to be the *whole* line — "---"
+    # followed by other text on the same line is never ambiguous, so no
+    # escape should be added (and, separately, checkpointing an already-
+    # unescaped "--- and more" must not spuriously start escaping it).
+    body = "--- and more text on the line\n"
+    doc = seed_doc_from_markdown(body)
+    root = _root(doc)
+    assert root.children[0].tag == "paragraph"
+    assert reconstruct_body(doc) == body
+
+
+def test_two_dashes_is_not_enough_for_a_thematic_break() -> None:
+    # Below the 3-dash threshold — not a break, not a bullet (no whitespace
+    # right after the first dash) — plain literal text, no escape needed.
+    body = "-- not enough dashes for a break\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
 def test_find_by_block_id() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     found = find_by_block_id(doc, "b1")

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -556,6 +556,75 @@ def test_paragraph_line_of_backticks_does_not_reactivate_as_a_fence() -> None:
     assert tags == ["paragraph"]
 
 
+def test_indented_block_markers_do_not_reactivate() -> None:
+    # Up to 3 leading spaces are insignificant to CommonMark — a heading,
+    # blockquote, bullet, ordered marker, thematic break, and fence opener
+    # all still reactivate through 1-3 spaces of indent the same as at
+    # column 0. _escape_line_start's checks used to require the marker at
+    # true column 0 and missed every one of these. The escape backslash
+    # lands before the line's leading spaces rather than before the marker
+    # itself, so (unlike the column-0 case) it isn't consumed as a
+    # single-character escape of the marker on the very next parse — the
+    # literal backslash it produces needs escaping in its own right, which
+    # doesn't happen until the round after. That's the same "correct but
+    # not byte-identical on the first round, stable from the second round
+    # on" tolerance already established elsewhere in this module (e.g.
+    # setext-to-ATX canonicalization) — checked here via the 2nd/3rd round
+    # comparison, not the 1st/2nd.
+    cases = [
+        "First line\n  # Heading",
+        "First line\n > Quote",
+        "First line\n   - item",
+        "First line\n  + item",
+        "First line\n  1. item",
+        "First line\n   ---",
+        "First line\n  ~~~\ncode\n~~~",
+    ]
+    for text in cases:
+        doc = _build_live_paragraph(text)
+        once = reconstruct_body(doc)
+        tags = [
+            c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+        ]
+        assert tags == ["paragraph"], f"expected a single paragraph for {text!r}, got tags={tags}"
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        thrice = reconstruct_body(seed_doc_from_markdown(twice))
+        assert twice == thrice, f"never stabilized for {text!r}: {twice!r} != {thrice!r}"
+
+
+def test_indented_first_line_does_not_reactivate_as_code_block() -> None:
+    # 4+ columns of leading indentation on a block's *first* line (4 spaces,
+    # or fewer spaces then a tab, which reaches the next 4-column stop)
+    # reactivates as an indented code block — a different, narrower case
+    # than the 1-3-space marker checks above, since indented code can't
+    # interrupt an already-started paragraph.
+    for text in ("    looks like code\nsecond line", "\ttab indented\nsecond line"):
+        doc = _build_live_paragraph(text)
+        once = reconstruct_body(doc)
+        tags = [
+            c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+        ]
+        assert tags == ["paragraph"], f"expected a single paragraph for {text!r}, got tags={tags}"
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        thrice = reconstruct_body(seed_doc_from_markdown(twice))
+        assert twice == thrice, f"never stabilized for {text!r}: {twice!r} != {thrice!r}"
+
+
+def test_indented_continuation_line_stays_safe_without_escaping() -> None:
+    # A *continuation* line (not the block's first line) with 4+ leading
+    # spaces is already safe without any escaping at all — indented code
+    # can't interrupt a paragraph, so it stays part of the same paragraph
+    # either way. Asserts the byte-identical (mod the trailing newline
+    # reconstruct_body always appends) round trip, not just the tag, to
+    # confirm no unnecessary backslash gets inserted here.
+    text = "First line\n    still one paragraph"
+    doc = _build_live_paragraph(text)
+    once = reconstruct_body(doc)
+    assert once == text + "\n"
+    tags = [c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children]
+    assert tags == ["paragraph"]
+
+
 def test_find_by_block_id() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     found = find_by_block_id(doc, "b1")

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -311,12 +311,35 @@ def test_escaped_block_start_markers_round_trip_as_literal_text() -> None:
         "\\+ not a bullet\n",
         "\\> not a quote\n",
         "\\* not a bullet\n",
+        "1\\. not a list\n",
+        "1\\) not a list\n",
     ]
     for raw in cases:
         once = reconstruct_body(seed_doc_from_markdown(raw))
         assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
         twice = reconstruct_body(seed_doc_from_markdown(once))
         assert twice == once
+
+
+def test_ordered_marker_escape_lands_on_the_delimiter_not_the_digits() -> None:
+    # Every other marker character this module escapes (#, >, -, +, ~, `)
+    # is ASCII punctuation, so a backslash placed directly before it is a
+    # valid CommonMark escape. A digit is not punctuation — a backslash
+    # before "1" is never consumed on reparse and survives as a literal
+    # extra character instead of protecting anything (confirmed against
+    # the forward parse: "\1. item" reparses to the *content* "\1. item",
+    # not "1. item"). The delimiter right after the digits ("." or ")")
+    # *is* punctuation, so that's where the escape has to go instead.
+    for text in ("First line\n1. item", "First line\n1) item", "First line\n10. item"):
+        doc = _build_live_paragraph(text)
+        once = reconstruct_body(doc)
+        reseeded = seed_doc_from_markdown(once)
+        tags = [c.tag for c in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children]
+        assert tags == ["paragraph"], f"expected a single paragraph for {text!r}, got tags={tags}"
+        twice = reconstruct_body(reseeded)
+        assert once == twice, f"not stable from round 1 for {text!r}: {once!r} != {twice!r}"
+        content = "".join(t for t, _ in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children[0].children[0].diff())
+        assert content == text, f"expected content {text!r} preserved exactly, got {content!r}"
 
 
 def test_mid_text_block_marker_characters_are_left_alone() -> None:
@@ -561,35 +584,44 @@ def test_indented_block_markers_do_not_reactivate() -> None:
     # blockquote, bullet, ordered marker, thematic break, and fence opener
     # all still reactivate through 1-3 spaces of indent the same as at
     # column 0. _escape_line_start's checks used to require the marker at
-    # true column 0 and missed every one of these. The escape backslash
-    # lands before the line's leading spaces rather than before the marker
-    # itself, so (unlike the column-0 case) it isn't consumed as a
-    # single-character escape of the marker on the very next parse — the
-    # literal backslash it produces needs escaping in its own right, which
-    # doesn't happen until the round after. That's the same "correct but
-    # not byte-identical on the first round, stable from the second round
-    # on" tolerance already established elsewhere in this module (e.g.
-    # setext-to-ATX canonicalization) — checked here via the 2nd/3rd round
-    # comparison, not the 1st/2nd.
+    # true column 0 and missed every one of these.
+    #
+    # The escape backslash goes immediately before the marker character,
+    # not before the line's leading spaces — CommonMark's backslash escape
+    # only applies to punctuation, never to whitespace (confirmed against
+    # the spec and the forward parse), so a backslash before a space is
+    # never consumed and would survive into the reparsed content as a
+    # literal extra character instead of protecting anything. The
+    # documented tradeoff (AGENT_WIKI_MARKDOWN_STANDARD.md §6): the
+    # indentation itself doesn't survive the checkpoint — CommonMark
+    # strips it as insignificant regardless of what this module emits, so
+    # dropping it here is a no-op as far as final content goes, not an
+    # extra loss. Checked via round 1 vs round 2 (an earlier version of
+    # this fix escaped in a position CommonMark doesn't treat as an
+    # escape at all, so it took an extra round to settle and, worse,
+    # settled on content with a stray backslash baked in — round-1
+    # fidelity is the real bar, not eventual stability).
     cases = [
-        "First line\n  # Heading",
-        "First line\n > Quote",
-        "First line\n   - item",
-        "First line\n  + item",
-        "First line\n  1. item",
-        "First line\n   ---",
-        "First line\n  ~~~\ncode\n~~~",
+        ("First line\n  # Heading", "First line\n# Heading"),
+        ("First line\n > Quote", "First line\n> Quote"),
+        ("First line\n   - item", "First line\n- item"),
+        ("First line\n  + item", "First line\n+ item"),
+        ("First line\n  1. item", "First line\n1. item"),
+        ("First line\n   ---", "First line\n---"),
+        ("First line\n  ~~~\ncode\n~~~", "First line\n~~~\ncode\n~~~"),
     ]
-    for text in cases:
+    for text, expected_content in cases:
         doc = _build_live_paragraph(text)
         once = reconstruct_body(doc)
-        tags = [
-            c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
-        ]
+        reseeded = seed_doc_from_markdown(once)
+        tags = [c.tag for c in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children]
         assert tags == ["paragraph"], f"expected a single paragraph for {text!r}, got tags={tags}"
-        twice = reconstruct_body(seed_doc_from_markdown(once))
-        thrice = reconstruct_body(seed_doc_from_markdown(twice))
-        assert twice == thrice, f"never stabilized for {text!r}: {twice!r} != {thrice!r}"
+        twice = reconstruct_body(reseeded)
+        assert once == twice, f"not stable from round 1 for {text!r}: {once!r} != {twice!r}"
+        content = "".join(t for t, _ in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children[0].children[0].diff())
+        assert content == expected_content, (
+            f"expected the leading indentation trimmed for {text!r}, got {content!r}"
+        )
 
 
 def test_indented_first_line_does_not_reactivate_as_code_block() -> None:
@@ -597,17 +629,27 @@ def test_indented_first_line_does_not_reactivate_as_code_block() -> None:
     # or fewer spaces then a tab, which reaches the next 4-column stop)
     # reactivates as an indented code block — a different, narrower case
     # than the 1-3-space marker checks above, since indented code can't
-    # interrupt an already-started paragraph.
-    for text in ("    looks like code\nsecond line", "\ttab indented\nsecond line"):
+    # interrupt an already-started paragraph. There's no marker character
+    # here to escape at all (the ambiguity is the indentation itself, and
+    # CommonMark can't escape whitespace), so the leading run is dropped
+    # outright rather than backslash-prefixed — same documented tradeoff
+    # and same round-1 fidelity bar as the marker cases above.
+    cases = [
+        ("    looks like code\nsecond line", "looks like code\nsecond line"),
+        ("\ttab indented\nsecond line", "tab indented\nsecond line"),
+    ]
+    for text, expected_content in cases:
         doc = _build_live_paragraph(text)
         once = reconstruct_body(doc)
-        tags = [
-            c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
-        ]
+        reseeded = seed_doc_from_markdown(once)
+        tags = [c.tag for c in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children]
         assert tags == ["paragraph"], f"expected a single paragraph for {text!r}, got tags={tags}"
-        twice = reconstruct_body(seed_doc_from_markdown(once))
-        thrice = reconstruct_body(seed_doc_from_markdown(twice))
-        assert twice == thrice, f"never stabilized for {text!r}: {twice!r} != {thrice!r}"
+        twice = reconstruct_body(reseeded)
+        assert once == twice, f"not stable from round 1 for {text!r}: {once!r} != {twice!r}"
+        content = "".join(t for t, _ in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children[0].children[0].diff())
+        assert content == expected_content, (
+            f"expected the leading indentation trimmed for {text!r}, got {content!r}"
+        )
 
 
 def test_indented_continuation_line_stays_safe_without_escaping() -> None:
@@ -649,8 +691,7 @@ def test_unrecognized_inline_construct_raises_not_implemented() -> None:
     # GFM strikethrough isn't in _KNOWN_INLINE_TYPES (no strikethrough
     # plugin enabled on gfm_parser()), so markdown-it never emits the token
     # type in the first place — use an image instead, which markdown-it
-    # does emit and this codec deliberately doesn't support yet (see
-    # docs/AGENT_WIKI_MARKDOWN_STANDARD.md's deferred items).
+    # does emit and this codec has no encoder for.
     body = "A picture: ![alt](https://x.example/img.png) here.\n"
     with pytest.raises(NotImplementedError):
         seed_doc_from_markdown(body)

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import pytest
-from pycrdt import XmlFragment
+from pycrdt import Doc, XmlElement, XmlFragment, XmlText
 
 from app.wiki.markdown_yjs import (
     BLOCK_ID_ATTR,
@@ -453,6 +453,107 @@ def test_escaped_block_start_marker_on_a_later_soft_break_line() -> None:
         # time must not raise (it did, for "#", before this fix).
         twice = reconstruct_body(seed_doc_from_markdown(once))
         assert twice == once
+
+
+def test_escaped_setext_underline_on_a_later_line_stays_literal() -> None:
+    # A setext heading underline (one or more contiguous "=" for level 1,
+    # or "-" for level 2 — a different, lower threshold than a thematic
+    # break's 3+) only ever reactivates a *preceding* line, i.e. exactly
+    # the per-line position _escape_line_start already runs at. "=" had no
+    # handling at all; a bare "-"/"--" (below the thematic-break floor,
+    # and not matching the bullet check either since nothing follows)
+    # fell through every existing check.
+    cases = [
+        "My Title\n\\===\n",
+        "My Title\n\\-\n",
+        "My Title\n\\--\n",
+        "- My Title\n  \\===\n",
+        "> My Title\n> \\===\n",
+    ]
+    for raw in cases:
+        once = reconstruct_body(seed_doc_from_markdown(raw))
+        assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
+        # Confirms no crash on re-seed for the nested cases (same failure
+        # mode as the "#" case: _build_block_sequence has no heading
+        # support inside a list item/blockquote at all).
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
+def _build_live_paragraph(text: str) -> Doc:
+    """A paragraph built directly (not via seed_doc_from_markdown), to
+    simulate what a user typing plain prose in the live editor actually
+    produces — critically, one that never went through the forward
+    markdown parser, so text that *happens* to look like table source
+    (e.g. "a | b" + a soft break + "---|---") was never classified as a
+    table in the first place. Round-tripping this through checkpoint
+    serialization is the only way this specific reactivation is
+    reachable; seeding directly from that same markdown text would
+    already (correctly) parse it as a table, not a paragraph."""
+    doc = Doc()
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    para = XmlElement("paragraph", {BLOCK_ID_ATTR: "b0", "_nl": "1"}, contents=[])
+    with doc.transaction():
+        root.children.append(para)
+    with doc.transaction():
+        para.children.append(XmlText(text))
+    return doc
+
+
+def test_paragraph_reactivates_as_table_without_escaping() -> None:
+    # A plain paragraph a user actually typed — "a | b" then a soft break
+    # then "---|---" — serializes with neither "|" nor the bare dash run
+    # escaped by anything else in this module, and a GFM table delimiter
+    # row needs only 1+ dashes per cell (no thematic-break-style 3+
+    # floor), so the checkpointed output reactivates as a table on the
+    # next parse.
+    doc = _build_live_paragraph("a | b\n---|---")
+    once = reconstruct_body(doc)
+    reseeded = seed_doc_from_markdown(once)
+    tags = [c.tag for c in reseeded.get(ROOT_XML_KEY, type=XmlFragment).children]
+    assert tags == ["paragraph"], (
+        f"expected the checkpointed text to stay a single paragraph, "
+        f"got tags={tags} for body={once!r}"
+    )
+
+
+def test_table_delimiter_row_escaping_is_stable() -> None:
+    for text in ("a | b\n---|---", "a | b\n--|--", "a | b\n:--|--:"):
+        doc = _build_live_paragraph(text)
+        once = reconstruct_body(doc)
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert once == twice
+        tags = [
+            c.tag
+            for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+        ]
+        assert tags == ["paragraph"]
+
+
+def test_paragraph_line_of_tildes_does_not_reactivate_as_a_fence() -> None:
+    # "~" isn't in _escape_inline_text's char set at all (only
+    # \`*_[] are), unlike backtick fences — a plain paragraph line typed
+    # as "~~~" reactivates as a fenced code block opener on the next
+    # parse, which is more severe than the other cases: a fence doesn't
+    # just misclassify one block, it swallows everything up to the *next*
+    # matching fence (or EOF) as raw content.
+    doc = _build_live_paragraph("some text:\n~~~\nmore text")
+    once = reconstruct_body(doc)
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert once == twice
+    tags = [c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children]
+    assert tags == ["paragraph"]
+
+
+def test_paragraph_line_of_backticks_does_not_reactivate_as_a_fence() -> None:
+    # Backtick is already in _escape_inline_text's char set, so this is
+    # already protected as a side effect (confirmed, not assumed) — kept
+    # as an explicit regression test alongside the tilde case rather than
+    # relying on that being obvious from reading _wrap_run alone.
+    doc = _build_live_paragraph("some text:\n```\nmore text")
+    once = reconstruct_body(doc)
+    tags = [c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children]
+    assert tags == ["paragraph"]
 
 
 def test_find_by_block_id() -> None:

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -371,6 +371,51 @@ def test_two_dashes_is_not_enough_for_a_thematic_break() -> None:
     assert reconstruct_body(doc) == body
 
 
+def test_escaped_block_start_markers_inside_list_item_stay_literal() -> None:
+    # _serialize_block_sequence (list item / blockquote content) used to
+    # call _serialize_inline_children directly, bypassing
+    # _escape_block_start_ambiguity entirely — a list item or blockquote's
+    # own first line is just as much a fresh block-start position as the
+    # top of the document. Without the fix, these reactivate as a nested
+    # list/blockquote; a nested heading attempt doesn't just misparse, it
+    # crashes outright (_build_block_sequence has no heading support at
+    # all), since escaping is also what prevents ever attempting that
+    # parse in the first place.
+    cases = [
+        "- \\- nested item text\n",
+        "- \\# nested heading text\n",
+        "- \\--- nested break only\n",
+    ]
+    for raw in cases:
+        doc = seed_doc_from_markdown(raw)
+        root = _root(doc)
+        assert root.children[0].tag == "bulletList"
+        item = root.children[0].children[0]
+        assert item.tag == "listItem"
+        assert item.children[0].tag == "paragraph"
+        once = reconstruct_body(doc)
+        assert once == raw
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
+def test_escaped_block_start_markers_inside_blockquote_stay_literal() -> None:
+    cases = [
+        "> \\> nested quote text\n",
+        "> \\# nested heading text\n",
+        "> \\--- nested break only\n",
+    ]
+    for raw in cases:
+        doc = seed_doc_from_markdown(raw)
+        root = _root(doc)
+        assert root.children[0].tag == "blockquote"
+        assert root.children[0].children[0].tag == "paragraph"
+        once = reconstruct_body(doc)
+        assert once == raw
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
 def test_find_by_block_id() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     found = find_by_block_id(doc, "b1")

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -1,0 +1,347 @@
+"""Tests for app/wiki/markdown_yjs.py — the markdown <-> Yjs codec."""
+
+from __future__ import annotations
+
+import pytest
+from pycrdt import XmlFragment
+
+from app.wiki.markdown_yjs import (
+    BLOCK_ID_ATTR,
+    ROOT_XML_KEY,
+    ROW_ID_ATTR,
+    find_by_block_id,
+    find_by_row_id,
+    reconstruct_body,
+    reconstruct_body_with_block_map,
+    seed_doc_from_markdown,
+)
+
+_SAMPLE = """# Heading
+
+Paragraph one has some **bold** text.
+
+- item one
+- item two
+
+| a | b |
+| --- | --- |
+| 1 | 2 |
+| 3 | 4 |
+
+Final paragraph.
+"""
+
+
+def _root(doc):
+    return doc.get(ROOT_XML_KEY, type=XmlFragment)
+
+
+def test_seed_doc_produces_one_element_per_top_level_block() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    root = _root(doc)
+    tags = [c.tag for c in root.children]
+    assert tags == ["heading", "paragraph", "bulletList", "table", "paragraph"]
+
+
+def test_block_ids_are_positional_and_stable() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    root = _root(doc)
+    ids = [dict(c.attributes).get(BLOCK_ID_ATTR) for c in root.children]
+    assert ids == ["b0", "b1", "b2", "b3", "b4"]
+
+
+def test_reconstruct_body_round_trips_simple_body() -> None:
+    body = "# Heading\n\nJust a paragraph.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_empty_heading_does_not_raise() -> None:
+    """`# ` with no title text after it — a real state while editing (type
+    `#`, hit space, haven't typed a title yet), not a hypothetical. Used to
+    raise StopIteration: parsing the stripped (empty) heading text standalone
+    produces zero markdown-it tokens at all, unlike parsing the unstripped
+    `"# "` line, which still produces an `inline` token with empty content."""
+    doc = seed_doc_from_markdown("# \n")
+    root = _root(doc)
+    assert root.children[0].tag == "heading"
+    assert reconstruct_body(doc) == "# \n"
+
+
+def test_reconstruct_body_round_trips_bold_italic_code_link() -> None:
+    body = "A **bold** and *italic* and `code` and [a link](https://x.example) end.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_reconstruct_body_round_trips_table() -> None:
+    body = "| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_reconstruct_body_round_trips_code_quote_and_raw_thematic_break() -> None:
+    body = "Intro.\n\n```python\nx = 1\n```\n\n> a quote\n\n---\n\nOutro.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_bullet_list_structure_and_nesting() -> None:
+    doc = seed_doc_from_markdown("- outer one\n  - inner\n- outer two\n")
+    root = _root(doc)
+    lst = root.children[0]
+    assert lst.tag == "bulletList"
+    items = list(lst.children)
+    assert [i.tag for i in items] == ["listItem", "listItem"]
+    # First item: a paragraph plus a nested bulletList.
+    first_item_children = list(items[0].children)
+    assert [c.tag for c in first_item_children] == ["paragraph", "bulletList"]
+    nested = first_item_children[1]
+    assert nested.children[0].tag == "listItem"
+
+
+def test_ordered_list_start_attribute_and_serialization() -> None:
+    body = "3. first\n4. second\n"
+    doc = seed_doc_from_markdown(body)
+    root = _root(doc)
+    lst = root.children[0]
+    assert lst.tag == "orderedList"
+    assert dict(lst.attributes)["start"] == "3"
+    # Content is preserved; loose-vs-tight spacing is not (documented,
+    # semantics-preserving normalization — see markdown_yjs.py).
+    got = reconstruct_body(doc)
+    assert "3. first" in got and "4. second" in got
+
+
+def test_task_list_structure_and_checked_attribute() -> None:
+    doc = seed_doc_from_markdown("- [ ] todo\n- [x] done\n")
+    root = _root(doc)
+    lst = root.children[0]
+    assert lst.tag == "taskList"
+    items = list(lst.children)
+    assert [i.tag for i in items] == ["taskItem", "taskItem"]
+    assert dict(items[0].attributes)["checked"] == "false"
+    assert dict(items[1].attributes)["checked"] == "true"
+    # The checkbox marker itself must not leak into the item's paragraph text.
+    assert items[0].children[0].children[0].to_py() == "todo"
+
+
+def test_mixed_task_and_plain_items_stays_plain_bullet_list() -> None:
+    """A taskList schema requires uniformly-taskItem children — a list
+    where only some items carry a checkbox marker can't become one, so it
+    stays a plain bulletList (the marker text is then literal, same as
+    pre-checkbox-support behavior)."""
+    doc = seed_doc_from_markdown("- [ ] marked\n- unmarked\n")
+    root = _root(doc)
+    lst = root.children[0]
+    assert lst.tag == "bulletList"
+    assert [i.tag for i in lst.children] == ["listItem", "listItem"]
+
+
+def test_task_list_reserialization_is_content_correct_and_idempotent() -> None:
+    body = "- [ ] buy milk\n- [x] walk dog\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert once == twice
+    assert "- [ ] buy milk" in once and "- [x] walk dog" in once
+
+
+def test_task_list_nesting_and_inside_blockquote() -> None:
+    body = "- [ ] top\n  - [x] nested\n\n> - [ ] quoted\n"
+    doc = seed_doc_from_markdown(body)
+    root = _root(doc)
+    top_list = root.children[0]
+    assert top_list.tag == "taskList"
+    nested = list(top_list.children[0].children)
+    assert [c.tag for c in nested] == ["paragraph", "taskList"]
+
+    bq = root.children[1]
+    assert bq.tag == "blockquote"
+    assert bq.children[0].tag == "taskList"
+
+
+def test_list_reserialization_is_content_correct_and_idempotent() -> None:
+    """The tight->loose list normalization (see markdown_yjs.py) means
+    output isn't byte-identical to a tight-list source, but re-parsing the
+    output must be a no-op (a well-defined normal form, not drift)."""
+    body = "- item one\n- item two\n- item three\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert once == twice
+    assert "item one" in once and "item two" in once and "item three" in once
+
+
+def test_blockquote_multi_paragraph_round_trips_exactly() -> None:
+    body = "> para one\n>\n> para two\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_blockquote_containing_list() -> None:
+    doc = seed_doc_from_markdown("> - a\n> - b\n")
+    root = _root(doc)
+    bq = root.children[0]
+    assert bq.tag == "blockquote"
+    inner_list = bq.children[0]
+    assert inner_list.tag == "bulletList"
+    assert len(list(inner_list.children)) == 2
+
+
+def test_code_block_language_and_content_stored_without_fence_syntax() -> None:
+    doc = seed_doc_from_markdown("```python\nx = 1\ny = 2\n```\n")
+    root = _root(doc)
+    block = root.children[0]
+    assert block.tag == "codeBlock"
+    attrs = dict(block.attributes)
+    assert attrs["language"] == "python"
+    assert block.children[0].to_py() == "x = 1\ny = 2\n"
+
+
+def test_code_block_round_trips_exactly_when_fenced() -> None:
+    body = "```python\nx = 1\ny = 2\n```\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_indented_code_block_becomes_fenced_but_content_preserved() -> None:
+    body = "    x = 1\n    y = 2\n"
+    doc = seed_doc_from_markdown(body)
+    got = reconstruct_body(doc)
+    assert got == "```\nx = 1\ny = 2\n```\n"
+    # Idempotent: re-parsing the fenced output is a no-op.
+    assert reconstruct_body(seed_doc_from_markdown(got)) == got
+
+
+def test_code_block_fence_extends_past_backticks_in_content() -> None:
+    doc = seed_doc_from_markdown("```\nhas ``` inside\n```\n")
+    root = _root(doc)
+    block = root.children[0]
+    assert block.children[0].to_py() == "has ``` inside\n"
+    got = reconstruct_body(doc)
+    # Must round-trip back to the same content when re-parsed (the fence
+    # itself is allowed to differ in length, just must be valid).
+    doc2 = seed_doc_from_markdown(got)
+    assert doc2.get(ROOT_XML_KEY, type=XmlFragment).children[0].children[0].to_py() == (
+        "has ``` inside\n"
+    )
+
+
+def test_heading_level_preserved() -> None:
+    doc = seed_doc_from_markdown("### Sub-heading\n\nBody.\n")
+    root = _root(doc)
+    heading = root.children[0]
+    assert dict(heading.attributes)["level"] == "3"
+    assert reconstruct_body(doc) == "### Sub-heading\n\nBody.\n"
+
+
+def test_find_by_block_id() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    found = find_by_block_id(doc, "b1")
+    assert found is not None
+    assert found.tag == "paragraph"
+    assert find_by_block_id(doc, "nonexistent") is None
+
+
+def test_find_by_row_id() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    root = _root(doc)
+    table = next(c for c in root.children if c.tag == "table")
+    first_row_id = dict(table.children[0].attributes)[ROW_ID_ATTR]
+
+    found = find_by_row_id(doc, first_row_id)
+    assert found is not None
+    assert dict(found.attributes)[ROW_ID_ATTR] == first_row_id
+    assert find_by_row_id(doc, "nonexistent") is None
+
+
+def test_unrecognized_inline_construct_raises_not_implemented() -> None:
+    # GFM strikethrough isn't in _KNOWN_INLINE_TYPES (no strikethrough
+    # plugin enabled on gfm_parser()), so markdown-it never emits the token
+    # type in the first place — use an image instead, which markdown-it
+    # does emit and this codec deliberately doesn't support yet (see
+    # docs/AGENT_WIKI_MARKDOWN_STANDARD.md's deferred items).
+    body = "A picture: ![alt](https://x.example/img.png) here.\n"
+    with pytest.raises(NotImplementedError):
+        seed_doc_from_markdown(body)
+
+
+def test_hard_line_break_backslash_form_round_trips_to_canonical_form() -> None:
+    """Both CommonMark hard-break spellings (trailing backslash, trailing
+    double-space) parse; output always canonicalizes to the double-space
+    form — same "correct, not necessarily byte-identical" tradeoff as list/
+    code-block normalization elsewhere in this module."""
+    doc = seed_doc_from_markdown("Line one\\\nLine two\n")
+    assert reconstruct_body(doc) == "Line one  \nLine two\n"
+
+
+def test_hard_line_break_double_space_form_round_trips_exactly() -> None:
+    body = "Line one  \nLine two\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_hard_line_break_distinct_from_soft_break() -> None:
+    """A bare newline (softbreak) must round-trip as a bare newline, not
+    grow a hard-break's trailing spaces — the two must stay distinguishable
+    through the codec, not collapse into the same representation."""
+    body = "Soft\nbreak stays soft.\n\nHard  \nbreak stays hard.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_hard_line_break_is_a_sibling_leaf_not_text() -> None:
+    """A hard break is a `hardBreak` XmlElement sibling of the surrounding
+    XmlText runs (matching how y-prosemirror represents any PM leaf/atom
+    node), not a character embedded inside a text run."""
+    doc = seed_doc_from_markdown("Before\\\nAfter\n")
+    root = _root(doc)
+    para = root.children[0]
+    children = list(para.children)
+    tags_or_text = [c.tag if hasattr(c, "tag") else "text" for c in children]
+    assert "hardBreak" in tags_or_text
+
+
+def test_hard_line_break_inside_bold_mark() -> None:
+    """A hard break inside emphasis is valid CommonMark — the mark doesn't
+    have to elegantly span the break (each text run around it re-wraps
+    independently), it just must round-trip to something that re-parses
+    with the same effective content and marks."""
+    body = "**bold  \ncontinues bold**\n"
+    doc = seed_doc_from_markdown(body)
+    once = reconstruct_body(doc)
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert once == twice
+    assert "bold" in once and "continues bold" in once
+
+
+def test_mark_edit_via_format_round_trips() -> None:
+    """Editing a mark through pycrdt's XmlText.format (not just seeding from
+    markdown) still serializes correctly — the live-editing path, not just
+    the initial parse."""
+    doc = seed_doc_from_markdown("Plain text here.\n")
+    root = _root(doc)
+    para = root.children[0]
+    xt = para.children[0]
+    with doc.transaction():
+        xt.format(0, 5, {"bold": True})
+    assert reconstruct_body(doc) == "**Plain** text here.\n"
+
+
+def test_reconstruct_body_with_block_map_spans_match_serialized_text() -> None:
+    doc = seed_doc_from_markdown(_SAMPLE)
+    body, spans = reconstruct_body_with_block_map(doc)
+    assert body == reconstruct_body(doc)
+    assert [s.block_id for s in spans] == ["b0", "b1", "b2", "b3", "b4"]
+    for s in spans:
+        assert body[s.start : s.end]
+    # Spans are in document order and non-overlapping, same invariant as
+    # markdown_blocks.top_level_block_ranges.
+    for prev, nxt in zip(spans, spans[1:]):
+        assert prev.end <= nxt.start
+
+
+def test_reconstruct_body_with_block_map_finds_offset_within_touched_block() -> None:
+    doc = seed_doc_from_markdown("First paragraph.\n\nSecond paragraph.\n")
+    body, spans = reconstruct_body_with_block_map(doc)
+    second = next(s for s in spans if s.block_id == "b1")
+    assert body[second.start : second.end] == "Second paragraph.\n"

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -384,7 +384,7 @@ def test_escaped_block_start_markers_inside_list_item_stay_literal() -> None:
     cases = [
         "- \\- nested item text\n",
         "- \\# nested heading text\n",
-        "- \\--- nested break only\n",
+        "- \\---\n",
     ]
     for raw in cases:
         doc = seed_doc_from_markdown(raw)
@@ -403,7 +403,7 @@ def test_escaped_block_start_markers_inside_blockquote_stay_literal() -> None:
     cases = [
         "> \\> nested quote text\n",
         "> \\# nested heading text\n",
-        "> \\--- nested break only\n",
+        "> \\---\n",
     ]
     for raw in cases:
         doc = seed_doc_from_markdown(raw)
@@ -414,6 +414,15 @@ def test_escaped_block_start_markers_inside_blockquote_stay_literal() -> None:
         assert once == raw
         twice = reconstruct_body(seed_doc_from_markdown(once))
         assert twice == once
+
+
+def test_nested_dash_run_with_trailing_content_does_not_need_escaping() -> None:
+    # Mirrors the top-level case: a dash run is only a thematic break when
+    # it's the *whole* line — trailing content after it was never ambiguous
+    # inside a list item/blockquote either, so no escape should be added
+    # (and an already-unescaped one must round-trip unchanged, not gain one).
+    for raw in ("- --- nested break text\n", "> --- nested break text\n"):
+        assert reconstruct_body(seed_doc_from_markdown(raw)) == raw
 
 
 def test_find_by_block_id() -> None:

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -298,6 +298,40 @@ def test_escaping_does_not_corrupt_inline_code_content() -> None:
     assert reconstruct_body(doc) == body
 
 
+def test_escaped_block_start_markers_round_trip_as_literal_text() -> None:
+    # A leading "-"/"+"/">"/"1." in a paragraph's serialized text is only
+    # ambiguous as a *block*-start marker — _wrap_run's mark-delimiter
+    # escaping is position-independent and doesn't cover this ("*" is the
+    # one marker character that's already covered there, for the unrelated
+    # emphasis reason). Without _escape_block_start_ambiguity, checkpointing
+    # a touched paragraph beginning with one of these silently turns it into
+    # a real bullet/blockquote/ordered-list item on the next parse.
+    cases = [
+        "\\- not a bullet\n",
+        "\\+ not a bullet\n",
+        "\\> not a quote\n",
+        "\\* not a bullet\n",
+    ]
+    for raw in cases:
+        once = reconstruct_body(seed_doc_from_markdown(raw))
+        assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
+def test_mid_text_block_marker_characters_are_left_alone() -> None:
+    # Only the block-start position is ambiguous — a dash or "1." elsewhere
+    # in a paragraph was never going to be misread as a marker, so it
+    # shouldn't gain a spurious escape.
+    cases = [
+        "A dash - mid sentence, not a marker.\n",
+        "A number 1. mid sentence, not a marker.\n",
+        "Just a dash alone: -\n",
+    ]
+    for raw in cases:
+        assert reconstruct_body(seed_doc_from_markdown(raw)) == raw
+
+
 def test_find_by_block_id() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     found = find_by_block_id(doc, "b1")

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -234,6 +234,70 @@ def test_heading_level_preserved() -> None:
     assert reconstruct_body(doc) == "### Sub-heading\n\nBody.\n"
 
 
+def test_setext_h1_becomes_level_1_atx() -> None:
+    # Setext (underline) headings have no leading hashes at all — a
+    # hand-rolled "count leading #" parse mislevels this to 0, which then
+    # serializes with no "#" marker, silently demoting the heading to a
+    # paragraph. Canonicalizing to ATX form (not byte-identical to the
+    # setext source) is the same "correct over byte-identical" tradeoff
+    # this module already makes for lists/hard-breaks.
+    doc = seed_doc_from_markdown("Title\n=====\n\nBody.\n")
+    root = _root(doc)
+    heading = root.children[0]
+    assert heading.tag == "heading"
+    assert dict(heading.attributes)["level"] == "1"
+    assert reconstruct_body(doc) == "# Title\n\nBody.\n"
+
+
+def test_setext_h2_becomes_level_2_atx() -> None:
+    doc = seed_doc_from_markdown("Sub\n---\n\nBody.\n")
+    root = _root(doc)
+    heading = root.children[0]
+    assert dict(heading.attributes)["level"] == "2"
+    assert reconstruct_body(doc) == "## Sub\n\nBody.\n"
+
+
+def test_setext_heading_does_not_leak_underline_into_title_text() -> None:
+    # The underline line must not become part of the heading's own inline
+    # content (a second, compounding failure mode alongside the wrong
+    # level: parsing "Title\n=====" as a whole would fold "=====" into the
+    # title text instead of recognizing it as the setext marker).
+    doc = seed_doc_from_markdown("Title\n=====\n")
+    root = _root(doc)
+    heading = root.children[0]
+    assert heading.children[0].to_py() == "Title"
+
+
+def test_escaped_mark_delimiters_round_trip_as_literal_text() -> None:
+    # markdown-it resolves `\*x\*` to the literal text "*x*" at parse time
+    # (correctly not treated as emphasis) — reserializing that text
+    # verbatim hands back active syntax on the next parse. Same failure
+    # mode for `\[text\](url)` and a leading `\#`.
+    cases = [
+        "A \\*literal\\* asterisk.\n",
+        "A \\_literal\\_ underscore.\n",
+        "A \\`literal\\` backtick.\n",
+        "A \\[link\\](x) escaped.\n",
+        "\\# not a heading\n",
+    ]
+    for raw in cases:
+        once = reconstruct_body(seed_doc_from_markdown(raw))
+        assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
+        # And re-parsing the output must not activate the escaped syntax —
+        # a second round-trip must be byte-identical to the first.
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
+def test_escaping_does_not_corrupt_inline_code_content() -> None:
+    # Inline code spans are verbatim — CommonMark never processes escapes
+    # inside them. Escaping backslash/backtick/etc. in code content would
+    # corrupt the code's actual text, not just its markdown presentation.
+    body = "Code with a literal backslash: `a\\\\b` and stars `*x*`.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
 def test_find_by_block_id() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     found = find_by_block_id(doc, "b1")

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -425,6 +425,36 @@ def test_nested_dash_run_with_trailing_content_does_not_need_escaping() -> None:
         assert reconstruct_body(seed_doc_from_markdown(raw)) == raw
 
 
+def test_escaped_block_start_marker_on_a_later_soft_break_line() -> None:
+    # _escape_block_start_ambiguity used to check only text[0] — the very
+    # first character of the whole (possibly multi-line) paragraph text.
+    # A paragraph's *second* line, produced by a soft break, is just as
+    # much a fresh block-start position once re-emitted: unconditionally
+    # at the top level (confirmed against the forward parse: "line one\n#
+    # line two" splits into a paragraph + a separate heading block), and
+    # doubly so once a list item's continuation indent or a blockquote's
+    # per-line "> " prefix (_serialize_blockquote adds that to *every*
+    # line, including a paragraph's internal soft breaks) gets added on
+    # top. The "#" case is the sharpest: reactivating it doesn't just
+    # misparse, it crashes outright the next time the checkpointed body is
+    # seeded (_build_block_sequence has no heading support inside a list
+    # item/blockquote at all).
+    cases = [
+        "first line\n\\# second line\n",
+        "first line\n\\- second line\n",
+        "- first line\n  \\# second line\n",
+        "> first line\n> \\# second line\n",
+        "> first line\n> \\- second line\n",
+    ]
+    for raw in cases:
+        once = reconstruct_body(seed_doc_from_markdown(raw))
+        assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
+        # The real regression: seeding the checkpointed output a second
+        # time must not raise (it did, for "#", before this fix).
+        twice = reconstruct_body(seed_doc_from_markdown(once))
+        assert twice == once
+
+
 def test_find_by_block_id() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     found = find_by_block_id(doc, "b1")

--- a/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
+++ b/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
@@ -76,3 +76,21 @@ The following constructs MUST NOT be supported:
    CommonMark construct — matched by a URI/email pattern, not the tag-name
    grammar above — and are unaffected by this exclusion; they MUST still
    render as links.
+
+## 6. Checkpoint Fidelity (Live-Editing Codec)
+
+`markdown_yjs.py`'s checkpoint serialization guarantees byte-for-byte
+stability only for blocks untouched since the last commit (see
+`markdown_splice.py`). A touched block's checkpoint MUST reparse to the same
+block type and content, but MAY normalize the following rather than
+preserve it byte-for-byte:
+
+1. Leading whitespace (1-3 columns) at the start of a paragraph line MAY be
+   trimmed when it precedes text that would otherwise reparse as a
+   block-start marker (heading `#`, blockquote `>`, list bullet `-`/`+`, an
+   ordered marker, a thematic break, a setext underline, or a fence
+   opener). CommonMark's backslash escape applies only to punctuation, never
+   to whitespace, so trimming that whitespace is the only way to guarantee
+   the line's block type is unchanged by the next parse — escaping just the
+   marker and leaving the whitespace in front of it round-trips the marker
+   characters as literal text but not the indentation that preceded them.


### PR DESCRIPTION
## Summary

First slice of a PR stack rebuilding the wiki's live editor on raw ProseMirror + Yjs (replacing Tiptap/OT — see #512 for the full picture, being split into a stack on top of this). This PR is **pure dead code**: three new modules nothing on `main` imports yet, so it's zero-risk to merge on its own.

- `markdown_blocks.py` — top-level block/row boundary parsing.
- `markdown_yjs.py` — the codec: markdown ⇄ a `pycrdt` Yjs `XmlFragment`, with a stable positional block-id scheme (`b0`, `b1`, ...) that survives later edits, which the splice-checkpoint engine depends on.
- `markdown_splice.py` — `TouchedTracker` + `checkpoint_body`: the byte-stability guarantee (untouched blocks re-serialize identically to the previously committed body) that the whole live-editing design's comment/source anchor resolution relies on.

Also adds `pycrdt`/`markdown-it-py` as core deps (not `pycrdt-websocket` — that's only needed once the live WS transport lands in a later PR in the stack) and the `basedpyright` relaxations these two files need (pycrdt's bundled stubs are loosely typed under strict mode).