### PR TITLE
feat(policy): ai_edits_disabled — the master AI Auto-Edits switch (backend)

### DIFF
--- a/backend/app/api/update_policy.py
+++ b/backend/app/api/update_policy.py
@@ -35,13 +35,18 @@ def _normalize(path: str) -> str:
 
 def _build_response(path: str) -> UpdatePolicyResponse:
     explicit = policy_repo.get(path)
-    effective = policy_repo.resolve_for_path(path)
+    # Display view (apply_master=False): the children keep their resolved
+    # values even under a disabled master, so the UI can show them preserved;
+    # the master state rides alongside. Enforcement paths resolve with the
+    # override applied (the default).
+    effective = policy_repo.resolve_for_path(path, apply_master=False)
     return UpdatePolicyResponse(
         explicit=ExplicitPolicy(**explicit) if explicit is not None else None,
         effective=EffectivePolicy(
             ingestion_auto_update_disabled=effective.ingestion_auto_update_disabled,
             update_instruction=effective.update_instruction,
             ai_management_allowed=effective.ai_management_allowed,
+            ai_edits_disabled=effective.ai_edits_disabled,
         ),
     )
 
@@ -71,6 +76,8 @@ def patch_update_policy(
         patch["update_instruction"] = req.update_instruction
     if "ai_management_allowed" in req.model_fields_set:
         patch["ai_management_allowed"] = req.ai_management_allowed
+    if "ai_edits_disabled" in req.model_fields_set:
+        patch["ai_edits_disabled"] = req.ai_edits_disabled
     if "warn_update_threshold" in req.model_fields_set:
         patch["warn_update_threshold"] = req.warn_update_threshold
     # Nothing to change — don't touch the row (would falsify updated_by/_at).

--- a/backend/app/db/migrations/versions/d7f2c8b4a1e6_ai_edits_disabled.py
+++ b/backend/app/db/migrations/versions/d7f2c8b4a1e6_ai_edits_disabled.py
@@ -1,0 +1,34 @@
+"""update_policies.ai_edits_disabled — the master AI Auto-Edits switch.
+
+Revision ID: d7f2c8b4a1e6
+Revises: c2e7a4d9f1b8
+
+Tri-state, cascaded like the sibling fields. When effectively disabled it
+overrides both sub-settings (ingestion auto-update, auto-management) at
+resolution time without changing their stored values, so re-enabling the
+master restores the children as they were.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d7f2c8b4a1e6"
+down_revision: str | None = "c2e7a4d9f1b8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    cols = {c["name"] for c in inspector.get_columns("update_policies")}
+    if "ai_edits_disabled" in cols:
+        return
+    op.add_column(
+        "update_policies", sa.Column("ai_edits_disabled", sa.Boolean(), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("update_policies", "ai_edits_disabled")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -657,12 +657,6 @@ class DocumentTemplate(Base):
     ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
     update_instruction: Mapped[str | None] = mapped_column(Text)
     ai_management_allowed: Mapped[bool | None] = mapped_column(Boolean)
-    # Master "AI Auto-Edits" switch. Tri-state, cascaded like the two fields
-    # above. When effectively True it OVERRIDES both sub-settings at
-    # resolution time (ingestion updates off, auto-management forbidden)
-    # WITHOUT changing their stored values — re-enabling the master restores
-    # whatever the children were set to.
-    ai_edits_disabled: Mapped[bool | None] = mapped_column(Boolean)
     # Admin-controlled ordering for the picker. Lower values render
     # first; ties fall back to ``name`` alphabetical. New rows land at
     # the end (max(sort_order) + 1) so admins decide where they live.

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -657,6 +657,12 @@ class DocumentTemplate(Base):
     ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
     update_instruction: Mapped[str | None] = mapped_column(Text)
     ai_management_allowed: Mapped[bool | None] = mapped_column(Boolean)
+    # Master "AI Auto-Edits" switch. Tri-state, cascaded like the two fields
+    # above. When effectively True it OVERRIDES both sub-settings at
+    # resolution time (ingestion updates off, auto-management forbidden)
+    # WITHOUT changing their stored values — re-enabling the master restores
+    # whatever the children were set to.
+    ai_edits_disabled: Mapped[bool | None] = mapped_column(Boolean)
     # Admin-controlled ordering for the picker. Lower values render
     # first; ties fall back to ``name`` alphabetical. New rows land at
     # the end (max(sort_order) + 1) so admins decide where they live.
@@ -1250,6 +1256,12 @@ class UpdatePolicy(Base):
     ingestion_auto_update_disabled: Mapped[bool | None] = mapped_column(Boolean)
     update_instruction: Mapped[str | None] = mapped_column(Text)
     ai_management_allowed: Mapped[bool | None] = mapped_column(Boolean)
+    # Master "AI Auto-Edits" switch. Tri-state, cascaded like the two fields
+    # above. When effectively True it OVERRIDES both sub-settings at
+    # resolution time (ingestion updates off, auto-management forbidden)
+    # WITHOUT changing their stored values — re-enabling the master restores
+    # whatever the children were set to.
+    ai_edits_disabled: Mapped[bool | None] = mapped_column(Boolean)
     # Owner-set per-page warning threshold: notify the owner once a page is
     # auto-updated more than this many times in 24h. ``NULL`` inherits the
     # global default (``ingest_settings.warn_update_threshold_default``). Per-page

--- a/backend/app/models/update_policy.py
+++ b/backend/app/models/update_policy.py
@@ -12,6 +12,11 @@ class EffectivePolicy(BaseModel):
     ingestion_auto_update_disabled: bool
     update_instruction: str | None = None
     ai_management_allowed: bool = False
+    # Master "AI Auto-Edits" switch. In this response the two fields above
+    # are the PRE-master (display) values — the preserved children — and the
+    # client derives the acting state from this flag; enforcement paths apply
+    # the override server-side.
+    ai_edits_disabled: bool = False
 
 
 class ExplicitPolicy(BaseModel):
@@ -22,6 +27,7 @@ class ExplicitPolicy(BaseModel):
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
     ai_management_allowed: bool | None = None
+    ai_edits_disabled: bool | None = None
     warn_update_threshold: int | None = None
     updated_by_user_id: str | None = None
     created_at: str | None = None
@@ -63,4 +69,5 @@ class PatchUpdatePolicyRequest(BaseModel):
     ingestion_auto_update_disabled: bool | None = None
     update_instruction: str | None = None
     ai_management_allowed: bool | None = None
+    ai_edits_disabled: bool | None = None
     warn_update_threshold: int | None = Field(default=None, ge=0)

--- a/backend/app/wiki/update_policy.py
+++ b/backend/app/wiki/update_policy.py
@@ -1,11 +1,16 @@
 """Update-policy repo — per-page / per-folder control over wiki auto-updates.
 
 Postgres-only governance metadata keyed by path (a ``.md`` page, a folder, or
-``""`` for the wiki root), mirroring ``app/wiki/acl.py``. Three independent
-settings — ``ingestion_auto_update_disabled`` (tri-state),
-``update_instruction``, and ``ai_management_allowed`` (tri-state) — are each
-resolved most-granular-wins by walking a path
-and its ancestor folders. See the design page
+``""`` for the wiki root), mirroring ``app/wiki/acl.py``. Four settings —
+``ingestion_auto_update_disabled`` (tri-state), ``update_instruction``,
+``ai_management_allowed`` (tri-state), and the master ``ai_edits_disabled``
+(tri-state) — are each resolved most-granular-wins by walking a path and its
+ancestor folders. The master is special: when effectively disabled it
+OVERRIDES the two sub-settings at resolution time (ingestion off,
+auto-management forbidden) without changing their stored values, so
+re-enabling it restores the children as they were. Enforcement consumers get
+the override by default; the API's display path opts out
+(``apply_master=False``) so the UI can render the preserved child values. See the design page
 ``Engineering Projects/Agent Wiki Project/design/Update Policy.md``.
 
 Free functions over the ``UpdatePolicy`` model; each opens its own session and
@@ -49,6 +54,9 @@ class ResolvedPolicy(BaseModel):
     # Effective default is False: without an explicit opt-in somewhere in the
     # scope chain, AI auto-management stays propose -> approve.
     ai_management_allowed: bool = False
+    # Master switch (default enabled). With apply_master=True (the default,
+    # enforcement view) a disabled master also forces the two fields above.
+    ai_edits_disabled: bool = False
 
 
 def _now() -> str:
@@ -76,6 +84,7 @@ def _to_dict(row: UpdatePolicy) -> dict[str, Any]:
         "ingestion_auto_update_disabled": row.ingestion_auto_update_disabled,
         "update_instruction": row.update_instruction,
         "ai_management_allowed": row.ai_management_allowed,
+        "ai_edits_disabled": row.ai_edits_disabled,
         "warn_update_threshold": row.warn_update_threshold,
         "updated_by_user_id": row.updated_by_user_id,
         "created_at": row.created_at,
@@ -111,6 +120,7 @@ def set_policy(
     ingestion_auto_update_disabled: bool | None | _UnsetType = _UNSET,
     update_instruction: str | None | _UnsetType = _UNSET,
     ai_management_allowed: bool | None | _UnsetType = _UNSET,
+    ai_edits_disabled: bool | None | _UnsetType = _UNSET,
     warn_update_threshold: int | None | _UnsetType = _UNSET,
     actor_user_id: str | None = None,
 ) -> dict[str, Any] | None:
@@ -133,6 +143,8 @@ def set_policy(
             row.update_instruction = update_instruction or None
         if not isinstance(ai_management_allowed, _UnsetType):
             row.ai_management_allowed = ai_management_allowed
+        if not isinstance(ai_edits_disabled, _UnsetType):
+            row.ai_edits_disabled = ai_edits_disabled
         if not isinstance(warn_update_threshold, _UnsetType):
             row.warn_update_threshold = warn_update_threshold
 
@@ -140,6 +152,7 @@ def set_policy(
             row.ingestion_auto_update_disabled is None
             and not row.update_instruction
             and row.ai_management_allowed is None
+            and row.ai_edits_disabled is None
             and row.warn_update_threshold is None
         ):
             if existed:
@@ -256,11 +269,20 @@ def _scope_chain(norm: str) -> list[str]:
     return chain
 
 
-def _resolve_chain(chain: list[str], by_path: dict[str, UpdatePolicy]) -> ResolvedPolicy:
-    """Resolve one scope chain (closest first) against pre-fetched rows."""
+def _resolve_chain(
+    chain: list[str], by_path: dict[str, UpdatePolicy], *, apply_master: bool = True
+) -> ResolvedPolicy:
+    """Resolve one scope chain (closest first) against pre-fetched rows.
+
+    ``apply_master`` (default, the enforcement view): an effectively disabled
+    master forces ingestion off and auto-management forbidden — the children's
+    stored values are preserved but overridden. The API's display path passes
+    ``False`` so the UI can render the preserved child values alongside the
+    master state."""
     disabled: bool | None = None
     instruction: str | None = None
     ai_managed: bool | None = None
+    master_off: bool | None = None
     for scope in chain:
         row = by_path.get(scope)
         if row is None:
@@ -271,12 +293,23 @@ def _resolve_chain(chain: list[str], by_path: dict[str, UpdatePolicy]) -> Resolv
             instruction = row.update_instruction
         if ai_managed is None and row.ai_management_allowed is not None:
             ai_managed = row.ai_management_allowed
-        if disabled is not None and instruction is not None and ai_managed is not None:
+        if master_off is None and row.ai_edits_disabled is not None:
+            master_off = row.ai_edits_disabled
+        if (
+            disabled is not None
+            and instruction is not None
+            and ai_managed is not None
+            and master_off is not None
+        ):
             break
+    if apply_master and master_off:
+        disabled = True
+        ai_managed = False
     return ResolvedPolicy(
         ingestion_auto_update_disabled=bool(disabled),
         update_instruction=instruction,
         ai_management_allowed=bool(ai_managed),
+        ai_edits_disabled=bool(master_off),
     )
 
 
@@ -299,12 +332,20 @@ def resolve_ai_management_for_paths(paths: Iterable[str]) -> dict[str, bool | No
     result: dict[str, bool | None] = {}
     for p, chain in chains.items():
         value: bool | None = None
+        master_off: bool | None = None
         for scope in chain:
             row = by_path.get(scope)
-            if row is not None and row.ai_management_allowed is not None:
+            if row is None:
+                continue
+            if value is None and row.ai_management_allowed is not None:
                 value = row.ai_management_allowed
+            if master_off is None and row.ai_edits_disabled is not None:
+                master_off = row.ai_edits_disabled
+            if value is not None and master_off is not None:
                 break
-        result[p] = value
+        # Master off = the do-not-touch override: detectors must skip the
+        # scope entirely, same semantics as an explicit False.
+        result[p] = False if master_off else value
     return result
 
 
@@ -320,7 +361,9 @@ def resolve_ai_management(path: str) -> bool | None:
     return resolve_ai_management_for_paths([path]).get(path)
 
 
-def resolve_for_paths(paths: Iterable[str]) -> dict[str, ResolvedPolicy]:
+def resolve_for_paths(
+    paths: Iterable[str], *, apply_master: bool = True
+) -> dict[str, ResolvedPolicy]:
     """Effective policy for many paths in a single query.
 
     Fetches the union of every path's scope chain once, then resolves each path
@@ -339,16 +382,21 @@ def resolve_for_paths(paths: Iterable[str]) -> dict[str, ResolvedPolicy]:
             .all()
         )
     by_path = {r.path: r for r in rows}
-    return {orig: _resolve_chain(chain, by_path) for orig, chain in chains.items()}
+    return {
+        orig: _resolve_chain(chain, by_path, apply_master=apply_master)
+        for orig, chain in chains.items()
+    }
 
 
-def resolve_for_path(path: str) -> ResolvedPolicy:
+def resolve_for_path(path: str, *, apply_master: bool = True) -> ResolvedPolicy:
     """Effective policy for a single ``path`` (convenience over
     :func:`resolve_for_paths`): most-granular scope that sets a field wins,
     walking the path then its ancestor folders, each field resolved
     independently — so a page can re-enable ingestion under a disabled folder.
     """
-    return resolve_for_paths([path]).get(path, ResolvedPolicy())
+    return resolve_for_paths([path], apply_master=apply_master).get(
+        path, ResolvedPolicy()
+    )
 
 
 def is_ingest_disabled(path: str) -> bool:

--- a/backend/tests/test_ai_edits_master.py
+++ b/backend/tests/test_ai_edits_master.py
@@ -1,0 +1,106 @@
+"""The master "AI Auto-Edits" switch (``ai_edits_disabled``).
+
+Tri-state, cascaded like its sibling fields. Effectively disabled, it
+overrides both sub-settings at resolution time — ingestion off,
+auto-management forbidden — WITHOUT changing their stored values, so
+re-enabling restores the children. Enforcement views get the override by
+default; the API display view opts out so the UI can render the preserved
+children.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import create_app
+from app.wiki import update_policy
+from tests._auth import login_fastapi
+from tests._seed import seed_user
+
+
+def test_master_overrides_but_preserves_children(tmp_repo):
+    update_policy.set_policy(
+        "team/page.md",
+        ingestion_auto_update_disabled=False,
+        ai_management_allowed=True,
+    )
+    update_policy.set_policy("team/page.md", ai_edits_disabled=True)
+
+    # Enforcement view: both children forced off.
+    eff = update_policy.resolve_for_path("team/page.md")
+    assert eff.ai_edits_disabled is True
+    assert eff.ingestion_auto_update_disabled is True
+    assert eff.ai_management_allowed is False
+
+    # Display view: children keep their stored values.
+    disp = update_policy.resolve_for_path("team/page.md", apply_master=False)
+    assert disp.ai_edits_disabled is True
+    assert disp.ingestion_auto_update_disabled is False
+    assert disp.ai_management_allowed is True
+
+    # Re-enable: children come back exactly as set.
+    update_policy.set_policy("team/page.md", ai_edits_disabled=None)
+    eff = update_policy.resolve_for_path("team/page.md")
+    assert eff.ai_edits_disabled is False
+    assert eff.ingestion_auto_update_disabled is False
+    assert eff.ai_management_allowed is True
+
+
+def test_master_cascades_folder_to_page(tmp_repo):
+    update_policy.set_policy("area", ai_edits_disabled=True)
+    eff = update_policy.resolve_for_path("area/deep/page.md")
+    assert eff.ai_edits_disabled is True
+    assert eff.ingestion_auto_update_disabled is True
+    # Most-granular-wins: a page can re-enable under a disabled folder.
+    update_policy.set_policy("area/deep/page.md", ai_edits_disabled=False)
+    eff = update_policy.resolve_for_path("area/deep/page.md")
+    assert eff.ai_edits_disabled is False
+
+
+def test_master_forbids_auto_management_tristate(tmp_repo):
+    """The runner's batch resolution treats a disabled master as an explicit
+    False — detectors skip the scope entirely."""
+    update_policy.set_policy("locked", ai_edits_disabled=True)
+    update_policy.set_policy("locked/page.md", ai_management_allowed=True)
+    out = update_policy.resolve_ai_management_for_paths(["locked/page.md"])
+    assert out["locked/page.md"] is False
+
+
+def test_master_alone_keeps_the_row_alive(tmp_repo):
+    update_policy.set_policy("solo/page.md", ai_edits_disabled=True)
+    row = update_policy.get("solo/page.md")
+    assert row is not None and row["ai_edits_disabled"] is True
+    # Clearing it removes the now-empty row.
+    assert update_policy.set_policy("solo/page.md", ai_edits_disabled=None) is None
+    assert update_policy.get("solo/page.md") is None
+
+
+def test_api_patch_and_display_roundtrip(tmp_repo):
+    client = TestClient(create_app())
+    uid = seed_user(uid="u1", email="u@x.com")
+    login_fastapi(client, uid)
+    from app.wiki import git as wiki_git
+
+    wiki_git.commit_file("team/page.md", "# P\n", "seed", author=None)
+
+    res = client.patch(
+        "/api/update-policy",
+        json={
+            "path": "team/page.md",
+            "ai_management_allowed": True,
+            "ai_edits_disabled": True,
+        },
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["explicit"]["ai_edits_disabled"] is True
+    # Display view: preserved child rides alongside the master state.
+    assert body["effective"]["ai_edits_disabled"] is True
+    assert body["effective"]["ai_management_allowed"] is True
+
+    # Clearing via explicit null.
+    res = client.patch(
+        "/api/update-policy",
+        json={"path": "team/page.md", "ai_edits_disabled": None},
+    )
+    assert res.status_code == 200
+    assert res.json()["effective"]["ai_edits_disabled"] is False


### PR DESCRIPTION
Backend for the AI Auto-Edits master toggle, per the design thread: **the master overrides the two children without changing them** — turn it off and the page stops changing unprompted; turn it back on and Update/Organize come back exactly as they were. (Prompted, user-attributed AI edits via chat/MCP are unaffected.)

- New tri-state `update_policies.ai_edits_disabled`, cascaded most-granular-wins like its siblings (a page can re-enable under a disabled folder). Migration `d7f2c8b4a1e6`, inspector-guarded.
- **Override at resolution**: with the master effectively disabled, `resolve_for_paths` forces `ingestion_auto_update_disabled=True` and `ai_management_allowed=False`, and the runner's batch tri-state resolution treats it as an explicit False (detectors skip the scope). Every existing enforcement consumer inherits the behavior with zero changes.\n- **Display vs enforcement**: the API GET resolves with `apply_master=False` so the UI can render the preserved child values alongside the master state; enforcement keeps the default. PATCH accepts the field (null clears back to inherit; an empty row is removed).

5 tests (override + preservation + restore, folder→page cascade with page-level re-enable, runner tri-state sees False, row lifecycle, API PATCH/display roundtrip). Frontend PR (master toggle per the mocks, children show/hide, limit bar hidden when off) stacks next.