### PR TITLE
feat(automanage): on-create trigger — focused detection for new pages

### DIFF
--- a/backend/app/tasks/automanage.py
+++ b/backend/app/tasks/automanage.py
@@ -26,6 +26,15 @@ def run_detection_sweep(triggered_by_user_id: str | None) -> None:
     runner.run_sweep(triggered_by_user_id=triggered_by_user_id)
 
 
+@automanage_offline_queue.task()
+def run_detection_on_create(path: str, creator_user_id: str | None) -> None:
+    """Focused detection for a just-created page (see ``runner.run_on_create``).
+    Offline: the creator isn't blocked on it, and it rides the same queue as
+    the sweeps whose detectors it reuses. ``creator_user_id`` is recorded as
+    the run's trigger attribution."""
+    runner.run_on_create(path, triggered_by_user_id=creator_user_id)
+
+
 @automanage_nearline_queue.task()
 def execute_approved_proposal(proposal_id: int) -> None:
     """Apply a **human-approved** proposal (commits to git). Nearline — a human

--- a/backend/app/tasks/automanage.py
+++ b/backend/app/tasks/automanage.py
@@ -31,7 +31,16 @@ def run_detection_on_create(path: str, creator_user_id: str | None) -> None:
     """Focused detection for a just-created page (see ``runner.run_on_create``).
     Offline: the creator isn't blocked on it, and it rides the same queue as
     the sweeps whose detectors it reuses. ``creator_user_id`` is recorded as
-    the run's trigger attribution."""
+    the run's trigger attribution.
+
+    State-based on purpose: the run checks ``path`` against wiki state at
+    execution time, not a snapshot from the creation event. A proposal is a
+    claim about *current* state — if the page was edited into uniqueness,
+    deleted, or moved before a delayed task runs, there is respectively
+    nothing true to propose, nothing to scan (singleton neighborhood
+    no-ops), or a skipped check the next sweep covers. Anchoring to
+    creation-time content would emit exactly the stale-premise proposals
+    the validate()/base-sha machinery exists to retire."""
     runner.run_on_create(path, triggered_by_user_id=creator_user_id)
 
 

--- a/backend/app/wiki/automanage/detectors/body_dup.py
+++ b/backend/app/wiki/automanage/detectors/body_dup.py
@@ -51,7 +51,10 @@ class _BodyDupDetector:
         self._min_bytes = min_body_bytes
 
     def applicable(self, trigger: TriggerKind) -> bool:
-        return trigger == TriggerKind.SWEEP
+        # On-create too: a new page duplicating an existing one is the
+        # canonical redundant-creation failure, and the check is one blob
+        # listing — instant-truth, no quiet window needed.
+        return trigger in (TriggerKind.SWEEP, TriggerKind.ON_CREATE)
 
     def detect(self, scope: Scope) -> list[ProposalDraft]:
         in_scope = {p for p in scope.paths if p.endswith(".md")}

--- a/backend/app/wiki/automanage/detectors/case_collision.py
+++ b/backend/app/wiki/automanage/detectors/case_collision.py
@@ -61,7 +61,10 @@ class _CaseCollisionDetector:
     pairs_paths = True  # names both colliding pages; pair within one audience
 
     def applicable(self, trigger: TriggerKind) -> bool:
-        return trigger == TriggerKind.SWEEP
+        # On-create too: the collision appears exactly when the name is
+        # chosen, and it's instant-truth — catching it at birth beats
+        # catching it at the weekly sweep.
+        return trigger in (TriggerKind.SWEEP, TriggerKind.ON_CREATE)
 
     def detect(self, scope: Scope) -> list[ProposalDraft]:
         pages = {p for p in scope.paths if p.endswith(".md")}

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -118,9 +118,20 @@ def _partition_by_audience(scope: Scope) -> list[Scope]:
 
 
 def run_detection(
-    *, trigger: TriggerKind, triggered_by_user_id: str | None, paths: list[str]
+    *,
+    trigger: TriggerKind,
+    triggered_by_user_id: str | None,
+    paths: list[str],
+    focus_paths: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Run every applicable detector over ``paths`` and emit proposals.
+
+    ``focus_paths`` scopes a focused run's *output*: drafts touching none of
+    the focus paths are dropped after detection. The scope's ``paths`` stay
+    wider than the focus (detectors pair within scope — a single-page scope
+    could never see the colliding sibling), and any incidental finding among
+    the neighbors is left for the sweep — a focused run only asks about the
+    event that triggered it.
 
     Records a ``detection_runs`` row (running → completed/failed) and returns
     ``{run_id, paths_scanned, proposals_emitted}``. Raises on failure after
@@ -181,6 +192,14 @@ def run_detection(
                 drafts = [d for sub in buckets for d in detector.detect(sub)]
             else:
                 drafts = detector.detect(scope)
+            if focus_paths is not None:
+                drafts = [
+                    d
+                    for d in drafts
+                    if any(
+                        p in focus_paths for p in d.source_paths + d.target_paths
+                    )
+                ]
             # One policy query per detector, not one per path per draft.
             mgmt = _resolve_management(drafts)
             for draft in drafts:
@@ -436,6 +455,52 @@ def run_detection(
         "paths_scanned": len(paths),
         "proposals_emitted": emitted,
     }
+
+
+def _creation_neighborhood(path: str) -> list[str]:
+    """The candidate set an on-create run pairs the new page against: pages
+    sharing its exact blob (body-dup's grouping unit) and pages colliding
+    with its path case-insensitively (case-collision's grouping unit). Two
+    git listings, no fingerprint pass over the whole space — the per-create
+    cost stays flat as the wiki grows.
+
+    This is the scope expansion the ``Scope`` contract requires of partial
+    triggers: detectors pair strictly *within* scope, so the trigger must
+    include every page its detectors could legitimately pair the seed with.
+    """
+    blobs = git.list_paths_with_blob_sha()
+    seed_blob = dict(blobs).get(path)
+    seed_lower = path.lower()
+    neighborhood = {path}
+    for p, blob in blobs:
+        if p.lower() == seed_lower or (seed_blob is not None and blob == seed_blob):
+            neighborhood.add(p)
+    return sorted(neighborhood)
+
+
+def run_on_create(path: str, *, triggered_by_user_id: str | None) -> dict[str, Any]:
+    """Focused detection for a just-created page — the on-create trigger.
+
+    Runs only the detectors that opted into ``ON_CREATE`` (instant-truth
+    checks: case-collision, body-dup; detectors whose findings need the page
+    to settle — stub, template-echo — stay sweep-only) over the page's
+    creation neighborhood, and emits only findings that involve the new page.
+    Reconciliation/invalidation stays sweep-only: a focused run's silence
+    proves nothing about the rest of the ledger.
+
+    The common create collides with nothing and duplicates nothing — its
+    neighborhood is just itself, no detector can pair it, and the run is
+    skipped before it writes a ``detection_runs`` row.
+    """
+    neighborhood = _creation_neighborhood(path)
+    if len(neighborhood) < 2:
+        return {"run_id": None, "paths_scanned": 0, "proposals_emitted": 0}
+    return run_detection(
+        trigger=TriggerKind.ON_CREATE,
+        triggered_by_user_id=triggered_by_user_id,
+        paths=neighborhood,
+        focus_paths=frozenset({path}),
+    )
 
 
 def run_sweep(*, triggered_by_user_id: str | None) -> dict[str, Any]:

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -34,6 +34,11 @@ import logging
 from app.db import fts, page_dirs, provenance as db_provenance
 from app.mcp_server import pubsub as mcp_pubsub
 from app.tasks import coedit_rebase as coedit_rebase_trigger
+# Module import, not name import: automanage tasks -> runner -> executor ->
+# notify is a cycle, and a name import here breaks whichever side loads
+# second. The attribute resolves at call time (same pattern as
+# coedit_rebase below).
+from app.tasks import automanage as automanage_tasks
 from app.tasks.reindex import drop_page_embedding, index_path
 from app.tasks.triggers import fan_out_trigger_eval
 from app.tasks.update_frequency import check_update_frequency
@@ -121,6 +126,14 @@ def after_doc_write(
         acl.on_page_created(rel_path, owner_user_id=owner_user_id)
         # Mint a stable id for the page (and seed rows for its ancestor folders).
         doc_ids.mint_for_page(rel_path)
+        # Focused Auto Organize check on the new page (case collision, exact
+        # duplicate). Only for attributable creations — a human or an agent
+        # acting for one (chat/MCP/API all pass the current user). System
+        # channels (ingestion, seeds) pass owner_user_id=None and are skipped:
+        # they arrive in bursts and have their own reconciliation; the sweep
+        # covers whatever they leave behind.
+        if owner_user_id is not None:
+            automanage_tasks.run_detection_on_create(rel_path, owner_user_id)
     index_path(rel_path)
     fan_out_trigger_eval(rel_path, sha, change_kind, actor)
     # Ingestion churn → check the page's 24h update frequency against the

--- a/backend/tests/_seed.py
+++ b/backend/tests/_seed.py
@@ -162,6 +162,7 @@ __all__ = [
     "count_rows",
     "insert_event",
     "list_events",
+    "plumb_commit",
     "seed_trigger",
     "seed_user",
 ]
@@ -173,3 +174,40 @@ def seed_docs(*paths: str) -> None:
 
     for path in paths:
         wiki_git.commit_file(path, f"# {path}\n\nseeded\n", "seed", author=None)
+
+
+def plumb_commit(path: str, body: str) -> None:
+    """Commit ``path`` via git plumbing (index + objects only) — the one way
+    to stage case-colliding paths on a case-insensitive dev filesystem, where
+    a worktree write would silently overwrite the other casing (the exact
+    hazard the case-collision detector exists for). Test seeding only: the
+    app's git wrapper deliberately has no such primitive, and the detectors
+    read the index/objects, never the worktree."""
+    import subprocess
+
+    import app.config
+
+    cwd = app.config.CONFIG.wiki_dir
+
+    def run(*args: str, inp: str | None = None) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            input=inp,
+        ).stdout.strip()
+
+    blob = run("hash-object", "-w", "--stdin", inp=body)
+    run("update-index", "--add", "--cacheinfo", f"100644,{blob},{path}")
+    tree = run("write-tree")
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    parent = ["-p", head] if head else []
+    commit = run("commit-tree", tree, *parent, "-m", f"seed {path}")
+    run("update-ref", "HEAD", commit)

--- a/backend/tests/test_automanage_on_create.py
+++ b/backend/tests/test_automanage_on_create.py
@@ -8,9 +8,6 @@ pass ``owner_user_id=None`` and are skipped; the sweep covers them.
 """
 from __future__ import annotations
 
-import subprocess
-
-import app.config
 from app.models.wiki import ChangeKind
 from app.tasks.queues import automanage_offline_queue
 from app.wiki import git as wiki_git
@@ -25,40 +22,11 @@ from app.wiki.change_proposals import (
     list_by_status,
     reject,
 )
-from tests._seed import seed_user
+from tests._seed import plumb_commit, seed_user
 
 # Bodies comfortably above body-dup's placeholder floor.
 _BODY = "# Setup\n\nInstall steps for the app.\n" + "content " * 40
 _OTHER = "# Notes\n\nEntirely different material.\n" + "words " * 40
-
-
-def _plumb_commit(path: str, body: str) -> None:
-    """Commit ``path`` via git plumbing (index + objects only) — the one way
-    to stage case-colliding paths on a case-insensitive dev filesystem."""
-    cwd = app.config.CONFIG.wiki_dir
-
-    def run(*args: str, inp: str | None = None) -> str:
-        return subprocess.run(
-            ["git", *args],
-            cwd=cwd,
-            check=True,
-            capture_output=True,
-            text=True,
-            input=inp,
-        ).stdout.strip()
-
-    blob = run("hash-object", "-w", "--stdin", inp=body)
-    run("update-index", "--add", "--cacheinfo", f"100644,{blob},{path}")
-    tree = run("write-tree")
-    head = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"],
-        cwd=cwd,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    parent = ["-p", head] if head else []
-    commit = run("commit-tree", tree, *parent, "-m", f"seed {path}")
-    run("update-ref", "HEAD", commit)
 
 
 def _pendings() -> list[dict]:
@@ -95,7 +63,7 @@ def test_common_create_skips_the_run_entirely(tmp_repo):
 
 def test_case_collision_on_create(tmp_repo):
     wiki_git.commit_file("docs/Setup.md", _BODY, "seed", author=None)
-    _plumb_commit("docs/setup.md", _OTHER)
+    plumb_commit("docs/setup.md", _OTHER)
 
     result = runner.run_on_create("docs/setup.md", triggered_by_user_id=None)
 

--- a/backend/tests/test_automanage_on_create.py
+++ b/backend/tests/test_automanage_on_create.py
@@ -1,0 +1,197 @@
+"""The on-create trigger — focused detection for a just-created page.
+
+Only instant-truth detectors run (case-collision, body-dup; settle-dependent
+detectors stay sweep-only), scoped to the page's creation neighborhood, and
+only findings involving the new page emit. The lifecycle hook enqueues the
+run for attributable creations only — system channels (ingestion, seeds)
+pass ``owner_user_id=None`` and are skipped; the sweep covers them.
+"""
+from __future__ import annotations
+
+import subprocess
+
+import app.config
+from app.models.wiki import ChangeKind
+from app.tasks.queues import automanage_offline_queue
+from app.wiki import git as wiki_git
+from app.wiki import notify
+from app.wiki.automanage import runner, runs
+from app.wiki.automanage.detectors.base import TriggerKind
+from app.wiki.change_proposals import (
+    ProposalCreatedVia,
+    ProposalOp,
+    ProposalStatus,
+    create as create_proposal,
+    list_by_status,
+    reject,
+)
+from tests._seed import seed_user
+
+# Bodies comfortably above body-dup's placeholder floor.
+_BODY = "# Setup\n\nInstall steps for the app.\n" + "content " * 40
+_OTHER = "# Notes\n\nEntirely different material.\n" + "words " * 40
+
+
+def _plumb_commit(path: str, body: str) -> None:
+    """Commit ``path`` via git plumbing (index + objects only) — the one way
+    to stage case-colliding paths on a case-insensitive dev filesystem."""
+    cwd = app.config.CONFIG.wiki_dir
+
+    def run(*args: str, inp: str | None = None) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            input=inp,
+        ).stdout.strip()
+
+    blob = run("hash-object", "-w", "--stdin", inp=body)
+    run("update-index", "--add", "--cacheinfo", f"100644,{blob},{path}")
+    tree = run("write-tree")
+    head = subprocess.run(
+        ["git", "rev-parse", "--verify", "HEAD"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    parent = ["-p", head] if head else []
+    commit = run("commit-tree", tree, *parent, "-m", f"seed {path}")
+    run("update-ref", "HEAD", commit)
+
+
+def _pendings() -> list[dict]:
+    return list_by_status(ProposalStatus.PENDING, limit=None)
+
+
+def test_duplicate_create_emits_a_focused_proposal(tmp_repo):
+    wiki_git.commit_file("team/original.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("team/copy.md", _BODY, "seed dup", author=None)
+
+    result = runner.run_on_create("team/copy.md", triggered_by_user_id=None)
+
+    assert result["proposals_emitted"] == 1
+    (row,) = _pendings()
+    assert row["detector"] == "body_dup"
+    assert row["created_via"] == ProposalCreatedVia.ON_CREATE.value
+    assert "team/copy.md" in row["source_paths"] + row["target_paths"]
+    (run_row,) = runs.list_recent()
+    assert run_row["trigger"] == TriggerKind.ON_CREATE.value
+
+
+def test_common_create_skips_the_run_entirely(tmp_repo):
+    """A page that collides with nothing and duplicates nothing — the
+    overwhelmingly common create — must not even record a run row."""
+    wiki_git.commit_file("team/original.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("team/unique.md", _OTHER, "seed", author=None)
+
+    result = runner.run_on_create("team/unique.md", triggered_by_user_id=None)
+
+    assert result == {"run_id": None, "paths_scanned": 0, "proposals_emitted": 0}
+    assert runs.list_recent() == []
+    assert _pendings() == []
+
+
+def test_case_collision_on_create(tmp_repo):
+    wiki_git.commit_file("docs/Setup.md", _BODY, "seed", author=None)
+    _plumb_commit("docs/setup.md", _OTHER)
+
+    result = runner.run_on_create("docs/setup.md", triggered_by_user_id=None)
+
+    assert result["proposals_emitted"] == 1
+    (row,) = _pendings()
+    assert row["detector"] == "case_collision"
+    assert "docs/setup.md" in row["source_paths"] + row["target_paths"]
+
+
+def test_focus_drops_findings_not_involving_the_new_page(tmp_repo):
+    """The focus filter is the scope-bounding net: a finding among the
+    neighbors that doesn't involve the created page is the sweep's business,
+    not this run's."""
+    wiki_git.commit_file("a/one.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("a/two.md", _BODY, "seed dup", author=None)
+
+    result = runner.run_detection(
+        trigger=TriggerKind.ON_CREATE,
+        triggered_by_user_id=None,
+        paths=["a/one.md", "a/two.md"],
+        focus_paths=frozenset({"elsewhere/new.md"}),
+    )
+
+    assert result["proposals_emitted"] == 0
+    assert _pendings() == []
+
+
+def test_settle_dependent_detectors_stay_sweep_only(tmp_repo):
+    """Two tiny identical pages: below body-dup's floor, and stub/template
+    findings must not fire at creation (every new page starts as a stub)."""
+    wiki_git.commit_file("t/a.md", "# a\n", "seed", author=None)
+    wiki_git.commit_file("t/b.md", "# a\n", "seed dup", author=None)
+
+    result = runner.run_on_create("t/b.md", triggered_by_user_id=None)
+
+    assert result["proposals_emitted"] == 0
+    assert _pendings() == []
+
+
+def test_focused_run_never_invalidates_the_ledger(tmp_repo):
+    """Reconciliation is sweep-only: a pending row about unrelated pages must
+    survive a focused run untouched (a partial scope's silence proves
+    nothing)."""
+    wiki_git.commit_file("keep/page.md", _OTHER, "seed", author=None)
+    unrelated = create_proposal(
+        op=ProposalOp.DELETE_PAGE,
+        source_paths=["keep/page.md"],
+        target_paths=[],
+        base_shas={},
+        summary="unrelated pending",
+        created_via=ProposalCreatedVia.SWEEP,
+        detector="stub_page",
+        dedup_key="stub_page|delete_page|unrelated|",
+    )
+    wiki_git.commit_file("team/original.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("team/copy.md", _BODY, "seed dup", author=None)
+
+    runner.run_on_create("team/copy.md", triggered_by_user_id=None)
+
+    ids = {r["id"] for r in _pendings()}
+    assert unrelated["id"] in ids  # still pending, not invalidated
+
+
+def test_rejection_suppresses_the_recreated_ask(tmp_repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("team/original.md", _BODY, "seed", author=None)
+    wiki_git.commit_file("team/copy.md", _BODY, "seed dup", author=None)
+    result = runner.run_on_create("team/copy.md", triggered_by_user_id=uid)
+    (row,) = _pendings()
+    assert result["proposals_emitted"] == 1
+    assert reject(row["id"], user_id=uid)
+
+    rerun = runner.run_on_create("team/copy.md", triggered_by_user_id=uid)
+
+    assert rerun["proposals_emitted"] == 0
+    assert _pendings() == []
+
+
+def test_create_hook_enqueues_for_attributable_creations_only(tmp_repo):
+    uid = seed_user(uid="u1", email="u@x.com")
+    wiki_git.commit_file("team/original.md", _BODY, "seed", author=None)
+
+    # System channel (owner_user_id=None): no focused run.
+    sha = wiki_git.commit_file("team/sys-copy.md", _BODY, "ingest", author=None)
+    with automanage_offline_queue.immediate_mode():
+        notify.after_doc_write(
+            "team/sys-copy.md", sha, ChangeKind.CREATE, None, owner_user_id=None
+        )
+    assert _pendings() == []
+
+    # Attributable creation: the hook runs focused detection.
+    sha = wiki_git.commit_file("team/user-copy.md", _BODY, "create", author=None)
+    with automanage_offline_queue.immediate_mode():
+        notify.after_doc_write(
+            "team/user-copy.md", sha, ChangeKind.CREATE, None, owner_user_id=uid
+        )
+    rows = _pendings()
+    assert len(rows) == 1
+    assert "team/user-copy.md" in rows[0]["source_paths"] + rows[0]["target_paths"]

--- a/backend/tests/test_case_collision_detector.py
+++ b/backend/tests/test_case_collision_detector.py
@@ -37,7 +37,7 @@ from app.wiki.change_proposals import (
     get as get_proposal,
     list_by_status,
 )
-from tests._seed import seed_user
+from tests._seed import plumb_commit, seed_user
 
 _A = "# Setup\n\nInstall steps for the app.\n" + "a" * 120
 _B = "# setup (draft)\n\nCompletely different notes.\n" + "b" * 120
@@ -58,36 +58,13 @@ def _fs_case_insensitive(tmp_path_factory=None) -> bool:
         return os.path.exists(os.path.join(d, "caseprobe"))
 
 
-def _plumb_commit(path: str, body: str) -> None:
-    """Commit ``path`` via git plumbing (index + objects only): the one way to
-    stage case-colliding paths on a case-insensitive dev filesystem, where a
-    worktree write would silently overwrite the other casing. Test seeding
-    only — the detector itself reads the index/objects, never the worktree."""
-    cwd = app.config.CONFIG.wiki_dir
-    def run(*args: str, inp: str | None = None) -> str:
-        return subprocess.run(
-            ["git", *args], cwd=cwd, check=True, capture_output=True, text=True,
-            input=inp,
-        ).stdout.strip()
-    blob = run("hash-object", "-w", "--stdin", inp=body)
-    run("update-index", "--add", "--cacheinfo", f"100644,{blob},{path}")
-    tree = run("write-tree")
-    head = subprocess.run(
-        ["git", "rev-parse", "--verify", "HEAD"], cwd=cwd,
-        capture_output=True, text=True,
-    ).stdout.strip()
-    parent = ["-p", head] if head else []
-    commit = run("commit-tree", tree, *parent, "-m", f"seed {path}")
-    run("update-ref", "HEAD", commit)
-
-
 def _scope(*paths: str) -> Scope:
     return Scope(trigger=TriggerKind.SWEEP, paths=tuple(paths))
 
 
 def test_distinct_content_collision_proposes_rename(repo):
-    _plumb_commit("docs/Setup.md", _A)
-    _plumb_commit("docs/setup.md", _B)
+    plumb_commit("docs/Setup.md", _A)
+    plumb_commit("docs/setup.md", _B)
 
     drafts = _CaseCollisionDetector().detect(_scope("docs/Setup.md", "docs/setup.md"))
 
@@ -105,16 +82,16 @@ def test_distinct_content_collision_proposes_rename(repo):
 
 
 def test_identical_content_collision_is_left_to_body_dup(repo):
-    _plumb_commit("docs/Guide.md", _A)
-    _plumb_commit("docs/guide.md", _A)
+    plumb_commit("docs/Guide.md", _A)
+    plumb_commit("docs/guide.md", _A)
 
     assert _CaseCollisionDetector().detect(_scope("docs/Guide.md", "docs/guide.md")) == []
 
 
 def test_deconflicted_name_avoids_new_collisions(repo):
-    _plumb_commit("n/Page.md", _A)
-    _plumb_commit("n/page.md", _B)
-    _plumb_commit("n/PAGE-2.md", "occupied " + "c" * 120)
+    plumb_commit("n/Page.md", _A)
+    plumb_commit("n/page.md", _B)
+    plumb_commit("n/PAGE-2.md", "occupied " + "c" * 120)
 
     (d,) = _CaseCollisionDetector().detect(
         _scope("n/Page.md", "n/page.md", "n/PAGE-2.md")
@@ -123,8 +100,8 @@ def test_deconflicted_name_avoids_new_collisions(repo):
 
 
 def test_validate_tracks_the_premise(repo):
-    _plumb_commit("v/Doc.md", _A)
-    _plumb_commit("v/doc.md", _B)
+    plumb_commit("v/Doc.md", _A)
+    plumb_commit("v/doc.md", _B)
     det = _CaseCollisionDetector()
     (d,) = det.detect(_scope("v/Doc.md", "v/doc.md"))
     proposal: dict[str, Any] = {
@@ -162,15 +139,15 @@ def test_validate_tracks_the_premise(repo):
 def test_validate_stays_valid_when_pages_converge(repo):
     """Pages that became identical while pending don't stale the proposal —
     the applier's merge branch resolves them."""
-    _plumb_commit("c/Doc.md", _A)
-    _plumb_commit("c/doc.md", _B)
+    plumb_commit("c/Doc.md", _A)
+    plumb_commit("c/doc.md", _B)
     det = _CaseCollisionDetector()
     (d,) = det.detect(_scope("c/Doc.md", "c/doc.md"))
     proposal: dict[str, Any] = {
         "source_paths": d.source_paths,
         "target_paths": d.target_paths,
     }
-    _plumb_commit("c/doc.md", _A)  # now byte-identical to the kept page
+    plumb_commit("c/doc.md", _A)  # now byte-identical to the kept page
     assert det.validate(proposal) is None
 
 
@@ -184,8 +161,8 @@ def test_rename_executes_end_to_end(repo, monkeypatch):
     via move_page, and the moved id — live at its new path — passes the
     forward check (enabler 2)."""
     monkeypatch.setattr(runner, "DETECTORS", [_CaseCollisionDetector()])
-    _plumb_commit("e/Notes.md", _A)
-    _plumb_commit("e/notes.md", _B)
+    plumb_commit("e/Notes.md", _A)
+    plumb_commit("e/notes.md", _B)
     subprocess.run(["git", "checkout", "--", "."], cwd=app.config.CONFIG.wiki_dir, check=True, capture_output=True)
     loser_id = doc_ids.get_or_mint("e/notes.md")
 
@@ -286,7 +263,7 @@ def test_file_read_falls_back_to_git_when_worktree_misses(repo):
     from app.main import create_app
     from tests._auth import login_fastapi
 
-    _plumb_commit("wt/miss.md", _A)  # in git, never materialized on disk
+    plumb_commit("wt/miss.md", _A)  # in git, never materialized on disk
     client = TestClient(create_app())
     uid = seed_user(uid="rd", email="rd@x.com", is_admin=True)
     login_fastapi(client, uid)


### PR DESCRIPTION
First of the focused-trigger pair (on-create now, the AI-create advisory in the write tool result stacks next). A just-created page gets an immediate, narrowly-scoped check instead of waiting for the sweep.

## Detector subset (the "some but not all" rule)
Only **instant-truth** detectors opt into `ON_CREATE` via the existing `applicable()` seam:
- **case-collision** — the collision exists the moment the name is chosen; catching it at birth beats the weekly sweep (and beats a case-insensitive clone eating one side).
- **body-dup** — the canonical redundant-creation failure.

Settle-dependent detectors (stub, template-echo) stay sweep-only — every new page starts small and template-shaped; flagging that at creation would nag mid-work. Template creates are quiet **by construction**: body-dup's template-echo precedence already skips groups whose shared body is a template body.

## Scope: the creation neighborhood
`runner.run_on_create(path)` pairs the new page against same-blob pages + case-colliding paths (two git listings — no whole-space fingerprint pass, per-create cost stays flat). Detectors pair strictly within scope, so this is the scope expansion the `Scope` contract requires of partial triggers. A new `focus_paths` filter on `run_detection` then keeps only findings **involving the new page** — incidental findings among neighbors are the sweep's business. The common create (no collision, no duplicate) short-circuits before even writing a `detection_runs` row.

Reconciliation/invalidation stays sweep-gated (a partial scope's silence proves nothing about the ledger), the sweep singleton is untouched, and dedup/cooldown/claims/do-not-manage all apply unchanged — they're trigger-agnostic.

## The two creation scenarios
The lifecycle hook (`after_doc_write(change_kind="create")`) enqueues the run on the automanage offline queue for **attributable creations only** — human and agent-for-a-user creates (UI/API/chat/MCP all pass `owner_user_id`). System channels (ingestion, seeds) pass `None` and are skipped: they arrive in bursts, have their own reconciliation, and the sweep covers whatever they leave behind.

Import note: the task is imported module-style in `notify` — `tasks.automanage → runner → executor → notify` is a cycle, and a name import breaks whichever side loads second (caught by the integration suite; same pattern as `coedit_rebase`).

8 new tests (duplicate create emits focused proposal; common create skips the run entirely; case-collision via git plumbing; focus filter drops neighbor-only findings; settle-dependent detectors stay out; focused runs never invalidate the ledger; rejection suppresses the re-created ask; hook fires for attributable creations only). Full backend suite: 1990 passed; ruff + basedpyright clean.