### PR TITLE
feat(automanage): frontend card — dismiss, batch actions, freshness line

### DIFF
--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -106,7 +106,7 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
               justifyContent="between"
               width="full"
             >
-              <div>
+              <Section flexDirection="row" alignItems="center">
                 {user?.is_admin && (
                   <Button
                     icon={SvgSettings}
@@ -116,7 +116,7 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
                     onClick={() => router.push("/admin/auto-organize")}
                   />
                 )}
-              </div>
+              </Section>
               <Section flexDirection="row" gap={0.5} alignItems="center">
                 <Button
                   icon={SvgSlash}

--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -31,6 +31,12 @@ interface Props {
    * viewers — the server write-scopes the list regardless, so this is an
    * optimization, not the authority. Defaults to true (always fetch). */
   canWrite?: boolean;
+  /** How the floating card pins to the top-right of the content area.
+   * `"sticky"` (default) suits a mount at the top of a scrolling container
+   * (folder view). `"absolute"` suits a mount inside a `relative` doc area
+   * whose scrolling happens in a nested element (FileView — sticky there
+   * would sit at the mount's natural flow position instead of the top). */
+  pin?: "sticky" | "absolute";
 }
 
 type RowAction = "approve" | "reject" | "dismiss";
@@ -62,7 +68,11 @@ function scanAge(ts: string | null): string | null {
  * editor gutter) and falls back to 0 where the container's own padding
  * already insets the content (folder view).
  */
-export function Path2ReviewBanner({ path, canWrite = true }: Props) {
+export function Path2ReviewBanner({
+  path,
+  canWrite = true,
+  pin = "sticky",
+}: Props) {
   const { proposals, refresh } = useProposalsByPath(path, canWrite);
   const { user } = useAuth();
   const router = useRouter();
@@ -89,7 +99,11 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
   }
 
   return (
-    <div className="pointer-events-none sticky top-0 z-30 h-0">
+    <div
+      className={`pointer-events-none z-30 ${
+        pin === "absolute" ? "absolute inset-x-0 top-0" : "sticky top-0 h-0"
+      }`}
+    >
       <div className="pointer-events-auto mr-[var(--cm-gutter,0px)] ml-auto w-[400px] max-w-full rounded-(--radius-12) bg-(--background-01) shadow-(--shadow-modal)">
         <MessageCard
           variant="info"

--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -55,6 +55,12 @@ function scanAge(ts: string | null): string | null {
  * Verbs: approve (do it) · dismiss (clear the card — may return if the finding
  * is still detected) · reject (durable — won't be suggested again). The X only
  * closes the card for this visit; the proposals persist.
+ *
+ * Placement: a floating card pinned to the top-right of the content column
+ * (sticky inside the scroll container, zero layout height). The right inset
+ * follows `--cm-gutter` when the mount's container defines it (FileView's
+ * editor gutter) and falls back to 0 where the container's own padding
+ * already insets the content (folder view).
  */
 export function Path2ReviewBanner({ path, canWrite = true }: Props) {
   const { proposals, refresh } = useProposalsByPath(path, canWrite);
@@ -83,63 +89,65 @@ export function Path2ReviewBanner({ path, canWrite = true }: Props) {
   }
 
   return (
-    <div className="mb-3">
-      <MessageCard
-        variant="info"
-        title={`Auto Organize suggests ${n} change${n === 1 ? "" : "s"} here`}
-        description={age ? `Confirmed by the last scan · ${age}` : undefined}
-        onClose={() => setClosed(true)}
-        bottomChildren={
-          <Section flexDirection="column" gap={0.25} width="full">
-            {proposals.map((p) => (
-              <ProposalRow
-                key={p.id}
-                proposal={p}
-                onActioned={refresh}
-                actions={rowActions.current}
-              />
-            ))}
-            <Section
-              flexDirection="row"
-              gap={0.5}
-              alignItems="center"
-              justifyContent="between"
-              width="full"
-            >
-              <Section flexDirection="row" alignItems="center">
-                {user?.is_admin && (
+    <div className="pointer-events-none sticky top-0 z-30 h-0">
+      <div className="pointer-events-auto mr-[var(--cm-gutter,0px)] ml-auto w-[400px] max-w-full rounded-(--radius-12) bg-(--background-01) shadow-(--shadow-modal)">
+        <MessageCard
+          variant="info"
+          title={`Auto Organize suggests ${n} change${n === 1 ? "" : "s"} here`}
+          description={age ? `Confirmed by the last scan · ${age}` : undefined}
+          onClose={() => setClosed(true)}
+          bottomChildren={
+            <Section flexDirection="column" gap={0.25} width="full">
+              {proposals.map((p) => (
+                <ProposalRow
+                  key={p.id}
+                  proposal={p}
+                  onActioned={refresh}
+                  actions={rowActions.current}
+                />
+              ))}
+              <Section
+                flexDirection="row"
+                gap={0.5}
+                alignItems="center"
+                justifyContent="between"
+                width="full"
+              >
+                <Section flexDirection="row" alignItems="center">
+                  {user?.is_admin && (
+                    <Button
+                      icon={SvgSettings}
+                      size="sm"
+                      prominence="tertiary"
+                      tooltip="Auto Organize settings"
+                      onClick={() => router.push("/admin/auto-organize")}
+                    />
+                  )}
+                </Section>
+                <Section flexDirection="row" gap={0.5} alignItems="center">
                   <Button
-                    icon={SvgSettings}
+                    icon={SvgSlash}
                     size="sm"
-                    prominence="tertiary"
-                    tooltip="Auto Organize settings"
-                    onClick={() => router.push("/admin/auto-organize")}
-                  />
-                )}
-              </Section>
-              <Section flexDirection="row" gap={0.5} alignItems="center">
-                <Button
-                  icon={SvgSlash}
-                  size="sm"
-                  prominence="secondary"
-                  tooltip="Clear these suggestions — they may return if still detected"
-                  onClick={() => actAll("dismiss")}
-                >
-                  Dismiss all
-                </Button>
-                <Button
-                  icon={SvgCheckAll}
-                  size="sm"
-                  prominence="primary"
-                  onClick={() => actAll("approve")}
-                >
-                  Approve all
-                </Button>
+                    prominence="secondary"
+                    tooltip="Clear these suggestions — they may return if still detected"
+                    onClick={() => actAll("dismiss")}
+                  >
+                    Dismiss all
+                  </Button>
+                  <Button
+                    icon={SvgCheckAll}
+                    size="sm"
+                    prominence="primary"
+                    onClick={() => actAll("approve")}
+                  >
+                    Approve all
+                  </Button>
+                </Section>
               </Section>
             </Section>
-          </Section>
-        }
-      />
+          }
+        />
+      </div>
     </div>
   );
 }
@@ -286,7 +294,11 @@ function ProposalRow({
       titleMaxLines={2}
       auxIcon={outcome === "error" ? "error" : undefined}
       description={
-        outcome === "error" ? (error ?? undefined) : operationDetail(proposal)
+        outcome === "error"
+          ? (error ?? undefined)
+          : // Every row names its location, like the mock's path chip — ops
+            // with a target get the full spelled-out operation instead.
+            (operationDetail(proposal) ?? proposal.source_paths[0])
       }
       rightChildren={
         TERMINAL.includes(outcome) ? (

--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -1,14 +1,24 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 import { Button, MessageCard, Text } from "@onyx-ai/opal/components";
+import {
+  SvgCheckAll,
+  SvgCheckCircle,
+  SvgSettings,
+  SvgSlash,
+} from "@onyx-ai/opal/icons";
 import { ContentAction, Section } from "@onyx-ai/opal/layouts";
+import { timeAgo } from "@onyx-ai/opal/time";
 
 import { ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
 import {
   type Proposal,
   approveProposal,
+  dismissProposal,
   fetchProposal,
   rejectProposal,
   useProposalsByPath,
@@ -23,30 +33,110 @@ interface Props {
   canWrite?: boolean;
 }
 
+type RowAction = "approve" | "reject" | "dismiss";
+
+/** UTC second-granular DB text ("YYYY-MM-DD HH:MM:SS") → relative age. */
+function scanAge(ts: string | null): string | null {
+  if (!ts) return null;
+  return timeAgo(ts.replace(" ", "T") + "Z");
+}
+
 /**
  * Path-2 review banner: surfaces the pending Auto Organize cleanup proposals
- * touching this page/folder to users who can act on them, with per-proposal
- * approve/reject. The list is write-scoped server-side (a read-only viewer gets
- * nothing), so we simply render nothing when it's empty. Execution is async, so
- * after an approve we poll the proposal to report the applied / went-stale
- * outcome rather than leaving it as a silent fire-and-forget.
+ * touching this page/folder to users who can act on them. A page carries at
+ * most one live proposal (sweep selection guarantees it); a folder aggregates
+ * its subtree, and the live set is pairwise-disjoint on claims, so the batch
+ * buttons can loop the rows in any order. The list is write-scoped server-side
+ * (a read-only viewer gets nothing), so we simply render nothing when it's
+ * empty. Execution is async, so after an approve we poll the proposal to
+ * report the applied / went-stale outcome rather than leaving it as a silent
+ * fire-and-forget.
+ *
+ * Verbs: approve (do it) · dismiss (clear the card — may return if the finding
+ * is still detected) · reject (durable — won't be suggested again). The X only
+ * closes the card for this visit; the proposals persist.
  */
 export function Path2ReviewBanner({ path, canWrite = true }: Props) {
   const { proposals, refresh } = useProposalsByPath(path, canWrite);
-  if (proposals.length === 0) return null;
+  const { user } = useAuth();
+  const router = useRouter();
+  const [closed, setClosed] = useState(false);
+  // Rows register their action dispatcher here so the footer's batch buttons
+  // can drive them without lifting each row's outcome state machine up.
+  const rowActions = useRef(new Map<number, (kind: RowAction) => void>());
+
+  if (closed || proposals.length === 0) return null;
 
   const n = proposals.length;
+  // Every sweep re-stamps carried pendings, so the newest stamp is "the last
+  // scan that confirmed these findings against current wiki state".
+  const newest = proposals.reduce<string | null>(
+    (acc, p) =>
+      (p.last_emitted_at ?? "") > (acc ?? "") ? p.last_emitted_at : acc,
+    null,
+  );
+  const age = scanAge(newest);
+
+  function actAll(kind: "approve" | "dismiss") {
+    // Rows that have already been actioned ignore the call (act() guards).
+    for (const act of rowActions.current.values()) act(kind);
+  }
+
   return (
     <div className="mb-3">
       <MessageCard
         variant="info"
-        title={`Auto Organize suggests ${n} cleanup${n === 1 ? "" : "s"} here`}
-        description="Approve a change to apply it, or reject to dismiss it (rejection is durable — it won't be suggested again)."
+        title={`Auto Organize suggests ${n} change${n === 1 ? "" : "s"} here`}
+        description={age ? `Confirmed by the last scan · ${age}` : undefined}
+        onClose={() => setClosed(true)}
         bottomChildren={
           <Section flexDirection="column" gap={0.25} width="full">
             {proposals.map((p) => (
-              <ProposalRow key={p.id} proposal={p} onActioned={refresh} />
+              <ProposalRow
+                key={p.id}
+                proposal={p}
+                onActioned={refresh}
+                actions={rowActions.current}
+              />
             ))}
+            <Section
+              flexDirection="row"
+              gap={0.5}
+              alignItems="center"
+              justifyContent="between"
+              width="full"
+            >
+              <div>
+                {user?.is_admin && (
+                  <Button
+                    icon={SvgSettings}
+                    size="sm"
+                    prominence="tertiary"
+                    tooltip="Auto Organize settings"
+                    onClick={() => router.push("/admin/auto-organize")}
+                  />
+                )}
+              </div>
+              <Section flexDirection="row" gap={0.5} alignItems="center">
+                <Button
+                  icon={SvgSlash}
+                  size="sm"
+                  prominence="secondary"
+                  tooltip="Clear these suggestions — they may return if still detected"
+                  onClick={() => actAll("dismiss")}
+                >
+                  Dismiss all
+                </Button>
+                <Button
+                  icon={SvgCheckAll}
+                  size="sm"
+                  prominence="primary"
+                  onClick={() => actAll("approve")}
+                >
+                  Approve all
+                </Button>
+              </Section>
+            </Section>
           </Section>
         }
       />
@@ -59,15 +149,23 @@ type Outcome =
   | "working"
   | "applied"
   | "rejected"
+  | "dismissed"
   | "stale"
   | "applying"
   | "error";
 
-const TERMINAL: Outcome[] = ["applied", "rejected", "stale", "applying"];
+const TERMINAL: Outcome[] = [
+  "applied",
+  "rejected",
+  "dismissed",
+  "stale",
+  "applying",
+];
 
 const STATUS_LABEL: Record<string, string> = {
   applied: "Applied ✓",
   rejected: "Rejected",
+  dismissed: "Dismissed",
   stale: "Skipped — the page changed since this was proposed",
   applying: "Applying…",
 };
@@ -97,9 +195,12 @@ function operationDetail(p: Proposal): string | undefined {
 function ProposalRow({
   proposal,
   onActioned,
+  actions,
 }: {
   proposal: Proposal;
   onActioned: () => void;
+  /** Shared registry the footer's batch buttons dispatch through. */
+  actions: Map<number, (kind: RowAction) => void>;
 }) {
   const [outcome, setOutcome] = useState<Outcome>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -113,7 +214,8 @@ function ProposalRow({
     if (
       outcome !== "applied" &&
       outcome !== "stale" &&
-      outcome !== "rejected"
+      outcome !== "rejected" &&
+      outcome !== "dismissed"
     ) {
       return;
     }
@@ -145,16 +247,20 @@ function ProposalRow({
     if (alive.current) onActioned(); // didn't settle in-window → refresh the list
   }
 
-  async function act(kind: "approve" | "reject") {
+  async function act(kind: RowAction) {
+    if (outcome !== "idle" && outcome !== "error") return; // already actioned
     setOutcome("working");
     setError(null);
     try {
       if (kind === "approve") {
         await approveProposal(proposal.id);
         if (alive.current) await pollApplied();
-      } else {
+      } else if (kind === "reject") {
         await rejectProposal(proposal.id);
         if (alive.current) setOutcome("rejected");
+      } else {
+        await dismissProposal(proposal.id);
+        if (alive.current) setOutcome("dismissed");
       }
     } catch (e) {
       if (!alive.current) return;
@@ -164,6 +270,13 @@ function ProposalRow({
       setError(e instanceof Error ? e.message : "failed");
     }
   }
+
+  // Keep the registry pointing at this render's `act` (it closes over
+  // `outcome`); drop the entry when the row unmounts.
+  useEffect(() => {
+    actions.set(proposal.id, (kind) => void act(kind));
+    return () => void actions.delete(proposal.id);
+  });
 
   return (
     <ContentAction
@@ -184,23 +297,23 @@ function ProposalRow({
             {STATUS_LABEL[outcome]}
           </Text>
         ) : (
-          <Section flexDirection="row" gap={0.5} alignItems="center">
+          <Section flexDirection="row" gap={0.25} alignItems="center">
             <Button
+              icon={SvgSlash}
               size="sm"
-              prominence="secondary"
+              prominence="tertiary"
               disabled={outcome === "working"}
+              tooltip="Reject — won't be suggested again"
               onClick={() => void act("reject")}
-            >
-              Reject
-            </Button>
+            />
             <Button
+              icon={SvgCheckCircle}
               size="sm"
-              prominence="primary"
+              prominence="tertiary"
               disabled={outcome === "working"}
+              tooltip="Approve — applies this change"
               onClick={() => void act("approve")}
-            >
-              {outcome === "working" ? "…" : "Approve"}
-            </Button>
+            />
           </Section>
         )
       }

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -91,6 +91,10 @@ export interface Proposal {
   created_via: string;
   run_id: string | null;
   created_at: string;
+  /** When a sweep last asserted this finding against current wiki state —
+   * every sweep re-stamps carried pendings, so this reads as "confirmed by
+   * the last scan". UTC DB text ("YYYY-MM-DD HH:MM:SS"). */
+  last_emitted_at: string | null;
 }
 
 /** Pending proposals touching `path` (a page or folder subtree) that the caller
@@ -133,6 +137,15 @@ export function approveProposal(id: number) {
 /** Reject a pending proposal — a durable "don't propose this again". */
 export function rejectProposal(id: number) {
   return apiFetch<{ status: string }>(`/automanage/proposals/${id}/reject`, {
+    method: "POST",
+  });
+}
+
+/** Dismiss a pending proposal — clears the card without reject's durable
+ * veto; it may return if the finding is still (or again) true at a later
+ * sweep. Rejects with `ApiError` (409 if it's no longer pending). */
+export function dismissProposal(id: number) {
+  return apiFetch<{ status: string }>(`/automanage/proposals/${id}/dismiss`, {
     method: "POST",
   });
 }

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1235,6 +1235,10 @@ export function FileView({ path }: FileViewProps) {
                     : "-mx-8 [--cm-gutter:2rem]"
                 }`}
               >
+                {/* Floating top-right of the content area (not the text
+                    column) — it positions itself; `--cm-gutter` above sets
+                    its right inset. */}
+                <Path2ReviewBanner path={path} canWrite={canWrite} />
                 <div
                   className={`rail-inset mx-auto flex w-full max-w-[768px] min-w-0 shrink-0 flex-col gap-3 empty:hidden ${
                     isMobile ? "px-3" : ""
@@ -1244,7 +1248,6 @@ export function FileView({ path }: FileViewProps) {
                     path={path}
                     onOpenPolicy={() => openPanel("updates")}
                   />
-                  <Path2ReviewBanner path={path} canWrite={canWrite} />
                   {(() => {
                     // Cards visible while the body is still "empty enough"
                     // to discard without losing user work: truly blank, or

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1236,9 +1236,14 @@ export function FileView({ path }: FileViewProps) {
                 }`}
               >
                 {/* Floating top-right of the content area (not the text
-                    column) — it positions itself; `--cm-gutter` above sets
-                    its right inset. */}
-                <Path2ReviewBanner path={path} canWrite={canWrite} />
+                    column) — absolute against the doc row's `relative` (the
+                    editor scrolls internally, so sticky would never pin);
+                    `--cm-gutter` above sets its right inset. */}
+                <Path2ReviewBanner
+                  path={path}
+                  canWrite={canWrite}
+                  pin="absolute"
+                />
                 <div
                   className={`rail-inset mx-auto flex w-full max-w-[768px] min-w-0 shrink-0 flex-col gap-3 empty:hidden ${
                     isMobile ? "px-3" : ""


### PR DESCRIPTION
Frontend for the card verbs shipped in #521, styled toward the new card mock.

## What changed on the banner
- **Per-row icon verbs** — reject (⊘, durable: won't be suggested again) and approve (✓), replacing the text buttons; the async-apply outcome polling ("Applying… → Applied ✓ / went stale") is unchanged.
- **Footer batch actions** — **Dismiss all** (the soft clear: dismissed findings go stale and may return if still detected) and **Approve all**. The batch buttons dispatch through a registry the rows register in, so each row keeps its own outcome state machine and already-actioned rows ignore the call. Safe as a dumb loop in any order because the live slate is pairwise-disjoint on claims — no approval can invalidate a sibling mid-batch.
- **Freshness line** — "Confirmed by the last scan · 2h ago" from the newest `last_emitted_at` (every sweep re-stamps carried pendings, so this is the last time a scan asserted these findings against current wiki state).
- **X close** — closes the card for this visit only (client state); proposals persist and the card returns on the next visit.
- **Admin gear** — links to `/admin/auto-organize`, rendered only for admins.

Per-page vs per-folder: unchanged mount points — a page shows its (at most one, by sweep selection) proposal; a folder aggregates its subtree.

`bun run typecheck` + prettier clean.