### PR TITLE
feat(wiki): header presence avatars merge users and agents

### DIFF
--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -1128,6 +1128,7 @@ def file_activity(
         path=rel,
         agents=[
             ActivityRowView(
+                user_id=r.user_id,
                 owner_display=r.owner_display,
                 agent_name=r.agent_name,
                 activity=r.activity,

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -388,16 +388,16 @@ class SearchResponse(BaseModel):
 
 
 class ActivityRowView(BaseModel):
-    """One active registration on a doc — what the UI / agents see.
+    """One active registration on a doc, as the UI and agents see it.
 
     Mirror of ``app.wiki.agent_activity.ActivityRow`` minus the internal
-    ``id``. ``user_id`` lets presence UI attribute the agent to the user
-    it acts for; ``owner_display`` is the user's display name (falling
-    back to email); ``agent_name`` is ``None`` when the agent didn't
-    identify itself.
+    ``id`` and the ``doc_path`` the response carries once. ``user_id``
+    ties the agent to the user it acts for. ``owner_display`` is the
+    user's display name, falling back to email. ``agent_name`` is
+    ``None`` when the agent didn't identify itself.
     """
 
-    user_id: str | None
+    user_id: str
     owner_display: str
     agent_name: str | None
     activity: str  # "read" | "wrote"

--- a/backend/app/models/file_system.py
+++ b/backend/app/models/file_system.py
@@ -391,11 +391,13 @@ class ActivityRowView(BaseModel):
     """One active registration on a doc — what the UI / agents see.
 
     Mirror of ``app.wiki.agent_activity.ActivityRow`` minus the internal
-    ``id`` and ``user_id``. ``owner_display`` is the user's display
-    name (falling back to email); ``agent_name`` is ``None`` when the
-    agent didn't identify itself.
+    ``id``. ``user_id`` lets presence UI attribute the agent to the user
+    it acts for; ``owner_display`` is the user's display name (falling
+    back to email); ``agent_name`` is ``None`` when the agent didn't
+    identify itself.
     """
 
+    user_id: str | None
     owner_display: str
     agent_name: str | None
     activity: str  # "read" | "wrote"

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -1,0 +1,527 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { Button, Switch, Text } from "@onyx-ai/opal/components";
+import { SvgArrowUpRight, SvgExpand, SvgSparkle } from "@onyx-ai/opal/icons";
+import type { IconProps } from "@onyx-ai/opal/types";
+import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
+
+import {
+  getUpdatePolicy,
+  patchUpdatePolicy,
+  type EffectivePolicy,
+} from "@/lib/updatePolicy";
+import { relativeTime } from "@/lib/users";
+import { fetchFileHistory } from "@/lib/wiki/svc";
+import type { CommitInfo } from "@/lib/wiki/types";
+import { parseCommitAuthor } from "@/lib/wiki/utils";
+import type { CoeditParticipant, CoeditPeer } from "@/lib/editor/types";
+import type { DocumentActivity } from "@/types";
+
+// Identity hues cycled per user. Semantic hues stay reserved:
+// red/green/orange for status, blue/amber/sky for selection. The mock
+// names five theme colors but Opal ships tokens for four non-reserved
+// hues today (mint/coral/violet are gaps), so the cycle runs on those.
+const USER_COLORS = [
+  "var(--neon-cyan-50)",
+  "var(--neon-yellow-50)",
+  "var(--neon-magenta-50)",
+  "var(--purple-50)",
+];
+
+const MAX_CHIPS = 5;
+
+const AGENT_GLYPHS: Record<string, ComponentType<IconProps>> = {
+  "claude code": SvgClaude,
+  codex: SvgOpenai,
+  "onyx craft": SvgOnyxLogo,
+};
+
+function agentGlyph(name: string | null): ComponentType<IconProps> | null {
+  if (!name) return null;
+  const key = name.trim().toLowerCase();
+  const direct = AGENT_GLYPHS[key];
+  if (direct) return direct;
+  if (key.includes("claude")) return SvgClaude;
+  if (key.includes("codex") || key.includes("openai")) return SvgOpenai;
+  if (key.includes("onyx") || key.includes("craft")) return SvgOnyxLogo;
+  return null;
+}
+
+interface PresenceEntry {
+  userId: string;
+  display: string;
+  initial: string;
+  color: string;
+  editing: boolean;
+  /** Live agent acting for this user on the page, when one is active. */
+  agentName: string | null;
+  /** Caret offset to scroll to when this entry is editing. */
+  caretHead: number | null;
+}
+
+interface PresenceAvatarsProps {
+  path: string;
+  participants: CoeditParticipant[];
+  peers: CoeditPeer[];
+  typing: string[];
+  myUserId: string | null;
+  agents: DocumentActivity[];
+  /** Scrolls the doc to a live caret offset (card click, mock: "Click to
+   * scroll to cursor"). */
+  onScrollToOffset?: (offset: number) => void;
+  /** Opens the given commit in the history view (edit-row click). */
+  onOpenCommit?: (sha: string) => void;
+  /** Opens the updates side panel (Page Instructions expand). */
+  onOpenUpdatesPanel?: () => void;
+}
+
+interface AvatarCircleProps {
+  entry: PresenceEntry;
+  size: number;
+}
+
+function AvatarCircle({ entry, size }: AvatarCircleProps) {
+  return (
+    <span
+      className="flex shrink-0 items-center justify-center rounded-full border bg-(--background-neutral-inverted-00)"
+      style={{ width: size, height: size, borderColor: entry.color }}
+    >
+      <Text font="secondary-action" color="text-inverted-05">
+        {entry.initial}
+      </Text>
+    </span>
+  );
+}
+
+function AgentBadge({ entry, size }: AvatarCircleProps) {
+  const Glyph = agentGlyph(entry.agentName);
+  if (!Glyph) return null;
+  return (
+    <span
+      className="flex shrink-0 items-center justify-center rounded-full border bg-(--background-neutral-00)"
+      style={{ width: size, height: size, borderColor: entry.color }}
+    >
+      <Glyph size={size - 4} />
+    </span>
+  );
+}
+
+interface PresenceCardProps {
+  entry: PresenceEntry;
+  commits: CommitInfo[];
+  onScrollToOffset?: (offset: number) => void;
+  onOpenCommit?: (sha: string) => void;
+}
+
+/** One user's card: identity, live state, and their recent edits on this
+ * page (mock 2079:379824 / 2079:381324). */
+function PresenceCard({
+  entry,
+  commits,
+  onScrollToOffset,
+  onOpenCommit,
+}: PresenceCardProps) {
+  const edits = commits.slice(0, 3);
+  const scrollable = entry.editing && entry.caretHead !== null;
+  return (
+    <div className="flex flex-col">
+      <div
+        data-presence-card={entry.userId}
+        // Mock card chrome: white surface lifted off the panel body.
+        className={`flex w-full items-start gap-1 rounded-(--radius-08) bg-(--background-tint-00) p-1 shadow-[0px_2px_6px_var(--shadow-02),0px_0px_2px_var(--shadow-01)] ${
+          scrollable ? "cursor-pointer" : ""
+        }`}
+        onClick={
+          scrollable
+            ? () => onScrollToOffset?.(entry.caretHead as number)
+            : undefined
+        }
+      >
+        <span className="flex shrink-0 items-center gap-0 p-[2px]">
+          <AvatarCircle entry={entry} size={20} />
+          {entry.agentName && <AgentBadge entry={entry} size={20} />}
+        </span>
+        <span className="min-w-0 flex-1 px-[2px]">
+          <Text font="main-ui-action" color="text-04" as="p" nowrap>
+            {entry.display}
+          </Text>
+          {entry.agentName && (
+            <Text font="secondary-body" color="text-03" as="p" nowrap>
+              {`Editing with ${entry.agentName}`}
+            </Text>
+          )}
+        </span>
+        <span className="flex shrink-0 items-center gap-[2px] pt-[2px]">
+          {/* raw-ok: no Opal Text color maps to the mock's status-text-info-05 state chip */}
+          <span className="px-[2px] text-[12px] leading-4 text-(--status-text-info-05)">
+            {entry.editing ? "Editing" : "Viewing"}
+          </span>
+          {entry.editing ? (
+            <SvgArrowUpRight size={12} />
+          ) : (
+            <span className="mx-[2px] size-[6px] rounded-full bg-(--status-text-info-05)" />
+          )}
+        </span>
+      </div>
+      {edits.length > 0 && (
+        <div className="flex flex-col py-1">
+          <div className="flex items-center px-1 py-[2px]">
+            <span className="w-[6px] border-t border-(--border-01)" />
+            <span className="px-1">
+              <Text font="secondary-body" color="text-03" nowrap>
+                Recent Edits
+              </Text>
+            </span>
+            <span className="min-w-0 flex-1 border-t border-(--border-01)" />
+            <span className="w-2 border-t border-(--border-01)" />
+          </div>
+          {edits.map((c) => {
+            const { agentLabel } = parseCommitAuthor(c.author);
+            const changed = c.added + c.removed;
+            const lines = `${changed} line${changed === 1 ? "" : "s"}`;
+            return (
+              // raw-ok: no Opal row control carries text plus a right-aligned time and glyph pair
+              <button
+                key={c.sha}
+                type="button"
+                className="flex w-full cursor-pointer items-center gap-[2px] rounded-(--radius-04) p-1 text-left hover:bg-(--background-tint-01)"
+                onClick={() => onOpenCommit?.(c.sha)}
+              >
+                <span className="min-w-0 flex-1 px-[2px]">
+                  <Text font="secondary-body" color="text-04" nowrap>
+                    {agentLabel
+                      ? `Updated ${lines} with ${agentLabel}`
+                      : `Updated ${lines}`}
+                  </Text>
+                </span>
+                <Text font="secondary-body" color="text-03" nowrap>
+                  {relativeTime(c.ts)}
+                </Text>
+                <SvgArrowUpRight size={12} />
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AnchoredPanelProps {
+  anchor: HTMLElement;
+  onDismiss: () => void;
+  /** Hover panels stay open while the pointer is inside them. */
+  hover?: { onEnter: () => void; onLeave: () => void };
+  children: ReactNode;
+}
+
+/** Anchors a floating panel to the header cluster: fixed-position, right
+ * edges aligned, just below the anchor (the mock's 344px activity panel). */
+function AnchoredPanel({
+  anchor,
+  onDismiss,
+  hover,
+  children,
+}: AnchoredPanelProps) {
+  const [rect, setRect] = useState(() => anchor.getBoundingClientRect());
+  useEffect(() => {
+    setRect(anchor.getBoundingClientRect());
+  }, [anchor]);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (hover) return;
+    const onDown = (e: PointerEvent) => {
+      const el = panelRef.current;
+      if (
+        el &&
+        !el.contains(e.target as Node) &&
+        !anchor.contains(e.target as Node)
+      )
+        onDismiss();
+    };
+    window.addEventListener("pointerdown", onDown, true);
+    return () => window.removeEventListener("pointerdown", onDown, true);
+  }, [anchor, hover, onDismiss]);
+  return createPortal(
+    <div
+      ref={panelRef}
+      className="fixed z-50 flex w-(--block-width-panel-medium-small) flex-col"
+      style={{ top: rect.bottom + 8, right: window.innerWidth - rect.right }}
+      onPointerEnter={hover?.onEnter}
+      onPointerLeave={hover?.onLeave}
+    >
+      {children}
+    </div>,
+    document.body,
+  );
+}
+
+interface PolicyPopoverProps {
+  path: string;
+  onOpenUpdatesPanel?: () => void;
+}
+
+/** The Auto popover (mock 1929:362227 "Policy Panel"): the AI Auto-Edits
+ * switch and the page's update instruction, both live on the update
+ * policy the full panel edits. */
+function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
+  const [policy, setPolicy] = useState<EffectivePolicy | null>(null);
+  useEffect(() => {
+    let alive = true;
+    getUpdatePolicy(path)
+      .then((p) => alive && setPolicy(p.effective))
+      .catch(() => alive && setPolicy(null));
+    return () => {
+      alive = false;
+    };
+  }, [path]);
+
+  const allowed = !!policy?.ai_management_allowed;
+  const toggle = async () => {
+    setPolicy((p) => (p ? { ...p, ai_management_allowed: !allowed } : p));
+    try {
+      await patchUpdatePolicy(path, { ai_management_allowed: !allowed });
+    } catch {
+      setPolicy((p) => (p ? { ...p, ai_management_allowed: allowed } : p));
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1 rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]">
+      <div className="flex items-start justify-between rounded-(--radius-08) p-2">
+        <span className="flex min-w-0 flex-1 items-start gap-1 pr-2">
+          <span className="p-[2px]">
+            <SvgSparkle size={16} />
+          </span>
+          <span className="min-w-0">
+            <Text font="main-ui-action" color="text-04" as="p">
+              AI Auto-Edits
+            </Text>
+            <Text font="secondary-body" color="text-03" as="p">
+              Let AI update/organize this page on its own.
+            </Text>
+          </span>
+        </span>
+        <Switch checked={allowed} onCheckedChange={() => void toggle()} />
+      </div>
+      <div className="mx-2 border-t border-(--border-01)" />
+      <div className="flex items-start gap-1 rounded-(--radius-08) p-1">
+        <span className="flex min-w-0 flex-1 items-start gap-1 p-1 pr-2">
+          <span className="p-[2px]">
+            <SvgSparkle size={16} />
+          </span>
+          <span className="min-w-0">
+            <Text font="main-ui-action" color="text-04" as="p">
+              Page Instructions
+            </Text>
+            <Text font="secondary-body" color="text-03" as="p">
+              {policy?.update_instruction || "How should this page be updated?"}
+            </Text>
+          </span>
+        </span>
+        <Button
+          icon={SvgExpand}
+          size="md"
+          prominence="tertiary"
+          tooltip="Open in panel"
+          onClick={onOpenUpdatesPanel}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The header's "who is on this page" cluster (mocks 2079:379824,
+ * 2079:381324, 2079:383512, 1929:361938): everyone active on the page as
+ * overlapping colored chips, agents badged onto the user they act for,
+ * a +N overflow, and the Auto slot controlling AI auto-edits. The
+ * current user is never shown.
+ */
+export function PresenceAvatars({
+  path,
+  participants,
+  peers,
+  typing,
+  myUserId,
+  agents,
+  onScrollToOffset,
+  onOpenCommit,
+  onOpenUpdatesPanel,
+}: PresenceAvatarsProps) {
+  const entries = useMemo<PresenceEntry[]>(() => {
+    const editingIds = new Set<string>([
+      ...peers.map((p) => p.user_id),
+      ...typing,
+    ]);
+    const caretByUser = new Map(peers.map((p) => [p.user_id, p.head]));
+    const agentByUser = new Map(
+      agents
+        .filter((a) => a.user_id && a.activity === "wrote")
+        .map((a) => [a.user_id as string, a.agent_name]),
+    );
+    return participants
+      .filter((p) => p.user_id !== myUserId)
+      .map((p, i) => ({
+        userId: p.user_id,
+        display: p.user_display,
+        initial: (p.user_display.trim().charAt(0) || "?").toUpperCase(),
+        color: USER_COLORS[i % USER_COLORS.length],
+        editing: editingIds.has(p.user_id),
+        agentName: agentByUser.get(p.user_id) ?? null,
+        caretHead: caretByUser.get(p.user_id) ?? null,
+      }));
+  }, [participants, peers, typing, myUserId, agents]);
+
+  const shown = entries.slice(0, MAX_CHIPS);
+  const overflow = entries.slice(MAX_CHIPS);
+
+  const clusterRef = useRef<HTMLDivElement | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
+  const [overflowOpen, setOverflowOpen] = useState(false);
+  const [autoOpen, setAutoOpen] = useState(false);
+  const closeTimer = useRef<number>(0);
+
+  const holdOpen = useCallback(
+    () => window.clearTimeout(closeTimer.current),
+    [],
+  );
+  const closeSoon = useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(() => setHoverId(null), 150);
+  }, []);
+  useEffect(() => () => window.clearTimeout(closeTimer.current), []);
+
+  // Recent edits load once per doc: first hover fetches, later hovers
+  // reuse the same list.
+  const [commits, setCommits] = useState<CommitInfo[] | null>(null);
+  const loadCommits = useCallback(() => {
+    if (commits) return;
+    fetchFileHistory(path)
+      .then((r) => setCommits(r.commits))
+      .catch(() => setCommits([]));
+  }, [commits, path]);
+
+  const commitsFor = useCallback(
+    (entry: PresenceEntry) =>
+      (commits ?? []).filter(
+        (c) => parseCommitAuthor(c.author).person === entry.display,
+      ),
+    [commits],
+  );
+
+  const hovered = entries.find((e) => e.userId === hoverId);
+
+  return (
+    <div ref={clusterRef} className="flex items-center gap-1 px-[2px]">
+      {entries.length > 0 && (
+        <div className="isolate flex items-center px-[2px]">
+          {shown.map((e, i) => (
+            // raw-ok: no Opal control renders an overlapping avatar-stack slot with a badge overhang
+            <button
+              key={e.userId}
+              type="button"
+              aria-label={e.display}
+              className="relative flex w-5 cursor-pointer items-center justify-center"
+              style={{ zIndex: shown.length - i }}
+              onPointerEnter={() => {
+                holdOpen();
+                setHoverId(e.userId);
+                loadCommits();
+              }}
+              onPointerLeave={closeSoon}
+            >
+              <AvatarCircle entry={e} size={24} />
+              {e.agentName && (
+                <span className="absolute top-[12px] left-[10px]">
+                  <AgentBadge entry={e} size={16} />
+                </span>
+              )}
+            </button>
+          ))}
+          {overflow.length > 0 && (
+            // raw-ok: the +N chip is the mock's borderless tinted pill, Tag renders border chrome
+            <button
+              type="button"
+              aria-label={`${overflow.length} more`}
+              className="ml-[2px] cursor-pointer rounded-(--radius-08) bg-(--background-tint-02) p-1"
+              onClick={() => {
+                setOverflowOpen((v) => !v);
+                loadCommits();
+              }}
+            >
+              <Text font="secondary-body" color="text-03" nowrap>
+                {`+${overflow.length}`}
+              </Text>
+            </button>
+          )}
+        </div>
+      )}
+      {entries.length > 0 && (
+        <span className="h-4 border-l border-(--border-01)" />
+      )}
+      {/* raw-ok: the Auto trigger is the mock's blue-ringed avatar circle, not a standard icon button */}
+      <button
+        type="button"
+        aria-label="AI auto-edits"
+        className="flex cursor-pointer items-center justify-center px-[2px]"
+        onClick={() => setAutoOpen((v) => !v)}
+      >
+        <span className="flex size-6 items-center justify-center rounded-full border border-(--theme-blue-05) bg-(--background-neutral-00)">
+          <SvgOnyxLogo size={16} />
+        </span>
+      </button>
+
+      {hovered && clusterRef.current && (
+        <AnchoredPanel
+          anchor={clusterRef.current}
+          onDismiss={() => setHoverId(null)}
+          hover={{ onEnter: holdOpen, onLeave: closeSoon }}
+        >
+          <PresenceCard
+            entry={hovered}
+            commits={commitsFor(hovered)}
+            onScrollToOffset={onScrollToOffset}
+            onOpenCommit={onOpenCommit}
+          />
+        </AnchoredPanel>
+      )}
+      {overflowOpen && clusterRef.current && (
+        <AnchoredPanel
+          anchor={clusterRef.current}
+          onDismiss={() => setOverflowOpen(false)}
+        >
+          <div className="flex flex-col gap-1">
+            {overflow.map((e) => (
+              <PresenceCard
+                key={e.userId}
+                entry={e}
+                commits={commitsFor(e)}
+                onScrollToOffset={onScrollToOffset}
+                onOpenCommit={onOpenCommit}
+              />
+            ))}
+          </div>
+        </AnchoredPanel>
+      )}
+      {autoOpen && clusterRef.current && (
+        <AnchoredPanel
+          anchor={clusterRef.current}
+          onDismiss={() => setAutoOpen(false)}
+        >
+          <PolicyPopover path={path} onOpenUpdatesPanel={onOpenUpdatesPanel} />
+        </AnchoredPanel>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -290,7 +290,7 @@ function AnchoredPanel({
     return () => window.removeEventListener("pointerdown", onDown, true);
   }, [anchor, hover, onDismiss]);
   return createPortal(
-    // raw-ok: Opal layout primitives are WithoutStyles and the panel needs runtime viewport coordinates
+    // raw-ok: Popover.Anchor exists but Popover.Content bakes neutral-00/rounded-12/shadow-md chrome (WithoutStyles, no escape) that the mock's tint-01 policy panel and chromeless floating cards contradict, and this wrapper also needs runtime viewport coordinates
     <div
       ref={panelRef}
       className="fixed z-50"
@@ -598,9 +598,13 @@ export function PresenceAvatars({
             >
               <AvatarCircle entry={e} size="main-content" />
               {e.agentName && (
-                <span className="absolute top-[12px] left-[10px]">
+                <Section
+                  width="fit"
+                  height="fit"
+                  className="absolute top-[12px] left-[10px]"
+                >
                   <AgentBadge entry={e} size="secondary" />
-                </span>
+                </Section>
               )}
             </Section>
           ))}

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -293,6 +293,9 @@ function PolicyPopover({
   const [saving, setSaving] = useState(false);
   useEffect(() => {
     let alive = true;
+    // Clearing first re-disables the switch, a stale page's policy must
+    // never drive a PATCH against the new path.
+    setPolicy(null);
     getUpdatePolicy(path)
       .then((p) => alive && setPolicy(p.effective))
       .catch(() => alive && setPolicy(null));
@@ -459,10 +462,15 @@ export function PresenceAvatars({
   }, []);
   useEffect(() => () => window.clearTimeout(closeTimer.current), []);
 
-  // Recent edits load lazily on first hover and cache until the path
-  // changes, so a stale doc's shas never feed the history view.
+  // Path changes drop every floating panel and the edits cache, nothing
+  // from the previous doc may drive fetches or clicks on the new one.
   const [commits, setCommits] = useState<CommitInfo[] | null>(null);
-  useEffect(() => setCommits(null), [path]);
+  useEffect(() => {
+    setCommits(null);
+    setHoverId(null);
+    setOverflowOpen(false);
+    setAutoOpen(false);
+  }, [path]);
   const loadCommits = useCallback(() => {
     if (commits) return;
     fetchFileHistory(path)

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -290,6 +290,7 @@ function PolicyPopover({
   onOpenUpdatesPanel,
 }: PolicyPopoverProps) {
   const [policy, setPolicy] = useState<EffectivePolicy | null>(null);
+  const [saving, setSaving] = useState(false);
   useEffect(() => {
     let alive = true;
     getUpdatePolicy(path)
@@ -302,6 +303,7 @@ function PolicyPopover({
 
   const allowed = !!policy?.ai_management_allowed;
   const toggle = async () => {
+    setSaving(true);
     setPolicy((p) => (p ? { ...p, ai_management_allowed: !allowed } : p));
     try {
       await patchUpdatePolicy(path, { ai_management_allowed: !allowed });
@@ -310,6 +312,8 @@ function PolicyPopover({
       toast.error(
         e instanceof Error ? e.message : "Couldn't update the page's policy",
       );
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -323,9 +327,10 @@ function PolicyPopover({
         >
           <Switch
             checked={allowed}
-            // Held until the policy loads: toggling against the null
-            // default would persist a wrong explicit override.
-            disabled={!canWrite || !policy}
+            // Held until the policy loads (toggling against the null
+            // default would persist a wrong override) and while a save is
+            // in flight (a second click would race the first PATCH).
+            disabled={!canWrite || !policy || saving}
             onCheckedChange={() => void toggle()}
           />
         </InputHorizontal>

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -323,7 +323,9 @@ function PolicyPopover({
         >
           <Switch
             checked={allowed}
-            disabled={!canWrite}
+            // Held until the policy loads: toggling against the null
+            // default would persist a wrong explicit override.
+            disabled={!canWrite || !policy}
             onCheckedChange={() => void toggle()}
           />
         </InputHorizontal>
@@ -375,11 +377,23 @@ export function PresenceAvatars({
       ...typing,
     ]);
     const caretByUser = new Map(peers.map((p) => [p.user_id, p.head]));
-    const writingAgents = new Map(
-      agents
-        .filter((a) => a.activity === "wrote")
-        .map((a) => [a.user_id, a.agent_name]),
-    );
+    // One agent summary per user: a user can hold a row per agent, and any
+    // writing agent outranks read rows for the badge and the state.
+    const agentPresence = new Map<
+      string,
+      { display: string; agentName: string | null; writing: boolean }
+    >();
+    for (const a of agents) {
+      const cur = agentPresence.get(a.user_id);
+      const writing = a.activity === "wrote";
+      if (!cur || (writing && !cur.writing)) {
+        agentPresence.set(a.user_id, {
+          display: a.owner_display,
+          agentName: a.agent_name,
+          writing,
+        });
+      }
+    }
     const entry = (
       userId: string,
       display: string,
@@ -397,30 +411,25 @@ export function PresenceAvatars({
     });
     const roster = participants
       .filter((p) => p.user_id !== myUserId)
-      .map((p, i) =>
+      .map((p, i) => {
         // A writing agent makes its user an editor even with an idle caret.
-        entry(
+        const presence = agentPresence.get(p.user_id);
+        return entry(
           p.user_id,
           p.user_display,
           i,
-          editingIds.has(p.user_id) || writingAgents.has(p.user_id),
-          writingAgents.get(p.user_id) ?? null,
-        ),
-      );
+          editingIds.has(p.user_id) || !!presence?.writing,
+          presence?.agentName ?? null,
+        );
+      });
     // Agents register as the user they act for, so a user whose agent is
     // active stays in the stack even without a browser session.
     const seated = new Set(roster.map((e) => e.userId));
-    for (const a of agents) {
-      if (a.user_id === myUserId || seated.has(a.user_id)) continue;
-      seated.add(a.user_id);
+    for (const [userId, p] of agentPresence) {
+      if (userId === myUserId || seated.has(userId)) continue;
+      seated.add(userId);
       roster.push(
-        entry(
-          a.user_id,
-          a.owner_display,
-          roster.length,
-          a.activity === "wrote",
-          a.agent_name,
-        ),
+        entry(userId, p.display, roster.length, p.writing, p.agentName),
       );
     }
     return roster;

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -10,8 +10,20 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { Button, Switch, Text } from "@onyx-ai/opal/components";
-import { SvgArrowUpRight, SvgExpand, SvgSparkle } from "@onyx-ai/opal/icons";
+import {
+  Button,
+  Divider,
+  LineItemButton,
+  Switch,
+  Text,
+} from "@onyx-ai/opal/components";
+import { InputHorizontal } from "@onyx-ai/opal/layouts";
+import {
+  SvgAddLines,
+  SvgArrowUpRight,
+  SvgExpand,
+  SvgSparkle,
+} from "@onyx-ai/opal/icons";
 import type { IconProps } from "@onyx-ai/opal/types";
 import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
 
@@ -27,30 +39,22 @@ import { parseCommitAuthor } from "@/lib/wiki/utils";
 import type { CoeditParticipant, CoeditPeer } from "@/lib/editor/types";
 import type { DocumentActivity } from "@/types";
 
-// Identity hues cycled per user. Semantic hues stay reserved:
-// red/green/orange for status, blue/amber/sky for selection. The mock
-// names five theme colors but Opal ships tokens for four non-reserved
-// hues today (mint/coral/violet are gaps), so the cycle runs on those.
+// Identity hues cycled per user. Semantic hues stay reserved: red/green/
+// orange for status, blue/amber/sky for selection. The mock's mint/coral/
+// violet have no Opal tokens, so the cycle substitutes shipped hues.
 const USER_COLORS = [
   "var(--neon-cyan-50)",
   "var(--neon-yellow-50)",
+  "var(--neon-lime-60)",
   "var(--neon-magenta-50)",
   "var(--purple-50)",
 ];
 
 const MAX_CHIPS = 5;
 
-const AGENT_GLYPHS: Record<string, ComponentType<IconProps>> = {
-  "claude code": SvgClaude,
-  codex: SvgOpenai,
-  "onyx craft": SvgOnyxLogo,
-};
-
 function agentGlyph(name: string | null): ComponentType<IconProps> | null {
-  if (!name) return null;
-  const key = name.trim().toLowerCase();
-  const direct = AGENT_GLYPHS[key];
-  if (direct) return direct;
+  const key = name?.trim().toLowerCase();
+  if (!key) return null;
   if (key.includes("claude")) return SvgClaude;
   if (key.includes("codex") || key.includes("openai")) return SvgOpenai;
   if (key.includes("onyx") || key.includes("craft")) return SvgOnyxLogo;
@@ -63,7 +67,7 @@ interface PresenceEntry {
   initial: string;
   color: string;
   editing: boolean;
-  /** Live agent acting for this user on the page, when one is active. */
+  /** Live agent writing for this user on the page, when one is. */
   agentName: string | null;
   /** Caret offset to scroll to when this entry is editing. */
   caretHead: number | null;
@@ -190,25 +194,25 @@ function PresenceCard({
             const changed = c.added + c.removed;
             const lines = `${changed} line${changed === 1 ? "" : "s"}`;
             return (
-              // raw-ok: no Opal row control carries text plus a right-aligned time and glyph pair
-              <button
+              <LineItemButton
                 key={c.sha}
-                type="button"
-                className="flex w-full cursor-pointer items-center gap-[2px] rounded-(--radius-04) p-1 text-left hover:bg-(--background-tint-01)"
+                title={
+                  agentLabel
+                    ? `Updated ${lines} with ${agentLabel}`
+                    : `Updated ${lines}`
+                }
+                sizePreset="secondary"
+                variant="body"
+                rightChildren={
+                  <span className="flex items-center gap-[2px]">
+                    <Text font="secondary-body" color="text-03" nowrap>
+                      {relativeTime(c.ts)}
+                    </Text>
+                    <SvgArrowUpRight size={12} />
+                  </span>
+                }
                 onClick={() => onOpenCommit?.(c.sha)}
-              >
-                <span className="min-w-0 flex-1 px-[2px]">
-                  <Text font="secondary-body" color="text-04" nowrap>
-                    {agentLabel
-                      ? `Updated ${lines} with ${agentLabel}`
-                      : `Updated ${lines}`}
-                  </Text>
-                </span>
-                <Text font="secondary-body" color="text-03" nowrap>
-                  {relativeTime(c.ts)}
-                </Text>
-                <SvgArrowUpRight size={12} />
-              </button>
+              />
             );
           })}
         </div>
@@ -226,7 +230,7 @@ interface AnchoredPanelProps {
 }
 
 /** Anchors a floating panel to the header cluster: fixed-position, right
- * edges aligned, just below the anchor (the mock's 344px activity panel). */
+ * edges aligned, just below the anchor. */
 function AnchoredPanel({
   anchor,
   onDismiss,
@@ -298,44 +302,32 @@ function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
 
   return (
     <div className="flex flex-col gap-1 rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]">
-      <div className="flex items-start justify-between rounded-(--radius-08) p-2">
-        <span className="flex min-w-0 flex-1 items-start gap-1 pr-2">
-          <span className="p-[2px]">
-            <SvgSparkle size={16} />
-          </span>
-          <span className="min-w-0">
-            <Text font="main-ui-action" color="text-04" as="p">
-              AI Auto-Edits
-            </Text>
-            <Text font="secondary-body" color="text-03" as="p">
-              Let AI update/organize this page on its own.
-            </Text>
-          </span>
-        </span>
-        <Switch checked={allowed} onCheckedChange={() => void toggle()} />
+      <div className="p-2">
+        <InputHorizontal
+          icon={SvgSparkle}
+          title="AI Auto-Edits"
+          description="Let AI update/organize this page on its own."
+        >
+          <Switch checked={allowed} onCheckedChange={() => void toggle()} />
+        </InputHorizontal>
       </div>
-      <div className="mx-2 border-t border-(--border-01)" />
-      <div className="flex items-start gap-1 rounded-(--radius-08) p-1">
-        <span className="flex min-w-0 flex-1 items-start gap-1 p-1 pr-2">
-          <span className="p-[2px]">
-            <SvgSparkle size={16} />
-          </span>
-          <span className="min-w-0">
-            <Text font="main-ui-action" color="text-04" as="p">
-              Page Instructions
-            </Text>
-            <Text font="secondary-body" color="text-03" as="p">
-              {policy?.update_instruction || "How should this page be updated?"}
-            </Text>
-          </span>
-        </span>
-        <Button
-          icon={SvgExpand}
-          size="md"
-          prominence="tertiary"
-          tooltip="Open in panel"
-          onClick={onOpenUpdatesPanel}
-        />
+      <Divider />
+      <div className="p-2">
+        <InputHorizontal
+          icon={SvgAddLines}
+          title="Page Instructions"
+          description={
+            policy?.update_instruction || "How should this page be updated?"
+          }
+        >
+          <Button
+            icon={SvgExpand}
+            size="md"
+            prominence="tertiary"
+            tooltip="Open in panel"
+            onClick={onOpenUpdatesPanel}
+          />
+        </InputHorizontal>
       </div>
     </div>
   );
@@ -343,7 +335,7 @@ function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
 
 /**
  * The header's "who is on this page" cluster (mocks 2079:379824,
- * 2079:381324, 2079:383512, 1929:361938): everyone active on the page as
+ * 2079:381324, 2079:383512, 1929:361938): every coedit participant as
  * overlapping colored chips, agents badged onto the user they act for,
  * a +N overflow, and the Auto slot controlling AI auto-edits. The
  * current user is never shown.
@@ -367,8 +359,8 @@ export function PresenceAvatars({
     const caretByUser = new Map(peers.map((p) => [p.user_id, p.head]));
     const agentByUser = new Map(
       agents
-        .filter((a) => a.user_id && a.activity === "wrote")
-        .map((a) => [a.user_id as string, a.agent_name]),
+        .filter((a) => a.activity === "wrote")
+        .map((a) => [a.user_id, a.agent_name]),
     );
     return participants
       .filter((p) => p.user_id !== myUserId)
@@ -402,9 +394,10 @@ export function PresenceAvatars({
   }, []);
   useEffect(() => () => window.clearTimeout(closeTimer.current), []);
 
-  // Recent edits load once per doc: first hover fetches, later hovers
-  // reuse the same list.
+  // Recent edits load lazily on first hover and cache until the path
+  // changes, so a stale doc's shas never feed the history view.
   const [commits, setCommits] = useState<CommitInfo[] | null>(null);
+  useEffect(() => setCommits(null), [path]);
   const loadCommits = useCallback(() => {
     if (commits) return;
     fetchFileHistory(path)

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -27,6 +27,7 @@ import {
 import type { IconProps } from "@onyx-ai/opal/types";
 import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
 
+import { toast } from "@/hooks/useToast";
 import {
   getUpdatePolicy,
   patchUpdatePolicy,
@@ -75,6 +76,8 @@ interface PresenceEntry {
 
 interface PresenceAvatarsProps {
   path: string;
+  /** Whether the current user may edit this page (policy writes gate on it). */
+  canWrite: boolean;
   participants: CoeditParticipant[];
   peers: CoeditPeer[];
   typing: string[];
@@ -161,7 +164,7 @@ function PresenceCard({
           </Text>
           {entry.agentName && (
             <Text font="secondary-body" color="text-03" as="p" nowrap>
-              {`Editing with ${entry.agentName}`}
+              {`${entry.editing ? "Editing" : "Viewing"} with ${entry.agentName}`}
             </Text>
           )}
         </span>
@@ -272,13 +275,20 @@ function AnchoredPanel({
 
 interface PolicyPopoverProps {
   path: string;
+  /** The policy PATCH is write-gated, so read-only viewers get a
+   * disabled switch instead of a doomed request. */
+  canWrite: boolean;
   onOpenUpdatesPanel?: () => void;
 }
 
 /** The Auto popover (mock 1929:362227 "Policy Panel"): the AI Auto-Edits
  * switch and the page's update instruction, both live on the update
  * policy the full panel edits. */
-function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
+function PolicyPopover({
+  path,
+  canWrite,
+  onOpenUpdatesPanel,
+}: PolicyPopoverProps) {
   const [policy, setPolicy] = useState<EffectivePolicy | null>(null);
   useEffect(() => {
     let alive = true;
@@ -295,8 +305,11 @@ function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
     setPolicy((p) => (p ? { ...p, ai_management_allowed: !allowed } : p));
     try {
       await patchUpdatePolicy(path, { ai_management_allowed: !allowed });
-    } catch {
+    } catch (e) {
       setPolicy((p) => (p ? { ...p, ai_management_allowed: allowed } : p));
+      toast.error(
+        e instanceof Error ? e.message : "Couldn't update the page's policy",
+      );
     }
   };
 
@@ -308,7 +321,11 @@ function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
           title="AI Auto-Edits"
           description="Let AI update/organize this page on its own."
         >
-          <Switch checked={allowed} onCheckedChange={() => void toggle()} />
+          <Switch
+            checked={allowed}
+            disabled={!canWrite}
+            onCheckedChange={() => void toggle()}
+          />
         </InputHorizontal>
       </div>
       <Divider />
@@ -342,6 +359,7 @@ function PolicyPopover({ path, onOpenUpdatesPanel }: PolicyPopoverProps) {
  */
 export function PresenceAvatars({
   path,
+  canWrite,
   participants,
   peers,
   typing,
@@ -357,22 +375,55 @@ export function PresenceAvatars({
       ...typing,
     ]);
     const caretByUser = new Map(peers.map((p) => [p.user_id, p.head]));
-    const agentByUser = new Map(
+    const writingAgents = new Map(
       agents
         .filter((a) => a.activity === "wrote")
         .map((a) => [a.user_id, a.agent_name]),
     );
-    return participants
+    const entry = (
+      userId: string,
+      display: string,
+      i: number,
+      editing: boolean,
+      agentName: string | null,
+    ): PresenceEntry => ({
+      userId,
+      display,
+      initial: (display.trim().charAt(0) || "?").toUpperCase(),
+      color: USER_COLORS[i % USER_COLORS.length],
+      editing,
+      agentName,
+      caretHead: caretByUser.get(userId) ?? null,
+    });
+    const roster = participants
       .filter((p) => p.user_id !== myUserId)
-      .map((p, i) => ({
-        userId: p.user_id,
-        display: p.user_display,
-        initial: (p.user_display.trim().charAt(0) || "?").toUpperCase(),
-        color: USER_COLORS[i % USER_COLORS.length],
-        editing: editingIds.has(p.user_id),
-        agentName: agentByUser.get(p.user_id) ?? null,
-        caretHead: caretByUser.get(p.user_id) ?? null,
-      }));
+      .map((p, i) =>
+        // A writing agent makes its user an editor even with an idle caret.
+        entry(
+          p.user_id,
+          p.user_display,
+          i,
+          editingIds.has(p.user_id) || writingAgents.has(p.user_id),
+          writingAgents.get(p.user_id) ?? null,
+        ),
+      );
+    // Agents register as the user they act for, so a user whose agent is
+    // active stays in the stack even without a browser session.
+    const seated = new Set(roster.map((e) => e.userId));
+    for (const a of agents) {
+      if (a.user_id === myUserId || seated.has(a.user_id)) continue;
+      seated.add(a.user_id);
+      roster.push(
+        entry(
+          a.user_id,
+          a.owner_display,
+          roster.length,
+          a.activity === "wrote",
+          a.agent_name,
+        ),
+      );
+    }
+    return roster;
   }, [participants, peers, typing, myUserId, agents]);
 
   const shown = entries.slice(0, MAX_CHIPS);
@@ -512,7 +563,11 @@ export function PresenceAvatars({
           anchor={clusterRef.current}
           onDismiss={() => setAutoOpen(false)}
         >
-          <PolicyPopover path={path} onOpenUpdatesPanel={onOpenUpdatesPanel} />
+          <PolicyPopover
+            path={path}
+            canWrite={canWrite}
+            onOpenUpdatesPanel={onOpenUpdatesPanel}
+          />
         </AnchoredPanel>
       )}
     </div>

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -555,36 +555,15 @@ export function PresenceAvatars({
       className="px-[2px]"
     >
       {entries.length > 0 && (
+        // DOM order runs last-chip-first so paint order stacks earlier
+        // chips on top (the mock), row-reverse restores the visual order.
         <Section
           flexDirection="row"
           alignItems="center"
           width="fit"
           height="fit"
-          className="isolate px-[2px]"
+          className="isolate flex-row-reverse px-[2px]"
         >
-          {shown.map((e, i) => (
-            // raw-ok: no Opal control renders an overlapping avatar-stack slot with a badge overhang
-            <button
-              key={e.userId}
-              type="button"
-              aria-label={e.display}
-              className="relative flex w-5 cursor-pointer items-center justify-center"
-              style={{ zIndex: shown.length - i }}
-              onPointerEnter={() => {
-                holdOpen();
-                setHoverId(e.userId);
-                loadCommits();
-              }}
-              onPointerLeave={closeSoon}
-            >
-              <AvatarCircle entry={e} size="main-content" />
-              {e.agentName && (
-                <span className="absolute top-[12px] left-[10px]">
-                  <AgentBadge entry={e} size="secondary" />
-                </span>
-              )}
-            </button>
-          ))}
           {overflow.length > 0 && (
             // raw-ok: Tag is a non-interactive div, the click needs a button wrapper
             <button
@@ -599,6 +578,32 @@ export function PresenceAvatars({
               <Tag title={`+${overflow.length}`} color="gray" />
             </button>
           )}
+          {[...shown].reverse().map((e) => (
+            // Each slot is 20px wide holding a 24px chip, the 4px overlap.
+            <Section
+              key={e.userId}
+              flexDirection="row"
+              alignItems="center"
+              justifyContent="center"
+              width="fit"
+              height="fit"
+              data-presence-chip={e.display}
+              className="relative w-5"
+              onPointerEnter={() => {
+                holdOpen();
+                setHoverId(e.userId);
+                loadCommits();
+              }}
+              onPointerLeave={closeSoon}
+            >
+              <AvatarCircle entry={e} size="main-content" />
+              {e.agentName && (
+                <span className="absolute top-[12px] left-[10px]">
+                  <AgentBadge entry={e} size="secondary" />
+                </span>
+              )}
+            </Section>
+          ))}
         </Section>
       )}
       {entries.length > 0 && (

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -289,29 +289,42 @@ function PolicyPopover({
   canWrite,
   onOpenUpdatesPanel,
 }: PolicyPopoverProps) {
-  const [policy, setPolicy] = useState<EffectivePolicy | null>(null);
+  // The policy carries the path it was fetched for: a mismatch reads as
+  // unloaded in the same render a navigation lands, so a stale page's
+  // value can never be shown or PATCHed against the new path.
+  const [policy, setPolicy] = useState<{
+    forPath: string;
+    effective: EffectivePolicy;
+  } | null>(null);
   const [saving, setSaving] = useState(false);
   useEffect(() => {
     let alive = true;
-    // Clearing first re-disables the switch, a stale page's policy must
-    // never drive a PATCH against the new path.
-    setPolicy(null);
     getUpdatePolicy(path)
-      .then((p) => alive && setPolicy(p.effective))
+      .then(
+        (p) => alive && setPolicy({ forPath: path, effective: p.effective }),
+      )
       .catch(() => alive && setPolicy(null));
     return () => {
       alive = false;
     };
   }, [path]);
+  const loaded = policy?.forPath === path ? policy.effective : null;
 
-  const allowed = !!policy?.ai_management_allowed;
+  const allowed = !!loaded?.ai_management_allowed;
   const toggle = async () => {
+    if (!loaded) return;
     setSaving(true);
-    setPolicy((p) => (p ? { ...p, ai_management_allowed: !allowed } : p));
+    setPolicy({
+      forPath: path,
+      effective: { ...loaded, ai_management_allowed: !allowed },
+    });
     try {
       await patchUpdatePolicy(path, { ai_management_allowed: !allowed });
     } catch (e) {
-      setPolicy((p) => (p ? { ...p, ai_management_allowed: allowed } : p));
+      setPolicy({
+        forPath: path,
+        effective: { ...loaded, ai_management_allowed: allowed },
+      });
       toast.error(
         e instanceof Error ? e.message : "Couldn't update the page's policy",
       );
@@ -330,10 +343,10 @@ function PolicyPopover({
         >
           <Switch
             checked={allowed}
-            // Held until the policy loads (toggling against the null
-            // default would persist a wrong override) and while a save is
-            // in flight (a second click would race the first PATCH).
-            disabled={!canWrite || !policy || saving}
+            // Held until this path's policy loads (toggling against the
+            // null default would persist a wrong override) and while a
+            // save is in flight (a second click would race the PATCH).
+            disabled={!canWrite || !loaded || saving}
             onCheckedChange={() => void toggle()}
           />
         </InputHorizontal>
@@ -344,7 +357,7 @@ function PolicyPopover({
           icon={SvgAddLines}
           title="Page Instructions"
           description={
-            policy?.update_instruction || "How should this page be updated?"
+            loaded?.update_instruction || "How should this page be updated?"
           }
         >
           <Button

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -6,13 +6,13 @@ import {
   useMemo,
   useRef,
   useState,
-  type ComponentType,
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
 import {
   Button,
   Divider,
+  IconContainer,
   LineItemButton,
   Switch,
   Text,
@@ -24,7 +24,7 @@ import {
   SvgExpand,
   SvgSparkle,
 } from "@onyx-ai/opal/icons";
-import type { IconProps } from "@onyx-ai/opal/types";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { SvgClaude, SvgOnyxLogo, SvgOpenai } from "@onyx-ai/opal/logos";
 
 import { toast } from "@/hooks/useToast";
@@ -53,7 +53,7 @@ const USER_COLORS = [
 
 const MAX_CHIPS = 5;
 
-function agentGlyph(name: string | null): ComponentType<IconProps> | null {
+function agentGlyph(name: string | null): IconFunctionComponent | null {
   const key = name?.trim().toLowerCase();
   if (!key) return null;
   if (key.includes("claude")) return SvgClaude;
@@ -65,7 +65,6 @@ function agentGlyph(name: string | null): ComponentType<IconProps> | null {
 interface PresenceEntry {
   userId: string;
   display: string;
-  initial: string;
   color: string;
   editing: boolean;
   /** Live agent writing for this user on the page, when one is. */
@@ -94,18 +93,27 @@ interface PresenceAvatarsProps {
 
 interface AvatarCircleProps {
   entry: PresenceEntry;
-  size: number;
+  /** IconContainer preset: main-content 24px, main-ui 20px, secondary 16px. */
+  size: "main-content" | "main-ui" | "secondary";
+}
+
+/** The identity-colored 1px ring: Opal's avatar circles carry no color
+ * prop, so the ring overlays without touching the primitive's box. */
+function IdentityRing({ color }: { color: string }) {
+  return (
+    <span
+      aria-hidden
+      className="pointer-events-none absolute inset-0 rounded-full border"
+      style={{ borderColor: color }}
+    />
+  );
 }
 
 function AvatarCircle({ entry, size }: AvatarCircleProps) {
   return (
-    <span
-      className="flex shrink-0 items-center justify-center rounded-full border bg-(--background-neutral-inverted-00)"
-      style={{ width: size, height: size, borderColor: entry.color }}
-    >
-      <Text font="secondary-action" color="text-inverted-05">
-        {entry.initial}
-      </Text>
+    <span className="relative flex shrink-0">
+      <IconContainer size={size} avatar="user" name={entry.display} />
+      <IdentityRing color={entry.color} />
     </span>
   );
 }
@@ -114,11 +122,9 @@ function AgentBadge({ entry, size }: AvatarCircleProps) {
   const Glyph = agentGlyph(entry.agentName);
   if (!Glyph) return null;
   return (
-    <span
-      className="flex shrink-0 items-center justify-center rounded-full border bg-(--background-neutral-00)"
-      style={{ width: size, height: size, borderColor: entry.color }}
-    >
-      <Glyph size={size - 4} />
+    <span className="relative flex shrink-0">
+      <IconContainer size={size} avatar="icon" icon={Glyph} />
+      <IdentityRing color={entry.color} />
     </span>
   );
 }
@@ -155,8 +161,8 @@ function PresenceCard({
         }
       >
         <span className="flex shrink-0 items-center gap-0 p-[2px]">
-          <AvatarCircle entry={entry} size={20} />
-          {entry.agentName && <AgentBadge entry={entry} size={20} />}
+          <AvatarCircle entry={entry} size="main-ui" />
+          {entry.agentName && <AgentBadge entry={entry} size="main-ui" />}
         </span>
         <span className="min-w-0 flex-1 px-[2px]">
           <Text font="main-ui-action" color="text-04" as="p" nowrap>
@@ -424,7 +430,6 @@ export function PresenceAvatars({
     ): PresenceEntry => ({
       userId,
       display,
-      initial: (display.trim().charAt(0) || "?").toUpperCase(),
       color: USER_COLORS[i % USER_COLORS.length],
       editing,
       agentName,
@@ -520,10 +525,10 @@ export function PresenceAvatars({
               }}
               onPointerLeave={closeSoon}
             >
-              <AvatarCircle entry={e} size={24} />
+              <AvatarCircle entry={e} size="main-content" />
               {e.agentName && (
                 <span className="absolute top-[12px] left-[10px]">
-                  <AgentBadge entry={e} size={16} />
+                  <AgentBadge entry={e} size="secondary" />
                 </span>
               )}
             </button>
@@ -556,8 +561,12 @@ export function PresenceAvatars({
         className="flex cursor-pointer items-center justify-center px-[2px]"
         onClick={() => setAutoOpen((v) => !v)}
       >
-        <span className="flex size-6 items-center justify-center rounded-full border border-(--theme-blue-05) bg-(--background-neutral-00)">
-          <SvgOnyxLogo size={16} />
+        <span className="relative flex">
+          <IconContainer size="main-content" avatar="icon" icon={SvgOnyxLogo} />
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 rounded-full border border-(--theme-blue-05)"
+          />
         </span>
       </button>
 

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -15,9 +15,10 @@ import {
   IconContainer,
   LineItemButton,
   Switch,
+  Tag,
   Text,
 } from "@onyx-ai/opal/components";
-import { InputHorizontal } from "@onyx-ai/opal/layouts";
+import { InputHorizontal, Section } from "@onyx-ai/opal/layouts";
 import {
   SvgAddLines,
   SvgArrowUpRight,
@@ -147,11 +148,16 @@ function PresenceCard({
   const edits = commits.slice(0, 3);
   const scrollable = entry.editing && entry.caretHead !== null;
   return (
-    <div className="flex flex-col">
-      <div
+    <Section justifyContent="start" alignItems="stretch" height="fit">
+      <Section
+        flexDirection="row"
+        justifyContent="start"
+        alignItems="start"
+        height="fit"
+        gap={0.25}
         data-presence-card={entry.userId}
         // Mock card chrome: white surface lifted off the panel body.
-        className={`flex w-full items-start gap-1 rounded-(--radius-08) bg-(--background-tint-00) p-1 shadow-[0px_2px_6px_var(--shadow-02),0px_0px_2px_var(--shadow-01)] ${
+        className={`w-full rounded-(--radius-08) bg-(--background-tint-00) p-1 shadow-[0px_2px_6px_var(--shadow-02),0px_0px_2px_var(--shadow-01)] ${
           scrollable ? "cursor-pointer" : ""
         }`}
         onClick={
@@ -160,11 +166,22 @@ function PresenceCard({
             : undefined
         }
       >
-        <span className="flex shrink-0 items-center gap-0 p-[2px]">
+        <Section
+          flexDirection="row"
+          alignItems="center"
+          width="fit"
+          height="fit"
+          className="shrink-0 p-[2px]"
+        >
           <AvatarCircle entry={entry} size="main-ui" />
           {entry.agentName && <AgentBadge entry={entry} size="main-ui" />}
-        </span>
-        <span className="min-w-0 flex-1 px-[2px]">
+        </Section>
+        <Section
+          justifyContent="start"
+          alignItems="stretch"
+          height="fit"
+          className="min-w-0 flex-1 px-[2px]"
+        >
           <Text font="main-ui-action" color="text-04" as="p" nowrap>
             {entry.display}
           </Text>
@@ -173,8 +190,14 @@ function PresenceCard({
               {`${entry.editing ? "Editing" : "Viewing"} with ${entry.agentName}`}
             </Text>
           )}
-        </span>
-        <span className="flex shrink-0 items-center gap-[2px] pt-[2px]">
+        </Section>
+        <Section
+          flexDirection="row"
+          alignItems="center"
+          width="fit"
+          height="fit"
+          className="shrink-0 gap-[2px] pt-[2px]"
+        >
           {/* raw-ok: no Opal Text color maps to the mock's status-text-info-05 state chip */}
           <span className="px-[2px] text-[12px] leading-4 text-(--status-text-info-05)">
             {entry.editing ? "Editing" : "Viewing"}
@@ -184,20 +207,16 @@ function PresenceCard({
           ) : (
             <span className="mx-[2px] size-[6px] rounded-full bg-(--status-text-info-05)" />
           )}
-        </span>
-      </div>
+        </Section>
+      </Section>
       {edits.length > 0 && (
-        <div className="flex flex-col py-1">
-          <div className="flex items-center px-1 py-[2px]">
-            <span className="w-[6px] border-t border-(--border-01)" />
-            <span className="px-1">
-              <Text font="secondary-body" color="text-03" nowrap>
-                Recent Edits
-              </Text>
-            </span>
-            <span className="min-w-0 flex-1 border-t border-(--border-01)" />
-            <span className="w-2 border-t border-(--border-01)" />
-          </div>
+        <Section
+          justifyContent="start"
+          alignItems="stretch"
+          height="fit"
+          className="py-1"
+        >
+          <Divider title="Recent Edits" />
           {edits.map((c) => {
             const { agentLabel } = parseCommitAuthor(c.author);
             const changed = c.added + c.removed;
@@ -213,20 +232,25 @@ function PresenceCard({
                 sizePreset="secondary"
                 variant="body"
                 rightChildren={
-                  <span className="flex items-center gap-[2px]">
+                  <Section
+                    flexDirection="row"
+                    alignItems="center"
+                    width="fit"
+                    className="gap-[2px]"
+                  >
                     <Text font="secondary-body" color="text-03" nowrap>
                       {relativeTime(c.ts)}
                     </Text>
                     <SvgArrowUpRight size={12} />
-                  </span>
+                  </Section>
                 }
                 onClick={() => onOpenCommit?.(c.sha)}
               />
             );
           })}
-        </div>
+        </Section>
       )}
-    </div>
+    </Section>
   );
 }
 
@@ -266,14 +290,22 @@ function AnchoredPanel({
     return () => window.removeEventListener("pointerdown", onDown, true);
   }, [anchor, hover, onDismiss]);
   return createPortal(
+    // raw-ok: Opal layout primitives are WithoutStyles and the panel needs runtime viewport coordinates
     <div
       ref={panelRef}
-      className="fixed z-50 flex w-(--block-width-panel-medium-small) flex-col"
+      className="fixed z-50"
       style={{ top: rect.bottom + 8, right: window.innerWidth - rect.right }}
       onPointerEnter={hover?.onEnter}
       onPointerLeave={hover?.onLeave}
     >
-      {children}
+      <Section
+        justifyContent="start"
+        alignItems="stretch"
+        height="fit"
+        className="w-(--block-width-panel-medium-small)"
+      >
+        {children}
+      </Section>
     </div>,
     document.body,
   );
@@ -340,8 +372,14 @@ function PolicyPopover({
   };
 
   return (
-    <div className="flex flex-col gap-1 rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]">
-      <div className="p-2">
+    <Section
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      gap={0.25}
+      className="rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]"
+    >
+      <Section height="fit" alignItems="stretch" padding={0.5}>
         <InputHorizontal
           icon={SvgSparkle}
           title="AI Auto-Edits"
@@ -356,9 +394,9 @@ function PolicyPopover({
             onCheckedChange={() => void toggle()}
           />
         </InputHorizontal>
-      </div>
+      </Section>
       <Divider />
-      <div className="p-2">
+      <Section height="fit" alignItems="stretch" padding={0.5}>
         <InputHorizontal
           icon={SvgAddLines}
           title="Page Instructions"
@@ -374,8 +412,8 @@ function PolicyPopover({
             onClick={onOpenUpdatesPanel}
           />
         </InputHorizontal>
-      </div>
-    </div>
+      </Section>
+    </Section>
   );
 }
 
@@ -507,9 +545,23 @@ export function PresenceAvatars({
   const hovered = entries.find((e) => e.userId === hoverId);
 
   return (
-    <div ref={clusterRef} className="flex items-center gap-1 px-[2px]">
+    <Section
+      ref={clusterRef}
+      flexDirection="row"
+      alignItems="center"
+      width="fit"
+      height="fit"
+      gap={0.25}
+      className="px-[2px]"
+    >
       {entries.length > 0 && (
-        <div className="isolate flex items-center px-[2px]">
+        <Section
+          flexDirection="row"
+          alignItems="center"
+          width="fit"
+          height="fit"
+          className="isolate px-[2px]"
+        >
           {shown.map((e, i) => (
             // raw-ok: no Opal control renders an overlapping avatar-stack slot with a badge overhang
             <button
@@ -534,25 +586,29 @@ export function PresenceAvatars({
             </button>
           ))}
           {overflow.length > 0 && (
-            // raw-ok: the +N chip is the mock's borderless tinted pill, Tag renders border chrome
+            // raw-ok: Tag is a non-interactive div, the click needs a button wrapper
             <button
               type="button"
               aria-label={`${overflow.length} more`}
-              className="ml-[2px] cursor-pointer rounded-(--radius-08) bg-(--background-tint-02) p-1"
+              className="ml-[2px] cursor-pointer"
               onClick={() => {
                 setOverflowOpen((v) => !v);
                 loadCommits();
               }}
             >
-              <Text font="secondary-body" color="text-03" nowrap>
-                {`+${overflow.length}`}
-              </Text>
+              <Tag title={`+${overflow.length}`} color="gray" />
             </button>
           )}
-        </div>
+        </Section>
       )}
       {entries.length > 0 && (
-        <span className="h-4 border-l border-(--border-01)" />
+        <Section height="fit" width="fit" className="h-4 self-center">
+          <Divider
+            orientation="vertical"
+            paddingParallel="fit"
+            paddingPerpendicular="fit"
+          />
+        </Section>
       )}
       {/* raw-ok: the Auto trigger is the mock's blue-ringed avatar circle, not a standard icon button */}
       <button
@@ -589,7 +645,12 @@ export function PresenceAvatars({
           anchor={clusterRef.current}
           onDismiss={() => setOverflowOpen(false)}
         >
-          <div className="flex flex-col gap-1">
+          <Section
+            justifyContent="start"
+            alignItems="stretch"
+            height="fit"
+            gap={0.25}
+          >
             {overflow.map((e) => (
               <PresenceCard
                 key={e.userId}
@@ -599,7 +660,7 @@ export function PresenceAvatars({
                 onOpenCommit={onOpenCommit}
               />
             ))}
-          </div>
+          </Section>
         </AnchoredPanel>
       )}
       {autoOpen && clusterRef.current && (
@@ -614,6 +675,6 @@ export function PresenceAvatars({
           />
         </AnchoredPanel>
       )}
-    </div>
+    </Section>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -34,8 +34,8 @@ export interface Event {
 
 export interface DocumentActivity {
   /** The user the agent acts for, so presence UI can badge that user's
-   * avatar. Null for activity registered outside a user context. */
-  user_id: string | null;
+   * avatar. */
+  user_id: string;
   owner_display: string;
   agent_name: string | null;
   activity: "read" | "wrote";

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -33,6 +33,9 @@ export interface Event {
 }
 
 export interface DocumentActivity {
+  /** The user the agent acts for, so presence UI can badge that user's
+   * avatar. Null for activity registered outside a user context. */
+  user_id: string | null;
   owner_display: string;
   agent_name: string | null;
   activity: "read" | "wrote";

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -957,6 +957,7 @@ export function FileView({ path }: FileViewProps) {
         {!viewingVersion && !isMobile && (
           <PresenceAvatars
             path={path}
+            canWrite={canWrite}
             participants={coedit.participants}
             peers={coedit.peers}
             typing={coedit.typing}

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -51,6 +51,7 @@ import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
 import { CommentMarginRail } from "@/components/wiki/CommentMarginRail";
+import { PresenceAvatars } from "@/components/wiki/PresenceAvatars";
 import { toast } from "@/hooks/useToast";
 import { useLeftPanel } from "@/providers/LeftPanelProvider";
 import { craftFailureMessage } from "@/lib/craft";
@@ -952,6 +953,26 @@ export function FileView({ path }: FileViewProps) {
           <span className="mr-1 text-[12px] text-(--text-03)">
             {coedit.saveStatus === "saving" ? "Saving…" : "Couldn't save"}
           </span>
+        )}
+        {!viewingVersion && !isMobile && (
+          <PresenceAvatars
+            path={path}
+            participants={coedit.participants}
+            peers={coedit.peers}
+            typing={coedit.typing}
+            myUserId={user?.id ?? null}
+            agents={agents}
+            onScrollToOffset={(offset) =>
+              coeditorRef.current?.scrollToOffset(offset)
+            }
+            onOpenCommit={(sha) => {
+              void (async () => {
+                if (!commits) await refreshHistory();
+                void onPickCommit(sha);
+              })();
+            }}
+            onOpenUpdatesPanel={() => openPanel("updates")}
+          />
         )}
         <Button
           icon={SvgShare}


### PR DESCRIPTION
## Description

The "who is on this page" row from Figma 2079-379824 / 1929-361938 / 2079-381324 / 2079-383512, task: merge active users and agents into one header stack.

- Overlapping avatar chips for every coedit participant except yourself, identity colors cycling five non-reserved Opal hues per the mock's annotation (semantic red/green/orange/blue/amber stay reserved).
- Agents register as the user they act for: a small badge with the agent's glyph overlays that user's chip (`agent_activity` rows now expose `user_id` for exact attribution).
- Hover a chip for the card: name, "Editing with Codex/Claude Code" when agent-driven, live Editing/Viewing state from coedit peers/typing, and that user's recent edits on the page. Card click scrolls to their caret, edit rows open that commit in history. "+N" opens the same cards for overflow users.
- The Auto slot opens the Policy Panel popover (mock 1929:362227): AI Auto-Edits switch and Page Instructions, backed by the existing update-policy lib, expand jumps to the updates panel.

## How Has This Been Tested?

Live on dev1 with two real sessions in both themes: second user's chip appears without refresh and never shows yourself, Viewing flips to Editing while they type, the Claude Code badge and subtitle render from a live activity row and disappear on expiry, computed chip tokens verified (24px, neon-cyan-50 border resolving light and dark). Activity endpoint pytest suites pass (15). A concurrent-typing collab RangeError seen during testing was A/B-proven pre-existing on main with this branch fully stashed.