### PR TITLE
fix(search): backfill the doc index at startup when it is empty

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,7 +64,7 @@ from app.llm.errors import LLMError
 from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestError
 from app.db.session import init_db
 from app.tasks.agent_activity import schedule_all_pending_cleanups
-from app.tasks.reindex import backfill_index_if_empty
+from app.tasks.reindex import backfill_unindexed_pages
 from app.tasks.queues import QueueFullError
 from app.triggers import reconcile as triggers_reconcile
 from app.triggers import repo as triggers_repo
@@ -182,7 +182,7 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # content (restored volume, migration) skips seeding — the only other
     # boot path that indexes — and would otherwise leave every page
     # unsearchable until it happened to be edited.
-    backfill_index_if_empty()
+    backfill_unindexed_pages()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_reconcile.reconcile_legacy_slack_triggers()
     triggers_repo.rebuild_from_filesystem()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,6 +64,7 @@ from app.llm.errors import LLMError
 from app.models._helpers import ErrorResponse, QueueFullErrorResponse, RequestError
 from app.db.session import init_db
 from app.tasks.agent_activity import schedule_all_pending_cleanups
+from app.tasks.reindex import backfill_index_if_empty
 from app.tasks.queues import QueueFullError
 from app.triggers import reconcile as triggers_reconcile
 from app.triggers import repo as triggers_repo
@@ -177,6 +178,11 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     # The index persists across reboots, so steady-state boots skip this.
     if comment_fts.count() == 0:
         _comments_repo.reindex_all_inline()
+    # Same backfill for the doc index: a first boot over pre-existing wiki
+    # content (restored volume, migration) skips seeding — the only other
+    # boot path that indexes — and would otherwise leave every page
+    # unsearchable until it happened to be edited.
+    backfill_index_if_empty()
     triggers_repo.purge_invalid_triggers(actor="system <system@agent-wiki>")
     triggers_reconcile.reconcile_legacy_slack_triggers()
     triggers_repo.rebuild_from_filesystem()

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -113,9 +113,9 @@ def index_path_inline(path: str) -> None:
 def reindex_all_inline() -> None:
     """Index every .md page currently in the wiki. Idempotent.
 
-    Runs only from the seed path, not every boot (O(pages) inline work) —
-    so a wiki booted over pre-existing content stays unindexed until pages
-    are edited or this is run manually.
+    Runs from the seed path (fresh wiki) and from ``backfill_index_if_empty``
+    (pre-existing wiki, empty index) — never on a steady-state boot, where
+    the O(pages) inline walk would be wasted work.
     """
     paths = [p for p in wiki_git.list_paths() if p.endswith(".md")]
     if not paths:
@@ -123,6 +123,20 @@ def reindex_all_inline() -> None:
     log.info("reindex: indexing %d wiki page(s) at startup", len(paths))
     for path in paths:
         index_path_inline(path)
+
+
+def backfill_index_if_empty() -> None:
+    """Startup backfill: index the whole wiki when the doc index is empty.
+
+    Covers a first boot over pre-existing content (restored volume,
+    migration, an already-populated ``WIKI_DIR``) — that path skips seeding,
+    which is the only other boot path that indexes, so without this every
+    page would be invisible to search until it happened to be edited.
+    ``count_documents()`` returns None when OpenSearch is unreachable —
+    skip then too, since indexing would fail just the same.
+    """
+    if fts.count_documents() == 0:
+        reindex_all_inline()
 
 
 @lightweight_maintenance_queue.periodic_task(crontab(minute="0"))

--- a/backend/app/tasks/reindex.py
+++ b/backend/app/tasks/reindex.py
@@ -21,6 +21,7 @@ import logging
 import re
 
 from app.db import fts, page_embeddings
+from app.db.session import advisory_xact_lock, session
 from app.llm import embeddings
 from app.tasks.queue import crontab
 from app.tasks.queues import lightweight_maintenance_queue
@@ -113,9 +114,9 @@ def index_path_inline(path: str) -> None:
 def reindex_all_inline() -> None:
     """Index every .md page currently in the wiki. Idempotent.
 
-    Runs from the seed path (fresh wiki) and from ``backfill_index_if_empty``
-    (pre-existing wiki, empty index) — never on a steady-state boot, where
-    the O(pages) inline walk would be wasted work.
+    Runs from the seed path (fresh wiki); a boot over pre-existing content
+    is covered by ``backfill_unindexed_pages``, which skips pages already
+    indexed.
     """
     paths = [p for p in wiki_git.list_paths() if p.endswith(".md")]
     if not paths:
@@ -125,18 +126,49 @@ def reindex_all_inline() -> None:
         index_path_inline(path)
 
 
-def backfill_index_if_empty() -> None:
-    """Startup backfill: index the whole wiki when the doc index is empty.
+# ASCII "ridx" — must stay distinct from other advisory-lock keys (e.g. the
+# triggers rebuild lock in app/triggers/repo.py).
+_BACKFILL_ADVISORY_LOCK = 0x72696478
+
+
+def backfill_unindexed_pages() -> None:
+    """Startup backfill: index every tracked .md page missing from the index.
 
     Covers a first boot over pre-existing content (restored volume,
     migration, an already-populated ``WIKI_DIR``) — that path skips seeding,
-    which is the only other boot path that indexes, so without this every
-    page would be invisible to search until it happened to be edited.
+    which is the only other boot path that indexes — and a partially
+    restored index, where some pages are present and the rest would stay
+    invisible to search until edited. Steady-state boots find no missing
+    pages and index nothing.
+
+    Concurrent replicas booting against the same index serialise on a
+    Postgres advisory lock, and the missing set is computed under it — so
+    followers observe the leader's writes and no-op instead of repeating
+    the walk (and its embedding calls).
+
     ``count_documents()`` returns None when OpenSearch is unreachable —
-    skip then too, since indexing would fail just the same.
+    skip then, since indexing would fail just the same; the next boot
+    retries. ``paths_under("")`` caps at 10k entries, so beyond that the
+    missing set over-approximates and re-indexes some already-indexed
+    pages — harmless (upserts are idempotent, embeddings skip on an
+    unchanged hash), just slower.
     """
-    if fts.count_documents() == 0:
-        reindex_all_inline()
+    if fts.count_documents() is None:
+        return
+    tracked = {p for p in wiki_git.list_paths() if p.endswith(".md")}
+    if not tracked:
+        return
+    try:
+        with session() as s:
+            advisory_xact_lock(s, _BACKFILL_ADVISORY_LOCK)
+            missing = sorted(tracked - set(fts.paths_under("")))
+            if not missing:
+                return
+            log.info("reindex: backfilling %d unindexed wiki page(s)", len(missing))
+            for path in missing:
+                index_path_inline(path)
+    except Exception:
+        log.warning("reindex: startup backfill failed", exc_info=True)
 
 
 @lightweight_maintenance_queue.periodic_task(crontab(minute="0"))

--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -17,7 +17,7 @@ Postgres on purpose, so wiping the wiki working tree alone doesn't
 re-arm seeding.
 
 Seeding indexes the pages it writes; a first boot over pre-existing
-content skips seeding, and the lifespan's ``backfill_index_if_empty``
+content skips seeding, and the lifespan's ``backfill_unindexed_pages``
 indexes that content instead.
 
 The CLI in ``app/scripts/seed_onboarding.py`` shares the helper below
@@ -144,7 +144,7 @@ def seed_if_empty(target_dir: str) -> bool:
         # Pre-existing content (admin seeded another way, migrating from
         # an older install). Stamp the marker so a future delete-all
         # doesn't trigger re-seeding. Indexing this content is the
-        # lifespan's job (backfill_index_if_empty).
+        # lifespan's job (backfill_unindexed_pages).
         log.info("wiki already has tracked pages, stamping marker without seeding")
         _stamp_seed_marker()
         return False

--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -16,9 +16,9 @@ and reboots gets an empty wiki, not a re-seed. The marker lives in
 Postgres on purpose, so wiping the wiki working tree alone doesn't
 re-arm seeding.
 
-Seeding is also the only startup path that indexes the wiki — a first
-boot over pre-existing content leaves those pages unsearchable
-(see ``reindex_all_inline``).
+Seeding indexes the pages it writes; a first boot over pre-existing
+content skips seeding, and the lifespan's ``backfill_index_if_empty``
+indexes that content instead.
 
 The CLI in ``app/scripts/seed_onboarding.py`` shares the helper below
 to write pages onto an already-populated wiki without nuking it. The
@@ -143,12 +143,9 @@ def seed_if_empty(target_dir: str) -> bool:
     if any(p.endswith(".md") for p in list_paths()):
         # Pre-existing content (admin seeded another way, migrating from
         # an older install). Stamp the marker so a future delete-all
-        # doesn't trigger re-seeding. Also skips the index backfill —
-        # these pages boot unsearchable (see reindex_all_inline).
-        log.info(
-            "wiki already has tracked pages, stamping marker without seeding "
-            "(search index not backfilled)"
-        )
+        # doesn't trigger re-seeding. Indexing this content is the
+        # lifespan's job (backfill_index_if_empty).
+        log.info("wiki already has tracked pages, stamping marker without seeding")
         _stamp_seed_marker()
         return False
     log.info("seeding empty wiki at %s from %s", target_dir, SEED_SOURCE_DIR)

--- a/backend/tests/test_reindex_backfill.py
+++ b/backend/tests/test_reindex_backfill.py
@@ -1,9 +1,9 @@
-"""Startup doc-index backfill (``backfill_index_if_empty``).
+"""Startup doc-index backfill (``backfill_unindexed_pages``).
 
 A first boot over pre-existing wiki content skips seeding — the only other
-boot path that indexes — so the lifespan backfills the doc index when it's
-empty. Steady-state boots (non-zero count) and unreachable OpenSearch
-(count None) both skip the O(pages) walk.
+boot path that indexes — so the lifespan backfills whatever tracked pages
+the doc index is missing. Steady-state boots (nothing missing) index
+nothing, and unreachable OpenSearch (count None) skips the walk entirely.
 """
 from __future__ import annotations
 
@@ -15,13 +15,23 @@ from app.wiki import git as wiki_git
 from tests.conftest import needs_opensearch
 
 
-def _boom() -> None:
-    raise AssertionError("reindex_all_inline should not run")
+def _recording_indexer(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Route ``backfill_unindexed_pages``'s per-page indexing through a
+    recorder so tests can assert exactly which pages it touched."""
+    calls: list[str] = []
+    real = reindex.index_path_inline
+
+    def record(path: str) -> None:
+        calls.append(path)
+        real(path)
+
+    monkeypatch.setattr(reindex, "index_path_inline", record)
+    return calls
 
 
 @needs_opensearch
 def test_backfill_indexes_preexisting_pages(tmp_repo):
-    """Pages committed before boot (no index entries) become searchable."""
+    """Pages committed before boot (empty index) become searchable."""
     wiki_git.commit_file(
         "guides/db.md", "# DB Guide\nconnection pool sizing\n", "seed", author=None
     )
@@ -30,23 +40,48 @@ def test_backfill_indexes_preexisting_pages(tmp_repo):
     )
     assert fts.count_documents() == 0
 
-    reindex.backfill_index_if_empty()
+    reindex.backfill_unindexed_pages()
 
     assert fts.count_documents() == 2
     hits = fts.search("connection pool", is_admin=True)
     assert [h.path for h in hits] == ["guides/db.md"]
 
 
-def test_backfill_skips_when_index_nonempty(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(reindex.fts, "count_documents", lambda: 3)
-    monkeypatch.setattr(reindex, "reindex_all_inline", _boom)
+@needs_opensearch
+def test_backfill_indexes_only_missing_pages(tmp_repo, monkeypatch: pytest.MonkeyPatch):
+    """A partially populated index (nonzero count, some pages absent) gets
+    exactly the absent pages indexed — not skipped, not fully re-walked."""
+    wiki_git.commit_file("indexed.md", "# Indexed\n", "seed", author=None)
+    wiki_git.commit_file("missing.md", "# Missing\nunsearchable so far\n", "seed", author=None)
+    reindex.index_path_inline("indexed.md")
+    assert fts.count_documents() == 1
 
-    reindex.backfill_index_if_empty()
+    calls = _recording_indexer(monkeypatch)
+    reindex.backfill_unindexed_pages()
+
+    assert calls == ["missing.md"]
+    assert fts.count_documents() == 2
+
+
+@needs_opensearch
+def test_backfill_noops_when_index_complete(tmp_repo, monkeypatch: pytest.MonkeyPatch):
+    wiki_git.commit_file("guide.md", "# Guide\n", "seed", author=None)
+    reindex.index_path_inline("guide.md")
+
+    calls = _recording_indexer(monkeypatch)
+    reindex.backfill_unindexed_pages()
+
+    assert calls == []
 
 
 def test_backfill_skips_when_opensearch_unreachable(monkeypatch: pytest.MonkeyPatch):
     """count None (client down) — indexing would fail too, so don't try."""
     monkeypatch.setattr(reindex.fts, "count_documents", lambda: None)
-    monkeypatch.setattr(reindex, "reindex_all_inline", _boom)
 
-    reindex.backfill_index_if_empty()
+    def boom(*_args: object) -> None:
+        raise AssertionError("nothing past the count check should run")
+
+    monkeypatch.setattr(reindex.fts, "paths_under", boom)
+    monkeypatch.setattr(reindex, "index_path_inline", boom)
+
+    reindex.backfill_unindexed_pages()

--- a/backend/tests/test_reindex_backfill.py
+++ b/backend/tests/test_reindex_backfill.py
@@ -1,0 +1,52 @@
+"""Startup doc-index backfill (``backfill_index_if_empty``).
+
+A first boot over pre-existing wiki content skips seeding — the only other
+boot path that indexes — so the lifespan backfills the doc index when it's
+empty. Steady-state boots (non-zero count) and unreachable OpenSearch
+(count None) both skip the O(pages) walk.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.db import fts
+from app.tasks import reindex
+from app.wiki import git as wiki_git
+from tests.conftest import needs_opensearch
+
+
+def _boom() -> None:
+    raise AssertionError("reindex_all_inline should not run")
+
+
+@needs_opensearch
+def test_backfill_indexes_preexisting_pages(tmp_repo):
+    """Pages committed before boot (no index entries) become searchable."""
+    wiki_git.commit_file(
+        "guides/db.md", "# DB Guide\nconnection pool sizing\n", "seed", author=None
+    )
+    wiki_git.commit_file(
+        "runbooks/deploy.md", "# Deploy Runbook\nhelm upgrade steps\n", "seed", author=None
+    )
+    assert fts.count_documents() == 0
+
+    reindex.backfill_index_if_empty()
+
+    assert fts.count_documents() == 2
+    hits = fts.search("connection pool", is_admin=True)
+    assert [h.path for h in hits] == ["guides/db.md"]
+
+
+def test_backfill_skips_when_index_nonempty(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(reindex.fts, "count_documents", lambda: 3)
+    monkeypatch.setattr(reindex, "reindex_all_inline", _boom)
+
+    reindex.backfill_index_if_empty()
+
+
+def test_backfill_skips_when_opensearch_unreachable(monkeypatch: pytest.MonkeyPatch):
+    """count None (client down) — indexing would fail too, so don't try."""
+    monkeypatch.setattr(reindex.fts, "count_documents", lambda: None)
+    monkeypatch.setattr(reindex, "reindex_all_inline", _boom)
+
+    reindex.backfill_index_if_empty()


### PR DESCRIPTION
## Why

Follow-up to #534, which documented (but deliberately didn't change) this gap: a first boot over pre-existing wiki content — restored `wiki-data` volume, migration from another install, an already-populated `WIKI_DIR` — skips seeding, and seeding was the only boot path that indexed pages. Every page rendered fine but was invisible to search until it happened to be edited; the hourly reconcile only re-indexes files touched in the last 2 hours, so nothing ever healed it. Agents following search-before-create (#533) would find nothing and create duplicates.

## What

Mirrors the comment-index backfill that already runs in the lifespan: `backfill_index_if_empty()` (new, in `app/tasks/reindex.py`) runs `reindex_all_inline()` when `fts.count_documents() == 0`.

- Steady-state boots skip on the count — the O(pages) walk only ever runs once per index lifetime (first boot over existing content, or after an index reset).
- `count_documents()` returning `None` (OpenSearch unreachable) also skips — indexing would fail just the same, and the next boot retries.
- Docstrings in `seed.py` / `reindex.py` that #534 added to describe the gap now describe the backfill instead; the "(search index not backfilled)" log suffix is gone.

## Testing

- 3 new tests in `test_reindex_backfill.py`: pre-existing pages become searchable after backfill; non-empty index skips; `None` count (OpenSearch down) skips.
- Full backend suite green locally; ruff + basedpyright clean via pre-commit.