### PR TITLE
fix(triggers): schedule diffs keep a long page's tail changes visible

### DIFF
--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -221,11 +221,15 @@ def _change_entry(
     diff = _unified_diff(before, after)
     if diff and len(diff) <= len(before) + len(after):
         return f"--- {path}  (edited)\n{_truncate(diff, budget).rstrip()}\n"
-    # Degenerate: the diff exceeds both bodies together — show the bodies.
+    # Degenerate: the diff exceeds both bodies together — show the bodies,
+    # sharing the entry budget between them so one rewritten entry can never
+    # weigh ~2x its allowance (an oversized payload risks a model-context
+    # error, which skips the fire while the window advances).
+    half = max(budget // 2, 1)
     return (
         f"--- {path}  (rewritten)\n"
-        f"BEFORE:\n{_truncate(before, budget).rstrip()}\n\n"
-        f"AFTER:\n{_truncate(after, budget).rstrip()}\n"
+        f"BEFORE:\n{_truncate(before, half).rstrip()}\n\n"
+        f"AFTER:\n{_truncate(after, half).rstrip()}\n"
     )
 
 
@@ -250,19 +254,12 @@ def build_changes_since(*, scope_path: str, since_iso: str) -> str:
     if not touched:
         return empty
 
-    chunks = [header]
-    total = len(header)
-    truncated = 0
-    # Dynamic per-entry budget: the block budget shared across the docs that
-    # actually changed, floored at the static per-body cap. A quiet window
-    # that touched one long page gets to show that page's changes whole
-    # instead of head-truncating them (the standup-trigger miss: the page's
-    # newest edits sat past the fixed cap and the LLM gate never saw them).
-    per_entry = max(_CHANGE_BODY_BUDGET, _CHANGES_TOTAL_BUDGET // len(touched))
+    # Gather the bodies first and drop net-zero paths (touched then
+    # reverted) BEFORE dividing the budget — they render nothing, and
+    # counting them would dilute the genuine docs' share back toward the
+    # static cap.
+    changes: list[tuple[str, str, str]] = []
     for path in touched:
-        if total >= _CHANGES_TOTAL_BUDGET:
-            truncated += 1
-            continue
         after = _read_or_empty(path, "HEAD")
         # The doc may have been renamed within the window; read its *before*
         # body at the name it had at ``before_ref``, or the diff degrades to a
@@ -271,6 +268,24 @@ def build_changes_since(*, scope_path: str, since_iso: str) -> str:
         if before_ref:
             before_path = wiki_git.path_at_ref(path, before_ref) or path
             before = _read_or_empty(before_path, before_ref)
+        if before != after:
+            changes.append((path, before, after))
+    if not changes:
+        return empty
+
+    chunks = [header]
+    total = len(header)
+    truncated = 0
+    # Dynamic per-entry budget: the block budget shared across the docs that
+    # actually changed, floored at the static per-body cap. A quiet window
+    # that touched one long page gets to show that page's changes whole
+    # instead of head-truncating them (the standup-trigger miss: the page's
+    # newest edits sat past the fixed cap and the LLM gate never saw them).
+    per_entry = max(_CHANGE_BODY_BUDGET, _CHANGES_TOTAL_BUDGET // len(changes))
+    for path, before, after in changes:
+        if total >= _CHANGES_TOTAL_BUDGET:
+            truncated += 1
+            continue
         entry = _change_entry(path, before, after, budget=per_entry)
         if entry is None:
             continue

--- a/backend/app/triggers/diff.py
+++ b/backend/app/triggers/diff.py
@@ -195,24 +195,37 @@ def _read_or_empty(path: str, ref: str) -> str:
     return wiki_git.read_file_opt(path, ref) or ""
 
 
-def _change_entry(path: str, before: str, after: str) -> str | None:
+def _change_entry(
+    path: str, before: str, after: str, budget: int = _CHANGE_BODY_BUDGET
+) -> str | None:
     """One ``--- <path> (kind)`` entry for the changes-since block. Returns
-    ``None`` when there's no effective change (touched then reverted)."""
+    ``None`` when there's no effective change (touched then reverted).
+
+    ``budget`` is per rendered body/diff; the schedule path passes a dynamic
+    value (few docs changed → each gets most of the block budget), because a
+    fixed cap head-truncates long pages and silently drops the tail — the
+    exact place a long page's newest edits tend to live.
+
+    Rendering prefers the unified diff even when it's dense: hunks carry the
+    changed regions wherever they sit in the page, while BEFORE/AFTER bodies
+    lose everything past the truncation point. The bodies fallback is kept
+    only for the degenerate case where the diff is literally bigger than
+    showing both bodies."""
     if before == after:
         return None
     if not before:
-        body = _truncate(after, _CHANGE_BODY_BUDGET)
+        body = _truncate(after, budget)
         return f"--- {path}  (new file)\n{body.rstrip()}\n"
     if not after:
         return f"--- {path}  (deleted)\n"
     diff = _unified_diff(before, after)
-    if diff and _diff_density(diff, after) <= _DIFF_DENSITY_FALLBACK:
-        return f"--- {path}  (edited)\n{_truncate(diff, _CHANGE_BODY_BUDGET).rstrip()}\n"
-    # High-density rewrite: the diff is noise; show both bodies.
+    if diff and len(diff) <= len(before) + len(after):
+        return f"--- {path}  (edited)\n{_truncate(diff, budget).rstrip()}\n"
+    # Degenerate: the diff exceeds both bodies together — show the bodies.
     return (
         f"--- {path}  (rewritten)\n"
-        f"BEFORE:\n{_truncate(before, _CHANGE_BODY_BUDGET).rstrip()}\n\n"
-        f"AFTER:\n{_truncate(after, _CHANGE_BODY_BUDGET).rstrip()}\n"
+        f"BEFORE:\n{_truncate(before, budget).rstrip()}\n\n"
+        f"AFTER:\n{_truncate(after, budget).rstrip()}\n"
     )
 
 
@@ -240,6 +253,12 @@ def build_changes_since(*, scope_path: str, since_iso: str) -> str:
     chunks = [header]
     total = len(header)
     truncated = 0
+    # Dynamic per-entry budget: the block budget shared across the docs that
+    # actually changed, floored at the static per-body cap. A quiet window
+    # that touched one long page gets to show that page's changes whole
+    # instead of head-truncating them (the standup-trigger miss: the page's
+    # newest edits sat past the fixed cap and the LLM gate never saw them).
+    per_entry = max(_CHANGE_BODY_BUDGET, _CHANGES_TOTAL_BUDGET // len(touched))
     for path in touched:
         if total >= _CHANGES_TOTAL_BUDGET:
             truncated += 1
@@ -252,7 +271,7 @@ def build_changes_since(*, scope_path: str, since_iso: str) -> str:
         if before_ref:
             before_path = wiki_git.path_at_ref(path, before_ref) or path
             before = _read_or_empty(before_path, before_ref)
-        entry = _change_entry(path, before, after)
+        entry = _change_entry(path, before, after, budget=per_entry)
         if entry is None:
             continue
         chunks.append(entry)

--- a/backend/tests/test_triggers_diff.py
+++ b/backend/tests/test_triggers_diff.py
@@ -394,3 +394,41 @@ def test_single_doc_window_gets_the_block_budget(repo_with_docs, monkeypatch):
     assert "(no changes in this window)" not in block
     # The last item's completion — deep past the old 8k cap — is visible.
     assert "+- [x] item 599" in block
+
+
+def test_rewritten_entry_stays_within_its_budget():
+    """The BEFORE/AFTER fallback shares one entry budget between the two
+    bodies — a rewritten entry must never weigh ~2x its allowance."""
+    before = "".join(f"alpha {i} padding padding padding\n" for i in range(3000))
+    after = "".join(f"omega {i} padding padding padding\n" for i in range(3000))
+    budget = 10_000
+    entry = _change_entry("doc.md", before, after, budget=budget)
+    assert entry is not None and "(rewritten)" in entry
+    assert len(entry) <= budget + 200  # headers/labels only beyond the shared budget
+
+
+def test_reverted_paths_do_not_dilute_the_budget(repo_with_docs):
+    """A touched-then-reverted page renders nothing and must not shrink the
+    genuinely-changed long page's budget share."""
+    import time
+    from datetime import datetime, timedelta, timezone
+
+    from app.wiki import git as wiki_git
+
+    long_body = "".join(f"- [ ] item {i} with some padding text\n" for i in range(600))
+    done_body = long_body.replace("- [ ] item 599", "- [x] item 599")
+    wiki_git.commit_file("todo.md", long_body, "seed", author=None)
+    wiki_git.commit_file("noise.md", "# noise\noriginal\n", "seed", author=None)
+    time.sleep(2.2)
+    since = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(
+        timespec="seconds"
+    )
+    # Touch-and-revert noise.md inside the window; really change todo.md.
+    wiki_git.commit_file("noise.md", "# noise\nedited\n", "edit", author=None)
+    wiki_git.commit_file("noise.md", "# noise\noriginal\n", "revert", author=None)
+    wiki_git.commit_file("todo.md", done_body, "check item", author=None)
+
+    block = diff_helper.build_changes_since(scope_path="", since_iso=since)
+
+    assert "noise.md" not in block  # net-zero renders nothing
+    assert "+- [x] item 599" in block  # tail change fully visible

--- a/backend/tests/test_triggers_diff.py
+++ b/backend/tests/test_triggers_diff.py
@@ -328,3 +328,69 @@ def test_schedule_payload_doc_scope_carries_doc_despite_large_siblings(repo_with
     )
     assert "--- auth/passwords.md" in payload
     assert "0_early/huge.md" not in payload
+
+
+# --------------------------------------------------------------------------- #
+# Schedule change entries: diff-first rendering + dynamic budget              #
+# --------------------------------------------------------------------------- #
+
+
+def test_dense_edit_on_long_page_keeps_tail_changes_visible():
+    """The standup-trigger miss: a dense edit to a long page used to render
+    as head-truncated BEFORE/AFTER bodies, losing the tail — where the new
+    completions lived. The diff-first rule keeps the changed hunks whatever
+    their position and density."""
+    lines = [f"- [x] item {i} stays unchanged and has padding\n" for i in range(400)]
+    before = "".join(lines) + "- [ ] ship the feature\n"
+    # Touch ~40% of the lines: the diff is dense (well past the old 0.5
+    # density threshold) but still smaller than both bodies together.
+    changed = [
+        line.replace("stays unchanged", "was reworded") if i % 5 < 2 else line
+        for i, line in enumerate(lines)
+    ]
+    after = "".join(changed) + "- [x] ship the feature\n"
+    entry = _change_entry("Individual Notes/Bo TODO.md", before, after, budget=60_000)
+    assert entry is not None
+    assert "(edited)" in entry
+    assert "+- [x] ship the feature" in entry  # the tail change survived
+
+
+def test_bodies_fallback_only_when_diff_exceeds_both_bodies():
+    """Total replacement: every line differs, the diff repeats both bodies
+    plus markers — showing the bodies is genuinely smaller."""
+    before = "".join(f"alpha {i}\n" for i in range(50))
+    after = "".join(f"omega {i}\n" for i in range(50))
+    entry = _change_entry("doc.md", before, after, budget=60_000)
+    assert entry is not None
+    assert "(rewritten)" in entry
+    assert "BEFORE:" in entry and "AFTER:" in entry
+
+
+def test_single_doc_window_gets_the_block_budget(repo_with_docs, monkeypatch):
+    """One changed doc in the window → its entry may use the whole block
+    budget instead of the fixed per-body cap (no head-truncation of a long
+    page's changes)."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.wiki import git as wiki_git
+
+    import time
+
+    long_body = "".join(f"- [ ] item {i} with some padding text\n" for i in range(600))
+    done_body = long_body.replace("- [ ] item 5 ", "- [x] item 5 ").replace(
+        "- [ ] item 599", "- [x] item 599"
+    )
+    wiki_git.commit_file("todo.md", long_body, "seed", author=None)
+    time.sleep(2.2)  # commit timestamps are second-granular
+    # Boundary strictly between the two commits: git --since excludes
+    # same-second commits, so "now" can race the second commit's timestamp.
+    since = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat(
+        timespec="seconds"
+    )
+    wiki_git.commit_file("todo.md", done_body, "check items", author=None)
+
+    block = diff_helper.build_changes_since(scope_path="todo.md", since_iso=since)
+
+    assert "(no changes in this window)" not in block
+    # The last item's completion — deep past the old 8k cap — is visible.
+    assert "+- [x] item 599" in block


### PR DESCRIPTION
Root-cause fix for a missed daily schedule fire: the trigger's condition ("there are new completed items") evaluated against a payload that never contained the completions.

## What happened
The page is long, and the day's edits were dense — so the changes-since renderer fell back to **BEFORE/AFTER whole bodies**, each head-truncated at a fixed 8k. The completions lived in the page's tail, past the cut; the LLM gate saw no completed items and correctly declined to fire. Verified by rebuilding the exact evaluation payload for the missed window: none of the completed items appeared anywhere in it.

## The fix (schedule path only)
- **Diff-first rendering** — the unified diff is preferred even when dense: hunks carry the changed regions wherever they sit in the page, while truncated bodies lose everything past the cut. The bodies fallback survives only for the degenerate case where the diff is literally larger than both bodies together (a total replacement).
- **Dynamic per-entry budget** — the 60k changes-block budget is shared across however many docs actually changed (floored at the old 8k). A quiet window that touched one long page — the standup case exactly — now shows that page's changes whole.

The per-commit delta path keeps its density fallback: its diffs are per-commit and small.

3 regression tests: a dense tail-edit on a long page renders as a diff with the tail change visible (the old rule lost it); the bodies fallback only on total replacement; a single-doc window uses the block budget (a completion 600 lines deep is visible). Trigger slice: 172 passed; ruff + basedpyright clean.