### PR TITLE
fix(wiki): Auto popover toggles in place on a cache the panel shares

### DIFF
--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -22,6 +22,7 @@ import {
   AnchoredPanel,
   AutoGlyph,
   PolicyPopover,
+  type OpenUpdatesPanelOpts,
 } from "@/components/wiki/policyPanels";
 import { relativeTime } from "@/lib/users";
 import { fetchFileHistory } from "@/lib/wiki/svc";
@@ -78,8 +79,8 @@ interface PresenceAvatarsProps {
   onScrollToOffset?: (offset: number) => void;
   /** Opens the given commit in the history view (edit-row click). */
   onOpenCommit?: (sha: string) => void;
-  /** Opens the updates side panel (Page Instructions expand). */
-  onOpenUpdatesPanel?: () => void;
+  /** Opens the updates side panel. */
+  onOpenUpdatesPanel?: (opts?: OpenUpdatesPanelOpts) => void;
 }
 
 interface AvatarCircleProps {
@@ -603,9 +604,9 @@ export function PresenceAvatars({
             canWrite={canWrite}
             // The popover hands off to the side panel in place: same UI,
             // so it dismisses as the panel opens.
-            onOpenUpdatesPanel={() => {
+            onOpenUpdatesPanel={(opts) => {
               setOpenPanel(null);
-              onOpenUpdatesPanel?.();
+              onOpenUpdatesPanel?.(opts);
             }}
           />
         </AnchoredPanel>

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -19,13 +19,7 @@ import {
   SvgSparkle,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 import { ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
@@ -60,8 +54,11 @@ interface Props {
   /** All-time commit count for the "Total Edits" summary column. Null while
    * the host hasn't loaded history yet, which hides the column. */
   totalEdits?: number | null;
-  /** Any change to this value opens the instruction editor. */
-  editInstructionsNonce?: number;
+  /** Opens the instruction editor once the policy loads. The panel clears it
+   * through `onInstructionEditorOpened` so a later ordinary open, or a remount
+   * after the panel closes, does not replay the request. */
+  openInstructionEditor?: boolean;
+  onInstructionEditorOpened?: () => void;
 }
 
 function capNote(health: UpdateHealth): string {
@@ -96,7 +93,8 @@ export function UpdatePolicyPanel({
   historyOpen,
   historyList,
   totalEdits,
-  editInstructionsNonce,
+  openInstructionEditor,
+  onInstructionEditorOpened,
 }: Props) {
   const kind = pathKind(path);
 
@@ -158,19 +156,14 @@ export function UpdatePolicyPanel({
     setEditing(true);
   }, [ownInstruction]);
 
-  // Each bump opens the editor once, after the policy lands so the draft seeds
-  // from it.
-  const lastEditNonce = useRef(0);
+  // Waits for the policy so the draft seeds from it, then clears the request:
+  // this panel unmounts when it closes, so an uncleared one would reopen the
+  // editor on the next ordinary open.
   useEffect(() => {
-    if (
-      editInstructionsNonce &&
-      editInstructionsNonce !== lastEditNonce.current &&
-      loaded
-    ) {
-      lastEditNonce.current = editInstructionsNonce;
-      beginEditing();
-    }
-  }, [editInstructionsNonce, loaded, beginEditing]);
+    if (!openInstructionEditor || !loaded) return;
+    beginEditing();
+    onInstructionEditorOpened?.();
+  }, [openInstructionEditor, loaded, beginEditing, onInstructionEditorOpened]);
 
   // The switch carries the inheritance story out of the card body: origin
   // in its tooltip, and a reset affordance that appears only while the card

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -54,9 +54,8 @@ interface Props {
   /** All-time commit count for the "Total Edits" summary column. Null while
    * the host hasn't loaded history yet, which hides the column. */
   totalEdits?: number | null;
-  /** Opens the instruction editor once the policy loads. The panel clears it
-   * through `onInstructionEditorOpened` so a later ordinary open, or a remount
-   * after the panel closes, does not replay the request. */
+  /** Opens the instruction editor once the policy loads. Cleared through
+   * `onInstructionEditorOpened` so a remount cannot replay it. */
   openInstructionEditor?: boolean;
   onInstructionEditorOpened?: () => void;
 }
@@ -156,9 +155,7 @@ export function UpdatePolicyPanel({
     setEditing(true);
   }, [ownInstruction]);
 
-  // Waits for the policy so the draft seeds from it, then clears the request:
-  // this panel unmounts when it closes, so an uncleared one would reopen the
-  // editor on the next ordinary open.
+  // Waits for the policy so the draft seeds from it, then clears the request.
   useEffect(() => {
     if (!openInstructionEditor || !loaded) return;
     beginEditing();

--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -19,7 +19,13 @@ import {
   SvgSparkle,
   SvgX,
 } from "@onyx-ai/opal/icons";
-import { useEffect, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
@@ -27,12 +33,12 @@ import {
   AutoEditLimitModal,
   UsageBar,
 } from "@/components/wiki/AutoEditLimitModal";
+import { type UpdatePolicyPatch } from "@/lib/updatePolicy";
 import {
-  getUpdatePolicy,
-  patchUpdatePolicy,
-  type UpdatePolicyResponse,
-} from "@/lib/updatePolicy";
-import { useUpdateHealth } from "@/lib/wiki/hooks";
+  saveUpdatePolicy,
+  useUpdateHealth,
+  useUpdatePolicy,
+} from "@/lib/wiki/hooks";
 import type { UpdateHealth } from "@/lib/wiki/types";
 import { pathKind, updateWarnLevel } from "@/lib/wiki/utils";
 import { absoluteTime } from "@/lib/time";
@@ -54,6 +60,8 @@ interface Props {
   /** All-time commit count for the "Total Edits" summary column. Null while
    * the host hasn't loaded history yet, which hides the column. */
   totalEdits?: number | null;
+  /** Any change to this value opens the instruction editor. */
+  editInstructionsNonce?: number;
 }
 
 function capNote(health: UpdateHealth): string {
@@ -88,14 +96,16 @@ export function UpdatePolicyPanel({
   historyOpen,
   historyList,
   totalEdits,
+  editInstructionsNonce,
 }: Props) {
   const kind = pathKind(path);
 
-  const [loading, setLoading] = useState(true);
-  const [loaded, setLoaded] = useState(false); // first fetch succeeded
-  const [policy, setPolicy] = useState<UpdatePolicyResponse | null>(null);
-  const [pendingOn, setPendingOn] = useState<boolean | null>(null); // optimistic toggle
-  const [pendingAiOn, setPendingAiOn] = useState<boolean | null>(null); // optimistic AI toggle
+  const {
+    policy,
+    isLoading: loading,
+    error: loadError,
+  } = useUpdatePolicy(path);
+  const loaded = !!policy;
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const [limitOpen, setLimitOpen] = useState(false);
@@ -106,28 +116,10 @@ export function UpdatePolicyPanel({
   const { health, refresh: refreshHealth } = useUpdateHealth(path);
   const { user } = useAuth();
 
+  // Drop the previous scope's unsaved editor state and stale save error.
   useEffect(() => {
-    let alive = true;
-    setLoading(true);
-    setLoaded(false);
-    setError(null);
     setEditing(false);
-    getUpdatePolicy(path)
-      .then((r) => {
-        if (alive) {
-          setPolicy(r);
-          setLoaded(true);
-        }
-      })
-      .catch((e) => {
-        if (alive) setError(errorMessage(e));
-      })
-      .finally(() => {
-        if (alive) setLoading(false);
-      });
-    return () => {
-      alive = false;
-    };
+    setError(null);
   }, [path]);
 
   // A field is "set here" only when explicit carries a value for it,
@@ -142,45 +134,43 @@ export function UpdatePolicyPanel({
   // Per-page warning threshold, null = using the workspace default.
   const ownThreshold = policy?.explicit?.warn_update_threshold ?? null;
 
-  async function save(
-    patch: Parameters<typeof patchUpdatePolicy>[1],
-    after?: () => void,
-  ): Promise<boolean> {
+  async function save(patch: UpdatePolicyPatch): Promise<boolean> {
+    if (!policy) return false;
     setSaving(true);
     setError(null);
     try {
-      setPolicy(await patchUpdatePolicy(path, patch));
+      await saveUpdatePolicy(path, patch, policy);
       // A policy change can move the health facts (auto-update on/off, the
       // threshold), so revalidate the shared update-health cache now. The
       // page-view banner reuses the same key and updates in lockstep.
       void refreshHealth();
-      after?.();
       return true;
     } catch (e) {
       setError(errorMessage(e));
       return false;
     } finally {
       setSaving(false);
-      setPendingOn(null);
-      setPendingAiOn(null);
     }
   }
 
-  // "Update" ON = ingestion auto-update enabled (NOT disabled).
-  function onToggle(on: boolean) {
-    setPendingOn(on);
-    void save({ ingestion_auto_update_disabled: !on });
-  }
+  const beginEditing = useCallback(() => {
+    setDraft(ownInstruction);
+    setEditing(true);
+  }, [ownInstruction]);
 
-  const switchOn = pendingOn ?? !effDisabled;
-
-  // "AI Auto-Edits" ON = ai_management_allowed (stored positively, no inversion).
-  function onToggleAiManaged(on: boolean) {
-    setPendingAiOn(on);
-    void save({ ai_management_allowed: on });
-  }
-
-  const aiSwitchOn = pendingAiOn ?? effAiManaged;
+  // Each bump opens the editor once, after the policy lands so the draft seeds
+  // from it.
+  const lastEditNonce = useRef(0);
+  useEffect(() => {
+    if (
+      editInstructionsNonce &&
+      editInstructionsNonce !== lastEditNonce.current &&
+      loaded
+    ) {
+      lastEditNonce.current = editInstructionsNonce;
+      beginEditing();
+    }
+  }, [editInstructionsNonce, loaded, beginEditing]);
 
   // The switch carries the inheritance story out of the card body: origin
   // in its tooltip, and a reset affordance that appears only while the card
@@ -269,7 +259,9 @@ export function UpdatePolicyPanel({
           // Load failed: never render the cards, the policy card's default
           // values would overwrite a real policy if the user interacted with it.
           <div className="py-1 text-xs text-(--status-text-error-05)">
-            {error ?? "Couldn't load the update policy."}
+            {loadError
+              ? errorMessage(loadError)
+              : "Couldn't load the update policy."}
           </div>
         ) : (
           <>
@@ -298,9 +290,11 @@ export function UpdatePolicyPanel({
                     title="Update"
                     description="Periodically scan ingested data sources to add relevant new information."
                   >
+                    {/* ON = auto-update enabled, so the stored flag inverts. */}
                     {policySwitch(
-                      switchOn,
-                      onToggle,
+                      !effDisabled,
+                      (on) =>
+                        void save({ ingestion_auto_update_disabled: !on }),
                       disableSetHere,
                       () => void save({ ingestion_auto_update_disabled: null }),
                     )}
@@ -310,8 +304,8 @@ export function UpdatePolicyPanel({
                     description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
                   >
                     {policySwitch(
-                      aiSwitchOn,
-                      onToggleAiManaged,
+                      effAiManaged,
+                      (on) => void save({ ai_management_allowed: on }),
                       aiManagedSetHere,
                       () => void save({ ai_management_allowed: null }),
                     )}
@@ -355,8 +349,7 @@ export function UpdatePolicyPanel({
                           setEditing(false);
                           return;
                         }
-                        setDraft(ownInstruction);
-                        setEditing(true);
+                        beginEditing();
                       }}
                     />
                   }

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -17,11 +17,8 @@ import {
 
 import { toast } from "@/hooks/useToast";
 import { pathKind } from "@/lib/wiki/utils";
-import {
-  getUpdatePolicy,
-  patchUpdatePolicy,
-  type EffectivePolicy,
-} from "@/lib/updatePolicy";
+import { type UpdatePolicyPatch } from "@/lib/updatePolicy";
+import { saveUpdatePolicy, useUpdatePolicy } from "@/lib/wiki/hooks";
 
 interface AutoGlyphProps {
   size?: number;
@@ -126,75 +123,53 @@ export function AnchoredPanel({
   );
 }
 
+export interface OpenUpdatesPanelOpts {
+  /** Open the side panel with the Page Instructions editor expanded. */
+  editInstructions?: boolean;
+}
+
 interface PolicyPopoverProps {
   path: string;
   /** The policy PATCH is write-gated, so read-only viewers get a
    * disabled switch instead of a doomed request. */
   canWrite: boolean;
-  onOpenUpdatesPanel?: () => void;
+  onOpenUpdatesPanel?: (opts?: OpenUpdatesPanelOpts) => void;
 }
 
-/** The Auto popover (mock 1929:362227 "Policy Panel"): the AI auto-edit
- * toggles and the scope's update instruction, all live on the update
- * policy the full panel edits. */
+/** The Auto popover (mock 1929:362227 "Policy Panel"): a read-write shortcut
+ * into the scope's update policy, editing the same cache the side panel
+ * reads. */
 export function PolicyPopover({
   path,
   canWrite,
   onOpenUpdatesPanel,
 }: PolicyPopoverProps) {
   const kind = pathKind(path);
-  // The policy carries the path it was fetched for: a mismatch reads as
-  // unloaded in the same render a navigation lands, so a stale page's
-  // value can never be shown or PATCHed against the new path.
-  const [policy, setPolicy] = useState<{
-    forPath: string;
-    effective: EffectivePolicy;
-  } | null>(null);
+  const { policy } = useUpdatePolicy(path);
+  const effective = policy?.effective ?? null;
   const [saving, setSaving] = useState(false);
-  useEffect(() => {
-    let alive = true;
-    getUpdatePolicy(path)
-      .then(
-        (p) => alive && setPolicy({ forPath: path, effective: p.effective }),
-      )
-      .catch(() => alive && setPolicy(null));
-    return () => {
-      alive = false;
-    };
-  }, [path]);
-  const loaded = policy?.forPath === path ? policy.effective : null;
 
-  const allowed = !!loaded?.ai_management_allowed;
-  const autoUpdateDisabled = !!loaded?.ingestion_auto_update_disabled;
-  const patchField = async (patch: Partial<EffectivePolicy>) => {
-    if (!loaded) return;
+  const allowed = !!effective?.ai_management_allowed;
+  const autoUpdateDisabled = !!effective?.ingestion_auto_update_disabled;
+  const toggle = (patch: UpdatePolicyPatch) => {
+    if (!policy) return;
     setSaving(true);
-    setPolicy({ forPath: path, effective: { ...loaded, ...patch } });
-    try {
-      await patchUpdatePolicy(path, patch);
-    } catch (e) {
-      // The pre-patch snapshot is still in `loaded`; putting it back
-      // rolls the optimistic write off.
-      setPolicy({ forPath: path, effective: loaded });
-      toast.error(
-        e instanceof Error ? e.message : "Couldn't update the policy",
-      );
-    } finally {
-      setSaving(false);
-    }
+    saveUpdatePolicy(path, patch, policy)
+      .catch((e) =>
+        toast.error(
+          e instanceof Error ? e.message : "Couldn't update the policy",
+        ),
+      )
+      .finally(() => setSaving(false));
   };
 
-  // Mock 2079:379824 annotation: clicking the popover body (any field)
-  // opens the full side panel; the switches keep their inline toggles by
-  // stopping the bubble.
   return (
     <Section
       justifyContent="start"
       alignItems="stretch"
       height="fit"
       gap={0.25}
-      className="w-full cursor-pointer"
-      onClick={onOpenUpdatesPanel}
+      className="w-full"
     >
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
         {/* Group header — the switches live on the two rows below:
@@ -204,47 +179,36 @@ export function PolicyPopover({
           title="AI Auto-Edits"
           description={`Let AI update/organize this ${kind} on its own.`}
         />
-        <Section
-          justifyContent="start"
-          alignItems="stretch"
-          height="fit"
-          gap={0.5}
-          className="mt-2 ml-6"
-        >
+        {/* raw-ok: Section drops pl-* for its own inline padding, and ml-*
+            would shift the row and push the right-aligned switches past the
+            popover edge. */}
+        <div className="mt-2 flex flex-col gap-2 pl-6">
           <InputHorizontal
             title="Update"
             description="Periodically scan ingested data sources to add relevant new information."
           >
-            <span onClick={(e) => e.stopPropagation()}>
-              <Switch
-                checked={!autoUpdateDisabled}
-                // Held until this path's policy loads (toggling against the
-                // null default would persist a wrong override) and while a
-                // save is in flight (a second click would race the PATCH).
-                disabled={!canWrite || !loaded || saving}
-                onCheckedChange={() =>
-                  void patchField({
-                    ingestion_auto_update_disabled: !autoUpdateDisabled,
-                  })
-                }
-              />
-            </span>
+            <Switch
+              checked={!autoUpdateDisabled}
+              // Held until this path's policy loads (toggling against the
+              // null default would persist a wrong override) and while a
+              // save is in flight (a second click would race the PATCH).
+              disabled={!canWrite || !effective || saving}
+              onCheckedChange={(on) =>
+                toggle({ ingestion_auto_update_disabled: !on })
+              }
+            />
           </InputHorizontal>
           <InputHorizontal
             title="Organize"
             description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
           >
-            <span onClick={(e) => e.stopPropagation()}>
-              <Switch
-                checked={allowed}
-                disabled={!canWrite || !loaded || saving}
-                onCheckedChange={() =>
-                  void patchField({ ai_management_allowed: !allowed })
-                }
-              />
-            </span>
+            <Switch
+              checked={allowed}
+              disabled={!canWrite || !effective || saving}
+              onCheckedChange={(on) => toggle({ ai_management_allowed: on })}
+            />
           </InputHorizontal>
-        </Section>
+        </div>
       </Section>
       <Divider />
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
@@ -254,7 +218,8 @@ export function PolicyPopover({
           icon={SvgAddLines}
           title="Page Instructions"
           description={
-            loaded?.update_instruction || `How should this ${kind} be updated?`
+            effective?.update_instruction ||
+            `How should this ${kind} be updated?`
           }
           descriptionMaxLines={3}
           sizePreset="main-ui"
@@ -266,13 +231,8 @@ export function PolicyPopover({
               icon={SvgExpand}
               size="md"
               prominence="tertiary"
-              tooltip="Open in panel"
-              // stopPropagation: the popover body opens the panel too, and
-              // the bubble would double-fire the handler.
-              onClick={(e) => {
-                e.stopPropagation();
-                onOpenUpdatesPanel?.();
-              }}
+              tooltip="Edit in panel"
+              onClick={() => onOpenUpdatesPanel?.({ editInstructions: true })}
             />
           }
         />

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -137,8 +137,7 @@ interface PolicyPopoverProps {
 }
 
 /** The Auto popover (mock 1929:362227 "Policy Panel"): a read-write shortcut
- * into the scope's update policy, editing the same cache the side panel
- * reads. */
+ * into the update policy, on the cache the side panel reads. */
 export function PolicyPopover({
   path,
   canWrite,
@@ -180,8 +179,7 @@ export function PolicyPopover({
           description={`Let AI update/organize this ${kind} on its own.`}
         />
         {/* raw-ok: Section drops pl-* for its own inline padding, and ml-*
-            would shift the row and push the right-aligned switches past the
-            popover edge. */}
+            pushes the right-aligned switches past the popover edge. */}
         <div className="mt-2 flex flex-col gap-2 pl-6">
           <InputHorizontal
             title="Update"
@@ -189,9 +187,7 @@ export function PolicyPopover({
           >
             <Switch
               checked={!autoUpdateDisabled}
-              // Held until this path's policy loads (toggling against the
-              // null default would persist a wrong override) and while a
-              // save is in flight (a second click would race the PATCH).
+              // Unloaded would persist a wrong override, in-flight would race.
               disabled={!canWrite || !effective || saving}
               onCheckedChange={(on) =>
                 toggle({ ingestion_auto_update_disabled: !on })

--- a/frontend/src/lib/swr-keys.ts
+++ b/frontend/src/lib/swr-keys.ts
@@ -15,6 +15,8 @@ export const SWR_KEYS = {
     `/wiki/deleted?path=${encodeURIComponent(path)}`,
   updateHealth: (path: string) =>
     `/wiki/update-health?path=${encodeURIComponent(path)}`,
+  updatePolicy: (path: string) =>
+    `/update-policy?path=${encodeURIComponent(path)}`,
   documentActivity: (path: string) =>
     `/wiki/file/activity?path=${encodeURIComponent(path)}`,
   /** Tuple key: the head sha busts the cache on new commits even though the

--- a/frontend/src/lib/updatePolicy.ts
+++ b/frontend/src/lib/updatePolicy.ts
@@ -42,12 +42,6 @@ export interface UpdatePolicyPatch {
   warn_update_threshold?: number | null;
 }
 
-export function getUpdatePolicy(path: string): Promise<UpdatePolicyResponse> {
-  return apiFetch<UpdatePolicyResponse>(
-    `/update-policy?path=${encodeURIComponent(path)}`,
-  );
-}
-
 export function patchUpdatePolicy(
   path: string,
   patch: UpdatePolicyPatch,

--- a/frontend/src/lib/wiki/hooks.ts
+++ b/frontend/src/lib/wiki/hooks.ts
@@ -10,23 +10,19 @@ import {
 } from "@/lib/updatePolicy";
 import type { ListResponse, UpdateHealth } from "@/lib/wiki/types";
 
-/** The scope's update policy as a shared SWR subscription. Every subscriber
- * keyed on this path reads one cache entry, so a write reflects everywhere.
- * Pass `null` to disable. */
+/** One cache entry per path, so a write reflects everywhere. `null` disables. */
 export function useUpdatePolicy(path: string | null) {
   const key = path ? SWR_KEYS.updatePolicy(path) : null;
   const { data, error, isLoading } = useSWR<UpdatePolicyResponse>(key, {
-    // Callers gate their switches on a loaded policy rather than on isLoading,
-    // so the app-wide keep-previous-data would let one scope's values render
-    // and be PATCHed against another's path.
+    // Callers gate on a loaded policy, not isLoading, so keeping previous data
+    // would PATCH one scope's values against another's path.
     keepPreviousData: false,
   });
   return { policy: data ?? null, error: error as Error | undefined, isLoading };
 }
 
-/** Only the toggles merge optimistically. `!= null` so a clear-to-null patch
- * doesn't guess the inherited value, which is also why the free-text
- * instruction stays out: it saves from the panel's editor, never a switch. */
+/** Only the toggles merge. `!= null` so a clear-to-null patch doesn't guess
+ * the inherited value. */
 function merged(
   current: UpdatePolicyResponse,
   patch: UpdatePolicyPatch,
@@ -40,9 +36,8 @@ function merged(
   return { ...current, effective };
 }
 
-/** PATCH the policy through the shared cache. An in-place toggle flips
- * immediately and snaps back if the request fails. `current` is the caller's
- * loaded policy, which the optimistic value is built from. */
+/** PATCH through the shared cache. The toggle flips immediately and snaps back
+ * if the request fails. */
 export async function saveUpdatePolicy(
   path: string,
   patch: UpdatePolicyPatch,

--- a/frontend/src/lib/wiki/hooks.ts
+++ b/frontend/src/lib/wiki/hooks.ts
@@ -1,9 +1,63 @@
-import useSWR from "swr";
+import useSWR, { mutate } from "swr";
 
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { getDeletedTombstone } from "@/lib/trash";
 import { resolveDocId, resolveIds } from "@/lib/wikiHref";
+import {
+  patchUpdatePolicy,
+  type UpdatePolicyPatch,
+  type UpdatePolicyResponse,
+} from "@/lib/updatePolicy";
 import type { ListResponse, UpdateHealth } from "@/lib/wiki/types";
+
+/** The scope's update policy as a shared SWR subscription. Every subscriber
+ * keyed on this path reads one cache entry, so a write reflects everywhere.
+ * Pass `null` to disable. */
+export function useUpdatePolicy(path: string | null) {
+  const key = path ? SWR_KEYS.updatePolicy(path) : null;
+  const { data, error, isLoading } = useSWR<UpdatePolicyResponse>(key, {
+    // Callers gate their switches on a loaded policy rather than on isLoading,
+    // so the app-wide keep-previous-data would let one scope's values render
+    // and be PATCHed against another's path.
+    keepPreviousData: false,
+  });
+  return { policy: data ?? null, error: error as Error | undefined, isLoading };
+}
+
+/** Only the toggles merge optimistically. `!= null` so a clear-to-null patch
+ * doesn't guess the inherited value, which is also why the free-text
+ * instruction stays out: it saves from the panel's editor, never a switch. */
+function merged(
+  current: UpdatePolicyResponse,
+  patch: UpdatePolicyPatch,
+): UpdatePolicyResponse {
+  const effective = { ...current.effective };
+  if (patch.ingestion_auto_update_disabled != null)
+    effective.ingestion_auto_update_disabled =
+      patch.ingestion_auto_update_disabled;
+  if (patch.ai_management_allowed != null)
+    effective.ai_management_allowed = patch.ai_management_allowed;
+  return { ...current, effective };
+}
+
+/** PATCH the policy through the shared cache. An in-place toggle flips
+ * immediately and snaps back if the request fails. `current` is the caller's
+ * loaded policy, which the optimistic value is built from. */
+export async function saveUpdatePolicy(
+  path: string,
+  patch: UpdatePolicyPatch,
+  current: UpdatePolicyResponse,
+): Promise<void> {
+  await mutate<UpdatePolicyResponse>(
+    SWR_KEYS.updatePolicy(path),
+    () => patchUpdatePolicy(path, patch),
+    {
+      optimisticData: merged(current, patch),
+      rollbackOnError: true,
+      revalidate: false,
+    },
+  );
+}
 
 /** The full flat wiki listing — backs the folder Explorer and the New Doc
  * destination picker. */

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -50,6 +50,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { Path2ReviewBanner } from "@/components/wiki/Path2ReviewBanner";
 import { UpdateHealthBanner } from "@/components/wiki/UpdateHealthBanner";
 import { UpdatePolicyPanel } from "@/components/wiki/UpdatePolicyPanel";
+import { type OpenUpdatesPanelOpts } from "@/components/wiki/policyPanels";
 import { CommentMarginRail } from "@/components/wiki/CommentMarginRail";
 import { PresenceAvatars } from "@/components/wiki/PresenceAvatars";
 import { toast } from "@/hooks/useToast";
@@ -232,12 +233,21 @@ export function FileView({ path }: FileViewProps) {
   // A `?comment=<id>` deep-link is focused once per id (reset on path change).
   const focusedCommentRef = useRef<string | null>(null);
 
+  const [editInstructionsNonce, setEditInstructionsNonce] = useState(0);
   // Opening the panel closes history mode, the other rail occupant. Every
   // entry point routes through here.
   const openPanel = useCallback((tab: DocPanelTab) => {
     setHistoryOpen(false);
     setPanelTab(tab);
   }, []);
+
+  const openUpdatesPanel = useCallback(
+    (opts?: OpenUpdatesPanelOpts) => {
+      openPanel("updates");
+      if (opts?.editInstructions) setEditInstructionsNonce((n) => n + 1);
+    },
+    [openPanel],
+  );
 
   const closePanel = useCallback(() => {
     setPanelTab(null);
@@ -968,7 +978,7 @@ export function FileView({ path }: FileViewProps) {
                 void onPickCommit(sha);
               })();
             }}
-            onOpenUpdatesPanel={() => openPanel("updates")}
+            onOpenUpdatesPanel={openUpdatesPanel}
           />
         )}
         <Button
@@ -1051,6 +1061,7 @@ export function FileView({ path }: FileViewProps) {
               historyList={versionList}
               totalEdits={commits ? commits.length : null}
               fullHeight
+              editInstructionsNonce={editInstructionsNonce}
             />
           </div>
         );

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -252,10 +252,14 @@ export function FileView({ path }: FileViewProps) {
     () => setOpenInstructionEditor(false),
     [],
   );
-  // Keyed on the tab, not on each close path, so none can forget to clear.
+  // A request is only good for the page and panel it was made in. Keyed on
+  // those rather than on each close path, so none can forget to clear.
   useEffect(() => {
     if (panelTab !== "updates") setOpenInstructionEditor(false);
   }, [panelTab]);
+  useEffect(() => {
+    setOpenInstructionEditor(false);
+  }, [path]);
 
   const closePanel = useCallback(() => {
     setPanelTab(null);

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -252,6 +252,10 @@ export function FileView({ path }: FileViewProps) {
     () => setOpenInstructionEditor(false),
     [],
   );
+  // Keyed on the tab, not on each close path, so none can forget to clear.
+  useEffect(() => {
+    if (panelTab !== "updates") setOpenInstructionEditor(false);
+  }, [panelTab]);
 
   const closePanel = useCallback(() => {
     setPanelTab(null);

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -233,7 +233,7 @@ export function FileView({ path }: FileViewProps) {
   // A `?comment=<id>` deep-link is focused once per id (reset on path change).
   const focusedCommentRef = useRef<string | null>(null);
 
-  const [editInstructionsNonce, setEditInstructionsNonce] = useState(0);
+  const [openInstructionEditor, setOpenInstructionEditor] = useState(false);
   // Opening the panel closes history mode, the other rail occupant. Every
   // entry point routes through here.
   const openPanel = useCallback((tab: DocPanelTab) => {
@@ -244,9 +244,13 @@ export function FileView({ path }: FileViewProps) {
   const openUpdatesPanel = useCallback(
     (opts?: OpenUpdatesPanelOpts) => {
       openPanel("updates");
-      if (opts?.editInstructions) setEditInstructionsNonce((n) => n + 1);
+      if (opts?.editInstructions) setOpenInstructionEditor(true);
     },
     [openPanel],
+  );
+  const clearInstructionEditorRequest = useCallback(
+    () => setOpenInstructionEditor(false),
+    [],
   );
 
   const closePanel = useCallback(() => {
@@ -1061,7 +1065,8 @@ export function FileView({ path }: FileViewProps) {
               historyList={versionList}
               totalEdits={commits ? commits.length : null}
               fullHeight
-              editInstructionsNonce={editInstructionsNonce}
+              openInstructionEditor={openInstructionEditor}
+              onInstructionEditorOpened={clearInstructionEditorRequest}
             />
           </div>
         );

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -446,10 +446,14 @@ function Explorer({ dir }: ExplorerProps) {
   const updatesPanelShowing = isMobile
     ? policyOpen
     : panelOpen && panelTab === "updates";
-  // Keyed on visibility, not on each close path, so none can forget to clear.
+  // A request is only good for the folder and panel it was made in. Keyed on
+  // those rather than on each close path, so none can forget to clear.
   useEffect(() => {
     if (!updatesPanelShowing) setOpenInstructionEditor(false);
   }, [updatesPanelShowing]);
+  useEffect(() => {
+    setOpenInstructionEditor(false);
+  }, [dir]);
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
   const highlightPath = useCallback(

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -443,6 +443,13 @@ function Explorer({ dir }: ExplorerProps) {
     () => setOpenInstructionEditor(false),
     [],
   );
+  const updatesPanelShowing = isMobile
+    ? policyOpen
+    : panelOpen && panelTab === "updates";
+  // Keyed on visibility, not on each close path, so none can forget to clear.
+  useEffect(() => {
+    if (!updatesPanelShowing) setOpenInstructionEditor(false);
+  }, [updatesPanelShowing]);
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
   const highlightPath = useCallback(

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -426,11 +426,11 @@ function Explorer({ dir }: ExplorerProps) {
     setHoverOpen(false);
   }, [dir]);
   const showPopup = !popupHidden && !panelVisible && proposals.length > 0;
-  const [editInstructionsNonce, setEditInstructionsNonce] = useState(0);
+  const [openInstructionEditor, setOpenInstructionEditor] = useState(false);
   const openSidePanel = useCallback(
     (opts?: OpenUpdatesPanelOpts) => {
       setHoverOpen(false);
-      if (opts?.editInstructions) setEditInstructionsNonce((n) => n + 1);
+      if (opts?.editInstructions) setOpenInstructionEditor(true);
       if (isMobile) setPolicyOpen(true);
       else {
         setPanelOpen(true);
@@ -438,6 +438,10 @@ function Explorer({ dir }: ExplorerProps) {
       }
     },
     [isMobile],
+  );
+  const clearInstructionEditorRequest = useCallback(
+    () => setOpenInstructionEditor(false),
+    [],
   );
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
@@ -828,7 +832,8 @@ function Explorer({ dir }: ExplorerProps) {
               <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 py-1">
                 <UpdatePolicyPanel
                   path={dir}
-                  editInstructionsNonce={editInstructionsNonce}
+                  openInstructionEditor={openInstructionEditor}
+                  onInstructionEditorOpened={clearInstructionEditorRequest}
                 />
                 {/* Not at root — a wiki-wide review is the admin queue's job. */}
                 {dir && (
@@ -901,7 +906,8 @@ function Explorer({ dir }: ExplorerProps) {
                 path={dir}
                 onClose={() => setPolicyOpen(false)}
                 fullHeight
-                editInstructionsNonce={editInstructionsNonce}
+                openInstructionEditor={openInstructionEditor}
+                onInstructionEditorOpened={clearInstructionEditorRequest}
               />
               {dir && (
                 <div className="px-2 pb-2">

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -56,6 +56,7 @@ import {
   AutoGlyph,
   PanelSurface,
   PolicyPopover,
+  type OpenUpdatesPanelOpts,
 } from "@/components/wiki/policyPanels";
 import { useProposalsByPath } from "@/lib/autoOrganize";
 import { deleteTrigger, useTriggers, type Trigger } from "@/lib/triggers";
@@ -425,14 +426,19 @@ function Explorer({ dir }: ExplorerProps) {
     setHoverOpen(false);
   }, [dir]);
   const showPopup = !popupHidden && !panelVisible && proposals.length > 0;
-  const openSidePanel = useCallback(() => {
-    setHoverOpen(false);
-    if (isMobile) setPolicyOpen(true);
-    else {
-      setPanelOpen(true);
-      setPanelTab("updates");
-    }
-  }, [isMobile]);
+  const [editInstructionsNonce, setEditInstructionsNonce] = useState(0);
+  const openSidePanel = useCallback(
+    (opts?: OpenUpdatesPanelOpts) => {
+      setHoverOpen(false);
+      if (opts?.editInstructions) setEditInstructionsNonce((n) => n + 1);
+      if (isMobile) setPolicyOpen(true);
+      else {
+        setPanelOpen(true);
+        setPanelTab("updates");
+      }
+    },
+    [isMobile],
+  );
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
   const highlightPath = useCallback(
@@ -481,7 +487,7 @@ function Explorer({ dir }: ExplorerProps) {
           type="button"
           aria-label="AI auto-edits"
           className="flex cursor-pointer items-center justify-center px-[2px]"
-          onClick={openSidePanel}
+          onClick={() => openSidePanel()}
           onPointerEnter={() => {
             holdOpen();
             setHoverOpen(true);
@@ -794,7 +800,9 @@ function Explorer({ dir }: ExplorerProps) {
                 <SuggestionsCard
                   path={dir}
                   onClose={() => setPopupHidden(true)}
-                  onOpenPanel={openSidePanel}
+                  // Wrapped: the prop is wired to onClick, so a bare reference
+                  // would pass the MouseEvent as the opts argument.
+                  onOpenPanel={() => openSidePanel()}
                   onHighlight={highlightPath}
                 />
               )}
@@ -818,7 +826,10 @@ function Explorer({ dir }: ExplorerProps) {
           >
             {panelTab === "updates" ? (
               <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2 py-1">
-                <UpdatePolicyPanel path={dir} />
+                <UpdatePolicyPanel
+                  path={dir}
+                  editInstructionsNonce={editInstructionsNonce}
+                />
                 {/* Not at root — a wiki-wide review is the admin queue's job. */}
                 {dir && (
                   <SuggestionsCard path={dir} onHighlight={highlightPath} />
@@ -890,6 +901,7 @@ function Explorer({ dir }: ExplorerProps) {
                 path={dir}
                 onClose={() => setPolicyOpen(false)}
                 fullHeight
+                editInstructionsNonce={editInstructionsNonce}
               />
               {dir && (
                 <div className="px-2 pb-2">


### PR DESCRIPTION
## Description

**Bug.** Toggling a switch in the Auto popover yanked you into the side panel, and the two surfaces disagreed: each fetched and PATCHed `/update-policy` on its own, so a write on one left the other stale. The popover's sub-toggle switches also overhang its right edge, because the indent is a left margin that shifts the whole row and pushes the right-aligned switches out of bounds.

**Fix.**
- Popover and panel share one SWR key (`useUpdatePolicy`) and one writer (`saveUpdatePolicy`, optimistic with `rollbackOnError`).
- Popover switches toggle in place and the popover stays open. The panel opens only from the Auto mark, or the Page Instructions expander, which opens it straight into the editor.
- Indent becomes a padding wrapper so the row's right edge stays pinned, matching the group `UpdatePolicyPanel` already renders.
- `keepPreviousData: false` on the policy hook. It is on app-wide, and the switches gate on a loaded policy rather than `isLoading`, so one scope's values could render and PATCH against another path.
- Removes the now-dead `getUpdatePolicy`.

The Organize toggle from #541 is unchanged.

## How Has This Been Tested?

| Before | After |
|---|---|
| <img alt="before" src="https://github.com/user-attachments/assets/76839267-e77f-443a-9f2d-20603a975651" /> | <img alt="after" src="https://github.com/user-attachments/assets/cf2aac41-d3c6-48f8-86a7-8df5516004f5" /> |

Both switches sat 11px past the panel's right edge and now sit 13px inside it, aligned with each other.

Captured in Chrome against the real Opal stylesheet at the real panel width (`--block-width-panel-medium-small`, 22.5rem), rendering the actual Opal primitives with each indent variant. The measurements match the running app exactly (switch right edge 395 vs panel right 384 before, 371 vs 384 after).

`bun run typecheck` and prettier are clean. No Python in the diff.
