### PR TITLE
feat(wiki): markdown export from every wiki ⋯ menu — folders as a zip, pages as markdown

### DIFF
--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -29,9 +29,9 @@ export interface WikiItemMenuProps {
 
 /**
  * Per-item "⋯" actions menu. Spec: 160px wide, compact line items, dividers,
- * Delete in danger red. Folders lead with New Page / New Folder and swap
- * "Launch Agent" for "Export as Zip". The caller supplies the trigger as
- * `children`.
+ * Delete in danger red. Every item can export — a folder as a zip, a page as
+ * markdown — while folders additionally lead with New Page / New Folder and
+ * omit "Launch Agent". The caller supplies the trigger as `children`.
  */
 export default function WikiItemMenu({
   path,
@@ -100,15 +100,14 @@ export default function WikiItemMenu({
             title="Copy Link"
             onClick={run(actions.copyLink)}
           />
-          {isFolder ? (
-            <LineItemButton
-              variant="body"
-              sizePreset="main-ui"
-              icon={SvgDownload}
-              title="Export as Zip"
-              onClick={run(actions.exportZip)}
-            />
-          ) : (
+          <LineItemButton
+            variant="body"
+            sizePreset="main-ui"
+            icon={SvgDownload}
+            title={isFolder ? "Export as Zip" : "Export as Markdown"}
+            onClick={run(actions.exportMarkdown)}
+          />
+          {!isFolder && (
             <LineItemButton
               variant="body"
               sizePreset="main-ui"

--- a/frontend/src/components/wiki/WikiItemActions.tsx
+++ b/frontend/src/components/wiki/WikiItemActions.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode } from "react";
 import { Divider, LineItemButton, Popover } from "@onyx-ai/opal/components";
 import {
+  SvgDownload,
   SvgEdit,
   SvgFolderIn,
   SvgFolderPlus,
@@ -28,8 +29,9 @@ export interface WikiItemMenuProps {
 
 /**
  * Per-item "⋯" actions menu. Spec: 160px wide, compact line items, dividers,
- * Delete in danger red. Folders lead with New Page / New Folder and omit
- * "Launch Agent". The caller supplies the trigger as `children`.
+ * Delete in danger red. Folders lead with New Page / New Folder and swap
+ * "Launch Agent" for "Export as Zip". The caller supplies the trigger as
+ * `children`.
  */
 export default function WikiItemMenu({
   path,
@@ -98,7 +100,15 @@ export default function WikiItemMenu({
             title="Copy Link"
             onClick={run(actions.copyLink)}
           />
-          {!isFolder && (
+          {isFolder ? (
+            <LineItemButton
+              variant="body"
+              sizePreset="main-ui"
+              icon={SvgDownload}
+              title="Export as Zip"
+              onClick={run(actions.exportZip)}
+            />
+          ) : (
             <LineItemButton
               variant="body"
               sizePreset="main-ui"

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -29,8 +29,9 @@ interface RowActions {
   move: (path: string) => void;
   copyLink: (path: string) => void;
   launchAgent: (path: string) => void;
-  /** Download a folder's readable pages as a markdown zip ("" = whole wiki). */
-  exportZip: (path: string) => void;
+  /** Download a page as markdown, or a folder's readable pages as a zip
+   * ("" = whole wiki). */
+  exportMarkdown: (path: string) => void;
   remove: (path: string, isFolder: boolean) => void;
   /** Route to the new-page flow scoped to a folder ("" = wiki root). */
   newPage: (dir: string) => void;
@@ -163,8 +164,8 @@ export function WikiItemActionsProvider({
         .then(() => setToast("Link copied"))
         .catch(() => setToast("Couldn't copy link"));
     },
-    exportZip: async (path) => {
-      // The zip is built server-side and only holds pages the caller can
+    exportMarkdown: async (path) => {
+      // A folder zip is built server-side and only holds pages the caller can
       // read, so an "empty" folder legitimately 404s — surface the backend's
       // message rather than a silent no-op download.
       try {

--- a/frontend/src/providers/WikiItemActionsProvider.tsx
+++ b/frontend/src/providers/WikiItemActionsProvider.tsx
@@ -12,6 +12,7 @@ import { createPortal } from "react-dom";
 import useSWR from "swr";
 
 import { apiFetch } from "@/lib/api";
+import { downloadMarkdownExport } from "@/lib/wiki/svc";
 import { revalidateWiki, shareableWikiUrl } from "@/lib/wikiHref";
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
@@ -28,6 +29,8 @@ interface RowActions {
   move: (path: string) => void;
   copyLink: (path: string) => void;
   launchAgent: (path: string) => void;
+  /** Download a folder's readable pages as a markdown zip ("" = whole wiki). */
+  exportZip: (path: string) => void;
   remove: (path: string, isFolder: boolean) => void;
   /** Route to the new-page flow scoped to a folder ("" = wiki root). */
   newPage: (dir: string) => void;
@@ -159,6 +162,16 @@ export function WikiItemActionsProvider({
         .writeText(url)
         .then(() => setToast("Link copied"))
         .catch(() => setToast("Couldn't copy link"));
+    },
+    exportZip: async (path) => {
+      // The zip is built server-side and only holds pages the caller can
+      // read, so an "empty" folder legitimately 404s — surface the backend's
+      // message rather than a silent no-op download.
+      try {
+        await downloadMarkdownExport(path);
+      } catch (e) {
+        setToast(e instanceof Error ? e.message : "Export failed");
+      }
     },
     remove: async (path, isFolder) => {
       const label = path.replace(/\.md$/, "").split("/").pop() ?? path;

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -30,6 +30,7 @@ import {
   SvgCheck,
   SvgChevronLeft,
   SvgDocFile,
+  SvgDownload,
   SvgFolder,
   SvgFolderPlus,
   SvgMoreHorizontal,
@@ -542,6 +543,18 @@ function Explorer({ dir }: ExplorerProps) {
               onClick={() => {
                 setMoreOpen(false);
                 rowActions.launchAgent(dir);
+              }}
+            />
+            {/* `dir` is "" at the wiki root, where this exports the whole
+                readable corpus rather than one folder. */}
+            <LineItemButton
+              title="Export as Zip"
+              icon={SvgDownload}
+              sizePreset="main-ui"
+              variant="section"
+              onClick={() => {
+                setMoreOpen(false);
+                rowActions.exportMarkdown(dir);
               }}
             />
           </PopoverMenu>


### PR DESCRIPTION
## What

Export is now reachable from every `⋯` menu that addresses a wiki item — a folder comes down as a zip of the pages beneath it, a page as markdown.

| Menu | Component | Target | Item |
| --- | --- | --- | --- |
| Row `⋯` (folder row) | `WikiItemActions.tsx` | the row pointed at | Export as Zip |
| Row `⋯` (page row) | `WikiItemActions.tsx` | the row pointed at | Export as Markdown |
| Folder-view header `⋯` | `WikiPage.tsx` | the folder you're inside | Export as Zip |
| Page-view header `⋯` | `FileView.tsx` | the page you're inside | Export as Markdown *(pre-existing)* |

The row menu is hosted by `WikiTree` (sidebar) and `WikiHome` (recent cards), so those come along with one edit. `commentCards.tsx` is the only other `⋯` in the wiki tree and it acts on a comment, so there's nothing to export there.

## Why this is UI-only

`GET /api/wiki/export` has always handled both arms: a `.md` path returns one page as an attachment, anything else (a folder, or `""` for the whole wiki) returns a zip of the readable pages under that prefix. `downloadMarkdownExport` in `lib/wiki/svc.ts` already picked the `.zip` filename for the folder case. Only the entry points were missing — the sole caller passed the open page's own path, so folder export was reachable only by hitting the endpoint directly.

## Whole-wiki export comes along free

In the folder-view header, `dir` is `""` at the wiki root, so the same item there exports the entire readable corpus as `wiki-export.zip`.

## Changes

- `providers/WikiItemActionsProvider.tsx` — new `exportMarkdown` row action. Errors go through the provider's existing toast: a folder with no readable pages legitimately 404s with `"nothing to export"`, and that message surfaces rather than a silent no-op download.
- `components/wiki/WikiItemActions.tsx` — an export line on every item, title switching on kind. Files keep `Launch Agent` below it, so the folder menu is one line shorter than the file menu — as it already was, folders having always omitted Launch Agent.
- `views/wiki/WikiPage.tsx` — export in the folder view's header menu, below Launch Agent.

## Behavior worth knowing

Folder permission filtering is per-page, not per-folder — an unreadable page is omitted from the zip rather than 403-ing the whole export (a directly-requested unreadable page still 403s). Zip entries keep full wiki-relative paths and `/app/wiki/` links are rewritten relative to each document, so cross-links resolve inside the extracted tree. ACLs, comments, and update policies are Postgres-only and are not part of an export.

## Testing

`bun run typecheck` and `prettier --check` pass; pre-commit clean. The backend arm was already covered by `backend/tests/test_wiki_export.py` (`test_export_folder_zip_scopes_to_prefix`, `test_export_whole_wiki_zip`, `test_export_zip_excludes_dot_metadata_pages`, `test_export_zip_drops_unreadable_pages`).

Verified against a locally deployed stack (rebuilt frontend image + docker compose), with a nested `ExportTest/` fixture and two users:

| Case | Result |
| --- | --- |
| Folder export | 3 entries, nested paths preserved (`ExportTest/nested/deep/c.md`) |
| Link rewriting | `/app/wiki/…` → `nested/b.md`, `../a.md#top`, `deep/c.md`; anchor kept, external link untouched |
| Subfolder scoping | `path=ExportTest/nested` → 2 entries, `nested-export.zip` |
| Whole wiki (`path=""`) | `wiki-export.zip`, 11 entries |
| Single page | `text/markdown; charset=utf-8`, `filename="b.md"`, links relativized |
| Unreadable page in a folder | owner's zip 4 entries, other user's 3 — dropped, not 403 |
| Unreadable page requested directly | 403 `forbidden: read on …` |
| Empty folder | 404 `{"error":"nothing to export"}` → the toast path |

The menu items themselves are verified only as far as both labels appearing in the deployed bundle (`Export as Zip` ×2, `Export as Markdown` ×2) — not clicked through in a browser.

## Known limit

`build_zip` buffers the whole archive in memory server-side (flagged in a comment in `app/wiki/export.py`), and the frontend holds it as a Blob. Fine at current corpus size; the root export of a large wiki is the case that bites first — and the root affordance this PR adds is what makes that reachable from the UI.