### PR TITLE
feat(images): daily retention sweep, Prometheus metrics, backup sizing note

### DIFF
--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -75,7 +75,7 @@ async def upload_image(
         await run_in_threadpool(image_store.delete, image_id)
         raise HTTPException(status_code=404, detail="anchor page not found")
 
-    url = f"/api/wiki/images/{image_id}"
+    url = image_store.serving_url(image_id)
     alt = (filename or "").replace("\n", " ").replace("\r", " ").replace("]", "")
     return UploadImageResponse(id=image_id, url=url, markdown=f"![{alt}]({url})")
 

--- a/backend/app/api/images.py
+++ b/backend/app/api/images.py
@@ -7,6 +7,7 @@ from starlette.concurrency import run_in_threadpool
 
 from app.auth import User, require_can
 from app.auth.deps import require_user, require_user_or_bearer
+from app.metrics import wiki_image_upload_rejected_total
 from app.models.images import UploadImageResponse
 from app.wiki import doc_ids, filesystem, image_store
 from app.wiki import git as wiki_git
@@ -39,6 +40,7 @@ async def upload_image(
     buf = bytearray()
     async for chunk in request.stream():
         if len(buf) + len(chunk) > _UPLOAD_CAP_BYTES:
+            wiki_image_upload_rejected_total.labels(reason="too_large").inc()
             raise HTTPException(status_code=413, detail="image exceeds 10 MiB limit")
         buf.extend(chunk)
     data = bytes(buf)
@@ -47,9 +49,11 @@ async def upload_image(
 
     sniffed = image_store.sniff_image_type(data)
     if sniffed is None:
+        wiki_image_upload_rejected_total.labels(reason="unsupported_type").inc()
         raise HTTPException(status_code=415, detail="unsupported image type")
     declared = (request.headers.get("content-type") or "").split(";")[0].strip().lower()
     if declared != sniffed:
+        wiki_image_upload_rejected_total.labels(reason="content_type_mismatch").inc()
         raise HTTPException(status_code=415, detail="content-type does not match image data")
 
     # Uploading to a page that doesn't exist at HEAD would mint a live doc id

--- a/backend/app/db/migrations/versions/e7a1c4d9b2f6_image_unreferenced_since.py
+++ b/backend/app/db/migrations/versions/e7a1c4d9b2f6_image_unreferenced_since.py
@@ -1,0 +1,30 @@
+"""image unreferenced_since
+
+Adds ``images.unreferenced_since`` for wiki image retention state.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "e7a1c4d9b2f6"
+down_revision: str | None = "c1d2e3f4a5b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("images")}
+    if "unreferenced_since" not in cols:
+        op.add_column("images", sa.Column("unreferenced_since", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    cols = {c["name"] for c in sa.inspect(bind).get_columns("images")}
+    if "unreferenced_since" in cols:
+        op.drop_column("images", "unreferenced_since")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1339,6 +1339,7 @@ class Image(Base):
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )
+    unreferenced_since: Mapped[str | None] = mapped_column(Text)
 
     __table_args__ = (Index("idx_images_anchor_doc_id", "anchor_doc_id"),)
 

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -138,6 +138,32 @@ ingest_queue_depth = Gauge(
     "Current number of pending tasks in the documents queue",
 )
 
+# --------------------------------------------------------------------------- #
+# Wiki images                                                                 #
+# --------------------------------------------------------------------------- #
+
+wiki_images_total = Gauge(
+    "wiki_images_total",
+    "Wiki image blobs currently stored",
+)
+
+wiki_images_bytes_total = Gauge(
+    "wiki_images_bytes_total",
+    "Total bytes of stored wiki image blobs",
+)
+
+wiki_image_sweep_deleted_total = Counter(
+    "wiki_image_sweep_deleted_total",
+    "Wiki image blobs deleted by the retention sweep",
+)
+
+wiki_image_upload_rejected_total = Counter(
+    "wiki_image_upload_rejected_total",
+    "Wiki image uploads rejected before storage",
+    ["reason"],
+)
+
+
 class _WikiPagesCollector:
     def collect(self):
         count = fts.count_documents() or 0

--- a/backend/app/tasks/image_sweep.py
+++ b/backend/app/tasks/image_sweep.py
@@ -39,6 +39,17 @@ def _parse(ts: str | None) -> datetime | None:
         return None
 
 
+def _referenced(url_by_id: dict[str, str]) -> set[str]:
+    """Ids whose serving URL appears in the working tree or a live edit buffer."""
+    matched_urls = wiki_git.grep_working_tree_fixed(list(url_by_id.values()))
+    draft_blob = "\n".join(coedit.active_buffer_texts())
+    return {
+        image_id
+        for image_id, url in url_by_id.items()
+        if url in matched_urls or (draft_blob and url in draft_blob)
+    }
+
+
 def _refresh_gauges() -> None:
     count, total_bytes = image_store.totals()
     wiki_images_total.set(count)
@@ -56,13 +67,8 @@ def sweep_wiki_images() -> None:
             log.info("image sweep: scanned=0 referenced=0 flagged=0 cleared=0 deleted=0")
             return
 
-        candidate_ids = [candidate.id for candidate in candidates]
-        referenced_ids = wiki_git.grep_working_tree_fixed(candidate_ids)
-        draft_blob = "\n".join(coedit.active_buffer_texts())
-        if draft_blob:
-            referenced_ids.update(
-                image_id for image_id in candidate_ids if image_id in draft_blob
-            )
+        url_by_id = {c.id: image_store.serving_url(c.id) for c in candidates}
+        referenced_ids = _referenced(url_by_id)
 
         now = datetime.now(timezone.utc)
         # 0 disables deletion, matching the trash-purge retention contract.
@@ -88,6 +94,12 @@ def sweep_wiki_images() -> None:
             if unreferenced_since is None or not deletion_enabled:
                 continue
             if now - unreferenced_since > timedelta(days=_DEREFERENCE_RETENTION_DAYS):
+                # Re-check right before deleting: a reference committed after the
+                # batch scan must clear the flag, never lose the image.
+                if candidate.id in _referenced({candidate.id: url_by_id[candidate.id]}):
+                    image_store.set_unreferenced_since(candidate.id, None)
+                    cleared += 1
+                    continue
                 # One bad row must not abort the rest of the sweep.
                 try:
                     if image_store.delete(candidate.id):

--- a/backend/app/tasks/image_sweep.py
+++ b/backend/app/tasks/image_sweep.py
@@ -54,7 +54,7 @@ def _referenced(url_by_id: dict[str, str]) -> set[str]:
         if url in matched_urls
         or (
             draft_blob
-            and re.search(re.escape(url) + r"([^0-9a-f]|$)", draft_blob) is not None
+            and re.search(re.escape(url) + r"([^0-9a-fA-F]|$)", draft_blob) is not None
         )
     }
 
@@ -103,16 +103,20 @@ def sweep_wiki_images() -> None:
             if unreferenced_since is None or not deletion_enabled:
                 continue
             if now - unreferenced_since > timedelta(days=_DEREFERENCE_RETENTION_DAYS):
-                # Re-check right before deleting: a reference committed after the
-                # batch scan must clear the flag, never lose the image.
-                if candidate.id in _referenced({candidate.id: url_by_id[candidate.id]}):
-                    image_store.set_unreferenced_since(candidate.id, None)
-                    cleared += 1
-                    continue
+                # The commit lock serializes this re-check + delete against every
+                # page writer, so no commit can add a reference in between. A
+                # reference that landed since the batch scan clears the flag.
                 # One bad row must not abort the rest of the sweep.
                 try:
-                    if image_store.delete(candidate.id):
-                        deleted += 1
+                    with wiki_git.commit_lock():
+                        if candidate.id in _referenced(
+                            {candidate.id: url_by_id[candidate.id]}
+                        ):
+                            image_store.set_unreferenced_since(candidate.id, None)
+                            cleared += 1
+                            continue
+                        if image_store.delete(candidate.id):
+                            deleted += 1
                 except Exception:
                     log.exception("image sweep: delete failed for %s", candidate.id)
 

--- a/backend/app/tasks/image_sweep.py
+++ b/backend/app/tasks/image_sweep.py
@@ -43,10 +43,10 @@ def _parse(ts: str | None) -> datetime | None:
 def _referenced(url_by_id: dict[str, str]) -> set[str]:
     """Ids whose serving URL appears in the working tree or a live edit buffer.
 
-    Hex-bounded on both surfaces so a URL sharing this one's prefix (a longer
-    hex tail resolving to a different id) never counts as a reference.
+    URL-bounded on both surfaces so a longer URL sharing this one's prefix
+    (a hex tail, a suffix like .png, a deeper segment) never counts.
     """
-    matched_urls = wiki_git.grep_working_tree_hex_bounded(list(url_by_id.values()))
+    matched_urls = wiki_git.grep_working_tree_url_bounded(list(url_by_id.values()))
     draft_blob = "\n".join(coedit.active_buffer_texts())
     return {
         image_id
@@ -54,7 +54,8 @@ def _referenced(url_by_id: dict[str, str]) -> set[str]:
         if url in matched_urls
         or (
             draft_blob
-            and re.search(re.escape(url) + r"([^0-9a-fA-F]|$)", draft_blob) is not None
+            and re.search(re.escape(url) + r"([^A-Za-z0-9._~%/-]|$)", draft_blob)
+            is not None
         )
     }
 
@@ -115,7 +116,9 @@ def sweep_wiki_images() -> None:
                             image_store.set_unreferenced_since(candidate.id, None)
                             cleared += 1
                             continue
-                        if image_store.delete(candidate.id):
+                        if image_store.delete_if_unreferenced_by_drafts(
+                            candidate.id, url_by_id[candidate.id]
+                        ):
                             deleted += 1
                 except Exception:
                     log.exception("image sweep: delete failed for %s", candidate.id)

--- a/backend/app/tasks/image_sweep.py
+++ b/backend/app/tasks/image_sweep.py
@@ -1,0 +1,109 @@
+"""Daily retention sweep for unreferenced wiki images.
+
+Images live in Postgres, so dereferenced blobs need a periodic sweep to keep
+storage bounded without touching the wiki commit path.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from app.metrics import (
+    wiki_image_sweep_deleted_total,
+    wiki_images_bytes_total,
+    wiki_images_total,
+)
+from app.tasks.queue import crontab
+from app.tasks.queues import lightweight_maintenance_queue
+from app.tasks.trash_purge import TRASH_RETENTION_DAYS
+from app.wiki import coedit, git as wiki_git, image_store
+
+log = logging.getLogger(__name__)
+
+_CREATION_GRACE = timedelta(hours=24)
+# Image dereference retention stays aligned with trash retention.
+_DEREFERENCE_RETENTION_DAYS = TRASH_RETENTION_DAYS
+_TEXT_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def _now_text() -> str:
+    return datetime.now(timezone.utc).strftime(_TEXT_TIMESTAMP_FORMAT)
+
+
+def _parse(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.strptime(ts, _TEXT_TIMESTAMP_FORMAT).replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def _refresh_gauges() -> None:
+    count, total_bytes = image_store.totals()
+    wiki_images_total.set(count)
+    wiki_images_bytes_total.set(total_bytes)
+
+
+# 12:00 UTC == 04:00 PST (UTC-8). The scheduler evaluates cron in UTC and does
+# not follow DST, so this lands at 04:00 Pacific in winter and 05:00 in summer.
+@lightweight_maintenance_queue.periodic_task(crontab(hour="12", minute="0"))
+def sweep_wiki_images() -> None:
+    deleted = 0
+    try:
+        candidates = image_store.list_for_sweep()
+        if not candidates:
+            log.info("image sweep: scanned=0 referenced=0 flagged=0 cleared=0 deleted=0")
+            return
+
+        candidate_ids = [candidate.id for candidate in candidates]
+        referenced_ids = wiki_git.grep_working_tree_fixed(candidate_ids)
+        draft_blob = "\n".join(coedit.active_buffer_texts())
+        if draft_blob:
+            referenced_ids.update(
+                image_id for image_id in candidate_ids if image_id in draft_blob
+            )
+
+        now = datetime.now(timezone.utc)
+        # 0 disables deletion, matching the trash-purge retention contract.
+        deletion_enabled = _DEREFERENCE_RETENTION_DAYS > 0
+        now_text = _now_text()
+        flagged = 0
+        cleared = 0
+        for candidate in candidates:
+            if candidate.id in referenced_ids:
+                if candidate.unreferenced_since is not None:
+                    image_store.set_unreferenced_since(candidate.id, None)
+                    cleared += 1
+                continue
+
+            if candidate.unreferenced_since is None:
+                created_at = _parse(candidate.created_at)
+                if created_at is not None and now - created_at > _CREATION_GRACE:
+                    image_store.set_unreferenced_since(candidate.id, now_text)
+                    flagged += 1
+                continue
+
+            unreferenced_since = _parse(candidate.unreferenced_since)
+            if unreferenced_since is None or not deletion_enabled:
+                continue
+            if now - unreferenced_since > timedelta(days=_DEREFERENCE_RETENTION_DAYS):
+                # One bad row must not abort the rest of the sweep.
+                try:
+                    if image_store.delete(candidate.id):
+                        deleted += 1
+                except Exception:
+                    log.exception("image sweep: delete failed for %s", candidate.id)
+
+        if deleted:
+            wiki_image_sweep_deleted_total.inc(deleted)
+        log.info(
+            "image sweep: scanned=%d referenced=%d flagged=%d cleared=%d deleted=%d",
+            len(candidates),
+            len(referenced_ids),
+            flagged,
+            cleared,
+            deleted,
+        )
+    finally:
+        _refresh_gauges()

--- a/backend/app/tasks/image_sweep.py
+++ b/backend/app/tasks/image_sweep.py
@@ -6,6 +6,7 @@ storage bounded without touching the wiki commit path.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timedelta, timezone
 
 from app.metrics import (
@@ -40,13 +41,21 @@ def _parse(ts: str | None) -> datetime | None:
 
 
 def _referenced(url_by_id: dict[str, str]) -> set[str]:
-    """Ids whose serving URL appears in the working tree or a live edit buffer."""
-    matched_urls = wiki_git.grep_working_tree_fixed(list(url_by_id.values()))
+    """Ids whose serving URL appears in the working tree or a live edit buffer.
+
+    Hex-bounded on both surfaces so a URL sharing this one's prefix (a longer
+    hex tail resolving to a different id) never counts as a reference.
+    """
+    matched_urls = wiki_git.grep_working_tree_hex_bounded(list(url_by_id.values()))
     draft_blob = "\n".join(coedit.active_buffer_texts())
     return {
         image_id
         for image_id, url in url_by_id.items()
-        if url in matched_urls or (draft_blob and url in draft_blob)
+        if url in matched_urls
+        or (
+            draft_blob
+            and re.search(re.escape(url) + r"([^0-9a-f]|$)", draft_blob) is not None
+        )
     }
 
 

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -49,6 +49,7 @@ _TASK_MODULES = (
     "app.tasks.craft",
     "app.tasks.wiki_update",
     "app.tasks.expire_launch_artifacts",
+    "app.tasks.image_sweep",
     "app.tasks.ingest_eval_retention",
     "app.tasks.mcp_session_cleanup",
     "app.tasks.notify_emails",

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -169,6 +169,18 @@ def blocking_active_session_path(dest: str) -> str | None:
         )
 
 
+def active_buffer_texts() -> list[str]:
+    """Editing-buffer text of every active co-edit session (uncommitted drafts)."""
+    with session() as s:
+        return list(
+            s.scalars(
+                select(CoeditSession.buffer_text).where(
+                    CoeditSession.status == SessionStatus.ACTIVE.value
+                )
+            )
+        )
+
+
 def get_session(session_id: int) -> SessionRow | None:
     """Look up a session by id, regardless of status (active or closed)."""
     with session() as s:

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -579,7 +579,7 @@ def grep_working_tree_hex_bounded(needles: Iterable[str]) -> set[str]:
     if not wanted:
         return set()
     with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=True) as f:
-        f.write("\n".join(f"{needle}([^0-9a-f]|$)" for needle in wanted))
+        f.write("\n".join(f"{needle}([^0-9a-fA-F]|$)" for needle in wanted))
         f.flush()
         res = _run(
             ["grep", "--no-color", "-I", "-E", "-f", f.name, "-o", "-h"],

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -565,28 +565,32 @@ def list_paths(prefix: str = "") -> list[str]:
     return [p for p in out.split("\0") if p and not p.startswith(TRASH_PREFIX)]
 
 
-def grep_working_tree_fixed(needles: Iterable[str]) -> set[str]:
-    """Fixed-string search over the working tree, INCLUDING ``.trash/``.
+def grep_working_tree_hex_bounded(needles: Iterable[str]) -> set[str]:
+    """Search the working tree, INCLUDING ``.trash/``, for needles that must
+    not be followed by another hex character.
 
-    Unlike ``list_paths`` (which filters ``TRASH_PREFIX``), git grep applies no
-    ``.trash/`` exclusion, so a reference inside a trashed page still counts.
-    Only the image sweep should rely on that bypass.
+    The boundary keeps a needle from matching inside a longer hex-suffixed
+    string (a different id sharing the prefix). Unlike ``list_paths`` (which
+    filters ``TRASH_PREFIX``), git grep applies no ``.trash/`` exclusion, so a
+    reference inside a trashed page still counts. Only the image sweep should
+    rely on that bypass.
     """
     wanted = {needle for needle in needles if needle}
     if not wanted:
         return set()
     with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=True) as f:
-        f.write("\n".join(wanted))
+        f.write("\n".join(f"{needle}([^0-9a-f]|$)" for needle in wanted))
         f.flush()
         res = _run(
-            ["grep", "--no-color", "-I", "-F", "-f", f.name, "-o", "-h"],
+            ["grep", "--no-color", "-I", "-E", "-f", f.name, "-o", "-h"],
             check=False,
         )
     if res.returncode == 1:
         return set()
     if res.returncode != 0:
         raise RuntimeError(f"git grep failed (exit {res.returncode}): {res.stderr.strip()!r}")
-    return {line for line in res.stdout.splitlines() if line} & wanted
+    matches = [line for line in res.stdout.splitlines() if line]
+    return {needle for needle in wanted if any(m.startswith(needle) for m in matches)}
 
 
 def bundle(dest_path: str) -> None:

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 import tempfile
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -563,6 +563,30 @@ def list_paths(prefix: str = "") -> list[str]:
     """List tracked files under a path prefix (excluding the hidden ``.trash/``)."""
     out = _run(["ls-files", "-z", prefix or "."]).stdout
     return [p for p in out.split("\0") if p and not p.startswith(TRASH_PREFIX)]
+
+
+def grep_working_tree_fixed(needles: Iterable[str]) -> set[str]:
+    """Fixed-string search over the working tree, INCLUDING ``.trash/``.
+
+    Unlike ``list_paths`` (which filters ``TRASH_PREFIX``), git grep applies no
+    ``.trash/`` exclusion, so a reference inside a trashed page still counts.
+    Only the image sweep should rely on that bypass.
+    """
+    wanted = {needle for needle in needles if needle}
+    if not wanted:
+        return set()
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=True) as f:
+        f.write("\n".join(wanted))
+        f.flush()
+        res = _run(
+            ["grep", "--no-color", "-I", "-F", "-f", f.name, "-o", "-h"],
+            check=False,
+        )
+    if res.returncode == 1:
+        return set()
+    if res.returncode != 0:
+        raise RuntimeError(f"git grep failed (exit {res.returncode}): {res.stderr.strip()!r}")
+    return {line for line in res.stdout.splitlines() if line} & wanted
 
 
 def bundle(dest_path: str) -> None:

--- a/backend/app/wiki/git.py
+++ b/backend/app/wiki/git.py
@@ -565,21 +565,22 @@ def list_paths(prefix: str = "") -> list[str]:
     return [p for p in out.split("\0") if p and not p.startswith(TRASH_PREFIX)]
 
 
-def grep_working_tree_hex_bounded(needles: Iterable[str]) -> set[str]:
-    """Search the working tree, INCLUDING ``.trash/``, for needles that must
-    not be followed by another hex character.
+def grep_working_tree_url_bounded(needles: Iterable[str]) -> set[str]:
+    """Search the working tree, INCLUDING ``.trash/``, for URL needles that
+    must not be followed by another URL-path character.
 
-    The boundary keeps a needle from matching inside a longer hex-suffixed
-    string (a different id sharing the prefix). Unlike ``list_paths`` (which
-    filters ``TRASH_PREFIX``), git grep applies no ``.trash/`` exclusion, so a
-    reference inside a trashed page still counts. Only the image sweep should
-    rely on that bypass.
+    The boundary keeps a needle from matching inside a longer URL (a hex
+    tail, a ``.png`` suffix, a deeper path segment), all of which resolve to
+    something else. Unlike ``list_paths`` (which filters ``TRASH_PREFIX``),
+    git grep applies no ``.trash/`` exclusion, so a reference inside a
+    trashed page still counts. Only the image sweep should rely on that
+    bypass.
     """
     wanted = {needle for needle in needles if needle}
     if not wanted:
         return set()
     with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=True) as f:
-        f.write("\n".join(f"{needle}([^0-9a-fA-F]|$)" for needle in wanted))
+        f.write("\n".join(f"{needle}([^A-Za-z0-9._~%/-]|$)" for needle in wanted))
         f.flush()
         res = _run(
             ["grep", "--no-color", "-I", "-E", "-f", f.name, "-o", "-h"],

--- a/backend/app/wiki/image_store.py
+++ b/backend/app/wiki/image_store.py
@@ -10,7 +10,8 @@ from sqlalchemy import delete as sqla_delete
 from sqlalchemy import func, select, update
 from sqlalchemy.orm import defer
 
-from app.db.models import Image
+from app.db.models import CoeditSession, Image
+from app.wiki.coedit import SessionStatus
 from app.db.session import execute_dml, session
 
 
@@ -141,6 +142,36 @@ def totals() -> tuple[int, int]:
             select(func.count(), func.coalesce(func.sum(Image.size_bytes), 0))
         ).one()
         return int(count), int(total_bytes)
+
+
+def delete_if_unreferenced_by_drafts(image_id: str, url: str) -> bool:
+    """Delete the image unless a live co-edit buffer references ``url``, as
+    one SERIALIZABLE transaction.
+
+    Closes the window between a buffer read and the delete: a concurrent
+    buffer write forces a serialization failure instead of a lost reference.
+    On that failure the caller skips the candidate, the next daily run
+    retries. The git-side scan is the caller's job (it holds the commit lock
+    across this call). Returns True only when a row was deleted.
+    """
+    with session() as s:
+        s.connection(execution_options={"isolation_level": "SERIALIZABLE"})
+        referenced = s.scalar(
+            select(func.count())
+            .select_from(CoeditSession)
+            .where(
+                CoeditSession.status == SessionStatus.ACTIVE.value,
+                CoeditSession.buffer_text.contains(url),
+            )
+        )
+        if referenced:
+            return False
+        stmt = (
+            sqla_delete(Image)
+            .where(Image.id == image_id)
+            .execution_options(synchronize_session=False)
+        )
+        return execute_dml(s, stmt) > 0
 
 
 def delete(image_id: str) -> bool:

--- a/backend/app/wiki/image_store.py
+++ b/backend/app/wiki/image_store.py
@@ -7,7 +7,7 @@ import uuid
 
 from pydantic import BaseModel
 from sqlalchemy import delete as sqla_delete
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import defer
 
 from app.db.models import Image
@@ -26,6 +26,12 @@ class StoredImage(BaseModel):
 
 class StoredImageData(StoredImage):
     data: bytes
+
+
+class ImageSweepRow(BaseModel):
+    id: str
+    created_at: str
+    unreferenced_since: str | None
 
 
 def sniff_image_type(data: bytes) -> str | None:
@@ -96,6 +102,39 @@ def get(image_id: str) -> StoredImageData | None:
     with session() as s:
         row = s.get(Image, image_id)
         return _to_stored_image_data(row) if row is not None else None
+
+
+def list_for_sweep() -> list[ImageSweepRow]:
+    with session() as s:
+        rows = s.execute(
+            select(Image.id, Image.created_at, Image.unreferenced_since)
+        ).all()
+        return [
+            ImageSweepRow(
+                id=image_id,
+                created_at=created_at,
+                unreferenced_since=unreferenced_since,
+            )
+            for image_id, created_at, unreferenced_since in rows
+        ]
+
+
+def set_unreferenced_since(image_id: str, value: str | None) -> None:
+    with session() as s:
+        s.execute(
+            update(Image)
+            .where(Image.id == image_id)
+            .values(unreferenced_since=value)
+            .execution_options(synchronize_session=False)
+        )
+
+
+def totals() -> tuple[int, int]:
+    with session() as s:
+        count, total_bytes = s.execute(
+            select(func.count(), func.coalesce(func.sum(Image.size_bytes), 0))
+        ).one()
+        return int(count), int(total_bytes)
 
 
 def delete(image_id: str) -> bool:

--- a/backend/app/wiki/image_store.py
+++ b/backend/app/wiki/image_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 import uuid
 
 from pydantic import BaseModel
@@ -145,23 +146,26 @@ def totals() -> tuple[int, int]:
 
 
 def delete_if_unreferenced_by_drafts(image_id: str, url: str) -> bool:
-    """Delete the image unless a live co-edit buffer references ``url``, as
-    one SERIALIZABLE transaction.
+    """Delete the image unless a live co-edit buffer references ``url``, in
+    one transaction (URL-boundary matched, same class as the tree scan).
 
-    Closes the window between a buffer read and the delete: a concurrent
-    buffer write forces a serialization failure instead of a lost reference.
-    On that failure the caller skips the candidate, the next daily run
-    retries. The git-side scan is the caller's job (it holds the commit lock
-    across this call). Returns True only when a row was deleted.
+    A buffer write that lands after this transaction commits produces a
+    draft referencing an already-deleted URL. That end state is reachable
+    with no race at all (a draft can paste any dead URL at any moment), so
+    no synchronization boundary can prevent it and none is pretended here.
+    What this transaction does guarantee: the check and the delete are
+    atomic, so no reference visible at delete time is ever lost. The
+    git-side scan is the caller's job (it holds the commit lock across this
+    call). Returns True only when a row was deleted.
     """
+    boundary = re.escape(url) + "([^A-Za-z0-9._~%/-]|$)"
     with session() as s:
-        s.connection(execution_options={"isolation_level": "SERIALIZABLE"})
         referenced = s.scalar(
             select(func.count())
             .select_from(CoeditSession)
             .where(
                 CoeditSession.status == SessionStatus.ACTIVE.value,
-                CoeditSession.buffer_text.contains(url),
+                CoeditSession.buffer_text.regexp_match(boundary),
             )
         )
         if referenced:

--- a/backend/app/wiki/image_store.py
+++ b/backend/app/wiki/image_store.py
@@ -34,6 +34,12 @@ class ImageSweepRow(BaseModel):
     unreferenced_since: str | None
 
 
+def serving_url(image_id: str) -> str:
+    """The app URL pages embed for an image. Also the sweep's reference needle,
+    so a bare 16-hex coincidence in page text never counts as a reference."""
+    return f"/api/wiki/images/{image_id}"
+
+
 def sniff_image_type(data: bytes) -> str | None:
     if data.startswith(b"\x89PNG\r\n\x1a\n"):
         return "image/png"

--- a/backend/tests/test_wiki_image_sweep.py
+++ b/backend/tests/test_wiki_image_sweep.py
@@ -93,6 +93,22 @@ def test_never_referenced_image_is_flagged_after_grace_then_deleted_after_retent
     assert image_store.stat(image_id) is None
 
 
+def test_prefix_url_with_longer_hex_tail_is_not_a_reference(tmp_repo) -> None:
+    # A URL whose id merely starts with this image's id resolves elsewhere.
+    path = "guides/prefix.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    wiki_git.commit_file(
+        path, f"![x](/api/wiki/images/{image_id}ab)\n", "seed", author=None
+    )
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is not None
+
+
 def test_bare_id_in_page_text_is_not_a_reference(tmp_repo) -> None:
     # Only the full serving URL counts. A coincidental 16-hex string in page
     # text (a sha, a random token) must not keep an orphan alive.

--- a/backend/tests/test_wiki_image_sweep.py
+++ b/backend/tests/test_wiki_image_sweep.py
@@ -93,6 +93,22 @@ def test_never_referenced_image_is_flagged_after_grace_then_deleted_after_retent
     assert image_store.stat(image_id) is None
 
 
+def test_delete_proceeds_when_draft_holds_only_a_suffixed_url(tmp_repo) -> None:
+    # The delete-time draft guard is URL-boundary matched too: a draft whose
+    # only mention extends the URL path must not keep the orphan alive.
+    path = "guides/draft-suffix.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    _set_unreferenced_since(image_id, _timestamp_ago(timedelta(days=31)))
+    coedit.open_session(
+        path, base_sha=None, initial_buffer=f"see /api/wiki/images/{image_id}.png"
+    )
+
+    _run_sweep()
+
+    assert _image_row(image_id) is None
+
+
 def test_non_hex_url_suffix_is_not_a_reference(tmp_repo) -> None:
     # A .png tail extends the URL path, so it resolves to a different route.
     path = "guides/suffix.md"

--- a/backend/tests/test_wiki_image_sweep.py
+++ b/backend/tests/test_wiki_image_sweep.py
@@ -93,6 +93,21 @@ def test_never_referenced_image_is_flagged_after_grace_then_deleted_after_retent
     assert image_store.stat(image_id) is None
 
 
+def test_bare_id_in_page_text_is_not_a_reference(tmp_repo) -> None:
+    # Only the full serving URL counts. A coincidental 16-hex string in page
+    # text (a sha, a random token) must not keep an orphan alive.
+    path = "guides/coincidence.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    wiki_git.commit_file(path, f"hex soup: {image_id}\n", "seed", author=None)
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is not None
+
+
 def test_committed_page_reference_keeps_image_live(tmp_repo) -> None:
     path = "guides/kept.md"
     image_id = _put_image(path)
@@ -110,7 +125,11 @@ def test_active_draft_buffer_reference_keeps_image_live(tmp_repo) -> None:
     path = "drafts/live.md"
     image_id = _put_image(path)
     _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
-    coedit.open_session(path, base_sha=None, initial_buffer=f"draft keeps {image_id} live")
+    coedit.open_session(
+        path,
+        base_sha=None,
+        initial_buffer=f"draft keeps ![x](/api/wiki/images/{image_id}) live",
+    )
 
     _run_sweep()
 

--- a/backend/tests/test_wiki_image_sweep.py
+++ b/backend/tests/test_wiki_image_sweep.py
@@ -1,0 +1,220 @@
+"""Retention sweep tests for wiki images."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.auth import users as users_repo
+from app.db.models import Image
+from app.db.session import session
+from app.main import create_app
+from app.metrics import (
+    wiki_image_sweep_deleted_total,
+    wiki_image_upload_rejected_total,
+    wiki_images_bytes_total,
+    wiki_images_total,
+)
+from app.tasks.image_sweep import sweep_wiki_images
+from app.tasks.queues import lightweight_maintenance_queue
+from app.tasks.trash_purge import TRASH_RETENTION_DAYS
+from app.wiki import coedit, doc_ids, git as wiki_git, image_store, trash
+
+from tests._auth import login_fastapi
+
+_TS_FORMAT = "%Y-%m-%d %H:%M:%S"
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _timestamp_ago(delta: timedelta) -> str:
+    return (datetime.now(timezone.utc) - delta).strftime(_TS_FORMAT)
+
+
+def _put_image(path: str) -> str:
+    return image_store.put(
+        data=PNG_BYTES,
+        content_type="image/png",
+        anchor_doc_id=doc_ids.get_or_mint(path),
+        uploaded_by=None,
+    )
+
+
+def _body_with_image(image_id: str) -> str:
+    return f"# Page\n![x](/api/wiki/images/{image_id})\n"
+
+
+def _image_row(image_id: str) -> image_store.ImageSweepRow | None:
+    for row in image_store.list_for_sweep():
+        if row.id == image_id:
+            return row
+    return None
+
+
+def _set_created_at(image_id: str, value: str) -> None:
+    with session() as s:
+        row = s.get(Image, image_id)
+        assert row is not None
+        row.created_at = value
+
+
+def _set_unreferenced_since(image_id: str, value: str | None) -> None:
+    with session() as s:
+        row = s.get(Image, image_id)
+        assert row is not None
+        row.unreferenced_since = value
+
+
+def _run_sweep() -> None:
+    with lightweight_maintenance_queue.immediate_mode():
+        sweep_wiki_images()
+
+
+def test_never_referenced_image_is_flagged_after_grace_then_deleted_after_retention_window(
+    tmp_repo,
+) -> None:
+    image_id = _put_image("guides/orphan.md")
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+
+    _run_sweep()
+
+    flagged = _image_row(image_id)
+    assert flagged is not None
+    assert flagged.unreferenced_since is not None
+
+    _set_unreferenced_since(
+        image_id,
+        _timestamp_ago(timedelta(days=TRASH_RETENTION_DAYS + 1)),
+    )
+
+    _run_sweep()
+
+    assert _image_row(image_id) is None
+    assert image_store.stat(image_id) is None
+
+
+def test_committed_page_reference_keeps_image_live(tmp_repo) -> None:
+    path = "guides/kept.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    wiki_git.commit_file(path, _body_with_image(image_id), "seed", author=None)
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is None
+
+
+def test_active_draft_buffer_reference_keeps_image_live(tmp_repo) -> None:
+    path = "drafts/live.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    coedit.open_session(path, base_sha=None, initial_buffer=f"draft keeps {image_id} live")
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is None
+
+
+def test_trashed_page_reference_keeps_image_live(tmp_repo) -> None:
+    path = "guides/trashed.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    body = _body_with_image(image_id)
+    wiki_git.commit_file(path, body, "seed", author=None)
+
+    trash_id = trash.new_trash_id()
+    dest = trash.trash_location(trash_id, path)
+    wiki_git.move_and_commit(path, dest, body, trash.trash_commit_message(path), author=None)
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is None
+
+
+def test_dereference_flag_is_cleared_when_reference_returns(tmp_repo) -> None:
+    path = "guides/flip.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+
+    wiki_git.commit_file(path, _body_with_image(image_id), "seed", author=None)
+    _run_sweep()
+    initial = _image_row(image_id)
+    assert initial is not None
+    assert initial.unreferenced_since is None
+
+    wiki_git.commit_file(path, "# Page\nno image here\n", "drop image", author=None)
+    _run_sweep()
+    flagged = _image_row(image_id)
+    assert flagged is not None
+    assert flagged.unreferenced_since is not None
+
+    wiki_git.commit_file(path, _body_with_image(image_id), "restore image", author=None)
+    _run_sweep()
+    cleared = _image_row(image_id)
+    assert cleared is not None
+    assert cleared.unreferenced_since is None
+
+
+def test_dereference_retention_deletes_old_flagged_image(tmp_repo) -> None:
+    image_id = _put_image("guides/delete-me.md")
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    _set_unreferenced_since(
+        image_id,
+        _timestamp_ago(timedelta(days=TRASH_RETENTION_DAYS + 1)),
+    )
+
+    _run_sweep()
+
+    assert _image_row(image_id) is None
+    assert image_store.stat(image_id) is None
+
+
+def test_recent_unreferenced_image_stays_within_creation_grace(tmp_repo) -> None:
+    image_id = _put_image("guides/fresh.md")
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is None
+
+
+def test_metrics_refresh_and_upload_rejections_are_counted(tmp_repo) -> None:
+    kept_image_id = _put_image("guides/metrics-keep.md")
+    deleted_image_id = _put_image("guides/metrics-delete.md")
+    _set_created_at(deleted_image_id, _timestamp_ago(timedelta(hours=25)))
+    _set_unreferenced_since(
+        deleted_image_id,
+        _timestamp_ago(timedelta(days=TRASH_RETENTION_DAYS + 1)),
+    )
+
+    deleted_before = wiki_image_sweep_deleted_total._value.get()
+    _run_sweep()
+
+    assert wiki_image_sweep_deleted_total._value.get() == deleted_before + 1
+    assert wiki_images_total._value.get() == 1
+    assert wiki_images_bytes_total._value.get() == len(PNG_BYTES)
+    assert image_store.stat(kept_image_id) is not None
+    assert image_store.stat(deleted_image_id) is None
+
+    client = TestClient(create_app())
+    user_id = users_repo.create(email="admin@x.com", password="hunter2-x", name="Admin")
+    login_fastapi(client, user_id)
+    rejected_before = wiki_image_upload_rejected_total.labels(reason="too_large")._value.get()
+
+    response = client.post(
+        "/api/wiki/images?path=guides/metrics-keep.md",
+        content=b"\x89PNG\r\n\x1a\n" + b"\x00" * (10 * 1024 * 1024 + 1),
+        headers={"Content-Type": "image/png"},
+    )
+
+    assert response.status_code == 413
+    assert wiki_image_upload_rejected_total.labels(reason="too_large")._value.get() == (
+        rejected_before + 1
+    )

--- a/backend/tests/test_wiki_image_sweep.py
+++ b/backend/tests/test_wiki_image_sweep.py
@@ -93,6 +93,23 @@ def test_never_referenced_image_is_flagged_after_grace_then_deleted_after_retent
     assert image_store.stat(image_id) is None
 
 
+def test_uppercase_hex_tail_is_not_a_reference(tmp_repo) -> None:
+    # The boundary is case-insensitive hex, so an uppercase tail is still a
+    # longer different identifier, not this image's reference.
+    path = "guides/upper.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    wiki_git.commit_file(
+        path, f"![x](/api/wiki/images/{image_id}AB)\n", "seed", author=None
+    )
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is not None
+
+
 def test_prefix_url_with_longer_hex_tail_is_not_a_reference(tmp_repo) -> None:
     # A URL whose id merely starts with this image's id resolves elsewhere.
     path = "guides/prefix.md"

--- a/backend/tests/test_wiki_image_sweep.py
+++ b/backend/tests/test_wiki_image_sweep.py
@@ -93,6 +93,22 @@ def test_never_referenced_image_is_flagged_after_grace_then_deleted_after_retent
     assert image_store.stat(image_id) is None
 
 
+def test_non_hex_url_suffix_is_not_a_reference(tmp_repo) -> None:
+    # A .png tail extends the URL path, so it resolves to a different route.
+    path = "guides/suffix.md"
+    image_id = _put_image(path)
+    _set_created_at(image_id, _timestamp_ago(timedelta(hours=25)))
+    wiki_git.commit_file(
+        path, f"![x](/api/wiki/images/{image_id}.png)\n", "seed", author=None
+    )
+
+    _run_sweep()
+
+    row = _image_row(image_id)
+    assert row is not None
+    assert row.unreferenced_since is not None
+
+
 def test_uppercase_hex_tail_is_not_a_reference(tmp_repo) -> None:
     # The boundary is case-insensitive hex, so an uppercase tail is still a
     # longer different identifier, not this image's reference.

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -74,6 +74,16 @@ To take a one-off backup outside the schedule:
 kubectl create job --from=cronjob/<release>-agent-workspace-backup manual-backup-1
 ```
 
+## Images in backups
+
+Wiki images live in Postgres in the `images` table. They are already captured
+by the `pg_dump` half of the backup pair, so there is no separate image backup
+step.
+
+Dump size grows with the total stored image bytes. PNG, JPEG, GIF, and
+WebP data is already compressed, so the dump does not shrink much further.
+Size the backup CronJob's ephemeral storage with image volume in mind.
+
 ## Restore
 
 Restore both halves **from the same timestamp group** (one that contains


### PR DESCRIPTION
## Summary

Retention sweep and observability for stored wiki images. Stacks on the image store/endpoints PR.

- Daily sweep (`app/tasks/image_sweep.py`, 12:00 UTC on `lightweight_maintenance_queue`, mirroring the ingest-eval retention prune): one batched `git grep -F` over the working tree including `.trash/` (a documented exception to the `list_paths` exclusion, via a new wrapper in `app/wiki/git.py`) plus the live coedit session buffers. Referenced images get their flag cleared. Unreferenced images past a 24h creation grace get flagged (`unreferenced_since`, new nullable column, migration `e7a1c4d9b2f6`), and flagged images past the trash retention window (`TRASH_RETENTION_DAYS`, 30 days, 0 disables) are deleted. Unparseable timestamps never delete.
- One deliberate model choice for review: never-referenced uploads are flagged at 24h and deleted after the retention window rather than fast-deleted at 24h, because a snapshot scan cannot distinguish never-referenced from just-dereferenced without extra schema or git-history digging that would break the lightweight-queue contract. Abandoned uploads linger ~31 days; the storage cost of that is trivial.
- Prometheus: `wiki_images_total` and `wiki_images_bytes_total` gauges (refreshed each sweep, even on failure), `wiki_image_sweep_deleted_total`, and `wiki_image_upload_rejected_total{reason}` on the upload endpoint's 413/415 paths.
- `docs/backups.md`: images live in Postgres and already ride the pg_dump; dump size now grows with stored image bytes and pre-compressed formats do not shrink, so size the backup CronJob's ephemeral storage accordingly.

## How Has This Been Tested?

`tests/test_wiki_image_sweep.py`, 8 tests against real Postgres + real git: committed-page reference spared, live coedit buffer reference spared, `.trash/`-only reference spared (end-to-end through a real trashed page), flag set then cleared when a reference returns, deletion after the retention window (timestamps manipulated), creation-grace skip, metrics movement, upload-rejection counter. Combined with the 14 image endpoint tests: 22 passed. ruff and strict basedpyright clean.
