### PR TITLE
feat(wiki): wire the Organize toggle to auto management

### DIFF
--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -73,27 +73,6 @@ function capNote(health: UpdateHealth): string {
   return "Auto-updating frequently.";
 }
 
-interface OrganizeComingSoonRowProps {
-  kind: string;
-}
-
-/** The Organize policy row, disabled until the backend grows the field. */
-export function OrganizeComingSoonRow({ kind }: OrganizeComingSoonRowProps) {
-  return (
-    <InputHorizontal
-      title="Organize"
-      description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
-    >
-      <Tooltip tooltip="Coming soon" side="left">
-        {/* raw-ok: a disabled control emits no pointer events, so Tooltip needs this enabled span as its hover target */}
-        <span className="inline-flex">
-          <Switch checked={false} disabled />
-        </span>
-      </Tooltip>
-    </InputHorizontal>
-  );
-}
-
 function errorMessage(e: unknown): string {
   if (e instanceof ApiError && e.status === 403) {
     return "You don't have permission to change this.";
@@ -306,18 +285,14 @@ export function UpdatePolicyPanel({
               className="group/policy rounded-(--radius-12) border border-(--border-01)"
             >
               <div className="flex flex-col gap-2 p-2">
+                {/* Group header — the switches live on the two rows below:
+                    Update = ingestion auto-update, Organize = auto
+                    management (Auto Organize may act on this scope). */}
                 <InputHorizontal
                   icon={SvgSparkle}
                   title="AI Auto-Edits"
                   description={`Let AI update/organize this ${kind} on its own.`}
-                >
-                  {policySwitch(
-                    aiSwitchOn,
-                    onToggleAiManaged,
-                    aiManagedSetHere,
-                    () => void save({ ai_management_allowed: null }),
-                  )}
-                </InputHorizontal>
+                />
                 <div className="flex flex-col gap-2 pl-6">
                   <InputHorizontal
                     title="Update"
@@ -330,7 +305,17 @@ export function UpdatePolicyPanel({
                       () => void save({ ingestion_auto_update_disabled: null }),
                     )}
                   </InputHorizontal>
-                  <OrganizeComingSoonRow kind={kind} />
+                  <InputHorizontal
+                    title="Organize"
+                    description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
+                  >
+                    {policySwitch(
+                      aiSwitchOn,
+                      onToggleAiManaged,
+                      aiManagedSetHere,
+                      () => void save({ ai_management_allowed: null }),
+                    )}
+                  </InputHorizontal>
                 </div>
               </div>
 

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -16,7 +16,6 @@ import {
 } from "@onyx-ai/opal/icons";
 
 import { toast } from "@/hooks/useToast";
-import { OrganizeComingSoonRow } from "@/components/wiki/UpdatePolicyPanel";
 import { pathKind } from "@/lib/wiki/utils";
 import {
   getUpdatePolicy,
@@ -198,51 +197,54 @@ export function PolicyPopover({
       onClick={onOpenUpdatesPanel}
     >
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
+        {/* Group header — the switches live on the two rows below:
+            Update = ingestion auto-update, Organize = auto management. */}
         <InputHorizontal
           icon={SvgSparkle}
           title="AI Auto-Edits"
           description={`Let AI update/organize this ${kind} on its own.`}
+        />
+        <Section
+          justifyContent="start"
+          alignItems="stretch"
+          height="fit"
+          gap={0.5}
+          className="mt-2 ml-6"
         >
-          <span onClick={(e) => e.stopPropagation()}>
-            <Switch
-              checked={allowed}
-              // Held until this path's policy loads (toggling against the
-              // null default would persist a wrong override) and while a
-              // save is in flight (a second click would race the PATCH).
-              disabled={!canWrite || !loaded || saving}
-              onCheckedChange={() =>
-                void patchField({ ai_management_allowed: !allowed })
-              }
-            />
-          </span>
-        </InputHorizontal>
-        {allowed && (
-          <Section
-            justifyContent="start"
-            alignItems="stretch"
-            height="fit"
-            gap={0.5}
-            className="mt-2 ml-6"
+          <InputHorizontal
+            title="Update"
+            description="Periodically scan ingested data sources to add relevant new information."
           >
-            <InputHorizontal
-              title="Update"
-              description="Periodically scan ingested data sources to add relevant new information."
-            >
-              <span onClick={(e) => e.stopPropagation()}>
-                <Switch
-                  checked={!autoUpdateDisabled}
-                  disabled={!canWrite || !loaded || saving}
-                  onCheckedChange={() =>
-                    void patchField({
-                      ingestion_auto_update_disabled: !autoUpdateDisabled,
-                    })
-                  }
-                />
-              </span>
-            </InputHorizontal>
-            <OrganizeComingSoonRow kind={kind} />
-          </Section>
-        )}
+            <span onClick={(e) => e.stopPropagation()}>
+              <Switch
+                checked={!autoUpdateDisabled}
+                // Held until this path's policy loads (toggling against the
+                // null default would persist a wrong override) and while a
+                // save is in flight (a second click would race the PATCH).
+                disabled={!canWrite || !loaded || saving}
+                onCheckedChange={() =>
+                  void patchField({
+                    ingestion_auto_update_disabled: !autoUpdateDisabled,
+                  })
+                }
+              />
+            </span>
+          </InputHorizontal>
+          <InputHorizontal
+            title="Organize"
+            description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
+          >
+            <span onClick={(e) => e.stopPropagation()}>
+              <Switch
+                checked={allowed}
+                disabled={!canWrite || !loaded || saving}
+                onCheckedChange={() =>
+                  void patchField({ ai_management_allowed: !allowed })
+                }
+              />
+            </span>
+          </InputHorizontal>
+        </Section>
       </Section>
       <Divider />
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>


### PR DESCRIPTION
The "Organize" toggle in the update-policy surfaces was a Coming-soon placeholder — while the field it should control (`ai_management_allowed`, live in the backend since #362 and honored by every Auto Organize path) was wired to the master "AI Auto-Edits" row, conflating content updates with reorganization.

Per the intended mapping:
- **Update** ↔ ingestion auto-update (`ingestion_auto_update_disabled`, inverted) — unchanged;
- **Organize** ↔ auto management (`ai_management_allowed`) — detectors skip a scope set to off; on = Auto Organize may auto-apply there;
- **AI Auto-Edits** becomes a plain group header (its switch moved down to Organize), and the popover no longer hides the sub-rows behind the master.

Applied to both surfaces (side panel `UpdatePolicyPanel`, header popover `policyPanels`); the placeholder component is deleted. `bun run typecheck` + prettier clean.
<img width="426" height="178" alt="Screenshot 2026-07-28 at 1 34 05 PM" src="https://github.com/user-attachments/assets/7ccf2ecc-496b-4574-88f8-56bca2249432" />

