### PR TITLE
chore(release): publish nginx + postgres images, point compose at Docker Hub

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -107,3 +107,79 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-nginx:
+    name: Build and Push Nginx Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-nginx
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push nginx image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./nginx
+          file: ./nginx/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-postgres:
+    name: Build and Push Postgres Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-postgres
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=latest
+
+      - name: Build and push postgres image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./deploy/postgres
+          file: ./deploy/postgres/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,6 +1,6 @@
 name: Nightly Image Build
 
-# Builds + pushes `onyxdotapp/agent-wiki-{backend,frontend}:nightly-latest-YYYYMMDD`
+# Builds + pushes `onyxdotapp/agent-wiki-{backend,frontend,nginx,postgres}:nightly-latest-YYYYMMDD`
 # to Docker Hub on a daily cron. The downstream deploy job in
 # cloud-deployment-yamls picks up the tag an hour later.
 #
@@ -32,7 +32,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component: [backend, frontend]
+        # ``context`` is explicit because postgres does not live at ./<component>.
+        include:
+          - component: backend
+            context: ./backend
+          - component: frontend
+            context: ./frontend
+          - component: nginx
+            context: ./nginx
+          - component: postgres
+            context: ./deploy/postgres
 
     steps:
       - name: Checkout
@@ -68,8 +77,8 @@ jobs:
       - name: Build and push image
         uses: docker/build-push-action@v5
         with:
-          context: ./${{ matrix.component }}
-          file: ./${{ matrix.component }}/Dockerfile
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/Dockerfile
           push: true
           platforms: linux/amd64
           tags: ${{ env.DOCKERHUB_USERNAME }}/agent-wiki-${{ matrix.component }}:${{ steps.tag.outputs.tag }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   #   opensearch 127.0.0.1:9201
   # ------------------------------------------------------------------ #
   postgres:
-    image: agent-wiki-postgres:local
+    image: ${AGENT_WIKI_POSTGRES_IMAGE:-onyxdotapp/agent-wiki-postgres:${IMAGE_TAG:-latest}}
     build:
       context: ./deploy/postgres
     command: ["postgres", "-c", "shared_preload_libraries=pg_textsearch"]
@@ -71,6 +71,7 @@ services:
   # ------------------------------------------------------------------ #
   backend:
     profiles: ["app"]
+    image: ${AGENT_WIKI_BACKEND_IMAGE:-onyxdotapp/agent-wiki-backend:${IMAGE_TAG:-latest}}
     build: ./backend
     env_file: .env
     environment:
@@ -98,6 +99,7 @@ services:
   # OOM can't take down the real-time/interactive/fast `light` tenants.
   worker-heavy:
     profiles: ["app"]
+    image: ${AGENT_WIKI_BACKEND_IMAGE:-onyxdotapp/agent-wiki-backend:${IMAGE_TAG:-latest}}
     build: ./backend
     command:
       [
@@ -129,6 +131,7 @@ services:
 
   worker-light:
     profiles: ["app"]
+    image: ${AGENT_WIKI_BACKEND_IMAGE:-onyxdotapp/agent-wiki-backend:${IMAGE_TAG:-latest}}
     build: ./backend
     command:
       [
@@ -160,6 +163,7 @@ services:
 
   frontend:
     profiles: ["app"]
+    image: ${AGENT_WIKI_FRONTEND_IMAGE:-onyxdotapp/agent-wiki-frontend:${IMAGE_TAG:-latest}}
     build: ./frontend
     env_file: .env
     environment:
@@ -171,6 +175,7 @@ services:
 
   nginx:
     profiles: ["app"]
+    image: ${AGENT_WIKI_NGINX_IMAGE:-onyxdotapp/agent-wiki-nginx:${IMAGE_TAG:-latest}}
     build: ./nginx
     ports:
       # Keep in sync with PUBLIC_BASE_URL in .env — this is the port the


### PR DESCRIPTION
## Description

Compose is the only install path that still compiles from source. Helm pulls `onyxdotapp/agent-wiki-{backend,frontend}`, but `docker-compose.yml` declared build contexts and no image names, so there was nothing for a user to pull — `install.sh` runs an explicit build, which is why the install is multi-minute and needs ~8 GB rather than the ~2.5 GB the stack actually runs in.

Two gaps closed:

- **nginx and postgres were never published.** Neither `onyxdotapp/agent-wiki-nginx` nor `-postgres` exists on Docker Hub, so even with image names wired up a pull-based install could not have worked. Adds those two publish jobs to `docker-build-push.yml` mirroring the existing backend/frontend jobs, and extends the nightly matrix from 2 components to 4. The nightly matrix now carries an explicit `context`, because postgres lives at `deploy/postgres` rather than `./postgres`.
- **Compose named no images.** Every app service now carries an `image:` alongside its existing `build:`, following `onyx/deployment/docker_compose/docker-compose.yml`. Overridable per-service (`AGENT_WIKI_BACKEND_IMAGE`, …) and by `IMAGE_TAG`.

## How Has This Been Tested?

- `docker compose --profile app config` validates, and every app service resolves to its published name (`onyxdotapp/agent-wiki-backend:latest`, `-frontend`, `-nginx`, `-postgres`).
- **Backward compatibility checked directly**, since this is the risk: with both `image:` and `build:` set and the image neither local nor pullable, Compose *builds* and tags it under the image name. Verified against a deliberately nonexistent `onyxdotapp/agent-wiki-doesnotexist:latest` — it built rather than failing. So nothing changes for anyone until the images are actually published.
- Workflow changes are not exercised until a `v*` tag or a manual dispatch.

## Follow-ups (deliberately not in this PR)

1. **Cut a `v*` tag** so all four images publish and `latest` refreshes. It currently points at a **2026-05-08** build — only `v0.0.1` and `v0.0.2` were ever cut, and the nightlies use their own `nightly-latest-*` tags. Worth knowing that the Helm chart defaults to `tag: latest`, so a default `helm install` today pulls that May image; `dev-wiki-values.yaml` pins explicit tags, which is why we don't see it.
2. **Flip `install.sh` to pull** once (1) has landed and the images exist. That is what drops the install from a multi-minute build to a pull and the documented requirement from 8 GB to 4 GB.

Docs for the Compose install are staged in onyx-dot-app/documentation#427 and describe the current build-based flow; they flip to the pull wording after (2).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check