### PR TITLE
feat(wiki): AI Auto-Edits master toggle (frontend)

### DIFF
--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -126,6 +126,11 @@ export function UpdatePolicyPanel({
     policy?.explicit?.ingestion_auto_update_disabled != null;
   const effAiManaged = policy?.effective.ai_management_allowed ?? false;
   const aiManagedSetHere = policy?.explicit?.ai_management_allowed != null;
+  // Master "AI Auto-Edits": overrides the two children server-side without
+  // changing their stored values; this panel gets the display view, so the
+  // children render as set even while overridden.
+  const masterOn = !(policy?.effective.ai_edits_disabled ?? false);
+  const masterSetHere = policy?.explicit?.ai_edits_disabled != null;
   const ownInstruction = policy?.explicit?.update_instruction ?? "";
   const effInstruction = policy?.effective.update_instruction ?? "";
   // Per-page warning threshold, null = using the workspace default.
@@ -267,40 +272,50 @@ export function UpdatePolicyPanel({
               className="group/policy rounded-(--radius-12) border border-(--border-01)"
             >
               <div className="flex flex-col gap-2 p-2">
-                {/* Group header — the switches live on the two rows below:
-                    Update = ingestion auto-update, Organize = auto
-                    management (Auto Organize may act on this scope). */}
+                {/* Master switch: overrides Update + Organize server-side
+                    without changing their stored values, and hides them
+                    while off (they come back as they were). */}
                 <InputHorizontal
                   icon={SvgSparkle}
                   title="AI Auto-Edits"
                   description={`Let AI update/organize this ${kind} on its own.`}
-                />
-                <div className="flex flex-col gap-2 pl-6">
-                  <InputHorizontal
-                    title="Update"
-                    description="Periodically scan ingested data sources to add relevant new information."
-                  >
-                    {/* ON = auto-update enabled, so the stored flag inverts. */}
-                    {policySwitch(
-                      !effDisabled,
-                      (on) =>
-                        void save({ ingestion_auto_update_disabled: !on }),
-                      disableSetHere,
-                      () => void save({ ingestion_auto_update_disabled: null }),
-                    )}
-                  </InputHorizontal>
-                  <InputHorizontal
-                    title="Organize"
-                    description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
-                  >
-                    {policySwitch(
-                      effAiManaged,
-                      (on) => void save({ ai_management_allowed: on }),
-                      aiManagedSetHere,
-                      () => void save({ ai_management_allowed: null }),
-                    )}
-                  </InputHorizontal>
-                </div>
+                >
+                  {policySwitch(
+                    masterOn,
+                    (on) => void save({ ai_edits_disabled: !on }),
+                    masterSetHere,
+                    () => void save({ ai_edits_disabled: null }),
+                  )}
+                </InputHorizontal>
+                {masterOn && (
+                  <div className="flex flex-col gap-2 pl-6">
+                    <InputHorizontal
+                      title="Update"
+                      description="Periodically scan ingested data sources to add relevant new information."
+                    >
+                      {/* ON = auto-update enabled, so the stored flag inverts. */}
+                      {policySwitch(
+                        !effDisabled,
+                        (on) =>
+                          void save({ ingestion_auto_update_disabled: !on }),
+                        disableSetHere,
+                        () =>
+                          void save({ ingestion_auto_update_disabled: null }),
+                      )}
+                    </InputHorizontal>
+                    <InputHorizontal
+                      title="Organize"
+                      description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
+                    >
+                      {policySwitch(
+                        effAiManaged,
+                        (on) => void save({ ai_management_allowed: on }),
+                        aiManagedSetHere,
+                        () => void save({ ai_management_allowed: null }),
+                      )}
+                    </InputHorizontal>
+                  </div>
+                )}
               </div>
 
               <Divider />
@@ -443,7 +458,7 @@ export function UpdatePolicyPanel({
                           <Text font="main-ui-action" color="text-04">
                             {String(health.count_24h)}
                           </Text>
-                          {(overCap || nearCap) && (
+                          {masterOn && (overCap || nearCap) && (
                             <Tooltip tooltip={capNote(health)} side="top">
                               <span className="flex size-4 items-center justify-center text-(--text-04)">
                                 {overCap ? (
@@ -482,34 +497,39 @@ export function UpdatePolicyPanel({
                       />
                     )}
                   </div>
-                  <div className="shrink-0">
-                    {kind === "page" &&
-                    health.can_manage &&
-                    health.cap_24h > 0 ? (
-                      // raw-ok: the mock's dialog trigger is the usage chart region itself. SelectCard, Opal's clickable card, is a selection-state div with no native button semantics, so a bare button keeps aria and keyboard.
-                      <button
-                        type="button"
-                        aria-label="Auto-edit limits"
-                        onClick={() => setLimitOpen(true)}
-                        className="block w-full cursor-pointer rounded-(--radius-08) border-none bg-transparent p-[2px] text-left hover:bg-(--background-tint-02)"
-                      >
-                        <UsageBar
-                          count={health.count_24h}
-                          threshold={health.threshold_24h}
-                          cap={health.cap_24h}
-                        />
-                      </button>
-                    ) : (
-                      <div className="rounded-(--radius-08) p-[2px]">
-                        <UsageBar
-                          count={health.count_24h}
-                          threshold={health.threshold_24h}
-                          cap={health.cap_24h}
-                        />
-                      </div>
-                    )}
-                  </div>
-                  {(overCap || nearCap) && (
+                  {/* No master = no auto-edits, so no limit bar; the limit
+                      itself is server state and NOT reset by toggling.
+                      History above stays — it's the full edit record. */}
+                  {masterOn && (
+                    <div className="shrink-0">
+                      {kind === "page" &&
+                      health.can_manage &&
+                      health.cap_24h > 0 ? (
+                        // raw-ok: the mock's dialog trigger is the usage chart region itself. SelectCard, Opal's clickable card, is a selection-state div with no native button semantics, so a bare button keeps aria and keyboard.
+                        <button
+                          type="button"
+                          aria-label="Auto-edit limits"
+                          onClick={() => setLimitOpen(true)}
+                          className="block w-full cursor-pointer rounded-(--radius-08) border-none bg-transparent p-[2px] text-left hover:bg-(--background-tint-02)"
+                        >
+                          <UsageBar
+                            count={health.count_24h}
+                            threshold={health.threshold_24h}
+                            cap={health.cap_24h}
+                          />
+                        </button>
+                      ) : (
+                        <div className="rounded-(--radius-08) p-[2px]">
+                          <UsageBar
+                            count={health.count_24h}
+                            threshold={health.threshold_24h}
+                            cap={health.cap_24h}
+                          />
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  {masterOn && (overCap || nearCap) && (
                     <div className="flex shrink-0 items-start gap-0.5">
                       <span className="flex size-4 shrink-0 items-center justify-center text-(--text-04)">
                         {overCap ? (

--- a/frontend/src/components/wiki/policyPanels.tsx
+++ b/frontend/src/components/wiki/policyPanels.tsx
@@ -150,6 +150,7 @@ export function PolicyPopover({
 
   const allowed = !!effective?.ai_management_allowed;
   const autoUpdateDisabled = !!effective?.ingestion_auto_update_disabled;
+  const masterOn = !effective?.ai_edits_disabled;
   const toggle = (patch: UpdatePolicyPatch) => {
     if (!policy) return;
     setSaving(true);
@@ -171,40 +172,48 @@ export function PolicyPopover({
       className="w-full"
     >
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>
-        {/* Group header — the switches live on the two rows below:
-            Update = ingestion auto-update, Organize = auto management. */}
+        {/* Master switch: overrides Update + Organize server-side without
+            changing their stored values, and hides them while off. */}
         <InputHorizontal
           icon={SvgSparkle}
           title="AI Auto-Edits"
           description={`Let AI update/organize this ${kind} on its own.`}
-        />
-        {/* raw-ok: Section drops pl-* for its own inline padding, and ml-*
-            pushes the right-aligned switches past the popover edge. */}
-        <div className="mt-2 flex flex-col gap-2 pl-6">
-          <InputHorizontal
-            title="Update"
-            description="Periodically scan ingested data sources to add relevant new information."
-          >
-            <Switch
-              checked={!autoUpdateDisabled}
-              // Unloaded would persist a wrong override, in-flight would race.
-              disabled={!canWrite || !effective || saving}
-              onCheckedChange={(on) =>
-                toggle({ ingestion_auto_update_disabled: !on })
-              }
-            />
-          </InputHorizontal>
-          <InputHorizontal
-            title="Organize"
-            description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
-          >
-            <Switch
-              checked={allowed}
-              disabled={!canWrite || !effective || saving}
-              onCheckedChange={(on) => toggle({ ai_management_allowed: on })}
-            />
-          </InputHorizontal>
-        </div>
+        >
+          <Switch
+            checked={masterOn}
+            disabled={!canWrite || !effective || saving}
+            onCheckedChange={(on) => toggle({ ai_edits_disabled: !on })}
+          />
+        </InputHorizontal>
+        {masterOn && (
+          // raw-ok: Section drops pl-* for its own inline padding, and ml-*
+          // pushes the right-aligned switches past the popover edge.
+          <div className="mt-2 flex flex-col gap-2 pl-6">
+            <InputHorizontal
+              title="Update"
+              description="Periodically scan ingested data sources to add relevant new information."
+            >
+              <Switch
+                checked={!autoUpdateDisabled}
+                // Unloaded would persist a wrong override, in-flight would race.
+                disabled={!canWrite || !effective || saving}
+                onCheckedChange={(on) =>
+                  toggle({ ingestion_auto_update_disabled: !on })
+                }
+              />
+            </InputHorizontal>
+            <InputHorizontal
+              title="Organize"
+              description={`Reorganize, move, and/or merge content in this ${kind} when needed.`}
+            >
+              <Switch
+                checked={allowed}
+                disabled={!canWrite || !effective || saving}
+                onCheckedChange={(on) => toggle({ ai_management_allowed: on })}
+              />
+            </InputHorizontal>
+          </div>
+        )}
       </Section>
       <Divider />
       <Section gap={0} height="fit" alignItems="stretch" padding={0.5}>

--- a/frontend/src/lib/updatePolicy.ts
+++ b/frontend/src/lib/updatePolicy.ts
@@ -10,6 +10,10 @@ export interface EffectivePolicy {
   ingestion_auto_update_disabled: boolean;
   update_instruction: string | null;
   ai_management_allowed: boolean;
+  // Master "AI Auto-Edits" switch. The two fields above are the PRE-master
+  // (display) values — preserved children; the server applies the override
+  // on enforcement paths.
+  ai_edits_disabled: boolean;
 }
 
 export interface ExplicitPolicy {
@@ -18,6 +22,7 @@ export interface ExplicitPolicy {
   ingestion_auto_update_disabled: boolean | null;
   update_instruction: string | null;
   ai_management_allowed: boolean | null;
+  ai_edits_disabled: boolean | null;
   // Owner-set per-page warning threshold (auto-updates/24h). Null inherits
   // the global default, 0 alerts on every update.
   warn_update_threshold: number | null;
@@ -38,6 +43,7 @@ export interface UpdatePolicyResponse {
 export interface UpdatePolicyPatch {
   ingestion_auto_update_disabled?: boolean | null;
   update_instruction?: string | null;
+  ai_edits_disabled?: boolean | null;
   ai_management_allowed?: boolean | null;
   warn_update_threshold?: number | null;
 }

--- a/frontend/src/lib/wiki/hooks.ts
+++ b/frontend/src/lib/wiki/hooks.ts
@@ -33,6 +33,8 @@ function merged(
       patch.ingestion_auto_update_disabled;
   if (patch.ai_management_allowed != null)
     effective.ai_management_allowed = patch.ai_management_allowed;
+  if (patch.ai_edits_disabled != null)
+    effective.ai_edits_disabled = patch.ai_edits_disabled;
   return { ...current, effective };
 }
 


### PR DESCRIPTION
Stacked on #547 (the `ai_edits_disabled` backend). Implements the mocks + the Slack spec:

- **AI Auto-Edits is a switch again**, bound to the master field. It **overrides without changing** Update/Organize — their stored values are preserved server-side and this panel receives the display view, so re-enabling brings them back exactly as they were.
- **Children show/hide with the master** (hidden while off), in both the side panel and the header popover.
- **The limit bar hides while the master is off** (no auto-edits to limit); the limit itself is server state and is not reset by toggling. **Update History stays visible regardless** — it is the page's full edit record.
- Side panel master switch carries the same inherit-origin tooltip + hover reset affordance as the other rows; the popover writes explicit booleans as it does for the children.
<img width="881" height="427" alt="Screenshot 2026-07-29 at 10 58 09 AM" src="https://github.com/user-attachments/assets/155ea0f9-a3f2-44ae-8502-4c6d3e2c3256" />
<img width="845" height="487" alt="Screenshot 2026-07-29 at 10 58 01 AM" src="https://github.com/user-attachments/assets/ef8c0127-4412-4de1-afb7-ded3a7ac4ac9" />

`bun run typecheck` + prettier clean.