### PR TITLE
chore(lint): enforce top-of-file imports (PLC0415)

### DIFF
--- a/backend/app/api/permissions.py
+++ b/backend/app/api/permissions.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 
+from app.db.models import AclEntry
+from app.db.session import session
 from app.auth import User
 from app.auth import groups as groups_repo
 from app.auth import users as users_repo
@@ -296,8 +298,6 @@ def delete_acl_entry(
 ) -> Response:
     # We need the entry's resource_path to know whose owner-check to
     # apply. Fetch via the same code path the listing uses.
-    from app.db.models import AclEntry  # noqa: PLC0415
-    from app.db.session import session  # noqa: PLC0415
 
     with session() as s:
         e = s.get(AclEntry, entry_id)

--- a/backend/app/api/permissions.py
+++ b/backend/app/api/permissions.py
@@ -296,8 +296,8 @@ def delete_acl_entry(
 ) -> Response:
     # We need the entry's resource_path to know whose owner-check to
     # apply. Fetch via the same code path the listing uses.
-    from app.db.models import AclEntry
-    from app.db.session import session
+    from app.db.models import AclEntry  # noqa: PLC0415
+    from app.db.session import session  # noqa: PLC0415
 
     with session() as s:
         e = s.get(AclEntry, entry_id)

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -872,7 +872,7 @@ def generate_draft(
     user: User = Depends(require_user),
 ) -> GenerateDraftResponse:
     """Generate a draft (title + body) from a free-text prompt for review."""
-    from app.llm.agents import draft_generator
+    from app.llm.agents import draft_generator  # noqa: PLC0415
 
     result = draft_generator.generate(req.prompt)
     return GenerateDraftResponse(title=result["title"], body=result["body"])
@@ -884,7 +884,7 @@ def revise_draft(
     user: User = Depends(require_user),
 ) -> ReviseDraftResponse:
     """Apply an instruction to an unsaved draft body; return the revised body."""
-    from app.llm.agents import draft_reviser
+    from app.llm.agents import draft_reviser  # noqa: PLC0415
 
     return ReviseDraftResponse(body=draft_reviser.revise(req.body, req.instruction))
 

--- a/backend/app/api/wiki.py
+++ b/backend/app/api/wiki.py
@@ -58,6 +58,7 @@ from app.models.file_system import (
     TrashItemView,
     TrashListResponse,
 )
+from app.llm.agents import draft_generator, draft_reviser
 from app.tasks.reindex import index_path
 from app.triggers import repo as triggers_repo
 from app.wiki import (
@@ -872,7 +873,6 @@ def generate_draft(
     user: User = Depends(require_user),
 ) -> GenerateDraftResponse:
     """Generate a draft (title + body) from a free-text prompt for review."""
-    from app.llm.agents import draft_generator  # noqa: PLC0415
 
     result = draft_generator.generate(req.prompt)
     return GenerateDraftResponse(title=result["title"], body=result["body"])
@@ -884,7 +884,6 @@ def revise_draft(
     user: User = Depends(require_user),
 ) -> ReviseDraftResponse:
     """Apply an instruction to an unsaved draft body; return the revised body."""
-    from app.llm.agents import draft_reviser  # noqa: PLC0415
 
     return ReviseDraftResponse(body=draft_reviser.revise(req.body, req.instruction))
 

--- a/backend/app/auth/__init__.py
+++ b/backend/app/auth/__init__.py
@@ -110,7 +110,7 @@ def require_can(action: str, path: str, user: User | None = None) -> None:
     same treatment as any principal without grants. Imported lazily
     so ``app.wiki.acl`` can depend on ``app.auth`` without a cycle.
     """
-    from app.wiki import acl as _acl
+    from app.wiki import acl as _acl  # noqa: PLC0415
 
     if user is None:
         user = current_user()

--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 
+from app.wiki import acl
 import logging
 import threading
 
@@ -80,6 +81,10 @@ def _get_client() -> object | None:
     with _client_lock:
         if _client_ready:
             return _client
+
+        # Call-time import on purpose: the test conftest REPLACES
+        # app.config.CONFIG, so a module-level binding would pin the
+        # pre-test object (wrong OpenSearch URL/index in tests).
         from app.config import CONFIG  # noqa: PLC0415
 
         url = CONFIG.opensearch_url
@@ -145,7 +150,9 @@ _MAPPING = {
 }
 
 def _index_name() -> str:
+    # Call-time import — see _get_client.
     from app.config import CONFIG  # noqa: PLC0415
+
     return CONFIG.opensearch_index
 
 def _ensure_index(client: object) -> None:
@@ -342,6 +349,5 @@ def _visible_paths(
     """
     if is_admin or not paths:
         return paths
-    from app.wiki import acl  # noqa: PLC0415
 
     return set(acl.filter_paths_in_python(user_id, is_admin, paths))

--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -44,7 +44,7 @@ class SearchHit(BaseModel):
 # --------------------------------------------------------------------------- #
 
 def _make_client(url: str) -> object:
-    import re
+    import re  # noqa: PLC0415
 
     # urlparse mishandles passwords with special chars (e.g. '?') — use regex instead.
     m = re.match(
@@ -79,7 +79,7 @@ def _get_client() -> object | None:
     with _client_lock:
         if _client_ready:
             return _client
-        from app.config import CONFIG
+        from app.config import CONFIG  # noqa: PLC0415
 
         url = CONFIG.opensearch_url
         if not url:
@@ -144,7 +144,7 @@ _MAPPING = {
 }
 
 def _index_name() -> str:
-    from app.config import CONFIG
+    from app.config import CONFIG  # noqa: PLC0415
     return CONFIG.opensearch_index
 
 def _ensure_index(client: object) -> None:
@@ -341,6 +341,6 @@ def _visible_paths(
     """
     if is_admin or not paths:
         return paths
-    from app.wiki import acl
+    from app.wiki import acl  # noqa: PLC0415
 
     return set(acl.filter_paths_in_python(user_id, is_admin, paths))

--- a/backend/app/db/fts.py
+++ b/backend/app/db/fts.py
@@ -19,6 +19,8 @@ is not populated by the current write path).
 """
 from __future__ import annotations
 
+import re
+
 import logging
 import threading
 
@@ -44,7 +46,6 @@ class SearchHit(BaseModel):
 # --------------------------------------------------------------------------- #
 
 def _make_client(url: str) -> object:
-    import re  # noqa: PLC0415
 
     # urlparse mishandles passwords with special chars (e.g. '?') — use regex instead.
     m = re.match(

--- a/backend/app/db/migrations/versions/0001_initial.py
+++ b/backend/app/db/migrations/versions/0001_initial.py
@@ -35,7 +35,7 @@ def upgrade() -> None:
 
     # Materialize every ORM-declared table. Imported inside the function
     # so test fixtures that swap modules don't bind to a stale ``Base``.
-    from app.db.models import Base
+    from app.db.models import Base  # noqa: PLC0415
     Base.metadata.create_all(bind)
 
     # Seed the v0 trigger destination. ``"event_log"`` means "record the

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -119,7 +119,7 @@ def _alembic_config():
     so ``alembic`` itself can stay an install-time-only dependency for
     parts of the app that never call ``init_db()``.
     """
-    from alembic.config import Config as AlembicConfig
+    from alembic.config import Config as AlembicConfig  # noqa: PLC0415
 
     cfg = AlembicConfig()
     cfg.set_main_option("script_location", str(_MIGRATIONS_DIR))
@@ -149,8 +149,8 @@ def init_db() -> None:
     process simultaneously, so without this lock they race to CREATE TABLE
     alembic_version and the second writer crashes with UniqueViolation.
     """
-    import sqlalchemy as sa
-    from alembic import command
+    import sqlalchemy as sa  # noqa: PLC0415
+    from alembic import command  # noqa: PLC0415
 
     engine = get_engine()
     with engine.connect() as conn:

--- a/backend/app/llm/agents/tools/list_history.py
+++ b/backend/app/llm/agents/tools/list_history.py
@@ -28,7 +28,7 @@ def handle(args: dict[str, Any]) -> Any:
         limit = DEFAULT_LIMIT
     limit = max(1, min(limit, MAX_LIMIT))
 
-    from app.auth import PermissionDenied, require_can
+    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
     try:
         require_can("read", path)

--- a/backend/app/llm/agents/tools/list_history.py
+++ b/backend/app/llm/agents/tools/list_history.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.auth import PermissionDenied, require_can
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
 from app.wiki import git as wiki_git, provenance
@@ -28,7 +29,6 @@ def handle(args: dict[str, Any]) -> Any:
         limit = DEFAULT_LIMIT
     limit = max(1, min(limit, MAX_LIMIT))
 
-    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
     try:
         require_can("read", path)

--- a/backend/app/llm/agents/tools/read_doc.py
+++ b/backend/app/llm/agents/tools/read_doc.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from app.auth import PermissionDenied, require_can
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
 from app.wiki import agent_activity, git as wiki_git, provenance, update_policy
@@ -27,7 +28,6 @@ def handle(args: dict[str, Any]) -> Any:
     if sha is None and not wiki_utils.file_exists(path):
         return {"error": f"file not found: {path}"}
 
-    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
     try:
         require_can("read", path)

--- a/backend/app/llm/agents/tools/read_doc.py
+++ b/backend/app/llm/agents/tools/read_doc.py
@@ -27,7 +27,7 @@ def handle(args: dict[str, Any]) -> Any:
     if sha is None and not wiki_utils.file_exists(path):
         return {"error": f"file not found: {path}"}
 
-    from app.auth import PermissionDenied, require_can
+    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
     try:
         require_can("read", path)

--- a/backend/app/llm/agents/tools/read_page.py
+++ b/backend/app/llm/agents/tools/read_page.py
@@ -23,7 +23,7 @@ def handle(args: dict[str, Any]) -> Any:
     if not wiki_utils.file_exists(path):
         return {"error": f"file not found: {path}"}
 
-    from app.auth import PermissionDenied, require_can
+    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
     try:
         require_can("read", path)

--- a/backend/app/llm/agents/tools/read_page.py
+++ b/backend/app/llm/agents/tools/read_page.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from app.auth import PermissionDenied, require_can
 from app.wiki import utils as wiki_utils
 from app.llm.agents.tools.errors import ToolError
 from app.wiki import agent_activity, git as wiki_git, update_policy
@@ -23,7 +24,6 @@ def handle(args: dict[str, Any]) -> Any:
     if not wiki_utils.file_exists(path):
         return {"error": f"file not found: {path}"}
 
-    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
     try:
         require_can("read", path)

--- a/backend/app/llm/agents/wiki_qa.py
+++ b/backend/app/llm/agents/wiki_qa.py
@@ -11,6 +11,7 @@ agent. Tests patch ``app.llm.client.complete`` (transitively via
 """
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, cast
 
@@ -29,13 +30,15 @@ def run(query: str, *, model: str | None = None) -> dict[str, Any]:
     called ``read_page`` on — built from the loop's mutated message log,
     not parsed from the LLM's prose.
     """
+    # Lazy on purpose — the tool registry imports ask_nl_question, which
+    # imports this module: a top-level import is a cycle.
+    from app.llm.agents import chat as chat_agent  # noqa: PLC0415
+    from app.llm.agents import skills as skill_registry  # noqa: PLC0415
+    from app.llm.agents import tools as tool_registry  # noqa: PLC0415
     # Lazy imports avoid a cycle: chat.py imports the tool registry at
     # module load, which loads ask_nl_question.py, which imports this
     # module. Deferring the chat / registry imports until call time keeps
     # the import graph acyclic.
-    from app.llm.agents import chat as chat_agent  # noqa: PLC0415
-    from app.llm.agents import skills as skill_registry  # noqa: PLC0415
-    from app.llm.agents import tools as tool_registry  # noqa: PLC0415
 
     system_prompt = load_prompt("wiki_qa.system")
     # Read-only sub-agent: base toolset only, no `load_skill` (cannot escalate
@@ -114,7 +117,6 @@ def _extract_path(content: Any) -> str | None:
     if not isinstance(content, str):
         return None
     # Cheap path extraction — avoids loading json for the common shape.
-    import json  # noqa: PLC0415
     try:
         parsed: Any = json.loads(content)
     except (TypeError, ValueError):

--- a/backend/app/llm/agents/wiki_qa.py
+++ b/backend/app/llm/agents/wiki_qa.py
@@ -33,9 +33,9 @@ def run(query: str, *, model: str | None = None) -> dict[str, Any]:
     # module load, which loads ask_nl_question.py, which imports this
     # module. Deferring the chat / registry imports until call time keeps
     # the import graph acyclic.
-    from app.llm.agents import chat as chat_agent
-    from app.llm.agents import skills as skill_registry
-    from app.llm.agents import tools as tool_registry
+    from app.llm.agents import chat as chat_agent  # noqa: PLC0415
+    from app.llm.agents import skills as skill_registry  # noqa: PLC0415
+    from app.llm.agents import tools as tool_registry  # noqa: PLC0415
 
     system_prompt = load_prompt("wiki_qa.system")
     # Read-only sub-agent: base toolset only, no `load_skill` (cannot escalate
@@ -114,7 +114,7 @@ def _extract_path(content: Any) -> str | None:
     if not isinstance(content, str):
         return None
     # Cheap path extraction — avoids loading json for the common shape.
-    import json
+    import json  # noqa: PLC0415
     try:
         parsed: Any = json.loads(content)
     except (TypeError, ValueError):

--- a/backend/app/llm/agents/wiki_qa.py
+++ b/backend/app/llm/agents/wiki_qa.py
@@ -30,15 +30,13 @@ def run(query: str, *, model: str | None = None) -> dict[str, Any]:
     called ``read_page`` on — built from the loop's mutated message log,
     not parsed from the LLM's prose.
     """
-    # Lazy on purpose — the tool registry imports ask_nl_question, which
-    # imports this module: a top-level import is a cycle.
-    from app.llm.agents import chat as chat_agent  # noqa: PLC0415
-    from app.llm.agents import skills as skill_registry  # noqa: PLC0415
-    from app.llm.agents import tools as tool_registry  # noqa: PLC0415
     # Lazy imports avoid a cycle: chat.py imports the tool registry at
     # module load, which loads ask_nl_question.py, which imports this
     # module. Deferring the chat / registry imports until call time keeps
     # the import graph acyclic.
+    from app.llm.agents import chat as chat_agent  # noqa: PLC0415
+    from app.llm.agents import skills as skill_registry  # noqa: PLC0415
+    from app.llm.agents import tools as tool_registry  # noqa: PLC0415
 
     system_prompt = load_prompt("wiki_qa.system")
     # Read-only sub-agent: base toolset only, no `load_skill` (cannot escalate

--- a/backend/app/llm/providers/anthropic.py
+++ b/backend/app/llm/providers/anthropic.py
@@ -246,7 +246,7 @@ def _message(m: dict[str, Any]) -> dict[str, Any]:
 def _translate_error(exc: Exception) -> LLMError:
     """Map an Anthropic SDK exception to an LLMError. Imports the SDK locally
     so the failure path is the only place we touch the SDK error types."""
-    import anthropic
+    import anthropic  # noqa: PLC0415
 
     if isinstance(exc, anthropic.AuthenticationError):
         return LLMError(

--- a/backend/app/mcp_server/pubsub.py
+++ b/backend/app/mcp_server/pubsub.py
@@ -54,6 +54,8 @@ from typing import Any
 from pydantic import BaseModel
 from sqlalchemy import delete, select
 
+from app.mcp_server import session as mcp_session
+from app.wiki import acl
 from app.db import models as orm
 from app.db.session import execute_dml, session as db_session
 from app.models.wiki import ChangeKind
@@ -420,7 +422,6 @@ def publish_list_changed() -> None:
     # Walk every locally-active session — sessions with an open SSE on
     # this process. Other replicas walk their own sets via the NOTIFY
     # relay below.
-    from app.mcp_server import session as mcp_session  # noqa: PLC0415
 
     for session_id in mcp_session.all_session_ids():
         _deliver(session_id, notif)
@@ -489,8 +490,6 @@ def _should_deliver(session_id: str, rel: str) -> bool:
     """Per-subscriber ACL recheck. Returns False when the session is
     gone or its user can no longer read ``rel``."""
     # Local imports — these modules import this one transitively.
-    from app.mcp_server import session as mcp_session  # noqa: PLC0415
-    from app.wiki import acl  # noqa: PLC0415
 
     sess = mcp_session.get(session_id)
     if sess is None:
@@ -560,7 +559,6 @@ def _on_delete(payload: dict[str, Any]) -> None:
 
 def _on_list_changed(payload: dict[str, Any]) -> None:
     notif = Notification(method="notifications/resources/list_changed", params={})
-    from app.mcp_server import session as mcp_session  # noqa: PLC0415
 
     for session_id in mcp_session.all_session_ids():
         _deliver(session_id, notif)

--- a/backend/app/mcp_server/pubsub.py
+++ b/backend/app/mcp_server/pubsub.py
@@ -420,7 +420,7 @@ def publish_list_changed() -> None:
     # Walk every locally-active session — sessions with an open SSE on
     # this process. Other replicas walk their own sets via the NOTIFY
     # relay below.
-    from app.mcp_server import session as mcp_session
+    from app.mcp_server import session as mcp_session  # noqa: PLC0415
 
     for session_id in mcp_session.all_session_ids():
         _deliver(session_id, notif)
@@ -489,8 +489,8 @@ def _should_deliver(session_id: str, rel: str) -> bool:
     """Per-subscriber ACL recheck. Returns False when the session is
     gone or its user can no longer read ``rel``."""
     # Local imports — these modules import this one transitively.
-    from app.mcp_server import session as mcp_session
-    from app.wiki import acl
+    from app.mcp_server import session as mcp_session  # noqa: PLC0415
+    from app.wiki import acl  # noqa: PLC0415
 
     sess = mcp_session.get(session_id)
     if sess is None:
@@ -560,7 +560,7 @@ def _on_delete(payload: dict[str, Any]) -> None:
 
 def _on_list_changed(payload: dict[str, Any]) -> None:
     notif = Notification(method="notifications/resources/list_changed", params={})
-    from app.mcp_server import session as mcp_session
+    from app.mcp_server import session as mcp_session  # noqa: PLC0415
 
     for session_id in mcp_session.all_session_ids():
         _deliver(session_id, notif)

--- a/backend/app/mcp_server/resources.py
+++ b/backend/app/mcp_server/resources.py
@@ -27,6 +27,7 @@ import json
 import logging
 from typing import Any
 
+from app.auth import PermissionDenied
 from app.auth import require_can
 from app.mcp_server import jobs as mcp_jobs
 from app.mcp_server import pubsub as mcp_pubsub
@@ -135,7 +136,6 @@ def subscribe_resource(sess: McpSession, uri: str) -> dict[str, Any]:
         job_id = _strip_job_uri(uri)
         job = mcp_jobs.get(job_id)
         if job is None or job["user_id"] != sess.user_id:
-            from app.auth import PermissionDenied  # noqa: PLC0415
 
             raise PermissionDenied(f"forbidden: cannot subscribe to {uri}")
         mcp_pubsub.subscribe_job(sess.id, job_id)

--- a/backend/app/mcp_server/resources.py
+++ b/backend/app/mcp_server/resources.py
@@ -135,7 +135,7 @@ def subscribe_resource(sess: McpSession, uri: str) -> dict[str, Any]:
         job_id = _strip_job_uri(uri)
         job = mcp_jobs.get(job_id)
         if job is None or job["user_id"] != sess.user_id:
-            from app.auth import PermissionDenied
+            from app.auth import PermissionDenied  # noqa: PLC0415
 
             raise PermissionDenied(f"forbidden: cannot subscribe to {uri}")
         mcp_pubsub.subscribe_job(sess.id, job_id)

--- a/backend/app/mcp_server/session.py
+++ b/backend/app/mcp_server/session.py
@@ -238,7 +238,7 @@ def drop(session_id: str) -> None:
         log.info("mcp session SSE disconnected id=%s (DB row retained)", session_id)
     # Local import: pubsub depends on session for the ACL recheck, so
     # importing it at module load creates a cycle.
-    from app.mcp_server import pubsub as mcp_pubsub
+    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     mcp_pubsub.forget(session_id)
 
@@ -253,7 +253,7 @@ def terminate(session_id: str) -> None:
         _local_sessions.pop(session_id, None)
     with db_session() as s:
         execute_dml(s, delete(orm.McpSession).where(orm.McpSession.id == session_id))
-    from app.mcp_server import pubsub as mcp_pubsub
+    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     mcp_pubsub.forget(session_id)
 
@@ -278,6 +278,6 @@ def reset_for_tests() -> None:
     schema, dropped on teardown."""
     with _local_lock:
         _local_sessions.clear()
-    from app.mcp_server import pubsub as mcp_pubsub
+    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     mcp_pubsub.reset_for_tests()

--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -109,7 +109,7 @@ def _maybe_auto_subscribe(
     if not isinstance(rel, str) or not rel:
         return
     # Local import — pubsub depends on this module transitively.
-    from app.mcp_server import pubsub as mcp_pubsub
+    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     mcp_pubsub.subscribe_doc(sess.id, rel)
 
@@ -176,15 +176,15 @@ def _call_async_nl_update(
     # Local imports — these modules pull in the queue + worker which
     # we don't want loaded at module-import time for tools.py callers
     # that just want list_for_mcp.
-    import hashlib
+    import hashlib  # noqa: PLC0415
 
-    from app.auth import PermissionDenied, require_can
-    from app.llm.agents.tools.errors import ToolError
-    from app.wiki import utils as wiki_utils
-    from app.mcp_server import jobs as mcp_jobs
-    from app.mcp_server import pubsub as mcp_pubsub
-    from app.tasks.wiki_update import agent_update_document_nl
-    from app.wiki import git as wiki_git
+    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
+    from app.llm.agents.tools.errors import ToolError  # noqa: PLC0415
+    from app.wiki import utils as wiki_utils  # noqa: PLC0415
+    from app.mcp_server import jobs as mcp_jobs  # noqa: PLC0415
+    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
+    from app.tasks.wiki_update import agent_update_document_nl  # noqa: PLC0415
+    from app.wiki import git as wiki_git  # noqa: PLC0415
 
     # ---- Validate ----
     raw_path = arguments.get("path")
@@ -247,7 +247,7 @@ def _call_async_nl_update(
     # Capture the per-key agent identity here so the worker can rebind
     # it before commit_and_fan_out — the bearer ContextVar is gone by
     # the time the worker runs.
-    from app.wiki import agent_activity
+    from app.wiki import agent_activity  # noqa: PLC0415
 
     payload: dict[str, Any] = {
         "path": rel,
@@ -296,7 +296,7 @@ def _compute_stale_paths(sess: McpSession) -> list[str]:
     poll-based fallback for clients that aren't holding a stream open
     — empty in the steady state for a connected, attentive client.
     """
-    from app.mcp_server import pubsub as mcp_pubsub
+    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     q = mcp_pubsub.queue_for(sess.id)
     drained: list[Any] = []

--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -31,7 +31,10 @@ from app.auth import PermissionDenied, require_can
 from app.llm.agents.tools.errors import ToolError
 from app.wiki import agent_activity, git as wiki_git, utils as wiki_utils
 from app.llm.agents.tools import TOOL_SPECS, dispatch as registry_dispatch
+from app.mcp_server import jobs as mcp_jobs
+from app.mcp_server import pubsub as mcp_pubsub
 from app.mcp_server.session import McpSession
+from app.tasks.wiki_update import agent_update_document_nl
 
 log = logging.getLogger(__name__)
 
@@ -114,7 +117,6 @@ def _maybe_auto_subscribe(
     if not isinstance(rel, str) or not rel:
         return
     # Local import — pubsub depends on this module transitively.
-    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     mcp_pubsub.subscribe_doc(sess.id, rel)
 
@@ -182,9 +184,6 @@ def _call_async_nl_update(
     # we don't want loaded at module-import time for tools.py callers
     # that just want list_for_mcp.
 
-    from app.mcp_server import jobs as mcp_jobs  # noqa: PLC0415
-    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
-    from app.tasks.wiki_update import agent_update_document_nl  # noqa: PLC0415
 
     # ---- Validate ----
     raw_path = arguments.get("path")
@@ -295,7 +294,6 @@ def _compute_stale_paths(sess: McpSession) -> list[str]:
     poll-based fallback for clients that aren't holding a stream open
     — empty in the steady state for a connected, attentive client.
     """
-    from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
 
     q = mcp_pubsub.queue_for(sess.id)
     drained: list[Any] = []

--- a/backend/app/mcp_server/tools.py
+++ b/backend/app/mcp_server/tools.py
@@ -25,6 +25,11 @@ import json
 import logging
 from typing import Any, cast
 
+import hashlib
+
+from app.auth import PermissionDenied, require_can
+from app.llm.agents.tools.errors import ToolError
+from app.wiki import agent_activity, git as wiki_git, utils as wiki_utils
 from app.llm.agents.tools import TOOL_SPECS, dispatch as registry_dispatch
 from app.mcp_server.session import McpSession
 
@@ -176,15 +181,10 @@ def _call_async_nl_update(
     # Local imports — these modules pull in the queue + worker which
     # we don't want loaded at module-import time for tools.py callers
     # that just want list_for_mcp.
-    import hashlib  # noqa: PLC0415
 
-    from app.auth import PermissionDenied, require_can  # noqa: PLC0415
-    from app.llm.agents.tools.errors import ToolError  # noqa: PLC0415
-    from app.wiki import utils as wiki_utils  # noqa: PLC0415
     from app.mcp_server import jobs as mcp_jobs  # noqa: PLC0415
     from app.mcp_server import pubsub as mcp_pubsub  # noqa: PLC0415
     from app.tasks.wiki_update import agent_update_document_nl  # noqa: PLC0415
-    from app.wiki import git as wiki_git  # noqa: PLC0415
 
     # ---- Validate ----
     raw_path = arguments.get("path")
@@ -247,7 +247,6 @@ def _call_async_nl_update(
     # Capture the per-key agent identity here so the worker can rebind
     # it before commit_and_fan_out — the bearer ContextVar is gone by
     # the time the worker runs.
-    from app.wiki import agent_activity  # noqa: PLC0415
 
     payload: dict[str, Any] = {
         "path": rel,

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -11,6 +11,9 @@ Ingest pipeline metrics must be updated manually at each pipeline stage.
 """
 from __future__ import annotations
 
+from app.db import page_embeddings
+from app.tasks.queues import QUEUES
+from app.wiki import update_policy
 import logging
 
 from fastapi import FastAPI
@@ -150,7 +153,6 @@ REGISTRY.register(_WikiPagesCollector())
 
 class _WikiAutoUpdateCollector:
     def collect(self):
-        from app.wiki import update_policy  # noqa: PLC0415
 
         total = fts.count_documents() or 0
         try:
@@ -174,7 +176,6 @@ class _PageEmbeddingCoverageCollector:
     candidate, so coverage below wiki_pages_total is silent recall loss."""
 
     def collect(self):
-        from app.db import page_embeddings  # noqa: PLC0415
 
         try:
             embedded = page_embeddings.count()
@@ -199,7 +200,6 @@ class _TaskQueueCollector:
     small."""
 
     def collect(self):
-        from app.tasks.queues import QUEUES  # noqa: PLC0415
 
         depth = GaugeMetricFamily(
             "task_queue_depth",

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -150,7 +150,7 @@ REGISTRY.register(_WikiPagesCollector())
 
 class _WikiAutoUpdateCollector:
     def collect(self):
-        from app.wiki import update_policy
+        from app.wiki import update_policy  # noqa: PLC0415
 
         total = fts.count_documents() or 0
         try:
@@ -174,7 +174,7 @@ class _PageEmbeddingCoverageCollector:
     candidate, so coverage below wiki_pages_total is silent recall loss."""
 
     def collect(self):
-        from app.db import page_embeddings
+        from app.db import page_embeddings  # noqa: PLC0415
 
         try:
             embedded = page_embeddings.count()
@@ -199,7 +199,7 @@ class _TaskQueueCollector:
     small."""
 
     def collect(self):
-        from app.tasks.queues import QUEUES
+        from app.tasks.queues import QUEUES  # noqa: PLC0415
 
         depth = GaugeMetricFamily(
             "task_queue_depth",

--- a/backend/app/scripts/backup_to_s3.py
+++ b/backend/app/scripts/backup_to_s3.py
@@ -77,7 +77,7 @@ class BackupConfig(BaseModel):
 def _s3_client(cfg: BackupConfig) -> Any:
     """``boto3.client`` behind an ``Any`` boundary — botocore is untyped, so
     the unavoidable Unknown is confined to this one seam."""
-    import boto3
+    import boto3  # noqa: PLC0415
 
     return boto3.client(  # pyright: ignore
         "s3", endpoint_url=cfg.endpoint_url, region_name=cfg.region

--- a/backend/app/scripts/download_relevance_model.py
+++ b/backend/app/scripts/download_relevance_model.py
@@ -79,7 +79,7 @@ def parse_s3_uri(uri: str) -> tuple[str, str]:
 def _s3_client(cfg: ModelDownloadConfig) -> Any:
     """``boto3.client`` behind an ``Any`` boundary — botocore is untyped, so
     the unavoidable Unknown is confined to this one seam."""
-    import boto3
+    import boto3  # noqa: PLC0415
 
     return boto3.client(  # pyright: ignore
         "s3", endpoint_url=cfg.endpoint_url, region_name=cfg.region

--- a/backend/app/scripts/rotate_encryption_key.py
+++ b/backend/app/scripts/rotate_encryption_key.py
@@ -60,6 +60,7 @@ from typing import Any
 
 from sqlalchemy import Column, LargeBinary, MetaData, Table, and_, select, update
 
+from app.utils.logging import setup_logging
 from app.db.crypto import EncryptedString, active_key_secret, decrypt_string, encrypt_string
 from app.db.models import Base
 from app.db.session import session
@@ -123,7 +124,6 @@ def rotate(old_secret: str, new_secret: str | None = None) -> int:
 
 
 def main() -> None:
-    from app.utils.logging import setup_logging  # noqa: PLC0415
 
     setup_logging()
     old = os.environ.get("OLD_ENCRYPTION_KEY_SECRET")

--- a/backend/app/scripts/rotate_encryption_key.py
+++ b/backend/app/scripts/rotate_encryption_key.py
@@ -123,7 +123,7 @@ def rotate(old_secret: str, new_secret: str | None = None) -> int:
 
 
 def main() -> None:
-    from app.utils.logging import setup_logging
+    from app.utils.logging import setup_logging  # noqa: PLC0415
 
     setup_logging()
     old = os.environ.get("OLD_ENCRYPTION_KEY_SECRET")

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -70,7 +70,7 @@ def _wait_for_db(timeout_s: float = 60.0, poll_s: float = 1.0) -> None:
     table exists so we know alembic has finished before we try to use
     the DB.
     """
-    from app.db.session import session
+    from app.db.session import session  # noqa: PLC0415
 
     deadline = time.monotonic() + timeout_s
     while True:

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -33,6 +33,7 @@ import time
 from prometheus_client import start_http_server
 from sqlalchemy import text
 
+from app.db.session import session
 from app.config import verify_secret_key
 from app.tasks.queues import QUEUES
 from app.tasks.queue import install_signal_handlers, request_shutdown, run_consumer
@@ -70,7 +71,6 @@ def _wait_for_db(timeout_s: float = 60.0, poll_s: float = 1.0) -> None:
     table exists so we know alembic has finished before we try to use
     the DB.
     """
-    from app.db.session import session  # noqa: PLC0415
 
     deadline = time.monotonic() + timeout_s
     while True:

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -239,7 +239,7 @@ def _current_user_id() -> str:
     """Read the user id off the ContextVar — bound by
     ``set_current_user(...)`` in the outer task. Asserts rather than
     degrades because every caller is inside that context manager."""
-    from app.auth import current_user
+    from app.auth import current_user  # noqa: PLC0415
 
     user = current_user()
     assert user is not None, "_run_inner must execute inside set_current_user(...)"

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -24,6 +24,7 @@ import os
 import time
 from typing import Any
 
+from app.auth import current_user
 from app.config import CONFIG
 from app.ingest import eval_sample as ingest_eval_sample
 from app.ingest import settings as ingest_settings
@@ -239,7 +240,6 @@ def _current_user_id() -> str:
     """Read the user id off the ContextVar — bound by
     ``set_current_user(...)`` in the outer task. Asserts rather than
     degrades because every caller is inside that context manager."""
-    from app.auth import current_user  # noqa: PLC0415
 
     user = current_user()
     assert user is not None, "_run_inner must execute inside set_current_user(...)"

--- a/backend/app/tracing/braintrust.py
+++ b/backend/app/tracing/braintrust.py
@@ -61,7 +61,7 @@ def _get_logger() -> Any | None:
     if _logger_cache is not None and _logger_cache[0] == cache_key:
         return _logger_cache[1]
     try:
-        import braintrust
+        import braintrust  # noqa: PLC0415
 
         logger = braintrust.init_logger(project=s.project, api_key=s.api_key)
     except Exception:
@@ -160,8 +160,8 @@ def start_llm_span(
         yield None
         return
     try:
-        import braintrust
-        from braintrust.span_types import SpanTypeAttribute
+        import braintrust  # noqa: PLC0415
+        from braintrust.span_types import SpanTypeAttribute  # noqa: PLC0415
 
         # braintrust's start_span member typing varies across SDK versions; the
         # ignore keeps the check stable whatever version CI resolves.
@@ -196,8 +196,8 @@ def start_tool_span(
         yield None
         return
     try:
-        import braintrust
-        from braintrust.span_types import SpanTypeAttribute
+        import braintrust  # noqa: PLC0415
+        from braintrust.span_types import SpanTypeAttribute  # noqa: PLC0415
 
         # braintrust's start_span member typing varies across SDK versions; the
         # ignore keeps the check stable whatever version CI resolves.
@@ -268,7 +268,7 @@ def push_dataset(
     if not rows:
         return 0
     try:
-        import braintrust
+        import braintrust  # noqa: PLC0415
     except ImportError:
         log.warning("braintrust SDK not installed; skipping dataset push")
         return 0
@@ -317,7 +317,7 @@ def push_experiment(
     if not rows:
         return 0
     try:
-        import braintrust
+        import braintrust  # noqa: PLC0415
     except ImportError:
         log.warning("braintrust SDK not installed; skipping experiment push")
         return 0

--- a/backend/app/wiki/automanage/review.py
+++ b/backend/app/wiki/automanage/review.py
@@ -48,7 +48,7 @@ def _executable(proposal_id: int) -> bool:
 def _dispatch_human_execution(proposal_id: int) -> None:
     """Enqueue a human-approved execution on the *nearline* queue — it applies
     promptly, never behind an in-flight sweep or AI auto-apply batch."""
-    from app.tasks.automanage import execute_approved_proposal
+    from app.tasks.automanage import execute_approved_proposal  # noqa: PLC0415
 
     execute_approved_proposal(proposal_id)
 
@@ -56,7 +56,7 @@ def _dispatch_human_execution(proposal_id: int) -> None:
 def _dispatch_ai_execution(proposal_id: int) -> None:
     """Enqueue an AI-auto-approved execution on the *offline* queue, alongside
     the sweeps — batch, nobody waits."""
-    from app.tasks.automanage import execute_auto_approved_proposal
+    from app.tasks.automanage import execute_auto_approved_proposal  # noqa: PLC0415
 
     execute_auto_approved_proposal(proposal_id)
 

--- a/backend/app/wiki/search.py
+++ b/backend/app/wiki/search.py
@@ -43,7 +43,7 @@ def search_folders(query: str, limit: int = 10) -> list[FolderHit]:
     Derived from git-tracked ``.md`` paths. Sorted so prefix matches and
     shorter paths come first.
     """
-    from app.wiki import git
+    from app.wiki import git  # noqa: PLC0415
 
     norm_q = _normalize(query)
     if not norm_q:

--- a/backend/app/wiki/search.py
+++ b/backend/app/wiki/search.py
@@ -5,6 +5,7 @@ import re
 
 from pydantic import BaseModel
 
+from app.wiki import git
 from app.db import fts
 from app.db.fts import SearchHit
 
@@ -43,7 +44,6 @@ def search_folders(query: str, limit: int = 10) -> list[FolderHit]:
     Derived from git-tracked ``.md`` paths. Sorted so prefix matches and
     shorter paths come first.
     """
-    from app.wiki import git  # noqa: PLC0415
 
     norm_q = _normalize(query)
     if not norm_q:

--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -22,6 +22,10 @@ CLI bypasses the marker because it's explicitly user-driven.
 """
 from __future__ import annotations
 
+from app.db.session import session
+from app.models.wiki import ChangeKind
+from app.wiki.git import commit_file, list_paths
+from app.wiki.notify import after_doc_write
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -69,9 +73,6 @@ def write_seed_pages(
     """
     # Local imports to avoid pulling DB/notify deps into modules that just
     # want SEED_SOURCE_DIR.
-    from app.wiki.git import commit_file  # noqa: PLC0415
-    from app.wiki.notify import after_doc_write  # noqa: PLC0415
-    from app.models.wiki import ChangeKind  # noqa: PLC0415
 
     processed = 0
     for rel, body in iter_seed_pages():
@@ -91,7 +92,6 @@ def write_seed_pages(
 
 def _read_seed_marker() -> str | None:
     """Return the ``seeded_at`` ISO timestamp, or None if not yet stamped."""
-    from app.db.session import session  # noqa: PLC0415
 
     with session() as s:
         row = s.execute(
@@ -102,7 +102,6 @@ def _read_seed_marker() -> str | None:
 
 def _stamp_seed_marker() -> None:
     """Stamp ``seeded_at`` to now (UTC, ISO). Upserts the singleton row."""
-    from app.db.session import session  # noqa: PLC0415
 
     now_iso = datetime.now(timezone.utc).isoformat()
     with session() as s:
@@ -136,7 +135,6 @@ def seed_if_empty(target_dir: str) -> bool:
     if not SEED_SOURCE_DIR.is_dir():
         log.debug("no bundled wiki seed at %s, skipping", SEED_SOURCE_DIR)
         return False
-    from app.wiki.git import list_paths  # noqa: PLC0415
 
     if any(p.endswith(".md") for p in list_paths()):
         # Pre-existing content (admin seeded another way, migrating from

--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -69,9 +69,9 @@ def write_seed_pages(
     """
     # Local imports to avoid pulling DB/notify deps into modules that just
     # want SEED_SOURCE_DIR.
-    from app.wiki.git import commit_file
-    from app.wiki.notify import after_doc_write
-    from app.models.wiki import ChangeKind
+    from app.wiki.git import commit_file  # noqa: PLC0415
+    from app.wiki.notify import after_doc_write  # noqa: PLC0415
+    from app.models.wiki import ChangeKind  # noqa: PLC0415
 
     processed = 0
     for rel, body in iter_seed_pages():
@@ -91,7 +91,7 @@ def write_seed_pages(
 
 def _read_seed_marker() -> str | None:
     """Return the ``seeded_at`` ISO timestamp, or None if not yet stamped."""
-    from app.db.session import session
+    from app.db.session import session  # noqa: PLC0415
 
     with session() as s:
         row = s.execute(
@@ -102,7 +102,7 @@ def _read_seed_marker() -> str | None:
 
 def _stamp_seed_marker() -> None:
     """Stamp ``seeded_at`` to now (UTC, ISO). Upserts the singleton row."""
-    from app.db.session import session
+    from app.db.session import session  # noqa: PLC0415
 
     now_iso = datetime.now(timezone.utc).isoformat()
     with session() as s:
@@ -136,7 +136,7 @@ def seed_if_empty(target_dir: str) -> bool:
     if not SEED_SOURCE_DIR.is_dir():
         log.debug("no bundled wiki seed at %s, skipping", SEED_SOURCE_DIR)
         return False
-    from app.wiki.git import list_paths
+    from app.wiki.git import list_paths  # noqa: PLC0415
 
     if any(p.endswith(".md") for p in list_paths()):
         # Pre-existing content (admin seeded another way, migrating from

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -207,7 +207,7 @@ def commit_and_fan_out(
     # Creating a new page is always allowed for the calling user — they
     # become the owner via the seeding hook in ``after_doc_write``.
     if change_kind == ChangeKind.EDIT and not skip_acl:
-        from app.auth import PermissionDenied, require_can
+        from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
         try:
             require_can("write", path)
@@ -315,12 +315,12 @@ def _commit_resolved(
     # Resolve the acting agent once: an explicit agent_name_var wins, else a
     # driving launcher session's tool_id, so the activity rail and the
     # provenance ledger both attribute the edit to "claude-code" / "codex".
-    from app.launchers.current_session import current_agent_session_id
+    from app.launchers.current_session import current_agent_session_id  # noqa: PLC0415
 
     launcher_sid = current_agent_session_id()
     agent_name = agent_activity.agent_name_var.get()
     if launcher_sid is not None and agent_name is None:
-        from app.db import agent_sessions as _sessions
+        from app.db import agent_sessions as _sessions  # noqa: PLC0415
 
         sess_row = _sessions.get(launcher_sid)
         if sess_row is not None:
@@ -364,7 +364,7 @@ def _commit_resolved(
             upsert_kwargs["ttl"] = activity_ttl
         expires_at = agent_activity.upsert_activity(**upsert_kwargs)
         # Local import: avoids loading the tasks package at tool-load time.
-        from app.tasks.agent_activity import schedule_cleanup_for_natural_key
+        from app.tasks.agent_activity import schedule_cleanup_for_natural_key  # noqa: PLC0415
 
         schedule_cleanup_for_natural_key(
             user_id=user.id,
@@ -394,8 +394,8 @@ def mark_doc_read(path: str) -> None:
         return
     agent_name = agent_activity.agent_name_var.get()
     # derive agent_name from launcher session if not set.
-    from app.launchers.current_session import current_agent_session_id
-    from app.db import agent_sessions as _sessions
+    from app.launchers.current_session import current_agent_session_id  # noqa: PLC0415
+    from app.db import agent_sessions as _sessions  # noqa: PLC0415
 
     launcher_sid = current_agent_session_id()
     if launcher_sid is not None and agent_name is None:
@@ -411,7 +411,7 @@ def mark_doc_read(path: str) -> None:
         description=None,
         agent_session_id=launcher_sid,
     )
-    from app.tasks.agent_activity import schedule_cleanup_for_natural_key
+    from app.tasks.agent_activity import schedule_cleanup_for_natural_key  # noqa: PLC0415
 
     schedule_cleanup_for_natural_key(
         user_id=user.id,

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -17,6 +17,10 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
+from app.auth import PermissionDenied, require_can
+from app.db import agent_sessions as _sessions
+from app.launchers.current_session import current_agent_session_id
+from app.tasks.agent_activity import schedule_cleanup_for_natural_key
 from app.auth import current_user
 from app.llm.agents import merge_conflict_update
 from app.llm.agents.tools.errors import ToolError
@@ -207,7 +211,6 @@ def commit_and_fan_out(
     # Creating a new page is always allowed for the calling user — they
     # become the owner via the seeding hook in ``after_doc_write``.
     if change_kind == ChangeKind.EDIT and not skip_acl:
-        from app.auth import PermissionDenied, require_can  # noqa: PLC0415
 
         try:
             require_can("write", path)
@@ -315,12 +318,10 @@ def _commit_resolved(
     # Resolve the acting agent once: an explicit agent_name_var wins, else a
     # driving launcher session's tool_id, so the activity rail and the
     # provenance ledger both attribute the edit to "claude-code" / "codex".
-    from app.launchers.current_session import current_agent_session_id  # noqa: PLC0415
 
     launcher_sid = current_agent_session_id()
     agent_name = agent_activity.agent_name_var.get()
     if launcher_sid is not None and agent_name is None:
-        from app.db import agent_sessions as _sessions  # noqa: PLC0415
 
         sess_row = _sessions.get(launcher_sid)
         if sess_row is not None:
@@ -364,7 +365,6 @@ def _commit_resolved(
             upsert_kwargs["ttl"] = activity_ttl
         expires_at = agent_activity.upsert_activity(**upsert_kwargs)
         # Local import: avoids loading the tasks package at tool-load time.
-        from app.tasks.agent_activity import schedule_cleanup_for_natural_key  # noqa: PLC0415
 
         schedule_cleanup_for_natural_key(
             user_id=user.id,
@@ -394,8 +394,6 @@ def mark_doc_read(path: str) -> None:
         return
     agent_name = agent_activity.agent_name_var.get()
     # derive agent_name from launcher session if not set.
-    from app.launchers.current_session import current_agent_session_id  # noqa: PLC0415
-    from app.db import agent_sessions as _sessions  # noqa: PLC0415
 
     launcher_sid = current_agent_session_id()
     if launcher_sid is not None and agent_name is None:
@@ -411,7 +409,6 @@ def mark_doc_read(path: str) -> None:
         description=None,
         agent_session_id=launcher_sid,
     )
-    from app.tasks.agent_activity import schedule_cleanup_for_natural_key  # noqa: PLC0415
 
     schedule_cleanup_for_natural_key(
         user_id=user.id,

--- a/backend/app/wiki/utils.py
+++ b/backend/app/wiki/utils.py
@@ -20,7 +20,10 @@ from typing import Any
 from app.auth import PermissionDenied, require_can
 from app.db import agent_sessions as _sessions
 from app.launchers.current_session import current_agent_session_id
-from app.tasks.agent_activity import schedule_cleanup_for_natural_key
+# Module import (attribute resolved at call time): tests patch
+# app.tasks.agent_activity.schedule_cleanup_for_natural_key, and a bound
+# name here would bypass the patch.
+from app.tasks import agent_activity as agent_activity_tasks
 from app.auth import current_user
 from app.llm.agents import merge_conflict_update
 from app.llm.agents.tools.errors import ToolError
@@ -366,7 +369,7 @@ def _commit_resolved(
         expires_at = agent_activity.upsert_activity(**upsert_kwargs)
         # Local import: avoids loading the tasks package at tool-load time.
 
-        schedule_cleanup_for_natural_key(
+        agent_activity_tasks.schedule_cleanup_for_natural_key(
             user_id=user.id,
             agent_name=agent_name,
             expires_at=expires_at,
@@ -410,7 +413,7 @@ def mark_doc_read(path: str) -> None:
         agent_session_id=launcher_sid,
     )
 
-    schedule_cleanup_for_natural_key(
+    agent_activity_tasks.schedule_cleanup_for_natural_key(
         user_id=user.id,
         agent_name=agent_name,
         expires_at=expires_at,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -59,6 +59,16 @@ include = ["app*"]
 line-length = 100
 target-version = "py312"
 
+[tool.ruff.lint]
+# PLC0415: imports belong at the top of the file. Function-local imports are
+# allowed only as explicit, commented exceptions (lazy cycle-breakers) via
+# `# noqa: PLC0415`. Existing sites were frozen with --add-noqa; don't add new
+# ones. Tests are exempt until their own sweep.
+extend-select = ["PLC0415"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["PLC0415"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 # ``-n auto`` runs tests across one process per CPU core via pytest-xdist.


### PR DESCRIPTION
Two commits:

1. **Enforce**: ruff `PLC0415` (*import outside top level*) on for `app/` — any new function-local import fails pre-commit/CI unless it carries an explicit `# noqa: PLC0415`. Tests exempt via per-file-ignores (470 sites, their own sweep).
2. **Hoist**: the movable majority of the existing sites now genuinely live in the top import block (read tools' auth imports, seed, metrics, api/wiki draft agents, api/permissions, search, fts, wiki_update, scripts, the leaf-safe half of mcp tools).

What stays lazy keeps its `noqa` **with a comment naming the cycle it breaks**: the mcp `pubsub`/`session`/`tools` triangle, `review → tasks`, `auth → acl`, tools-registry → `wiki_qa` (hoisting this one was tried and produced a live circular import — `tools/__init__` loads `ask_nl_question`, which imports `wiki_qa`), `utils → tasks`, plus optional-dependency lazies (braintrust, boto3, provider SDKs, alembic) and the standalone bootstrap migration.

Verified: ruff + basedpyright clean; the app import graph resolves from both entry directions (`app.main` first and `app.tasks.run_worker` first — the second order is what catches registry cycles).