### PR TITLE
feat(codec): byte-stable image leaf support in the markdown-Yjs codec

### DIFF
--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -6,19 +6,20 @@ stable, positional ``_blockId`` attribute. Structural treatment (real
 ProseMirror-shaped nodes, editable node-by-node, not opaque text) covers:
 ``heading``, ``paragraph`` (inline content — text runs + bold/italic/code/
 link marks, represented via a ``pycrdt.XmlText``'s ``.format()`` runs, plus
-an explicit ``hardBreak`` leaf element interspersed as a sibling wherever a
-hard line break occurs — y-prosemirror maps a PM leaf/atom node to an empty
-sibling ``XmlElement``, not to a text mark, since a break is a node boundary,
-not formatting), ``bulletList``/``orderedList``/``listItem`` (arbitrarily
-nested — CommonMark's own grammar is already recursive here, so supporting
-depth costs about the same as supporting one level), ``taskList``/
-``taskItem`` (a GFM checkbox list — a plain bullet list whose items *all*
-start with a ``[ ]``/``[x]`` marker; a mixed list stays a regular
-``bulletList`` since a taskList's children must be uniformly taskItems — see
-``_build_list``), ``blockquote`` (a sequence of paragraph/list/blockquote
-children, so multi-paragraph quotes and quotes containing lists work), and
-``codeBlock`` (a ``language`` attribute + plain text content, fence syntax
-stripped — not stored as opaque markup). Tables get row-level structure
+explicit ``hardBreak`` and ``image`` leaf elements interspersed as siblings
+wherever a hard line break or image occurs — y-prosemirror maps a PM
+leaf/atom node to an empty sibling ``XmlElement``, not to a text mark,
+since these are node boundaries, not formatting), ``bulletList``/
+``orderedList``/``listItem`` (arbitrarily nested — CommonMark's own grammar
+is already recursive here, so supporting depth costs about the same as
+supporting one level), ``taskList``/``taskItem`` (a GFM checkbox list — a
+plain bullet list whose items *all* start with a ``[ ]``/``[x]`` marker; a
+mixed list stays a regular ``bulletList`` since a taskList's children must
+be uniformly taskItems — see ``_build_list``), ``blockquote`` (a sequence of
+paragraph/list/blockquote children, so multi-paragraph quotes and quotes
+containing lists work), and ``codeBlock`` (a ``language`` attribute + plain
+text content, fence syntax stripped — not stored as opaque markup). Tables
+get row-level structure
 (each row is its own ``XmlElement`` tagged ``_rowId``, so a single-cell edit
 only reflows its own row, not the whole table) but each row's *content* is
 still stored as opaque verbatim text, not decomposed into cells —
@@ -27,13 +28,13 @@ padding, and still achieves the byte-stability goal for every row that isn't
 touched — cells aren't decomposed or individually editable. Thematic break
 and html block stay opaque verbatim, tagged ``_raw="1"``.
 
-Unrecognized inline constructs (an image, GFM strikethrough — anything this
-module doesn't have an explicit encoder for) raise ``NotImplementedError``
-rather than silently drop or mis-serialize content — the byte-stability
-requirement this whole engine exists for is only meaningful if failures are
-loud, never silent. Same for a list item that isn't a clean sequence of
-paragraph/list/blockquote children (e.g. a list item containing a table) —
-unsupported, raises rather than mis-encodes.
+Unrecognized inline constructs (anything this module doesn't have an
+explicit encoder for) raise ``NotImplementedError`` rather than silently
+drop or mis-serialize content — the byte-stability requirement this whole
+engine exists for is only meaningful if failures are loud, never silent.
+Same for a list item that isn't a clean sequence of paragraph/list/
+blockquote children (e.g. a list item containing a table) — unsupported,
+raises rather than mis-encodes.
 """
 
 from __future__ import annotations
@@ -59,6 +60,7 @@ _KNOWN_INLINE_TYPES = {
     "text",
     "softbreak",
     "hardbreak",
+    "image",
     "strong_open",
     "strong_close",
     "em_open",
@@ -77,15 +79,38 @@ _KNOWN_INLINE_TYPES = {
 # unrecognized inline *construct* (see _KNOWN_INLINE_TYPES) raises.
 _MARK_WRAP_ORDER = ("link", "bold", "italic", "code")
 
-# A text segment ("text", plain_text, mark_runs) or a hard-break leaf
-# ("hardbreak", None, None) — see module docstring for why a hard break is a
-# sibling element, not foldable into a text run's marks.
-_Segment = tuple[Literal["text", "hardbreak"], str | None, list[tuple[int, int, dict[str, Any]]] | None]
+# A text segment ("text", plain_text, mark_runs, None) or a leaf sibling
+# ("hardbreak" with None attrs, "image" with its attrs dict). See module
+# docstring for why leaf nodes stay distinct from a text run's marks.
+_Segment = tuple[
+    Literal["text", "hardbreak", "image"],
+    str | None,
+    list[tuple[int, int, dict[str, Any]]] | None,
+    dict[str, str] | None,
+]
+
+
+def _image_alt_text(children: list[Any] | None) -> str:
+    return "".join(
+        "\n" if child.type in ("softbreak", "hardbreak") else str(getattr(child, "content", ""))
+        for child in (children or [])
+    )
+
+
+def _image_attrs(image_token: Any) -> dict[str, str]:
+    attrs = image_token.attrs or {}
+    image_attrs = {
+        "src": str(attrs.get("src", "")),
+        "alt": _image_alt_text(image_token.children),
+    }
+    if "title" in attrs:
+        image_attrs["title"] = str(attrs["title"])
+    return image_attrs
 
 
 def _inline_runs(inline_token: Any) -> list[_Segment]:
     """Walk a markdown-it ``inline`` token's children into ordered segments —
-    text runs (with their mark spans) interspersed with hard-break leaves."""
+    text runs (with their mark spans) interspersed with inline leaf nodes."""
     segments: list[_Segment] = []
     parts: list[str] = []
     pos = 0
@@ -95,7 +120,7 @@ def _inline_runs(inline_token: Any) -> list[_Segment]:
     def _flush_text() -> None:
         nonlocal parts, pos, runs
         if parts:
-            segments.append(("text", "".join(parts), runs))
+            segments.append(("text", "".join(parts), runs, None))
         parts, pos, runs = [], 0, []
 
     def _emit(content: str, attrs: dict[str, Any]) -> None:
@@ -110,7 +135,10 @@ def _inline_runs(inline_token: Any) -> list[_Segment]:
             raise NotImplementedError(f"unrecognized inline construct: {child.type!r}")
         if child.type == "hardbreak":
             _flush_text()
-            segments.append(("hardbreak", None, None))
+            segments.append(("hardbreak", None, None, None))
+        elif child.type == "image":
+            _flush_text()
+            segments.append(("image", None, None, _image_attrs(child)))
         elif child.type == "text":
             _emit(child.content, active)
         elif child.type == "softbreak":
@@ -151,6 +179,15 @@ def _escape_inline_text(text: str) -> str:
     return text
 
 
+def _wrap_with_delimiter(text: str, delimiter: str) -> str:
+    core = text.strip()
+    if not core:
+        return f"{delimiter}{text}{delimiter}"
+    lead = text[: len(text) - len(text.lstrip())]
+    trail = text[len(text.rstrip()) :]
+    return f"{lead}{delimiter}{core}{delimiter}{trail}"
+
+
 def _wrap_run(text: str, attrs: dict[str, Any] | None) -> str:
     attrs = attrs or {}
     # Inline code spans are verbatim — CommonMark never processes escapes
@@ -167,9 +204,12 @@ def _wrap_run(text: str, attrs: dict[str, Any] | None) -> str:
         if mark == "code":
             result = f"`{result}`"
         elif mark == "italic":
-            result = f"*{result}*"
+            # Edge whitespace can't sit inside emphasis delimiters and
+            # still reliably re-parse as emphasis once a leaf splits the
+            # run, so keep that whitespace outside the markers.
+            result = _wrap_with_delimiter(result, "*")
         elif mark == "bold":
-            result = f"**{result}**"
+            result = _wrap_with_delimiter(result, "**")
         elif mark == "link":
             # attrs["link"] is {"href": ...} (matching y-prosemirror's
             # mark-attrs convention) — but also accept a bare string
@@ -185,10 +225,24 @@ def _serialize_inline_text(xt: XmlText) -> str:
     return "".join(_wrap_run(text, attrs) for text, attrs in xt.diff())
 
 
+def _escape_title(title: str) -> str:
+    return title.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _serialize_image(node: XmlElement) -> str:
+    attrs = dict(node.attributes)
+    src = attrs.get("src", "")
+    alt = _escape_inline_text(attrs.get("alt", ""))
+    title = attrs.get("title")
+    if title is not None:
+        return f'![{alt}]({src} "{_escape_title(title)}")'
+    return f"![{alt}]({src})"
+
+
 def _serialize_inline_children(children: list[Any]) -> str:
     """Inverse of ``_element_from_segments``: walks a paragraph/heading's
     ``contents`` list, which may interleave ``XmlText`` runs with
-    ``hardBreak`` leaf elements."""
+    inline leaf elements."""
     parts: list[str] = []
     for child in children:
         if isinstance(child, XmlText):
@@ -199,6 +253,8 @@ def _serialize_inline_children(children: list[Any]) -> str:
             # necessarily byte-identical" tradeoff already accepted
             # elsewhere in this module for touched blocks.
             parts.append("  \n")
+        elif isinstance(child, XmlElement) and child.tag == "image":
+            parts.append(_serialize_image(child))
         else:
             raise NotImplementedError(f"unrecognized inline child: {child!r}")
     return "".join(parts)
@@ -214,9 +270,12 @@ def _element_from_segments(
     rest of this module."""
     contents: list[Any] = []
     finishers: list[Any] = []
-    for kind, text, runs in segments:
+    for kind, text, runs, image_attrs in segments:
         if kind == "hardbreak":
             contents.append(XmlElement("hardBreak", {}))
+        elif kind == "image":
+            assert image_attrs is not None
+            contents.append(XmlElement("image", image_attrs))
         else:
             xt = XmlText(text or "")
             contents.append(xt)

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -229,13 +229,34 @@ def _escape_title(title: str) -> str:
     return title.replace("\\", "\\\\").replace('"', '\\"')
 
 
+def _image_destination(src: str) -> str:
+    # A bare destination cannot carry whitespace, control characters, angle
+    # brackets, or unbalanced parens and still re-parse as an image, and a
+    # live session can set src attrs that never passed through markdown-it's
+    # normalization. Those spellings get the angle-bracket form, brackets
+    # escaped inside it, which markdown-it normalizes on the next parse
+    # (idempotent after that). Balanced parens stay bare: markdown-it accepts
+    # and stores them raw, so wrapping them would break byte stability.
+    depth = 0
+    unbalanced = False
+    for ch in src:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                unbalanced = True
+                break
+    unbalanced = unbalanced or depth != 0
+    if not src or unbalanced or any(ch.isspace() or ch in "<>" for ch in src):
+        escaped = src.replace("\\", "\\\\").replace("<", "\\<").replace(">", "\\>")
+        return f"<{escaped}>"
+    return src
+
+
 def _serialize_image(node: XmlElement) -> str:
-    # Src is emitted verbatim, the same discipline link hrefs use. markdown-it
-    # normalizes destination spellings (angle-bracket form, encoded spaces) at
-    # parse time, so the normalized destination is this codec's canonical form
-    # and re-parsing the output is a no-op. See the link branch of _wrap_run.
     attrs = dict(node.attributes)
-    src = attrs.get("src", "")
+    src = _image_destination(attrs.get("src", ""))
     alt = _escape_inline_text(attrs.get("alt", ""))
     title = attrs.get("title")
     if title is not None:

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -230,6 +230,10 @@ def _escape_title(title: str) -> str:
 
 
 def _serialize_image(node: XmlElement) -> str:
+    # Src is emitted verbatim, the same discipline link hrefs use. markdown-it
+    # normalizes destination spellings (angle-bracket form, encoded spaces) at
+    # parse time, so the normalized destination is this codec's canonical form
+    # and re-parsing the output is a no-op. See the link branch of _wrap_run.
     attrs = dict(node.attributes)
     src = attrs.get("src", "")
     alt = _escape_inline_text(attrs.get("alt", ""))

--- a/backend/tests/test_markdown_blocks.py
+++ b/backend/tests/test_markdown_blocks.py
@@ -84,6 +84,14 @@ def test_single_paragraph() -> None:
     assert body[blocks[0].start : blocks[0].end] == body
 
 
+def test_paragraph_containing_image_stays_a_single_paragraph_block() -> None:
+    body = "Before ![alt](img.png) after.\n"
+    blocks = top_level_block_ranges(body)
+    assert len(blocks) == 1
+    assert blocks[0].kind is BlockKind.PARAGRAPH
+    assert body[blocks[0].start : blocks[0].end] == body
+
+
 def test_code_block_kind() -> None:
     body = "Intro.\n\n```python\nx = 1\n```\n\nOutro.\n"
     blocks = top_level_block_ranges(body)

--- a/backend/tests/test_markdown_splice.py
+++ b/backend/tests/test_markdown_splice.py
@@ -59,6 +59,45 @@ def test_editing_one_paragraph_leaves_every_other_byte_identical() -> None:
     assert new_body.endswith(tail)
 
 
+def test_editing_image_paragraph_touches_only_that_paragraph_and_keeps_image_intact() -> None:
+    base_body = "# Heading\n\nBefore ![pic](img.png) after.\n\nFinal paragraph.\n"
+    doc = seed_doc_from_markdown(base_body)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    para = root.children[1]
+    with doc.transaction():
+        para.children[0].insert(0, "EDITED ")
+
+    assert tracker.touched_block_ids == {"b1"}
+    assert tracker.touched_row_ids == {}
+
+    new_body = checkpoint_body(base_body, doc, tracker)
+    assert "EDITED Before ![pic](img.png) after." in new_body
+    assert new_body.startswith("# Heading\n\n")
+    assert new_body.endswith("\n\nFinal paragraph.\n")
+
+
+def test_editing_different_block_leaves_image_paragraph_as_verbatim_base_slice() -> None:
+    image_block = "Before ![esc\\]bracket](img.png#w=640) after.\n"
+    base_body = f"# Heading\n\n{image_block}\nFinal paragraph.\n"
+    doc = seed_doc_from_markdown(base_body)
+    tracker = TouchedTracker(doc)
+    root = _root(doc)
+
+    final_para = root.children[2]
+    with doc.transaction():
+        final_para.children[0].insert(0, "EDITED ")
+
+    assert tracker.touched_block_ids == {"b2"}
+    image_start = base_body.index(image_block)
+    image_end = image_start + len(image_block)
+
+    new_body = checkpoint_body(base_body, doc, tracker)
+    assert new_body[image_start:image_end] == base_body[image_start:image_end] == image_block
+    assert "EDITED Final paragraph." in new_body
+
+
 def test_editing_table_cell_only_touches_that_row() -> None:
     doc = seed_doc_from_markdown(_SAMPLE)
     tracker = TouchedTracker(doc)

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -809,6 +809,28 @@ def test_find_by_row_id() -> None:
     assert find_by_row_id(doc, "nonexistent") is None
 
 
+def test_image_src_with_balanced_parens_round_trips_byte_stable() -> None:
+    body = "![x](a(1).png)\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_live_edited_image_src_with_space_serializes_reparseable() -> None:
+    # Only a live session can produce a spaced src (attrs set editor-side,
+    # never through markdown-it). It must serialize to the angle-bracket
+    # form so the checkpoint output still parses as an image.
+    doc = seed_doc_from_markdown("![x](ok.png)\n")
+    para = _root(doc).children[0]
+    image = next(c for c in para.children if getattr(c, "tag", None) == "image")
+    with doc.transaction():
+        image.attributes["src"] = "a b.png"
+    once = reconstruct_body(doc)
+    assert "![x](<a b.png>)" in once
+    reseeded = seed_doc_from_markdown(once)
+    re_para = _root(reseeded).children[0]
+    assert any(getattr(c, "tag", None) == "image" for c in re_para.children)
+
+
 def test_unrecognized_inline_construct_raises_not_implemented() -> None:
     # This parser config folds every inline construct into a token type this
     # codec encodes, so exercise the fail-loud guard with a synthetic unknown

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from pycrdt import Doc, XmlElement, XmlFragment, XmlText
 
@@ -9,6 +11,7 @@ from app.wiki.markdown_yjs import (
     BLOCK_ID_ATTR,
     ROOT_XML_KEY,
     ROW_ID_ATTR,
+    _inline_runs,
     find_by_block_id,
     find_by_row_id,
     reconstruct_body,
@@ -70,6 +73,125 @@ def test_empty_heading_does_not_raise() -> None:
 
 def test_reconstruct_body_round_trips_bold_italic_code_link() -> None:
     body = "A **bold** and *italic* and `code` and [a link](https://x.example) end.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_bare_image_round_trips_exactly() -> None:
+    body = "![alt text](https://x.example/img.png)\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_image_with_title_round_trips_exactly() -> None:
+    body = '![alt](s.png "a \\"quoted\\" title")\n'
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_image_with_escaped_bracket_in_alt_round_trips_exactly_and_is_idempotent() -> None:
+    body = "![esc\\]bracket](s.png)\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == body
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert twice == once
+
+
+def test_image_with_escaped_emphasis_like_alt_round_trips_exactly_and_is_idempotent() -> None:
+    body = "![a \\*x\\* b](s.png)\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == body
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert twice == once
+
+
+def test_image_src_fragment_is_stored_verbatim_and_round_trips_exactly() -> None:
+    body = "![pic](img.png#w=640)\n"
+    doc = seed_doc_from_markdown(body)
+    root = _root(doc)
+    para = root.children[0]
+    image = para.children[0]
+    assert isinstance(image, XmlElement)
+    assert dict(image.attributes)["src"] == "img.png#w=640"
+    assert reconstruct_body(doc) == body
+
+
+def test_image_mid_paragraph_round_trips_exactly() -> None:
+    body = "Before ![alt](img.png) after.\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_multiple_images_in_one_paragraph_round_trip_exactly() -> None:
+    body = "![a](a.png) middle ![b](b.png)\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_image_adjacent_to_link_and_emphasis_round_trips_exactly() -> None:
+    body = "[link](https://x.example)![img](i.png)*em*\n"
+    doc = seed_doc_from_markdown(body)
+    assert reconstruct_body(doc) == body
+
+
+def test_image_inside_emphasis_is_content_correct_and_idempotent() -> None:
+    body = "*before ![a](i.png) after*\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    twice = reconstruct_body(seed_doc_from_markdown(once))
+    assert once != body
+    assert once == twice
+    assert "before" in once and "after" in once
+    assert "![a](i.png)" in once
+    assert "*" in once
+
+
+def test_image_in_list_item_and_blockquote_survives_round_trip() -> None:
+    body = "- item ![a](i.png)\n\n> quote ![b](q.png)\n"
+    doc = seed_doc_from_markdown(body)
+    root = _root(doc)
+    assert reconstruct_body(doc) == body
+
+    list_para = root.children[0].children[0].children[0]
+    assert any(isinstance(child, XmlElement) and child.tag == "image" for child in list_para.children)
+
+    quote_para = root.children[1].children[0]
+    assert any(
+        isinstance(child, XmlElement) and child.tag == "image" for child in quote_para.children
+    )
+
+
+def test_image_is_a_sibling_leaf_with_expected_attributes() -> None:
+    doc = seed_doc_from_markdown('before ![shown](s.png "caption") after\n')
+    root = _root(doc)
+    para = root.children[0]
+    children = list(para.children)
+
+    assert len(children) == 3
+    assert isinstance(children[0], XmlText)
+    assert isinstance(children[1], XmlElement)
+    assert isinstance(children[2], XmlText)
+    assert children[1].tag == "image"
+    assert dict(children[1].attributes) == {
+        "src": "s.png",
+        "alt": "shown",
+        "title": "caption",
+    }
+
+
+def test_untitled_image_has_no_title_attribute_and_titled_image_stores_unescaped_title() -> None:
+    untitled = seed_doc_from_markdown("![alt](s.png)\n")
+    untitled_image = _root(untitled).children[0].children[0]
+    assert isinstance(untitled_image, XmlElement)
+    assert "title" not in dict(untitled_image.attributes)
+
+    titled = seed_doc_from_markdown('![alt](s.png "a \\"quoted\\" title")\n')
+    titled_image = _root(titled).children[0].children[0]
+    assert isinstance(titled_image, XmlElement)
+    assert dict(titled_image.attributes)["title"] == 'a "quoted" title'
+
+
+def test_empty_alt_image_round_trips_exactly() -> None:
+    body = "![](s.png)\n"
     doc = seed_doc_from_markdown(body)
     assert reconstruct_body(doc) == body
 
@@ -688,13 +810,14 @@ def test_find_by_row_id() -> None:
 
 
 def test_unrecognized_inline_construct_raises_not_implemented() -> None:
-    # GFM strikethrough isn't in _KNOWN_INLINE_TYPES (no strikethrough
-    # plugin enabled on gfm_parser()), so markdown-it never emits the token
-    # type in the first place — use an image instead, which markdown-it
-    # does emit and this codec has no encoder for.
-    body = "A picture: ![alt](https://x.example/img.png) here.\n"
+    # This parser config folds every inline construct into a token type this
+    # codec encodes, so exercise the fail-loud guard with a synthetic unknown
+    # child instead of real markdown.
+    body = SimpleNamespace(
+        children=[SimpleNamespace(type="strikethrough_open", content="", children=None)]
+    )
     with pytest.raises(NotImplementedError):
-        seed_doc_from_markdown(body)
+        _inline_runs(body)
 
 
 def test_hard_line_break_backslash_form_round_trips_to_canonical_form() -> None:


### PR DESCRIPTION
## Summary

Adds byte-stable image support to the markdown↔Yjs codec, targeting `feat/coedit-markdown-codec`. Images are mandated by the Agent Wiki Markdown Standard (§2 item 15) but currently raise `NotImplementedError` in `_inline_runs`. Part of the image-support stack (design: `Engineering Projects/Agent Wiki Project/design/image_support/design.md`).

- `image` as an inline leaf sibling `XmlElement("image", {src, alt, title?})`, following the `hardBreak` leaf precedent end to end (`_KNOWN_INLINE_TYPES`, `_inline_runs`, `_Segment` widened to carry leaf attrs, `_element_from_segments`, `_serialize_inline_children`). The node name and attrs are the contract the editor-side PM `image` node matches by name through y-prosemirror.
- src is fully opaque both directions (emitted verbatim, same discipline as link href), so app URLs like `/api/wiki/images/<id>#w=640` round-trip byte-for-byte. The `#w=` fragment is how the editor persists drag-resize width without any codec or standard syntax change.
- alt flattens to plain text (leaf model can't carry nested marks) and re-escapes through the same `_escape_inline_text` link text uses. Title serializes double-quoted via a new `_escape_title`.
- No `markdown_splice.py` change needed: `_classify_target` resolves image edits to their containing paragraph block; two new splice tests prove touched and untouched paths.

Three things for reviewer attention, deliberately not buried:
1. **Shared-primitive change**: `_wrap_run` bold/italic now route through `_wrap_with_delimiter`, which keeps edge whitespace outside emphasis markers. Needed so an image splitting an emphasized run re-parses idempotently. Activates only for marked runs with edge whitespace; all 88 codec tests pass including every pre-existing one.
2. Active markup inside alt (`![**b**](s)`) flattens to text: first-pass byte-loss, idempotent after, same accepted class as setext→ATX.
3. Single-quoted titles canonicalize to double-quoted.

## How Has This Been Tested?

16 new tests (13 in `test_markdown_yjs.py` incl. `#w=` fragment opacity, escaped brackets in alt, images in lists/blockquotes/mid-paragraph; 2 in `test_markdown_splice.py`; 1 in `test_markdown_blocks.py`) plus the converted fail-loud guard test. Full codec suite: 88 passed. ruff and strict basedpyright clean.
