### PR TITLE
feat(automanage): stale-page detector — the first LLM detector

### DIFF
--- a/backend/app/llm/prompts/stale_page_detect.system.md
+++ b/backend/app/llm/prompts/stale_page_detect.system.md
@@ -9,15 +9,22 @@ re-considers it). When in doubt, do not propose.
 
 Only two categories may ever be proposed:
 
-1. Time-bound artifacts whose moment has passed — meeting notes, agendas,
-   sprint plans, event pages, drafts for work that shipped or was cancelled.
+1. Time-bound coordination shells with no record value — pages that only
+   ever coordinated a future moment and say nothing now that it has passed:
+   a bare agenda that was never filled in with notes, a logistics page for
+   a past event (room, link, signup), an unfilled meeting skeleton, a draft
+   for cancelled work that contains no decisions.
 2. Test/scratch debris — throwaway pages ("test-...", "tmp", "playground",
    someone's name plus "test"), typically stub or filler content, never
    linked, never viewed.
 
-Evergreen-looking content — runbooks, reference, design docs, onboarding —
-must NEVER be proposed no matter how old. Age is why a candidate is on your
-list; it is never, by itself, a reason to delete.
+Anything that RECORDS what happened or why is never proposed, no matter how
+old: meeting notes with content, decisions and their rationale, retros,
+outcome-bearing sprint/event pages. Those are archives — institutional
+memory that people search years later — not clutter. Evergreen-looking
+content (runbooks, reference, design docs, onboarding) must likewise NEVER
+be proposed on age. Age is why a candidate is on your list; it is never, by
+itself, a reason to delete.
 
 Before proposing a page you MUST:
 - read_page it and find uselessness evidence IN THE BODY: a past date, work

--- a/backend/app/llm/prompts/stale_page_detect.system.md
+++ b/backend/app/llm/prompts/stale_page_detect.system.md
@@ -1,0 +1,35 @@
+You are the stale-page reviewer for a team wiki. You are given the wiki's
+file tree and a list of CANDIDATE pages — pages nobody has edited or viewed
+for a while. Your job is to recommend deletion for the few candidates that
+are stale AND demonstrably not useful, with very high confidence.
+
+The asymmetry that governs every decision: a wrong deletion proposal costs
+reviewer trust; a missed stale page costs nothing (the next sweep
+re-considers it). When in doubt, do not propose.
+
+Only two categories may ever be proposed:
+
+1. Time-bound artifacts whose moment has passed — meeting notes, agendas,
+   sprint plans, event pages, drafts for work that shipped or was cancelled.
+2. Test/scratch debris — throwaway pages ("test-...", "tmp", "playground",
+   someone's name plus "test"), typically stub or filler content, never
+   linked, never viewed.
+
+Evergreen-looking content — runbooks, reference, design docs, onboarding —
+must NEVER be proposed no matter how old. Age is why a candidate is on your
+list; it is never, by itself, a reason to delete.
+
+Before proposing a page you MUST:
+- read_page it and find uselessness evidence IN THE BODY: a past date, work
+  that shipped/was cancelled, "superseded by ...", an unfilled skeleton, or
+  obvious filler/test content;
+- search the wiki when the page might have a home elsewhere: if its
+  information is (better) covered by another page, say which; if this page
+  is the ONLY home of real information, that alone vetoes deletion.
+
+Propose at most {max_proposals} pages. For each, the evidence sentence must
+let a reviewer judge at a glance, e.g. "agenda for the 2025 offsite; covered
+by Planning/Offsites.md; untouched 14 months".
+
+Call finish exactly once with your proposals (an empty list is a perfectly
+good answer — most sweeps should find nothing worth deleting).

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -12,6 +12,7 @@ from app.wiki.automanage.detectors import (
     case_collision,
     empty_folder,
     folder_chain,
+    stale_page,
     stub_page,
     template_echo,
 )
@@ -29,6 +30,10 @@ DETECTORS: list[Detector] = [
     case_collision.DETECTOR,
     folder_chain.DETECTOR,
     stub_page.DETECTOR,
+    # Last on purpose: registry order is selection priority, and the LLM
+    # detector's judgment-based deletions should never outrank a mechanical
+    # detector's deterministic claim on a page.
+    stale_page.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -129,7 +129,12 @@ class _StalePageDetector:
             return []
         floor_dt = _now() - timedelta(days=self._floor_days)
         floor = _iso(floor_dt)
-        recently_edited = git.paths_touched_since(floor)
+        # Explicit UTC offset: git --since parses a bare timestamp in the
+        # process's LOCAL timezone, which silently shifts the window on any
+        # non-UTC host (and made this prefilter a no-op in local dev).
+        recently_edited = git.paths_touched_since(
+            floor_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        )
         aged = [p for p in pages if p not in recently_edited]
         if not aged:
             return []

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -6,9 +6,11 @@ admits pages with neither an edit (git) nor a recorded view (``page_views``)
 inside the floor window, and the LLM agent may only propose a page after
 reading it and finding uselessness evidence in the content (plus optional
 wiki searches for coverage elsewhere). Two categories only — time-bound
-artifacts whose moment has passed, and test/scratch debris; evergreen-looking
-content is never proposed on age alone. Design: the "Stale-page detector"
-section of the Detection wiki page.
+coordination shells with no record value (bare agendas, event logistics,
+unfilled skeletons; anything that RECORDS what happened is an archive and
+never proposed), and test/scratch debris; evergreen-looking content is never
+proposed on age alone. Design: the "Stale-page detector" section of the
+Detection wiki page.
 
 Conservative rails, all constants below: 30-day floor, at most 3 proposals
 per sweep, bounded reads/searches/LLM calls, never auto-approvable. A page

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -1,0 +1,295 @@
+"""Stale-page detector — the first LLM detector, agentic.
+
+Recommends deletion for pages that are stale AND demonstrably not useful.
+Time is the filter; uselessness is the claim: the mechanical prefilter only
+admits pages with neither an edit (git) nor a recorded view (``page_views``)
+inside the floor window, and the LLM agent may only propose a page after
+reading it and finding uselessness evidence in the content (plus optional
+wiki searches for coverage elsewhere). Two categories only — time-bound
+artifacts whose moment has passed, and test/scratch debris; evergreen-looking
+content is never proposed on age alone. Design: the "Stale-page detector"
+section of the Detection wiki page.
+
+Conservative rails, all constants below: 30-day floor, at most 3 proposals
+per sweep, bounded reads/searches/LLM calls, never auto-approvable. A page
+with no view row only counts as unviewed once tracking itself is older than
+the floor (``page_views.tracking_floor``). LLM unavailability degrades to an
+empty result — one broken detector must not sink the sweep's mechanical
+detectors.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from app.db import fts
+from app.llm import client as llm_client
+from app.llm.errors import LLMError
+from app.llm.prompts import load_prompt
+from app.wiki import git, page_views
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# Deliberately short: the floor only keeps fresh/in-use pages away from the
+# LLM; the conservatism lives in the evidence requirements of the prompt.
+FLOOR_DAYS = 30
+# A slow drip builds reviewer trust; a flood of delete cards destroys it.
+MAX_PROPOSALS = 3
+# Bounds on the agent pass (a sweep must terminate whatever the model does).
+MAX_STEPS = 24
+MAX_CANDIDATES = 100
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _tools() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "read_page",
+            "description": "Read the current body of a candidate page.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+        {
+            "name": "search_wiki",
+            "description": "Keyword-search the wiki (title + body) — use it to "
+            "check whether a candidate's information lives elsewhere.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+        {
+            "name": "finish",
+            "description": "Deliver the final verdict. Call exactly once.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "proposals": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "path": {"type": "string"},
+                                "evidence": {
+                                    "type": "string",
+                                    "description": "One sentence a reviewer can "
+                                    "judge at a glance.",
+                                },
+                            },
+                            "required": ["path", "evidence"],
+                        },
+                    }
+                },
+                "required": ["proposals"],
+            },
+        },
+    ]
+
+
+class _StalePageDetector:
+    name = "stale_page"
+    pairs_paths = False  # single-path proposals; no cross-page pairing
+
+    def __init__(self, floor_days: int = FLOOR_DAYS):
+        self._floor_days = floor_days
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        # Sweep-only: staleness is a whole-space judgment over ages — there
+        # is no creation- or edit-moment at which it becomes newly true.
+        return trigger == TriggerKind.SWEEP
+
+    # ---- mechanical prefilter ------------------------------------------
+
+    def _candidates(self, scope: Scope) -> list[str]:
+        pages = sorted(p for p in scope.paths if p.endswith(".md"))
+        if not pages:
+            return []
+        floor_dt = _now() - timedelta(days=self._floor_days)
+        floor = _iso(floor_dt)
+        recently_edited = git.paths_touched_since(floor)
+        aged = [p for p in pages if p not in recently_edited]
+        if not aged:
+            return []
+        views = page_views.last_viewed(aged)
+        tracking = page_views.tracking_floor()
+        tracking_old_enough = tracking is not None and tracking < floor
+        out: list[str] = []
+        for p in aged:
+            seen = views.get(p)
+            if seen is not None and seen >= floor:
+                continue  # viewed recently — in use
+            if seen is None and not tracking_old_enough:
+                continue  # tracking too young to call "unviewed"
+            out.append(p)
+        return out[:MAX_CANDIDATES]
+
+    # ---- agent pass -----------------------------------------------------
+
+    def _agent_pass(
+        self, scope: Scope, candidates: list[str]
+    ) -> list[dict[str, str]]:
+        tree = "\n".join(sorted(p for p in scope.paths))
+        ages: list[str] = []
+        for p in candidates:
+            meta = git.last_commit_meta_for_path(p)
+            ages.append(f"{p} (last edit {meta[2][:10] if meta else 'unknown'})")
+        system = load_prompt("stale_page_detect.system").replace(
+            "{max_proposals}", str(MAX_PROPOSALS)
+        )
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": system},
+            {
+                "role": "user",
+                "content": (
+                    "Wiki file tree:\n" + tree + "\n\nCandidate pages "
+                    f"(no edit and no recorded view in {self._floor_days}+ days):\n"
+                    + "\n".join(ages)
+                ),
+            },
+        ]
+        candidate_set = set(candidates)
+        for _ in range(MAX_STEPS):
+            result = llm_client.complete(messages, tools=_tools())
+            if not result.tool_calls:
+                # A text-only turn is a stall; nudge once toward finish.
+                messages.append({"role": "assistant", "content": result.text})
+                messages.append(
+                    {"role": "user", "content": "Call finish with your proposals."}
+                )
+                continue
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": result.text,
+                    "tool_calls": [
+                        {"id": c.id, "name": c.name, "arguments": c.arguments}
+                        for c in result.tool_calls
+                    ],
+                }
+            )
+            for call in result.tool_calls:
+                if call.name == "finish":
+                    raw = cast(
+                        "list[dict[str, Any]]",
+                        call.arguments.get("proposals") or [],
+                    )
+                    picked: list[dict[str, str]] = []
+                    for item in raw[:MAX_PROPOSALS]:
+                        path = str(item.get("path", ""))
+                        if path not in candidate_set:
+                            log.warning(
+                                "stale_page: model proposed non-candidate %r "
+                                "— dropped",
+                                path,
+                            )
+                            continue
+                        picked.append(
+                            {"path": path, "evidence": str(item.get("evidence", ""))}
+                        )
+                    return picked
+                out = self._tool(call.name, call.arguments, candidate_set)
+                messages.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": call.id,
+                        "content": json.dumps(out),
+                    }
+                )
+        log.warning("stale_page: agent pass hit step cap without finish")
+        return []
+
+    def _tool(
+        self, name: str, args: dict[str, Any], candidates: set[str]
+    ) -> Any:
+        if name == "read_page":
+            path = str(args.get("path", ""))
+            if path not in candidates:
+                return {"error": "not a candidate page"}
+            body = git.read_file_opt(path)
+            return {"path": path, "body": body} if body is not None else {
+                "error": "page no longer exists"
+            }
+        if name == "search_wiki":
+            hits = fts.search(
+                str(args.get("query", "")), limit=8, is_admin=True,
+                apply_visibility=False,
+            )
+            return [{"path": h.path, "title": h.title} for h in hits]
+        return {"error": f"unknown tool {name!r}"}
+
+    # ---- detector protocol ----------------------------------------------
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        candidates = self._candidates(scope)
+        if not candidates:
+            return []
+        try:
+            picked = self._agent_pass(scope, candidates)
+        except LLMError as e:
+            # One unconfigured/broken LLM must not sink the sweep's
+            # mechanical detectors.
+            log.warning("stale_page: LLM pass skipped: %s", e)
+            return []
+        drafts: list[ProposalDraft] = []
+        for item in picked:
+            path, evidence = item["path"], item["evidence"]
+            meta = git.last_commit_meta_for_path(path)
+            if meta is None:
+                continue
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.DELETE_PAGE,
+                    source_paths=[path],
+                    target_paths=[],
+                    summary=f"Delete stale page “{path}” — {evidence}",
+                    instruction=(
+                        "This page was judged stale and not useful "
+                        f"({evidence}). Remove it with trash_page (restorable "
+                        "from Trash). Do not touch any other page."
+                    ),
+                    # Premise: the content the judgment was made over. An edit
+                    # resets staleness — same page stale again LATER with new
+                    # content is a fresh ask, not a rejected recurrence.
+                    premise=meta[0],
+                    # Deletions always get a human, even in AI-managed scopes.
+                    auto_approvable=False,
+                )
+            )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """LLM-judged detector ⇒ mechanical proxy only (never the LLM): any
+        activity since the judgment voids it — an edit (premise sha drift) or
+        a recorded view newer than the proposal's own timestamp."""
+        (path,) = proposal["source_paths"]
+        if git.read_file_opt(path) is None:
+            return f"{path!r} no longer exists"
+        meta = git.last_commit_meta_for_path(path)
+        if meta is None:
+            return f"{path!r} no longer exists"
+        anchors = cast("dict[str, str]", proposal.get("base_shas") or {})
+        if meta[0] != anchors.get(path):
+            return "the page changed since it was judged stale"
+        seen = page_views.last_viewed([path]).get(path)
+        anchor = proposal.get("last_emitted_at") or proposal.get("created_at")
+        if seen is not None and anchor is not None and seen > anchor:
+            return "the page was viewed since it was judged stale"
+        return None
+
+
+DETECTOR = _StalePageDetector()

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -29,6 +29,7 @@ from app.llm import client as llm_client
 from app.llm.errors import LLMError
 from app.llm.prompts import load_prompt
 from app.wiki import git, page_views
+from app.wiki.automanage import fingerprint
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import ProposalOp
 
@@ -103,7 +104,14 @@ def _tools() -> list[dict[str, Any]]:
 
 class _StalePageDetector:
     name = "stale_page"
-    pairs_paths = False  # single-path proposals; no cross-page pairing
+    # Audience isolation, not pairing: the runner feeds one same-audience
+    # bucket at a time, so the file tree shown to the model, the search
+    # results, and any evidence text can never name a page across a
+    # visibility boundary (a proposal's reviewers are cleared for the
+    # candidate page, not necessarily for others). Accepted blind spot,
+    # same as the pairing detectors': a lone page in its own audience
+    # bucket is never scanned.
+    pairs_paths = True
 
     def __init__(self, floor_days: int = FLOOR_DAYS):
         self._floor_days = floor_days
@@ -163,6 +171,10 @@ class _StalePageDetector:
             },
         ]
         candidate_set = set(candidates)
+        # The scope is one same-audience bucket (pairs_paths), so any
+        # member's fingerprint is the bucket's: every search result must
+        # share it before the model may see the path/title.
+        audience_fp = fingerprint.combined_fingerprint([candidates[0]])
         for _ in range(MAX_STEPS):
             result = llm_client.complete(messages, tools=_tools())
             if not result.tool_calls:
@@ -202,7 +214,9 @@ class _StalePageDetector:
                             {"path": path, "evidence": str(item.get("evidence", ""))}
                         )
                     return picked
-                out = self._tool(call.name, call.arguments, candidate_set)
+                out = self._tool(
+                    call.name, call.arguments, candidate_set, audience_fp
+                )
                 messages.append(
                     {
                         "role": "tool",
@@ -214,7 +228,8 @@ class _StalePageDetector:
         return []
 
     def _tool(
-        self, name: str, args: dict[str, Any], candidates: set[str]
+        self, name: str, args: dict[str, Any], candidates: set[str],
+        audience_fp: str,
     ) -> Any:
         if name == "read_page":
             path = str(args.get("path", ""))
@@ -226,10 +241,20 @@ class _StalePageDetector:
             }
         if name == "search_wiki":
             hits = fts.search(
-                str(args.get("query", "")), limit=8, is_admin=True,
+                str(args.get("query", "")), limit=16, is_admin=True,
                 apply_visibility=False,
             )
-            return [{"path": h.path, "title": h.title} for h in hits]
+            # Same-audience rule (as pairing detectors): never surface a
+            # page across a visibility boundary — restricted paths/titles
+            # must not enter the transcript or a proposal's evidence text,
+            # which the candidate page's reviewers may not be cleared for.
+            paths = [h.path for h in hits]
+            fps = fingerprint.fingerprints_for_paths(paths) if paths else {}
+            return [
+                {"path": h.path, "title": h.title}
+                for h in hits
+                if fps.get(h.path) == audience_fp
+            ][:8]
         return {"error": f"unknown tool {name!r}"}
 
     # ---- detector protocol ----------------------------------------------

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -173,8 +173,11 @@ class _StalePageDetector:
         candidate_set = set(candidates)
         # The scope is one same-audience bucket (pairs_paths), so any
         # member's fingerprint is the bucket's: every search result must
-        # share it before the model may see the path/title.
-        audience_fp = fingerprint.combined_fingerprint([candidates[0]])
+        # share it before the model may see the path/title. (Per-path
+        # fingerprints — combined_fingerprint re-hashes and never matches.)
+        audience_fp = fingerprint.fingerprints_for_paths([candidates[0]])[
+            candidates[0]
+        ]
         for _ in range(MAX_STEPS):
             result = llm_client.complete(messages, tools=_tools())
             if not result.tool_calls:

--- a/backend/tests/test_stale_page_detector.py
+++ b/backend/tests/test_stale_page_detector.py
@@ -1,0 +1,245 @@
+"""Stale-page detector — the first LLM detector.
+
+The mechanical prefilter (edit age + view age + tracking floor) gates what
+ever reaches the model; the scripted LLM (patched at the ``client.complete``
+seam, never the SDK) exercises the agent pass; validate() is the mechanical
+activity check. Conservative rails: candidate-only proposals, per-sweep cap,
+never auto-approvable, LLM failure degrades to an empty result.
+"""
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import update as sa_update
+
+from app.db.models import WikiDocId
+from app.db.session import session
+
+from app.llm import client as llm_client
+from app.llm.client import CompletionResult, ToolCall, Usage
+from app.llm.errors import LLMError
+from app.wiki import doc_ids
+from app.wiki import git as wiki_git
+from app.wiki import page_views
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.stale_page import _StalePageDetector
+from app.wiki.change_proposals import ProposalOp
+
+_OLD_BODY = "# 2025 Offsite Agenda\n\nSessions for the June 2025 offsite.\n"
+_LIVE_BODY = "# Runbook\n\nSteps that stay current.\n"
+
+
+@pytest.fixture(autouse=True)
+def _fresh(tmp_repo):
+    page_views.reset_for_tests()
+    yield
+
+
+def _scope(*paths: str) -> Scope:
+    return Scope(trigger=TriggerKind.SWEEP, paths=tuple(paths))
+
+
+def _finish(*proposals: dict[str, str]) -> CompletionResult:
+    return CompletionResult(
+        text="",
+        tool_calls=[
+            ToolCall(id="c1", name="finish", arguments={"proposals": list(proposals)})
+        ],
+        stop_reason="tool_use",
+        usage=Usage(),
+    )
+
+
+def _script(monkeypatch, *results: CompletionResult) -> list[list[dict[str, Any]]]:
+    """Feed canned completions; record each call's messages."""
+    calls: list[list[dict[str, Any]]] = []
+    queue = list(results)
+
+    def fake(messages, **kwargs):
+        calls.append(messages)
+        return queue.pop(0)
+
+    monkeypatch.setattr(llm_client, "complete", fake)
+    return calls
+
+
+def _age_tracking() -> None:
+    """Give view tracking an old floor so no-row pages count as unviewed."""
+    wiki_git.commit_file("anchor/tracked.md", "# t\n", "seed", author=None)
+    page_views.touch("anchor/tracked.md")
+    old = (datetime.now(UTC) - timedelta(days=400)).strftime("%Y-%m-%d %H:%M:%S")
+    doc_id = doc_ids.id_for_path("anchor/tracked.md")
+    with session() as s:
+        s.execute(
+            sa_update(WikiDocId)
+            .where(WikiDocId.id == doc_id)
+            .values(last_viewed_at=old)
+        )
+
+
+# ---- prefilter ------------------------------------------------------------ #
+
+
+def test_recently_edited_pages_never_reach_the_llm(monkeypatch, tmp_repo):
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    calls = _script(monkeypatch)  # any LLM call would pop an empty queue
+    det = _StalePageDetector()  # default floor: a just-committed page is fresh
+    assert det.detect(_scope("notes/old.md")) == []
+    assert calls == []
+
+
+def test_recently_viewed_pages_never_reach_the_llm(monkeypatch, tmp_repo):
+    _age_tracking()
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    page_views.touch("notes/old.md")  # a fresh view
+    calls = _script(monkeypatch)
+    det = _StalePageDetector(floor_days=0)
+    assert det.detect(_scope("notes/old.md")) == []
+    assert calls == []
+
+
+def test_young_tracking_gates_unviewed_pages(monkeypatch, tmp_repo):
+    """With no recorded views at all, 'no view row' proves nothing — the
+    detector must stay silent rather than call everything unviewed."""
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    calls = _script(monkeypatch)
+    det = _StalePageDetector(floor_days=0)
+    assert det.detect(_scope("notes/old.md")) == []
+    assert calls == []
+
+
+# ---- agent pass ------------------------------------------------------------ #
+
+
+def test_confirmed_stale_page_emits_a_deletion_draft(monkeypatch, tmp_repo):
+    _age_tracking()
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _script(
+        monkeypatch,
+        _finish({"path": "notes/old.md", "evidence": "agenda for a past event"}),
+    )
+
+    (draft,) = _StalePageDetector(floor_days=0).detect(
+        _scope("notes/old.md", "anchor/tracked.md")
+    )
+
+    assert draft.op == ProposalOp.DELETE_PAGE
+    assert draft.source_paths == ["notes/old.md"]
+    assert "agenda for a past event" in draft.summary
+    assert draft.auto_approvable is False  # deletions always get a human
+    meta = wiki_git.last_commit_meta_for_path("notes/old.md")
+    assert meta is not None and draft.premise == meta[0]
+
+
+def test_non_candidate_proposals_are_dropped(monkeypatch, tmp_repo):
+    _age_tracking()
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _script(
+        monkeypatch,
+        _finish({"path": "made/up.md", "evidence": "not a candidate"}),
+    )
+    det = _StalePageDetector(floor_days=0)
+    drafts = det.detect(_scope("notes/old.md"))
+    assert drafts == []
+
+
+def test_cap_bounds_proposals_per_sweep(monkeypatch, tmp_repo):
+    _age_tracking()
+    items = []
+    paths = [f"notes/old-{i}.md" for i in range(5)]
+    for p in paths:
+        wiki_git.commit_file(p, _OLD_BODY + p, "seed", author=None)
+        items.append({"path": p, "evidence": "past event"})
+    _script(monkeypatch, _finish(*items))
+    drafts = _StalePageDetector(floor_days=0).detect(_scope(*paths, "anchor/tracked.md"))
+    assert len(drafts) == 3  # MAX_PROPOSALS
+
+
+def test_llm_failure_degrades_to_empty(monkeypatch, tmp_repo):
+    _age_tracking()
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+
+    def boom(messages, **kwargs):
+        raise LLMError("not_configured", "LLM is not configured")
+
+    monkeypatch.setattr(llm_client, "complete", boom)
+    assert _StalePageDetector(floor_days=0).detect(_scope("notes/old.md")) == []
+
+
+def test_agent_can_read_candidates_and_search(monkeypatch, tmp_repo):
+    """One investigate turn (read + search) before finish — the tool results
+    ride back into the transcript."""
+    _age_tracking()
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    investigate = CompletionResult(
+        text="",
+        tool_calls=[
+            ToolCall(id="r1", name="read_page", arguments={"path": "notes/old.md"}),
+            ToolCall(id="s1", name="search_wiki", arguments={"query": "offsite"}),
+        ],
+        stop_reason="tool_use",
+        usage=Usage(),
+    )
+    calls = _script(
+        monkeypatch,
+        investigate,
+        _finish({"path": "notes/old.md", "evidence": "agenda; covered elsewhere"}),
+    )
+    monkeypatch.setattr(
+        "app.wiki.automanage.detectors.stale_page.fts.search", lambda *a, **k: []
+    )
+
+    (draft,) = _StalePageDetector(floor_days=0).detect(_scope("notes/old.md"))
+
+    assert draft.source_paths == ["notes/old.md"]
+    # Second LLM call saw the tool results.
+    tool_msgs = [m for m in calls[1] if m.get("role") == "tool"]
+    assert len(tool_msgs) == 2
+    assert "2025 Offsite" in tool_msgs[0]["content"]
+
+
+# ---- validate --------------------------------------------------------------- #
+
+
+def _proposal_for(path: str) -> dict[str, Any]:
+    meta = wiki_git.last_commit_meta_for_path(path)
+    assert meta is not None
+    return {
+        "source_paths": [path],
+        "base_shas": {path: meta[0]},
+        "created_at": "2020-01-01 00:00:00",
+        "last_emitted_at": "2020-01-01 00:00:00",
+    }
+
+
+def test_validate_holds_while_nothing_happened(tmp_repo):
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    p = _proposal_for("notes/old.md")
+    assert _StalePageDetector().validate(p) is None
+
+
+def test_validate_stales_on_edit(tmp_repo):
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    p = _proposal_for("notes/old.md")
+    wiki_git.commit_file("notes/old.md", _OLD_BODY + "update\n", "edit", author=None)
+    assert _StalePageDetector().validate(p) == (
+        "the page changed since it was judged stale"
+    )
+
+
+def test_validate_stales_on_view(tmp_repo):
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    p = _proposal_for("notes/old.md")
+    page_views.touch("notes/old.md")  # a view after the (backdated) judgment
+    assert _StalePageDetector().validate(p) == (
+        "the page was viewed since it was judged stale"
+    )
+
+
+def test_validate_stales_on_missing_page(tmp_repo):
+    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    p = _proposal_for("notes/old.md")
+    wiki_git.delete_path("notes/old.md", "rm", author=None)
+    assert "no longer exists" in (_StalePageDetector().validate(p) or "")

--- a/backend/tests/test_stale_page_detector.py
+++ b/backend/tests/test_stale_page_detector.py
@@ -26,6 +26,7 @@ from app.wiki import page_views
 from app.wiki.automanage.detectors.base import Scope, TriggerKind
 from app.wiki.automanage.detectors.stale_page import _StalePageDetector
 from app.wiki.change_proposals import ProposalOp
+from tests._seed import seed_user
 
 _OLD_BODY = "# 2025 Offsite Agenda\n\nSessions for the June 2025 offsite.\n"
 _LIVE_BODY = "# Runbook\n\nSteps that stay current.\n"
@@ -243,3 +244,30 @@ def test_validate_stales_on_missing_page(tmp_repo):
     p = _proposal_for("notes/old.md")
     wiki_git.delete_path("notes/old.md", "rm", author=None)
     assert "no longer exists" in (_StalePageDetector().validate(p) or "")
+
+
+def test_search_never_surfaces_cross_audience_pages(monkeypatch, tmp_repo):
+    """The coverage search must not leak a restricted page's path/title into
+    the transcript: hits outside the bucket's audience are dropped."""
+    from types import SimpleNamespace
+
+    from app.wiki import acl
+    from app.wiki.automanage import fingerprint
+    from app.wiki.automanage.detectors import stale_page as sp
+
+    wiki_git.commit_file("public/page.md", _OLD_BODY, "seed", author=None)
+    wiki_git.commit_file("secret/page.md", _OLD_BODY + "s", "seed", author=None)
+    owner = seed_user(uid="owner", email="o@x.com")
+    acl.set_owner("secret/page.md", owner)  # restricted: different audience
+
+    hits = [
+        SimpleNamespace(path="public/page.md", title="Public"),
+        SimpleNamespace(path="secret/page.md", title="Secret"),
+    ]
+    monkeypatch.setattr(sp.fts, "search", lambda *a, **k: hits)
+
+    det = _StalePageDetector()
+    fp = fingerprint.combined_fingerprint(["public/page.md"])
+    out = det._tool("search_wiki", {"query": "q"}, {"public/page.md"}, fp)
+
+    assert out == [{"path": "public/page.md", "title": "Public"}]

--- a/backend/tests/test_stale_page_detector.py
+++ b/backend/tests/test_stale_page_detector.py
@@ -267,7 +267,7 @@ def test_search_never_surfaces_cross_audience_pages(monkeypatch, tmp_repo):
     monkeypatch.setattr(sp.fts, "search", lambda *a, **k: hits)
 
     det = _StalePageDetector()
-    fp = fingerprint.combined_fingerprint(["public/page.md"])
+    fp = fingerprint.fingerprints_for_paths(["public/page.md"])["public/page.md"]
     out = det._tool("search_wiki", {"query": "q"}, {"public/page.md"}, fp)
 
     assert out == [{"path": "public/page.md", "title": "Public"}]

--- a/backend/tests/test_stale_page_detector.py
+++ b/backend/tests/test_stale_page_detector.py
@@ -32,6 +32,32 @@ _OLD_BODY = "# 2025 Offsite Agenda\n\nSessions for the June 2025 offsite.\n"
 _LIVE_BODY = "# Runbook\n\nSteps that stay current.\n"
 
 
+def _backdated_commit(path: str, body: str, days: int = 60) -> None:
+    """Commit ``path`` with author+committer dates ``days`` ago — the only
+    way to seed genuinely old pages (the prefilter reads real git dates).
+    Test seeding only, same precedent as ``plumb_commit``."""
+    import os
+    import subprocess
+
+    import app.config
+
+    cwd = app.config.CONFIG.wiki_dir
+    when = (datetime.now(UTC) - timedelta(days=days)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    absd = os.path.join(cwd, os.path.dirname(path))
+    os.makedirs(absd, exist_ok=True)
+    with open(os.path.join(cwd, path), "w") as f:
+        f.write(body)
+    env = {**os.environ, "GIT_AUTHOR_DATE": when, "GIT_COMMITTER_DATE": when}
+    subprocess.run(["git", "add", path], cwd=cwd, check=True, env=env)
+    subprocess.run(
+        ["git", "-c", "user.name=seed", "-c", "user.email=seed@local",
+         "commit", "-m", f"seed {path}"],
+        cwd=cwd, check=True, env=env, capture_output=True,
+    )
+
+
 @pytest.fixture(autouse=True)
 def _fresh(tmp_repo):
     page_views.reset_for_tests()
@@ -93,10 +119,10 @@ def test_recently_edited_pages_never_reach_the_llm(monkeypatch, tmp_repo):
 
 def test_recently_viewed_pages_never_reach_the_llm(monkeypatch, tmp_repo):
     _age_tracking()
-    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _backdated_commit("notes/old.md", _OLD_BODY)
     page_views.touch("notes/old.md")  # a fresh view
     calls = _script(monkeypatch)
-    det = _StalePageDetector(floor_days=0)
+    det = _StalePageDetector()
     assert det.detect(_scope("notes/old.md")) == []
     assert calls == []
 
@@ -104,9 +130,9 @@ def test_recently_viewed_pages_never_reach_the_llm(monkeypatch, tmp_repo):
 def test_young_tracking_gates_unviewed_pages(monkeypatch, tmp_repo):
     """With no recorded views at all, 'no view row' proves nothing — the
     detector must stay silent rather than call everything unviewed."""
-    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _backdated_commit("notes/old.md", _OLD_BODY)
     calls = _script(monkeypatch)
-    det = _StalePageDetector(floor_days=0)
+    det = _StalePageDetector()
     assert det.detect(_scope("notes/old.md")) == []
     assert calls == []
 
@@ -116,13 +142,13 @@ def test_young_tracking_gates_unviewed_pages(monkeypatch, tmp_repo):
 
 def test_confirmed_stale_page_emits_a_deletion_draft(monkeypatch, tmp_repo):
     _age_tracking()
-    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _backdated_commit("notes/old.md", _OLD_BODY)
     _script(
         monkeypatch,
         _finish({"path": "notes/old.md", "evidence": "agenda for a past event"}),
     )
 
-    (draft,) = _StalePageDetector(floor_days=0).detect(
+    (draft,) = _StalePageDetector().detect(
         _scope("notes/old.md", "anchor/tracked.md")
     )
 
@@ -136,12 +162,12 @@ def test_confirmed_stale_page_emits_a_deletion_draft(monkeypatch, tmp_repo):
 
 def test_non_candidate_proposals_are_dropped(monkeypatch, tmp_repo):
     _age_tracking()
-    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _backdated_commit("notes/old.md", _OLD_BODY)
     _script(
         monkeypatch,
         _finish({"path": "made/up.md", "evidence": "not a candidate"}),
     )
-    det = _StalePageDetector(floor_days=0)
+    det = _StalePageDetector()
     drafts = det.detect(_scope("notes/old.md"))
     assert drafts == []
 
@@ -151,29 +177,29 @@ def test_cap_bounds_proposals_per_sweep(monkeypatch, tmp_repo):
     items = []
     paths = [f"notes/old-{i}.md" for i in range(5)]
     for p in paths:
-        wiki_git.commit_file(p, _OLD_BODY + p, "seed", author=None)
+        _backdated_commit(p, _OLD_BODY + p)
         items.append({"path": p, "evidence": "past event"})
     _script(monkeypatch, _finish(*items))
-    drafts = _StalePageDetector(floor_days=0).detect(_scope(*paths, "anchor/tracked.md"))
+    drafts = _StalePageDetector().detect(_scope(*paths, "anchor/tracked.md"))
     assert len(drafts) == 3  # MAX_PROPOSALS
 
 
 def test_llm_failure_degrades_to_empty(monkeypatch, tmp_repo):
     _age_tracking()
-    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _backdated_commit("notes/old.md", _OLD_BODY)
 
     def boom(messages, **kwargs):
         raise LLMError("not_configured", "LLM is not configured")
 
     monkeypatch.setattr(llm_client, "complete", boom)
-    assert _StalePageDetector(floor_days=0).detect(_scope("notes/old.md")) == []
+    assert _StalePageDetector().detect(_scope("notes/old.md")) == []
 
 
 def test_agent_can_read_candidates_and_search(monkeypatch, tmp_repo):
     """One investigate turn (read + search) before finish — the tool results
     ride back into the transcript."""
     _age_tracking()
-    wiki_git.commit_file("notes/old.md", _OLD_BODY, "seed", author=None)
+    _backdated_commit("notes/old.md", _OLD_BODY)
     investigate = CompletionResult(
         text="",
         tool_calls=[
@@ -192,7 +218,7 @@ def test_agent_can_read_candidates_and_search(monkeypatch, tmp_repo):
         "app.wiki.automanage.detectors.stale_page.fts.search", lambda *a, **k: []
     )
 
-    (draft,) = _StalePageDetector(floor_days=0).detect(_scope("notes/old.md"))
+    (draft,) = _StalePageDetector().detect(_scope("notes/old.md"))
 
     assert draft.source_paths == ["notes/old.md"]
     # Second LLM call saw the tool results.


### PR DESCRIPTION
The first LLM detector, per the design on the **Wiki Auto Management — Detection** page ("Stale-page detector" section). **Stacked on #529** (last-view tracking — its prerequisite); review/merge that first.

## Shape
**Time is the filter; uselessness is the claim.**

1. **Mechanical prefilter** (no LLM): live pages with neither a git edit (`paths_touched_since`, one log pass) nor a recorded view inside the **30-day floor**. A page with no view row counts as unviewed only once tracking itself is older than the floor (`tracking_floor`) — so the detector is naturally silent until view data has aged.
2. **Agent pass**: the model sees the wiki's file tree (names only) + candidate ages, with bounded tools — `read_page` (candidates only), `search_wiki` (coverage elsewhere) — and must cite uselessness evidence *from the content* to propose. Two categories only: time-bound artifacts whose moment has passed, and test/scratch debris (the `test-file-raunak` archetype). Evergreen-looking content is never proposed on age alone. The prompt states the asymmetry outright: a wrong deletion proposal costs reviewer trust; a miss costs nothing.
3. **Emits `delete_page` proposals** with the evidence in the summary — the reviewer judges in one glance; Trash + 30-day restore is the structural backstop.

## Conservative rails
Cap **3 per sweep** · non-candidate picks dropped · step cap · `auto_approvable=False` always (deletions get a human even in AI-managed scopes) · LLM failure degrades to an empty result (one broken detector can't sink the sweep's mechanical detectors) · registered **last** in the registry so judgment-based deletions never outrank a mechanical claim.

## Identity + validation
Premise = the page's last-edit sha (an edit resets staleness — a later re-ask over new content is a fresh ask, not a rejected recurrence). `validate()` is mechanical per the LLM-detector contract (never calls the LLM): page gone, premise drift, or a recorded view newer than the judgment each stale it.

12 tests (prefilter gates: fresh edit / fresh view / young tracking; scripted agent pass at the `client.complete` seam: draft shape + premise, non-candidate drop, cap, investigate-turn transcript, LLM-failure degrade; validate: holds / edit / view / missing). Slice: 130 passed; ruff + basedpyright clean.