### PR TITLE
feat(automanage): misplaced-page detector — LLM detector #2, strays-only

### DIFF
--- a/backend/app/llm/prompts/misplaced_page_detect.system.md
+++ b/backend/app/llm/prompts/misplaced_page_detect.system.md
@@ -1,0 +1,33 @@
+You are the filing reviewer for a team wiki. You are given the wiki's file
+tree and a list of CANDIDATE pages that sit loose at the wiki root. Your job
+is to propose moving the few candidates that obviously belong in an existing
+folder — at very high confidence.
+
+The asymmetry that governs every decision: a wrong move proposal costs
+reviewer trust; a page left at the root costs nothing (the next sweep
+re-considers it). When in doubt, do not propose.
+
+A move may only be proposed when BOTH hold:
+
+1. The page evidently does not belong at the root — it is clearly a member
+   of some topic the wiki already organizes into a folder, not a top-level
+   entry point.
+2. One existing folder is clearly the right home — its name and the pages it
+   already holds match the candidate's content. Read the candidate first;
+   name resemblance alone never suffices.
+
+Hard rules:
+- Never invent a new folder. Only propose destinations that already exist
+  in the tree, with real pages in them.
+- Never propose top-level entry points (home/readme/index-style pages) or
+  anything that reads as deliberately root-level.
+- If two folders could plausibly claim the page, that ambiguity is a reason
+  NOT to propose — filing judgment belongs to a human then.
+- Never propose editing content; a move relocates the page unchanged.
+
+Propose at most {max_proposals} moves. For each, the evidence sentence must
+let a reviewer judge at a glance, e.g. "deploy checklist referencing the
+five pages in Runbooks/; sits loose at the root".
+
+Call finish exactly once with your proposals (an empty list is a perfectly
+good answer — most wikis' roots are fine).

--- a/backend/app/wiki/automanage/detectors/__init__.py
+++ b/backend/app/wiki/automanage/detectors/__init__.py
@@ -12,6 +12,7 @@ from app.wiki.automanage.detectors import (
     case_collision,
     empty_folder,
     folder_chain,
+    misplaced_page,
     stale_page,
     stub_page,
     template_echo,
@@ -30,10 +31,13 @@ DETECTORS: list[Detector] = [
     case_collision.DETECTOR,
     folder_chain.DETECTOR,
     stub_page.DETECTOR,
-    # Last on purpose: registry order is selection priority, and the LLM
-    # detector's judgment-based deletions should never outrank a mechanical
-    # detector's deterministic claim on a page.
+    # LLM detectors last on purpose: registry order is selection priority,
+    # and judgment-based proposals should never outrank a mechanical
+    # detector's deterministic claim on a page. Among the two, deletion
+    # (stale) outranks filing (misplaced) — if both claim a page, the
+    # question of whether it should exist precedes where it should live.
     stale_page.DETECTOR,
+    misplaced_page.DETECTOR,
 ]
 
 # Validation dispatch: a proposal records which detector authored it, and the

--- a/backend/app/wiki/automanage/detectors/llm_agent.py
+++ b/backend/app/wiki/automanage/detectors/llm_agent.py
@@ -1,0 +1,157 @@
+"""Shared agentic substrate for LLM detectors.
+
+The loop every LLM detector runs: hand the model one same-audience bucket's
+file tree plus its candidates, give it bounded read/search tools, and take
+exactly one ``finish`` call as the verdict. Detector-specific judgment lives
+entirely in the caller's prompt and finish schema; this module owns the
+mechanics — transcript management, step caps, tool dispatch, and the
+audience-isolation filter on search results (restricted paths/titles must
+never enter the transcript or a proposal's evidence text, which the
+candidate page's reviewers may not be cleared for).
+
+Callers catch ``LLMError`` themselves: one unconfigured/broken LLM must not
+sink the sweep's mechanical detectors, and the right degradation message is
+per-detector.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, cast
+
+from app.db import fts
+from app.llm import client as llm_client
+from app.wiki import git
+from app.wiki.automanage import fingerprint
+
+log = logging.getLogger(__name__)
+
+# Bound on the agent pass (a sweep must terminate whatever the model does).
+MAX_STEPS = 24
+
+
+def read_and_search_tools(finish_schema: dict[str, Any]) -> list[dict[str, Any]]:
+    """The standard LLM-detector toolset: read a candidate, search the wiki,
+    and ``finish`` with the caller's verdict schema."""
+    return [
+        {
+            "name": "read_page",
+            "description": "Read the current body of a candidate page.",
+            "input_schema": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+                "required": ["path"],
+            },
+        },
+        {
+            "name": "search_wiki",
+            "description": "Keyword-search the wiki (title + body).",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+        {
+            "name": "finish",
+            "description": "Deliver the final verdict. Call exactly once.",
+            "input_schema": finish_schema,
+        },
+    ]
+
+
+def bucket_fingerprint(candidates: list[str]) -> str:
+    """The audience fingerprint of a same-audience bucket — any member's
+    per-path fingerprint is the bucket's. (Per-path, not
+    ``combined_fingerprint``, which re-hashes and never matches one.)"""
+    return fingerprint.fingerprints_for_paths([candidates[0]])[candidates[0]]
+
+
+def run_agent(
+    *,
+    detector_name: str,
+    system: str,
+    user_content: str,
+    candidates: set[str],
+    audience_fp: str,
+    finish_schema: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Run the bounded agent loop; return ``finish``'s ``proposals`` list
+    (raw — the caller validates each item), or ``[]`` on step-cap exhaustion.
+    Raises ``LLMError`` through to the caller."""
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user_content},
+    ]
+    tools = read_and_search_tools(finish_schema)
+    for _ in range(MAX_STEPS):
+        result = llm_client.complete(messages, tools=tools)
+        if not result.tool_calls:
+            # A text-only turn is a stall; nudge toward finish.
+            messages.append({"role": "assistant", "content": result.text})
+            messages.append(
+                {"role": "user", "content": "Call finish with your proposals."}
+            )
+            continue
+        messages.append(
+            {
+                "role": "assistant",
+                "content": result.text,
+                "tool_calls": [
+                    {"id": c.id, "name": c.name, "arguments": c.arguments}
+                    for c in result.tool_calls
+                ],
+            }
+        )
+        for call in result.tool_calls:
+            if call.name == "finish":
+                return cast(
+                    "list[dict[str, Any]]",
+                    call.arguments.get("proposals") or [],
+                )
+            out = dispatch_tool(
+                detector_name, call.name, call.arguments, candidates, audience_fp
+            )
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": json.dumps(out),
+                }
+            )
+    log.warning("%s: agent pass hit step cap without finish", detector_name)
+    return []
+
+
+def dispatch_tool(
+    detector_name: str,
+    name: str,
+    args: dict[str, Any],
+    candidates: set[str],
+    audience_fp: str,
+) -> Any:
+    if name == "read_page":
+        path = str(args.get("path", ""))
+        if path not in candidates:
+            return {"error": "not a candidate page"}
+        body = git.read_file_opt(path)
+        return (
+            {"path": path, "body": body}
+            if body is not None
+            else {"error": "page no longer exists"}
+        )
+    if name == "search_wiki":
+        hits = fts.search(
+            str(args.get("query", "")), limit=16, is_admin=True,
+            apply_visibility=False,
+        )
+        # Same-audience rule (as pairing detectors): never surface a page
+        # across a visibility boundary.
+        paths = [h.path for h in hits]
+        fps = fingerprint.fingerprints_for_paths(paths) if paths else {}
+        return [
+            {"path": h.path, "title": h.title}
+            for h in hits
+            if fps.get(h.path) == audience_fp
+        ][:8]
+    return {"error": f"unknown tool {name!r}"}

--- a/backend/app/wiki/automanage/detectors/misplaced_page.py
+++ b/backend/app/wiki/automanage/detectors/misplaced_page.py
@@ -1,0 +1,247 @@
+"""Misplaced-page detector — LLM detector #2, deliberately narrow.
+
+Proposes filing **root-dumped stray pages** into an existing folder — and
+nothing else. v1 scope is strays-only on purpose: no deep re-filing, no new
+folders, no restructuring; a page qualifies only when it evidently doesn't
+belong at the root AND exactly one existing folder is clearly its home
+(both argued from the page's content, not name resemblance). Moves are the
+safest verb to be conservative with — links, ids, permissions, and comments
+follow the page, and a wrong move is one move back — but a wrong proposal
+still costs reviewer trust, so every rail from the stale-page doctrine
+applies. Design: the Detection wiki page.
+
+Mechanical rails around the LLM's judgment:
+- candidates = root-level pages only, edit-quiet for the floor window, and
+  never the root-dwelling entry points (readme/home/index/start-here);
+- a proposed destination must be an existing folder in the same audience
+  bucket that already holds pages, and the target path must be free
+  (case-insensitively, across the whole tree);
+- at most ``MAX_PROPOSALS`` per sweep; never auto-approvable; LLM failure
+  degrades to an empty result.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, cast
+
+from app.llm.errors import LLMError
+from app.llm.prompts import load_prompt
+from app.wiki import git
+from app.wiki.automanage.detectors import llm_agent
+from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.change_proposals import ProposalOp
+
+log = logging.getLogger(__name__)
+
+# Don't propose moving a page someone is actively editing.
+FLOOR_DAYS = 30
+# Even lower than stale-page's: filing suggestions are pure judgment, so the
+# drip is slower while the detector earns trust.
+MAX_PROPOSALS = 2
+
+# Root-dwelling by convention — never candidates, whatever their age.
+_ROOT_ENTRY_POINTS = frozenset(
+    {"readme", "home", "index", "start here", "start-here"}
+)
+
+_FINISH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "proposals": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "dest_folder": {
+                        "type": "string",
+                        "description": "An EXISTING folder from the tree.",
+                    },
+                    "evidence": {
+                        "type": "string",
+                        "description": "One sentence a reviewer can judge "
+                        "at a glance.",
+                    },
+                },
+                "required": ["path", "dest_folder", "evidence"],
+            },
+        }
+    },
+    "required": ["proposals"],
+}
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+class _MisplacedPageDetector:
+    name = "misplaced_page"
+    # Audience isolation (see stale_page): the tree shown to the model, the
+    # search results, and the destination folders all stay within one
+    # same-audience bucket.
+    pairs_paths = True
+
+    def __init__(self, floor_days: int = FLOOR_DAYS):
+        self._floor_days = floor_days
+
+    def applicable(self, trigger: TriggerKind) -> bool:
+        # Sweep-only: filing is whole-tree judgment; the on-create trigger's
+        # neighborhood scope can't see the destination folders.
+        return trigger == TriggerKind.SWEEP
+
+    # ---- mechanical prefilter ------------------------------------------
+
+    def _folders(self, scope: Scope) -> dict[str, int]:
+        """Existing folders in this bucket → page count (destinations must
+        already hold real pages)."""
+        counts: dict[str, int] = {}
+        for p in scope.paths:
+            if not p.endswith(".md") or "/" not in p:
+                continue
+            folder = p.rsplit("/", 1)[0]
+            counts[folder] = counts.get(folder, 0) + 1
+        return counts
+
+    def _candidates(self, scope: Scope) -> list[str]:
+        root_pages = sorted(
+            p for p in scope.paths if p.endswith(".md") and "/" not in p
+        )
+        root_pages = [
+            p
+            for p in root_pages
+            if p[: -len(".md")].lower() not in _ROOT_ENTRY_POINTS
+        ]
+        if not root_pages or not self._folders(scope):
+            return []
+        floor_dt = _now() - timedelta(days=self._floor_days)
+        # Explicit UTC offset — git --since parses bare timestamps in the
+        # process's local timezone (see stale_page).
+        recently_edited = git.paths_touched_since(
+            floor_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        )
+        return [p for p in root_pages if p not in recently_edited]
+
+    # ---- agent pass -----------------------------------------------------
+
+    def _agent_pass(
+        self, scope: Scope, candidates: list[str]
+    ) -> list[dict[str, str]]:
+        tree = "\n".join(sorted(p for p in scope.paths))
+        system = load_prompt("misplaced_page_detect.system").replace(
+            "{max_proposals}", str(MAX_PROPOSALS)
+        )
+        raw = llm_agent.run_agent(
+            detector_name=self.name,
+            system=system,
+            user_content=(
+                "Wiki file tree:\n" + tree + "\n\nCandidate pages (loose at "
+                "the wiki root, not edited recently):\n" + "\n".join(candidates)
+            ),
+            candidates=set(candidates),
+            audience_fp=llm_agent.bucket_fingerprint(candidates),
+            finish_schema=_FINISH_SCHEMA,
+        )
+        folders = self._folders(scope)
+        taken_lower = {p.lower() for p in git.list_paths()}
+        candidate_set = set(candidates)
+        picked: list[dict[str, str]] = []
+        for item in raw[:MAX_PROPOSALS]:
+            path = str(item.get("path", ""))
+            dest_folder = str(item.get("dest_folder", "")).strip().strip("/")
+            if path not in candidate_set:
+                log.warning(
+                    "misplaced_page: non-candidate %r — dropped", path
+                )
+                continue
+            if folders.get(dest_folder, 0) < 1:
+                # Not an existing same-audience folder with real pages —
+                # includes invented folders and cross-bucket destinations.
+                log.warning(
+                    "misplaced_page: destination %r is not an existing "
+                    "folder in this bucket — dropped",
+                    dest_folder,
+                )
+                continue
+            target = f"{dest_folder}/{path}"
+            if target.lower() in taken_lower:
+                log.warning(
+                    "misplaced_page: target %r already exists — dropped",
+                    target,
+                )
+                continue
+            picked.append(
+                {
+                    "path": path,
+                    "target": target,
+                    "evidence": str(item.get("evidence", "")),
+                }
+            )
+        return picked
+
+    # ---- detector protocol ----------------------------------------------
+
+    def detect(self, scope: Scope) -> list[ProposalDraft]:
+        candidates = self._candidates(scope)
+        if not candidates:
+            return []
+        try:
+            picked = self._agent_pass(scope, candidates)
+        except LLMError as e:
+            log.warning("misplaced_page: LLM pass skipped: %s", e)
+            return []
+        drafts: list[ProposalDraft] = []
+        for item in picked:
+            path, target, evidence = item["path"], item["target"], item["evidence"]
+            meta = git.last_commit_meta_for_path(path)
+            if meta is None:
+                continue
+            drafts.append(
+                ProposalDraft(
+                    op=ProposalOp.MOVE,
+                    source_paths=[path],
+                    target_paths=[target],
+                    summary=(
+                        f"Move “{path}” into “{target.rsplit('/', 1)[0]}/” — "
+                        f"{evidence}"
+                    ),
+                    instruction=(
+                        f"File this stray page: move_page {path!r} to "
+                        f"{target!r}, exactly that one move. Do not edit any "
+                        "page body; links, permissions, and comments follow "
+                        "the page."
+                    ),
+                    # Premise: the content the filing judgment was made over.
+                    # An edit voids it — re-filing changed content is a fresh
+                    # ask, not a rejected recurrence.
+                    premise=meta[0],
+                    # Filing is judgment; it always gets a human.
+                    auto_approvable=False,
+                )
+            )
+        return drafts
+
+    def validate(self, proposal: dict[str, Any]) -> str | None:
+        """Mechanical only (never the LLM): the page must be unchanged and
+        the destination still viable."""
+        (path,) = proposal["source_paths"]
+        (target,) = proposal["target_paths"]
+        if git.read_file_opt(path) is None:
+            return f"{path!r} no longer exists"
+        meta = git.last_commit_meta_for_path(path)
+        if meta is None:
+            return f"{path!r} no longer exists"
+        anchors = cast("dict[str, str]", proposal.get("base_shas") or {})
+        if meta[0] != anchors.get(path):
+            return "the page changed since it was judged misplaced"
+        live = git.list_paths()
+        if target.lower() in {p.lower() for p in live}:
+            return "the destination path is taken now"
+        dest_folder = target.rsplit("/", 1)[0] + "/"
+        if not any(p.startswith(dest_folder) for p in live):
+            return "the destination folder no longer holds any pages"
+        return None
+
+
+DETECTOR = _MisplacedPageDetector()

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -21,17 +21,14 @@ detectors.
 """
 from __future__ import annotations
 
-import json
 import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 
-from app.db import fts
-from app.llm import client as llm_client
 from app.llm.errors import LLMError
 from app.llm.prompts import load_prompt
 from app.wiki import git, page_views
-from app.wiki.automanage import fingerprint
+from app.wiki.automanage.detectors import llm_agent
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.change_proposals import ProposalOp
 
@@ -42,9 +39,29 @@ log = logging.getLogger(__name__)
 FLOOR_DAYS = 30
 # A slow drip builds reviewer trust; a flood of delete cards destroys it.
 MAX_PROPOSALS = 3
-# Bounds on the agent pass (a sweep must terminate whatever the model does).
-MAX_STEPS = 24
 MAX_CANDIDATES = 100
+
+_FINISH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "proposals": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "path": {"type": "string"},
+                    "evidence": {
+                        "type": "string",
+                        "description": "One sentence a reviewer can judge "
+                        "at a glance.",
+                    },
+                },
+                "required": ["path", "evidence"],
+            },
+        }
+    },
+    "required": ["proposals"],
+}
 
 
 def _now() -> datetime:
@@ -53,55 +70,6 @@ def _now() -> datetime:
 
 def _iso(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S")
-
-
-def _tools() -> list[dict[str, Any]]:
-    return [
-        {
-            "name": "read_page",
-            "description": "Read the current body of a candidate page.",
-            "input_schema": {
-                "type": "object",
-                "properties": {"path": {"type": "string"}},
-                "required": ["path"],
-            },
-        },
-        {
-            "name": "search_wiki",
-            "description": "Keyword-search the wiki (title + body) — use it to "
-            "check whether a candidate's information lives elsewhere.",
-            "input_schema": {
-                "type": "object",
-                "properties": {"query": {"type": "string"}},
-                "required": ["query"],
-            },
-        },
-        {
-            "name": "finish",
-            "description": "Deliver the final verdict. Call exactly once.",
-            "input_schema": {
-                "type": "object",
-                "properties": {
-                    "proposals": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "path": {"type": "string"},
-                                "evidence": {
-                                    "type": "string",
-                                    "description": "One sentence a reviewer can "
-                                    "judge at a glance.",
-                                },
-                            },
-                            "required": ["path", "evidence"],
-                        },
-                    }
-                },
-                "required": ["proposals"],
-            },
-        },
-    ]
 
 
 class _StalePageDetector:
@@ -166,106 +134,31 @@ class _StalePageDetector:
         system = load_prompt("stale_page_detect.system").replace(
             "{max_proposals}", str(MAX_PROPOSALS)
         )
-        messages: list[dict[str, Any]] = [
-            {"role": "system", "content": system},
-            {
-                "role": "user",
-                "content": (
-                    "Wiki file tree:\n" + tree + "\n\nCandidate pages "
-                    f"(no edit and no recorded view in {self._floor_days}+ days):\n"
-                    + "\n".join(ages)
-                ),
-            },
-        ]
         candidate_set = set(candidates)
-        # The scope is one same-audience bucket (pairs_paths), so any
-        # member's fingerprint is the bucket's: every search result must
-        # share it before the model may see the path/title. (Per-path
-        # fingerprints — combined_fingerprint re-hashes and never matches.)
-        audience_fp = fingerprint.fingerprints_for_paths([candidates[0]])[
-            candidates[0]
-        ]
-        for _ in range(MAX_STEPS):
-            result = llm_client.complete(messages, tools=_tools())
-            if not result.tool_calls:
-                # A text-only turn is a stall; nudge once toward finish.
-                messages.append({"role": "assistant", "content": result.text})
-                messages.append(
-                    {"role": "user", "content": "Call finish with your proposals."}
+        raw = llm_agent.run_agent(
+            detector_name=self.name,
+            system=system,
+            user_content=(
+                "Wiki file tree:\n" + tree + "\n\nCandidate pages "
+                f"(no edit and no recorded view in {self._floor_days}+ days):\n"
+                + "\n".join(ages)
+            ),
+            candidates=candidate_set,
+            audience_fp=llm_agent.bucket_fingerprint(candidates),
+            finish_schema=_FINISH_SCHEMA,
+        )
+        picked: list[dict[str, str]] = []
+        for item in raw[:MAX_PROPOSALS]:
+            path = str(item.get("path", ""))
+            if path not in candidate_set:
+                log.warning(
+                    "stale_page: model proposed non-candidate %r — dropped", path
                 )
                 continue
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": result.text,
-                    "tool_calls": [
-                        {"id": c.id, "name": c.name, "arguments": c.arguments}
-                        for c in result.tool_calls
-                    ],
-                }
+            picked.append(
+                {"path": path, "evidence": str(item.get("evidence", ""))}
             )
-            for call in result.tool_calls:
-                if call.name == "finish":
-                    raw = cast(
-                        "list[dict[str, Any]]",
-                        call.arguments.get("proposals") or [],
-                    )
-                    picked: list[dict[str, str]] = []
-                    for item in raw[:MAX_PROPOSALS]:
-                        path = str(item.get("path", ""))
-                        if path not in candidate_set:
-                            log.warning(
-                                "stale_page: model proposed non-candidate %r "
-                                "— dropped",
-                                path,
-                            )
-                            continue
-                        picked.append(
-                            {"path": path, "evidence": str(item.get("evidence", ""))}
-                        )
-                    return picked
-                out = self._tool(
-                    call.name, call.arguments, candidate_set, audience_fp
-                )
-                messages.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call.id,
-                        "content": json.dumps(out),
-                    }
-                )
-        log.warning("stale_page: agent pass hit step cap without finish")
-        return []
-
-    def _tool(
-        self, name: str, args: dict[str, Any], candidates: set[str],
-        audience_fp: str,
-    ) -> Any:
-        if name == "read_page":
-            path = str(args.get("path", ""))
-            if path not in candidates:
-                return {"error": "not a candidate page"}
-            body = git.read_file_opt(path)
-            return {"path": path, "body": body} if body is not None else {
-                "error": "page no longer exists"
-            }
-        if name == "search_wiki":
-            hits = fts.search(
-                str(args.get("query", "")), limit=16, is_admin=True,
-                apply_visibility=False,
-            )
-            # Same-audience rule (as pairing detectors): never surface a
-            # page across a visibility boundary — restricted paths/titles
-            # must not enter the transcript or a proposal's evidence text,
-            # which the candidate page's reviewers may not be cleared for.
-            paths = [h.path for h in hits]
-            fps = fingerprint.fingerprints_for_paths(paths) if paths else {}
-            return [
-                {"path": h.path, "title": h.title}
-                for h in hits
-                if fps.get(h.path) == audience_fp
-            ][:8]
-        return {"error": f"unknown tool {name!r}"}
+        return picked
 
     # ---- detector protocol ----------------------------------------------
 

--- a/backend/tests/test_misplaced_page_detector.py
+++ b/backend/tests/test_misplaced_page_detector.py
@@ -1,0 +1,248 @@
+"""Misplaced-page detector — LLM detector #2, strays-only.
+
+The prefilter admits only quiet root-level pages (never entry points); the
+scripted LLM (patched at the ``client.complete`` seam) proposes filings; the
+mechanical guards drop anything outside the rails — non-candidates, invented
+or empty destinations, taken targets. validate() re-checks the page and the
+destination.
+"""
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+
+import app.config
+from app.llm import client as llm_client
+from app.llm.client import CompletionResult, ToolCall, Usage
+from app.llm.errors import LLMError
+from app.wiki import git as wiki_git
+from app.wiki.automanage.detectors.base import Scope, TriggerKind
+from app.wiki.automanage.detectors.misplaced_page import _MisplacedPageDetector
+from app.wiki.change_proposals import ProposalOp
+
+_BODY = "# Deploy checklist\n\nSteps referenced by the runbooks.\n" + "step " * 30
+
+
+def _backdated_commit(path: str, body: str, days: int = 60) -> None:
+    """Commit with old author+committer dates (test seeding only)."""
+    import os
+
+    cwd = app.config.CONFIG.wiki_dir
+    when = (datetime.now(UTC) - timedelta(days=days)).strftime(
+        "%Y-%m-%dT%H:%M:%S+00:00"
+    )
+    absd = os.path.join(cwd, os.path.dirname(path))
+    if os.path.dirname(path):
+        os.makedirs(absd, exist_ok=True)
+    with open(os.path.join(cwd, path), "w") as f:
+        f.write(body)
+    env = {**os.environ, "GIT_AUTHOR_DATE": when, "GIT_COMMITTER_DATE": when}
+    subprocess.run(["git", "add", path], cwd=cwd, check=True, env=env)
+    subprocess.run(
+        ["git", "-c", "user.name=seed", "-c", "user.email=seed@local",
+         "commit", "-m", f"seed {path}"],
+        cwd=cwd, check=True, env=env, capture_output=True,
+    )
+
+
+def _scope(*paths: str) -> Scope:
+    return Scope(trigger=TriggerKind.SWEEP, paths=tuple(paths))
+
+
+def _finish(*proposals: dict[str, str]) -> CompletionResult:
+    return CompletionResult(
+        text="",
+        tool_calls=[
+            ToolCall(id="c1", name="finish", arguments={"proposals": list(proposals)})
+        ],
+        stop_reason="tool_use",
+        usage=Usage(),
+    )
+
+
+def _script(monkeypatch, *results: CompletionResult) -> list[list[dict[str, Any]]]:
+    calls: list[list[dict[str, Any]]] = []
+    queue = list(results)
+
+    def fake(messages, **kwargs):
+        calls.append(messages)
+        return queue.pop(0)
+
+    monkeypatch.setattr(llm_client, "complete", fake)
+    return calls
+
+
+def _seed_home() -> None:
+    """A real destination folder with pages."""
+    wiki_git.commit_file("Runbooks/restore.md", "# Restore\nsteps\n", "seed", author=None)
+    wiki_git.commit_file("Runbooks/rotate.md", "# Rotate\nsteps\n", "seed", author=None)
+
+
+# ---- prefilter ------------------------------------------------------------ #
+
+
+def test_nested_pages_are_never_candidates(monkeypatch, tmp_repo):
+    _seed_home()
+    _backdated_commit("Runbooks/old.md", _BODY)
+    calls = _script(monkeypatch)
+    det = _MisplacedPageDetector()
+    assert det.detect(_scope("Runbooks/old.md", "Runbooks/restore.md")) == []
+    assert calls == []
+
+
+def test_entry_points_are_never_candidates(monkeypatch, tmp_repo):
+    _seed_home()
+    for name in ("README.md", "Home.md", "index.md", "Start Here.md"):
+        _backdated_commit(name, _BODY)
+    calls = _script(monkeypatch)
+    det = _MisplacedPageDetector()
+    scope = _scope("README.md", "Home.md", "index.md", "Start Here.md",
+                   "Runbooks/restore.md", "Runbooks/rotate.md")
+    assert det.detect(scope) == []
+    assert calls == []
+
+
+def test_recently_edited_root_pages_are_excluded(monkeypatch, tmp_repo):
+    _seed_home()
+    wiki_git.commit_file("fresh.md", _BODY, "seed", author=None)  # edited now
+    calls = _script(monkeypatch)
+    det = _MisplacedPageDetector()
+    assert det.detect(_scope("fresh.md", "Runbooks/restore.md")) == []
+    assert calls == []
+
+
+def test_no_folders_means_no_candidates(monkeypatch, tmp_repo):
+    _backdated_commit("stray.md", _BODY)
+    calls = _script(monkeypatch)
+    det = _MisplacedPageDetector()
+    assert det.detect(_scope("stray.md")) == []
+    assert calls == []
+
+
+# ---- agent pass + mechanical guards ---------------------------------------- #
+
+
+def _stray_scope() -> Scope:
+    return _scope("stray.md", "Runbooks/restore.md", "Runbooks/rotate.md")
+
+
+def test_confirmed_stray_emits_a_move_draft(monkeypatch, tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    _script(
+        monkeypatch,
+        _finish({"path": "stray.md", "dest_folder": "Runbooks",
+                 "evidence": "deploy checklist referencing the runbooks"}),
+    )
+
+    (draft,) = _MisplacedPageDetector().detect(_stray_scope())
+
+    assert draft.op == ProposalOp.MOVE
+    assert draft.source_paths == ["stray.md"]
+    assert draft.target_paths == ["Runbooks/stray.md"]
+    assert "deploy checklist" in draft.summary
+    assert draft.auto_approvable is False
+    meta = wiki_git.last_commit_meta_for_path("stray.md")
+    assert meta is not None and draft.premise == meta[0]
+
+
+def test_invented_destination_is_dropped(monkeypatch, tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    _script(
+        monkeypatch,
+        _finish({"path": "stray.md", "dest_folder": "Made Up Folder",
+                 "evidence": "x"}),
+    )
+    assert _MisplacedPageDetector().detect(_stray_scope()) == []
+
+
+def test_taken_target_is_dropped(monkeypatch, tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    # Occupy the target with a different casing — the guard is
+    # case-insensitive, matching the filesystem hazard.
+    wiki_git.commit_file("Runbooks/STRAY.md", "# other\n", "seed", author=None)
+    _script(
+        monkeypatch,
+        _finish({"path": "stray.md", "dest_folder": "Runbooks", "evidence": "x"}),
+    )
+    scope = _scope("stray.md", "Runbooks/restore.md", "Runbooks/rotate.md",
+                   "Runbooks/STRAY.md")
+    assert _MisplacedPageDetector().detect(scope) == []
+
+
+def test_cap_bounds_proposals(monkeypatch, tmp_repo):
+    _seed_home()
+    items = []
+    paths = [f"stray-{i}.md" for i in range(4)]
+    for p in paths:
+        _backdated_commit(p, _BODY + p)
+        items.append({"path": p, "dest_folder": "Runbooks", "evidence": "x"})
+    _script(monkeypatch, _finish(*items))
+    scope = _scope(*paths, "Runbooks/restore.md", "Runbooks/rotate.md")
+    drafts = _MisplacedPageDetector().detect(scope)
+    assert len(drafts) == 2  # MAX_PROPOSALS
+
+
+def test_llm_failure_degrades_to_empty(monkeypatch, tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+
+    def boom(messages, **kwargs):
+        raise LLMError("not_configured", "LLM is not configured")
+
+    monkeypatch.setattr(llm_client, "complete", boom)
+    assert _MisplacedPageDetector().detect(_stray_scope()) == []
+
+
+# ---- validate --------------------------------------------------------------- #
+
+
+def _proposal_for(path: str, target: str) -> dict[str, Any]:
+    meta = wiki_git.last_commit_meta_for_path(path)
+    assert meta is not None
+    return {
+        "source_paths": [path],
+        "target_paths": [target],
+        "base_shas": {path: meta[0]},
+    }
+
+
+def test_validate_holds_while_nothing_happened(tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    p = _proposal_for("stray.md", "Runbooks/stray.md")
+    assert _MisplacedPageDetector().validate(p) is None
+
+
+def test_validate_stales_on_edit(tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    p = _proposal_for("stray.md", "Runbooks/stray.md")
+    wiki_git.commit_file("stray.md", _BODY + "update\n", "edit", author=None)
+    assert _MisplacedPageDetector().validate(p) == (
+        "the page changed since it was judged misplaced"
+    )
+
+
+def test_validate_stales_when_target_taken(tmp_repo):
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    p = _proposal_for("stray.md", "Runbooks/stray.md")
+    wiki_git.commit_file("Runbooks/STRAY.md", "# other\n", "seed", author=None)
+    assert _MisplacedPageDetector().validate(p) == (
+        "the destination path is taken now"
+    )
+
+
+def test_validate_stales_when_destination_empties(tmp_repo):
+    wiki_git.commit_file("Runbooks/only.md", "# only\n", "seed", author=None)
+    _backdated_commit("stray.md", _BODY)
+    p = _proposal_for("stray.md", "Runbooks/stray.md")
+    wiki_git.delete_path("Runbooks/only.md", "rm", author=None)
+    assert _MisplacedPageDetector().validate(p) == (
+        "the destination folder no longer holds any pages"
+    )

--- a/backend/tests/test_stale_page_detector.py
+++ b/backend/tests/test_stale_page_detector.py
@@ -215,7 +215,7 @@ def test_agent_can_read_candidates_and_search(monkeypatch, tmp_repo):
         _finish({"path": "notes/old.md", "evidence": "agenda; covered elsewhere"}),
     )
     monkeypatch.setattr(
-        "app.wiki.automanage.detectors.stale_page.fts.search", lambda *a, **k: []
+        "app.wiki.automanage.detectors.llm_agent.fts.search", lambda *a, **k: []
     )
 
     (draft,) = _StalePageDetector().detect(_scope("notes/old.md"))
@@ -279,7 +279,7 @@ def test_search_never_surfaces_cross_audience_pages(monkeypatch, tmp_repo):
 
     from app.wiki import acl
     from app.wiki.automanage import fingerprint
-    from app.wiki.automanage.detectors import stale_page as sp
+    from app.wiki.automanage.detectors import llm_agent
 
     wiki_git.commit_file("public/page.md", _OLD_BODY, "seed", author=None)
     wiki_git.commit_file("secret/page.md", _OLD_BODY + "s", "seed", author=None)
@@ -290,10 +290,11 @@ def test_search_never_surfaces_cross_audience_pages(monkeypatch, tmp_repo):
         SimpleNamespace(path="public/page.md", title="Public"),
         SimpleNamespace(path="secret/page.md", title="Secret"),
     ]
-    monkeypatch.setattr(sp.fts, "search", lambda *a, **k: hits)
+    monkeypatch.setattr(llm_agent.fts, "search", lambda *a, **k: hits)
 
-    det = _StalePageDetector()
     fp = fingerprint.fingerprints_for_paths(["public/page.md"])["public/page.md"]
-    out = det._tool("search_wiki", {"query": "q"}, {"public/page.md"}, fp)
+    out = llm_agent.dispatch_tool(
+        "stale_page", "search_wiki", {"query": "q"}, {"public/page.md"}, fp
+    )
 
     assert out == [{"path": "public/page.md", "title": "Public"}]


### PR DESCRIPTION
The "move wikis to the right folders" detector, at its most conservative. Two commits:

1. **Substrate extraction** (behavior-preserving): the bounded agent loop, read/search/finish toolset, tool dispatch, and the audience-isolation search filter move from `stale_page` into `detectors/llm_agent.py`. Stale-page keeps only its judgment; its 13 tests pass unchanged.
2. **`misplaced_page`**: proposes filing **root-dumped stray pages** into an existing folder — nothing else. No deep re-filing, no invented folders, no restructuring.

## Conservative by construction
- **Both conditions required**, argued from content after a mandatory read: the page evidently doesn't belong at the root, AND one existing folder is clearly its home. The prompt treats *two plausible homes* as a reason **not** to propose, and name resemblance never suffices.
- **Mechanical rails** the model cannot cross: candidates = quiet (30d) root-level pages, never entry points (readme/home/index/start-here); destinations must already exist **in the same audience bucket** with real pages in them; the target path must be free case-insensitively across the whole tree; cap **2 per sweep**; `auto_approvable=False` always; LLM failure → empty result.
- **Moves are the gentlest verb anyway** — links, ids, permissions, and comments follow the page; a wrong move is one move back. The asymmetry note (wrong proposal costs trust; a stray left alone costs nothing) is in the prompt verbatim.
- **Premise** = the page's sha (an edit voids the filing judgment); **validate()** mechanical: page unchanged, target still free, destination still populated.
- **Registry order**: after stale-page — if both claim a page, whether it should exist precedes where it should live.

13 new tests (prefilter: nested/entry-point/fresh/no-folders; guards: invented destination, case-insensitively taken target, cap; draft shape + premise; LLM-failure degrade; validate: holds/edit/target-taken/destination-empties). Automanage slice green; ruff + basedpyright clean.