### PR TITLE
feat(automanage): card actions backend — dismiss verb + freshness stamp

### DIFF
--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -188,13 +188,16 @@ def reject_one(
     every touched page — the caller just proved write on all of them."""
     _require_writable(proposal_id, user)
     proposal = get_proposal(proposal_id)
-    if not review.reject(proposal_id, user_id=user.id):
-        raise HTTPException(status_code=409, detail="proposal is not pending")
+    # Markers before the transition: set_policy is idempotent, so if a write
+    # fails mid-way the proposal is still pending and the call is retryable.
+    # The reverse order would strand partial markers behind a 409.
     if req is not None and req.dont_ask_again and proposal is not None:
         for path in list(proposal["source_paths"]) + list(proposal["target_paths"]):
             update_policy.set_policy(
                 path, ai_management_allowed=False, actor_user_id=user.id
             )
+    if not review.reject(proposal_id, user_id=user.id):
+        raise HTTPException(status_code=409, detail="proposal is not pending")
     return ProposalActionResponse(status="rejected")
 
 

--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from app.auth import User, require_can
 from app.auth.deps import require_admin, require_user
 from app.models.automanage import (
+    RejectRequest,
     DetectionRunView,
     DetectionSettingsUpdate,
     DetectionSettingsView,
@@ -23,7 +24,7 @@ from app.models.automanage import (
     SweepTriggerResponse,
 )
 from app.tasks.automanage import run_detection_sweep
-from app.wiki import acl
+from app.wiki import acl, update_policy
 from app.wiki.automanage import review, runs, settings
 from app.wiki.change_proposals import (
     ProposalStatus,
@@ -178,10 +179,33 @@ def approve_one(
 
 @router.post("/proposals/{proposal_id}/reject", response_model=ProposalActionResponse)
 def reject_one(
-    proposal_id: int, user: User = Depends(require_user)
+    proposal_id: int,
+    req: RejectRequest | None = None,
+    user: User = Depends(require_user),
 ) -> ProposalActionResponse:
-    """Reject a pending proposal (durable do-not-propose). 409 if not pending."""
+    """Reject a pending proposal (durable do-not-propose). 409 if not pending.
+    With ``dont_ask_again``, also stamps the do-not-consolidate marker on
+    every touched page — the caller just proved write on all of them."""
     _require_writable(proposal_id, user)
+    proposal = get_proposal(proposal_id)
     if not review.reject(proposal_id, user_id=user.id):
         raise HTTPException(status_code=409, detail="proposal is not pending")
+    if req is not None and req.dont_ask_again and proposal is not None:
+        for path in list(proposal["source_paths"]) + list(proposal["target_paths"]):
+            update_policy.set_policy(
+                path, ai_management_allowed=False, actor_user_id=user.id
+            )
     return ProposalActionResponse(status="rejected")
+
+
+@router.post("/proposals/{proposal_id}/dismiss", response_model=ProposalActionResponse)
+def dismiss_one(
+    proposal_id: int, user: User = Depends(require_user)
+) -> ProposalActionResponse:
+    """Dismiss a pending proposal — clears the card without reject's durable
+    veto; it may return if the finding is still (or again) true at a later
+    sweep. 409 if not pending."""
+    _require_writable(proposal_id, user)
+    if not review.dismiss(proposal_id, user_id=user.id):
+        raise HTTPException(status_code=409, detail="proposal is not pending")
+    return ProposalActionResponse(status="dismissed")

--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -13,7 +13,6 @@ from fastapi import APIRouter, Depends, HTTPException
 from app.auth import User, require_can
 from app.auth.deps import require_admin, require_user
 from app.models.automanage import (
-    RejectRequest,
     DetectionRunView,
     DetectionSettingsUpdate,
     DetectionSettingsView,
@@ -24,7 +23,7 @@ from app.models.automanage import (
     SweepTriggerResponse,
 )
 from app.tasks.automanage import run_detection_sweep
-from app.wiki import acl, update_policy
+from app.wiki import acl
 from app.wiki.automanage import review, runs, settings
 from app.wiki.change_proposals import (
     ProposalStatus,
@@ -179,23 +178,10 @@ def approve_one(
 
 @router.post("/proposals/{proposal_id}/reject", response_model=ProposalActionResponse)
 def reject_one(
-    proposal_id: int,
-    req: RejectRequest | None = None,
-    user: User = Depends(require_user),
+    proposal_id: int, user: User = Depends(require_user)
 ) -> ProposalActionResponse:
-    """Reject a pending proposal (durable do-not-propose). 409 if not pending.
-    With ``dont_ask_again``, also stamps the do-not-consolidate marker on
-    every touched page — the caller just proved write on all of them."""
+    """Reject a pending proposal (durable do-not-propose). 409 if not pending."""
     _require_writable(proposal_id, user)
-    proposal = get_proposal(proposal_id)
-    # Markers before the transition: set_policy is idempotent, so if a write
-    # fails mid-way the proposal is still pending and the call is retryable.
-    # The reverse order would strand partial markers behind a 409.
-    if req is not None and req.dont_ask_again and proposal is not None:
-        for path in list(proposal["source_paths"]) + list(proposal["target_paths"]):
-            update_policy.set_policy(
-                path, ai_management_allowed=False, actor_user_id=user.id
-            )
     if not review.reject(proposal_id, user_id=user.id):
         raise HTTPException(status_code=409, detail="proposal is not pending")
     return ProposalActionResponse(status="rejected")

--- a/backend/app/models/automanage.py
+++ b/backend/app/models/automanage.py
@@ -58,15 +58,27 @@ class ProposalView(BaseModel):
     created_via: str
     run_id: str | None
     created_at: str
+    # When a sweep last asserted this finding against current wiki state —
+    # created/revived/carried all stamp it. Backs the card's freshness line.
+    last_emitted_at: str | None = None
 
 
 class ProposalsResponse(BaseModel):
     proposals: list[ProposalView]
 
 
-class ProposalActionResponse(BaseModel):
-    """Result of approving/rejecting a proposal. On approve, execution is
-    enqueued on the detection queue, so ``status`` reflects the decision, not
-    the applied state."""
+class RejectRequest(BaseModel):
+    """Optional body for reject. ``dont_ask_again`` also sets the
+    do-not-consolidate marker (``ai_management_allowed=False``) on every
+    page the proposal touches, so detectors skip them entirely from now
+    on — the durable, explicit "never ask about these pages"."""
 
-    status: Literal["approved", "rejected"]
+    dont_ask_again: bool = False
+
+
+class ProposalActionResponse(BaseModel):
+    """Result of actioning a proposal. On approve, execution is enqueued on
+    the detection queue, so ``status`` reflects the decision, not the
+    applied state."""
+
+    status: Literal["approved", "rejected", "dismissed"]

--- a/backend/app/models/automanage.py
+++ b/backend/app/models/automanage.py
@@ -67,15 +67,6 @@ class ProposalsResponse(BaseModel):
     proposals: list[ProposalView]
 
 
-class RejectRequest(BaseModel):
-    """Optional body for reject. ``dont_ask_again`` also sets the
-    do-not-consolidate marker (``ai_management_allowed=False``) on every
-    page the proposal touches, so detectors skip them entirely from now
-    on — the durable, explicit "never ask about these pages"."""
-
-    dont_ask_again: bool = False
-
-
 class ProposalActionResponse(BaseModel):
     """Result of actioning a proposal. On approve, execution is enqueued on
     the detection queue, so ``status`` reflects the decision, not the

--- a/backend/app/wiki/automanage/review.py
+++ b/backend/app/wiki/automanage/review.py
@@ -110,6 +110,16 @@ def auto_approve(proposal_id: int, *, acting_user_id: str) -> bool:
     return True
 
 
+def dismiss(proposal_id: int, *, user_id: str) -> bool:
+    """Dismiss a pending proposal — clear the card without reject's durable
+    veto (it may revive if the finding is still/again true at a later
+    sweep). Returns False if it wasn't pending, or if Auto Organize is
+    disabled."""
+    if not settings.is_enabled():
+        return False
+    return change_proposals.dismiss(proposal_id, user_id=user_id)
+
+
 def reject(proposal_id: int, *, user_id: str, reason: str | None = None) -> bool:
     """Reject a pending proposal (durable do-not-propose). No execution.
     Returns False if it wasn't pending, or if Auto Organize is disabled (pending

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -46,6 +46,7 @@ from app.wiki.change_proposals import (
     ProposalStatus,
     list_by_status,
     mark_stale,
+    touch_last_emitted,
 )
 from app.wiki.change_proposals import (
     create as create_proposal,
@@ -227,6 +228,12 @@ def run_detection(
         # pendings visible and admit claims that conflict with omitted
         # rows.
         pending_rows = list_by_status(ProposalStatus.PENDING, limit=None)
+        # Carried pendings were just re-confirmed against current wiki
+        # state — stamp them so the banner's freshness line ("confirmed by
+        # the last scan …") reflects this run, not the original emit.
+        touch_last_emitted(
+            [row["id"] for row in pending_rows if row["id"] in carried_ids]
+        )
         if trigger is TriggerKind.SWEEP:
             revive_ids = {
                 d.existing_id for _, _, d, _ in candidates

--- a/backend/app/wiki/change_proposals.py
+++ b/backend/app/wiki/change_proposals.py
@@ -258,6 +258,10 @@ def revive(
             .values(
                 status=ProposalStatus.PENDING.value,
                 status_reason=None,
+                # A past dismissal's reviewer must not linger: the auto-apply
+                # visibility gate reads reviewed_by IS NULL as "no human saw
+                # this", and a revived finding is a fresh ask.
+                reviewed_by_user_id=None,
                 source_paths=source_paths,
                 target_paths=target_paths,
                 base_shas=base_shas,
@@ -339,6 +343,39 @@ def reject(proposal_id: int, *, user_id: str, reason: str | None = None) -> bool
         reviewed_by_user_id=user_id,
         status_reason=reason,
     )
+
+
+def dismiss(proposal_id: int, *, user_id: str) -> bool:
+    """``pending → stale`` by a human — the middle verb between approve and
+    reject. Machine-invalidation semantics on purpose: no durable veto, so
+    the finding may revive if the situation is still (or again) true at a
+    later sweep. Right for "I fixed this myself, clear it now" and for
+    "not now"."""
+    return _transition(
+        proposal_id,
+        from_statuses=(ProposalStatus.PENDING,),
+        to=ProposalStatus.STALE,
+        reviewed_by_user_id=user_id,
+        status_reason="dismissed by reviewer",
+    )
+
+
+def touch_last_emitted(proposal_ids: list[int]) -> None:
+    """Stamp ``last_emitted_at`` on carried pending rows — the sweep just
+    re-confirmed these findings against current wiki state, and the banner's
+    freshness line ("confirmed by the last scan …") must reflect that, not
+    the original emit time."""
+    if not proposal_ids:
+        return
+    with session() as s:
+        s.execute(
+            update(ChangeProposal)
+            .where(
+                ChangeProposal.id.in_(proposal_ids),
+                ChangeProposal.status == ProposalStatus.PENDING.value,
+            )
+            .values(last_emitted_at=_now())
+        )
 
 
 def mark_applied(proposal_id: int, *, applied_sha: str) -> bool:

--- a/backend/tests/test_automanage_card_actions.py
+++ b/backend/tests/test_automanage_card_actions.py
@@ -1,8 +1,8 @@
 """The card's human verbs and freshness stamp (backend).
 
 Verb ladder: approve (do it) · dismiss (clear the card, machine-invalidation
-semantics — revivable while the finding stays true) · reject (never again;
-optionally also stamps the do-not-consolidate marker). Freshness: carried
+semantics — revivable while the finding stays true) · reject (never again,
+content-scoped). Freshness: carried
 pendings get `last_emitted_at` re-stamped each sweep, so the banner's
 "confirmed by the last scan" line reflects the run that just re-verified
 the finding, not the original emit.
@@ -14,7 +14,6 @@ from fastapi.testclient import TestClient
 
 from app.main import create_app
 from app.wiki import git as wiki_git
-from app.wiki import update_policy
 from app.wiki.automanage import runner
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import (
@@ -118,41 +117,6 @@ def test_revival_clears_the_dismissers_mark(client, monkeypatch):
     revived = get(row["id"])
     assert revived is not None
     assert revived["reviewed_by_user_id"] is None
-
-
-def test_reject_with_dont_ask_again_stamps_the_marker(client, monkeypatch):
-    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
-    _sweep(monkeypatch, [det])
-    row = _pending_one()
-    uid = seed_user(uid="u1", email="u@x.com")
-    login_fastapi(client, uid)
-
-    resp = client.post(
-        f"/api/automanage/proposals/{row['id']}/reject",
-        json={"dont_ask_again": True},
-    )
-    assert resp.status_code == 200
-
-    # Assert the EXPLICIT row, not the resolved view — resolution fills
-    # defaults, so a resolved False wouldn't prove the marker was stamped.
-    explicit = update_policy.get("team/a.md")
-    assert explicit is not None and explicit["ai_management_allowed"] is False
-
-    # The marker keeps even *new* findings on that page from emitting.
-    result = _sweep(monkeypatch, [det])
-    assert result["proposals_emitted"] == 0
-    assert len(list_by_status(ProposalStatus.PENDING)) == 0
-
-
-def test_plain_reject_stamps_no_marker(client, monkeypatch):
-    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
-    _sweep(monkeypatch, [det])
-    row = _pending_one()
-    uid = seed_user(uid="u1", email="u@x.com")
-    login_fastapi(client, uid)
-    assert client.post(f"/api/automanage/proposals/{row['id']}/reject").status_code == 200
-    explicit = update_policy.get("team/a.md")
-    assert explicit is None or explicit["ai_management_allowed"] is None
 
 
 def test_carried_pending_gets_freshness_restamped(client, monkeypatch):

--- a/backend/tests/test_automanage_card_actions.py
+++ b/backend/tests/test_automanage_card_actions.py
@@ -1,0 +1,194 @@
+"""The card's human verbs and freshness stamp (backend).
+
+Verb ladder: approve (do it) · dismiss (clear the card, machine-invalidation
+semantics — revivable while the finding stays true) · reject (never again;
+optionally also stamps the do-not-consolidate marker). Freshness: carried
+pendings get `last_emitted_at` re-stamped each sweep, so the banner's
+"confirmed by the last scan" line reflects the run that just re-verified
+the finding, not the original emit.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import git as wiki_git
+from app.wiki import update_policy
+from app.wiki.automanage import runner
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import (
+    ProposalOp,
+    ProposalStatus,
+    get,
+    list_by_status,
+)
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+class _FixedDetector:
+    pairs_paths = False
+
+    def __init__(self, name: str, drafts: list[ProposalDraft]) -> None:
+        self.name = name
+        self.drafts = drafts
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        return trigger is TriggerKind.SWEEP
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        return list(self.drafts)
+
+    def validate(self, proposal) -> str | None:
+        return None
+
+
+def _stub_draft(path: str) -> ProposalDraft:
+    return ProposalDraft(
+        op=ProposalOp.DELETE_PAGE,
+        source_paths=[path],
+        summary=f"remove {path}",
+        auto_approvable=False,
+    )
+
+
+@pytest.fixture
+def client(tmp_db, tmp_repo):
+    wiki_git.commit_file("team/a.md", "# A\n", "seed", author=None)
+    return TestClient(create_app())
+
+
+def _sweep(monkeypatch, detectors) -> dict:
+    monkeypatch.setattr(runner, "DETECTORS", detectors)
+    return runner.run_sweep(triggered_by_user_id=None)
+
+
+def _pending_one() -> dict:
+    (row,) = list_by_status(ProposalStatus.PENDING)
+    return row
+
+
+def test_dismiss_clears_without_veto_and_revives_while_true(client, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    row = _pending_one()
+
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+    resp = client.post(f"/api/automanage/proposals/{row['id']}/dismiss")
+    assert resp.status_code == 200 and resp.json()["status"] == "dismissed"
+
+    dismissed = get(row["id"])
+    assert dismissed is not None
+    assert dismissed["status"] == "stale"
+    assert "dismissed" in (dismissed["status_reason"] or "")
+
+    # Machine-invalidation semantics: the finding is still true, so the
+    # next sweep revives the same row — no snooze in v1 (dial open).
+    _sweep(monkeypatch, [det])
+    revived = get(row["id"])
+    assert revived is not None and revived["status"] == "pending"
+    assert revived["revive_count"] == 1
+
+
+def test_dismiss_is_pending_only(client, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    row = _pending_one()
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+    assert client.post(f"/api/automanage/proposals/{row['id']}/dismiss").status_code == 200
+    # Second dismiss: no longer pending.
+    assert client.post(f"/api/automanage/proposals/{row['id']}/dismiss").status_code == 409
+
+
+def test_revival_clears_the_dismissers_mark(client, monkeypatch):
+    """A revived finding is a fresh ask: the past dismissal's reviewer must
+    not linger on the row (the auto-apply visibility gate reads
+    reviewed_by IS NULL as 'no human decision')."""
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    row = _pending_one()
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+    client.post(f"/api/automanage/proposals/{row['id']}/dismiss")
+
+    _sweep(monkeypatch, [det])
+    revived = get(row["id"])
+    assert revived is not None
+    assert revived["reviewed_by_user_id"] is None
+
+
+def test_reject_with_dont_ask_again_stamps_the_marker(client, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    row = _pending_one()
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+
+    resp = client.post(
+        f"/api/automanage/proposals/{row['id']}/reject",
+        json={"dont_ask_again": True},
+    )
+    assert resp.status_code == 200
+
+    # Assert the EXPLICIT row, not the resolved view — resolution fills
+    # defaults, so a resolved False wouldn't prove the marker was stamped.
+    explicit = update_policy.get("team/a.md")
+    assert explicit is not None and explicit["ai_management_allowed"] is False
+
+    # The marker keeps even *new* findings on that page from emitting.
+    result = _sweep(monkeypatch, [det])
+    assert result["proposals_emitted"] == 0
+    assert len(list_by_status(ProposalStatus.PENDING)) == 0
+
+
+def test_plain_reject_stamps_no_marker(client, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    row = _pending_one()
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+    assert client.post(f"/api/automanage/proposals/{row['id']}/reject").status_code == 200
+    explicit = update_policy.get("team/a.md")
+    assert explicit is None or explicit["ai_management_allowed"] is None
+
+
+def test_carried_pending_gets_freshness_restamped(client, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    row = _pending_one()
+    first_stamp = row["last_emitted_at"]
+    assert first_stamp is not None
+
+    # Make the stamp visibly old, then re-sweep: the carry must re-stamp.
+    from sqlalchemy import update as sa_update
+
+    from app.db.models import ChangeProposal
+    from app.db.session import session
+
+    with session() as s:
+        s.execute(
+            sa_update(ChangeProposal)
+            .where(ChangeProposal.id == row["id"])
+            .values(last_emitted_at="2026-01-01 00:00:00")
+        )
+
+    _sweep(monkeypatch, [det])
+    carried = get(row["id"])
+    assert carried is not None
+    assert carried["status"] == "pending"
+    assert carried["last_emitted_at"] != "2026-01-01 00:00:00"  # re-stamped
+
+
+def test_last_emitted_at_is_exposed_to_the_banner(client, monkeypatch):
+    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
+    _sweep(monkeypatch, [det])
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+
+    resp = client.get("/api/automanage/proposals", params={"path": "team/a.md"})
+    assert resp.status_code == 200
+    (view,) = resp.json()["proposals"]
+    assert view["last_emitted_at"] is not None


### PR DESCRIPTION
Backend for the banner card's final shape, per the pull-only / banner-only design decisions (see the **Wiki Auto Management — Dedup** page). Frontend (buttons + freshness line) stacks next.

## The verb ladder
- **`POST /proposals/{id}/dismiss`** — the missing middle verb (approve / dismiss / reject): `pending → stale` "dismissed by reviewer", **machine-invalidation semantics** — no durable veto, so the finding revives if still (or again) true at a later sweep. Right for "I fixed it myself, clear it now" and "not now". Same writable-envelope gate as approve/reject. Revival now also clears `reviewed_by` — a past dismissal must not read as a human decision on the fresh ask (the auto-apply visibility gate keys on it).

## Freshness ("confirmed by the last scan …")
Transparency over validation: instead of validating proposals at read time (which would eventually tempt LLM calls — now banned by contract), the card shows *when the finding was last verified*. Mechanics: the sweep re-stamps `last_emitted_at` on **carried** pending rows (previously only create/revive stamped it), so the field genuinely means "last asserted against current wiki state"; exposed on `ProposalView`.

Deferred by design (both purely additive later): a `dont_ask_again` flag on reject (page-scoped durable opt-out — the `ai_management_allowed` policy field already exists and is untouched), and a snooze window on dismiss (v1: a still-true dismissed finding returns on the next sweep).

5 tests (dismiss lifecycle incl. revival + reviewer clearing, pending-only guard, carry re-stamps freshness, field exposed to the banner). Automanage slice: 71 passed; ruff + basedpyright clean.