### PR TITLE
refactor(automanage): remove the dismiss verb

### DIFF
--- a/backend/app/api/automanage.py
+++ b/backend/app/api/automanage.py
@@ -185,16 +185,3 @@ def reject_one(
     if not review.reject(proposal_id, user_id=user.id):
         raise HTTPException(status_code=409, detail="proposal is not pending")
     return ProposalActionResponse(status="rejected")
-
-
-@router.post("/proposals/{proposal_id}/dismiss", response_model=ProposalActionResponse)
-def dismiss_one(
-    proposal_id: int, user: User = Depends(require_user)
-) -> ProposalActionResponse:
-    """Dismiss a pending proposal — clears the card without reject's durable
-    veto; it may return if the finding is still (or again) true at a later
-    sweep. 409 if not pending."""
-    _require_writable(proposal_id, user)
-    if not review.dismiss(proposal_id, user_id=user.id):
-        raise HTTPException(status_code=409, detail="proposal is not pending")
-    return ProposalActionResponse(status="dismissed")

--- a/backend/app/models/automanage.py
+++ b/backend/app/models/automanage.py
@@ -72,4 +72,4 @@ class ProposalActionResponse(BaseModel):
     the detection queue, so ``status`` reflects the decision, not the
     applied state."""
 
-    status: Literal["approved", "rejected", "dismissed"]
+    status: Literal["approved", "rejected"]

--- a/backend/app/wiki/automanage/review.py
+++ b/backend/app/wiki/automanage/review.py
@@ -110,16 +110,6 @@ def auto_approve(proposal_id: int, *, acting_user_id: str) -> bool:
     return True
 
 
-def dismiss(proposal_id: int, *, user_id: str) -> bool:
-    """Dismiss a pending proposal — clear the card without reject's durable
-    veto (it may revive if the finding is still/again true at a later
-    sweep). Returns False if it wasn't pending, or if Auto Organize is
-    disabled."""
-    if not settings.is_enabled():
-        return False
-    return change_proposals.dismiss(proposal_id, user_id=user_id)
-
-
 def reject(proposal_id: int, *, user_id: str, reason: str | None = None) -> bool:
     """Reject a pending proposal (durable do-not-propose). No execution.
     Returns False if it wasn't pending, or if Auto Organize is disabled (pending

--- a/backend/app/wiki/change_proposals.py
+++ b/backend/app/wiki/change_proposals.py
@@ -258,9 +258,9 @@ def revive(
             .values(
                 status=ProposalStatus.PENDING.value,
                 status_reason=None,
-                # A past dismissal's reviewer must not linger: the auto-apply
-                # visibility gate reads reviewed_by IS NULL as "no human saw
-                # this", and a revived finding is a fresh ask.
+                # A revived finding is a fresh ask — no stale reviewer mark
+                # may linger (the auto-apply visibility gate reads
+                # reviewed_by IS NULL as "no human saw this").
                 reviewed_by_user_id=None,
                 source_paths=source_paths,
                 target_paths=target_paths,
@@ -342,21 +342,6 @@ def reject(proposal_id: int, *, user_id: str, reason: str | None = None) -> bool
         to=ProposalStatus.REJECTED,
         reviewed_by_user_id=user_id,
         status_reason=reason,
-    )
-
-
-def dismiss(proposal_id: int, *, user_id: str) -> bool:
-    """``pending → stale`` by a human — the middle verb between approve and
-    reject. Machine-invalidation semantics on purpose: no durable veto, so
-    the finding may revive if the situation is still (or again) true at a
-    later sweep. Right for "I fixed this myself, clear it now" and for
-    "not now"."""
-    return _transition(
-        proposal_id,
-        from_statuses=(ProposalStatus.PENDING,),
-        to=ProposalStatus.STALE,
-        reviewed_by_user_id=user_id,
-        status_reason="dismissed by reviewer",
     )
 
 

--- a/backend/tests/test_automanage_card_actions.py
+++ b/backend/tests/test_automanage_card_actions.py
@@ -1,11 +1,11 @@
-"""The card's human verbs and freshness stamp (backend).
+"""The card's freshness stamp and revival hygiene (backend).
 
-Verb ladder: approve (do it) · dismiss (clear the card, machine-invalidation
-semantics — revivable while the finding stays true) · reject (never again,
-content-scoped). Freshness: carried
-pendings get `last_emitted_at` re-stamped each sweep, so the banner's
-"confirmed by the last scan" line reflects the run that just re-verified
-the finding, not the original emit.
+Verbs are approve (do it) and reject (never again, content-scoped) — the
+card's X is client-side only. Freshness: carried pendings get
+`last_emitted_at` re-stamped each sweep, so the banner's "confirmed by the
+last scan" line reflects the run that just re-verified the finding, not the
+original emit. Revival hygiene: a revived finding is a fresh ask, so no
+reviewer mark may linger on the row.
 """
 from __future__ import annotations
 
@@ -68,54 +68,31 @@ def _pending_one() -> dict:
     return row
 
 
-def test_dismiss_clears_without_veto_and_revives_while_true(client, monkeypatch):
+def test_revival_clears_a_lingering_reviewer_mark(client, monkeypatch):
+    """A revived finding is a fresh ask: no reviewer mark may linger on the
+    row (the auto-apply visibility gate reads reviewed_by IS NULL as 'no
+    human decision'). No verb produces a reviewed stale row today, so this
+    guards the defensive clear in revive()."""
+    from sqlalchemy import update as sa_update
+
+    from app.db.models import ChangeProposal
+    from app.db.session import session
+
     det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
     _sweep(monkeypatch, [det])
     row = _pending_one()
-
     uid = seed_user(uid="u1", email="u@x.com")
-    login_fastapi(client, uid)
-    resp = client.post(f"/api/automanage/proposals/{row['id']}/dismiss")
-    assert resp.status_code == 200 and resp.json()["status"] == "dismissed"
+    with session() as s:
+        s.execute(
+            sa_update(ChangeProposal)
+            .where(ChangeProposal.id == row["id"])
+            .values(status="stale", reviewed_by_user_id=uid)
+        )
 
-    dismissed = get(row["id"])
-    assert dismissed is not None
-    assert dismissed["status"] == "stale"
-    assert "dismissed" in (dismissed["status_reason"] or "")
-
-    # Machine-invalidation semantics: the finding is still true, so the
-    # next sweep revives the same row — no snooze in v1 (dial open).
     _sweep(monkeypatch, [det])
     revived = get(row["id"])
     assert revived is not None and revived["status"] == "pending"
     assert revived["revive_count"] == 1
-
-
-def test_dismiss_is_pending_only(client, monkeypatch):
-    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
-    _sweep(monkeypatch, [det])
-    row = _pending_one()
-    uid = seed_user(uid="u1", email="u@x.com")
-    login_fastapi(client, uid)
-    assert client.post(f"/api/automanage/proposals/{row['id']}/dismiss").status_code == 200
-    # Second dismiss: no longer pending.
-    assert client.post(f"/api/automanage/proposals/{row['id']}/dismiss").status_code == 409
-
-
-def test_revival_clears_the_dismissers_mark(client, monkeypatch):
-    """A revived finding is a fresh ask: the past dismissal's reviewer must
-    not linger on the row (the auto-apply visibility gate reads
-    reviewed_by IS NULL as 'no human decision')."""
-    det = _FixedDetector("det_one", [_stub_draft("team/a.md")])
-    _sweep(monkeypatch, [det])
-    row = _pending_one()
-    uid = seed_user(uid="u1", email="u@x.com")
-    login_fastapi(client, uid)
-    client.post(f"/api/automanage/proposals/{row['id']}/dismiss")
-
-    _sweep(monkeypatch, [det])
-    revived = get(row["id"])
-    assert revived is not None
     assert revived["reviewed_by_user_id"] is None
 
 


### PR DESCRIPTION
Team decision: the card's verbs are **approve** and **reject** only — dismiss is gone.

Why it's safe to drop: the two things dismiss covered are covered elsewhere. "Not now" is the card's client-side X (closes for this visit, proposals persist). "I fixed it myself" self-resolves — the finding stops re-detecting and the sweep stales the row on its own.

Removed: `POST /proposals/{id}/dismiss`, `review.dismiss`, `change_proposals.dismiss`, the `"dismissed"` action-response literal, and the dismiss tests.

Kept from #521 (independent of the verb):
- the freshness stamp — sweeps re-stamp `last_emitted_at` on carried pendings; exposed on `ProposalView` for the card's "confirmed by the last scan …" line (Nik's UI pass will use it);
- `revive()` clearing `reviewed_by` — a revived finding is a fresh ask; no verb produces a reviewed stale row anymore, so the test now stages one directly and guards the defensive clear.

Automanage slice: 69 passed; ruff + basedpyright clean.