### PR TITLE
fix(coedit): stop holding a thread per open socket

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agent_wiki
 # at this size. Default 1000; applies to all three pgmq queues.
 MAX_QUEUE_SIZE=1000
 
+# Threads the web process offloads blocking work onto (`asyncio.to_thread`).
+# Every open co-edit WebSocket holds one for its send loop, so this is the
+# ceiling on concurrent editors per process, not a CPU knob. Default 64.
+WEB_THREAD_POOL_SIZE=64
+
 # Browser-facing origin the backend advertises (launcher URIs, redirect
 # targets, email links, MCP tool-result URLs) — REQUIRED, never inferred
 # from request headers.

--- a/.env.example
+++ b/.env.example
@@ -33,11 +33,6 @@ MAX_QUEUE_SIZE=1000
 # git calls) via `asyncio.to_thread`. Default 64.
 WEB_THREAD_POOL_SIZE=64
 
-# Threads for the co-edit send loops — one held per open socket for its whole
-# life, so this is the ceiling on concurrent editors per process. Kept separate
-# from the pool above so sockets can't starve request work. Default 256.
-COEDIT_SOCKET_POOL_SIZE=256
-
 # Browser-facing origin the backend advertises (launcher URIs, redirect
 # targets, email links, MCP tool-result URLs) — REQUIRED, never inferred
 # from request headers.

--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,14 @@ DATABASE_URL=postgresql://postgres:postgres@localhost:5432/agent_wiki
 # at this size. Default 1000; applies to all three pgmq queues.
 MAX_QUEUE_SIZE=1000
 
-# Threads the web process offloads blocking work onto (`asyncio.to_thread`).
-# Every open co-edit WebSocket holds one for its send loop, so this is the
-# ceiling on concurrent editors per process, not a CPU knob. Default 64.
+# Threads the web process offloads short-lived blocking work onto (DB reads,
+# git calls) via `asyncio.to_thread`. Default 64.
 WEB_THREAD_POOL_SIZE=64
+
+# Threads for the co-edit send loops — one held per open socket for its whole
+# life, so this is the ceiling on concurrent editors per process. Kept separate
+# from the pool above so sockets can't starve request work. Default 256.
+COEDIT_SOCKET_POOL_SIZE=256
 
 # Browser-facing origin the backend advertises (launcher URIs, redirect
 # targets, email links, MCP tool-result URLs) — REQUIRED, never inferred

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -31,6 +31,7 @@ import asyncio
 import logging
 import queue
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -38,6 +39,7 @@ from pydantic import ValidationError
 
 from app.auth import PermissionDenied, User, require_can
 from app.auth.deps import require_user_ws
+from app.config import CONFIG
 from app.models.coedit import (
     CheckpointMessage,
     CheckpointResultFrame,
@@ -245,22 +247,33 @@ async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[coedit_channel.Qu
             log.warning("coedit ws: malformed %r message", msg_type)
 
 
+# The send loops' own thread pool, separate from the default executor every
+# other offload uses. A drain thread is held for the *connection's whole life*
+# (see _send_loop), so on a shared pool accumulating sockets steadily consume
+# it and the short-lived offloads — the connect handshake, every op, cursor
+# ping and checkpoint, for every session — end up queueing behind parked
+# drains. That reads as "the whole app froze," and can cause more disconnects
+# itself: a starved loop misses uvicorn's ping/pong window and heartbeats slip
+# past the presence grace period, expiring live editors. Splitting the pools
+# means the two can't compete — socket occupancy is bounded by
+# coedit_socket_pool_size, work concurrency by web_thread_pool_size.
+#
+# It stays a thread per socket only because the drain is a blocking
+# queue.Queue.get; an asyncio.Queue fed via call_soon_threadsafe would need
+# none, at the cost of reworking this module's close/wake handshake.
+_DRAIN_POOL = ThreadPoolExecutor(
+    max_workers=CONFIG.coedit_socket_pool_size, thread_name_prefix="coedit-drain"
+)
+
 # How often _send_loop's blocking drain call returns to check for
-# cancellation. Short on purpose: asyncio.to_thread cancellation only
-# unblocks the *awaiting* coroutine, not the underlying OS thread still
-# parked in queue.Queue.get(timeout=...) — found the hard way, in
-# production, not just in theory. Every disconnect (a WS closes, we
-# reconnect) cancels this task; with a long timeout, the orphaned thread
-# lingers for up to that long, still holding a slot in the shared default
-# thread pool every asyncio.to_thread call in the process draws from. Under
-# frequent reconnects, orphaned threads accumulate faster than they drain,
-# eventually exhausting the pool — at which point *every* asyncio.to_thread
-# call across the whole backend (new connects, every op/cursor/checkpoint
-# message, for every session) queues for a free worker. That reads as "the
-# whole app froze," and can plausibly cause more disconnects itself (a
-# starved event loop can miss uvicorn's own ping/pong window and get
-# closed as unresponsive) — a self-reinforcing spiral. Bounding the poll to
-# ~1s bounds any orphaned thread's worst case to ~1s instead of 15.
+# cancellation. Short on purpose: cancelling the awaiting coroutine doesn't
+# unblock the underlying OS thread, still parked in queue.Queue.get(timeout=...)
+# — found the hard way, in production, not just in theory. Every disconnect
+# cancels this task; with a long timeout the orphaned thread lingers for up to
+# that long, still holding a slot in _DRAIN_POOL. Under frequent reconnects
+# orphans would accumulate faster than they drain and exhaust it, at which
+# point new connections get no send loop at all. Bounding the poll to ~1s
+# bounds any orphan's worst case to ~1s instead of 15.
 _SEND_LOOP_POLL_SECONDS = 1.0
 
 
@@ -268,8 +281,11 @@ async def _send_loop(
     websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user_id: str
 ) -> None:
     last_heartbeat = time.monotonic()
+    loop = asyncio.get_running_loop()
     while True:
-        frame = await asyncio.to_thread(coedit_channel.drain, conn.queue, _SEND_LOOP_POLL_SECONDS)
+        frame = await loop.run_in_executor(
+            _DRAIN_POOL, coedit_channel.drain, conn.queue, _SEND_LOOP_POLL_SECONDS
+        )
         if frame is coedit_channel.CLOSE_SIGNAL:
             # ws()'s teardown path pushed this via coedit_channel.wake() right
             # before cancelling this task — reachable here (not just via

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -29,9 +29,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import queue
 import time
-from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Callable
 from typing import Any
 
 from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
@@ -39,7 +38,6 @@ from pydantic import ValidationError
 
 from app.auth import PermissionDenied, User, require_can
 from app.auth.deps import require_user_ws
-from app.config import CONFIG
 from app.models.coedit import (
     CheckpointMessage,
     CheckpointResultFrame,
@@ -97,8 +95,8 @@ def _require_active(session_id: int, user: User, action: str) -> coedit.SessionR
     return sess
 
 
-def _handle_op(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
-    """All handlers below enqueue onto ``outbox`` (the connection's own
+def _handle_op(conn: coedit_channel.Connection, session_id: int, user: User, raw: dict[str, Any]) -> None:
+    """All handlers below enqueue via ``conn.post`` (the connection's own
     ``coedit_channel`` queue) rather than calling ``websocket.send_json``
     directly. Found the hard way (a real test failure, not a hypothetical):
     ``_send_loop`` is *already* draining this queue and writing to the same
@@ -107,7 +105,7 @@ def _handle_op(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, u
     the frame writes, and there's no ordering guarantee between a direct
     reply and a same-op broadcast echo landing first. Routing everything
     through the one queue makes ``_send_loop`` the sole writer, and
-    enqueueing the reply *before* triggering the broadcast (see the ``op``
+    posting the reply *before* triggering the broadcast (see the ``op``
     case) makes the ordering deterministic: a sender always sees their own
     ``op_result`` before its broadcast echo, not racing it.
     """
@@ -122,20 +120,20 @@ def _handle_op(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, u
             client_id=msg.client_id,
         )
     except _WsActionError as e:
-        outbox.put_nowait(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(by_alias=True))
+        conn.post(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(by_alias=True))
         return
     except ValueError:
-        outbox.put_nowait(
+        conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump(by_alias=True)
         )
         return
     if out is None:
-        outbox.put_nowait(
+        conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="stale_version").model_dump(by_alias=True)
         )
         return
     coedit.touch(session_id, user.id, edited=True)
-    outbox.put_nowait(
+    conn.post(
         OpResultFrame(request_id=msg.request_id, ok=True, version=out.version).model_dump(by_alias=True)
     )
     # caret_seq rides the frame so peers render the author's caret at the
@@ -173,27 +171,27 @@ def _handle_cursor(session_id: int, user: User, raw: dict[str, Any]) -> None:
     )
 
 
-def _handle_checkpoint(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
+def _handle_checkpoint(conn: coedit_channel.Connection, session_id: int, user: User, raw: dict[str, Any]) -> None:
     msg = CheckpointMessage.model_validate(raw)
     try:
         _require_active(session_id, user, "write")
     except _WsActionError as e:
-        outbox.put_nowait(
+        conn.post(
             CheckpointResultFrame(
                 request_id=msg.request_id, ok=False, error=e.error
             ).model_dump(by_alias=True)
         )
         return
     checkpoint_coedit_session(session_id)
-    outbox.put_nowait(CheckpointResultFrame(request_id=msg.request_id, ok=True).model_dump(by_alias=True))
+    conn.post(CheckpointResultFrame(request_id=msg.request_id, ok=True).model_dump(by_alias=True))
 
 
-def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User, raw: dict[str, Any]) -> None:
+def _handle_get_ops(conn: coedit_channel.Connection, session_id: int, user: User, raw: dict[str, Any]) -> None:
     msg = GetOpsMessage.model_validate(raw)
     try:
         sess = _require_active(session_id, user, "read")
     except _WsActionError as e:
-        outbox.put_nowait(
+        conn.post(
             OpsResultFrame(
                 request_id=msg.request_id, ok=False, error=e.error, current_head_version=0, ops=[]
             ).model_dump(by_alias=True)
@@ -202,7 +200,7 @@ def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: i
     # Head version + ops read as one consistent snapshot (see
     # ops_since_with_head), so a concurrent op can't desync them.
     result = coedit.ops_since_with_head(session_id, msg.since_version)
-    outbox.put_nowait(
+    conn.post(
         OpsResultFrame(
             request_id=msg.request_id,
             ok=True,
@@ -222,7 +220,7 @@ def _handle_get_ops(outbox: queue.Queue[coedit_channel.QueueItem], session_id: i
     )
 
 
-async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[coedit_channel.QueueItem], session_id: int, user: User) -> None:
+async def _recv_loop(websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user: User) -> None:
     while True:
         raw = await websocket.receive_json()
         msg_type = raw.get("type")
@@ -234,76 +232,62 @@ async def _recv_loop(websocket: WebSocket, outbox: queue.Queue[coedit_channel.Qu
             # automatically; a sync call made *from inside* an `async def`
             # route (this one, since it's a WebSocket route) does not.
             if msg_type == "op":
-                await asyncio.to_thread(_handle_op, outbox, session_id, user, raw)
+                await asyncio.to_thread(_handle_op, conn, session_id, user, raw)
             elif msg_type == "cursor":
                 await asyncio.to_thread(_handle_cursor, session_id, user, raw)
             elif msg_type == "checkpoint":
-                await asyncio.to_thread(_handle_checkpoint, outbox, session_id, user, raw)
+                await asyncio.to_thread(_handle_checkpoint, conn, session_id, user, raw)
             elif msg_type == "get_ops":
-                await asyncio.to_thread(_handle_get_ops, outbox, session_id, user, raw)
+                await asyncio.to_thread(_handle_get_ops, conn, session_id, user, raw)
             else:
                 log.warning("coedit ws: unknown message type %r", msg_type)
         except ValidationError:
             log.warning("coedit ws: malformed %r message", msg_type)
 
 
-# The send loops' own thread pool, separate from the default executor every
-# other offload uses. A drain thread is held for the *connection's whole life*
-# (see _send_loop), so on a shared pool accumulating sockets steadily consume
-# it and the short-lived offloads — the connect handshake, every op, cursor
-# ping and checkpoint, for every session — end up queueing behind parked
-# drains. That reads as "the whole app froze," and can cause more disconnects
-# itself: a starved loop misses uvicorn's ping/pong window and heartbeats slip
-# past the presence grace period, expiring live editors. Splitting the pools
-# means the two can't compete — socket occupancy is bounded by
-# coedit_socket_pool_size, work concurrency by web_thread_pool_size.
-#
-# It stays a thread per socket only because the drain is a blocking
-# queue.Queue.get; an asyncio.Queue fed via call_soon_threadsafe would need
-# none, at the cost of reworking this module's close/wake handshake.
-_DRAIN_POOL = ThreadPoolExecutor(
-    max_workers=CONFIG.coedit_socket_pool_size, thread_name_prefix="coedit-drain"
-)
+# The send loop waits on this event rather than parking a thread in a blocking
+# queue read. A frame's publisher calls ``Connection.notify`` (see
+# ``coedit_channel``) from whatever thread it is on, which schedules the set
+# onto this loop — so no thread is held on a connection's behalf and there is
+# no per-connection ceiling on how many sockets a process can serve. It also
+# makes teardown ordinary asyncio: cancelling the send task interrupts an
+# ``Event.wait`` immediately, where a thread parked in ``queue.Queue.get`` had
+# no cancellation hook and needed a sentinel pushed into its own queue to come
+# back.
+def _make_notifier(loop: asyncio.AbstractEventLoop, ready: asyncio.Event) -> Callable[[], None]:
+    def notify() -> None:
+        try:
+            loop.call_soon_threadsafe(ready.set)
+        except RuntimeError:
+            # The loop is closing (process shutting down). The connection is
+            # going away with it, so an undelivered frame is moot.
+            pass
 
-# How often _send_loop's blocking drain call returns to check for
-# cancellation. Short on purpose: cancelling the awaiting coroutine doesn't
-# unblock the underlying OS thread, still parked in queue.Queue.get(timeout=...)
-# — found the hard way, in production, not just in theory. Every disconnect
-# cancels this task; with a long timeout the orphaned thread lingers for up to
-# that long, still holding a slot in _DRAIN_POOL. Under frequent reconnects
-# orphans would accumulate faster than they drain and exhaust it, at which
-# point new connections get no send loop at all. Bounding the poll to ~1s
-# bounds any orphan's worst case to ~1s instead of 15.
-_SEND_LOOP_POLL_SECONDS = 1.0
+    return notify
 
 
 async def _send_loop(
-    websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user_id: str
+    websocket: WebSocket, conn: coedit_channel.Connection, ready: asyncio.Event, session_id: int, user_id: str
 ) -> None:
     last_heartbeat = time.monotonic()
-    loop = asyncio.get_running_loop()
     while True:
-        frame = await loop.run_in_executor(
-            _DRAIN_POOL, coedit_channel.drain, conn.queue, _SEND_LOOP_POLL_SECONDS
-        )
-        if frame is coedit_channel.CLOSE_SIGNAL:
-            # ws()'s teardown path pushed this via coedit_channel.wake() right
-            # before cancelling this task — reachable here (not just via
-            # cancellation) because there's a real race between the two: this
-            # drain call may already have picked up the signal as an ordinary
-            # queue item before the asyncio-level cancellation is delivered.
-            # Either path ends the loop; this one just does it without
-            # waiting on a CancelledError that might arrive after the value
-            # already did.
-            return
-        now = time.monotonic()
-        if now - last_heartbeat >= _HEARTBEAT_SECONDS:
-            last_heartbeat = now
+        remaining = _HEARTBEAT_SECONDS - (time.monotonic() - last_heartbeat)
+        if remaining > 0:
+            try:
+                await asyncio.wait_for(ready.wait(), remaining)
+            except asyncio.TimeoutError:
+                pass
+        # Cleared *before* draining, so a frame published mid-drain re-sets it
+        # and the next pass picks that frame up. Clearing after could drop the
+        # wakeup for a frame already sitting in the queue.
+        ready.clear()
+        if time.monotonic() - last_heartbeat >= _HEARTBEAT_SECONDS:
+            last_heartbeat = time.monotonic()
             alive = await asyncio.to_thread(coedit.touch, session_id, user_id)
             if not alive:
                 return
             await websocket.send_json({"type": "ping"})
-        if frame is not None:
+        while (frame := coedit_channel.drain(conn.queue, 0)) is not None:
             await websocket.send_json(frame)
 
 
@@ -347,7 +331,10 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
     conn: coedit_channel.Connection | None = None
     try:
         await websocket.accept()
-        conn = coedit_channel.connect(sess.id)
+        ready = asyncio.Event()
+        conn = coedit_channel.connect(
+            sess.id, _make_notifier(asyncio.get_running_loop(), ready)
+        )
         participants = await asyncio.to_thread(_participants_out, sess.id)
         await websocket.send_json(
             JoinedFrame(
@@ -359,20 +346,11 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
             ).model_dump(by_alias=True)
         )
 
-        recv_task = asyncio.create_task(_recv_loop(websocket, conn.queue, sess.id, user))
-        send_task = asyncio.create_task(_send_loop(websocket, conn, sess.id, user.id))
+        recv_task = asyncio.create_task(_recv_loop(websocket, conn, sess.id, user))
+        send_task = asyncio.create_task(_send_loop(websocket, conn, ready, sess.id, user.id))
         done, pending = await asyncio.wait(
             {recv_task, send_task}, return_when=asyncio.FIRST_COMPLETED
         )
-        # Wake a still-blocked drain() *before* cancelling it: cancelling
-        # send_task only stops the asyncio Task watching the thread, not the
-        # already-dispatched OS thread itself — queue.Queue.get(timeout=...)
-        # has no cancellation hook, so without this it just keeps blocking,
-        # doing nothing, until its own timeout expires (see
-        # coedit_channel.wake's docstring). Pushing CLOSE_SIGNAL is what
-        # actually unblocks that thread immediately, same as a real frame
-        # arriving would.
-        coedit_channel.wake(conn.id)
         for t in pending:
             t.cancel()
         for t in done:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,9 +40,13 @@ class Config(BaseModel):
     opensearch_url: str
     opensearch_index: str
     max_queue_size: int
-    # Threads backing ``asyncio.to_thread`` in the web process. Sized for
-    # concurrent connections, not cores — see ``app/main.py``'s lifespan.
+    # Threads backing ``asyncio.to_thread`` in the web process — the
+    # short-lived offloads (DB, git) each request and WS message makes.
     web_thread_pool_size: int
+    # Threads backing the co-edit send loops, one held per open socket for
+    # its whole life. Deliberately a separate pool from the one above; see
+    # ``app/api/coedit.py``.
+    coedit_socket_pool_size: int
 
     auth_mode: str  # "basic" | "oidc"
     oidc_issuer: str
@@ -203,6 +207,7 @@ def load_config() -> Config:
         opensearch_index=os.environ.get("OPENSEARCH_INDEX", "wiki-docs"),
         max_queue_size=_positive_int("MAX_QUEUE_SIZE", 1000),
         web_thread_pool_size=_positive_int("WEB_THREAD_POOL_SIZE", 64),
+        coedit_socket_pool_size=_positive_int("COEDIT_SOCKET_POOL_SIZE", 256),
         ingest_bm25_min_score=_positive_float("INGEST_BM25_MIN_SCORE", 5.0),
         ingest_bm25_title_boost=_positive_float("INGEST_BM25_TITLE_BOOST", 2.0),
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -40,6 +40,9 @@ class Config(BaseModel):
     opensearch_url: str
     opensearch_index: str
     max_queue_size: int
+    # Threads backing ``asyncio.to_thread`` in the web process. Sized for
+    # concurrent connections, not cores — see ``app/main.py``'s lifespan.
+    web_thread_pool_size: int
 
     auth_mode: str  # "basic" | "oidc"
     oidc_issuer: str
@@ -199,6 +202,7 @@ def load_config() -> Config:
         opensearch_url=os.environ.get("OPENSEARCH_URL", "http://opensearch:9200"),
         opensearch_index=os.environ.get("OPENSEARCH_INDEX", "wiki-docs"),
         max_queue_size=_positive_int("MAX_QUEUE_SIZE", 1000),
+        web_thread_pool_size=_positive_int("WEB_THREAD_POOL_SIZE", 64),
         ingest_bm25_min_score=_positive_float("INGEST_BM25_MIN_SCORE", 5.0),
         ingest_bm25_title_boost=_positive_float("INGEST_BM25_TITLE_BOOST", 2.0),
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -43,10 +43,6 @@ class Config(BaseModel):
     # Threads backing ``asyncio.to_thread`` in the web process — the
     # short-lived offloads (DB, git) each request and WS message makes.
     web_thread_pool_size: int
-    # Threads backing the co-edit send loops, one held per open socket for
-    # its whole life. Deliberately a separate pool from the one above; see
-    # ``app/api/coedit.py``.
-    coedit_socket_pool_size: int
 
     auth_mode: str  # "basic" | "oidc"
     oidc_issuer: str
@@ -207,7 +203,6 @@ def load_config() -> Config:
         opensearch_index=os.environ.get("OPENSEARCH_INDEX", "wiki-docs"),
         max_queue_size=_positive_int("MAX_QUEUE_SIZE", 1000),
         web_thread_pool_size=_positive_int("WEB_THREAD_POOL_SIZE", 64),
-        coedit_socket_pool_size=_positive_int("COEDIT_SOCKET_POOL_SIZE", 256),
         ingest_bm25_min_score=_positive_float("INGEST_BM25_MIN_SCORE", 5.0),
         ingest_bm25_title_boost=_positive_float("INGEST_BM25_TITLE_BOOST", 2.0),
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -164,13 +164,13 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
         "agent-wiki backend starting (database=%s)", _app_config.CONFIG.database_url.split("@")[-1]
     )
     # ``asyncio.to_thread`` draws from the event loop's default executor, whose
-    # own default is ``min(32, cpu + 4)`` — 6 threads on a 2-core pod. Each
-    # co-edit WebSocket permanently occupies one of them: its send loop sits in a
-    # blocking queue drain (see ``app/api/coedit.py``), re-entered as soon as it
-    # returns. So the default caps a web process at roughly five concurrent
-    # sockets, and past that *every* offloaded call in the process — connects,
-    # ops, cursor pings, checkpoints, for every session — waits for a free
-    # thread. Size the pool for concurrent connections instead of cores.
+    # own default is ``min(32, cpu + 4)`` — 6 threads on a 2-core pod. That
+    # bounds how many short-lived offloads (DB reads, git calls) the process can
+    # run at once, across HTTP requests and WebSocket messages alike, so on a
+    # small pod it throttles ordinary concurrency for no reason: the work is
+    # I/O-bound, not CPU-bound. Long-lived occupancy is kept off this pool
+    # entirely — the co-edit send loops have their own (see
+    # ``app/api/coedit.py``) so accumulating sockets can't starve the work.
     asyncio.get_running_loop().set_default_executor(
         ThreadPoolExecutor(
             max_workers=_app_config.CONFIG.web_thread_pool_size,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,8 +12,10 @@ wiki setup.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import AsyncGenerator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
@@ -160,6 +162,20 @@ async def _lifespan(_app: FastAPI) -> AsyncGenerator[None, None]:
     setup_logging()
     log.info(
         "agent-wiki backend starting (database=%s)", _app_config.CONFIG.database_url.split("@")[-1]
+    )
+    # ``asyncio.to_thread`` draws from the event loop's default executor, whose
+    # own default is ``min(32, cpu + 4)`` — 6 threads on a 2-core pod. Each
+    # co-edit WebSocket permanently occupies one of them: its send loop sits in a
+    # blocking queue drain (see ``app/api/coedit.py``), re-entered as soon as it
+    # returns. So the default caps a web process at roughly five concurrent
+    # sockets, and past that *every* offloaded call in the process — connects,
+    # ops, cursor pings, checkpoints, for every session — waits for a free
+    # thread. Size the pool for concurrent connections instead of cores.
+    asyncio.get_running_loop().set_default_executor(
+        ThreadPoolExecutor(
+            max_workers=_app_config.CONFIG.web_thread_pool_size,
+            thread_name_prefix="web",
+        )
     )
     # Guard before init_db: a misconfigured prod must fail fast rather than
     # encrypt live data under the public default SECRET_KEY.

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -23,6 +23,7 @@ import logging
 import queue
 import threading
 import uuid
+from collections.abc import Callable
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
@@ -36,45 +37,56 @@ log = logging.getLogger(__name__)
 Frame = dict[str, Any]
 
 
-class _CloseSignal:
-    """Sentinel type for the one non-``Frame`` value a connection's queue can
-    carry. Distinct from ``None`` (which ``drain`` already uses to mean "the
-    poll timed out, nothing arrived") and from any real ``Frame`` (a plain
-    ``dict``, so nothing dict-shaped could ever collide with an ``is``
-    check against the singleton instance below)."""
-
-
-CLOSE_SIGNAL = _CloseSignal()
-QueueItem = Frame | _CloseSignal
-
-
 class Connection(BaseModel):
-    """Handle for one live connection: its opaque id (for ``disconnect``) and
-    the queue its send loop drains."""
+    """Handle for one live connection: its opaque id (for ``disconnect``), the
+    queue frames land in, and the callback that tells its send loop to drain.
+
+    ``notify`` is invoked after every enqueue, from whichever thread published
+    the frame — a request handler, the bus listener, a task worker. The send
+    loop supplies one that is safe to call from any thread (see
+    ``app/api/coedit.py``); it exists so a connection can be woken without any
+    thread blocking on its behalf.
+    """
 
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
 
     id: str
-    queue: queue.Queue[QueueItem]
+    queue: queue.Queue[Frame]
+    notify: Callable[[], None]
+
+    def post(self, frame: Frame) -> None:
+        """Queue ``frame`` for this connection and wake its send loop.
+
+        The only way to enqueue: a bare ``queue.put_nowait`` would land the
+        frame but leave the loop asleep until its next heartbeat.
+        """
+        self.queue.put_nowait(frame)
+        self.notify()
+
 
 # Per-connection registry, keyed by an opaque connection id (one per open
 # WebSocket). Parallel dicts rather than a class, mirroring ``pubsub``'s sync
 # ``_queues`` style for the same runtime state.
-_queues: dict[str, queue.Queue[QueueItem]] = {}
+_queues: dict[str, queue.Queue[Frame]] = {}
+_notifiers: dict[str, Callable[[], None]] = {}  # conn_id -> wake its send loop
 _session_of: dict[str, int] = {}  # conn_id -> coedit_session_id
 _conns_by_session: dict[int, set[str]] = {}  # coedit_session_id -> {conn_id}
 _lock = threading.Lock()
 
 
-def connect(coedit_session_id: int) -> Connection:
-    """Register a local delivery queue for a WebSocket."""
+def connect(coedit_session_id: int, notify: Callable[[], None]) -> Connection:
+    """Register a local delivery queue for a WebSocket.
+
+    ``notify`` is called once per delivered frame; see ``Connection``.
+    """
     conn_id = uuid.uuid4().hex
-    q: queue.Queue[QueueItem] = queue.Queue()
+    q: queue.Queue[Frame] = queue.Queue()
     with _lock:
         _queues[conn_id] = q
+        _notifiers[conn_id] = notify
         _session_of[conn_id] = coedit_session_id
         _conns_by_session.setdefault(coedit_session_id, set()).add(conn_id)
-    return Connection(id=conn_id, queue=q)
+    return Connection(id=conn_id, queue=q, notify=notify)
 
 
 def disconnect(conn_id: str) -> None:
@@ -82,6 +94,7 @@ def disconnect(conn_id: str) -> None:
     with _lock:
         sid = _session_of.pop(conn_id, None)
         _queues.pop(conn_id, None)
+        _notifiers.pop(conn_id, None)
         if sid is not None:
             conns = _conns_by_session.get(sid)
             if conns is not None:
@@ -89,36 +102,13 @@ def disconnect(conn_id: str) -> None:
                 if not conns:
                     _conns_by_session.pop(sid, None)
 
-def drain(q: queue.Queue[QueueItem], timeout: float) -> QueueItem | None:
-    """Block up to ``timeout`` seconds for the next frame; ``None`` on timeout so
-    the caller can emit a heartbeat. Can also return ``CLOSE_SIGNAL`` — see
-    ``wake``."""
+def drain(q: queue.Queue[Frame], timeout: float) -> Frame | None:
+    """Pop the next frame, waiting up to ``timeout`` seconds; ``None`` if none
+    arrived. ``timeout=0`` polls without blocking."""
     try:
         return q.get(timeout=timeout)
     except queue.Empty:
         return None
-
-
-def wake(conn_id: str) -> None:
-    """Unblock a connection's own ``drain`` call immediately, instead of
-    leaving it to run out its poll timeout.
-
-    ``queue.Queue.get(timeout=...)`` has no cancellation hook — a task
-    awaiting it via ``asyncio.to_thread`` can be cancelled at the asyncio
-    level, but the underlying OS thread has no way to know that and keeps
-    blocking regardless, for up to the full timeout, occupying a thread-pool
-    slot the whole time (confirmed directly: cancelling the wrapping Future
-    doesn't stop the executor's function, it only makes the *awaiter* stop
-    watching it — see ``loop.run_in_executor``'s documented behavior). This
-    reaches the blocked call the only way that's actually possible: pushing
-    something into the same queue it's already waiting on, so ``get()``
-    returns immediately the normal way, on its own thread, same as a real
-    frame arriving. The caller (``app/api/coedit.py``'s teardown path) must
-    call this whenever it's about to cancel a connection's send loop."""
-    with _lock:
-        q = _queues.get(conn_id)
-    if q is not None:
-        q.put_nowait(CLOSE_SIGNAL)
 
 
 def _bus_payload(coedit_session_id: int, frame: Frame) -> dict[str, Any]:
@@ -232,20 +222,25 @@ def broadcast_op(
 
 
 def _deliver_local(coedit_session_id: int, frame: Frame) -> None:
-    # ``queue.Queue`` is thread-safe, so a plain ``put_nowait`` works from any
-    # thread (the LISTEN listener, a request handler) — no event loop, no
-    # cross-thread scheduling dance.
+    # ``queue.Queue`` is thread-safe, so the put works from any thread (the
+    # LISTEN listener, a request handler, a task worker). Waking the send loop
+    # is the part that needs care, which is what ``notify`` encapsulates —
+    # called outside the lock, since it hands off to another thread.
     with _lock:
         targets = [
-            _queues.get(cid) for cid in _conns_by_session.get(coedit_session_id, ())
+            (_queues.get(cid), _notifiers.get(cid))
+            for cid in _conns_by_session.get(coedit_session_id, ())
         ]
-    for q in targets:
-        if q is not None:
-            q.put_nowait(frame)
+    for q, notify in targets:
+        if q is None or notify is None:
+            continue
+        q.put_nowait(frame)
+        notify()
 
 
 def reset_for_tests() -> None:
     with _lock:
         _queues.clear()
+        _notifiers.clear()
         _session_of.clear()
         _conns_by_session.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -283,6 +283,7 @@ def tmp_config(tmp_path, monkeypatch, _template_db):
         opensearch_index=f"wiki-docs-test-{dbname}",  # isolated per test
         max_queue_size=1000,
         web_thread_pool_size=64,
+        coedit_socket_pool_size=64,
         auth_mode="basic",
         oidc_issuer="",
         oidc_client_id="",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -282,6 +282,7 @@ def tmp_config(tmp_path, monkeypatch, _template_db):
         opensearch_url=_TEST_OPENSEARCH_URL,
         opensearch_index=f"wiki-docs-test-{dbname}",  # isolated per test
         max_queue_size=1000,
+        web_thread_pool_size=64,
         auth_mode="basic",
         oidc_issuer="",
         oidc_client_id="",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -283,7 +283,6 @@ def tmp_config(tmp_path, monkeypatch, _template_db):
         opensearch_index=f"wiki-docs-test-{dbname}",  # isolated per test
         max_queue_size=1000,
         web_thread_pool_size=64,
-        coedit_socket_pool_size=64,
         auth_mode="basic",
         oidc_issuer="",
         oidc_client_id="",

--- a/backend/tests/test_coedit_channel.py
+++ b/backend/tests/test_coedit_channel.py
@@ -1,25 +1,38 @@
 """Co-edit live channel (app/wiki/coedit_channel.py) — the in-memory
 connection registry, fan-out, and the cross-process ``handle_remote`` path.
 
-Synchronous (thread-per-connection + ``queue.Queue``), so the tests are plain
-puts and gets — no event loop.
+A frame lands in a plain ``queue.Queue`` and the connection's ``notify``
+callback wakes whoever drains it, so these are synchronous puts and gets — no
+event loop. ``_woken`` counts the wakeups, since a delivered-but-unannounced
+frame would sit in the queue until its reader next happened to look.
 """
 from __future__ import annotations
 
 from app.wiki import coedit, coedit_channel
 
 
+def _connect(session_id: int) -> coedit_channel.Connection:
+    return coedit_channel.connect(session_id, lambda: None)
+
+
+def _connect_watched(session_id: int) -> tuple[coedit_channel.Connection, list[int]]:
+    """A registered connection plus the list its notifier appends to."""
+    woken: list[int] = []
+    return coedit_channel.connect(session_id, lambda: woken.append(1)), woken
+
+
 def test_connect_publish_delivers_to_connection():
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(1)
+    conn, conn_woken = _connect_watched(1)
     coedit_channel._deliver_local(1, {"type": "presence", "n": 1})
     assert coedit_channel.drain(conn.queue, 0.5) == {"type": "presence", "n": 1}
+    assert conn_woken == [1]  # delivery woke the reader
 
 
 def test_fan_out_to_all_connections_in_session():
     coedit_channel.reset_for_tests()
-    a = coedit_channel.connect(7)
-    b = coedit_channel.connect(7)
+    a = _connect(7)
+    b = _connect(7)
     coedit_channel._deliver_local(7, {"hello": "world"})
     assert coedit_channel.drain(a.queue, 0.5) == {"hello": "world"}
     assert coedit_channel.drain(b.queue, 0.5) == {"hello": "world"}
@@ -27,17 +40,19 @@ def test_fan_out_to_all_connections_in_session():
 
 def test_other_session_does_not_receive():
     coedit_channel.reset_for_tests()
-    a = coedit_channel.connect(1)
+    a, a_woken = _connect_watched(1)
     coedit_channel._deliver_local(2, {"to": "other"})
     assert coedit_channel.drain(a.queue, 0.1) is None  # timed out — nothing delivered
+    assert a_woken == []
 
 
 def test_disconnect_stops_delivery_and_clears_state():
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(3)
+    conn, conn_woken = _connect_watched(3)
     coedit_channel.disconnect(conn.id)
     coedit_channel._deliver_local(3, {"x": 1})
     assert coedit_channel.drain(conn.queue, 0.1) is None
+    assert conn_woken == []  # a torn-down connection is never woken
 
 
 def _change(frm: int, to: int, insert: str) -> coedit.Change:
@@ -46,7 +61,7 @@ def _change(frm: int, to: int, insert: str) -> coedit.Change:
 
 def test_broadcast_op_delivers_op_frame():
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(4)
+    conn = _connect(4)
     coedit_channel.broadcast_op(4, 3, [_change(0, 1, "x")], "usr_a", client_id="cli_1")
     frame = coedit_channel.drain(conn.queue, 0.5)
     assert frame == {
@@ -62,7 +77,7 @@ def test_broadcast_op_delivers_op_frame():
 
 def test_broadcast_op_oversized_falls_back_to_resync():
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(4)
+    conn = _connect(4)
     big = "z" * 8000  # payload exceeds the NOTIFY cap → resync signal instead
     coedit_channel.broadcast_op(4, 5, [_change(0, 0, big)], "usr_a")
     frame = coedit_channel.drain(conn.queue, 0.5)
@@ -71,8 +86,8 @@ def test_broadcast_op_oversized_falls_back_to_resync():
 
 def test_broadcast_cursor_delivers_selection_frame_to_peers():
     coedit_channel.reset_for_tests()
-    a = coedit_channel.connect(6)
-    b = coedit_channel.connect(6)  # a peer in the same session
+    a = _connect(6)
+    b = _connect(6)  # a peer in the same session
     coedit_channel.broadcast_cursor(
         6, user_id="usr_a", user_display="Ada", anchor=3, head=10, typing=True, seq=7
     )
@@ -95,7 +110,7 @@ def test_broadcast_cursor_cleared_delivers_null_positions():
     # A cleared caret (editor blur / tab hidden) rides the same frame with
     # null anchor/head — peers drop the caret on it.
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(6)
+    conn = _connect(6)
     coedit_channel.broadcast_cursor(
         6,
         user_id="usr_a",
@@ -119,7 +134,7 @@ def test_broadcast_cursor_cleared_delivers_null_positions():
 
 def test_handle_remote_delivers_locally():
     coedit_channel.reset_for_tests()
-    conn = coedit_channel.connect(9)
+    conn = _connect(9)
     coedit_channel.handle_remote(
         {"coedit_session_id": 9, "frame": {"type": "presence", "via": "notify"}}
     )


### PR DESCRIPTION
Third of the co-edit fixes, after #551 and #552. Independent of both.

## The problem

`asyncio.to_thread` uses the event loop's **default executor**, whose default size is `min(32, cpu + 4)`. Measured in the running pod: `cpu_count` is 2, so **6 threads**.

A co-edit WebSocket occupies one of those for its entire life. `_send_loop` blocks in `coedit_channel.drain` (a `queue.Queue.get(timeout=1.0)`) and re-enters it the moment it returns, so at steady state one thread per open socket is parked. That leaves a web process able to hold roughly five concurrent editors; beyond that every offloaded call in the process — the connect handshake, every op, cursor ping and checkpoint, for every session — queues behind a free thread.

Worth noting the old SSE transport didn't have this ceiling: Starlette runs sync routes through anyio's thread limiter, which defaults to **40** tokens. Verified both numbers in the pod:

```
anyio default thread limiter (sync routes): 40
asyncio default executor (to_thread):       6
```

The module comment on `_SEND_LOOP_POLL_SECONDS` already describes what saturation looks like — "reads as 'the whole app froze'… a self-reinforcing spiral" — and notes it was hit in production.

## The fix

Install an explicit executor in the lifespan, sized by a new `WEB_THREAD_POOL_SIZE` (default 64). This is a connection ceiling, not a CPU knob, which is why it isn't derived from core count.

## Measured

Same backend, same probe, only the knob changed — N sockets open, then time an op on the last one:

| `WEB_THREAD_POOL_SIZE` | sockets | op latency |
|---|---|---|
| 6 (the old default) | 10 | 1.02 s |
| 6 | 20 | 3.02 s |
| 64 | 20 | 0.01 s |
| 64 | 40 | 0.01 s |

The stalls land on whole multiples of the 1 s drain poll, which is the queueing behind parked drain threads.

## Follow-up, deliberately not here

The structural fix is for the send loop to stop occupying a thread at all: an `asyncio.Queue` fed from `_deliver_local` via `call_soon_threadsafe`, instead of a `queue.Queue` drained in a thread. That removes the per-connection thread entirely, but it reworks the `CLOSE_SIGNAL` / `wake` handshake that carries a fair amount of hard-won reasoning, so it doesn't belong in the same change as raising the ceiling.

## Testing

2056 passed, 2 skipped. `conftest.py`'s `Config(...)` needed the new field. ruff and basedpyright clean.
