### PR TITLE
feat(automanage): selection + reconciliation — the sweep's third step

### DIFF
--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -222,7 +222,11 @@ def run_detection(
         # Approved rows are a human decision in flight — the executor's to
         # re-validate, never the sweep's to retract.
         invalidated = 0
-        pending_rows = list_by_status(ProposalStatus.PENDING)
+        # limit=None: reconciliation and claim-blocking must see the
+        # COMPLETE live set — a truncated read would leave obsolete
+        # pendings visible and admit claims that conflict with omitted
+        # rows.
+        pending_rows = list_by_status(ProposalStatus.PENDING, limit=None)
         if trigger is TriggerKind.SWEEP:
             revive_ids = {
                 d.existing_id for _, _, d, _ in candidates
@@ -250,7 +254,7 @@ def run_detection(
         # the ledger records every detected finding, and the row is the
         # revival anchor once its page frees up.
         blocked: set[str] = set()
-        for row in list_by_status(ProposalStatus.APPROVED):
+        for row in list_by_status(ProposalStatus.APPROVED, limit=None):
             blocked |= selection.claim_of(row["source_paths"] + row["target_paths"])
         for row in pending_rows:
             if row["id"] in carried_ids:
@@ -259,13 +263,20 @@ def run_detection(
                 )
 
         emitted = 0
+        persisted_invalid = 0
         for detector, draft, decision, auto_ok in candidates:
-            if emitted >= MAX_PROPOSALS_PER_RUN:
+            # The cap bounds total ledger writes this run — selected AND
+            # persisted-invalid rows — so a pathological sweep can't flood
+            # the table through the invalid path either. Deferred drafts
+            # re-detect next sweep; nothing is lost.
+            if emitted + persisted_invalid >= MAX_PROPOSALS_PER_RUN:
                 log.warning(
-                    "detection run %s hit per-run cap (%d); "
-                    "remaining drafts deferred to next run",
+                    "detection run %s hit per-run write cap (%d: %d selected"
+                    " + %d invalid); remaining drafts deferred to next run",
                     run_id,
                     MAX_PROPOSALS_PER_RUN,
+                    emitted,
+                    persisted_invalid,
                 )
                 break
             base_shas = _base_shas(draft.source_paths, draft.target_paths)
@@ -313,6 +324,7 @@ def run_detection(
                         f"in cooldown until {until} — these pages were "
                         "recently declined"
                     )
+                    persisted_invalid += 1
                 # REVIVE: the row already rests as persisted-invalid.
                 continue
             if selection.conflicts(frozenset(claim), frozenset(blocked)):
@@ -321,6 +333,7 @@ def run_detection(
                         f"not selected by run {run_id} — a live proposal "
                         "holds the page"
                     )
+                    persisted_invalid += 1
                 # A REVIVE candidate stays at rest (stale/expired) — its
                 # row already is the persisted-invalid form.
                 continue

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -30,11 +30,22 @@ from typing import Any
 
 from app.auth.users import AI_USER_ID
 from app.wiki import git, update_policy
-from app.wiki.automanage import dedup, executor, fingerprint, review, runs, settings
+from app.wiki.automanage import (
+    dedup,
+    executor,
+    fingerprint,
+    review,
+    runs,
+    selection,
+    settings,
+)
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
     ProposalCreatedVia,
+    ProposalStatus,
+    list_by_status,
+    mark_stale,
 )
 from app.wiki.change_proposals import (
     create as create_proposal,
@@ -149,17 +160,18 @@ def run_detection(
     try:
         scope = Scope(trigger=trigger, paths=tuple(paths), run_id=run_id)
         deduper = dedup.Deduper(paths)
-        emitted = 0
-        capped = False
-        # Pairing detectors compare pages against each other; feeding them one
-        # permission bucket at a time means pages with different audiences are
-        # never mentioned in one proposal (which alone would leak a restricted
-        # page's existence to whoever sees the review surface). Buckets are
-        # computed once per run and only when a pairing detector will run.
+
+        # ---- Steps 1+2: detect all, dedup -------------------------------
+        # Collect every viable candidate before persisting anything, so
+        # selection composes the slate over the whole picture (a pure
+        # function of candidates + existing claims) instead of emitting
+        # as-you-go. Pairing detectors get one same-audience bucket at a
+        # time (a cross-audience proposal alone would leak a restricted
+        # page's existence to whoever sees the review surface).
+        candidates: list[tuple[Any, ProposalDraft, dedup.DedupDecision, bool]] = []
+        carried_ids: set[int] = set()
         buckets: list[Scope] | None = None
         for detector in DETECTORS:
-            if capped:
-                break
             if not detector.applicable(trigger):
                 continue
             if getattr(detector, "pairs_paths", False):
@@ -172,10 +184,10 @@ def run_detection(
             mgmt = _resolve_management(drafts)
             for draft in drafts:
                 draft_paths = draft.source_paths + draft.target_paths
-                # Emit safety: never persist a draft the executor can't apply —
-                # a detector landing ahead of its op's executor degrades to this
-                # loud skip instead of filling the queue with proposals that
-                # dead-end at approval (review re-checks the same set).
+                # Emit safety: never persist a draft the executor can't
+                # apply — a detector landing ahead of its op's executor
+                # degrades to this loud skip instead of filling the queue
+                # with proposals that dead-end at approval.
                 if draft.op.value not in executor.SUPPORTED_OPS:
                     log.error(
                         "detection run %s: detector %s emitted op %r with no "
@@ -188,109 +200,203 @@ def run_detection(
                     continue
                 if any(mgmt.get(p) is False for p in draft_paths):
                     continue  # explicitly hands-off scope
-                # Dedup is pure identity: a new premise on recently
-                # rejected pages CREATEs immediately by design. The
-                # post-rejection cooldown is a *selection*-step concern
-                # (persisted but unselectable — see the Dedup design page)
-                # and lands with the reconciliation work, not here.
                 decision = deduper.decide(detector.name, draft)
-                if decision.action not in (
-                    dedup.DedupAction.CREATE,
-                    dedup.DedupAction.REVIVE,
-                ):
-                    continue  # carried, or rejected-forever
-                if emitted >= MAX_PROPOSALS_PER_RUN:
-                    log.warning(
-                        "detection run %s hit per-run cap (%d); "
-                        "remaining drafts deferred to next run",
-                        run_id,
-                        MAX_PROPOSALS_PER_RUN,
-                    )
-                    capped = True
-                    break
-                base_shas = _base_shas(draft.source_paths, draft.target_paths)
-                if base_shas is None:
+                if decision.action is dedup.DedupAction.SKIP_REJECTED:
+                    continue  # same ask was declined — never again
+                if decision.action is dedup.DedupAction.SKIP_LIVE:
+                    if decision.existing_id is not None:
+                        carried_ids.add(decision.existing_id)
                     continue
-                # Audience snapshot at emit time — staleness re-checks can
-                # notice a permission change (e.g. group-membership drift)
-                # between proposal and execution.
-                acl_fp = fingerprint.combined_fingerprint(draft_paths)
-                resolution = deduper.resolution(draft)
-                if decision.action is dedup.DedupAction.REVIVE:
-                    if decision.existing_id is None:
-                        # Unreachable: DedupDecision enforces this at
-                        # construction. Skip loudly rather than crash a run.
-                        log.error(
-                            "detection run %s: REVIVE decision without a row "
-                            "(%s) — skipped",
-                            run_id,
-                            decision.dedup_key,
-                        )
-                        continue
-                    if not change_proposals_revive(
-                        decision.existing_id,
-                        source_paths=draft.source_paths,
-                        target_paths=draft.target_paths,
-                        base_shas=base_shas,
-                        summary=draft.summary,
-                        instruction=draft.instruction,
-                        proposed_bodies=draft.proposed_bodies,
-                        run_id=run_id,
-                        acl_fingerprint_before=acl_fp,
-                        doc_ids=resolution,
-                    ):
-                        # A race moved the row out of stale/expired since the
-                        # decision — whatever won represents the finding now.
-                        continue
-                    proposal = get_proposal(decision.existing_id)
-                    if proposal is None:
-                        continue
-                    log.info(
-                        "detection run %s: revived proposal %s (%s)",
-                        run_id,
-                        decision.existing_id,
-                        decision.dedup_key,
-                    )
-                else:
-                    proposal = create_proposal(
-                        op=draft.op,
-                        source_paths=draft.source_paths,
-                        target_paths=draft.target_paths,
-                        base_shas=base_shas,
-                        summary=draft.summary,
-                        created_via=created_via,
-                        detector=detector.name,
-                        instruction=draft.instruction,
-                        proposed_bodies=draft.proposed_bodies,
-                        run_id=run_id,
-                        acl_fingerprint_before=acl_fp,
-                        dedup_key=decision.dedup_key,
-                        doc_ids=resolution,
-                    )
-                emitted += 1
-                # Whole operation inside an AI-managed scope → auto-apply as the
-                # AI system user (no human queue). Otherwise it waits for a
-                # human in the pending-cleanups queue. The detector must also
-                # consent (`auto_approvable`) — probabilistic detectors emit
-                # False so their proposals always get a human even in
-                # AI-managed scopes.
-                if (
+                auto_ok = bool(
                     draft.auto_approvable
                     and draft_paths
                     and all(mgmt.get(p) is True for p in draft_paths)
-                ) and not review.auto_approve(
-                    proposal["id"], acting_user_id=AI_USER_ID
+                )
+                candidates.append((detector, draft, decision, auto_ok))
+
+        # ---- Reconciliation: retire pendings that stopped being true ----
+        # A full sweep re-derives ground truth, so a pending row whose
+        # finding neither carried nor revived is no longer true — a
+        # reviewer must never be shown an ask the wiki has outgrown.
+        # Full sweeps only: a partial scope's silence proves nothing.
+        # Approved rows are a human decision in flight — the executor's to
+        # re-validate, never the sweep's to retract.
+        invalidated = 0
+        pending_rows = list_by_status(ProposalStatus.PENDING)
+        if trigger is TriggerKind.SWEEP:
+            revive_ids = {
+                d.existing_id for _, _, d, _ in candidates
+                if d.action is dedup.DedupAction.REVIVE
+            }
+            for row in pending_rows:
+                if row["id"] in carried_ids or row["id"] in revive_ids:
+                    continue
+                if mark_stale(
+                    row["id"], reason=f"not re-detected by run {run_id}"
                 ):
-                        # Shouldn't happen for a just-created proposal; if a race
-                        # transitioned it out of pending, it stays pending (a
-                        # human can still action it) — surface the anomaly loudly.
-                        log.warning(
-                            "detection run %s: auto-approve did not take for "
-                            "proposal %s (%s); left pending",
-                            run_id,
-                            proposal["id"],
-                            decision.dedup_key,
-                        )
+                    invalidated += 1
+            if invalidated:
+                log.info(
+                    "detection run %s: invalidated %d pending proposal(s) "
+                    "no longer detected",
+                    run_id,
+                    invalidated,
+                )
+
+        # ---- Step 3: selection — a slate of compatible claims -----------
+        # Stability-first: approved rows and carried pendings hold their
+        # claims (a surfaced ask is never bumped); new findings fill free
+        # pages in registry order. Everything else is persisted invalid —
+        # the ledger records every detected finding, and the row is the
+        # revival anchor once its page frees up.
+        blocked: set[str] = set()
+        for row in list_by_status(ProposalStatus.APPROVED):
+            blocked |= selection.claim_of(row["source_paths"] + row["target_paths"])
+        for row in pending_rows:
+            if row["id"] in carried_ids:
+                blocked |= selection.claim_of(
+                    row["source_paths"] + row["target_paths"]
+                )
+
+        emitted = 0
+        for detector, draft, decision, auto_ok in candidates:
+            if emitted >= MAX_PROPOSALS_PER_RUN:
+                log.warning(
+                    "detection run %s hit per-run cap (%d); "
+                    "remaining drafts deferred to next run",
+                    run_id,
+                    MAX_PROPOSALS_PER_RUN,
+                )
+                break
+            base_shas = _base_shas(draft.source_paths, draft.target_paths)
+            if base_shas is None:
+                continue
+            # Closure-visible narrowed binding (pyright doesn't narrow
+            # captured variables inside _persist_invalid).
+            anchors: dict[str, str] = base_shas
+            draft_paths = draft.source_paths + draft.target_paths
+            # Audience snapshot at emit time — staleness re-checks can
+            # notice a permission change (e.g. group-membership drift)
+            # between proposal and execution.
+            acl_fp = fingerprint.combined_fingerprint(draft_paths)
+            resolution = deduper.resolution(draft)
+            claim = selection.claim_of(draft_paths)
+
+            def _persist_invalid(reason: str) -> None:
+                row = create_proposal(
+                    op=draft.op,
+                    source_paths=draft.source_paths,
+                    target_paths=draft.target_paths,
+                    base_shas=anchors,
+                    summary=draft.summary,
+                    created_via=created_via,
+                    detector=detector.name,
+                    instruction=draft.instruction,
+                    proposed_bodies=draft.proposed_bodies,
+                    run_id=run_id,
+                    acl_fingerprint_before=acl_fp,
+                    dedup_key=decision.dedup_key,
+                    doc_ids=resolution,
+                )
+                mark_stale(row["id"], reason=reason)
+
+            # Post-rejection cooldown: a *new* premise on freshly declined
+            # pages stays quiet for the window — persisted (the ledger is
+            # the complete detection record; the row is the revival anchor)
+            # but unselectable. Checked for REVIVE too: the cooled row gets
+            # re-detected every sweep and must stay at rest until the
+            # window passes, not revive on the next pass.
+            until = selection.cooldown_until(decision.dedup_key)
+            if until is not None:
+                if decision.action is dedup.DedupAction.CREATE:
+                    _persist_invalid(
+                        f"in cooldown until {until} — these pages were "
+                        "recently declined"
+                    )
+                # REVIVE: the row already rests as persisted-invalid.
+                continue
+            if selection.conflicts(frozenset(claim), frozenset(blocked)):
+                if decision.action is dedup.DedupAction.CREATE:
+                    _persist_invalid(
+                        f"not selected by run {run_id} — a live proposal "
+                        "holds the page"
+                    )
+                # A REVIVE candidate stays at rest (stale/expired) — its
+                # row already is the persisted-invalid form.
+                continue
+
+            if decision.action is dedup.DedupAction.REVIVE:
+                if decision.existing_id is None:
+                    # Unreachable: DedupDecision enforces this at
+                    # construction. Skip loudly rather than crash a run.
+                    log.error(
+                        "detection run %s: REVIVE decision without a row "
+                        "(%s) — skipped",
+                        run_id,
+                        decision.dedup_key,
+                    )
+                    continue
+                if not change_proposals_revive(
+                    decision.existing_id,
+                    source_paths=draft.source_paths,
+                    target_paths=draft.target_paths,
+                    base_shas=anchors,
+                    summary=draft.summary,
+                    instruction=draft.instruction,
+                    proposed_bodies=draft.proposed_bodies,
+                    run_id=run_id,
+                    acl_fingerprint_before=acl_fp,
+                    doc_ids=resolution,
+                ):
+                    # A race moved the row out of stale/expired since the
+                    # decision — whatever won represents the finding now.
+                    continue
+                proposal = get_proposal(decision.existing_id)
+                if proposal is None:
+                    continue
+                log.info(
+                    "detection run %s: revived proposal %s (%s)",
+                    run_id,
+                    decision.existing_id,
+                    decision.dedup_key,
+                )
+            else:
+                proposal = create_proposal(
+                    op=draft.op,
+                    source_paths=draft.source_paths,
+                    target_paths=draft.target_paths,
+                    base_shas=anchors,
+                    summary=draft.summary,
+                    created_via=created_via,
+                    detector=detector.name,
+                    instruction=draft.instruction,
+                    proposed_bodies=draft.proposed_bodies,
+                    run_id=run_id,
+                    acl_fingerprint_before=acl_fp,
+                    dedup_key=decision.dedup_key,
+                    doc_ids=resolution,
+                )
+            blocked |= claim
+            emitted += 1
+            # Whole operation inside an AI-managed scope → auto-apply as the
+            # AI system user (no human queue). Otherwise it waits for a
+            # human in the pending-cleanups queue. The detector must also
+            # consent (`auto_approvable`) — probabilistic detectors emit
+            # False so their proposals always get a human even in
+            # AI-managed scopes.
+            if auto_ok and not review.auto_approve(
+                proposal["id"], acting_user_id=AI_USER_ID
+            ):
+                # Shouldn't happen for a just-created proposal; if a race
+                # transitioned it out of pending, it stays pending (a
+                # human can still action it) — surface the anomaly loudly.
+                log.warning(
+                    "detection run %s: auto-approve did not take for "
+                    "proposal %s (%s); left pending",
+                    run_id,
+                    proposal["id"],
+                    decision.dedup_key,
+                )
         runs.mark_completed(
             run_id, paths_scanned=len(paths), proposals_emitted=emitted
         )

--- a/backend/app/wiki/automanage/selection.py
+++ b/backend/app/wiki/automanage/selection.py
@@ -1,0 +1,83 @@
+"""Selection — step 3 of the sweep's reconciliation pipeline.
+
+After *detect all* (every detector over the scope) and *dedup* (map each
+finding onto its identity), selection decides which findings become the
+live slate and which are persisted-but-invalid. Two mechanisms live here:
+
+**Claims.** A proposal's claim is every path it touches — sources, targets,
+reserved names — compared case-insensitively (case-insensitive filesystems
+are a hazard we detect, never manufacture) and subtree-aware (a folder
+claims everything under it, and anything under it claims the folder).
+Selected proposals have pairwise-disjoint claims, which yields "at most one
+live proposal per page" as the common case and makes the slate
+order-independent: any subset can be approved and executed in any order
+without one proposal racing another for a path. A claim is exactly the
+agentic applier's sandbox (the executor's allowed-set), so the selection
+lock and the execution scope-check are one definition read at two times.
+
+**Cooldown.** A rejection quiets its content-free scope — the ``dedup_key``
+prefix before the premise — for ``SUBJECT_COOLDOWN_DAYS``: a *new* premise
+on freshly rejected pages is detected and persisted but unselectable, so
+content churn can't turn into immediate re-asks after a human said no.
+(The *same* premise never returns at all — that's dedup's job.)
+
+Deliberately mechanical (set intersections and one timestamp compare) and
+**pure** where it counts: `conflicts` and claim construction take values and
+return values, so slate composition is unit-testable without a database.
+Full doctrine: the "Wiki Auto Management — Dedup" design page.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.wiki import change_proposals
+
+# The post-rejection quiet window on a subject: long enough that periodic
+# content syncs don't nag, short enough that a real new situation resurfaces
+# within a quarter.
+SUBJECT_COOLDOWN_DAYS = 30
+
+
+def claim_of(paths: list[str]) -> frozenset[str]:
+    """The normalized claim for a proposal's paths: case-folded, deduped.
+    Subtree semantics live in :func:`conflicts`, not in the set itself."""
+    return frozenset(p.casefold() for p in paths)
+
+
+def conflicts(claim: frozenset[str], blocked: frozenset[str]) -> bool:
+    """True when ``claim`` overlaps ``blocked`` — equal paths, or one side
+    holding an ancestor folder of the other's path. Both sets are already
+    case-folded (see :func:`claim_of`)."""
+    if claim & blocked:
+        return True
+    for c in claim:
+        prefix = c + "/"
+        for b in blocked:
+            if b.startswith(prefix) or c.startswith(b + "/"):
+                return True
+    return False
+
+
+def cooldown_until(dedup_key: str, *, days: int | None = None) -> str | None:
+    """If the key's content-free scope was rejected within the window, the
+    UTC ``YYYY-MM-DD HH:MM:SS`` timestamp when the cooldown ends — else None.
+
+    The scope is everything before the premise (the final ``|``-segment), so
+    a rejection of one premise quiets *different* premises on the same
+    (detector, op, documents). The exact same premise never reaches here —
+    dedup suppresses it outright."""
+    if days is None:
+        days = SUBJECT_COOLDOWN_DAYS  # read at call time — tunable/patchable
+    prefix = dedup_key.rsplit("|", 1)[0] + "|"
+    rejected = change_proposals.latest_rejection_with_dedup_prefix(prefix)
+    if rejected is None:
+        return None
+    _rejected_id, rejected_at = rejected
+    try:
+        ts = datetime.strptime(rejected_at, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
+    except ValueError:
+        return None
+    until = ts + timedelta(days=days)
+    if datetime.now(UTC) >= until:
+        return None
+    return until.strftime("%Y-%m-%d %H:%M:%S")

--- a/backend/app/wiki/change_proposals.py
+++ b/backend/app/wiki/change_proposals.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 
 from app.db.models import ChangeProposal
 from app.db.session import execute_dml, session
@@ -204,6 +204,25 @@ def get_by_dedup_key(dedup_key: str) -> dict[str, Any] | None:
             select(ChangeProposal).where(ChangeProposal.dedup_key == dedup_key)
         ).one_or_none()
         return _to_dict(row) if row is not None else None
+
+
+def latest_rejection_with_dedup_prefix(prefix: str) -> tuple[int, str] | None:
+    """``(id, updated_at)`` of the most recent *rejected* row whose
+    ``dedup_key`` starts with ``prefix`` — the cooldown scope is the key's
+    content-free prefix (everything before the premise), so no separate
+    column is stored. ``starts_with`` is exact byte-prefix semantics —
+    immune to LIKE-metacharacter issues in path fallback terms."""
+    with session() as s:
+        row = s.execute(
+            select(ChangeProposal.id, ChangeProposal.updated_at)
+            .where(
+                func.starts_with(ChangeProposal.dedup_key, prefix),
+                ChangeProposal.status == ProposalStatus.REJECTED.value,
+            )
+            .order_by(ChangeProposal.updated_at.desc(), ChangeProposal.id.desc())
+            .limit(1)
+        ).first()
+        return (row[0], row[1]) if row is not None else None
 
 
 def revive(

--- a/backend/tests/test_automanage_selection.py
+++ b/backend/tests/test_automanage_selection.py
@@ -228,3 +228,20 @@ def test_folder_claim_locks_pages_beneath_it(repo, monkeypatch):
     assert pending["detector"] == "det_folder"
     (invalid,) = list_by_status(ProposalStatus.STALE)
     assert invalid["detector"] == "det_page"
+
+
+def test_cap_bounds_total_writes_including_invalid(repo, monkeypatch):
+    """The per-run cap counts persisted-invalid rows too — a pathological
+    sweep can't flood the ledger through the not-selected path."""
+    monkeypatch.setattr(runner, "MAX_PROPOSALS_PER_RUN", 2)
+    contenders = [
+        _FixedDetector("det_one", [_stub_draft("team/a.md")]),
+        _FixedDetector("det_two", [_stub_draft("team/a.md", premise="x")]),
+        _FixedDetector("det_three", [_stub_draft("team/a.md", premise="y")]),
+        _FixedDetector("det_four", [_stub_draft("team/a.md", premise="z")]),
+    ]
+    result = _sweep(monkeypatch, contenders)
+
+    assert result["proposals_emitted"] == 1  # one selected
+    stale = list_by_status(ProposalStatus.STALE)
+    assert len(stale) == 1  # one invalid persisted, then the cap cut off

--- a/backend/tests/test_automanage_selection.py
+++ b/backend/tests/test_automanage_selection.py
@@ -1,0 +1,230 @@
+"""Selection + reconciliation — step 3 of the sweep pipeline.
+
+Pure claim mechanics first (no DB), then runner-level behavior: one live
+proposal per page with stability-first selection, unselected findings
+persisted invalid, pendings that stopped being true invalidated, and the
+post-rejection cooldown in its selection-step home (persisted but
+unselectable; same-premise rejection stays dedup's forever-suppression).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.wiki import git as wiki_git
+from app.wiki.automanage import runner, selection
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import (
+    ProposalOp,
+    ProposalStatus,
+    approve,
+    get,
+    list_by_status,
+    reject,
+)
+from tests._seed import seed_user
+
+# --- pure claim mechanics ----------------------------------------------------
+
+
+def test_claims_conflict_on_equal_paths_case_insensitively():
+    a = selection.claim_of(["docs/Setup.md"])
+    b = selection.claim_of(["docs/setup.md"])
+    assert selection.conflicts(a, b)
+
+
+def test_claims_conflict_subtree_both_directions():
+    folder = selection.claim_of(["team"])
+    page = selection.claim_of(["team/notes/plan.md"])
+    assert selection.conflicts(page, folder)
+    assert selection.conflicts(folder, page)
+
+
+def test_disjoint_claims_pass():
+    a = selection.claim_of(["team/a.md", "guides"])
+    b = selection.claim_of(["docs/b.md", "teammates/c.md"])
+    assert not selection.conflicts(a, b)
+
+
+# --- runner-level: reconciliation + slate -------------------------------------
+
+
+class _FixedDetector:
+    """Emits a fixed draft list — lets tests stage same-page contention and
+    disappearing findings without real detector mechanics."""
+
+    pairs_paths = False
+
+    def __init__(self, name: str, drafts: list[ProposalDraft]) -> None:
+        self.name = name
+        self.drafts = drafts
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        return trigger is TriggerKind.SWEEP
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        return list(self.drafts)
+
+    def validate(self, proposal) -> str | None:
+        return None
+
+
+def _stub_draft(path: str, premise: str | None = None) -> ProposalDraft:
+    return ProposalDraft(
+        op=ProposalOp.DELETE_PAGE,
+        source_paths=[path],
+        summary=f"remove {path}",
+        premise=premise,
+        auto_approvable=False,
+    )
+
+
+@pytest.fixture
+def repo(tmp_repo, tmp_db):
+    wiki_git.commit_file("team/a.md", "# A\n", "seed", author=None)
+    wiki_git.commit_file("team/b.md", "# B\n", "seed", author=None)
+    return tmp_repo
+
+
+def _sweep(monkeypatch, detectors) -> dict:
+    monkeypatch.setattr(runner, "DETECTORS", detectors)
+    return runner.run_sweep(triggered_by_user_id=None)
+
+
+def test_one_live_proposal_per_page(repo, monkeypatch):
+    """Two detectors, same page: registry order wins; the loser is persisted
+    invalid with a not-selected reason — recorded, not lost."""
+    first = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    second = _FixedDetector("det_two", [_stub_draft("team/a.md", premise="x")])
+
+    result = _sweep(monkeypatch, [first, second])
+
+    assert result["proposals_emitted"] == 1
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+    assert pending["detector"] == "det_one"
+    (invalid,) = list_by_status(ProposalStatus.STALE)
+    assert invalid["detector"] == "det_two"
+    assert "not selected" in (invalid["status_reason"] or "")
+
+
+def test_unselected_finding_revives_once_the_page_frees(repo, monkeypatch):
+    first = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    second = _FixedDetector("det_two", [_stub_draft("team/a.md", premise="x")])
+    _sweep(monkeypatch, [first, second])
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+    (invalid,) = list_by_status(ProposalStatus.STALE)
+
+    uid = seed_user(uid="u1", email="u@x.com")
+    assert reject(pending["id"], user_id=uid)  # frees the page
+
+    # det_one gone (its ask was rejected); det_two re-detects.
+    result = _sweep(monkeypatch, [_FixedDetector("det_two", [_stub_draft("team/a.md", premise="x")])])
+    assert result["proposals_emitted"] == 1
+    revived = get(invalid["id"])
+    assert revived is not None and revived["status"] == "pending"
+    assert revived["revive_count"] == 1  # same row came back — no sibling
+
+
+def test_pending_not_redetected_is_invalidated(repo, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+
+    # Next sweep: the finding no longer exists (detector sees nothing).
+    _sweep(monkeypatch, [_FixedDetector("det_one", [])])
+
+    row = get(pending["id"])
+    assert row is not None and row["status"] == "stale"
+    assert "not re-detected" in (row["status_reason"] or "")
+    assert list_by_status(ProposalStatus.PENDING) == []
+
+
+def test_approved_rows_are_untouchable_and_hold_their_claim(repo, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+    uid = seed_user(uid="u1", email="u@x.com")
+    assert approve(pending["id"], user_id=uid)
+
+    # The finding vanished AND a rival wants the page: the approved row is
+    # neither invalidated nor bumped; the rival is persisted invalid.
+    _sweep(monkeypatch, [_FixedDetector("det_two", [_stub_draft("team/a.md", premise="x")])])
+
+    row = get(pending["id"])
+    assert row is not None and row["status"] == "approved"
+    (invalid,) = list_by_status(ProposalStatus.STALE)
+    assert invalid["detector"] == "det_two"
+
+
+def test_carried_pending_outranks_new_contender(repo, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+
+    # Same finding still true; a new detector also wants the page. Even
+    # listed first in the registry, the newcomer must not bump the
+    # already-surfaced ask.
+    rival = _FixedDetector("det_zero", [_stub_draft("team/a.md", premise="x")])
+    result = _sweep(monkeypatch, [rival, det])
+
+    assert result["proposals_emitted"] == 0  # carried isn't re-emitted
+    row = get(pending["id"])
+    assert row is not None and row["status"] == "pending"
+    (invalid,) = list_by_status(ProposalStatus.STALE)
+    assert invalid["detector"] == "det_zero"
+
+
+def test_new_premise_after_rejection_cools_down_then_asks(repo, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+    uid = seed_user(uid="u1", email="u@x.com")
+    assert reject(pending["id"], user_id=uid)
+
+    # Different premise, same detector+op+page, right after the "no":
+    # persisted but unselectable.
+    fresh = _FixedDetector("det_one", [_stub_draft("team/a.md", premise="new")])
+    result = _sweep(monkeypatch, [fresh])
+    assert result["proposals_emitted"] == 0
+    cooled = [
+        r for r in list_by_status(ProposalStatus.STALE)
+        if "cooldown" in (r["status_reason"] or "")
+    ]
+    assert len(cooled) == 1
+
+    # Still inside the window, the next sweep re-detects the cooled row —
+    # it must stay at rest, not slip back in through the revive path.
+    result = _sweep(monkeypatch, [fresh])
+    assert result["proposals_emitted"] == 0
+    still = get(cooled[0]["id"])
+    assert still is not None and still["status"] == "stale"
+
+    # Window elapsed: the same finding revives into the queue.
+    monkeypatch.setattr(selection, "SUBJECT_COOLDOWN_DAYS", 0)
+    result = _sweep(monkeypatch, [fresh])
+    assert result["proposals_emitted"] == 1
+    row = get(cooled[0]["id"])
+    assert row is not None and row["status"] == "pending"
+    assert row["revive_count"] == 1
+
+
+def test_folder_claim_locks_pages_beneath_it(repo, monkeypatch):
+    folder_det = _FixedDetector(
+        "det_folder",
+        [
+            ProposalDraft(
+                op=ProposalOp.DELETE_EMPTY_FOLDER,
+                source_paths=["team"],
+                summary="remove folder team",
+                auto_approvable=False,
+            )
+        ],
+    )
+    page_det = _FixedDetector("det_page", [_stub_draft("team/a.md")])
+
+    result = _sweep(monkeypatch, [folder_det, page_det])
+
+    assert result["proposals_emitted"] == 1
+    (pending,) = list_by_status(ProposalStatus.PENDING)
+    assert pending["detector"] == "det_folder"
+    (invalid,) = list_by_status(ProposalStatus.STALE)
+    assert invalid["detector"] == "det_page"


### PR DESCRIPTION
Completes the pipeline from the **Wiki Auto Management — Dedup** design page: **detect all → dedup (#516) → rank/select a slate of compatible claims, invalidate the rest.** The sweep becomes a reconciliation: after a full run, the pending set is exactly what the sweep would say today.

## `selection.py`
- **Claims**: a proposal's claim is every path it touches — case-folded (case-insensitive filesystems are a hazard we detect, never manufacture) and subtree-aware (a folder claims everything under it, both directions). Selected proposals have **pairwise-disjoint claims**: at most one live proposal per page as the common case, order-independent approval/execution, and the claim is exactly the agentic applier's sandbox — the selection lock and the execution scope-check are one definition read at two times. `conflicts` is pure (values in, bool out).
- **Cooldown, in its rightful home**: a rejection quiets the `dedup_key`'s content-free prefix (`starts_with`; no stored column) for 30 days — a *new* premise on freshly declined pages is **persisted but unselectable** ("in cooldown until …"). Checked for **REVIVE too**: writing the tests exposed that a cooled row is re-detected every sweep and would slip back in through the revive path after one sweep interval — it now stays at rest until the window passes.

## Runner: collect → reconcile → select
- **Collect** every viable candidate (detect + dedup) before persisting anything — slate composition sees the whole picture instead of emitting as-you-go.
- **Reconcile**: pending rows whose finding neither carried nor revived are invalidated ("not re-detected by run X") — a reviewer is never shown an ask the wiki has outgrown. Full sweeps only (a partial scope's silence proves nothing); **approved rows untouchable** (a human decision in flight is the executor's to re-validate).
- **Select, stability-first**: approved + carried claims hold their pages — a surfaced ask is never bumped, so banners don't churn; new findings fill free pages in registry order (safest-first); losers are persisted invalid ("not selected by run X") so the ledger records **every** detected finding and the row is the revival anchor once its page frees.

**No schema changes** — statuses + reasons carry all of it, per the schema-stability audit on #515.

## Tests (10 new)
Pure claim mechanics (case-insensitive equality, subtree both directions, disjoint pass); one-per-page with registry priority; unselected finding revives once the page frees (same row, `revive_count` 1); pending-not-redetected invalidated; approved untouchable + claim held; carried pending outranks a newcomer even when the newcomer runs first; cooldown persisted-then-quiet-then-revives (including the still-in-window sweep that pins the revive-bypass fix); folder claims lock pages beneath. Full automanage slice: 167 passed.