### PR TITLE
fix(coedit): record the checkpoint watermark when a keystroke races the commit

### DIFF
--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -173,13 +173,28 @@ def _checkpoint_locked(session_id: int) -> str | None:
             new_base_sha=result.sha,
             checkpointed=True,
         )
-        if res is None:
-            # A human op raced in during the commit, so the buffer moved past
-            # what we committed. Leave base_sha / checkpointed_version untouched:
-            # the session stays dirty and the next checkpoint does a proper 3-way
-            # merge (base=old, current=HEAD, incoming=newer buffer) that preserves
-            # the folded-in agent edit. Advancing base_sha to result.sha here
-            # would make that next merge base==current and drop the agent's edit.
+        if res is None and result.new_body == sess.buffer_text:
+            # A human op raced in during the commit — the buffer moved past what
+            # we committed, so the write-back CAS missed. Nothing foreign was
+            # folded in, so the commit *is* the buffer at ``sess.version``, and
+            # recording that is simply true: the session stays dirty for the ops
+            # that landed after it, and the next checkpoint merges from the sha we
+            # just wrote.
+            #
+            # Skipping this is what made a busy session never converge. Typing
+            # through a commit is the ordinary case, not an edge case, so the
+            # watermark would stay behind forever: ``last_checkpoint_at`` never
+            # advanced, leaving the session permanently overdue for the periodic
+            # scan, and ``base_sha`` stayed pinned so every later checkpoint
+            # 3-way merged a moving buffer against an ever-older base — which
+            # duplicates and drops text.
+            coedit.mark_checkpointed(session_id, base_sha=result.sha, version=sess.version)
+        elif res is None:
+            # Same race, but the commit-time merge folded in a concurrent
+            # agent/ingest commit that never reached the buffer. Leave base_sha
+            # where it is so the next checkpoint merges base=old, current=HEAD,
+            # incoming=newer buffer and keeps that edit; advancing it would make
+            # base == current and drop it.
             log.info(
                 "coedit checkpoint: concurrent op during commit of %s; reconciling next checkpoint",
                 path,

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -5,12 +5,13 @@ trailers. DB + real git (the ``tmp_repo`` fixture).
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text, update
 
 from app.auth import users as users_repo
-from app.db.models import CoeditParticipant, DocumentTemplate
+from app.db.models import CoeditParticipant, CoeditSession, DocumentTemplate
 from app.db.session import session as db_session
 from app.db.session import try_advisory_xact_lock
 from app.tasks import coedit_checkpoint as coedit_checkpoint_task
@@ -109,6 +110,94 @@ def test_checkpoint_raced_fallback_leaves_session_dirty(repo, monkeypatch):
     assert st is not None
     assert st.base_sha == sha  # NOT advanced past the buffer's ancestor
     assert st.version > st.checkpointed_version  # still dirty → next checkpoint reconciles
+
+
+def _racing_rebase(monkeypatch, author_user_id: str, change: coedit.Change):
+    """Land ``change`` between the commit and its write-back, so the CAS misses.
+
+    Typing through a checkpoint is the ordinary case — the commit takes long
+    enough (a git write, sometimes an LLM merge) that a keystroke lands inside
+    it — so this is the common path, not a rare interleaving.
+    """
+    real_rebase = coedit.rebase_onto
+
+    def racing(session_id, **kwargs):
+        coedit.apply_op(
+            session_id,
+            base_version=kwargs["base_version"],
+            changes=[change],
+            author_user_id=author_user_id,
+        )
+        return real_rebase(session_id, **kwargs)
+
+    monkeypatch.setattr(coedit, "rebase_onto", racing)
+    return real_rebase
+
+
+def test_raced_checkpoint_advances_watermark_and_converges(repo, monkeypatch):
+    # A raced write-back with nothing foreign folded in: the commit *is* the
+    # buffer at the version we read, so the watermark records it. The session
+    # stays dirty for the keystroke that raced in, and the next checkpoint
+    # converges on it — merging from the sha just written rather than an
+    # ever-older base, which is what duplicated and dropped text.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+
+    real_rebase = _racing_rebase(monkeypatch, uid, _ch(8, 8, "!"))
+    assert coedit_checkpoint.checkpoint_session(sess.id) is not None
+    monkeypatch.setattr(coedit, "rebase_onto", real_rebase)
+
+    st = coedit.get_active_session(_PATH)
+    assert st is not None
+    assert wiki_git.read_file(_PATH) == "hi world"
+    assert st.base_sha == wiki_git.head_sha_for_path(_PATH)
+    assert st.checkpointed_version == 1
+    assert st.last_checkpoint_at is not None
+    assert st.version == 2  # the raced keystroke is still uncommitted
+
+    assert coedit_checkpoint.checkpoint_session(sess.id) is not None
+    assert wiki_git.read_file(_PATH) == "hi world!"
+    st = coedit.get_active_session(_PATH)
+    assert st is not None and st.version == st.checkpointed_version
+
+
+def test_raced_checkpoint_stops_reenqueueing_every_scan(repo, monkeypatch):
+    # The scan's overdue arm measures from last_checkpoint_at, so a raced
+    # checkpoint that recorded nothing left the session overdue forever: every
+    # scan re-enqueued it, and each attempt committed again.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page("hello world")
+    sess = coedit.open_session(_PATH, base_sha=sha, initial_buffer="hello world")
+    coedit.join(sess.id, uid)
+    coedit.apply_op(sess.id, base_version=0, changes=[_ch(0, 5, "hi")], author_user_id=uid)
+    # Age it past the overdue threshold; never-checkpointed sessions measure from
+    # created_at.
+    aged = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    with db_session() as s:
+        s.execute(update(CoeditSession).where(CoeditSession.id == sess.id).values(created_at=aged))
+
+    def due() -> list[int]:
+        return [
+            d.id
+            for d in coedit.sessions_due_for_checkpoint(
+                idle_seconds=3600, max_interval_seconds=60
+            )
+        ]
+
+    assert due() == [sess.id]
+
+    real_rebase = _racing_rebase(monkeypatch, uid, _ch(8, 8, "!"))
+    coedit_checkpoint.checkpoint_session(sess.id)
+    monkeypatch.setattr(coedit, "rebase_onto", real_rebase)
+
+    # Still dirty from the raced keystroke, but no longer overdue — the next
+    # commit waits for the interval instead of firing on every scan.
+    st = coedit.get_active_session(_PATH)
+    assert st is not None and st.version > st.checkpointed_version
+    assert due() == []
 
 
 def test_checkpoint_is_noop_when_clean(repo):


### PR DESCRIPTION
Follow-up to #551. That one fixed sessions being closed under live sockets; this one fixes the checkpoint loop that corrupts content.

## The bug

`checkpoint_session` commits the buffer, then writes the committed content back into the session under a version CAS (`rebase_onto(base_version=sess.version)`). Any op landing during the commit fails that CAS — and typing through a commit is the *ordinary* case, since a commit is a git write and sometimes an LLM merge.

On that path nothing was recorded at all, so a session being actively typed in never converged:

- **The scan re-enqueued it every minute.** `last_checkpoint_at` stayed null, so the overdue arm of `sessions_due_for_checkpoint` measured from `created_at` and the session was permanently overdue. Each run committed again.
- **Every later checkpoint merged against a staler base.** `base_sha` stayed pinned while the buffer grew, so the 3-way merge base drifted arbitrarily far behind HEAD. Those merges duplicate and drop text, and conflicts git can't resolve are handed to the LLM merge.

Observed in production on a page four people had open: ~124 `Co-editing checkpoint` commits in a few hours (a page with a handful of edits normally gets 10–20 in a day), one commit re-inserting two lines that had already existed for 75 minutes, and another leaving spliced text mid-word.

## The fix

When the commit-time merge folded in nothing foreign (`result.new_body == sess.buffer_text`), the commit *is* the buffer at the version we read, so recording that is simply true:

```python
coedit.mark_checkpointed(session_id, base_sha=result.sha, version=sess.version)
```

The session stays dirty for the ops that arrived after `sess.version`, which is accurate, and the next checkpoint merges from the sha just written instead of an ever-older one. `mark_checkpointed` only ever advances (`checkpointed_version < version`), so a slower checkpoint can't regress a faster one's watermark.

The conservative behaviour is kept for the case the old comment was actually reasoning about — the merge folded in a concurrent agent/ingest commit that never reached the buffer. There, advancing `base_sha` would make the next merge's base == current and drop that edit, so the session is deliberately left pinned. `test_checkpoint_raced_fallback_leaves_session_dirty` covers that and still passes unchanged.

## Tests

Two new tests, both verified to fail without the fix:

- `test_raced_checkpoint_advances_watermark_and_converges` — a keystroke lands between the commit and the write-back (a `rebase_onto` wrapper applies a real op, so the CAS genuinely misses). Asserts `base_sha` advances to the new HEAD, `checkpointed_version` records the committed version, the session stays dirty for the raced op, and the *next* checkpoint converges on the newer text with no duplication. Without the fix: `assert st.base_sha == wiki_git.head_sha_for_path(_PATH)` fails.
- `test_raced_checkpoint_stops_reenqueueing_every_scan` — ages `created_at` past the overdue threshold, confirms the session is due, runs the raced checkpoint, and asserts it is no longer due. Without the fix: `assert due() == []` fails with `[1]`.

99 co-edit tests pass; ruff and basedpyright clean.

## Still open

`resync` remains unactionable client-side: a buffer rebase writes no `coedit_ops` row, so the client's `pull()` receives an empty op list, ignores `current_head_version`, and silently keeps a stale document — after which its ops anchor against text the server doesn't have. That needs a `get_session` WS message plus a `setDoc` on resync, and is the other half of "different people see different things". Next PR.
