### PR TITLE
chore(helm): bump chart 0.3.34 -> 0.3.35 to publish the heavy/light worker regroup

### DIFF
--- a/deploy/helm/agent-workspace/Chart.yaml
+++ b/deploy/helm/agent-workspace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: agent-workspace
 description: Self-updating wiki for AI agents (FastAPI + Postgres 17 + Redis + Next.js).
 type: application
-version: 0.3.34
+version: 0.3.35
 appVersion: "0.1.0"


### PR DESCRIPTION
## Summary

PR #473 regrouped the worker Deployments (per-queue → `heavy`/`light`) and renamed the `detection` queue to `automanage_nearline`/`automanage_offline`, but didn't bump the chart version. `helm-release.yml` runs chart-releaser with `skip_existing: true`, so the gh-pages Helm repo still serves chart 0.3.34 with the old per-queue layout.

The deployed cluster therefore runs the pre-#473 manifests against post-#473 nightly images:

- `worker-detection` crash-loops: `run_worker.py: error: argument queues: invalid choice: 'detection'`
- no worker consumes `automanage_offline` / `automanage_nearline`, so sweeps and approved proposal executes queue up and never run

Bumping the version republishes the chart; the next deploy replaces the five per-queue worker Deployments with `worker-heavy` + `worker-light`.

## Test plan

- `helm lint` passes (pre-commit)
- After merge: confirm the chart-release workflow publishes 0.3.35, redeploy, and verify `worker-heavy`/`worker-light` come up and the queued automanage messages drain