### PR TITLE
feat(coedit): get_session — the catch-up a resync actually needs

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -23,6 +23,13 @@ vs viewers client-side from the live caret frames — a rendered caret IS the
 Participants leave after their shared heartbeat expires. A disconnect never
 deletes shared presence based on one process's local socket registry — it
 only commits the buffer, which needs no liveness information.
+
+Two catch-up reads, for the two ways a client can fall behind. ``get_ops``
+replays the op log after a missed frame or a stale-version reject, preserving
+the client's unconfirmed edits. ``get_session`` re-reads the whole buffer, for
+a ``resync`` — the buffer was *replaced* by a git commit folded into the
+session (a checkpoint merge, an inbound agent edit), which logs no op and so
+cannot be replayed.
 """
 
 from __future__ import annotations
@@ -43,12 +50,14 @@ from app.models.coedit import (
     CheckpointResultFrame,
     CursorMessage,
     GetOpsMessage,
+    GetSessionMessage,
     JoinedFrame,
     OpMessage,
     Operation,
     OpResultFrame,
     OpsResultFrame,
     ParticipantOut,
+    SessionResultFrame,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session
 from app.wiki import coedit, coedit_channel, git
@@ -123,11 +132,30 @@ def _handle_op(conn: coedit_channel.Connection, session_id: int, user: User, raw
         conn.post(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(by_alias=True))
         return
     except ValueError:
+        # Out of bounds for the current buffer, which means the sender's
+        # document has diverged from the server's — worth a log line, since the
+        # client sees only an error code and this is the shape a desync takes.
+        log.warning(
+            "coedit: invalid op on session %s from user %s (base_version=%s, changes=%s)",
+            session_id,
+            user.id,
+            msg.base_version,
+            [c.model_dump(by_alias=True) for c in msg.changes],
+        )
         conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump(by_alias=True)
         )
         return
     if out is None:
+        # Expected under concurrent editing: the client rebases and retries.
+        # Logged at debug so a storm of them is visible when investigating
+        # without adding noise in steady state.
+        log.debug(
+            "coedit: stale op on session %s from user %s (base_version=%s)",
+            session_id,
+            user.id,
+            msg.base_version,
+        )
         conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="stale_version").model_dump(by_alias=True)
         )
@@ -220,6 +248,32 @@ def _handle_get_ops(conn: coedit_channel.Connection, session_id: int, user: User
     )
 
 
+def _handle_get_session(conn: coedit_channel.Connection, session_id: int, user: User, raw: dict[str, Any]) -> None:
+    """Serve the live buffer at its current version — the catch-up for a
+    ``resync``, which ``get_ops`` structurally cannot answer: the replacement
+    it announces is a git commit folded into the buffer, so it appends no
+    ``coedit_ops`` row for the client to replay."""
+    msg = GetSessionMessage.model_validate(raw)
+    try:
+        sess = _require_active(session_id, user, "read")
+    except _WsActionError as e:
+        conn.post(
+            SessionResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(
+                by_alias=True
+            )
+        )
+        return
+    conn.post(
+        SessionResultFrame(
+            request_id=msg.request_id,
+            ok=True,
+            buffer=sess.buffer_text,
+            version=sess.version,
+            base_sha=sess.base_sha,
+        ).model_dump(by_alias=True)
+    )
+
+
 async def _recv_loop(websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user: User) -> None:
     while True:
         raw = await websocket.receive_json()
@@ -237,6 +291,8 @@ async def _recv_loop(websocket: WebSocket, conn: coedit_channel.Connection, sess
                 await asyncio.to_thread(_handle_cursor, session_id, user, raw)
             elif msg_type == "checkpoint":
                 await asyncio.to_thread(_handle_checkpoint, conn, session_id, user, raw)
+            elif msg_type == "get_session":
+                await asyncio.to_thread(_handle_get_session, conn, session_id, user, raw)
             elif msg_type == "get_ops":
                 await asyncio.to_thread(_handle_get_ops, conn, session_id, user, raw)
             else:

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -135,12 +135,14 @@ def _handle_op(conn: coedit_channel.Connection, session_id: int, user: User, raw
         # Out of bounds for the current buffer, which means the sender's
         # document has diverged from the server's — worth a log line, since the
         # client sees only an error code and this is the shape a desync takes.
+        # Offsets and insert *lengths* only: the insert itself is page content,
+        # which has no business in production logs.
         log.warning(
             "coedit: invalid op on session %s from user %s (base_version=%s, changes=%s)",
             session_id,
             user.id,
             msg.base_version,
-            [c.model_dump(by_alias=True) for c in msg.changes],
+            [{"from": c.from_, "to": c.to, "insert_len": len(c.insert)} for c in msg.changes],
         )
         conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump(by_alias=True)

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -85,6 +85,21 @@ class GetOpsMessage(BaseModel):
     since_version: int
 
 
+class GetSessionMessage(BaseModel):
+    """Client -> server ``{"type": "get_session", ...}`` — re-read the live
+    buffer at its current version.
+
+    The catch-up call for a ``resync`` frame, which announces that the buffer
+    was *replaced* out of band (a checkpoint's merge folded in a committed
+    change, or an inbound agent commit was rebased in). Such a replacement is
+    a git commit, not a co-edit op, so it appends no ``coedit_ops`` row and
+    ``get_ops`` cannot express it — a client that only replayed ops would
+    silently keep the pre-merge document.
+    """
+
+    request_id: str
+
+
 class ParticipantOut(BaseModel):
     user_id: str
     user_display: str
@@ -119,6 +134,20 @@ class Operation(BaseModel):
     author: str  # author_user_id
     client_id: str | None  # originating connection (collab); None for non-collab ops
     changes: list[Change]
+
+
+class SessionResultFrame(BaseModel):
+    """Server -> client reply to a ``GetSessionMessage``, correlated by
+    ``request_id``. The whole buffer and the version it is current as of, so
+    the caller can reset its document and its collab baseline together."""
+
+    type: str = "session_result"
+    request_id: str
+    ok: bool = True
+    error: str | None = None  # "no_active_session" | "forbidden"
+    buffer: str = ""
+    version: int = 0
+    base_sha: str | None = None
 
 
 class OpsResultFrame(BaseModel):

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -84,6 +84,11 @@ def _get_ops(ws, since_version: int) -> dict:
     return _receive_typed(ws, "ops_result")
 
 
+def _get_session(ws) -> dict:
+    ws.send_json({"type": "get_session", "request_id": "s"})
+    return _receive_typed(ws, "session_result")
+
+
 def _wait_for(predicate, timeout: float = 15.0) -> None:
     """Wait for a disconnect side effect. The server's disconnect handler is
     the leave signal, and nothing guarantees it has finished by the time
@@ -266,6 +271,72 @@ def test_checkpoint_message_commits_buffer(client):
 
     assert git.read_file(_PATH) == "hi world"
     assert sid is not None
+
+
+def test_get_session_returns_the_live_buffer(client):
+    # The catch-up a `resync` frame calls for: a buffer replacement is a git
+    # commit folded into the session, so it appends no op and `get_ops` has
+    # nothing to hand back. Only a whole-buffer read can express it.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    sha = _seed_page("hello world")
+
+    with _ws(client) as (ws, joined):
+        sid = joined["session_id"]
+        _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
+        # Replace the buffer the way a checkpoint's merge does — no op logged.
+        merged = "hi world (merged)"
+        assert (
+            coedit.rebase_onto(
+                sid, base_version=1, merged_text=merged, new_base_sha=sha, checkpointed=False
+            )
+            is not None
+        )
+
+        result = _get_session(ws)
+        assert result["ok"] is True
+        assert result["buffer"] == merged
+        assert result["version"] == 2
+        assert result["base_sha"] == sha
+        # The replacement really is invisible to the op log.
+        assert _get_ops(ws, 1)["ops"] == []
+
+
+def test_get_session_on_closed_session_reports_terminal_error(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page("hello world")
+
+    with _ws(client) as (ws, joined):
+        coedit.close_session(joined["session_id"])
+        result = _get_session(ws)
+        assert result["ok"] is False
+        assert result["error"] == "no_active_session"
+
+
+def test_get_session_requires_read(client):
+    # Read-gated like get_ops: the whole buffer is the payload, so losing read
+    # mid-session must stop serving it.
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    reader = users_repo.create(email="reader@x.com", password="hunter2-x", name="Reader")
+    _seed_page("secret")
+    acl.set_owner(_PATH, owner)  # owner-only page...
+    entry = acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=reader,
+        permission="read",
+        granted_by_user_id=owner,
+    )  # ...plus an explicit read grant, revoked below
+
+    login_fastapi(client, reader)
+    with _ws(client) as (ws, _joined):
+        assert _get_session(ws)["ok"] is True
+        acl.revoke(entry)
+        result = _get_session(ws)
+        assert result["ok"] is False
+        assert result["error"] == "forbidden"
 
 
 def test_checkpoint_requires_write(client):


### PR DESCRIPTION
Backend half of the last co-edit correctness item, after #551, #552 and #553. Frontend stacked on top.

## The gap

`resync` tells participants the buffer was **replaced** out of band — a checkpoint's merge folded in a committed change, or an inbound agent commit was rebased into the session. `rebase_onto` writes no `coedit_ops` row (deliberately: it isn't a co-edit op), and `get_ops` is the only read the WS protocol offers.

So a client handling a resync calls `get_ops`, receives an empty list, and keeps its pre-merge document — permanently. From then on its ops are anchored against text the server doesn't have, and `apply_op` only bounds-checks, so they splice in at the wrong offsets. That's the "different people see different things" half of the original report, and the mechanism behind the production commit that left `# Bugsemove active agent bar from top of wiki doc` with a stray `- [ ] r`.

The gap predates the WebSocket migration: the old transport had `GET /coedit/session`, but `svc.ts` never called it on resync either.

## The change

`get_session` returns the buffer plus the version it is current as of, so a caller can reset its document and its collab baseline together. Read-gated and `request_id`-correlated like the other request frames.

The two catch-up reads now cover the two ways a client falls behind, which the module docstring spells out:

- `get_ops` — a missed frame or a stale-version reject. Replays the op log, preserving unconfirmed local edits.
- `get_session` — a resync. Re-reads the buffer, because there is no op to replay.

## Also here

The two rejections that were silent are now logged: `invalid_op` at warning with the offending offsets (it means the sender's document has diverged — the shape a desync takes), and `stale_version` at debug (ordinary under concurrent editing, but a storm of them should be visible). Their absence is why none of this appeared in the logs while it was happening.

## Tests

- `test_get_session_returns_the_live_buffer` — replaces the buffer through `rebase_onto` the way a checkpoint merge does, then asserts `get_session` returns the merged text at the bumped version **and** that `get_ops` returns `[]` for the same interval. That second assertion is the point: it pins down why this endpoint has to exist.
- `test_get_session_on_closed_session_reports_terminal_error` — `no_active_session` rather than a hanging promise.
- `test_get_session_requires_read` — succeeds, then the read grant is revoked mid-session and it returns `forbidden`.

2059 passed, 2 skipped; ruff and basedpyright clean.

## Next

The frontend change consumes this: on `resync`, fetch the session and reset the editor's document and collab version instead of calling `pull()`. There's a design call to make there — unconfirmed local edits can't be rebased across an out-of-band replacement, so they're either dropped or flushed first — which is worth deciding explicitly rather than in passing.
