### PR TITLE
feat(tools): delete_doc — agent-initiated soft delete over chat + MCP

### DIFF
--- a/backend/app/llm/agents/skills/__init__.py
+++ b/backend/app/llm/agents/skills/__init__.py
@@ -56,6 +56,7 @@ SKILLS: dict[str, Skill] = {
             "multi_edit",
             "apply_patch",
             "move_path",
+            "delete_doc",
             "create_directory",
             "update_doc_nl",
             "list_history",

--- a/backend/app/llm/agents/tools/delete_doc.json
+++ b/backend/app/llm/agents/tools/delete_doc.json
@@ -1,0 +1,14 @@
+{
+  "name": "delete_doc",
+  "description": "Soft-delete a single wiki markdown page: moves it to Trash, where it is restorable for 30 days (same flow as deleting from the UI). Use when the user asks to delete/remove a page, or to clean up a page you created that turned out to be redundant. Pages only — folders cannot be deleted with this tool. Requires write access to the page. Not for consolidation: if the page's content should live on in another page, merge/update first, then delete.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string",
+        "description": "Wiki-relative path of the page to delete (e.g. `notes/old-draft.md`). Must end in `.md` and exist."
+      }
+    },
+    "required": ["path"]
+  }
+}

--- a/backend/app/llm/agents/tools/delete_doc.py
+++ b/backend/app/llm/agents/tools/delete_doc.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.auth import PermissionDenied, require_can
 from app.models.wiki import PathMove
 from app.wiki import git as wiki_git
 from app.wiki import notify, trash
@@ -24,8 +25,6 @@ def handle(args: dict[str, Any]) -> Any:
 
     if not wiki_utils.file_exists(path):
         return {"error": f"file not found: {path}"}
-
-    from app.auth import PermissionDenied, require_can
 
     try:
         require_can("write", path)

--- a/backend/app/llm/agents/tools/delete_doc.py
+++ b/backend/app/llm/agents/tools/delete_doc.py
@@ -1,0 +1,49 @@
+"""Handler for the `delete_doc` tool. Spec lives in `delete_doc.json`.
+
+Soft-deletes a single wiki page: the same Trash flow as the UI delete
+(``DELETE /file``) — a move into the hidden trash location with the full
+``after_doc_trashed`` lifecycle, restorable from Trash for 30 days. Pages
+only: folder deletion has a bigger blast radius and stays a human action.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.wiki import PathMove
+from app.wiki import git as wiki_git
+from app.wiki import notify, trash
+from app.wiki import utils as wiki_utils
+from app.llm.agents.tools.errors import ToolError
+
+
+def handle(args: dict[str, Any]) -> Any:
+    try:
+        path = wiki_utils.validate_doc_path(args.get("path"))
+    except ToolError as exc:
+        return {"error": str(exc)}
+
+    if not wiki_utils.file_exists(path):
+        return {"error": f"file not found: {path}"}
+
+    from app.auth import PermissionDenied, require_can
+
+    try:
+        require_can("write", path)
+    except PermissionDenied as exc:
+        return {"error": str(exc)}
+
+    author = wiki_utils.author_string()
+    trash_id = trash.new_trash_id()
+    dest = trash.trash_location(trash_id, path)
+    sha, moves = wiki_git.move_path(
+        path, dest, trash.trash_commit_message(path), author=author
+    )
+    notify.after_doc_trashed(
+        moves, sha, author, root_move=PathMove(old=path, new=dest)
+    )
+    return {
+        "deleted": path,
+        "sha": sha,
+        "trash_id": trash_id,
+        "note": "moved to Trash — restorable for 30 days",
+    }

--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -50,6 +50,7 @@ MCP_ALLOWED_TOOLS: frozenset[str] = frozenset(
         "write_doc",
         "apply_patch",
         "move_path",
+        "delete_doc",
         "create_directory",
         "add_comment",
         "reply_comment",

--- a/backend/tests/test_delete_doc_tool.py
+++ b/backend/tests/test_delete_doc_tool.py
@@ -5,6 +5,8 @@ Pages only; write-gated; folder paths and missing files are errors.
 """
 from __future__ import annotations
 
+from typing import Any
+
 from app.auth import User, set_current_user
 from app.llm.agents.tools import dispatch as registry_dispatch
 from app.wiki import git as wiki_git
@@ -13,7 +15,7 @@ from app.wiki import utils as wiki_utils
 from tests._seed import seed_user
 
 
-def _delete(path: str) -> dict:
+def _delete(path: str) -> dict[str, Any]:
     return registry_dispatch("delete_doc", {"path": path})
 
 

--- a/backend/tests/test_delete_doc_tool.py
+++ b/backend/tests/test_delete_doc_tool.py
@@ -1,0 +1,56 @@
+"""The `delete_doc` tool — agent-initiated soft delete (chat + MCP).
+
+Same Trash flow as the UI delete: trash-move + full lifecycle, restorable.
+Pages only; write-gated; folder paths and missing files are errors.
+"""
+from __future__ import annotations
+
+from app.auth import User, set_current_user
+from app.llm.agents.tools import dispatch as registry_dispatch
+from app.wiki import git as wiki_git
+from app.wiki import trash
+from app.wiki import utils as wiki_utils
+from tests._seed import seed_user
+
+
+def _delete(path: str) -> dict:
+    return registry_dispatch("delete_doc", {"path": path})
+
+
+def test_delete_moves_page_to_trash(tmp_repo):
+    wiki_git.commit_file("notes/old.md", "# Old\n\nstale\n", "seed", author=None)
+
+    out = _delete("notes/old.md")
+
+    assert out["deleted"] == "notes/old.md"
+    assert not wiki_utils.file_exists("notes/old.md")
+    entry = trash.entry_for_original_path("notes/old.md")
+    assert entry is not None  # restorable from Trash
+
+
+def test_delete_missing_page_errors(tmp_repo):
+    out = _delete("nope.md")
+    assert "file not found" in out["error"]
+
+
+def test_delete_folder_path_errors(tmp_repo):
+    wiki_git.commit_file("dir/page.md", "# P\n", "seed", author=None)
+    out = _delete("dir")
+    assert "error" in out  # not a .md page
+
+
+def test_delete_requires_write_access(tmp_repo):
+    wiki_git.commit_file("locked/page.md", "# L\n", "seed", author=None)
+    owner = seed_user(uid="owner", email="o@x.com")
+    from app.wiki import acl
+
+    # Owner stamp with no grants = private to the owner (managed page).
+    acl.set_owner("locked/page.md", owner)
+
+    outsider = seed_user(uid="outsider", email="x@x.com")
+    with set_current_user(
+        User(id=outsider, email="x@x.com", name=None, is_admin=False)
+    ):
+        out = _delete("locked/page.md")
+    assert "error" in out
+    assert wiki_utils.file_exists("locked/page.md")  # untouched


### PR DESCRIPTION
Agents can create, edit, and move wiki pages but had no way to clean one up — the "agent removes its own redundant page" flow, or a user simply asking their agent to delete something, dead-ended. Team decision: Trash makes deletion reversible, so agents get the verb.

## Semantics
- **Same flow as the UI delete**: trash-move + the full `after_doc_trashed` lifecycle (ACL/comments/policy re-point to the trash location, search drops it, ids tombstone) — restorable from Trash for 30 days, and the tool result says so.
- **Pages only** — folder deletion has a bigger blast radius and stays a human action.
- **Write-gated** (`require_can("write")`), same as edits.
- One implementation serves both surfaces: registered in the chat `modify_wiki` skill and the MCP allowlist.
- The spec steers composition: "not for consolidation — if the content should live on elsewhere, merge/update first, then delete."

4 tests (trash-move + restorability, missing page, folder path rejected, write-denied leaves the page untouched). Tool/MCP/skill slice: 286 passed; ruff + basedpyright clean.