### PR TITLE
fix(wiki): reject-only suggestions after #524, docked watcher editor

### DIFF
--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -137,9 +137,12 @@ export function SuggestionsCard({
       }
     } catch (e) {
       if (!alive.current) return;
-      // 409: someone else already actioned it. The refresh drops it.
-      if (e instanceof ApiError && e.status === 409)
-        return setOutcome(id, "rejected");
+      // 409: someone else already actioned it. Sync to the server's
+      // reality instead of guessing which outcome won.
+      if (e instanceof ApiError && e.status === 409) {
+        void refresh();
+        return;
+      }
       setOutcome(id, "error");
     }
   }

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -137,9 +137,16 @@ export function SuggestionsCard({
       }
     } catch (e) {
       if (!alive.current) return;
-      // 409: someone else already actioned it. Sync to the server's
-      // reality instead of guessing which outcome won.
+      // 409: someone else already actioned it. Clear the local outcome so
+      // the row cannot strand at working if the refresh fails, then sync
+      // to the server's reality instead of guessing which outcome won.
       if (e instanceof ApiError && e.status === 409) {
+        if (!alive.current) return;
+        setOutcomes((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
         void refresh();
         return;
       }

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /** Auto-Organize suggestions card (mocks 2236:78296 / 2240:59533): pending
- * change proposals for a folder subtree with per-row approve/dismiss, bulk
+ * change proposals for a folder subtree with per-row approve/reject, bulk
  * actions, and the admin shortcut. Rows keep their outcome in place. Once
  * all rows are handled the list refreshes them away after a beat (mock
  * annotation: leave time for user confirmation). */
@@ -32,7 +32,7 @@ import { useAuth } from "@/lib/auth";
 import {
   type Proposal,
   approveProposal,
-  dismissProposal,
+  rejectProposal,
   fetchProposal,
   useProposalsByPath,
 } from "@/lib/autoOrganize";
@@ -41,11 +41,11 @@ type Outcome =
   | "working"
   | "applying"
   | "applied"
-  | "dismissed"
+  | "rejected"
   | "stale"
   | "error";
 
-const HANDLED = new Set<Outcome>(["applied", "dismissed", "stale"]);
+const HANDLED = new Set<Outcome>(["applied", "rejected", "stale"]);
 
 /** Row glyph per the mock (2236:78296): merges show the scope being
  * merged (pages icon for a page, folder for a folder), empty-folder
@@ -125,21 +125,21 @@ export function SuggestionsCard({
     if (alive.current) void refresh();
   }
 
-  async function act(id: number, kind: "approve" | "dismiss") {
+  async function act(id: number, kind: "approve" | "reject") {
     setOutcome(id, "working");
     try {
       if (kind === "approve") {
         await approveProposal(id);
         if (alive.current) void pollApplied(id);
       } else {
-        await dismissProposal(id);
-        setOutcome(id, "dismissed");
+        await rejectProposal(id);
+        setOutcome(id, "rejected");
       }
     } catch (e) {
       if (!alive.current) return;
       // 409: someone else already actioned it. The refresh drops it.
       if (e instanceof ApiError && e.status === 409)
-        return setOutcome(id, "dismissed");
+        return setOutcome(id, "rejected");
       setOutcome(id, "error");
     }
   }
@@ -154,7 +154,7 @@ export function SuggestionsCard({
   // Bulk actions hit every untouched or failed row (mock annotation:
   // "apply to any that is not already selected"). Rows show their
   // outcomes in place.
-  async function actAll(kind: "approve" | "dismiss") {
+  async function actAll(kind: "approve" | "reject") {
     for (const id of pendingIds) await act(id, kind);
   }
 
@@ -225,7 +225,7 @@ export function SuggestionsCard({
               proposal={p}
               outcome={outcomes[p.id]}
               onApprove={() => void act(p.id, "approve")}
-              onDismiss={() => void act(p.id, "dismiss")}
+              onDismiss={() => void act(p.id, "reject")}
               onClick={
                 onHighlight ? () => onHighlight(p.source_paths) : undefined
               }
@@ -277,9 +277,9 @@ export function SuggestionsCard({
                 prominence="secondary"
                 rightIcon={SvgSlashCircle}
                 disabled={pendingIds.length === 0}
-                onClick={() => void actAll("dismiss")}
+                onClick={() => void actAll("reject")}
               >
-                Dismiss All
+                Reject All
               </Button>
               <Button
                 size="sm"
@@ -301,7 +301,7 @@ const OUTCOME_LABEL: Partial<Record<Outcome, string>> = {
   applying: "Applying…",
   applied: "Applied",
   stale: "Skipped",
-  dismissed: "Dismissed",
+  rejected: "Rejected",
   error: "Failed",
 };
 
@@ -314,8 +314,8 @@ interface SuggestionRowProps {
 }
 
 /** One suggestion (mock Line, 56px): op icon, summary over the path chip,
- * dismiss/approve controls. Handled rows keep their place with the outcome
- * shown (strikethrough for dismissed, check for applied). */
+ * reject/approve controls. Handled rows keep their place with the outcome
+ * shown (strikethrough for rejected, check for applied). */
 function SuggestionRow({
   proposal,
   outcome,
@@ -324,7 +324,7 @@ function SuggestionRow({
   onClick,
 }: SuggestionRowProps) {
   const Icon = opIcon(proposal.op, proposal.source_paths[0] ?? "");
-  const struck = outcome === "dismissed";
+  const struck = outcome === "rejected";
   const chipPath = proposal.source_paths[0] ?? proposal.target_paths[0] ?? "";
   return (
     <Section
@@ -372,7 +372,7 @@ function SuggestionRow({
               icon={SvgSlashCircle}
               size="sm"
               prominence="tertiary"
-              tooltip="Dismiss"
+              tooltip="Reject"
               disabled={outcome === "working"}
               onClick={onDismiss}
             />

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -136,11 +136,3 @@ export function rejectProposal(id: number) {
     method: "POST",
   });
 }
-
-/** Dismiss a pending proposal: clears it from review surfaces without the
- * durable veto a reject carries (the sweep may re-propose it later). */
-export function dismissProposal(id: number) {
-  return apiFetch<{ status: string }>(`/automanage/proposals/${id}/dismiss`, {
-    method: "POST",
-  });
-}

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -57,7 +57,7 @@ import {
   PolicyPopover,
 } from "@/components/wiki/policyPanels";
 import { useProposalsByPath } from "@/lib/autoOrganize";
-import type { Trigger } from "@/lib/triggers";
+import { deleteTrigger, useTriggers, type Trigger } from "@/lib/triggers";
 import WikiItemMenu from "@/components/wiki/WikiItemActions";
 import { useRowActions } from "@/providers/WikiItemActionsProvider";
 import { apiFetch, ApiError } from "@/lib/api";
@@ -411,6 +411,7 @@ function Explorer({ dir }: ExplorerProps) {
 
   // Folder-level actions portal into the single pinned header (mock
   // 705:142993).
+  const { refresh: refreshTriggers } = useTriggers();
   const { health } = useUpdateHealth(dir || null);
   const warnLevel = updateWarnLevel(health);
   const { proposals } = useProposalsByPath(dir, !!dir);
@@ -526,6 +527,10 @@ function Explorer({ dir }: ExplorerProps) {
               variant="section"
               onClick={() => {
                 setMoreOpen(false);
+                if (!isMobile) {
+                  setPanelOpen(true);
+                  setPanelTab("watching");
+                }
                 setWatcherEditor({ trigger: null });
               }}
             />
@@ -567,13 +572,21 @@ function Explorer({ dir }: ExplorerProps) {
       <div
         className={`min-w-0 flex-1 overflow-y-auto ${isMobile ? "px-3 py-4" : "px-8 py-6"}`}
       >
-        <TriggerPanel
-          open={watcherEditor !== null}
-          initial={watcherEditor?.trigger ?? { scope_path: dir || "/" }}
-          lockScope={!watcherEditor?.trigger}
-          onClose={() => setWatcherEditor(null)}
-          onSaved={(t) => setTriggerStatus(`Saved trigger for ${t.scope_path}`)}
-        />
+        {/* Desktop docks the editor inside the Watching tab; the modal is
+            the mobile path only. */}
+        {isMobile && (
+          <TriggerPanel
+            open={watcherEditor !== null}
+            initial={watcherEditor?.trigger ?? { scope_path: dir || "/" }}
+            lockScope={!watcherEditor?.trigger}
+            onClose={() => setWatcherEditor(null)}
+            onSaved={(t) => {
+              setWatcherEditor(null);
+              void refreshTriggers();
+              setTriggerStatus(`Saved trigger for ${t.scope_path}`);
+            }}
+          />
+        )}
 
         {triggerStatus && (
           <div className="mb-3 text-xs text-(--text-04)">{triggerStatus}</div>
@@ -799,12 +812,53 @@ function Explorer({ dir }: ExplorerProps) {
                 )}
               </div>
             ) : (
-              <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-2 py-1">
-                <WatchingPanel
-                  path={dir}
-                  onNew={() => setWatcherEditor({ trigger: null })}
-                  onEdit={(t) => setWatcherEditor({ trigger: t })}
-                />
+              <div
+                className={`flex min-h-0 flex-1 flex-col px-2 py-1 ${
+                  watcherEditor
+                    ? "scroll-y-hidden overflow-y-auto"
+                    : "overflow-y-auto"
+                }`}
+              >
+                {watcherEditor ? (
+                  <TriggerPanel
+                    open
+                    docked
+                    initial={
+                      watcherEditor.trigger ?? { scope_path: dir || "/" }
+                    }
+                    lockScope={!watcherEditor.trigger}
+                    onClose={() => setWatcherEditor(null)}
+                    onSaved={(t) => {
+                      setWatcherEditor(null);
+                      void refreshTriggers();
+                      setTriggerStatus(`Saved trigger for ${t.scope_path}`);
+                    }}
+                    onDelete={
+                      watcherEditor.trigger
+                        ? async () => {
+                            const t = watcherEditor.trigger as Trigger;
+                            if (
+                              !(await confirmDialog({
+                                title: "Delete this watcher?",
+                                body: `"${t.nl_description}"`,
+                                confirmLabel: "Delete",
+                              }))
+                            )
+                              return;
+                            await deleteTrigger(t.id);
+                            await refreshTriggers();
+                            setWatcherEditor(null);
+                          }
+                        : undefined
+                    }
+                  />
+                ) : (
+                  <WatchingPanel
+                    path={dir}
+                    onNew={() => setWatcherEditor({ trigger: null })}
+                    onEdit={(t) => setWatcherEditor({ trigger: t })}
+                  />
+                )}
               </div>
             )}
           </DocPanel>,


### PR DESCRIPTION
## Description

Two follow-ups to #523.

- Bug: every suggestion dismiss click on main 404s. #524 removed the dismiss verb (approve and reject only; the card's X covers "not now"), but #523 merged after it still calling the deleted endpoint. Fix: the card's slash action and the bulk button call `rejectProposal`, outcomes and labels follow the live verb, and `dismissProposal` leaves the lib. Note: button copy is now "Reject" / "Reject All" per #524's decision, diverging from the mock's "Dismiss All" wording, which predates it — veto welcome.
- The folder Watching tab's New/Edit now docks the TriggerPanel in place of the watcher list, the doc view's composition, instead of opening the standalone modal (which remains the mobile path). Delete goes through the confirm dialog and the shared triggers cache refreshes the list.

## How Has This Been Tested?
