### PR TITLE
feat(images): Postgres image store, upload + authenticated serving endpoints

### DIFF
--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -1,0 +1,102 @@
+"""Image upload and serving API for wiki pages."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from starlette.concurrency import run_in_threadpool
+
+from app.auth import User, require_can
+from app.auth.deps import require_user, require_user_or_bearer
+from app.models.images import UploadImageResponse
+from app.wiki import doc_ids, filesystem, image_store
+
+router = APIRouter()
+
+_UPLOAD_CAP_BYTES = 10 * 1024 * 1024
+
+
+@router.post("", response_model=UploadImageResponse)
+async def upload_image(
+    request: Request,
+    path: str = "",
+    filename: str | None = None,
+    user: User = Depends(require_user),
+) -> UploadImageResponse:
+    # Cross-site POSTs arrive without the session cookie (SameSite=lax, app/main.py), so require_user rejects them.
+    if not path.strip():
+        raise HTTPException(status_code=400, detail="path required")
+    try:
+        rel = filesystem.safe_rel_path(path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    await run_in_threadpool(require_can, "write", rel, user)
+
+    buf = bytearray()
+    async for chunk in request.stream():
+        if len(buf) + len(chunk) > _UPLOAD_CAP_BYTES:
+            raise HTTPException(status_code=413, detail="image exceeds 10 MiB limit")
+        buf.extend(chunk)
+    data = bytes(buf)
+    if not data:
+        raise HTTPException(status_code=400, detail="empty image body")
+
+    sniffed = image_store.sniff_image_type(data)
+    if sniffed is None:
+        raise HTTPException(status_code=415, detail="unsupported image type")
+    declared = (request.headers.get("content-type") or "").split(";")[0].strip().lower()
+    if declared != sniffed:
+        raise HTTPException(status_code=415, detail="content-type does not match image data")
+
+    anchor_doc_id = await run_in_threadpool(doc_ids.get_or_mint, rel)
+    image_id = await run_in_threadpool(
+        image_store.put,
+        data=data,
+        content_type=sniffed,
+        anchor_doc_id=anchor_doc_id,
+        uploaded_by=user.id,
+    )
+
+    url = f"/api/wiki/images/{image_id}"
+    alt = (filename or "").replace("\n", " ").replace("\r", " ").replace("]", "")
+    return UploadImageResponse(id=image_id, url=url, markdown=f"![{alt}]({url})")
+
+
+@router.get("/{image_id}")
+def serve_image(
+    image_id: str,
+    request: Request,
+    user: User = Depends(require_user_or_bearer),
+) -> Response:
+    meta = image_store.stat(image_id)
+    if meta is None:
+        raise HTTPException(status_code=404, detail="not found")
+    row = doc_ids.resolve(meta.anchor_doc_id)
+    if row is None or row["deleted_at"] is not None:
+        raise HTTPException(status_code=404, detail="not found")
+    try:
+        rel = filesystem.safe_rel_path(str(row["path"]))
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail="not found") from e
+    require_can("read", rel, user)
+
+    etag = f'"{meta.sha256}"'
+    raw_if_none_match = request.headers.get("if-none-match", "")
+    if_none_match = {candidate.strip() for candidate in raw_if_none_match.split(",") if candidate.strip()}
+    if "*" in if_none_match or etag in if_none_match:
+        return Response(
+            status_code=304,
+            headers={"ETag": etag, "Cache-Control": "private, no-cache"},
+        )
+
+    rec = image_store.get(image_id)
+    if rec is None:
+        raise HTTPException(status_code=404, detail="not found")
+    return Response(
+        content=rec.data,
+        media_type=meta.content_type,
+        headers={
+            "ETag": etag,
+            "Cache-Control": "private, no-cache",
+            "X-Content-Type-Options": "nosniff",
+        },
+    )

--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -9,6 +9,7 @@ from app.auth import User, require_can
 from app.auth.deps import require_user, require_user_or_bearer
 from app.models.images import UploadImageResponse
 from app.wiki import doc_ids, filesystem, image_store
+from app.wiki import git as wiki_git
 
 router = APIRouter()
 
@@ -47,6 +48,9 @@ async def upload_image(
     if declared != sniffed:
         raise HTTPException(status_code=415, detail="content-type does not match image data")
 
+    # Uploading to a page that doesn't exist would mint a live doc id for it.
+    if await run_in_threadpool(wiki_git.head_sha_for_path, rel) is None:
+        raise HTTPException(status_code=404, detail="anchor page not found")
     anchor_doc_id = await run_in_threadpool(doc_ids.get_or_mint, rel)
     image_id = await run_in_threadpool(
         image_store.put,

--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -30,6 +30,10 @@ async def upload_image(
         rel = filesystem.safe_rel_path(path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    # Anchors are wiki pages. Folders and tracked non-page files (trigger
+    # YAML, .gitkeep) must not accumulate image anchors.
+    if not rel.endswith(".md"):
+        raise HTTPException(status_code=400, detail="anchor must be a wiki page")
     await run_in_threadpool(require_can, "write", rel, user)
 
     buf = bytearray()

--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -48,8 +48,10 @@ async def upload_image(
     if declared != sniffed:
         raise HTTPException(status_code=415, detail="content-type does not match image data")
 
-    # Uploading to a page that doesn't exist would mint a live doc id for it.
-    if await run_in_threadpool(wiki_git.head_sha_for_path, rel) is None:
+    # Uploading to a page that doesn't exist at HEAD would mint a live doc id
+    # for it. Presence check, not history: a deleted or trashed page still has
+    # commits touching its old path.
+    if not await run_in_threadpool(wiki_git.exists_at_head, rel):
         raise HTTPException(status_code=404, detail="anchor page not found")
     anchor_doc_id = await run_in_threadpool(doc_ids.get_or_mint, rel)
     image_id = await run_in_threadpool(
@@ -60,8 +62,8 @@ async def upload_image(
         uploaded_by=user.id,
     )
     # Brackets the mint+put against a concurrent page move/trash/delete: if
-    # the page vanished in the window, drop the blob instead of orphaning it.
-    if await run_in_threadpool(wiki_git.head_sha_for_path, rel) is None:
+    # the page left HEAD in the window, drop the blob instead of orphaning it.
+    if not await run_in_threadpool(wiki_git.exists_at_head, rel):
         await run_in_threadpool(image_store.delete, image_id)
         raise HTTPException(status_code=404, detail="anchor page not found")
 

--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -59,6 +59,11 @@ async def upload_image(
         anchor_doc_id=anchor_doc_id,
         uploaded_by=user.id,
     )
+    # Brackets the mint+put against a concurrent page move/trash/delete: if
+    # the page vanished in the window, drop the blob instead of orphaning it.
+    if await run_in_threadpool(wiki_git.head_sha_for_path, rel) is None:
+        await run_in_threadpool(image_store.delete, image_id)
+        raise HTTPException(status_code=404, detail="anchor page not found")
 
     url = f"/api/wiki/images/{image_id}"
     alt = (filename or "").replace("\n", " ").replace("\r", " ").replace("]", "")

--- a/backend/app/db/migrations/versions/c1d2e3f4a5b6_images.py
+++ b/backend/app/db/migrations/versions/c1d2e3f4a5b6_images.py
@@ -1,0 +1,53 @@
+"""images
+
+Adds ``images``: binary wiki image blobs anchored to stable doc ids.
+Guarded with the inspector because ``0001_initial`` builds fresh
+databases from the current models.
+
+Revision ID: c1d2e3f4a5b6
+Revises: c2e7a4d9f1b8
+Create Date: 2026-07-24 19:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | None = "c2e7a4d9f1b8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("images"):
+        return
+    op.create_table(
+        "images",
+        sa.Column("id", sa.Text(), nullable=False),
+        sa.Column("sha256", sa.Text(), nullable=False),
+        sa.Column("content_type", sa.Text(), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("data", sa.LargeBinary(), nullable=False),
+        sa.Column("anchor_doc_id", sa.Text(), nullable=False),
+        sa.Column("uploaded_by", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["uploaded_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("idx_images_anchor_doc_id", "images", ["anchor_doc_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_images_anchor_doc_id", table_name="images")
+    op.drop_table("images")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1322,6 +1322,27 @@ class WikiDocId(Base):
     )
 
 
+class Image(Base):
+    """Binary image blob anchored to a wiki page's stable doc id."""
+
+    __tablename__ = "images"
+
+    id: Mapped[str] = mapped_column(Text, primary_key=True)
+    sha256: Mapped[str] = mapped_column(Text, nullable=False)
+    content_type: Mapped[str] = mapped_column(Text, nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    data: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    anchor_doc_id: Mapped[str] = mapped_column(Text, nullable=False)
+    uploaded_by: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+    __table_args__ = (Index("idx_images_anchor_doc_id", "anchor_doc_id"),)
+
+
 # --------------------------------------------------------------------------- #
 # Wiki auto-management — change proposals (Postgres-only)                     #
 # --------------------------------------------------------------------------- #

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -37,6 +37,7 @@ from app.api import (
     email_verify,
     events,
     health,
+    images,
     installer,
     launchers,
     llm,
@@ -242,6 +243,7 @@ def create_app() -> FastAPI:
     app.include_router(agent_sessions.router, prefix="/api/agent-sessions")
     app.include_router(triggers.router, prefix="/api/triggers")
     app.include_router(automanage.router, prefix="/api/automanage")
+    app.include_router(images.router, prefix="/api/wiki/images")
     app.include_router(wiki.router, prefix="/api/wiki")
     app.include_router(coedit.router, prefix="/api/coedit")
     app.include_router(comments.router, prefix="/api/comments")

--- a/backend/app/models/images.py
+++ b/backend/app/models/images.py
@@ -1,0 +1,11 @@
+"""HTTP shapes for /api/wiki/images."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UploadImageResponse(BaseModel):
+    id: str
+    url: str
+    markdown: str

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -278,6 +278,16 @@ def read_file(rel_path: str, ref: str = "HEAD") -> str:
         raise UnknownSha(ref) from e
 
 
+def exists_at_head(rel_path: str) -> bool:
+    """True when ``rel_path`` is present in HEAD's tree.
+
+    Presence, not history: ``head_sha_for_path`` answers "which commit last
+    touched this path" and stays truthy forever after a delete or trash move,
+    so it must never gate on whether a page currently exists.
+    """
+    return _run(["cat-file", "-e", f"HEAD:{rel_path}"], check=False).returncode == 0
+
+
 def read_file_opt(rel_path: str, ref: str = "HEAD") -> str | None:
     """Like ``read_file`` but returns ``None`` when the path doesn't exist
     at ``ref`` — and stays quiet about it.

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -279,13 +279,15 @@ def read_file(rel_path: str, ref: str = "HEAD") -> str:
 
 
 def exists_at_head(rel_path: str) -> bool:
-    """True when ``rel_path`` is present in HEAD's tree.
+    """True when ``rel_path`` is a file (blob) in HEAD's tree.
 
     Presence, not history: ``head_sha_for_path`` answers "which commit last
     touched this path" and stays truthy forever after a delete or trash move,
-    so it must never gate on whether a page currently exists.
+    so it must never gate on whether a page currently exists. Blob-typed so a
+    directory at the path does not count as an existing file.
     """
-    return _run(["cat-file", "-e", f"HEAD:{rel_path}"], check=False).returncode == 0
+    res = _run(["cat-file", "-t", f"HEAD:{rel_path}"], check=False)
+    return res.returncode == 0 and res.stdout.strip() == "blob"
 
 
 def read_file_opt(rel_path: str, ref: str = "HEAD") -> str | None:

--- a/backend/app/wiki/image_store.py
+++ b/backend/app/wiki/image_store.py
@@ -1,0 +1,109 @@
+"""Postgres-backed image blob storage seam."""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+from pydantic import BaseModel
+from sqlalchemy import delete as sqla_delete
+from sqlalchemy import select
+from sqlalchemy.orm import defer
+
+from app.db.models import Image
+from app.db.session import execute_dml, session
+
+
+class StoredImage(BaseModel):
+    id: str
+    sha256: str
+    content_type: str
+    size_bytes: int
+    anchor_doc_id: str
+    uploaded_by: str | None
+    created_at: str
+
+
+class StoredImageData(StoredImage):
+    data: bytes
+
+
+def sniff_image_type(data: bytes) -> str | None:
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return "image/gif"
+    if len(data) >= 12 and data[0:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _to_stored_image(row: Image) -> StoredImage:
+    return StoredImage(
+        id=row.id,
+        sha256=row.sha256,
+        content_type=row.content_type,
+        size_bytes=row.size_bytes,
+        anchor_doc_id=row.anchor_doc_id,
+        uploaded_by=row.uploaded_by,
+        created_at=row.created_at,
+    )
+
+
+def _to_stored_image_data(row: Image) -> StoredImageData:
+    return StoredImageData(
+        id=row.id,
+        sha256=row.sha256,
+        content_type=row.content_type,
+        size_bytes=row.size_bytes,
+        anchor_doc_id=row.anchor_doc_id,
+        uploaded_by=row.uploaded_by,
+        created_at=row.created_at,
+        data=row.data,
+    )
+
+
+def put(
+    *, data: bytes, content_type: str, anchor_doc_id: str, uploaded_by: str | None
+) -> str:
+    image_id = uuid.uuid4().hex[:16]
+    with session() as s:
+        s.add(
+            Image(
+                id=image_id,
+                sha256=hashlib.sha256(data).hexdigest(),
+                content_type=content_type,
+                size_bytes=len(data),
+                data=data,
+                anchor_doc_id=anchor_doc_id,
+                uploaded_by=uploaded_by,
+            )
+        )
+    return image_id
+
+
+def stat(image_id: str) -> StoredImage | None:
+    with session() as s:
+        row = s.scalar(
+            select(Image).options(defer(Image.data)).where(Image.id == image_id)
+        )
+        return _to_stored_image(row) if row is not None else None
+
+
+def get(image_id: str) -> StoredImageData | None:
+    with session() as s:
+        row = s.get(Image, image_id)
+        return _to_stored_image_data(row) if row is not None else None
+
+
+def delete(image_id: str) -> bool:
+    # Statement delete so the blob column is never fetched just to drop the row.
+    with session() as s:
+        stmt = (
+            sqla_delete(Image)
+            .where(Image.id == image_id)
+            .execution_options(synchronize_session=False)
+        )
+        return execute_dml(s, stmt) > 0

--- a/backend/tests/test_wiki_images.py
+++ b/backend/tests/test_wiki_images.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from app.auth import users as users_repo
 from app.main import create_app
 from app.wiki import acl, doc_ids, image_store
+from app.wiki import git as wiki_git
 from app.wiki.image_store import sniff_image_type
 from tests._auth import login_fastapi
 
@@ -21,7 +22,23 @@ WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 8
 
 @pytest.fixture
 def client(tmp_repo):
+    # Upload anchors must be real pages, so seed the ones the tests target.
+    wiki_git.commit_file("guides/setup.md", "# Setup\n", "seed")
+    wiki_git.commit_file("priv/secret.md", "# Secret\n", "seed")
     return TestClient(create_app())
+
+
+def test_upload_404_for_nonexistent_anchor_page(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+    resp = client.post(
+        "/api/wiki/images?path=nope/missing.md",
+        content=PNG_BYTES,
+        headers={"content-type": "image/png"},
+    )
+    assert resp.status_code == 404
+    # No doc id row may be minted for the nonexistent page.
+    assert doc_ids.id_for_path("nope/missing.md") is None
 
 
 def _make_private(path: str, owner_uid: str) -> None:

--- a/backend/tests/test_wiki_images.py
+++ b/backend/tests/test_wiki_images.py
@@ -9,8 +9,10 @@ from fastapi.testclient import TestClient
 
 from app.auth import users as users_repo
 from app.main import create_app
+from app.db.models import Image
 from app.wiki import acl, doc_ids, image_store
 from app.wiki import git as wiki_git
+from tests._seed import count_rows
 from app.wiki.image_store import sniff_image_type
 from tests._auth import login_fastapi
 
@@ -26,6 +28,30 @@ def client(tmp_repo):
     wiki_git.commit_file("guides/setup.md", "# Setup\n", "seed")
     wiki_git.commit_file("priv/secret.md", "# Secret\n", "seed")
     return TestClient(create_app())
+
+
+def test_upload_cleans_up_when_page_vanishes_mid_upload(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulates the page being trashed between the pre-mint existence check
+    # and the post-put re-check: first probe sees the page, second does not.
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+    real = wiki_git.head_sha_for_path
+    calls = {"n": 0}
+
+    def racing(rel_path: str) -> str | None:
+        calls["n"] += 1
+        return None if calls["n"] > 1 else real(rel_path)
+
+    monkeypatch.setattr("app.api.images.wiki_git.head_sha_for_path", racing)
+    resp = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=PNG_BYTES,
+        headers={"content-type": "image/png"},
+    )
+    assert resp.status_code == 404
+    assert count_rows(Image) == 0
 
 
 def test_upload_404_for_nonexistent_anchor_page(client: TestClient) -> None:

--- a/backend/tests/test_wiki_images.py
+++ b/backend/tests/test_wiki_images.py
@@ -1,0 +1,253 @@
+"""Tests for wiki image upload, storage, auth, and conditional serving."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.main import create_app
+from app.wiki import acl, doc_ids, image_store
+from app.wiki.image_store import sniff_image_type
+from tests._auth import login_fastapi
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + b"\x00" * 16
+GIF_BYTES = b"GIF89a" + b"\x00" * 16
+WEBP_BYTES = b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP" + b"\x00" * 8
+
+
+@pytest.fixture
+def client(tmp_repo):
+    return TestClient(create_app())
+
+
+def _make_private(path: str, owner_uid: str) -> None:
+    acl.set_owner(path, owner_uid)
+    for grant in acl.list_for_path(path):
+        if grant["principal_kind"] == "everyone":
+            acl.revoke(grant["id"])
+
+
+def test_sniff_image_type_detects_supported_magic_bytes() -> None:
+    assert sniff_image_type(PNG_BYTES) == "image/png"
+    assert sniff_image_type(JPEG_BYTES) == "image/jpeg"
+    assert sniff_image_type(GIF_BYTES) == "image/gif"
+    assert sniff_image_type(WEBP_BYTES) == "image/webp"
+
+
+def test_sniff_image_type_rejects_unknown_and_too_short() -> None:
+    assert sniff_image_type(b"not an image") is None
+    assert sniff_image_type(b"RIFF") is None
+
+
+def test_upload_rejects_content_type_mismatch(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    resp = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/jpeg"},
+    )
+
+    assert resp.status_code == 415
+    assert resp.json() == {"error": "content-type does not match image data"}
+
+
+def test_upload_rejects_missing_content_type(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    resp = client.post("/api/wiki/images?path=guides/setup.md", content=PNG_BYTES)
+
+    assert resp.status_code == 415
+    assert resp.json() == {"error": "content-type does not match image data"}
+
+
+def test_upload_rejects_oversize_body(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    resp = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=b"\x89PNG\r\n\x1a\n" + b"\x00" * (10 * 1024 * 1024 + 1),
+        headers={"Content-Type": "image/png"},
+    )
+
+    assert resp.status_code == 413
+    assert resp.json() == {"error": "image exceeds 10 MiB limit"}
+
+
+def test_image_store_round_trip(tmp_db) -> None:
+    uid = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+
+    image_id = image_store.put(
+        data=PNG_BYTES,
+        content_type="image/png",
+        anchor_doc_id="doc-1",
+        uploaded_by=uid,
+    )
+
+    rec = image_store.get(image_id)
+    assert rec is not None
+    assert rec.data == PNG_BYTES
+    assert rec.sha256 == hashlib.sha256(PNG_BYTES).hexdigest()
+    assert rec.size_bytes == len(PNG_BYTES)
+    assert rec.anchor_doc_id == "doc-1"
+    assert rec.uploaded_by == uid
+
+    meta = image_store.stat(image_id)
+    assert meta is not None
+    assert meta.id == image_id
+    assert meta.sha256 == rec.sha256
+    assert meta.size_bytes == len(PNG_BYTES)
+    assert not hasattr(meta, "data")
+
+    assert image_store.delete(image_id) is True
+    assert image_store.get(image_id) is None
+
+
+def test_upload_and_serve_round_trip(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    upload = client.post(
+        "/api/wiki/images?path=guides/setup.md&filename=logo.png",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+
+    assert upload.status_code == 200
+    payload = upload.json()
+    assert payload["id"]
+    assert payload["url"] == f"/api/wiki/images/{payload['id']}"
+    assert payload["markdown"] == f"![logo.png]({payload['url']})"
+
+    served = client.get(payload["url"])
+
+    assert served.status_code == 200
+    assert served.content == PNG_BYTES
+    assert served.headers["Content-Type"] == "image/png"
+    assert served.headers["ETag"]
+    assert served.headers["Cache-Control"] == "private, no-cache"
+    assert served.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_upload_is_403_without_write_permission(client: TestClient) -> None:
+    owner_uid = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    denied_uid = users_repo.create(email="denied@x.com", password="hunter2-x", name="Denied")
+    _make_private("priv/secret.md", owner_uid)
+    login_fastapi(client, denied_uid)
+
+    resp = client.post(
+        "/api/wiki/images?path=priv/secret.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+
+    assert resp.status_code == 403
+
+
+def test_serve_is_403_without_read_permission(client: TestClient) -> None:
+    owner_uid = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    denied_uid = users_repo.create(email="denied@x.com", password="hunter2-x", name="Denied")
+    _make_private("priv/secret.md", owner_uid)
+    login_fastapi(client, owner_uid)
+
+    upload = client.post(
+        "/api/wiki/images?path=priv/secret.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+    assert upload.status_code == 200
+    image_url = upload.json()["url"]
+
+    login_fastapi(client, denied_uid)
+    resp = client.get(image_url)
+
+    assert resp.status_code == 403
+
+
+def test_serve_unknown_image_is_404(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    resp = client.get("/api/wiki/images/doesnotexist")
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "not found"}
+
+
+def test_serve_tombstoned_anchor_is_404(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    upload = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+    assert upload.status_code == 200
+
+    rel = "guides/setup.md"
+    doc_ids.on_deleted(rel)
+    resp = client.get(upload.json()["url"])
+
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "not found"}
+
+
+def test_serve_returns_304_for_matching_etag(client: TestClient) -> None:
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+
+    upload = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+    assert upload.status_code == 200
+    image_url = upload.json()["url"]
+
+    first = client.get(image_url)
+    assert first.status_code == 200
+    etag = first.headers["ETag"]
+
+    second = client.get(image_url, headers={"If-None-Match": etag})
+
+    assert second.status_code == 304
+    assert second.content == b""
+    assert second.headers["ETag"] == etag
+    assert second.headers["Cache-Control"] == "private, no-cache"
+
+
+def test_unauthenticated_upload_is_401(client: TestClient) -> None:
+    resp = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+
+    assert resp.status_code == 401
+    assert resp.json() == {"error": "unauthorized"}
+
+
+def test_unauthenticated_serve_is_401(client: TestClient) -> None:
+    owner_uid = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    login_fastapi(client, owner_uid)
+    upload = client.post(
+        "/api/wiki/images?path=guides/setup.md",
+        content=PNG_BYTES,
+        headers={"Content-Type": "image/png"},
+    )
+    assert upload.status_code == 200
+    image_url = upload.json()["url"]
+    client.cookies.delete("session")
+
+    resp = client.get(image_url)
+
+    assert resp.status_code == 401
+    assert resp.json() == {"error": "missing bearer token"}

--- a/backend/tests/test_wiki_images.py
+++ b/backend/tests/test_wiki_images.py
@@ -30,6 +30,21 @@ def client(tmp_repo):
     return TestClient(create_app())
 
 
+def test_upload_400_for_folder_and_non_page_anchors(client: TestClient) -> None:
+    # A directory or a tracked non-page file is a git object but not a page.
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+    wiki_git.commit_file("guides/.gitkeep", "", "seed")
+    for bad in ("guides", "guides/.gitkeep"):
+        resp = client.post(
+            f"/api/wiki/images?path={bad}",
+            content=PNG_BYTES,
+            headers={"content-type": "image/png"},
+        )
+        assert resp.status_code == 400
+    assert count_rows(Image) == 0
+
+
 def test_upload_404_for_formerly_existing_deleted_page(client: TestClient) -> None:
     # A deleted page still has commits touching its path, so the guard must
     # test HEAD presence, not history.

--- a/backend/tests/test_wiki_images.py
+++ b/backend/tests/test_wiki_images.py
@@ -30,6 +30,22 @@ def client(tmp_repo):
     return TestClient(create_app())
 
 
+def test_upload_404_for_formerly_existing_deleted_page(client: TestClient) -> None:
+    # A deleted page still has commits touching its path, so the guard must
+    # test HEAD presence, not history.
+    uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, uid)
+    wiki_git.commit_file("guides/gone.md", "# Gone\n", "seed")
+    wiki_git.delete_path("guides/gone.md", "remove")
+    resp = client.post(
+        "/api/wiki/images?path=guides/gone.md",
+        content=PNG_BYTES,
+        headers={"content-type": "image/png"},
+    )
+    assert resp.status_code == 404
+    assert count_rows(Image) == 0
+
+
 def test_upload_cleans_up_when_page_vanishes_mid_upload(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -37,14 +53,14 @@ def test_upload_cleans_up_when_page_vanishes_mid_upload(
     # and the post-put re-check: first probe sees the page, second does not.
     uid = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
     login_fastapi(client, uid)
-    real = wiki_git.head_sha_for_path
+    real = wiki_git.exists_at_head
     calls = {"n": 0}
 
-    def racing(rel_path: str) -> str | None:
+    def racing(rel_path: str) -> bool:
         calls["n"] += 1
-        return None if calls["n"] > 1 else real(rel_path)
+        return False if calls["n"] > 1 else real(rel_path)
 
-    monkeypatch.setattr("app.api.images.wiki_git.head_sha_for_path", racing)
+    monkeypatch.setattr("app.api.images.wiki_git.exists_at_head", racing)
     resp = client.post(
         "/api/wiki/images?path=guides/setup.md",
         content=PNG_BYTES,


### PR DESCRIPTION
## Summary

Backend slice of wiki image support, per the design doc (`Engineering Projects/Agent Wiki Project/design/image_support/design.md`, signed off 2026-07-21).

- New `images` table (Alembic migration `c1d2e3f4a5b6`): bytes as `bytea` behind a storage seam, sha256, sniffed content type, anchor `doc_id`, uploader.
- `app/wiki/image_store.py`: the only module that touches the blob column (put/get/stat/delete). `stat` never loads bytes.
- `POST /api/wiki/images?path=<page>`: raw-body upload (no multipart dependency). Gated by `require_can("write", path)` on the anchor page. Magic-byte allowlist (png/jpeg/gif/webp, SVG deliberately excluded), declared Content-Type must match the sniffed type, 10 MiB cap enforced while streaming. Returns `{id, url, markdown}` with ready-to-paste markdown.
- `GET /api/wiki/images/{id}`: cookie or bearer auth (`require_user_or_bearer`), then `require_can("read", <anchor's current path>)` resolved at request time. Strong ETag (sha256) with If-None-Match 304 after the ACL check, `Cache-Control: private, no-cache` so ACL revocation is never defeated by a cached copy, `X-Content-Type-Options: nosniff`.
- Markdown carries only the stable app URL `![](/api/wiki/images/<id>)`, never a storage path, so page moves/renames never break references and a later S3 move behind the seam needs no content changes.

Design deviation worth review: a trashed anchor serves 404 immediately rather than through the trash grace window. The doc-id row keeps the original path while trash moves the ACL rows away from it, so honoring the window via `require_can` on that path would fall into the implicit-public default. Bytes are not deleted before purge + retention (see the sweep PR), so restore fully revives images.

## How Has This Been Tested?

`tests/test_wiki_images.py`, 14 tests against real Postgres + tmp wiki repo: sniffer types and spoof mismatch, missing/mismatched Content-Type 415s, 10 MiB cap 413, store roundtrip, upload-then-serve roundtrip, 403 upload without write, 403 serve without read, 404 unknown id, 404 tombstoned anchor, If-None-Match 304, 401s without auth. ruff and strict basedpyright clean.
