### PR TITLE
feat(wiki): folder tabbed side panel with Auto-Organize suggestions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -460,3 +460,18 @@ body {
   font-size: 14px;
   line-height: 20px;
 }
+
+/* Suggestions-card row highlight (mock annotation "Click to highlight
+   folder"): a brief tint flash on the targeted listing row. */
+.wiki-row-flash {
+  animation: wiki-row-flash 2s ease-out;
+}
+@keyframes wiki-row-flash {
+  0%,
+  60% {
+    background-color: var(--background-tint-03);
+  }
+  100% {
+    background-color: transparent;
+  }
+}

--- a/frontend/src/components/wiki/DocPanel.tsx
+++ b/frontend/src/components/wiki/DocPanel.tsx
@@ -17,6 +17,9 @@ const tabIndex = (tab: DocPanelTab) => TABS.findIndex((t) => t.value === tab);
 interface DocPanelProps {
   tab: DocPanelTab;
   onTabChange: (tab: DocPanelTab) => void;
+  /** Which tabs the strip offers, in TABS order. Folder pages show a
+   * subset (Updates | Watching, mock 2240:59533); omit for all four. */
+  tabs?: DocPanelTab[];
   /** Active tab's surface. The page renders it so cross-tab state (comment
    * threads, trigger status) lives above the panel and survives tab moves. */
   children: ReactNode;
@@ -26,7 +29,8 @@ interface DocPanelProps {
  * Sources | Watching tab strip over the active surface. The rail holds one
  * occupant at a time, so the tabbed surfaces render inside this panel
  * rather than as their own rail columns. */
-export function DocPanel({ tab, onTabChange, children }: DocPanelProps) {
+export function DocPanel({ tab, onTabChange, tabs, children }: DocPanelProps) {
+  const shown = tabs ? TABS.filter((t) => tabs.includes(t.value)) : TABS;
   // The incoming surface slides from the side the underline travels toward.
   // Adjust-during-render binds the direction to the committed tree, safe
   // under StrictMode double renders and abandoned concurrent renders.
@@ -49,7 +53,7 @@ export function DocPanel({ tab, onTabChange, children }: DocPanelProps) {
           onValueChange={(v) => onTabChange(v as DocPanelTab)}
         >
           <Tabs.List>
-            {TABS.map((t) => (
+            {shown.map((t) => (
               <Tabs.Trigger key={t.value} value={t.value}>
                 {t.label}
               </Tabs.Trigger>

--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -1,42 +1,28 @@
 "use client";
 
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Button,
   Divider,
   IconContainer,
   LineItemButton,
-  Switch,
   Tag,
   Text,
 } from "@onyx-ai/opal/components";
 import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
 import {
-  SvgAddLines,
   SvgArrowUpRight,
-  SvgExpand,
   SvgOnyxOctagon,
-  SvgSparkle,
   SvgTextLinesSmall,
 } from "@onyx-ai/opal/icons";
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { SvgAnthropic, SvgOpenai } from "@onyx-ai/opal/logos";
 
-import { toast } from "@/hooks/useToast";
-import { OrganizeComingSoonRow } from "@/components/wiki/UpdatePolicyPanel";
 import {
-  getUpdatePolicy,
-  patchUpdatePolicy,
-  type EffectivePolicy,
-} from "@/lib/updatePolicy";
+  AnchoredPanel,
+  AutoGlyph,
+  PolicyPopover,
+} from "@/components/wiki/policyPanels";
 import { relativeTime } from "@/lib/users";
 import { fetchFileHistory } from "@/lib/wiki/svc";
 import { useUpdateHealth } from "@/lib/wiki/hooks";
@@ -57,35 +43,6 @@ const USER_COLORS = [
 ];
 
 const MAX_CHIPS = 5;
-
-interface AutoGlyphProps {
-  size?: number;
-}
-
-/** The Auto mark (mock 2079:379954): the octagon outline holding the blue
- * lines glyph, composed from Opal icons since no single asset ships it. */
-function AutoGlyph({ size = 16 }: AutoGlyphProps) {
-  return (
-    <Section
-      gap={0}
-      width="fit"
-      height="fit"
-      className="relative text-(--text-05)"
-    >
-      <SvgOnyxOctagon size={size} />
-      <Section
-        gap={0}
-        width="full"
-        height="full"
-        alignItems="center"
-        justifyContent="center"
-        className="absolute inset-0 text-(--theme-blue-05)"
-      >
-        <SvgTextLinesSmall size={Math.round(size * 0.55)} />
-      </Section>
-    </Section>
-  );
-}
 
 function agentGlyph(name: string | null): IconFunctionComponent | null {
   const key = name?.trim().toLowerCase();
@@ -331,218 +288,6 @@ function PresenceCard({
           })}
         </Section>
       )}
-    </Section>
-  );
-}
-
-interface AnchoredPanelProps {
-  anchor: HTMLElement;
-  onDismiss: () => void;
-  /** Hover panels stay open while the pointer is inside them. */
-  hover?: { onEnter: () => void; onLeave: () => void };
-  children: ReactNode;
-}
-
-/** Anchors a floating panel to the header cluster: fixed-position, right
- * edges aligned, just below the anchor. */
-function AnchoredPanel({
-  anchor,
-  onDismiss,
-  hover,
-  children,
-}: AnchoredPanelProps) {
-  const [rect, setRect] = useState(() => anchor.getBoundingClientRect());
-  useEffect(() => {
-    setRect(anchor.getBoundingClientRect());
-  }, [anchor]);
-  const panelRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (hover) return;
-    const onDown = (e: PointerEvent) => {
-      const el = panelRef.current;
-      if (
-        el &&
-        !el.contains(e.target as Node) &&
-        !anchor.contains(e.target as Node)
-      )
-        onDismiss();
-    };
-    window.addEventListener("pointerdown", onDown, true);
-    return () => window.removeEventListener("pointerdown", onDown, true);
-  }, [anchor, hover, onDismiss]);
-  return createPortal(
-    // raw-ok: Popover.Anchor exists but Popover.Content bakes neutral-00/rounded-12/shadow-md chrome (WithoutStyles, no escape) that the mock's tint-01 policy panel and chromeless floating cards contradict, and this wrapper also needs runtime viewport coordinates
-    <div
-      ref={panelRef}
-      className="fixed z-50 w-(--block-width-panel-medium-small)"
-      style={{ top: rect.bottom + 8, right: window.innerWidth - rect.right }}
-      onPointerEnter={hover?.onEnter}
-      onPointerLeave={hover?.onLeave}
-    >
-      {/* Shared panel chrome (mock 1929:362227 "Policy Panel"; the hover
-          card and overflow panels carry the same surface). */}
-      <Section
-        gap={0}
-        justifyContent="start"
-        alignItems="stretch"
-        height="fit"
-        padding={0.25}
-        className="rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]"
-      >
-        {children}
-      </Section>
-    </div>,
-    document.body,
-  );
-}
-
-interface PolicyPopoverProps {
-  path: string;
-  /** The policy PATCH is write-gated, so read-only viewers get a
-   * disabled switch instead of a doomed request. */
-  canWrite: boolean;
-  onOpenUpdatesPanel?: () => void;
-}
-
-/** The Auto popover (mock 1929:362227 "Policy Panel"): the AI auto-edit
- * toggles and the page's update instruction, all live on the update
- * policy the full panel edits. */
-function PolicyPopover({
-  path,
-  canWrite,
-  onOpenUpdatesPanel,
-}: PolicyPopoverProps) {
-  // The policy carries the path it was fetched for: a mismatch reads as
-  // unloaded in the same render a navigation lands, so a stale page's
-  // value can never be shown or PATCHed against the new path.
-  const [policy, setPolicy] = useState<{
-    forPath: string;
-    effective: EffectivePolicy;
-  } | null>(null);
-  const [saving, setSaving] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    getUpdatePolicy(path)
-      .then(
-        (p) => alive && setPolicy({ forPath: path, effective: p.effective }),
-      )
-      .catch(() => alive && setPolicy(null));
-    return () => {
-      alive = false;
-    };
-  }, [path]);
-  const loaded = policy?.forPath === path ? policy.effective : null;
-
-  const allowed = !!loaded?.ai_management_allowed;
-  const autoUpdateDisabled = !!loaded?.ingestion_auto_update_disabled;
-  const patchField = async (patch: Partial<EffectivePolicy>) => {
-    if (!loaded) return;
-    setSaving(true);
-    setPolicy({ forPath: path, effective: { ...loaded, ...patch } });
-    try {
-      await patchUpdatePolicy(path, patch);
-    } catch (e) {
-      // The pre-patch snapshot is still in `loaded`; putting it back
-      // rolls the optimistic write off.
-      setPolicy({ forPath: path, effective: loaded });
-      toast.error(
-        e instanceof Error ? e.message : "Couldn't update the page's policy",
-      );
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  // Mock 2079:379824 annotation: clicking the popover body (any field)
-  // opens the full side panel; the switches keep their inline toggles by
-  // stopping the bubble.
-  return (
-    <Section
-      justifyContent="start"
-      alignItems="stretch"
-      height="fit"
-      gap={0.25}
-      className="w-full cursor-pointer"
-      onClick={onOpenUpdatesPanel}
-    >
-      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        <InputHorizontal
-          icon={SvgSparkle}
-          title="AI Auto-Edits"
-          description="Let AI update/organize this page on its own."
-        >
-          <span onClick={(e) => e.stopPropagation()}>
-            <Switch
-              checked={allowed}
-              // Held until this path's policy loads (toggling against the
-              // null default would persist a wrong override) and while a
-              // save is in flight (a second click would race the PATCH).
-              disabled={!canWrite || !loaded || saving}
-              onCheckedChange={() =>
-                void patchField({ ai_management_allowed: !allowed })
-              }
-            />
-          </span>
-        </InputHorizontal>
-        {allowed && (
-          <Section
-            justifyContent="start"
-            alignItems="stretch"
-            height="fit"
-            gap={0.5}
-            className="mt-2 ml-6"
-          >
-            <InputHorizontal
-              title="Update"
-              description="Periodically scan ingested data sources to add relevant new information."
-            >
-              <span onClick={(e) => e.stopPropagation()}>
-                <Switch
-                  checked={!autoUpdateDisabled}
-                  disabled={!canWrite || !loaded || saving}
-                  onCheckedChange={() =>
-                    void patchField({
-                      ingestion_auto_update_disabled: !autoUpdateDisabled,
-                    })
-                  }
-                />
-              </span>
-            </InputHorizontal>
-            <OrganizeComingSoonRow kind="page" />
-          </Section>
-        )}
-      </Section>
-      <Divider />
-      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        {/* ContentAction is the only layout that forwards descriptionMaxLines
-            (mock annotation: real value, 3 lines). */}
-        <ContentAction
-          icon={SvgAddLines}
-          title="Page Instructions"
-          description={
-            loaded?.update_instruction || "How should this page be updated?"
-          }
-          descriptionMaxLines={3}
-          sizePreset="main-ui"
-          variant="section"
-          width="full"
-          padding="fit"
-          rightChildren={
-            <Button
-              icon={SvgExpand}
-              size="md"
-              prominence="tertiary"
-              tooltip="Open in panel"
-              // stopPropagation: the popover body opens the panel too, and
-              // the bubble would double-fire the handler.
-              onClick={(e) => {
-                e.stopPropagation();
-                onOpenUpdatesPanel?.();
-              }}
-            />
-          }
-        />
-      </Section>
     </Section>
   );
 }

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -1,0 +1,395 @@
+"use client";
+
+/** Auto-Organize suggestions card (mocks 2236:78296 / 2240:59533): pending
+ * change proposals for a folder subtree with per-row approve/reject, bulk
+ * actions, and the admin shortcut. Acted-on rows stay visible with their
+ * outcome for a few seconds before the list refreshes them away (mock
+ * annotation: leave time for user confirmation). */
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Button, Tag, Text } from "@onyx-ai/opal/components";
+import { ContentAction, Section } from "@onyx-ai/opal/layouts";
+import {
+  SvgCheckCircle,
+  SvgExpand,
+  SvgFile,
+  SvgFold,
+  SvgFolder,
+  SvgFolderIn,
+  SvgSettings,
+  SvgStopCircle,
+  SvgX,
+} from "@onyx-ai/opal/icons";
+import type { IconFunctionComponent } from "@onyx-ai/opal/types";
+
+import { ApiError } from "@/lib/api";
+import { useAuth } from "@/lib/auth";
+import {
+  type Proposal,
+  approveProposal,
+  dismissProposal,
+  fetchProposal,
+  rejectProposal,
+  useProposalsByPath,
+} from "@/lib/autoOrganize";
+
+type Outcome =
+  | "working"
+  | "applying"
+  | "applied"
+  | "rejected"
+  | "dismissed"
+  | "stale"
+  | "error";
+
+const HANDLED: Outcome[] = ["applied", "rejected", "dismissed", "stale"];
+
+/** Per-op row glyph; unknown ops fall back to the page icon. */
+const OP_ICON: Record<string, IconFunctionComponent> = {
+  move: SvgFolderIn,
+  rename: SvgFolder,
+  merge: SvgFolderIn,
+  split: SvgFile,
+  create_folder: SvgFolder,
+  delete_empty_folder: SvgFolder,
+  delete_page: SvgFile,
+};
+
+interface SuggestionsCardProps {
+  /** Folder (or page) scope the proposals are listed for. */
+  path: string;
+  /** Skip fetching for viewers; the server write-scopes regardless. */
+  canWrite?: boolean;
+  /** Popover hosting: shows the open-in-side-panel action. */
+  onOpenPanel?: () => void;
+  /** Popover hosting: the header X. Hides the popup only — suggestions
+   * persist and re-show (mock annotation). */
+  onClose?: () => void;
+  /** Row click, with the proposal's source paths (mock: highlight folder). */
+  onHighlight?: (paths: string[]) => void;
+}
+
+export function SuggestionsCard({
+  path,
+  canWrite = true,
+  onOpenPanel,
+  onClose,
+  onHighlight,
+}: SuggestionsCardProps) {
+  const router = useRouter();
+  const { user } = useAuth();
+  const { proposals, refresh } = useProposalsByPath(path, canWrite);
+  const [open, setOpen] = useState(true);
+  const [outcomes, setOutcomes] = useState<Record<number, Outcome>>({});
+  const alive = useRef(true);
+  useEffect(() => () => void (alive.current = false), []);
+
+  const setOutcome = (id: number, o: Outcome) =>
+    alive.current && setOutcomes((prev) => ({ ...prev, [id]: o }));
+
+  // Execution runs async on the automanage worker: show "Applying…" and
+  // poll to a terminal status. Transient failures keep polling; an
+  // unsettled poll falls back to the delayed refresh below.
+  async function pollApplied(id: number) {
+    setOutcome(id, "applying");
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, Math.min(1000 + i * 250, 3000)));
+      if (!alive.current) return;
+      try {
+        const fresh = await fetchProposal(id);
+        if (fresh.status === "applied") return setOutcome(id, "applied");
+        if (fresh.status === "stale") return setOutcome(id, "stale");
+      } catch {
+        // transient failure (or the row was purged) — keep polling
+      }
+    }
+  }
+
+  async function act(id: number, kind: "approve" | "reject" | "dismiss") {
+    setOutcome(id, "working");
+    try {
+      if (kind === "approve") {
+        await approveProposal(id);
+        if (alive.current) void pollApplied(id);
+      } else if (kind === "reject") {
+        await rejectProposal(id);
+        setOutcome(id, "rejected");
+      } else {
+        await dismissProposal(id);
+        setOutcome(id, "dismissed");
+      }
+    } catch (e) {
+      if (!alive.current) return;
+      // 409: someone else already actioned it; the refresh will drop it.
+      if (e instanceof ApiError && e.status === 409)
+        return setOutcome(id, "dismissed");
+      setOutcome(id, "error");
+    }
+  }
+
+  const pendingIds = proposals
+    .filter((p) => {
+      const o = outcomes[p.id];
+      return !o || o === "error";
+    })
+    .map((p) => p.id);
+
+  // Bulk actions hit every not-yet-handled row (mock annotation: "apply to
+  // any that is not already selected"); rows show their outcomes in place.
+  async function actAll(kind: "approve" | "dismiss") {
+    for (const id of pendingIds) await act(id, kind);
+  }
+
+  // Once every row is handled, leave the outcomes visible briefly, then
+  // refresh so the settled rows drop out (they have left `pending`).
+  const allHandled =
+    proposals.length > 0 &&
+    proposals.every((p) => HANDLED.includes(outcomes[p.id] as Outcome));
+  useEffect(() => {
+    if (!allHandled) return;
+    const t = setTimeout(() => {
+      if (alive.current) void refresh();
+    }, 4000);
+    return () => clearTimeout(t);
+  }, [allHandled, refresh]);
+
+  if (proposals.length === 0) return null;
+  const n = proposals.length;
+
+  return (
+    <Section
+      gap={0}
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      padding={0.25}
+      data-suggestions-card
+      className="w-full rounded-(--radius-12) border border-(--status-info-02) bg-(--status-info-01)"
+    >
+      <Section gap={0} height="fit" alignItems="stretch" padding={0.25}>
+        <ContentAction
+          icon={AutoSuggestIcon}
+          title={`AI Auto-Edit suggests ${n} change${n === 1 ? "" : "s"}.`}
+          description="based on your admin auto-organize settings."
+          sizePreset="main-ui"
+          variant="section"
+          width="full"
+          padding="fit"
+          rightChildren={
+            onClose ? (
+              <Button
+                icon={SvgX}
+                size="sm"
+                prominence="tertiary"
+                tooltip="Hide (suggestions stay in the side panel)"
+                onClick={onClose}
+              />
+            ) : (
+              <Button
+                icon={open ? SvgFold : SvgExpand}
+                size="sm"
+                prominence="tertiary"
+                tooltip={open ? "Collapse" : "Expand"}
+                onClick={() => setOpen((v) => !v)}
+              />
+            )
+          }
+        />
+      </Section>
+      {open && (
+        <Section gap={0.25} height="fit" alignItems="stretch" className="mt-1">
+          {proposals.map((p) => (
+            <SuggestionRow
+              key={p.id}
+              proposal={p}
+              outcome={outcomes[p.id]}
+              onApprove={() => void act(p.id, "approve")}
+              onReject={() => void act(p.id, "reject")}
+              onClick={
+                onHighlight ? () => onHighlight(p.source_paths) : undefined
+              }
+            />
+          ))}
+          <Section
+            gap={0}
+            flexDirection="row"
+            alignItems="center"
+            justifyContent="between"
+            height="fit"
+            className="mt-1"
+          >
+            <Section
+              gap={0.25}
+              flexDirection="row"
+              alignItems="center"
+              width="fit"
+              height="fit"
+            >
+              {user?.is_admin && (
+                <Button
+                  icon={SvgSettings}
+                  size="sm"
+                  prominence="tertiary"
+                  tooltip="Auto-organize settings"
+                  onClick={() => router.push("/admin/auto-organize")}
+                />
+              )}
+              {onOpenPanel && (
+                <Button
+                  icon={SvgExpand}
+                  size="sm"
+                  prominence="tertiary"
+                  tooltip="Open in side panel"
+                  onClick={onOpenPanel}
+                />
+              )}
+            </Section>
+            <Section
+              gap={0.25}
+              flexDirection="row"
+              alignItems="center"
+              width="fit"
+              height="fit"
+            >
+              <Button
+                size="sm"
+                prominence="secondary"
+                disabled={pendingIds.length === 0}
+                onClick={() => void actAll("dismiss")}
+              >
+                Dismiss All
+              </Button>
+              <Button
+                size="sm"
+                icon={SvgCheckCircle}
+                disabled={pendingIds.length === 0}
+                onClick={() => void actAll("approve")}
+              >
+                Approve All
+              </Button>
+            </Section>
+          </Section>
+        </Section>
+      )}
+    </Section>
+  );
+}
+
+/** The card's header mark reuses the octagon Auto glyph family. */
+function AutoSuggestIcon({ size = 16 }: { size?: number }) {
+  return <SvgCheckCircle size={size} />;
+}
+
+const OUTCOME_LABEL: Record<string, string> = {
+  applying: "Applying…",
+  applied: "Applied",
+  stale: "Skipped",
+  error: "Failed",
+};
+
+interface SuggestionRowProps {
+  proposal: Proposal;
+  outcome?: Outcome;
+  onApprove: () => void;
+  onReject: () => void;
+  onClick?: () => void;
+}
+
+/** One suggestion (mock Line, 56px): op icon, summary over the path chip,
+ * reject/approve controls. Handled rows keep their place with the outcome
+ * shown (strikethrough for rejected/dismissed, check for applied). */
+function SuggestionRow({
+  proposal,
+  outcome,
+  onApprove,
+  onReject,
+  onClick,
+}: SuggestionRowProps) {
+  const Icon = OP_ICON[proposal.op] ?? SvgFile;
+  const struck = outcome === "rejected" || outcome === "dismissed";
+  const chipPath = proposal.source_paths[0] ?? proposal.target_paths[0] ?? "";
+  return (
+    <Section
+      gap={0.25}
+      flexDirection="row"
+      alignItems="start"
+      height="fit"
+      padding={0.25}
+      className={`w-full rounded-(--radius-08) bg-(--background-tint-00) ${
+        onClick ? "cursor-pointer" : ""
+      }`}
+      onClick={onClick}
+    >
+      <Section gap={0} width="fit" height="fit" className="mt-[2px] shrink-0">
+        <Icon size={16} />
+      </Section>
+      <Section
+        gap={0.125}
+        justifyContent="start"
+        alignItems="start"
+        height="fit"
+        className="min-w-0 flex-1"
+      >
+        {/* raw-ok: Text drops className, so the strikethrough state wraps it */}
+        <span className={struck ? "line-through opacity-60" : ""}>
+          <Text font="main-ui-action" color="text-04" nowrap maxLines={1}>
+            {proposal.summary}
+          </Text>
+        </span>
+        <Tag icon={SvgFolder} title={chipPath} color="gray" size="sm" />
+      </Section>
+      <Section
+        gap={0.125}
+        flexDirection="row"
+        alignItems="center"
+        width="fit"
+        height="fit"
+        className="shrink-0"
+        // Row clicks highlight the target; the action buttons must not.
+        onClick={(e) => e.stopPropagation()}
+      >
+        {outcome && outcome !== "working" && outcome !== "rejected" ? (
+          outcome === "applied" || outcome === "applying" ? (
+            <Section
+              gap={0.125}
+              flexDirection="row"
+              alignItems="center"
+              width="fit"
+              height="fit"
+              className="text-(--theme-blue-05)"
+            >
+              <Text font="secondary-body" color="inherit" nowrap>
+                {OUTCOME_LABEL[outcome]}
+              </Text>
+              <SvgCheckCircle size={16} />
+            </Section>
+          ) : (
+            <Text font="secondary-body" color="text-03" nowrap>
+              {OUTCOME_LABEL[outcome] ?? ""}
+            </Text>
+          )
+        ) : (
+          <>
+            <Button
+              icon={SvgStopCircle}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Dismiss"
+              disabled={outcome === "working"}
+              onClick={onReject}
+            />
+            <Button
+              icon={SvgCheckCircle}
+              size="sm"
+              prominence="tertiary"
+              tooltip="Approve"
+              disabled={outcome === "working"}
+              onClick={onApprove}
+            />
+          </>
+        )}
+      </Section>
+    </Section>
+  );
+}

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+/** The Auto policy surfaces shared by the doc header cluster and the folder
+ * page: the composite Auto mark, the anchored floating-panel positioner, and
+ * the hover policy popover (mock 1929:362227). */
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { Button, Divider, Switch } from "@onyx-ai/opal/components";
+import { ContentAction, InputHorizontal, Section } from "@onyx-ai/opal/layouts";
+import {
+  SvgAddLines,
+  SvgExpand,
+  SvgOnyxOctagon,
+  SvgSparkle,
+  SvgTextLinesSmall,
+} from "@onyx-ai/opal/icons";
+
+import { toast } from "@/hooks/useToast";
+import { OrganizeComingSoonRow } from "@/components/wiki/UpdatePolicyPanel";
+import {
+  getUpdatePolicy,
+  patchUpdatePolicy,
+  type EffectivePolicy,
+} from "@/lib/updatePolicy";
+
+interface AutoGlyphProps {
+  size?: number;
+}
+
+/** The Auto mark (mock 2079:379954): the octagon outline holding the blue
+ * lines glyph, composed from Opal icons since no single asset ships it. */
+export function AutoGlyph({ size = 16 }: AutoGlyphProps) {
+  return (
+    <Section
+      gap={0}
+      width="fit"
+      height="fit"
+      className="relative text-(--text-05)"
+    >
+      <SvgOnyxOctagon size={size} />
+      <Section
+        gap={0}
+        width="full"
+        height="full"
+        alignItems="center"
+        justifyContent="center"
+        className="absolute inset-0 text-(--theme-blue-05)"
+      >
+        <SvgTextLinesSmall size={Math.round(size * 0.55)} />
+      </Section>
+    </Section>
+  );
+}
+
+interface PanelSurfaceProps {
+  children: ReactNode;
+}
+
+/** The shared floating-panel chrome (mock 1929:362227 "Policy Panel"). */
+export function PanelSurface({ children }: PanelSurfaceProps) {
+  return (
+    <Section
+      gap={0}
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      padding={0.25}
+      className="rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) shadow-[0px_2px_12px_0px_var(--shadow-02),0px_0px_4px_1px_var(--shadow-01)]"
+    >
+      {children}
+    </Section>
+  );
+}
+
+interface AnchoredPanelProps {
+  anchor: HTMLElement;
+  onDismiss: () => void;
+  /** Hover panels stay open while the pointer is inside them. */
+  hover?: { onEnter: () => void; onLeave: () => void };
+  /** Pass false when children carry their own surfaces (stacked panels,
+   * self-chromed cards, mock 2283:84706). */
+  chrome?: boolean;
+  children: ReactNode;
+}
+
+/** Anchors a floating panel to a header cluster: fixed-position, right
+ * edges aligned, just below the anchor. */
+export function AnchoredPanel({
+  anchor,
+  onDismiss,
+  hover,
+  chrome = true,
+  children,
+}: AnchoredPanelProps) {
+  const [rect, setRect] = useState(() => anchor.getBoundingClientRect());
+  useEffect(() => {
+    setRect(anchor.getBoundingClientRect());
+  }, [anchor]);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (hover) return;
+    const onDown = (e: PointerEvent) => {
+      const el = panelRef.current;
+      if (
+        el &&
+        !el.contains(e.target as Node) &&
+        !anchor.contains(e.target as Node)
+      )
+        onDismiss();
+    };
+    window.addEventListener("pointerdown", onDown, true);
+    return () => window.removeEventListener("pointerdown", onDown, true);
+  }, [anchor, hover, onDismiss]);
+  return createPortal(
+    // raw-ok: Popover.Anchor exists but Popover.Content bakes neutral-00/rounded-12/shadow-md chrome (WithoutStyles, no escape) that the mock's tint-01 policy panel and chromeless floating cards contradict, and this wrapper also needs runtime viewport coordinates
+    <div
+      ref={panelRef}
+      className="fixed z-50 w-(--block-width-panel-medium-small)"
+      style={{ top: rect.bottom + 8, right: window.innerWidth - rect.right }}
+      onPointerEnter={hover?.onEnter}
+      onPointerLeave={hover?.onLeave}
+    >
+      {chrome ? <PanelSurface>{children}</PanelSurface> : children}
+    </div>,
+    document.body,
+  );
+}
+
+interface PolicyPopoverProps {
+  path: string;
+  /** The policy PATCH is write-gated, so read-only viewers get a
+   * disabled switch instead of a doomed request. */
+  canWrite: boolean;
+  /** "page" for docs, "folder" for directory scopes — drives row copy. */
+  kind?: "page" | "folder";
+  onOpenUpdatesPanel?: () => void;
+}
+
+/** The Auto popover (mock 1929:362227 "Policy Panel"): the AI auto-edit
+ * toggles and the scope's update instruction, all live on the update
+ * policy the full panel edits. */
+export function PolicyPopover({
+  path,
+  canWrite,
+  kind = "page",
+  onOpenUpdatesPanel,
+}: PolicyPopoverProps) {
+  // The policy carries the path it was fetched for: a mismatch reads as
+  // unloaded in the same render a navigation lands, so a stale page's
+  // value can never be shown or PATCHed against the new path.
+  const [policy, setPolicy] = useState<{
+    forPath: string;
+    effective: EffectivePolicy;
+  } | null>(null);
+  const [saving, setSaving] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    getUpdatePolicy(path)
+      .then(
+        (p) => alive && setPolicy({ forPath: path, effective: p.effective }),
+      )
+      .catch(() => alive && setPolicy(null));
+    return () => {
+      alive = false;
+    };
+  }, [path]);
+  const loaded = policy?.forPath === path ? policy.effective : null;
+
+  const allowed = !!loaded?.ai_management_allowed;
+  const autoUpdateDisabled = !!loaded?.ingestion_auto_update_disabled;
+  const patchField = async (patch: Partial<EffectivePolicy>) => {
+    if (!loaded) return;
+    setSaving(true);
+    setPolicy({ forPath: path, effective: { ...loaded, ...patch } });
+    try {
+      await patchUpdatePolicy(path, patch);
+    } catch (e) {
+      // The pre-patch snapshot is still in `loaded`; putting it back
+      // rolls the optimistic write off.
+      setPolicy({ forPath: path, effective: loaded });
+      toast.error(
+        e instanceof Error ? e.message : "Couldn't update the policy",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // Mock 2079:379824 annotation: clicking the popover body (any field)
+  // opens the full side panel; the switches keep their inline toggles by
+  // stopping the bubble.
+  return (
+    <Section
+      justifyContent="start"
+      alignItems="stretch"
+      height="fit"
+      gap={0.25}
+      className="w-full cursor-pointer"
+      onClick={onOpenUpdatesPanel}
+    >
+      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
+        <InputHorizontal
+          icon={SvgSparkle}
+          title="AI Auto-Edits"
+          description={`Let AI update/organize this ${kind} on its own.`}
+        >
+          <span onClick={(e) => e.stopPropagation()}>
+            <Switch
+              checked={allowed}
+              // Held until this path's policy loads (toggling against the
+              // null default would persist a wrong override) and while a
+              // save is in flight (a second click would race the PATCH).
+              disabled={!canWrite || !loaded || saving}
+              onCheckedChange={() =>
+                void patchField({ ai_management_allowed: !allowed })
+              }
+            />
+          </span>
+        </InputHorizontal>
+        {allowed && (
+          <Section
+            justifyContent="start"
+            alignItems="stretch"
+            height="fit"
+            gap={0.5}
+            className="mt-2 ml-6"
+          >
+            <InputHorizontal
+              title="Update"
+              description="Periodically scan ingested data sources to add relevant new information."
+            >
+              <span onClick={(e) => e.stopPropagation()}>
+                <Switch
+                  checked={!autoUpdateDisabled}
+                  disabled={!canWrite || !loaded || saving}
+                  onCheckedChange={() =>
+                    void patchField({
+                      ingestion_auto_update_disabled: !autoUpdateDisabled,
+                    })
+                  }
+                />
+              </span>
+            </InputHorizontal>
+            <OrganizeComingSoonRow kind={kind} />
+          </Section>
+        )}
+      </Section>
+      <Divider />
+      <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
+        {/* ContentAction is the only layout that forwards descriptionMaxLines
+            (mock annotation: real value, 3 lines). */}
+        <ContentAction
+          icon={SvgAddLines}
+          title="Page Instructions"
+          description={
+            loaded?.update_instruction || `How should this ${kind} be updated?`
+          }
+          descriptionMaxLines={3}
+          sizePreset="main-ui"
+          variant="section"
+          width="full"
+          padding="fit"
+          rightChildren={
+            <Button
+              icon={SvgExpand}
+              size="md"
+              prominence="tertiary"
+              tooltip="Open in panel"
+              // stopPropagation: the popover body opens the panel too, and
+              // the bubble would double-fire the handler.
+              onClick={(e) => {
+                e.stopPropagation();
+                onOpenUpdatesPanel?.();
+              }}
+            />
+          }
+        />
+      </Section>
+    </Section>
+  );
+}

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -136,3 +136,11 @@ export function rejectProposal(id: number) {
     method: "POST",
   });
 }
+
+/** Dismiss a pending proposal — clears it from review surfaces without the
+ * durable veto a reject carries (the sweep may re-propose it later). */
+export function dismissProposal(id: number) {
+  return apiFetch<{ status: string }>(`/automanage/proposals/${id}/dismiss`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -14,10 +14,12 @@ import {
   Button,
   Divider,
   EmptyMessageCard,
+  IconContainer,
   InputTypeIn,
   MessageCard,
   Text,
 } from "@onyx-ai/opal/components";
+import { Section } from "@onyx-ai/opal/layouts";
 import { cn } from "@onyx-ai/opal/utils";
 import {
   SvgAlertTriangle,
@@ -38,11 +40,21 @@ import {
 import { useConfirm } from "@/components/common/ConfirmDialog";
 import { LoadingSpinner } from "@/components/common/LoadingSpinner";
 import { TriggerPanel } from "@/components/triggers/TriggerPanel";
-import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { WikiHome } from "@/components/wiki/WikiHome";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { StartNewPage } from "@/components/wiki/StartNewPage";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
+import { DocPanel, type DocPanelTab } from "@/components/wiki/DocPanel";
+import { SuggestionsCard } from "@/components/wiki/SuggestionsCard";
+import { WatchingPanel } from "@/components/wiki/WatchingPanel";
+import {
+  AnchoredPanel,
+  AutoGlyph,
+  PanelSurface,
+  PolicyPopover,
+} from "@/components/wiki/policyPanels";
+import { useProposalsByPath } from "@/lib/autoOrganize";
+import type { Trigger } from "@/lib/triggers";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import { useRowActions } from "@/providers/WikiItemActionsProvider";
 import { apiFetch, ApiError } from "@/lib/api";
@@ -57,8 +69,9 @@ import {
   FilenameRow,
 } from "@/views/wiki/FileView";
 import { AI_DRAFT_KEY } from "@/lib/wiki/constants";
-import { pageTitle } from "@/lib/wiki/utils";
+import { pageTitle, updateWarnLevel } from "@/lib/wiki/utils";
 import {
+  useUpdateHealth,
   useWikiTree,
   useDeletedTombstone,
   useDocIdResolve,
@@ -218,6 +231,30 @@ function Explorer({ dir }: ExplorerProps) {
   const [dropTarget, setDropTarget] = useState<string | null>(null);
   const [sharePath, setSharePath] = useState<string | null>(null);
   const [policyOpen, setPolicyOpen] = useState(false);
+  const [panelTab, setPanelTab] = useState<DocPanelTab>("updates");
+  const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
+  // One floating surface at a time: the on-load suggestions popup or the
+  // hover policy/suggestions stack (mocks 2236:78296 / 2283:84706).
+  const [folderPanel, setFolderPanel] = useState<"hover" | "popup" | null>(
+    null,
+  );
+  // X only hides the popup for this visit; suggestions persist in the
+  // side panel and the popup returns on the next page open.
+  const popupHidden = useRef(false);
+  const clusterRef = useRef<HTMLDivElement | null>(null);
+  const closeTimer = useRef<number>(0);
+  const holdOpen = useCallback(
+    () => window.clearTimeout(closeTimer.current),
+    [],
+  );
+  const closeSoon = useCallback(() => {
+    window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(
+      () => setFolderPanel((p) => (p === "hover" ? null : p)),
+      150,
+    );
+  }, []);
+  useEffect(() => () => window.clearTimeout(closeTimer.current), []);
 
   const { subdirs, files } = useMemo(() => {
     const prefix = dir ? dir + "/" : "";
@@ -371,6 +408,44 @@ function Explorer({ dir }: ExplorerProps) {
   // 705:142993): New Page + new-folder, then share / trigger / launch-agent
   // past a divider. The update policy lives inline in the side column. Mobile
   // keeps it behind a header button + drawer instead.
+  const { health } = useUpdateHealth(dir || null);
+  const warnLevel = updateWarnLevel(health);
+  const { proposals } = useProposalsByPath(dir, !!dir);
+  // The suggestions popup self-opens when pending proposals exist (mock
+  // 2236:78296) until the X hides it for this visit.
+  useEffect(() => {
+    popupHidden.current = false;
+    setFolderPanel(null);
+  }, [dir]);
+  useEffect(() => {
+    if (proposals.length > 0 && !popupHidden.current) {
+      setFolderPanel((prev) => (prev === null ? "popup" : prev));
+    }
+  }, [proposals.length]);
+  const openSidePanel = useCallback(() => {
+    setFolderPanel(null);
+    if (isMobile) setPolicyOpen(true);
+    else setPanelTab("updates");
+  }, [isMobile]);
+  // Mock annotation "Click to highlight folder": flash the listing row for
+  // the proposal's first path segment under this folder.
+  const highlightPath = useCallback(
+    (paths: string[]) => {
+      const target = paths.find((x) => x.startsWith(dir ? dir + "/" : ""));
+      if (!target) return;
+      const rel = dir ? target.slice(dir.length + 1) : target;
+      const childPath = (dir ? dir + "/" : "") + rel.split("/")[0];
+      const el = document.querySelector(
+        `[data-wiki-row="${CSS.escape(childPath)}"]`,
+      );
+      if (!el) return;
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      el.classList.add("wiki-row-flash");
+      window.setTimeout(() => el.classList.remove("wiki-row-flash"), 2000);
+    },
+    [dir],
+  );
+
   const headerActions = (
     <>
       <Button
@@ -389,6 +464,35 @@ function Explorer({ dir }: ExplorerProps) {
           setCreating((v) => (v === "folder" ? null : "folder"));
         }}
       />
+      <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
+      <Section ref={clusterRef} gap={0} width="fit" height="fit">
+        {/* raw-ok: the Auto trigger is the mock's ringed avatar circle, not a standard icon button */}
+        <button
+          type="button"
+          aria-label="AI auto-edits"
+          className="flex cursor-pointer items-center justify-center px-[2px]"
+          onClick={openSidePanel}
+          onPointerEnter={() => {
+            holdOpen();
+            setFolderPanel("hover");
+          }}
+          onPointerLeave={closeSoon}
+        >
+          <Section gap={0} width="fit" height="fit" className="relative">
+            <IconContainer size="main-content" avatar="icon" icon={AutoGlyph} />
+            <span
+              aria-hidden
+              className={`pointer-events-none absolute inset-0 rounded-full border ${
+                warnLevel === "over"
+                  ? "border-(--status-warning-02)"
+                  : warnLevel === "near"
+                    ? "border-(--theme-amber-02)"
+                    : "border-(--theme-blue-05)"
+              }`}
+            />
+          </Section>
+        </button>
+      </Section>
       <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
       <Button
         prominence="tertiary"
@@ -434,17 +538,16 @@ function Explorer({ dir }: ExplorerProps) {
       >
         <TriggerPanel
           open={triggerModalOpen}
-          initial={{ scope_path: dir || "/" }}
-          lockScope
-          onClose={() => setTriggerModalOpen(false)}
+          initial={editTrigger ?? { scope_path: dir || "/" }}
+          lockScope={!editTrigger}
+          onClose={() => {
+            setTriggerModalOpen(false);
+            setEditTrigger(null);
+          }}
           onSaved={(t) =>
             setTriggerStatus(`Created trigger for ${t.scope_path}`)
           }
         />
-
-        {/* Auto Organize review banner for this folder's subtree (not root —
-            a wiki-wide review is the admin queue's job). */}
-        {dir && <Path2ReviewBanner path={dir} />}
 
         {triggerStatus && (
           <div className="mb-3 text-xs text-(--text-04)">{triggerStatus}</div>
@@ -610,14 +713,80 @@ function Explorer({ dir }: ExplorerProps) {
             onClose={() => setSharePath(null)}
           />
         )}
+
+        {folderPanel === "hover" && clusterRef.current && (
+          // Mock 2283:84706: the policy panel stacked over the suggestions
+          // card, each with its own surface.
+          <AnchoredPanel
+            anchor={clusterRef.current}
+            onDismiss={() => setFolderPanel(null)}
+            hover={{ onEnter: holdOpen, onLeave: closeSoon }}
+            chrome={false}
+          >
+            <Section gap={0.25} height="fit" alignItems="stretch">
+              <PanelSurface>
+                <PolicyPopover
+                  path={dir}
+                  canWrite
+                  kind="folder"
+                  onOpenUpdatesPanel={openSidePanel}
+                />
+              </PanelSurface>
+              <SuggestionsCard
+                path={dir}
+                onOpenPanel={openSidePanel}
+                onHighlight={highlightPath}
+              />
+            </Section>
+          </AnchoredPanel>
+        )}
+        {folderPanel === "popup" && clusterRef.current && (
+          <AnchoredPanel
+            anchor={clusterRef.current}
+            onDismiss={() => setFolderPanel(null)}
+            chrome={false}
+          >
+            <SuggestionsCard
+              path={dir}
+              onClose={() => {
+                popupHidden.current = true;
+                setFolderPanel(null);
+              }}
+              onOpenPanel={openSidePanel}
+              onHighlight={highlightPath}
+            />
+          </AnchoredPanel>
+        )}
       </div>
 
       {/* Folder policy applies to every page under this folder. Desktop shows
           it inline in the side column (mock 1673:32813). Mobile keeps the
           header button + drawer. */}
       {!isMobile && (
-        <aside className="w-[360px] shrink-0 overflow-y-auto p-2">
-          <UpdatePolicyPanel path={dir} />
+        <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto">
+          <DocPanel
+            tab={panelTab}
+            onTabChange={setPanelTab}
+            tabs={["updates", "watching"]}
+          >
+            {panelTab === "updates" ? (
+              <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 py-1">
+                <UpdatePolicyPanel path={dir} />
+                <SuggestionsCard path={dir} onHighlight={highlightPath} />
+              </div>
+            ) : (
+              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 py-1">
+                <WatchingPanel
+                  path={dir}
+                  onNew={() => setTriggerModalOpen(true)}
+                  onEdit={(t) => {
+                    setEditTrigger(t);
+                    setTriggerModalOpen(true);
+                  }}
+                />
+              </div>
+            )}
+          </DocPanel>
         </aside>
       )}
       {policyOpen && isMobile && (
@@ -628,11 +797,16 @@ function Explorer({ dir }: ExplorerProps) {
             className="fixed inset-0 z-[60] bg-(--mask-03)"
           />
           <div className="fixed top-0 right-0 bottom-0 z-[70] flex w-[min(400px,100vw)] shadow-(--shadow-panel)">
-            <UpdatePolicyPanel
-              path={dir}
-              onClose={() => setPolicyOpen(false)}
-              fullHeight
-            />
+            <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto bg-(--background-tint-00)">
+              <UpdatePolicyPanel
+                path={dir}
+                onClose={() => setPolicyOpen(false)}
+                fullHeight
+              />
+              <div className="px-2 pb-2">
+                <SuggestionsCard path={dir} />
+              </div>
+            </div>
           </div>
         </>
       )}
@@ -1063,6 +1237,7 @@ function Row({
   // double-fire row navigation.
   return (
     <li
+      data-wiki-row={path}
       draggable={!renaming}
       onClick={(e) => {
         if (renaming) return;

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -16,7 +16,10 @@ import {
   EmptyMessageCard,
   IconContainer,
   InputTypeIn,
+  LineItemButton,
   MessageCard,
+  Popover,
+  PopoverMenu,
   Text,
 } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
@@ -29,10 +32,10 @@ import {
   SvgDocFile,
   SvgFolder,
   SvgFolderPlus,
-  SvgLock,
+  SvgShare,
+  SvgSidebar,
   SvgMoreHorizontal,
   SvgPlus,
-  SvgShield,
   SvgTrash,
   SvgWorkflow,
   SvgZap,
@@ -232,6 +235,8 @@ function Explorer({ dir }: ExplorerProps) {
   const [sharePath, setSharePath] = useState<string | null>(null);
   const [policyOpen, setPolicyOpen] = useState(false);
   const [panelTab, setPanelTab] = useState<DocPanelTab>("updates");
+  const [panelOpen, setPanelOpen] = useState(true);
+  const [moreOpen, setMoreOpen] = useState(false);
   const [editTrigger, setEditTrigger] = useState<Trigger | null>(null);
   // One floating surface at a time: the on-load suggestions popup or the
   // hover policy/suggestions stack (mocks 2236:78296 / 2283:84706).
@@ -425,7 +430,10 @@ function Explorer({ dir }: ExplorerProps) {
   const openSidePanel = useCallback(() => {
     setFolderPanel(null);
     if (isMobile) setPolicyOpen(true);
-    else setPanelTab("updates");
+    else {
+      setPanelOpen(true);
+      setPanelTab("updates");
+    }
   }, [isMobile]);
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
@@ -493,34 +501,57 @@ function Explorer({ dir }: ExplorerProps) {
           </Section>
         </button>
       </Section>
-      <span aria-hidden className="mx-2 h-5 w-px bg-(--border-01)" />
       <Button
+        icon={SvgShare}
         prominence="tertiary"
-        rightIcon={SvgLock}
+        tooltip="Share"
         onClick={() => setSharePath(dir)}
-      >
-        Share
-      </Button>
-      <Button
-        icon={SvgWorkflow}
-        prominence="tertiary"
-        tooltip="Trigger"
-        onClick={() => setTriggerModalOpen(true)}
       />
+      <Popover open={moreOpen} onOpenChange={setMoreOpen}>
+        <Popover.Trigger asChild>
+          <span className="inline-flex">
+            <Button
+              icon={SvgMoreHorizontal}
+              prominence="tertiary"
+              tooltip="More"
+            />
+          </span>
+        </Popover.Trigger>
+        <Popover.Content width="fit" align="end">
+          <PopoverMenu>
+            <LineItemButton
+              title="Trigger"
+              icon={SvgWorkflow}
+              sizePreset="main-ui"
+              variant="section"
+              onClick={() => {
+                setMoreOpen(false);
+                setTriggerModalOpen(true);
+              }}
+            />
+            <LineItemButton
+              title="Launch Agent"
+              icon={SvgZap}
+              sizePreset="main-ui"
+              variant="section"
+              onClick={() => {
+                setMoreOpen(false);
+                rowActions.launchAgent(dir);
+              }}
+            />
+          </PopoverMenu>
+        </Popover.Content>
+      </Popover>
       <Button
-        icon={SvgZap}
+        icon={SvgSidebar}
         prominence="tertiary"
-        tooltip="Launch Agent"
-        onClick={() => rowActions.launchAgent(dir)}
+        tooltip={
+          isMobile ? "Update Policy" : panelOpen ? "Close panel" : "Open panel"
+        }
+        onClick={() =>
+          isMobile ? setPolicyOpen(true) : setPanelOpen((v) => !v)
+        }
       />
-      {isMobile && (
-        <Button
-          icon={SvgShield}
-          prominence="tertiary"
-          tooltip="Update Policy"
-          onClick={() => setPolicyOpen(true)}
-        />
-      )}
     </>
   );
 
@@ -762,7 +793,7 @@ function Explorer({ dir }: ExplorerProps) {
       {/* Folder policy applies to every page under this folder. Desktop shows
           it inline in the side column (mock 1673:32813). Mobile keeps the
           header button + drawer. */}
-      {!isMobile && (
+      {!isMobile && panelOpen && (
         <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto">
           <DocPanel
             tab={panelTab}


### PR DESCRIPTION
## Description

Folders view gets the tabbed side panel and Auto-Organize suggestions flow (nodes 705:142872, 2236:78296, 2283:84706, 2240:59533). Stacked on #523 (shares the policy popover code this branch extracts).

- The folder page's bare policy aside becomes the Updates | Watching side panel: Updates stacks the policy card and the new `SuggestionsCard`; Watching hosts the watcher list with the existing trigger editor.
- `SuggestionsCard` lists the folder's pending change proposals: per-row approve/dismiss with path chips, admin-only settings shortcut, Dismiss All / Approve All sweeping unhandled rows while outcomes stay visible a few seconds (mock annotation). Row click flashes the target listing row.
- The popup self-opens when proposals exist; X hides it for the visit only (suggestions persist in the panel). Folder header gains the Auto cluster: hover stacks policy over suggestions, click focuses the panel.
- Header adopts the doc page's icon pattern: icon Share, More menu (Trigger, Launch Agent), sidebar toggle folding the panel (drawer on mobile).
- Shared pieces move to `policyPanels` (AutoGlyph, AnchoredPanel with a chrome pass-through, kind-aware PolicyPopover); `DocPanel` accepts a tab subset; the auto-organize lib gains `dismissProposal`.

## How Has This Been Tested?
