### PR TITLE
feat(wiki): page instructions polish and folder side panel with Auto-Organize suggestions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -460,3 +460,18 @@ body {
   font-size: 14px;
   line-height: 20px;
 }
+
+/* Suggestions-card row highlight (mock annotation "Click to highlight
+   folder"): a brief tint flash on the targeted listing row. */
+.wiki-row-flash {
+  animation: wiki-row-flash 2s ease-out;
+}
+@keyframes wiki-row-flash {
+  0%,
+  60% {
+    background-color: var(--background-tint-03);
+  }
+  100% {
+    background-color: transparent;
+  }
+}

--- a/frontend/src/components/wiki/DocPanel.tsx
+++ b/frontend/src/components/wiki/DocPanel.tsx
@@ -17,15 +17,14 @@ const tabIndex = (tab: DocPanelTab) => TABS.findIndex((t) => t.value === tab);
 interface DocPanelProps {
   tab: DocPanelTab;
   onTabChange: (tab: DocPanelTab) => void;
-  /** Which tabs the strip offers, in TABS order. Folder pages show a
-   * subset (Updates | Watching, mock 2240:59533); omit for all four. */
+  /** Which tabs the strip offers, in TABS order. Omit for all four. */
   tabs?: DocPanelTab[];
   /** Active tab's surface. The page renders it so cross-tab state (comment
    * threads, trigger status) lives above the panel and survives tab moves. */
   children: ReactNode;
 }
 
-/** The doc page's right-rail panel (mock 1790:52200): an Updates | Comments |
+/** The right-rail panel (mock 1790:52200): an Updates | Comments |
  * Sources | Watching tab strip over the active surface. The rail holds one
  * occupant at a time, so the tabbed surfaces render inside this panel
  * rather than as their own rail columns. */

--- a/frontend/src/components/wiki/DocPanel.tsx
+++ b/frontend/src/components/wiki/DocPanel.tsx
@@ -17,6 +17,9 @@ const tabIndex = (tab: DocPanelTab) => TABS.findIndex((t) => t.value === tab);
 interface DocPanelProps {
   tab: DocPanelTab;
   onTabChange: (tab: DocPanelTab) => void;
+  /** Which tabs the strip offers, in TABS order. Folder pages show a
+   * subset (Updates | Watching, mock 2240:59533); omit for all four. */
+  tabs?: DocPanelTab[];
   /** Active tab's surface. The page renders it so cross-tab state (comment
    * threads, trigger status) lives above the panel and survives tab moves. */
   children: ReactNode;
@@ -26,7 +29,8 @@ interface DocPanelProps {
  * Sources | Watching tab strip over the active surface. The rail holds one
  * occupant at a time, so the tabbed surfaces render inside this panel
  * rather than as their own rail columns. */
-export function DocPanel({ tab, onTabChange, children }: DocPanelProps) {
+export function DocPanel({ tab, onTabChange, tabs, children }: DocPanelProps) {
+  const shown = tabs ? TABS.filter((t) => tabs.includes(t.value)) : TABS;
   // The incoming surface slides from the side the underline travels toward.
   // Adjust-during-render binds the direction to the committed tree, safe
   // under StrictMode double renders and abandoned concurrent renders.
@@ -49,7 +53,7 @@ export function DocPanel({ tab, onTabChange, children }: DocPanelProps) {
           onValueChange={(v) => onTabChange(v as DocPanelTab)}
         >
           <Tabs.List>
-            {TABS.map((t) => (
+            {shown.map((t) => (
               <Tabs.Trigger key={t.value} value={t.value}>
                 {t.label}
               </Tabs.Trigger>

--- a/frontend/src/components/wiki/Path2ReviewBanner.tsx
+++ b/frontend/src/components/wiki/Path2ReviewBanner.tsx
@@ -104,7 +104,10 @@ function ProposalRow({
   const [outcome, setOutcome] = useState<Outcome>("idle");
   const [error, setError] = useState<string | null>(null);
   const alive = useRef(true);
-  useEffect(() => () => void (alive.current = false), []);
+  useEffect(() => {
+    alive.current = true;
+    return () => void (alive.current = false);
+  }, []);
 
   // Once a row has shown its terminal outcome, briefly leave it up, then refresh
   // the list so it drops out (it has left `pending`). `onActioned` is SWR's

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -514,8 +514,8 @@ function PolicyPopover({
       </Section>
       <Divider />
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        {/* ContentAction over InputHorizontal: only the former forwards
-            descriptionMaxLines (mock annotation: real value, 3 lines). */}
+        {/* ContentAction is the only layout that forwards descriptionMaxLines
+            (mock annotation: real value, 3 lines). */}
         <ContentAction
           icon={SvgAddLines}
           title="Page Instructions"

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -18,7 +18,7 @@ import {
   Tag,
   Text,
 } from "@onyx-ai/opal/components";
-import { InputHorizontal, Section } from "@onyx-ai/opal/layouts";
+import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
 import {
   SvgAddLines,
   SvgArrowUpRight,
@@ -453,13 +453,17 @@ function PolicyPopover({
     }
   };
 
+  // Mock 2079:379824 annotation: clicking the popover body (any field)
+  // opens the full side panel; the switches keep their inline toggles by
+  // stopping the bubble.
   return (
     <Section
       justifyContent="start"
       alignItems="stretch"
       height="fit"
       gap={0.25}
-      className="w-full"
+      className="w-full cursor-pointer"
+      onClick={onOpenUpdatesPanel}
     >
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
         <InputHorizontal
@@ -467,16 +471,18 @@ function PolicyPopover({
           title="AI Auto-Edits"
           description="Let AI update/organize this page on its own."
         >
-          <Switch
-            checked={allowed}
-            // Held until this path's policy loads (toggling against the
-            // null default would persist a wrong override) and while a
-            // save is in flight (a second click would race the PATCH).
-            disabled={!canWrite || !loaded || saving}
-            onCheckedChange={() =>
-              void patchField({ ai_management_allowed: !allowed })
-            }
-          />
+          <span onClick={(e) => e.stopPropagation()}>
+            <Switch
+              checked={allowed}
+              // Held until this path's policy loads (toggling against the
+              // null default would persist a wrong override) and while a
+              // save is in flight (a second click would race the PATCH).
+              disabled={!canWrite || !loaded || saving}
+              onCheckedChange={() =>
+                void patchField({ ai_management_allowed: !allowed })
+              }
+            />
+          </span>
         </InputHorizontal>
         {allowed && (
           <Section
@@ -490,15 +496,17 @@ function PolicyPopover({
               title="Update"
               description="Periodically scan ingested data sources to add relevant new information."
             >
-              <Switch
-                checked={!autoUpdateDisabled}
-                disabled={!canWrite || !loaded || saving}
-                onCheckedChange={() =>
-                  void patchField({
-                    ingestion_auto_update_disabled: !autoUpdateDisabled,
-                  })
-                }
-              />
+              <span onClick={(e) => e.stopPropagation()}>
+                <Switch
+                  checked={!autoUpdateDisabled}
+                  disabled={!canWrite || !loaded || saving}
+                  onCheckedChange={() =>
+                    void patchField({
+                      ingestion_auto_update_disabled: !autoUpdateDisabled,
+                    })
+                  }
+                />
+              </span>
             </InputHorizontal>
             <OrganizeComingSoonRow kind="page" />
           </Section>
@@ -506,21 +514,34 @@ function PolicyPopover({
       </Section>
       <Divider />
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        <InputHorizontal
+        {/* ContentAction over InputHorizontal: only the former forwards
+            descriptionMaxLines (mock annotation: real value, 3 lines). */}
+        <ContentAction
           icon={SvgAddLines}
           title="Page Instructions"
           description={
             loaded?.update_instruction || "How should this page be updated?"
           }
-        >
-          <Button
-            icon={SvgExpand}
-            size="md"
-            prominence="tertiary"
-            tooltip="Open in panel"
-            onClick={onOpenUpdatesPanel}
-          />
-        </InputHorizontal>
+          descriptionMaxLines={3}
+          sizePreset="main-ui"
+          variant="section"
+          width="full"
+          padding="fit"
+          rightChildren={
+            <Button
+              icon={SvgExpand}
+              size="md"
+              prominence="tertiary"
+              tooltip="Open in panel"
+              // stopPropagation: the popover body opens the panel too, and
+              // the bubble would double-fire the handler.
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenUpdatesPanel?.();
+              }}
+            />
+          }
+        />
       </Section>
     </Section>
   );
@@ -760,11 +781,14 @@ export function PresenceAvatars({
       <button
         type="button"
         aria-label="AI auto-edits"
-        aria-expanded={openPanel?.kind === "auto"}
         className="flex cursor-pointer items-center justify-center px-[2px]"
-        onClick={() =>
-          setOpenPanel((p) => (p?.kind === "auto" ? null : { kind: "auto" }))
-        }
+        // Hover previews the popover; click commits to the side panel
+        // (mock annotation: "Clicking on the auto icon or panel will open
+        // in the side panel").
+        onClick={() => {
+          setOpenPanel(null);
+          onOpenUpdatesPanel?.();
+        }}
         onPointerEnter={() => {
           holdOpen();
           setOpenPanel({ kind: "auto" });
@@ -832,7 +856,12 @@ export function PresenceAvatars({
           <PolicyPopover
             path={path}
             canWrite={canWrite}
-            onOpenUpdatesPanel={onOpenUpdatesPanel}
+            // The popover hands off to the side panel in place: same UI,
+            // so it dismisses as the panel opens.
+            onOpenUpdatesPanel={() => {
+              setOpenPanel(null);
+              onOpenUpdatesPanel?.();
+            }}
           />
         </AnchoredPanel>
       )}

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -1,42 +1,28 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   Divider,
   IconContainer,
   LineItemButton,
-  Switch,
   Tag,
   Text,
 } from "@onyx-ai/opal/components";
 import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
 import {
-  SvgAddLines,
   SvgArrowUpRight,
-  SvgExpand,
   SvgOnyxOctagon,
-  SvgSparkle,
   SvgTextLinesSmall,
 } from "@onyx-ai/opal/icons";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { SvgAnthropic, SvgOpenai } from "@onyx-ai/opal/logos";
 
-import { toast } from "@/hooks/useToast";
-import { OrganizeComingSoonRow } from "@/components/wiki/UpdatePolicyPanel";
 import {
-  getUpdatePolicy,
-  patchUpdatePolicy,
-  type EffectivePolicy,
-} from "@/lib/updatePolicy";
+  AnchoredPanel,
+  AutoGlyph,
+  PolicyPopover,
+} from "@/components/wiki/policyPanels";
 import { relativeTime } from "@/lib/users";
 import { fetchFileHistory } from "@/lib/wiki/svc";
 import { useUpdateHealth } from "@/lib/wiki/hooks";
@@ -57,35 +43,6 @@ const USER_COLORS = [
 ];
 
 const MAX_CHIPS = 5;
-
-interface AutoGlyphProps {
-  size?: number;
-}
-
-/** The Auto mark (mock 2079:379954): the octagon outline holding the blue
- * lines glyph, composed from Opal icons since no single asset ships it. */
-function AutoGlyph({ size = 16 }: AutoGlyphProps) {
-  return (
-    <Section
-      gap={0}
-      width="fit"
-      height="fit"
-      className="relative text-(--text-05)"
-    >
-      <SvgOnyxOctagon size={size} />
-      <Section
-        gap={0}
-        width="full"
-        height="full"
-        alignItems="center"
-        justifyContent="center"
-        className="absolute inset-0 text-(--theme-blue-05)"
-      >
-        <SvgTextLinesSmall size={Math.round(size * 0.55)} />
-      </Section>
-    </Section>
-  );
-}
 
 function agentGlyph(name: string | null): IconFunctionComponent | null {
   const key = name?.trim().toLowerCase();
@@ -331,218 +288,6 @@ function PresenceCard({
           })}
         </Section>
       )}
-    </Section>
-  );
-}
-
-interface AnchoredPanelProps {
-  anchor: HTMLElement;
-  onDismiss: () => void;
-  /** Hover panels stay open while the pointer is inside them. */
-  hover?: { onEnter: () => void; onLeave: () => void };
-  children: ReactNode;
-}
-
-/** Anchors a floating panel to the header cluster: fixed-position, right
- * edges aligned, just below the anchor. */
-function AnchoredPanel({
-  anchor,
-  onDismiss,
-  hover,
-  children,
-}: AnchoredPanelProps) {
-  const [rect, setRect] = useState(() => anchor.getBoundingClientRect());
-  useEffect(() => {
-    setRect(anchor.getBoundingClientRect());
-  }, [anchor]);
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (hover) return;
-    const onDown = (e: PointerEvent) => {
-      const el = panelRef.current;
-      if (
-        el &&
-        !el.contains(e.target as Node) &&
-        !anchor.contains(e.target as Node)
-      )
-        onDismiss();
-    };
-    window.addEventListener("pointerdown", onDown, true);
-    return () => window.removeEventListener("pointerdown", onDown, true);
-  }, [anchor, hover, onDismiss]);
-  return createPortal(
-    // raw-ok: Popover.Anchor exists but Popover.Content bakes neutral-00/rounded-12/shadow-md chrome (WithoutStyles, no escape) that the mock's tint-01 policy panel and chromeless floating cards contradict, and this wrapper also needs runtime viewport coordinates
-    <div
-      ref={panelRef}
-      className="fixed z-50 w-(--block-width-panel-medium-small)"
-      style={{ top: rect.bottom + 8, right: window.innerWidth - rect.right }}
-      onPointerEnter={hover?.onEnter}
-      onPointerLeave={hover?.onLeave}
-    >
-      {/* Shared panel chrome (mock 1929:362227 "Policy Panel"; the hover
-          card and overflow panels carry the same surface). */}
-      <Section
-        gap={0}
-        justifyContent="start"
-        alignItems="stretch"
-        height="fit"
-        padding={0.25}
-        className="rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]"
-      >
-        {children}
-      </Section>
-    </div>,
-    document.body,
-  );
-}
-
-interface PolicyPopoverProps {
-  path: string;
-  /** The policy PATCH is write-gated, so read-only viewers get a
-   * disabled switch instead of a doomed request. */
-  canWrite: boolean;
-  onOpenUpdatesPanel?: () => void;
-}
-
-/** The Auto popover (mock 1929:362227 "Policy Panel"): the AI auto-edit
- * toggles and the page's update instruction, all live on the update
- * policy the full panel edits. */
-function PolicyPopover({
-  path,
-  canWrite,
-  onOpenUpdatesPanel,
-}: PolicyPopoverProps) {
-  // The policy carries the path it was fetched for: a mismatch reads as
-  // unloaded in the same render a navigation lands, so a stale page's
-  // value can never be shown or PATCHed against the new path.
-  const [policy, setPolicy] = useState<{
-    forPath: string;
-    effective: EffectivePolicy;
-  } | null>(null);
-  const [saving, setSaving] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    getUpdatePolicy(path)
-      .then(
-        (p) => alive && setPolicy({ forPath: path, effective: p.effective }),
-      )
-      .catch(() => alive && setPolicy(null));
-    return () => {
-      alive = false;
-    };
-  }, [path]);
-  const loaded = policy?.forPath === path ? policy.effective : null;
-
-  const allowed = !!loaded?.ai_management_allowed;
-  const autoUpdateDisabled = !!loaded?.ingestion_auto_update_disabled;
-  const patchField = async (patch: Partial<EffectivePolicy>) => {
-    if (!loaded) return;
-    setSaving(true);
-    setPolicy({ forPath: path, effective: { ...loaded, ...patch } });
-    try {
-      await patchUpdatePolicy(path, patch);
-    } catch (e) {
-      // The pre-patch snapshot is still in `loaded`; putting it back
-      // rolls the optimistic write off.
-      setPolicy({ forPath: path, effective: loaded });
-      toast.error(
-        e instanceof Error ? e.message : "Couldn't update the page's policy",
-      );
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  // Mock 2079:379824 annotation: clicking the popover body (any field)
-  // opens the full side panel; the switches keep their inline toggles by
-  // stopping the bubble.
-  return (
-    <Section
-      justifyContent="start"
-      alignItems="stretch"
-      height="fit"
-      gap={0.25}
-      className="w-full cursor-pointer"
-      onClick={onOpenUpdatesPanel}
-    >
-      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        <InputHorizontal
-          icon={SvgSparkle}
-          title="AI Auto-Edits"
-          description="Let AI update/organize this page on its own."
-        >
-          <span onClick={(e) => e.stopPropagation()}>
-            <Switch
-              checked={allowed}
-              // Held until this path's policy loads (toggling against the
-              // null default would persist a wrong override) and while a
-              // save is in flight (a second click would race the PATCH).
-              disabled={!canWrite || !loaded || saving}
-              onCheckedChange={() =>
-                void patchField({ ai_management_allowed: !allowed })
-              }
-            />
-          </span>
-        </InputHorizontal>
-        {allowed && (
-          <Section
-            justifyContent="start"
-            alignItems="stretch"
-            height="fit"
-            gap={0.5}
-            className="mt-2 ml-6"
-          >
-            <InputHorizontal
-              title="Update"
-              description="Periodically scan ingested data sources to add relevant new information."
-            >
-              <span onClick={(e) => e.stopPropagation()}>
-                <Switch
-                  checked={!autoUpdateDisabled}
-                  disabled={!canWrite || !loaded || saving}
-                  onCheckedChange={() =>
-                    void patchField({
-                      ingestion_auto_update_disabled: !autoUpdateDisabled,
-                    })
-                  }
-                />
-              </span>
-            </InputHorizontal>
-            <OrganizeComingSoonRow kind="page" />
-          </Section>
-        )}
-      </Section>
-      <Divider />
-      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        {/* ContentAction is the only layout that forwards descriptionMaxLines
-            (mock annotation: real value, 3 lines). */}
-        <ContentAction
-          icon={SvgAddLines}
-          title="Page Instructions"
-          description={
-            loaded?.update_instruction || "How should this page be updated?"
-          }
-          descriptionMaxLines={3}
-          sizePreset="main-ui"
-          variant="section"
-          width="full"
-          padding="fit"
-          rightChildren={
-            <Button
-              icon={SvgExpand}
-              size="md"
-              prominence="tertiary"
-              tooltip="Open in panel"
-              // stopPropagation: the popover body opens the panel too, and
-              // the bubble would double-fire the handler.
-              onClick={(e) => {
-                e.stopPropagation();
-                onOpenUpdatesPanel?.();
-              }}
-            />
-          }
-        />
-      </Section>
     </Section>
   );
 }

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -9,7 +9,7 @@ import {
   Tag,
   Text,
 } from "@onyx-ai/opal/components";
-import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
+import { Section } from "@onyx-ai/opal/layouts";
 import {
   SvgArrowUpRight,
   SvgOnyxOctagon,

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+/** Auto-Organize suggestions card (mocks 2236:78296 / 2240:59533): pending
+ * change proposals for a folder subtree with per-row approve/reject, bulk
+ * actions, and the admin shortcut. Acted-on rows stay visible with their
+ * outcome for a few seconds before the list refreshes them away (mock
+ * annotation: leave time for user confirmation). */
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button, Tag, Text } from "@onyx-ai/opal/components";
+import { ContentAction, Section } from "@onyx-ai/opal/layouts";
+import {
+  SvgCheckCircle,
+  SvgExpand,
+  SvgFile,
+  SvgFold,
+  SvgFolder,
+  SvgFolderIn,
+  SvgSettings,
+  SvgStopCircle,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+
+import { ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import {
+  type Proposal,
+  approveProposal,
+  dismissProposal,
+  fetchProposal,
+  rejectProposal,
+  useProposalsByPath,
+} from "@/lib/autoOrganize";
+
+type Outcome =
+  | "working"
+  | "applying"
+  | "applied"
+  | "rejected"
+  | "dismissed"
+  | "stale"
+  | "error";
+
+const HANDLED: Outcome[] = ["applied", "rejected", "dismissed", "stale"];
+
+/** Per-op row glyph; unknown ops fall back to the page icon. */
+const OP_ICON: Record<string, IconFunctionComponent> = {
+  move: SvgFolderIn,
+  rename: SvgFolder,
+  merge: SvgFolderIn,
+  split: SvgFile,
+  create_folder: SvgFolder,
+  delete_empty_folder: SvgFolder,
+  delete_page: SvgFile,
+};
+
+interface SuggestionsCardProps {
+  /** Folder (or page) scope the proposals are listed for. */
+  path: string;
+  /** Skip fetching for viewers; the server write-scopes regardless. */
+  canWrite?: boolean;
+  /** Popover hosting: shows the open-in-side-panel action. */
+  onOpenPanel?: () => void;
+  /** Popover hosting: the header X. Hides the popup only — suggestions
+   * persist and re-show (mock annotation). */
+  onClose?: () => void;
+  /** Row click, with the proposal's source paths (mock: highlight folder). */
+  onHighlight?: (paths: string[]) => void;
+}
+
+export function SuggestionsCard({
+  path,
+  canWrite = true,
+  onOpenPanel,
+  onClose,
+  onHighlight,
+}: SuggestionsCardProps) {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { proposals, refresh } = useProposalsByPath(path, canWrite);
+  const [open, setOpen] = useState(true);
+  const [outcomes, setOutcomes] = useState<Record<number, Outcome>>({});
+  const alive = useRef(true);
+  useEffect(() => () => void (alive.current = false), []);
+
+  const setOutcome = (id: number, o: Outcome) =>
+    alive.current && setOutcomes((prev) => ({ ...prev, [id]: o }));
+
+  // Execution runs async on the automanage worker: show "Applying…" and
+  // poll to a terminal status. Transient failures keep polling; an
+  // unsettled poll falls back to the delayed refresh below.
+  async function pollApplied(id: number) {
+    setOutcome(id, "applying");
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, Math.min(1000 + i * 250, 3000)));
+      if (!alive.current) return;
+      try {
+        const fresh = await fetchProposal(id);
+        if (fresh.status === "applied") return setOutcome(id, "applied");
+        if (fresh.status === "stale") return setOutcome(id, "stale");
+      } catch {
+        // transient failure (or the row was purged) — keep polling
+      }
+    }
+  }
+
+  async function act(id: number, kind: "approve" | "reject" | "dismiss") {
+    setOutcome(id, "working");
+    try {
+      if (kind === "approve") {
+        await approveProposal(id);
+        if (alive.current) void pollApplied(id);
+      } else if (kind === "reject") {
+        await rejectProposal(id);
+        setOutcome(id, "rejected");
+      } else {
+        await dismissProposal(id);
+        setOutcome(id, "dismissed");
+      }
+    } catch (e) {
+      if (!alive.current) return;
+      // 409: someone else already actioned it; the refresh will drop it.
+      if (e instanceof ApiError && e.status === 409)
+        return setOutcome(id, "dismissed");
+      setOutcome(id, "error");
+    }
+  }
+
+  const pendingIds = proposals
+    .filter((p) => {
+      const o = outcomes[p.id];
+      return !o || o === "error";
+    })
+    .map((p) => p.id);
+
+  // Bulk actions hit every not-yet-handled row (mock annotation: "apply to
+  // any that is not already selected"); rows show their outcomes in place.
+  async function actAll(kind: "approve" | "dismiss") {
+    for (const id of pendingIds) await act(id, kind);
+  }
+
+  // Once every row is handled, leave the outcomes visible briefly, then
+  // refresh so the settled rows drop out (they have left `pending`).
+  const allHandled =
+    proposals.length > 0 &&
+    proposals.every((p) => HANDLED.includes(outcomes[p.id] as Outcome));
+  useEffect(() => {
+    if (!allHandled) return;
+    const t = setTimeout(() => {
+      if (alive.current) void refresh();
+    }, 4000);
+    return () => clearTimeout(t);
+  }, [allHandled, refresh]);
+
+  if (proposals.length === 0) return null;
+  const n = proposals.length;
+
+  return (
+    <Section
+      gap={0}
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      padding={0.25}
+      data-suggestions-card
+      className="w-full rounded-(--radius-12) border border-(--status-info-02) bg-(--status-info-01)"
+    >
+      <Section gap={0} height="fit" alignItems="stretch" padding={0.25}>
+        <ContentAction
+          icon={AutoSuggestIcon}
+          title={`AI Auto-Edit suggests ${n} change${n === 1 ? "" : "s"}.`}
+          description="based on your admin auto-organize settings."
+          sizePreset="main-ui"
+          variant="section"
+          width="full"
+          padding="fit"
+          rightChildren={
+            onClose ? (
+              <Button
+                icon={SvgX}
+                size="sm"
+                prominence="tertiary"
+                tooltip="Hide (suggestions stay in the side panel)"
+                onClick={onClose}
+              />
+            ) : (
+              <Button
+                icon={open ? SvgFold : SvgExpand}
+                size="sm"
+                prominence="tertiary"
+                tooltip={open ? "Collapse" : "Expand"}
+                onClick={() => setOpen((v) => !v)}
+              />
+            )
+          }
+        />
+      </Section>
+      {open && (
+        <Section gap={0.25} height="fit" alignItems="stretch" className="mt-1">
+          {proposals.map((p) => (
+            <SuggestionRow
+              key={p.id}
+              proposal={p}
+              outcome={outcomes[p.id]}
+              onApprove={() => void act(p.id, "approve")}
+              onReject={() => void act(p.id, "reject")}
+              onClick={
+                onHighlight ? () => onHighlight(p.source_paths) : undefined
+              }
+            />
+          ))}
+          <Section
+            gap={0}
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="between"
+            height="fit"
+            className="mt-1"
+          >
+            <Section
+              gap={0.25}
+              flexDirection="row"
+              alignItems="center"
+              width="fit"
+              height="fit"
+            >
+              {user?.is_admin && (
+                <Button
+                  icon={SvgSettings}
+                  size="sm"
+                  prominence="tertiary"
+                  tooltip="Auto-organize settings"
+                  onClick={() => router.push("/admin/auto-organize")}
+                />
+              )}
+              {onOpenPanel && (
+                <Button
+                  icon={SvgExpand}
+                  size="sm"
+                  prominence="tertiary"
+                  tooltip="Open in side panel"
+                  onClick={onOpenPanel}
+                />
+              )}
+            </Section>
+            <Section
+              gap={0.25}
+              flexDirection="row"
+              alignItems="center"
+              width="fit"
+              height="fit"
+            >
+              <Button
+                size="sm"
+                prominence="secondary"
+                disabled={pendingIds.length === 0}
+                onClick={() => void actAll("dismiss")}
+              >
+                Dismiss All
+              </Button>
+              <Button
+                size="sm"
+                icon={SvgCheckCircle}
+                disabled={pendingIds.length === 0}
+                onClick={() => void actAll("approve")}
+              >
+                Approve All
+              </Button>
+            </Section>
+          </Section>
+        </Section>
+      )}
+    </Section>
+  );
+}
+
+/** The card's header mark reuses the octagon Auto glyph family. */
+function AutoSuggestIcon({ size = 16 }: { size?: number }) {
+  return <SvgCheckCircle size={size} />;
+}
+
+const OUTCOME_LABEL: Record<string, string> = {
+  applying: "Applying…",
+  applied: "Applied",
+  stale: "Skipped",
+  error: "Failed",
+};
+
+interface SuggestionRowProps {
+  proposal: Proposal;
+  outcome?: Outcome;
+  onApprove: () => void;
+  onReject: () => void;
+  onClick?: () => void;
+}
+
+/** One suggestion (mock Line, 56px): op icon, summary over the path chip,
+ * reject/approve controls. Handled rows keep their place with the outcome
+ * shown (strikethrough for rejected/dismissed, check for applied). */
+function SuggestionRow({
+  proposal,
+  outcome,
+  onApprove,
+  onReject,
+  onClick,
+}: SuggestionRowProps) {
+  const Icon = OP_ICON[proposal.op] ?? SvgFile;
+  const struck = outcome === "rejected" || outcome === "dismissed";
+  const chipPath = proposal.source_paths[0] ?? proposal.target_paths[0] ?? "";
+  return (
+    <Section
+      gap={0.25}
+      flexDirection="row"
+      alignItems="start"
+      height="fit"
+      padding={0.25}
+      className={`w-full rounded-(--radius-08) bg-(--background-tint-00) ${
+        onClick ? "cursor-pointer" : ""
+      }`}
+      onClick={onClick}
+    >
+      <Section gap={0} width="fit" height="fit" className="mt-[2px] shrink-0">
+        <Icon size={16} />
+      </Section>
+      <Section
+        gap={0.125}
+        justifyContent="start"
+        alignItems="start"
+        height="fit"
+        className="min-w-0 flex-1"
+      >
+        {/* raw-ok: Text drops className, so the strikethrough state wraps it */}
+        <span className={struck ? "line-through opacity-60" : ""}>
+          <Text font="main-ui-action" color="text-04" nowrap maxLines={1}>
+            {proposal.summary}
+          </Text>
+        </span>
+        <Tag icon={SvgFolder} title={chipPath} color="gray" size="sm" />
+      </Section>
+      <Section
+        gap={0.125}
+        flexDirection="row"
+        alignItems="center"
+        width="fit"
+        height="fit"
+        className="shrink-0"
+        // Row clicks highlight the target; the action buttons must not.
+        onClick={(e) => e.stopPropagation()}
+      >
+        {outcome && outcome !== "working" && outcome !== "rejected" ? (
+          outcome === "applied" || outcome === "applying" ? (
+            <Section
+              gap={0.125}
+              flexDirection="row"
+              alignItems="center"
+              width="fit"
+              height="fit"
+              className="text-(--theme-blue-05)"
+            >
+              <Text font="secondary-body" color="inherit" nowrap>
+                {OUTCOME_LABEL[outcome]}
+              </Text>
+              <SvgCheckCircle size={16} />
+            </Section>
+          ) : (
+            <Text font="secondary-body" color="text-03" nowrap>
+              {OUTCOME_LABEL[outcome] ?? ""}
+            </Text>
+          )
+        ) : (
+          <>
+            <Button
+              icon={SvgStopCircle}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Dismiss"
+              disabled={outcome === "working"}
+              onClick={onReject}
+            />
+            <Button
+              icon={SvgCheckCircle}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Approve"
+              disabled={outcome === "working"}
+              onClick={onApprove}
+            />
+          </>
+        )}
+      </Section>
+    </Section>
+  );
+}

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -14,14 +14,18 @@ import {
   SvgCheckCircle,
   SvgExpand,
   SvgFile,
+  SvgFiles,
   SvgFold,
   SvgFolder,
   SvgFolderIn,
+  SvgFolderPlus,
   SvgSettings,
-  SvgStopCircle,
+  SvgSidebar,
   SvgX,
 } from "@onyx-ai/opal/icons";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+import { SvgFolderDashed, SvgSlashCircle } from "@/components/wiki/icons";
+import { pathKind } from "@/lib/wiki/utils";
 
 import { ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
@@ -43,16 +47,29 @@ type Outcome =
 
 const HANDLED = new Set<Outcome>(["applied", "dismissed", "stale"]);
 
-/** Per-op row glyph; unknown ops fall back to the page icon. */
-const OP_ICON: Record<string, IconFunctionComponent> = {
-  move: SvgFolderIn,
-  rename: SvgFolder,
-  merge: SvgFolderIn,
-  split: SvgFile,
-  create_folder: SvgFolder,
-  delete_empty_folder: SvgFolder,
-  delete_page: SvgFile,
-};
+/** Row glyph per the mock (2236:78296): merges show the scope being
+ * merged (pages icon for a page, folder for a folder), empty-folder
+ * deletes the dashed folder. Unknown ops fall back to the page icon. */
+function opIcon(op: string, sourcePath: string): IconFunctionComponent {
+  const pageScope = pathKind(sourcePath) === "page";
+  switch (op) {
+    case "merge":
+    case "split":
+      return pageScope ? SvgFiles : SvgFolder;
+    case "move":
+      return SvgFolderIn;
+    case "rename":
+      return pageScope ? SvgFile : SvgFolder;
+    case "create_folder":
+      return SvgFolderPlus;
+    case "delete_empty_folder":
+      return SvgFolderDashed;
+    case "delete_page":
+      return SvgFile;
+    default:
+      return SvgFile;
+  }
+}
 
 interface SuggestionsCardProps {
   /** Folder (or page) scope the proposals are listed for. */
@@ -240,7 +257,7 @@ export function SuggestionsCard({
               )}
               {onOpenPanel && (
                 <Button
-                  icon={SvgExpand}
+                  icon={SvgSidebar}
                   size="sm"
                   prominence="tertiary"
                   tooltip="Open in side panel"
@@ -258,6 +275,7 @@ export function SuggestionsCard({
               <Button
                 size="sm"
                 prominence="secondary"
+                rightIcon={SvgSlashCircle}
                 disabled={pendingIds.length === 0}
                 onClick={() => void actAll("dismiss")}
               >
@@ -265,7 +283,7 @@ export function SuggestionsCard({
               </Button>
               <Button
                 size="sm"
-                icon={SvgCheckCircle}
+                rightIcon={SvgCheckCircle}
                 disabled={pendingIds.length === 0}
                 onClick={() => void actAll("approve")}
               >
@@ -305,7 +323,7 @@ function SuggestionRow({
   onDismiss,
   onClick,
 }: SuggestionRowProps) {
-  const Icon = OP_ICON[proposal.op] ?? SvgFile;
+  const Icon = opIcon(proposal.op, proposal.source_paths[0] ?? "");
   const struck = outcome === "dismissed";
   const chipPath = proposal.source_paths[0] ?? proposal.target_paths[0] ?? "";
   return (
@@ -351,7 +369,7 @@ function SuggestionRow({
         {!outcome || outcome === "working" ? (
           <>
             <Button
-              icon={SvgStopCircle}
+              icon={SvgSlashCircle}
               size="sm"
               prominence="tertiary"
               tooltip="Dismiss"

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -83,7 +83,10 @@ export function SuggestionsCard({
   const [open, setOpen] = useState(true);
   const [outcomes, setOutcomes] = useState<Record<number, Outcome>>({});
   const alive = useRef(true);
-  useEffect(() => () => void (alive.current = false), []);
+  useEffect(() => {
+    alive.current = true;
+    return () => void (alive.current = false);
+  }, []);
 
   const setOutcome = (id: number, o: Outcome) =>
     alive.current && setOutcomes((prev) => ({ ...prev, [id]: o }));
@@ -104,6 +107,9 @@ export function SuggestionsCard({
         // transient failure (or the row was purged) — keep polling
       }
     }
+    // Didn't settle in-window: the row has left `pending` server-side, so
+    // a refresh reconciles it rather than freezing it at "Applying…".
+    if (alive.current) void refresh();
   }
 
   async function act(id: number, kind: "approve" | "reject" | "dismiss") {
@@ -285,6 +291,8 @@ const OUTCOME_LABEL: Record<string, string> = {
   applying: "Applying…",
   applied: "Applied",
   stale: "Skipped",
+  rejected: "Rejected",
+  dismissed: "Dismissed",
   error: "Failed",
 };
 
@@ -349,7 +357,7 @@ function SuggestionRow({
         // Row clicks highlight the target; the action buttons must not.
         onClick={(e) => e.stopPropagation()}
       >
-        {outcome && outcome !== "working" && outcome !== "rejected" ? (
+        {outcome && outcome !== "working" ? (
           outcome === "applied" || outcome === "applying" ? (
             <Section
               gap={0.125}

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 /** Auto-Organize suggestions card (mocks 2236:78296 / 2240:59533): pending
- * change proposals for a folder subtree with per-row approve/reject, bulk
- * actions, and the admin shortcut. Acted-on rows stay visible with their
- * outcome for a few seconds before the list refreshes them away (mock
+ * change proposals for a folder subtree with per-row approve/dismiss, bulk
+ * actions, and the admin shortcut. Rows keep their outcome in place. Once
+ * all rows are handled the list refreshes them away after a beat (mock
  * annotation: leave time for user confirmation). */
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -30,7 +30,6 @@ import {
   approveProposal,
   dismissProposal,
   fetchProposal,
-  rejectProposal,
   useProposalsByPath,
 } from "@/lib/autoOrganize";
 
@@ -38,12 +37,11 @@ type Outcome =
   | "working"
   | "applying"
   | "applied"
-  | "rejected"
   | "dismissed"
   | "stale"
   | "error";
 
-const HANDLED: Outcome[] = ["applied", "rejected", "dismissed", "stale"];
+const HANDLED = new Set<Outcome>(["applied", "dismissed", "stale"]);
 
 /** Per-op row glyph; unknown ops fall back to the page icon. */
 const OP_ICON: Record<string, IconFunctionComponent> = {
@@ -59,12 +57,10 @@ const OP_ICON: Record<string, IconFunctionComponent> = {
 interface SuggestionsCardProps {
   /** Folder (or page) scope the proposals are listed for. */
   path: string;
-  /** Skip fetching for viewers; the server write-scopes regardless. */
-  canWrite?: boolean;
   /** Popover hosting: shows the open-in-side-panel action. */
   onOpenPanel?: () => void;
-  /** Popover hosting: the header X. Hides the popup only — suggestions
-   * persist and re-show (mock annotation). */
+  /** Popover hosting: the header X. Hides this surface only, proposals
+   * stay pending (mock annotation). */
   onClose?: () => void;
   /** Row click, with the proposal's source paths (mock: highlight folder). */
   onHighlight?: (paths: string[]) => void;
@@ -72,16 +68,17 @@ interface SuggestionsCardProps {
 
 export function SuggestionsCard({
   path,
-  canWrite = true,
   onOpenPanel,
   onClose,
   onHighlight,
 }: SuggestionsCardProps) {
   const router = useRouter();
   const { user } = useAuth();
-  const { proposals, refresh } = useProposalsByPath(path, canWrite);
+  const { proposals, refresh } = useProposalsByPath(path);
   const [open, setOpen] = useState(true);
-  const [outcomes, setOutcomes] = useState<Record<number, Outcome>>({});
+  const [outcomes, setOutcomes] = useState<Partial<Record<number, Outcome>>>(
+    {},
+  );
   const alive = useRef(true);
   useEffect(() => {
     alive.current = true;
@@ -92,8 +89,7 @@ export function SuggestionsCard({
     alive.current && setOutcomes((prev) => ({ ...prev, [id]: o }));
 
   // Execution runs async on the automanage worker: show "Applying…" and
-  // poll to a terminal status. Transient failures keep polling; an
-  // unsettled poll falls back to the delayed refresh below.
+  // poll to a terminal status. Transient failures keep polling.
   async function pollApplied(id: number) {
     setOutcome(id, "applying");
     for (let i = 0; i < 20; i++) {
@@ -112,22 +108,19 @@ export function SuggestionsCard({
     if (alive.current) void refresh();
   }
 
-  async function act(id: number, kind: "approve" | "reject" | "dismiss") {
+  async function act(id: number, kind: "approve" | "dismiss") {
     setOutcome(id, "working");
     try {
       if (kind === "approve") {
         await approveProposal(id);
         if (alive.current) void pollApplied(id);
-      } else if (kind === "reject") {
-        await rejectProposal(id);
-        setOutcome(id, "rejected");
       } else {
         await dismissProposal(id);
         setOutcome(id, "dismissed");
       }
     } catch (e) {
       if (!alive.current) return;
-      // 409: someone else already actioned it; the refresh will drop it.
+      // 409: someone else already actioned it. The refresh drops it.
       if (e instanceof ApiError && e.status === 409)
         return setOutcome(id, "dismissed");
       setOutcome(id, "error");
@@ -141,8 +134,9 @@ export function SuggestionsCard({
     })
     .map((p) => p.id);
 
-  // Bulk actions hit every not-yet-handled row (mock annotation: "apply to
-  // any that is not already selected"); rows show their outcomes in place.
+  // Bulk actions hit every untouched or failed row (mock annotation:
+  // "apply to any that is not already selected"). Rows show their
+  // outcomes in place.
   async function actAll(kind: "approve" | "dismiss") {
     for (const id of pendingIds) await act(id, kind);
   }
@@ -151,7 +145,10 @@ export function SuggestionsCard({
   // refresh so the settled rows drop out (they have left `pending`).
   const allHandled =
     proposals.length > 0 &&
-    proposals.every((p) => HANDLED.includes(outcomes[p.id] as Outcome));
+    proposals.every((p) => {
+      const o = outcomes[p.id];
+      return !!o && HANDLED.has(o);
+    });
   useEffect(() => {
     if (!allHandled) return;
     const t = setTimeout(() => {
@@ -175,7 +172,7 @@ export function SuggestionsCard({
     >
       <Section gap={0} height="fit" alignItems="stretch" padding={0.25}>
         <ContentAction
-          icon={AutoSuggestIcon}
+          icon={SvgCheckCircle}
           title={`AI Auto-Edit suggests ${n} change${n === 1 ? "" : "s"}.`}
           description="based on your admin auto-organize settings."
           sizePreset="main-ui"
@@ -211,7 +208,7 @@ export function SuggestionsCard({
               proposal={p}
               outcome={outcomes[p.id]}
               onApprove={() => void act(p.id, "approve")}
-              onReject={() => void act(p.id, "reject")}
+              onDismiss={() => void act(p.id, "dismiss")}
               onClick={
                 onHighlight ? () => onHighlight(p.source_paths) : undefined
               }
@@ -282,16 +279,10 @@ export function SuggestionsCard({
   );
 }
 
-/** The card's header mark reuses the octagon Auto glyph family. */
-function AutoSuggestIcon({ size = 16 }: { size?: number }) {
-  return <SvgCheckCircle size={size} />;
-}
-
-const OUTCOME_LABEL: Record<string, string> = {
+const OUTCOME_LABEL: Partial<Record<Outcome, string>> = {
   applying: "Applying…",
   applied: "Applied",
   stale: "Skipped",
-  rejected: "Rejected",
   dismissed: "Dismissed",
   error: "Failed",
 };
@@ -300,22 +291,22 @@ interface SuggestionRowProps {
   proposal: Proposal;
   outcome?: Outcome;
   onApprove: () => void;
-  onReject: () => void;
+  onDismiss: () => void;
   onClick?: () => void;
 }
 
 /** One suggestion (mock Line, 56px): op icon, summary over the path chip,
- * reject/approve controls. Handled rows keep their place with the outcome
- * shown (strikethrough for rejected/dismissed, check for applied). */
+ * dismiss/approve controls. Handled rows keep their place with the outcome
+ * shown (strikethrough for dismissed, check for applied). */
 function SuggestionRow({
   proposal,
   outcome,
   onApprove,
-  onReject,
+  onDismiss,
   onClick,
 }: SuggestionRowProps) {
   const Icon = OP_ICON[proposal.op] ?? SvgFile;
-  const struck = outcome === "rejected" || outcome === "dismissed";
+  const struck = outcome === "dismissed";
   const chipPath = proposal.source_paths[0] ?? proposal.target_paths[0] ?? "";
   return (
     <Section
@@ -341,7 +332,7 @@ function SuggestionRow({
       >
         {/* raw-ok: Text drops className, so the strikethrough state wraps it */}
         <span className={struck ? "line-through opacity-60" : ""}>
-          <Text font="main-ui-action" color="text-04" nowrap maxLines={1}>
+          <Text font="main-ui-action" color="text-04" maxLines={1}>
             {proposal.summary}
           </Text>
         </span>
@@ -357,27 +348,7 @@ function SuggestionRow({
         // Row clicks highlight the target; the action buttons must not.
         onClick={(e) => e.stopPropagation()}
       >
-        {outcome && outcome !== "working" ? (
-          outcome === "applied" || outcome === "applying" ? (
-            <Section
-              gap={0.125}
-              flexDirection="row"
-              alignItems="center"
-              width="fit"
-              height="fit"
-              className="text-(--theme-blue-05)"
-            >
-              <Text font="secondary-body" color="inherit" nowrap>
-                {OUTCOME_LABEL[outcome]}
-              </Text>
-              <SvgCheckCircle size={16} />
-            </Section>
-          ) : (
-            <Text font="secondary-body" color="text-03" nowrap>
-              {OUTCOME_LABEL[outcome] ?? ""}
-            </Text>
-          )
-        ) : (
+        {!outcome || outcome === "working" ? (
           <>
             <Button
               icon={SvgStopCircle}
@@ -385,7 +356,7 @@ function SuggestionRow({
               prominence="tertiary"
               tooltip="Dismiss"
               disabled={outcome === "working"}
-              onClick={onReject}
+              onClick={onDismiss}
             />
             <Button
               icon={SvgCheckCircle}
@@ -396,6 +367,24 @@ function SuggestionRow({
               onClick={onApprove}
             />
           </>
+        ) : outcome === "applied" || outcome === "applying" ? (
+          <Section
+            gap={0.125}
+            flexDirection="row"
+            alignItems="center"
+            width="fit"
+            height="fit"
+            className="text-(--theme-blue-05)"
+          >
+            <Text font="secondary-body" color="inherit" nowrap>
+              {OUTCOME_LABEL[outcome]}
+            </Text>
+            <SvgCheckCircle size={16} />
+          </Section>
+        ) : (
+          <Text font="secondary-body" color="text-03" nowrap>
+            {OUTCOME_LABEL[outcome]}
+          </Text>
         )}
       </Section>
     </Section>

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   Tooltip,
 } from "@onyx-ai/opal/components";
-import { InputHorizontal, Section } from "@onyx-ai/opal/layouts";
+import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
 import {
   SvgAddLines,
   SvgAlertTriangle,
@@ -338,9 +338,11 @@ export function UpdatePolicyPanel({
 
               <div className="flex flex-col gap-1 p-2">
                 {/* Collapsed, the row's description is the instruction when
-                    one exists (mock 1855:273683). While the editor is open
-                    the row shows the generic hint (mock 1855:273690). */}
-                <InputHorizontal
+                    one exists (mock 1855:273683), clamped to 5 lines. While
+                    the editor is open the row shows the generic hint (mock
+                    1855:273690). ContentAction over InputHorizontal: only
+                    the former forwards descriptionMaxLines. */}
+                <ContentAction
                   icon={SvgAddLines}
                   title="Page Instructions"
                   description={
@@ -350,22 +352,28 @@ export function UpdatePolicyPanel({
                         effInstruction ||
                         `Instruct the wiki on how to update this ${kind}.`
                   }
-                >
-                  <Button
-                    icon={editing ? SvgFold : SvgExpand}
-                    prominence="tertiary"
-                    size="md"
-                    tooltip={editing ? "Collapse" : "Edit instructions"}
-                    onClick={() => {
-                      if (editing) {
-                        setEditing(false);
-                        return;
-                      }
-                      setDraft(ownInstruction);
-                      setEditing(true);
-                    }}
-                  />
-                </InputHorizontal>
+                  descriptionMaxLines={5}
+                  sizePreset="main-ui"
+                  variant="section"
+                  width="full"
+                  padding="fit"
+                  rightChildren={
+                    <Button
+                      icon={editing ? SvgFold : SvgExpand}
+                      prominence="tertiary"
+                      size="md"
+                      tooltip={editing ? "Collapse" : "Edit instructions"}
+                      onClick={() => {
+                        if (editing) {
+                          setEditing(false);
+                          return;
+                        }
+                        setDraft(ownInstruction);
+                        setEditing(true);
+                      }}
+                    />
+                  }
+                />
 
                 {!editing && !ownInstruction && effInstruction && (
                   <Text font="secondary-body" color="text-03">
@@ -377,9 +385,14 @@ export function UpdatePolicyPanel({
                   // Implicit save per the mock: blur persists, collapse only
                   // hides. A failed save reopens with the draft intact.
                   <div className="instructions-editor">
+                    {/* rows = maxRows pins the editor at 8 lines (Opal's
+                        autoResize clamps between the two); longer content
+                        scrolls in place instead of resizing the panel. */}
                     <InputTextArea
-                      rows={5}
-                      resizable
+                      rows={8}
+                      autoResize
+                      maxRows={8}
+                      resizable={false}
                       value={draft}
                       autoFocus
                       placeholder={`How should this ${kind} be updated?`}

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -340,14 +340,17 @@ export function UpdatePolicyPanel({
                 {/* Collapsed, the row's description is the instruction when
                     one exists (mock 1855:273683), clamped to 5 lines. While
                     the editor is open the row shows the generic hint (mock
-                    1855:273690). ContentAction over InputHorizontal: only
-                    the former forwards descriptionMaxLines. */}
+                    1855:273690). ContentAction is the only layout that
+                    forwards descriptionMaxLines. */}
                 <ContentAction
                   icon={SvgAddLines}
                   title="Page Instructions"
+                  // While the editor is open the guidance renders below the
+                  // input (node 2185:50866), so the row carries no
+                  // description of its own.
                   description={
                     editing
-                      ? `Instruct the wiki on how to update this ${kind}.`
+                      ? undefined
                       : ownInstruction ||
                         effInstruction ||
                         `Instruct the wiki on how to update this ${kind}.`
@@ -395,7 +398,7 @@ export function UpdatePolicyPanel({
                       resizable={false}
                       value={draft}
                       autoFocus
-                      placeholder={`How should this ${kind} be updated?`}
+                      placeholder="e.g. This page covers engineering onboarding. Keep setup steps current, removing ones that no longer apply. Keep it sequential and high-level, linking out to sources instead of duplicating other docs."
                       onChange={(e) => setDraft(e.target.value)}
                       onKeyDown={(e) => {
                         // Enter saves through the blur path and collapses
@@ -417,6 +420,15 @@ export function UpdatePolicyPanel({
                         );
                       }}
                     />
+                    {/* Guidance below the input (node 2185:50866 "Message
+                        Section"); the copy is verbatim from the mock. */}
+                    <div className="px-2 pt-1 pb-2">
+                      <Text font="secondary-body" color="text-03" as="p">
+                        Describe what this page covers and what is out of scope;
+                        what information to keep current; how detailed it should
+                        be and in what format.
+                      </Text>
+                    </div>
                   </div>
                 )}
               </div>

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -34,7 +34,7 @@ import {
 } from "@/lib/updatePolicy";
 import { useUpdateHealth } from "@/lib/wiki/hooks";
 import type { UpdateHealth } from "@/lib/wiki/types";
-import { updateWarnLevel } from "@/lib/wiki/utils";
+import { pathKind, updateWarnLevel } from "@/lib/wiki/utils";
 import { absoluteTime } from "@/lib/time";
 
 interface Props {
@@ -65,8 +65,8 @@ function capNote(health: UpdateHealth): string {
   if (health.cap_24h > 0) {
     return "Approaching daily auto-edit limit. Updates will pause when the limit is reached.";
   }
-  // Threshold guard stays local: the message prints the threshold, so a
-  // zero threshold must fall through to the generic note.
+  // The threshold guard stays local: the message prints the threshold, so
+  // a zero threshold must fall through to the generic note.
   if (health.threshold_24h > 0 && health.count_24h >= health.threshold_24h) {
     return `Reached the alert threshold of ${health.threshold_24h} auto-edits in 24 hours.`;
   }
@@ -110,7 +110,7 @@ export function UpdatePolicyPanel({
   historyList,
   totalEdits,
 }: Props) {
-  const kind = path.endsWith(".md") ? "page" : "folder";
+  const kind = pathKind(path);
 
   const [loading, setLoading] = useState(true);
   const [loaded, setLoaded] = useState(false); // first fetch succeeded
@@ -338,10 +338,9 @@ export function UpdatePolicyPanel({
 
               <div className="flex flex-col gap-1 p-2">
                 {/* Collapsed, the row's description is the instruction when
-                    one exists (mock 1855:273683), clamped to 5 lines. While
-                    the editor is open the row shows the generic hint (mock
-                    1855:273690). ContentAction is the only layout that
-                    forwards descriptionMaxLines. */}
+                    one exists (mock 1855:273683), clamped to 5 lines.
+                    ContentAction rather than InputHorizontal, which has no
+                    description clamp. */}
                 <ContentAction
                   icon={SvgAddLines}
                   title="Page Instructions"
@@ -389,7 +388,7 @@ export function UpdatePolicyPanel({
                   // hides. A failed save reopens with the draft intact.
                   <div className="instructions-editor">
                     {/* rows = maxRows pins the editor at 8 lines (Opal's
-                        autoResize clamps between the two); longer content
+                        autoResize clamps between the two). Longer content
                         scrolls in place instead of resizing the panel. */}
                     <InputTextArea
                       rows={8}

--- a/frontend/src/components/wiki/icons.tsx
+++ b/frontend/src/components/wiki/icons.tsx
@@ -28,3 +28,48 @@ export function SvgListLines({ size = 16, ...props }: IconProps) {
     </svg>
   );
 }
+
+/** The suggestions mock's dismiss glyph (2236:78296): a slashed circle. */
+export function SvgSlashCircle({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      {...props}
+    >
+      <circle cx="8" cy="8" r="6.25" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M3.9 12.1 12.1 3.9"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+/** The suggestions mock's empty-folder glyph (2236:78296): a dashed
+ * folder outline. */
+export function SvgFolderDashed({ size = 16, ...props }: IconProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="none"
+      {...props}
+    >
+      <path
+        d="M1.75 4.25c0-.55.45-1 1-1h3.1l1.4 1.5h6c.55 0 1 .45 1 1v6c0 .55-.45 1-1 1h-10.5c-.55 0-1-.45-1-1v-7.5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeDasharray="2.2 1.8"
+      />
+    </svg>
+  );
+}

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-/** The Auto policy surfaces shared by the doc header cluster and the folder
- * page: the composite Auto mark, the anchored floating-panel positioner, and
- * the hover policy popover (mock 1929:362227). */
+/** The Auto policy surfaces: the composite Auto mark, the anchored
+ * floating-panel positioner, and the hover policy popover (mock
+ * 1929:362227). */
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { Button, Divider, Switch } from "@onyx-ai/opal/components";
@@ -17,6 +17,7 @@ import {
 
 import { toast } from "@/hooks/useToast";
 import { OrganizeComingSoonRow } from "@/components/wiki/UpdatePolicyPanel";
+import { pathKind } from "@/lib/wiki/utils";
 import {
   getUpdatePolicy,
   patchUpdatePolicy,
@@ -131,8 +132,6 @@ interface PolicyPopoverProps {
   /** The policy PATCH is write-gated, so read-only viewers get a
    * disabled switch instead of a doomed request. */
   canWrite: boolean;
-  /** "page" for docs, "folder" for directory scopes — drives row copy. */
-  kind?: "page" | "folder";
   onOpenUpdatesPanel?: () => void;
 }
 
@@ -142,9 +141,9 @@ interface PolicyPopoverProps {
 export function PolicyPopover({
   path,
   canWrite,
-  kind = "page",
   onOpenUpdatesPanel,
 }: PolicyPopoverProps) {
+  const kind = pathKind(path);
   // The policy carries the path it was fetched for: a mismatch reads as
   // unloaded in the same render a navigation lands, so a stale page's
   // value can never be shown or PATCHed against the new path.
@@ -247,8 +246,8 @@ export function PolicyPopover({
       </Section>
       <Divider />
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        {/* ContentAction is the only layout that forwards descriptionMaxLines
-            (mock annotation: real value, 3 lines). */}
+        {/* ContentAction rather than InputHorizontal for the
+            descriptionMaxLines clamp (mock annotation: real value, 3 lines). */}
         <ContentAction
           icon={SvgAddLines}
           title="Page Instructions"

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+/** The Auto policy surfaces shared by the doc header cluster and the folder
+ * page: the composite Auto mark, the anchored floating-panel positioner, and
+ * the hover policy popover (mock 1929:362227). */
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Button, Divider, Switch } from "@onyx-ai/opal/components";
+import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
+import {
+  SvgAddLines,
+  SvgExpand,
+  SvgOnyxOctagon,
+  SvgSparkle,
+  SvgTextLinesSmall,
+} from "@onyx-ai/opal/icons";
+
+import { toast } from "@/hooks/useToast";
+import { OrganizeComingSoonRow } from "@/components/wiki/UpdatePolicyPanel";
+import {
+  getUpdatePolicy,
+  patchUpdatePolicy,
+  type EffectivePolicy,
+} from "@/lib/updatePolicy";
+
+interface AutoGlyphProps {
+  size?: number;
+}
+
+/** The Auto mark (mock 2079:379954): the octagon outline holding the blue
+ * lines glyph, composed from Opal icons since no single asset ships it. */
+export function AutoGlyph({ size = 16 }: AutoGlyphProps) {
+  return (
+    <Section
+      gap={0}
+      width="fit"
+      height="fit"
+      className="relative text-(--text-05)"
+    >
+      <SvgOnyxOctagon size={size} />
+      <Section
+        gap={0}
+        width="full"
+        height="full"
+        alignItems="center"
+        justifyContent="center"
+        className="absolute inset-0 text-(--theme-blue-05)"
+      >
+        <SvgTextLinesSmall size={Math.round(size * 0.55)} />
+      </Section>
+    </Section>
+  );
+}
+
+interface PanelSurfaceProps {
+  children: ReactNode;
+}
+
+/** The shared floating-panel chrome (mock 1929:362227 "Policy Panel"). */
+export function PanelSurface({ children }: PanelSurfaceProps) {
+  return (
+    <Section
+      gap={0}
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      padding={0.25}
+      className="rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]"
+    >
+      {children}
+    </Section>
+  );
+}
+
+interface AnchoredPanelProps {
+  anchor: HTMLElement;
+  onDismiss: () => void;
+  /** Hover panels stay open while the pointer is inside them. */
+  hover?: { onEnter: () => void; onLeave: () => void };
+  /** Pass false when children carry their own surfaces (stacked panels,
+   * self-chromed cards, mock 2283:84706). */
+  chrome?: boolean;
+  children: ReactNode;
+}
+
+/** Anchors a floating panel to a header cluster: fixed-position, right
+ * edges aligned, just below the anchor. */
+export function AnchoredPanel({
+  anchor,
+  onDismiss,
+  hover,
+  chrome = true,
+  children,
+}: AnchoredPanelProps) {
+  const [rect, setRect] = useState(() => anchor.getBoundingClientRect());
+  useEffect(() => {
+    setRect(anchor.getBoundingClientRect());
+  }, [anchor]);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (hover) return;
+    const onDown = (e: PointerEvent) => {
+      const el = panelRef.current;
+      if (
+        el &&
+        !el.contains(e.target as Node) &&
+        !anchor.contains(e.target as Node)
+      )
+        onDismiss();
+    };
+    window.addEventListener("pointerdown", onDown, true);
+    return () => window.removeEventListener("pointerdown", onDown, true);
+  }, [anchor, hover, onDismiss]);
+  return createPortal(
+    // raw-ok: Popover.Anchor exists but Popover.Content bakes neutral-00/rounded-12/shadow-md chrome (WithoutStyles, no escape) that the mock's tint-01 policy panel and chromeless floating cards contradict, and this wrapper also needs runtime viewport coordinates
+    <div
+      ref={panelRef}
+      className="fixed z-50 w-(--block-width-panel-medium-small)"
+      style={{ top: rect.bottom + 8, right: window.innerWidth - rect.right }}
+      onPointerEnter={hover?.onEnter}
+      onPointerLeave={hover?.onLeave}
+    >
+      {chrome ? <PanelSurface>{children}</PanelSurface> : children}
+    </div>,
+    document.body,
+  );
+}
+
+interface PolicyPopoverProps {
+  path: string;
+  /** The policy PATCH is write-gated, so read-only viewers get a
+   * disabled switch instead of a doomed request. */
+  canWrite: boolean;
+  /** "page" for docs, "folder" for directory scopes — drives row copy. */
+  kind?: "page" | "folder";
+  onOpenUpdatesPanel?: () => void;
+}
+
+/** The Auto popover (mock 1929:362227 "Policy Panel"): the AI auto-edit
+ * toggles and the scope's update instruction, all live on the update
+ * policy the full panel edits. */
+export function PolicyPopover({
+  path,
+  canWrite,
+  kind = "page",
+  onOpenUpdatesPanel,
+}: PolicyPopoverProps) {
+  // The policy carries the path it was fetched for: a mismatch reads as
+  // unloaded in the same render a navigation lands, so a stale page's
+  // value can never be shown or PATCHed against the new path.
+  const [policy, setPolicy] = useState<{
+    forPath: string;
+    effective: EffectivePolicy;
+  } | null>(null);
+  const [saving, setSaving] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    getUpdatePolicy(path)
+      .then(
+        (p) => alive && setPolicy({ forPath: path, effective: p.effective }),
+      )
+      .catch(() => alive && setPolicy(null));
+    return () => {
+      alive = false;
+    };
+  }, [path]);
+  const loaded = policy?.forPath === path ? policy.effective : null;
+
+  const allowed = !!loaded?.ai_management_allowed;
+  const autoUpdateDisabled = !!loaded?.ingestion_auto_update_disabled;
+  const patchField = async (patch: Partial<EffectivePolicy>) => {
+    if (!loaded) return;
+    setSaving(true);
+    setPolicy({ forPath: path, effective: { ...loaded, ...patch } });
+    try {
+      await patchUpdatePolicy(path, patch);
+    } catch (e) {
+      // The pre-patch snapshot is still in `loaded`; putting it back
+      // rolls the optimistic write off.
+      setPolicy({ forPath: path, effective: loaded });
+      toast.error(
+        e instanceof Error ? e.message : "Couldn't update the policy",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Mock 2079:379824 annotation: clicking the popover body (any field)
+  // opens the full side panel; the switches keep their inline toggles by
+  // stopping the bubble.
+  return (
+    <Section
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      gap={0.25}
+      className="w-full cursor-pointer"
+      onClick={onOpenUpdatesPanel}
+    >
+      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
+        <InputHorizontal
+          icon={SvgSparkle}
+          title="AI Auto-Edits"
+          description={`Let AI update/organize this ${kind} on its own.`}
+        >
+          <span onClick={(e) => e.stopPropagation()}>
+            <Switch
+              checked={allowed}
+              // Held until this path's policy loads (toggling against the
+              // null default would persist a wrong override) and while a
+              // save is in flight (a second click would race the PATCH).
+              disabled={!canWrite || !loaded || saving}
+              onCheckedChange={() =>
+                void patchField({ ai_management_allowed: !allowed })
+              }
+            />
+          </span>
+        </InputHorizontal>
+        {allowed && (
+          <Section
+            justifyContent="start"
+            alignItems="stretch"
+            height="fit"
+            gap={0.5}
+            className="mt-2 ml-6"
+          >
+            <InputHorizontal
+              title="Update"
+              description="Periodically scan ingested data sources to add relevant new information."
+            >
+              <span onClick={(e) => e.stopPropagation()}>
+                <Switch
+                  checked={!autoUpdateDisabled}
+                  disabled={!canWrite || !loaded || saving}
+                  onCheckedChange={() =>
+                    void patchField({
+                      ingestion_auto_update_disabled: !autoUpdateDisabled,
+                    })
+                  }
+                />
+              </span>
+            </InputHorizontal>
+            <OrganizeComingSoonRow kind={kind} />
+          </Section>
+        )}
+      </Section>
+      <Divider />
+      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
+        {/* ContentAction is the only layout that forwards descriptionMaxLines
+            (mock annotation: real value, 3 lines). */}
+        <ContentAction
+          icon={SvgAddLines}
+          title="Page Instructions"
+          description={
+            loaded?.update_instruction || `How should this ${kind} be updated?`
+          }
+          descriptionMaxLines={3}
+          sizePreset="main-ui"
+          variant="section"
+          width="full"
+          padding="fit"
+          rightChildren={
+            <Button
+              icon={SvgExpand}
+              size="md"
+              prominence="tertiary"
+              tooltip="Open in panel"
+              // stopPropagation: the popover body opens the panel too, and
+              // the bubble would double-fire the handler.
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenUpdatesPanel?.();
+              }}
+            />
+          }
+        />
+      </Section>
+    </Section>
+  );
+}

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -136,3 +136,11 @@ export function rejectProposal(id: number) {
     method: "POST",
   });
 }
+
+/** Dismiss a pending proposal — clears it from review surfaces without the
+ * durable veto a reject carries (the sweep may re-propose it later). */
+export function dismissProposal(id: number) {
+  return apiFetch<{ status: string }>(`/automanage/proposals/${id}/dismiss`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -95,7 +95,7 @@ export interface Proposal {
 
 /** Pending proposals touching `path` (a page or folder subtree) that the caller
  * can act on — the server write-scopes to edit access, so a read-only viewer
- * gets an empty list. Backs the Path-2 review banner on the page/folder.
+ * gets an empty list.
  *
  * `enabled` (default true) gates the fetch — pass the caller's known write
  * capability to skip polling for viewers; the server remains the authority. */
@@ -137,7 +137,7 @@ export function rejectProposal(id: number) {
   });
 }
 
-/** Dismiss a pending proposal — clears it from review surfaces without the
+/** Dismiss a pending proposal: clears it from review surfaces without the
  * durable veto a reject carries (the sweep may re-propose it later). */
 export function dismissProposal(id: number) {
   return apiFetch<{ status: string }>(`/automanage/proposals/${id}/dismiss`, {

--- a/frontend/src/lib/wiki/utils.ts
+++ b/frontend/src/lib/wiki/utils.ts
@@ -26,6 +26,11 @@ export function lastSegment(path: string): string {
   return seg.endsWith(".md") ? seg.slice(0, -3) : seg;
 }
 
+/** Scope flavor for policy copy: .md paths are pages, all else folders. */
+export function pathKind(path: string): "page" | "folder" {
+  return path.endsWith(".md") ? "page" : "folder";
+}
+
 /** Strip the directory prefix and `.md` extension from a wiki file path to
  * get the human-readable page title. See also {@link lastSegment} for the
  * generic (possibly folder/root) path case. */

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -53,6 +53,7 @@ import { WatchingPanel } from "@/components/wiki/WatchingPanel";
 import {
   AnchoredPanel,
   AutoGlyph,
+  PanelSurface,
   PolicyPopover,
 } from "@/components/wiki/policyPanels";
 import { useProposalsByPath } from "@/lib/autoOrganize";
@@ -421,8 +422,7 @@ function Explorer({ dir }: ExplorerProps) {
     setPopupHidden(false);
     setHoverOpen(false);
   }, [dir]);
-  const showPopup =
-    !hoverOpen && !popupHidden && !panelVisible && proposals.length > 0;
+  const showPopup = !popupHidden && !panelVisible && proposals.length > 0;
   const openSidePanel = useCallback(() => {
     setHoverOpen(false);
     if (isMobile) setPolicyOpen(true);
@@ -740,33 +740,39 @@ function Explorer({ dir }: ExplorerProps) {
           />
         )}
 
-        {hoverOpen && clusterRef.current && (
-          // Hover previews the policy popover only. Suggestions self-show
-          // as the dismissible popup and live in the side panel.
+        {(hoverOpen || showPopup) && clusterRef.current && (
+          // Mock 2283:84706: hovering Auto stacks the policy panel ABOVE
+          // the persistent suggestions popup; the popup itself self-shows
+          // and only the X (or the side panel) removes it.
           <AnchoredPanel
             anchor={clusterRef.current}
-            onDismiss={() => setHoverOpen(false)}
-            hover={{ onEnter: holdOpen, onLeave: closeSoon }}
-          >
-            <PolicyPopover
-              path={dir}
-              canWrite
-              onOpenUpdatesPanel={openSidePanel}
-            />
-          </AnchoredPanel>
-        )}
-        {showPopup && clusterRef.current && (
-          <AnchoredPanel
-            anchor={clusterRef.current}
-            onDismiss={() => setPopupHidden(true)}
+            onDismiss={() =>
+              hoverOpen ? setHoverOpen(false) : setPopupHidden(true)
+            }
+            hover={
+              hoverOpen ? { onEnter: holdOpen, onLeave: closeSoon } : undefined
+            }
             chrome={false}
           >
-            <SuggestionsCard
-              path={dir}
-              onClose={() => setPopupHidden(true)}
-              onOpenPanel={openSidePanel}
-              onHighlight={highlightPath}
-            />
+            <Section gap={0.25} height="fit" alignItems="stretch">
+              {hoverOpen && (
+                <PanelSurface>
+                  <PolicyPopover
+                    path={dir}
+                    canWrite
+                    onOpenUpdatesPanel={openSidePanel}
+                  />
+                </PanelSurface>
+              )}
+              {showPopup && (
+                <SuggestionsCard
+                  path={dir}
+                  onClose={() => setPopupHidden(true)}
+                  onOpenPanel={openSidePanel}
+                  onHighlight={highlightPath}
+                />
+              )}
+            </Section>
           </AnchoredPanel>
         )}
       </div>

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -32,9 +32,9 @@ import {
   SvgDocFile,
   SvgFolder,
   SvgFolderPlus,
+  SvgMoreHorizontal,
   SvgShare,
   SvgSidebar,
-  SvgMoreHorizontal,
   SvgPlus,
   SvgTrash,
   SvgWorkflow,
@@ -225,7 +225,6 @@ function Explorer({ dir }: ExplorerProps) {
   const [creating, setCreating] = useState<"folder" | null>(null);
   const [newName, setNewName] = useState("");
   const [createBusy, setCreateBusy] = useState(false);
-  const [triggerModalOpen, setTriggerModalOpen] = useState(false);
   const [triggerStatus, setTriggerStatus] = useState<string | null>(null);
   const [sort, setSort] = useState<SortMode>("name-asc");
   const [renaming, setRenaming] = useState<string | null>(null);
@@ -236,15 +235,15 @@ function Explorer({ dir }: ExplorerProps) {
   const [panelTab, setPanelTab] = useState<DocPanelTab>("updates");
   const [panelOpen, setPanelOpen] = useState(true);
   const [moreOpen, setMoreOpen] = useState(false);
-  const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
-  // One floating surface at a time: the on-load suggestions popup or the
-  // hover policy/suggestions stack (mocks 2236:78296 / 2283:84706).
-  const [folderPanel, setFolderPanel] = useState<"hover" | "popup" | null>(
-    null,
-  );
+  // Single editor state, FileView's shape: null = closed, trigger null =
+  // creating, trigger set = editing an existing watcher.
+  const [watcherEditor, setWatcherEditor] = useState<{
+    trigger: Trigger | null;
+  } | null>(null);
+  const [hoverOpen, setHoverOpen] = useState(false);
   // X only hides the popup for this visit; suggestions persist in the
   // side panel and the popup returns on the next page open.
-  const popupHidden = useRef(false);
+  const [popupHidden, setPopupHidden] = useState(false);
   const clusterRef = useRef<HTMLDivElement | null>(null);
   const closeTimer = useRef<number>(0);
   const holdOpen = useCallback(
@@ -253,10 +252,7 @@ function Explorer({ dir }: ExplorerProps) {
   );
   const closeSoon = useCallback(() => {
     window.clearTimeout(closeTimer.current);
-    closeTimer.current = window.setTimeout(
-      () => setFolderPanel((p) => (p === "hover" ? null : p)),
-      150,
-    );
+    closeTimer.current = window.setTimeout(() => setHoverOpen(false), 150);
   }, []);
   useEffect(() => () => window.clearTimeout(closeTimer.current), []);
 
@@ -409,31 +405,22 @@ function Explorer({ dir }: ExplorerProps) {
   }
 
   // Folder-level actions portal into the single pinned header (mock
-  // 705:142993): New Page + new-folder, then share / trigger / launch-agent
-  // past a divider. The update policy lives inline in the side column. Mobile
-  // keeps it behind a header button + drawer instead.
+  // 705:142993).
   const { health } = useUpdateHealth(dir || null);
   const warnLevel = updateWarnLevel(health);
   const { proposals } = useProposalsByPath(dir, !!dir);
-  // The suggestions popup self-opens when pending proposals exist (mock
-  // 2236:78296) until the X hides it for this visit — but never while the
-  // side panel already shows the card (one surface at a time).
+  // The suggestions popup self-shows while proposals exist (mock
+  // 2236:78296) until the X hides it for the visit — never while the side
+  // panel already shows the card, and it yields to the hover popover.
   const panelVisible = !isMobile && panelOpen;
   useEffect(() => {
-    popupHidden.current = false;
-    setFolderPanel(null);
+    setPopupHidden(false);
+    setHoverOpen(false);
   }, [dir]);
-  useEffect(() => {
-    if (panelVisible) {
-      setFolderPanel((p) => (p === "popup" ? null : p));
-      return;
-    }
-    if (proposals.length > 0 && !popupHidden.current) {
-      setFolderPanel((prev) => (prev === null ? "popup" : prev));
-    }
-  }, [proposals.length, panelVisible]);
+  const showPopup =
+    !hoverOpen && !popupHidden && !panelVisible && proposals.length > 0;
   const openSidePanel = useCallback(() => {
-    setFolderPanel(null);
+    setHoverOpen(false);
     if (isMobile) setPolicyOpen(true);
     else {
       setPanelOpen(true);
@@ -454,7 +441,11 @@ function Explorer({ dir }: ExplorerProps) {
       if (!el) return;
       el.scrollIntoView({ block: "center", behavior: "smooth" });
       el.classList.add("wiki-row-flash");
-      window.setTimeout(() => el.classList.remove("wiki-row-flash"), 2000);
+      el.addEventListener(
+        "animationend",
+        () => el.classList.remove("wiki-row-flash"),
+        { once: true },
+      );
     },
     [dir],
   );
@@ -487,7 +478,7 @@ function Explorer({ dir }: ExplorerProps) {
           onClick={openSidePanel}
           onPointerEnter={() => {
             holdOpen();
-            setFolderPanel("hover");
+            setHoverOpen(true);
           }}
           onPointerLeave={closeSoon}
         >
@@ -531,7 +522,7 @@ function Explorer({ dir }: ExplorerProps) {
               variant="section"
               onClick={() => {
                 setMoreOpen(false);
-                setTriggerModalOpen(true);
+                setWatcherEditor({ trigger: null });
               }}
             />
             <LineItemButton
@@ -573,16 +564,11 @@ function Explorer({ dir }: ExplorerProps) {
         className={`min-w-0 flex-1 overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
       >
         <TriggerPanel
-          open={triggerModalOpen}
-          initial={editTrigger ?? { scope_path: dir || "/" }}
-          lockScope={!editTrigger}
-          onClose={() => {
-            setTriggerModalOpen(false);
-            setEditTrigger(null);
-          }}
-          onSaved={(t) =>
-            setTriggerStatus(`Created trigger for ${t.scope_path}`)
-          }
+          open={watcherEditor !== null}
+          initial={watcherEditor?.trigger ?? { scope_path: dir || "/" }}
+          lockScope={!watcherEditor?.trigger}
+          onClose={() => setWatcherEditor(null)}
+          onSaved={(t) => setTriggerStatus(`Saved trigger for ${t.scope_path}`)}
         />
 
         {triggerStatus && (
@@ -750,35 +736,30 @@ function Explorer({ dir }: ExplorerProps) {
           />
         )}
 
-        {folderPanel === "hover" && clusterRef.current && (
-          // Hover previews the policy popover only; suggestions never
-          // ride the hover — they self-show as the dismissible popup and
-          // live in the side panel (Nik, 2026-07-27).
+        {hoverOpen && clusterRef.current && (
+          // Hover previews the policy popover only. Suggestions self-show
+          // as the dismissible popup and live in the side panel.
           <AnchoredPanel
             anchor={clusterRef.current}
-            onDismiss={() => setFolderPanel(null)}
+            onDismiss={() => setHoverOpen(false)}
             hover={{ onEnter: holdOpen, onLeave: closeSoon }}
           >
             <PolicyPopover
               path={dir}
               canWrite
-              kind="folder"
               onOpenUpdatesPanel={openSidePanel}
             />
           </AnchoredPanel>
         )}
-        {folderPanel === "popup" && clusterRef.current && (
+        {showPopup && clusterRef.current && (
           <AnchoredPanel
             anchor={clusterRef.current}
-            onDismiss={() => setFolderPanel(null)}
+            onDismiss={() => setPopupHidden(true)}
             chrome={false}
           >
             <SuggestionsCard
               path={dir}
-              onClose={() => {
-                popupHidden.current = true;
-                setFolderPanel(null);
-              }}
+              onClose={() => setPopupHidden(true)}
               onOpenPanel={openSidePanel}
               onHighlight={highlightPath}
             />
@@ -786,9 +767,9 @@ function Explorer({ dir }: ExplorerProps) {
         )}
       </div>
 
-      {/* Folder policy applies to every page under this folder. Desktop shows
-          it inline in the side column (mock 1673:32813). Mobile keeps the
-          header button + drawer. */}
+      {/* Desktop: the folder's right rail is the tabbed panel (Updates |
+          Watching, mock 2240:59533). Mobile keeps the header button +
+          drawer. */}
       {!isMobile && panelOpen && (
         <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto">
           <DocPanel
@@ -799,17 +780,17 @@ function Explorer({ dir }: ExplorerProps) {
             {panelTab === "updates" ? (
               <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 py-1">
                 <UpdatePolicyPanel path={dir} />
-                <SuggestionsCard path={dir} onHighlight={highlightPath} />
+                {/* Not at root — a wiki-wide review is the admin queue's job. */}
+                {dir && (
+                  <SuggestionsCard path={dir} onHighlight={highlightPath} />
+                )}
               </div>
             ) : (
               <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 py-1">
                 <WatchingPanel
                   path={dir}
-                  onNew={() => setTriggerModalOpen(true)}
-                  onEdit={(t) => {
-                    setEditTrigger(t);
-                    setTriggerModalOpen(true);
-                  }}
+                  onNew={() => setWatcherEditor({ trigger: null })}
+                  onEdit={(t) => setWatcherEditor({ trigger: t })}
                 />
               </div>
             )}
@@ -830,9 +811,11 @@ function Explorer({ dir }: ExplorerProps) {
                 onClose={() => setPolicyOpen(false)}
                 fullHeight
               />
-              <div className="px-2 pb-2">
-                <SuggestionsCard path={dir} />
-              </div>
+              {dir && (
+                <div className="px-2 pb-2">
+                  <SuggestionsCard path={dir} />
+                </div>
+              )}
             </div>
           </div>
         </>

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -53,7 +53,6 @@ import { WatchingPanel } from "@/components/wiki/WatchingPanel";
 import {
   AnchoredPanel,
   AutoGlyph,
-  PanelSurface,
   PolicyPopover,
 } from "@/components/wiki/policyPanels";
 import { useProposalsByPath } from "@/lib/autoOrganize";
@@ -746,29 +745,20 @@ function Explorer({ dir }: ExplorerProps) {
         )}
 
         {folderPanel === "hover" && clusterRef.current && (
-          // Mock 2283:84706: the policy panel stacked over the suggestions
-          // card, each with its own surface.
+          // Hover previews the policy popover only; suggestions never
+          // ride the hover — they self-show as the dismissible popup and
+          // live in the side panel (Nik, 2026-07-27).
           <AnchoredPanel
             anchor={clusterRef.current}
             onDismiss={() => setFolderPanel(null)}
             hover={{ onEnter: holdOpen, onLeave: closeSoon }}
-            chrome={false}
           >
-            <Section gap={0.25} height="fit" alignItems="stretch">
-              <PanelSurface>
-                <PolicyPopover
-                  path={dir}
-                  canWrite
-                  kind="folder"
-                  onOpenUpdatesPanel={openSidePanel}
-                />
-              </PanelSurface>
-              <SuggestionsCard
-                path={dir}
-                onOpenPanel={openSidePanel}
-                onHighlight={highlightPath}
-              />
-            </Section>
+            <PolicyPopover
+              path={dir}
+              canWrite
+              kind="folder"
+              onOpenUpdatesPanel={openSidePanel}
+            />
           </AnchoredPanel>
         )}
         {folderPanel === "popup" && clusterRef.current && (

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -14,10 +14,12 @@ import {
   Button,
   Divider,
   EmptyMessageCard,
+  IconContainer,
   InputTypeIn,
   MessageCard,
   Text,
 } from "@onyx-ai/opal/components";
+import { Section } from "@onyx-ai/opal/layouts";
 import { cn } from "@onyx-ai/opal/utils";
 import {
   SvgAlertTriangle,
@@ -38,11 +40,21 @@ import {
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { TriggerPanel } from "@/components/triggers/TriggerPanel";
-import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { WikiHome } from "@/components/wiki/WikiHome";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { StartNewPage } from "@/components/wiki/StartNewPage";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
+import { DocPanel, type DocPanelTab } from "@/components/wiki/DocPanel";
+import { SuggestionsCard } from "@/components/wiki/SuggestionsCard";
+import { WatchingPanel } from "@/components/wiki/WatchingPanel";
+import {
+  AnchoredPanel,
+  AutoGlyph,
+  PanelSurface,
+  PolicyPopover,
+} from "@/components/wiki/policyPanels";
+import { useProposalsByPath } from "@/lib/autoOrganize";
+import type { Trigger } from "@/lib/triggers";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import { useRowActions } from "@/providers/WikiItemActionsProvider";
 import { apiFetch, ApiError } from "@/lib/api";
@@ -57,8 +69,9 @@ import {
   FilenameRow,
 } from "@/views/wiki/FileView";
 import { AI_DRAFT_KEY } from "@/lib/wiki/constants";
-import { pageTitle } from "@/lib/wiki/utils";
+import { pageTitle, updateWarnLevel } from "@/lib/wiki/utils";
 import {
+  useUpdateHealth,
   useWikiTree,
   useDeletedTombstone,
   useDocIdResolve,
@@ -218,6 +231,30 @@ function Explorer({ dir }: ExplorerProps) {
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const [sharePath, setSharePath] = useState<string | null>(null);
   const [policyOpen, setPolicyOpen] = useState(false);
+  const [panelTab, setPanelTab] = useState<DocPanelTab>("updates");
+  const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
+  // One floating surface at a time: the on-load suggestions popup or the
+  // hover policy/suggestions stack (mocks 2236:78296 / 2283:84706).
+  const [folderPanel, setFolderPanel] = useState<"hover" | "popup" | null>(
+    null,
+  );
+  // X only hides the popup for this visit; suggestions persist in the
+  // side panel and the popup returns on the next page open.
+  const popupHidden = useRef(false);
+  const clusterRef = useRef<HTMLDivElement | null>(null);
+  const closeTimer = useRef<number>(0);
+  const holdOpen = useCallback(
+    () => window.clearTimeout(closeTimer.current),
+    [],
+  );
+  const closeSoon = useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(
+      () => setFolderPanel((p) => (p === "hover" ? null : p)),
+      150,
+    );
+  }, []);
+  useEffect(() => () => window.clearTimeout(closeTimer.current), []);
 
   const { subdirs, files } = useMemo(() => {
     const prefix = dir ? dir + "/" : "";
@@ -371,6 +408,44 @@ function Explorer({ dir }: ExplorerProps) {
   // 705:142993): New Page + new-folder, then share / trigger / launch-agent
   // past a divider. The update policy lives inline in the side column. Mobile
   // keeps it behind a header button + drawer instead.
+  const { health } = useUpdateHealth(dir || null);
+  const warnLevel = updateWarnLevel(health);
+  const { proposals } = useProposalsByPath(dir, !!dir);
+  // The suggestions popup self-opens when pending proposals exist (mock
+  // 2236:78296) until the X hides it for this visit.
+  useEffect(() => {
+    popupHidden.current = false;
+    setFolderPanel(null);
+  }, [dir]);
+  useEffect(() => {
+    if (proposals.length > 0 && !popupHidden.current) {
+      setFolderPanel((prev) => (prev === null ? "popup" : prev));
+    }
+  }, [proposals.length]);
+  const openSidePanel = useCallback(() => {
+    setFolderPanel(null);
+    if (isMobile) setPolicyOpen(true);
+    else setPanelTab("updates");
+  }, [isMobile]);
+  // Mock annotation "Click to highlight folder": flash the listing row for
+  // the proposal's first path segment under this folder.
+  const highlightPath = useCallback(
+    (paths: string[]) => {
+      const target = paths.find((x) => x.startsWith(dir ? dir + "/" : ""));
+      if (!target) return;
+      const rel = dir ? target.slice(dir.length + 1) : target;
+      const childPath = (dir ? dir + "/" : "") + rel.split("/")[0];
+      const el = document.querySelector(
+        `[data-wiki-row="${CSS.escape(childPath)}"]`,
+      );
+      if (!el) return;
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      el.classList.add("wiki-row-flash");
+      window.setTimeout(() => el.classList.remove("wiki-row-flash"), 2000);
+    },
+    [dir],
+  );
+
   const headerActions = (
     <>
       <Button
@@ -389,6 +464,35 @@ function Explorer({ dir }: ExplorerProps) {
           setCreating((v) => (v === "folder" ? null : "folder"));
         }}
       />
+      <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
+      <Section ref={clusterRef} gap={0} width="fit" height="fit">
+        {/* raw-ok: the Auto trigger is the mock's ringed avatar circle, not a standard icon button */}
+        <button
+          type="button"
+          aria-label="AI auto-edits"
+          className="flex cursor-pointer items-center justify-center px-[2px]"
+          onClick={openSidePanel}
+          onPointerEnter={() => {
+            holdOpen();
+            setFolderPanel("hover");
+          }}
+          onPointerLeave={closeSoon}
+        >
+          <Section gap={0} width="fit" height="fit" className="relative">
+            <IconContainer size="main-content" avatar="icon" icon={AutoGlyph} />
+            <span
+              aria-hidden
+              className={`pointer-events-none absolute inset-0 rounded-full border ${
+                warnLevel === "over"
+                  ? "border-(--status-warning-02)"
+                  : warnLevel === "near"
+                    ? "border-(--theme-amber-02)"
+                    : "border-(--theme-blue-05)"
+              }`}
+            />
+          </Section>
+        </button>
+      </Section>
       <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
       <Button
         prominence="tertiary"
@@ -434,17 +538,16 @@ function Explorer({ dir }: ExplorerProps) {
       >
         <TriggerPanel
           open={triggerModalOpen}
-          initial={{ scope_path: dir || "/" }}
-          lockScope
-          onClose={() => setTriggerModalOpen(false)}
+          initial={editTrigger ?? { scope_path: dir || "/" }}
+          lockScope={!editTrigger}
+          onClose={() => {
+            setTriggerModalOpen(false);
+            setEditTrigger(null);
+          }}
           onSaved={(t) =>
             setTriggerStatus(`Created trigger for ${t.scope_path}`)
           }
         />
-
-        {/* Auto Organize review banner for this folder's subtree (not root —
-            a wiki-wide review is the admin queue's job). */}
-        {dir && <Path2ReviewBanner path={dir} />}
 
         {triggerStatus && (
           <div className="mb-3 text-xs text-(--text-04)">{triggerStatus}</div>
@@ -610,14 +713,80 @@ function Explorer({ dir }: ExplorerProps) {
             onClose={() => setSharePath(null)}
           />
         )}
+
+        {folderPanel === "hover" && clusterRef.current && (
+          // Mock 2283:84706: the policy panel stacked over the suggestions
+          // card, each with its own surface.
+          <AnchoredPanel
+            anchor={clusterRef.current}
+            onDismiss={() => setFolderPanel(null)}
+            hover={{ onEnter: holdOpen, onLeave: closeSoon }}
+            chrome={false}
+          >
+            <Section gap={0.25} height="fit" alignItems="stretch">
+              <PanelSurface>
+                <PolicyPopover
+                  path={dir}
+                  canWrite
+                  kind="folder"
+                  onOpenUpdatesPanel={openSidePanel}
+                />
+              </PanelSurface>
+              <SuggestionsCard
+                path={dir}
+                onOpenPanel={openSidePanel}
+                onHighlight={highlightPath}
+              />
+            </Section>
+          </AnchoredPanel>
+        )}
+        {folderPanel === "popup" && clusterRef.current && (
+          <AnchoredPanel
+            anchor={clusterRef.current}
+            onDismiss={() => setFolderPanel(null)}
+            chrome={false}
+          >
+            <SuggestionsCard
+              path={dir}
+              onClose={() => {
+                popupHidden.current = true;
+                setFolderPanel(null);
+              }}
+              onOpenPanel={openSidePanel}
+              onHighlight={highlightPath}
+            />
+          </AnchoredPanel>
+        )}
       </div>
 
       {/* Folder policy applies to every page under this folder. Desktop shows
           it inline in the side column (mock 1673:32813). Mobile keeps the
           header button + drawer. */}
       {!isMobile && (
-        <aside className="w-[360px] shrink-0 overflow-y-auto p-2">
-          <UpdatePolicyPanel path={dir} />
+        <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto">
+          <DocPanel
+            tab={panelTab}
+            onTabChange={setPanelTab}
+            tabs={["updates", "watching"]}
+          >
+            {panelTab === "updates" ? (
+              <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 py-1">
+                <UpdatePolicyPanel path={dir} />
+                <SuggestionsCard path={dir} onHighlight={highlightPath} />
+              </div>
+            ) : (
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 py-1">
+                <WatchingPanel
+                  path={dir}
+                  onNew={() => setTriggerModalOpen(true)}
+                  onEdit={(t) => {
+                    setEditTrigger(t);
+                    setTriggerModalOpen(true);
+                  }}
+                />
+              </div>
+            )}
+          </DocPanel>
         </aside>
       )}
       {policyOpen && isMobile && (
@@ -628,11 +797,16 @@ function Explorer({ dir }: ExplorerProps) {
             className="fixed inset-0 z-[60] bg-(--mask-03)"
           />
           <div className="fixed top-0 right-0 bottom-0 z-[70] flex w-[min(400px,100vw)] shadow-(--shadow-panel)">
-            <UpdatePolicyPanel
-              path={dir}
-              onClose={() => setPolicyOpen(false)}
-              fullHeight
-            />
+            <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto bg-(--background-tint-00)">
+              <UpdatePolicyPanel
+                path={dir}
+                onClose={() => setPolicyOpen(false)}
+                fullHeight
+              />
+              <div className="px-2 pb-2">
+                <SuggestionsCard path={dir} />
+              </div>
+            </div>
           </div>
         </>
       )}
@@ -1063,6 +1237,7 @@ function Row({
   // double-fire row navigation.
   return (
     <li
+      data-wiki-row={path}
       draggable={!renaming}
       onClick={(e) => {
         if (renaming) return;

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -416,16 +416,22 @@ function Explorer({ dir }: ExplorerProps) {
   const warnLevel = updateWarnLevel(health);
   const { proposals } = useProposalsByPath(dir, !!dir);
   // The suggestions popup self-opens when pending proposals exist (mock
-  // 2236:78296) until the X hides it for this visit.
+  // 2236:78296) until the X hides it for this visit — but never while the
+  // side panel already shows the card (one surface at a time).
+  const panelVisible = !isMobile && panelOpen;
   useEffect(() => {
     popupHidden.current = false;
     setFolderPanel(null);
   }, [dir]);
   useEffect(() => {
+    if (panelVisible) {
+      setFolderPanel((p) => (p === "popup" ? null : p));
+      return;
+    }
     if (proposals.length > 0 && !popupHidden.current) {
       setFolderPanel((prev) => (prev === null ? "popup" : prev));
     }
-  }, [proposals.length]);
+  }, [proposals.length, panelVisible]);
   const openSidePanel = useCallback(() => {
     setFolderPanel(null);
     if (isMobile) setPolicyOpen(true);

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -80,7 +80,10 @@ import {
   usePathToId,
 } from "@/lib/wiki/hooks";
 import { useRequireAuth } from "@/lib/auth";
-import { useHeaderActionsHost } from "@/providers/WikiHeaderActionsProvider";
+import {
+  useHeaderActionsHost,
+  useRightPanelHost,
+} from "@/providers/WikiHeaderActionsProvider";
 import { useDrafting } from "@/lib/drafting";
 import { rememberWikiPath } from "@/lib/lastViewed";
 import { recordRecentDoc } from "@/lib/recents";
@@ -204,6 +207,7 @@ function Explorer({ dir }: ExplorerProps) {
   const router = useRouter();
   const isMobile = useIsMobile();
   const host = useHeaderActionsHost();
+  const rightHost = useRightPanelHost();
   const rowActions = useRowActions();
   const { entries, error: listError, mutate: mutatePaths } = useWikiTree();
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -768,10 +772,13 @@ function Explorer({ dir }: ExplorerProps) {
       </div>
 
       {/* Desktop: the folder's right rail is the tabbed panel (Updates |
-          Watching, mock 2240:59533). Mobile keeps the header button +
-          drawer. */}
-      {!isMobile && panelOpen && (
-        <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto">
+          Watching, mock 2240:59533). It portals into the right-panel host
+          so the column shifts the header, the doc page's composition.
+          Mobile keeps the header button + drawer. */}
+      {!isMobile &&
+        panelOpen &&
+        rightHost?.el &&
+        createPortal(
           <DocPanel
             tab={panelTab}
             onTabChange={setPanelTab}
@@ -794,9 +801,9 @@ function Explorer({ dir }: ExplorerProps) {
                 />
               </div>
             )}
-          </DocPanel>
-        </aside>
-      )}
+          </DocPanel>,
+          rightHost.el,
+        )}
       {policyOpen && isMobile && (
         <>
           <div
@@ -833,6 +840,7 @@ function NewDocView({ dir }: NewDocViewProps) {
   const searchParams = useSearchParams();
   const isMobile = useIsMobile();
   const host = useHeaderActionsHost();
+  const rightHost = useRightPanelHost();
   const { setDrafting, requestExpand, registerDraftBridge } = useDrafting();
   // "Start writing with AI" hands a generated draft (+ the prompt) here via
   // sessionStorage, paired with ?ai=1. Read it synchronously so the editor and

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -16,7 +16,10 @@ import {
   EmptyMessageCard,
   IconContainer,
   InputTypeIn,
+  LineItemButton,
   MessageCard,
+  Popover,
+  PopoverMenu,
   Text,
 } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
@@ -29,10 +32,10 @@ import {
   SvgDocFile,
   SvgFolder,
   SvgFolderPlus,
-  SvgLock,
+  SvgShare,
+  SvgSidebar,
   SvgMoreHorizontal,
   SvgPlus,
-  SvgShield,
   SvgTrash,
   SvgWorkflow,
   SvgZap,
@@ -232,6 +235,8 @@ function Explorer({ dir }: ExplorerProps) {
   const [sharePath, setSharePath] = useState<string | null>(null);
   const [policyOpen, setPolicyOpen] = useState(false);
   const [panelTab, setPanelTab] = useState<DocPanelTab>("updates");
+  const [panelOpen, setPanelOpen] = useState(true);
+  const [moreOpen, setMoreOpen] = useState(false);
   const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
   // One floating surface at a time: the on-load suggestions popup or the
   // hover policy/suggestions stack (mocks 2236:78296 / 2283:84706).
@@ -425,7 +430,10 @@ function Explorer({ dir }: ExplorerProps) {
   const openSidePanel = useCallback(() => {
     setFolderPanel(null);
     if (isMobile) setPolicyOpen(true);
-    else setPanelTab("updates");
+    else {
+      setPanelOpen(true);
+      setPanelTab("updates");
+    }
   }, [isMobile]);
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
@@ -493,34 +501,57 @@ function Explorer({ dir }: ExplorerProps) {
           </Section>
         </button>
       </Section>
-      <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
       <Button
+        icon={SvgShare}
         prominence="tertiary"
-        rightIcon={SvgLock}
+        tooltip="Share"
         onClick={() => setSharePath(dir)}
-      >
-        Share
-      </Button>
-      <Button
-        icon={SvgWorkflow}
-        prominence="tertiary"
-        tooltip="Trigger"
-        onClick={() => setTriggerModalOpen(true)}
       />
+      <Popover open={moreOpen} onOpenChange={setMoreOpen}>
+        <Popover.Trigger asChild>
+          <span className="inline-flex">
+            <Button
+              icon={SvgMoreHorizontal}
+              prominence="tertiary"
+              tooltip="More"
+            />
+          </span>
+        </Popover.Trigger>
+        <Popover.Content width="fit" align="end">
+          <PopoverMenu>
+            <LineItemButton
+              title="Trigger"
+              icon={SvgWorkflow}
+              sizePreset="main-ui"
+              variant="section"
+              onClick={() => {
+                setMoreOpen(false);
+                setTriggerModalOpen(true);
+              }}
+            />
+            <LineItemButton
+              title="Launch Agent"
+              icon={SvgZap}
+              sizePreset="main-ui"
+              variant="section"
+              onClick={() => {
+                setMoreOpen(false);
+                rowActions.launchAgent(dir);
+              }}
+            />
+          </PopoverMenu>
+        </Popover.Content>
+      </Popover>
       <Button
-        icon={SvgZap}
+        icon={SvgSidebar}
         prominence="tertiary"
-        tooltip="Launch Agent"
-        onClick={() => rowActions.launchAgent(dir)}
+        tooltip={
+          isMobile ? "Update Policy" : panelOpen ? "Close panel" : "Open panel"
+        }
+        onClick={() =>
+          isMobile ? setPolicyOpen(true) : setPanelOpen((v) => !v)
+        }
       />
-      {isMobile && (
-        <Button
-          icon={SvgShield}
-          prominence="tertiary"
-          tooltip="Update Policy"
-          onClick={() => setPolicyOpen(true)}
-        />
-      )}
     </>
   );
 
@@ -762,7 +793,7 @@ function Explorer({ dir }: ExplorerProps) {
       {/* Folder policy applies to every page under this folder. Desktop shows
           it inline in the side column (mock 1673:32813). Mobile keeps the
           header button + drawer. */}
-      {!isMobile && (
+      {!isMobile && panelOpen && (
         <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto">
           <DocPanel
             tab={panelTab}


### PR DESCRIPTION
## Description

Page Instructions behavior plus the folders-view side panel, one arc (nodes 2185:50866, 705:142872, 2236:78296, 2283:84706, 2240:59533).

Page Instructions:
- Rows render via `ContentAction` (the only layout forwarding `descriptionMaxLines`): 3-line clamp in the popover, 5 in the panel's collapsed row; the editor pins at 8 lines and scrolls. Placeholder and below-input guidance verbatim from the mock.
- Clicking the Auto icon or the popover body opens the side panel Updates tab; switches keep inline toggling.

Folders view:
- The folder page's policy aside becomes the Updates | Watching side panel: Updates stacks the policy card and the new `SuggestionsCard`; Watching hosts the watcher list with the existing trigger editor.
- `SuggestionsCard` lists pending Auto-Organize proposals: per-row approve/dismiss with path chips, admin-only settings shortcut, Dismiss All / Approve All sweeping unhandled rows while outcomes stay visible a few seconds. Row click flashes the target listing row.
- Suggestions self-show as a dismissible popup (X hides for the visit; they persist in the panel) and never ride the Auto hover — hover previews the policy popover only.
- Folder header adopts the doc page's icon pattern: icon Share, More menu (Trigger, Launch Agent), sidebar panel toggle.
- Shared `policyPanels` module (AutoGlyph, AnchoredPanel, kind-aware PolicyPopover); `DocPanel` tab subsets; `dismissProposal` in the auto-organize lib.

Review: Greptile P1s fixed in 7ceab246 (StrictMode alive ref — also in the doc banner, unsettled poll reconciliation, settled rows no longer re-offer actions); canWrite finding declined on-thread (server-authoritative, no folder access read exists).

## How Has This Been Tested?
