### PR TITLE
fix(coedit): resync — re-read the buffer the op log can't replay

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -23,6 +23,13 @@ vs viewers client-side from the live caret frames — a rendered caret IS the
 Participants leave after their shared heartbeat expires. A disconnect never
 deletes shared presence based on one process's local socket registry — it
 only commits the buffer, which needs no liveness information.
+
+Two catch-up reads, for the two ways a client can fall behind. ``get_ops``
+replays the op log after a missed frame or a stale-version reject, preserving
+the client's unconfirmed edits. ``get_session`` re-reads the whole buffer, for
+a ``resync`` — the buffer was *replaced* by a git commit folded into the
+session (a checkpoint merge, an inbound agent edit), which logs no op and so
+cannot be replayed.
 """
 
 from __future__ import annotations
@@ -43,12 +50,14 @@ from app.models.coedit import (
     CheckpointResultFrame,
     CursorMessage,
     GetOpsMessage,
+    GetSessionMessage,
     JoinedFrame,
     OpMessage,
     Operation,
     OpResultFrame,
     OpsResultFrame,
     ParticipantOut,
+    SessionResultFrame,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session
 from app.wiki import coedit, coedit_channel, git
@@ -123,11 +132,30 @@ def _handle_op(conn: coedit_channel.Connection, session_id: int, user: User, raw
         conn.post(OpResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(by_alias=True))
         return
     except ValueError:
+        # Out of bounds for the current buffer, which means the sender's
+        # document has diverged from the server's — worth a log line, since the
+        # client sees only an error code and this is the shape a desync takes.
+        log.warning(
+            "coedit: invalid op on session %s from user %s (base_version=%s, changes=%s)",
+            session_id,
+            user.id,
+            msg.base_version,
+            [c.model_dump(by_alias=True) for c in msg.changes],
+        )
         conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump(by_alias=True)
         )
         return
     if out is None:
+        # Expected under concurrent editing: the client rebases and retries.
+        # Logged at debug so a storm of them is visible when investigating
+        # without adding noise in steady state.
+        log.debug(
+            "coedit: stale op on session %s from user %s (base_version=%s)",
+            session_id,
+            user.id,
+            msg.base_version,
+        )
         conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="stale_version").model_dump(by_alias=True)
         )
@@ -220,6 +248,32 @@ def _handle_get_ops(conn: coedit_channel.Connection, session_id: int, user: User
     )
 
 
+def _handle_get_session(conn: coedit_channel.Connection, session_id: int, user: User, raw: dict[str, Any]) -> None:
+    """Serve the live buffer at its current version — the catch-up for a
+    ``resync``, which ``get_ops`` structurally cannot answer: the replacement
+    it announces is a git commit folded into the buffer, so it appends no
+    ``coedit_ops`` row for the client to replay."""
+    msg = GetSessionMessage.model_validate(raw)
+    try:
+        sess = _require_active(session_id, user, "read")
+    except _WsActionError as e:
+        conn.post(
+            SessionResultFrame(request_id=msg.request_id, ok=False, error=e.error).model_dump(
+                by_alias=True
+            )
+        )
+        return
+    conn.post(
+        SessionResultFrame(
+            request_id=msg.request_id,
+            ok=True,
+            buffer=sess.buffer_text,
+            version=sess.version,
+            base_sha=sess.base_sha,
+        ).model_dump(by_alias=True)
+    )
+
+
 async def _recv_loop(websocket: WebSocket, conn: coedit_channel.Connection, session_id: int, user: User) -> None:
     while True:
         raw = await websocket.receive_json()
@@ -237,6 +291,8 @@ async def _recv_loop(websocket: WebSocket, conn: coedit_channel.Connection, sess
                 await asyncio.to_thread(_handle_cursor, session_id, user, raw)
             elif msg_type == "checkpoint":
                 await asyncio.to_thread(_handle_checkpoint, conn, session_id, user, raw)
+            elif msg_type == "get_session":
+                await asyncio.to_thread(_handle_get_session, conn, session_id, user, raw)
             elif msg_type == "get_ops":
                 await asyncio.to_thread(_handle_get_ops, conn, session_id, user, raw)
             else:

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -135,12 +135,14 @@ def _handle_op(conn: coedit_channel.Connection, session_id: int, user: User, raw
         # Out of bounds for the current buffer, which means the sender's
         # document has diverged from the server's — worth a log line, since the
         # client sees only an error code and this is the shape a desync takes.
+        # Offsets and insert *lengths* only: the insert itself is page content,
+        # which has no business in production logs.
         log.warning(
             "coedit: invalid op on session %s from user %s (base_version=%s, changes=%s)",
             session_id,
             user.id,
             msg.base_version,
-            [c.model_dump(by_alias=True) for c in msg.changes],
+            [{"from": c.from_, "to": c.to, "insert_len": len(c.insert)} for c in msg.changes],
         )
         conn.post(
             OpResultFrame(request_id=msg.request_id, ok=False, error="invalid_op").model_dump(by_alias=True)

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -85,6 +85,21 @@ class GetOpsMessage(BaseModel):
     since_version: int
 
 
+class GetSessionMessage(BaseModel):
+    """Client -> server ``{"type": "get_session", ...}`` — re-read the live
+    buffer at its current version.
+
+    The catch-up call for a ``resync`` frame, which announces that the buffer
+    was *replaced* out of band (a checkpoint's merge folded in a committed
+    change, or an inbound agent commit was rebased in). Such a replacement is
+    a git commit, not a co-edit op, so it appends no ``coedit_ops`` row and
+    ``get_ops`` cannot express it — a client that only replayed ops would
+    silently keep the pre-merge document.
+    """
+
+    request_id: str
+
+
 class ParticipantOut(BaseModel):
     user_id: str
     user_display: str
@@ -119,6 +134,20 @@ class Operation(BaseModel):
     author: str  # author_user_id
     client_id: str | None  # originating connection (collab); None for non-collab ops
     changes: list[Change]
+
+
+class SessionResultFrame(BaseModel):
+    """Server -> client reply to a ``GetSessionMessage``, correlated by
+    ``request_id``. The whole buffer and the version it is current as of, so
+    the caller can reset its document and its collab baseline together."""
+
+    type: str = "session_result"
+    request_id: str
+    ok: bool = True
+    error: str | None = None  # "no_active_session" | "forbidden"
+    buffer: str = ""
+    version: int = 0
+    base_sha: str | None = None
 
 
 class OpsResultFrame(BaseModel):

--- a/backend/tests/test_coedit_api.py
+++ b/backend/tests/test_coedit_api.py
@@ -84,6 +84,11 @@ def _get_ops(ws, since_version: int) -> dict:
     return _receive_typed(ws, "ops_result")
 
 
+def _get_session(ws) -> dict:
+    ws.send_json({"type": "get_session", "request_id": "s"})
+    return _receive_typed(ws, "session_result")
+
+
 def _wait_for(predicate, timeout: float = 15.0) -> None:
     """Wait for a disconnect side effect. The server's disconnect handler is
     the leave signal, and nothing guarantees it has finished by the time
@@ -266,6 +271,72 @@ def test_checkpoint_message_commits_buffer(client):
 
     assert git.read_file(_PATH) == "hi world"
     assert sid is not None
+
+
+def test_get_session_returns_the_live_buffer(client):
+    # The catch-up a `resync` frame calls for: a buffer replacement is a git
+    # commit folded into the session, so it appends no op and `get_ops` has
+    # nothing to hand back. Only a whole-buffer read can express it.
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    sha = _seed_page("hello world")
+
+    with _ws(client) as (ws, joined):
+        sid = joined["session_id"]
+        _apply_op(ws, 0, [{"from": 0, "to": 5, "insert": "hi"}])
+        # Replace the buffer the way a checkpoint's merge does — no op logged.
+        merged = "hi world (merged)"
+        assert (
+            coedit.rebase_onto(
+                sid, base_version=1, merged_text=merged, new_base_sha=sha, checkpointed=False
+            )
+            is not None
+        )
+
+        result = _get_session(ws)
+        assert result["ok"] is True
+        assert result["buffer"] == merged
+        assert result["version"] == 2
+        assert result["base_sha"] == sha
+        # The replacement really is invisible to the op log.
+        assert _get_ops(ws, 1)["ops"] == []
+
+
+def test_get_session_on_closed_session_reports_terminal_error(client):
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    _seed_page("hello world")
+
+    with _ws(client) as (ws, joined):
+        coedit.close_session(joined["session_id"])
+        result = _get_session(ws)
+        assert result["ok"] is False
+        assert result["error"] == "no_active_session"
+
+
+def test_get_session_requires_read(client):
+    # Read-gated like get_ops: the whole buffer is the payload, so losing read
+    # mid-session must stop serving it.
+    owner = users_repo.create(email="owner@x.com", password="hunter2-x", name="Owner")
+    reader = users_repo.create(email="reader@x.com", password="hunter2-x", name="Reader")
+    _seed_page("secret")
+    acl.set_owner(_PATH, owner)  # owner-only page...
+    entry = acl.grant(
+        resource_kind="page",
+        resource_path=_PATH,
+        principal_kind="user",
+        principal_id=reader,
+        permission="read",
+        granted_by_user_id=owner,
+    )  # ...plus an explicit read grant, revoked below
+
+    login_fastapi(client, reader)
+    with _ws(client) as (ws, _joined):
+        assert _get_session(ws)["ok"] is True
+        acl.revoke(entry)
+        result = _get_session(ws)
+        assert result["ok"] is False
+        assert result["error"] == "forbidden"
 
 
 def test_checkpoint_requires_write(client):

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -619,13 +619,12 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         }
       };
 
-      // The document at `getSyncedVersion()`. Maintained here because it is not
-      // recoverable from the current state: inverting the un-acked ChangeSets
-      // would need the very document they were applied to. `applyServerBuffer`
-      // needs it as the base to diff against, and every confirmation must go
-      // through `confirmUpdates` to keep it true — a path that bypasses it
-      // computes the diff against the wrong base and lands edits in the wrong
-      // place, which is the bug class this whole change exists to close.
+      // The document at `getSyncedVersion()` — the base `applyServerBuffer`
+      // diffs against. Tracked because it is not recoverable from the current
+      // state (inverting the un-acked ChangeSets would need the very document
+      // they were applied to). Invariant: every confirmation goes through
+      // `confirmUpdates`; a path that bypasses it diffs against the wrong
+      // base and anchors edits at the wrong offsets.
       const syncedDoc = { current: Text.of(session.startDoc.split("\n")) };
 
       const confirmUpdates = (

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -15,6 +15,7 @@ import {
   EditorState,
   StateEffect,
   StateField,
+  Text,
 } from "@codemirror/state";
 import {
   Decoration,
@@ -32,11 +33,12 @@ import type {
   CoeditPeer,
   CoeditSessionHandle,
 } from "@/lib/editor/types";
-import { getOps, sendOp } from "@/lib/editor/svc";
+import { getOps, getSession, sendOp } from "@/lib/editor/svc";
 import { IDLE_UNFOCUS_MS } from "@/lib/editor/constants";
 import {
   changeSetToChanges,
   colorFor,
+  diffToChange,
   syncedDocLength,
 } from "@/lib/editor/utils";
 import { wysiwygMarkdown } from "@/lib/editor/wysiwyg";
@@ -585,6 +587,8 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
       // The synced version we last sent an op at — so we don't re-send the same
       // op while awaiting its echo (which advances synced past this).
       const sentAtVersion = { current: -1 };
+      // Consecutive non-409 push rejections, for exponential backoff.
+      const pushBackoff = { current: 0 };
 
       // Idle auto-unfocus: N minutes without local activity blurs the editor.
       // The blur runs the normal focus-loss path (caret clear broadcast,
@@ -615,6 +619,57 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         }
       };
 
+      // The document at `getSyncedVersion()`. Maintained here because it is not
+      // recoverable from the current state: inverting the un-acked ChangeSets
+      // would need the very document they were applied to. `applyServerBuffer`
+      // needs it as the base to diff against, and every confirmation must go
+      // through `confirmUpdates` to keep it true — a path that bypasses it
+      // computes the diff against the wrong base and lands edits in the wrong
+      // place, which is the bug class this whole change exists to close.
+      const syncedDoc = { current: Text.of(session.startDoc.split("\n")) };
+
+      const confirmUpdates = (
+        updates: readonly { changes: ChangeSet; clientID: string }[],
+      ): void => {
+        for (const u of updates)
+          syncedDoc.current = u.changes.apply(syncedDoc.current);
+        dispatchRemote(receiveUpdates(v.state, updates));
+      };
+
+      // The buffer was replaced out of band — a checkpoint's merge folded in a
+      // committed change, or an agent commit was rebased into the session. That
+      // is a git commit, so it logged no op and `pull` has nothing to return.
+      //
+      // Hand it to collab as the update the server never wrote: one synthesized
+      // change from the synced text to the server's. `receiveUpdates` then does
+      // what it does for any remote op — applies it, advances the version, and
+      // rebases our un-acked edits over it. So local typing survives (it lands
+      // at the boundary if it fell inside the rewritten span), and the caret,
+      // selection and undo history survive too, because the editor is not
+      // rebuilt. Empty padding updates carry the version the rest of the way
+      // when more than one bump happened, since collab counts versions in
+      // updates.
+      const applyServerBuffer = (buffer: string, version: number): void => {
+        const synced = getSyncedVersion(v.state);
+        if (version <= synced) return; // stale read; a newer one already landed
+        const base = syncedDoc.current.toString();
+        if (base === buffer && version === synced + 1) return;
+        const change = diffToChange(base, buffer);
+        const updates = [
+          {
+            changes: ChangeSet.of(change ? [change] : [], base.length),
+            clientID: "",
+          },
+        ];
+        while (updates.length < version - synced)
+          updates.push({
+            changes: ChangeSet.empty(buffer.length),
+            clientID: "",
+          });
+        confirmUpdates(updates);
+        if (sendableUpdates(v.state).length > 0) void doPush();
+      };
+
       // Push the first un-acked op at the synced version (our /op is one op per
       // version). We do NOT confirm locally — the op echoes back over the stream
       // (client_id === ours) and is confirmed via receiveUpdates like any other,
@@ -640,9 +695,19 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
             getCaretSeqRef.current(),
           );
           sentAtVersion.current = version;
+          pushBackoff.current = 0;
         } catch (e) {
-          if (e instanceof ApiError && e.status === 409) await pull();
-          // else transient — the op stays sendable; a later echo/edit retries
+          if (e instanceof ApiError && e.status === 409) {
+            await pull();
+            pushBackoff.current = 0;
+          } else {
+            // Not a stale version, so rebasing won't clear it — `invalid_op`
+            // (our offsets don't fit the server's buffer) repeats forever
+            // otherwise, since the tail below re-pushes immediately. Back off
+            // so a permanently-rejected op can't spin on the socket.
+            const wait = Math.min(8000, 250 * 2 ** pushBackoff.current++);
+            await new Promise((r) => setTimeout(r, wait));
+          }
         } finally {
           pushing.current = false;
         }
@@ -677,7 +742,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
             len = cs.newLength;
             return { changes: cs, clientID: o.client_id ?? "" };
           });
-          dispatchRemote(receiveUpdates(v.state, updates));
+          confirmUpdates(updates);
           if (sendableUpdates(v.state).length > 0) void doPush();
         })();
         pullPromise.current = run;
@@ -693,7 +758,21 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
 
       const applyFrame = (frame: CoeditFrame): void => {
         if (frame.type === "resync") {
-          void pull();
+          // Two causes, and the cheap one first: `broadcast_op` degrades to a
+          // resync when an op's frame exceeds the bus payload cap, and that op
+          // *is* in the log, so a pull closes the gap and keeps our pending
+          // edits untouched. Only if the log can't get us there was the buffer
+          // actually replaced, which needs the whole-buffer read.
+          void (async () => {
+            await pull();
+            if (getSyncedVersion(v.state) >= frame.version) return;
+            try {
+              const snap = await getSession(session.id);
+              applyServerBuffer(snap.buffer, snap.version);
+            } catch {
+              // Transient; the next resync, gap or reconnect retries.
+            }
+          })();
           return;
         }
         if (frame.type !== "op") return;
@@ -712,11 +791,7 @@ export const Coeditor = forwardRef<CoeditorHandle, CoeditorProps>(
         }
         try {
           const cs = ChangeSet.of(frame.changes, syncedDocLength(v.state));
-          dispatchRemote(
-            receiveUpdates(v.state, [
-              { changes: cs, clientID: frame.client_id ?? "" },
-            ]),
-          );
+          confirmUpdates([{ changes: cs, clientID: frame.client_id ?? "" }]);
         } catch (err) {
           // A malformed / mis-anchored op would otherwise be swallowed by the SSE
           // reader. Surface it and re-sync from the authoritative op log.

--- a/frontend/src/lib/editor/constants.ts
+++ b/frontend/src/lib/editor/constants.ts
@@ -19,11 +19,21 @@ export const TYPING_IDLE_MS = 1500;
 /** Ms without a ping before a peer's "typing" badge is cleared (covers crash / lost tab). */
 export const TYPING_EXPIRY_MS = 4000;
 
-/** Ms of doc-change silence before an autosave checkpoint fires. */
-export const AUTOSAVE_IDLE_MS = 2000;
+/** Ms of doc-change silence before an autosave checkpoint fires.
+ *
+ * A checkpoint is a git commit (and, when a concurrent change has landed, a
+ * 3-way merge), so the engine is built around one commit per editing session,
+ * not per keystroke — see `app/wiki/coedit_checkpoint.py`. Durability doesn't
+ * ride on this: every op is already in Postgres, and the hook checkpoints on
+ * teardown and `pagehide`. This only governs how fresh git is for everyone
+ * else while a tab stays open, so seconds of lag costs nothing and a commit
+ * per pause costs history. */
+export const AUTOSAVE_IDLE_MS = 15000;
 
-/** Hard cap: force a checkpoint at least this often even under continuous typing. */
-export const AUTOSAVE_MAX_INTERVAL_MS = 30000;
+/** Hard cap: force a checkpoint at least this often even under continuous typing.
+ * A backstop against a marathon session leaving git far behind, not an autosave
+ * interval — the server's own scan (idle 5min / overdue 15min) sits behind it. */
+export const AUTOSAVE_MAX_INTERVAL_MS = 180000;
 
 /** Ms of no local activity (edits, caret moves) before the editor auto-blurs.
  * Blurring routes through the normal focus-loss path, so the idle user's

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -158,7 +158,8 @@ export function connectSession(
       if (
         type === "op_result" ||
         type === "checkpoint_result" ||
-        type === "ops_result"
+        type === "ops_result" ||
+        type === "session_result"
       ) {
         const p = pending.get(msg.request_id as string);
         if (!p) return;
@@ -263,6 +264,28 @@ export function sendCursor(
  * (or completed) the checkpoint. */
 export async function checkpointSession(sessionId: number): Promise<void> {
   await request<{ ok: boolean }>(sessionId, { type: "checkpoint" });
+}
+
+/** Re-read the whole live buffer at its current version.
+ *
+ * The catch-up for a `resync`, which announces that the buffer was *replaced*
+ * out of band — a checkpoint's merge folding in a committed change, or an
+ * inbound agent commit rebased into the session. Such a replacement is a git
+ * commit, not a co-edit op, so it logs nothing for `getOps` to return: a
+ * client that only replayed ops would keep the pre-merge document forever. */
+export async function getSession(
+  sessionId: number,
+): Promise<{ buffer: string; version: number; base_sha: string | null }> {
+  const result = await request<{
+    buffer: string;
+    version: number;
+    base_sha: string | null;
+  }>(sessionId, { type: "get_session" });
+  return {
+    buffer: result.buffer,
+    version: result.version,
+    base_sha: result.base_sha,
+  };
 }
 
 /** Fetch all ops after `sinceVersion` (oldest first) plus the current head


### PR DESCRIPTION
Was #554 (backend) + a stacked frontend PR; folded into one since the protocol addition and the client that consumes it are easiest to review together. Last of the co-edit fixes after #551, #552, #553.

## The bug

`resync` announces the buffer was **replaced** out of band — a checkpoint's merge folded in a committed change, or an agent/ingest commit was rebased into the open session (`rebase_onto`). That replacement is a git commit, not a co-edit op, so it writes no `coedit_ops` row. The client's handler was `pull()`, i.e. `get_ops` — which returned `[]`, early-returned, and never looked at `current_head_version`.

So the client kept the pre-merge document at its old version, permanently:

- every push carried a stale `base_version` → `stale_version` → pull → `[]` → repeat, no backoff — the "Couldn't save" people saw
- if versions ever re-aligned, ops applied at offsets that meant something else in the server's buffer — the production commit that left `# Bugsemove active agent bar from top of wiki doc` with a stray `- [ ] r`

Only a reload recovered. The gap predates the WS migration (the old `GET /coedit/session` existed but was never called on resync); #552 was what made it fire constantly.

## Backend

- **`get_session`** WS message: the buffer plus the version it is current as of, read-gated, `request_id`-correlated. The key test replaces the buffer via `rebase_onto` exactly as a checkpoint merge does, then asserts `get_session` returns the merged text **and** `get_ops` returns `[]` over the same interval — pinning down why the endpoint must exist.
- The two silent rejections now log: `invalid_op` at warning (offsets + insert *length* only — the text is page content and stays out of logs), `stale_version` at debug.

## Frontend

**Cheap cause first.** `broadcast_op` degrades to a resync when an op exceeds the bus payload cap; that op *is* in the log, so `pull()` closes the gap with pending edits untouched. Only if the log can't reach the announced version was the buffer replaced — then `get_session`.

**The replacement is handed to collab as the update the server never wrote**: one synthesized change from the last-confirmed text to the server's, padded with empty updates when several versions passed. `receiveUpdates` applies it, advances the version, and rebases un-acked local edits over it — so typing survives (an edit inside the rewritten span lands at its boundary, visible and fixable, rather than silently dropped), and caret/selection/undo survive because the editor is never rebuilt.

**Invariant to watch in review:** the synthesized change needs the last-*confirmed* document, which is unrecoverable from current state (inverting un-acked ChangeSets needs the document they applied to). It is tracked, and every confirmation routes through one `confirmUpdates` helper. A path that bypasses it diffs against the wrong base and mis-anchors edits — the bug class this closes.

Also: `doPush` backs off exponentially on rejections a rebase can't clear (`invalid_op` used to re-push forever), and autosave moves 2s/30s → 15s/3min (the checkpoint engine is one-commit-per-session by design; durability rides on Postgres + teardown/`pagehide` checkpoints).

## Testing

- Backend: full suite green; new `get_session` tests (live-buffer read, closed-session error, mid-session read revocation).
- Collab semantics headlessly (`EditorState` needs no DOM): 3 un-acked keystrokes + a v7 replacement → merged line **and** all three keystrokes kept, still queued (`"Xalpha\nbeta\ngamma\nYZW"`); version padding correct; in-span edit kept at the boundary (`"hello universeWORLD\n"`).
- End-to-end in a real browser against a 2-worker backend running this branch: typed live, forced a buffer replacement server-side, watched the editor converge on the merged text with local typing intact — full transcript in the PR thread.

No committed frontend test: there's no test runner in `frontend/` today. Worth a follow-up (the `confirmUpdates` invariant deserves CI), but that's runner + CI wiring, not this PR.

