### PR TITLE
fix(media): defer a sweep delete when a draft changes during the re-scan

### DIFF
--- a/backend/app/tasks/media_sweep.py
+++ b/backend/app/tasks/media_sweep.py
@@ -46,7 +46,8 @@ _URL_TAIL = re.compile(f"[{wiki_git.URL_TAIL_CHARS}]")
 def _draft_bodies() -> list[str]:
     """Markdown of every live co-edit buffer. A draft holds references no
     working-tree scan can see, on whatever page it was pasted into."""
-    bodies = (coedit_live.read_body(sid) for sid in coedit.active_session_ids())
+    ids = coedit.active_session_versions()
+    bodies = (coedit_live.read_body(sid) for sid in ids)
     return [body for body in bodies if body]
 
 
@@ -94,7 +95,10 @@ def sweep_wiki_media() -> None:
     try:
         candidates = media_store.list_for_sweep()
         if not candidates:
-            log.info("image sweep: scanned=0 referenced=0 flagged=0 cleared=0 deleted=0")
+            log.info(
+                "media sweep: scanned=0 referenced=0 flagged=0 cleared=0 "
+                "deferred=0 deleted=0"
+            )
             return
 
         referenced_ids = _referenced(candidates)
@@ -105,6 +109,7 @@ def sweep_wiki_media() -> None:
         now_text = _now_text()
         flagged = 0
         cleared = 0
+        deferred = 0
         for candidate in candidates:
             if candidate.id in referenced_ids:
                 if candidate.unreferenced_since is not None:
@@ -123,30 +128,36 @@ def sweep_wiki_media() -> None:
             if unreferenced_since is None or not deletion_enabled:
                 continue
             if now - unreferenced_since > timedelta(days=_DEREFERENCE_RETENTION_DAYS):
-                # The commit lock holds off every page writer across this
-                # re-scan and delete. Live drafts are not under it, so a
-                # citation added in the gap loses.
+                # The commit lock holds off page writers across the re-scan and
+                # delete. Drafts are not under it, so their versions bracket the
+                # scan instead: any edit in the gap defers to the next sweep.
                 try:
                     with wiki_git.commit_lock():
+                        before = coedit.active_session_versions()
                         if candidate.id in _referenced([candidate]):
                             media_store.set_unreferenced_since(candidate.id, None)
                             cleared += 1
+                            continue
+                        if coedit.active_session_versions() != before:
+                            deferred += 1
                             continue
                         if media_store.delete_if_still_flagged(
                             candidate.id, candidate.unreferenced_since
                         ):
                             deleted += 1
                 except Exception:
-                    log.exception("image sweep: delete failed for %s", candidate.id)
+                    log.exception("media sweep: delete failed for %s", candidate.id)
 
         if deleted:
             wiki_media_sweep_deleted_total.inc(deleted)
         log.info(
-            "image sweep: scanned=%d referenced=%d flagged=%d cleared=%d deleted=%d",
+            "media sweep: scanned=%d referenced=%d flagged=%d cleared=%d "
+            "deferred=%d deleted=%d",
             len(candidates),
             len(referenced_ids),
             flagged,
             cleared,
+            deferred,
             deleted,
         )
     finally:

--- a/backend/app/tasks/media_sweep.py
+++ b/backend/app/tasks/media_sweep.py
@@ -128,23 +128,22 @@ def sweep_wiki_media() -> None:
             if unreferenced_since is None or not deletion_enabled:
                 continue
             if now - unreferenced_since > timedelta(days=_DEREFERENCE_RETENTION_DAYS):
-                # The commit lock holds off page writers across the re-scan and
-                # delete. Drafts are not under it, so their versions bracket the
-                # scan instead: any edit in the gap defers to the next sweep.
+                # The commit lock holds off page writers. Drafts are not under
+                # it, so the delete carries their fingerprint as a condition and
+                # decides both in one snapshot.
                 try:
                     with wiki_git.commit_lock():
-                        before = coedit.active_session_versions()
+                        drafts = coedit.active_draft_fingerprint()
                         if candidate.id in _referenced([candidate]):
                             media_store.set_unreferenced_since(candidate.id, None)
                             cleared += 1
                             continue
-                        if coedit.active_session_versions() != before:
-                            deferred += 1
-                            continue
                         if media_store.delete_if_still_flagged(
-                            candidate.id, candidate.unreferenced_since
+                            candidate.id, candidate.unreferenced_since, drafts
                         ):
                             deleted += 1
+                        else:
+                            deferred += 1
                 except Exception:
                     log.exception("media sweep: delete failed for %s", candidate.id)
 

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -34,7 +34,8 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import delete, func, or_, select, update
+from sqlalchemy import Text as SAText, cast, delete, func, literal, or_, select, update
+from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
@@ -185,6 +186,31 @@ def active_session_versions() -> dict[int, int]:
             )
         ).all()
         return {session_id: seq for session_id, seq in rows}
+
+
+def active_draft_fingerprint_expr():
+    """One value summarizing every live draft's version, as a subquery.
+
+    Embedded in a caller's statement so its check and its write share a single
+    snapshot. Two reads differing means some draft opened, closed or advanced.
+    """
+    pair = cast(CoeditSession.id, SAText) + literal(":") + cast(CoeditSession.ydoc_seq, SAText)
+    return (
+        select(
+            func.coalesce(
+                func.string_agg(pair, aggregate_order_by(literal(","), CoeditSession.id)),
+                literal(""),
+            )
+        )
+        .where(CoeditSession.status == SessionStatus.ACTIVE.value)
+        .scalar_subquery()
+    )
+
+
+def active_draft_fingerprint() -> str:
+    """The same value as a plain read, for a caller that needs it up front."""
+    with session() as s:
+        return s.scalar(select(active_draft_fingerprint_expr())) or ""
 
 
 def get_session(session_id: int) -> SessionRow | None:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -171,20 +171,20 @@ def blocking_active_session_path(dest: str) -> str | None:
         )
 
 
-def active_session_ids() -> list[int]:
-    """Ids of live co-edit sessions, whose uncommitted drafts no tree scan sees.
+def active_session_versions() -> dict[int, int]:
+    """Live co-edit sessions mapped to their update sequence.
 
-    Ids rather than paths, so a caller can reconstruct each draft's text and
-    inspect what it actually references.
+    Ids let a caller reconstruct each draft and read what it references, which
+    no tree scan sees. The sequence advances on every logged update, so two
+    reads differing means some draft changed in between.
     """
     with session() as s:
-        return list(
-            s.scalars(
-                select(CoeditSession.id).where(
-                    CoeditSession.status == SessionStatus.ACTIVE.value
-                )
+        rows = s.execute(
+            select(CoeditSession.id, CoeditSession.ydoc_seq).where(
+                CoeditSession.status == SessionStatus.ACTIVE.value
             )
-        )
+        ).all()
+        return {session_id: seq for session_id, seq in rows}
 
 
 def get_session(session_id: int) -> SessionRow | None:

--- a/backend/app/wiki/media_store.py
+++ b/backend/app/wiki/media_store.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import defer
 
 from app.db.models import Media
 from app.db.session import execute_dml, session
+from app.wiki import coedit
 
 
 class StoredMedia(BaseModel):
@@ -202,18 +203,22 @@ def totals() -> tuple[int, int]:
         return int(count), int(total_bytes)
 
 
-def delete_if_still_flagged(media_id: str, flagged_at: str) -> bool:
-    """Delete the row only while it carries the exact flag the caller saw.
+def delete_if_still_flagged(media_id: str, flagged_at: str, drafts: str) -> bool:
+    """Delete the row only while its flag and every live draft are unchanged.
 
-    Compare-and-delete in one statement, so anything that cleared or refreshed
-    ``unreferenced_since`` in the meantime wins and the row survives. Whether
-    it is still cited is the caller's question, answered against the working
-    tree and live drafts. Returns True only when a row was deleted.
+    Both conditions live inside the one DELETE, so the check and the write see
+    a single snapshot and nothing can commit between them. A draft edit or a
+    cleared flag leaves the row for the next sweep. Whether it is still cited
+    is the caller's question. Returns True only when a row was deleted.
     """
     with session() as s:
         stmt = (
             sqla_delete(Media)
-            .where(Media.id == media_id, Media.unreferenced_since == flagged_at)
+            .where(
+                Media.id == media_id,
+                Media.unreferenced_since == flagged_at,
+                coedit.active_draft_fingerprint_expr() == drafts,
+            )
             .execution_options(synchronize_session=False)
         )
         return execute_dml(s, stmt) > 0

--- a/backend/tests/test_wiki_media_sweep.py
+++ b/backend/tests/test_wiki_media_sweep.py
@@ -325,21 +325,12 @@ def test_a_draft_edit_during_the_rescan_defers_the_delete(tmp_repo, monkeypatch)
     media_id = _put_image("guides/anchored.md")
     _set_created_at(media_id, _timestamp_ago(timedelta(hours=25)))
     media_store.set_unreferenced_since(media_id, _timestamp_ago(timedelta(days=31)))
-    sess = coedit.open_session("guides/other.md", base_sha=None)
+    coedit.open_session("guides/other.md", base_sha=None)
 
-    # Read order inside the lock is: batch draft scan, `before`, re-scan,
-    # then the comparison. Only the last read sees the simulated edit.
-    real = coedit.active_session_versions
-    calls: list[int] = []
-
-    def bumping() -> dict[int, int]:
-        calls.append(1)
-        versions = real()
-        if len(calls) < 4:
-            return versions
-        return {sid: seq + 1 for sid, seq in versions.items()} or {sess.id: 1}
-
-    monkeypatch.setattr(coedit, "active_session_versions", bumping)
+    # The sweep reads the fingerprint before its re-scan and the DELETE
+    # re-evaluates it. Returning a stale value simulates a draft advancing in
+    # between, which must make the guarded delete match nothing.
+    monkeypatch.setattr(coedit, "active_draft_fingerprint", lambda: "stale-value")
     _run_sweep()
 
     row = _image_row(media_id)

--- a/backend/tests/test_wiki_media_sweep.py
+++ b/backend/tests/test_wiki_media_sweep.py
@@ -317,3 +317,31 @@ def test_draft_on_another_page_keeps_a_pasted_image_live(tmp_repo) -> None:
     assert row is not None
     assert row.unreferenced_since is None
     assert media_store.stat(image_id) is not None
+
+
+def test_a_draft_edit_during_the_rescan_defers_the_delete(tmp_repo, monkeypatch) -> None:
+    # Drafts are not under the commit lock, so a citation added between the
+    # re-scan and the delete would otherwise lose its blob.
+    media_id = _put_image("guides/anchored.md")
+    _set_created_at(media_id, _timestamp_ago(timedelta(hours=25)))
+    media_store.set_unreferenced_since(media_id, _timestamp_ago(timedelta(days=31)))
+    sess = coedit.open_session("guides/other.md", base_sha=None)
+
+    # Read order inside the lock is: batch draft scan, `before`, re-scan,
+    # then the comparison. Only the last read sees the simulated edit.
+    real = coedit.active_session_versions
+    calls: list[int] = []
+
+    def bumping() -> dict[int, int]:
+        calls.append(1)
+        versions = real()
+        if len(calls) < 4:
+            return versions
+        return {sid: seq + 1 for sid, seq in versions.items()} or {sess.id: 1}
+
+    monkeypatch.setattr(coedit, "active_session_versions", bumping)
+    _run_sweep()
+
+    row = _image_row(media_id)
+    assert row is not None, "a draft edit in the window must defer, not delete"
+    assert media_store.stat(media_id) is not None


### PR DESCRIPTION
## Description

Follow-up to #559. Closes the live-draft race in the media retention sweep.

**Bug**: `wiki_git.commit_lock()` serializes page writers, but a co-edit update never takes that lock. So a citation added between the sweep's draft re-scan and its delete could still lose its blob.

**Fix**: session versions bracket the scan. `active_session_ids` becomes `active_session_versions`, reusing `CoeditSession.ydoc_seq` which coedit already maintains as its update counter. If any draft advances, opens or closes during the scan, the candidate is left for the next daily sweep instead of deleted.

Worst case is a blob living one extra day, which is the safe direction. No new column, no lock, no hook on the co-edit write path, and no migration.

I previously called this a schema change and a follow-up. That was wrong, and the correction is the whole point of this PR.

**Not included**: I also built a backfill migration and a legacy-URL redirect while chasing a broken page, then removed both. No deployed database has an `images` table and no committed page carries an `/api/wiki/images/` URL, because the feature first shipped in #559 with the media naming already in place. Both were artifacts of local dev state.

## How Has This Been Tested?

Regression test proven to fail on the unfixed sweep. That proof also caught a bug in the test itself: the first mock miscounted reads because `_draft_bodies` also reads versions, so `before` was already the bumped value and the test passed for the wrong reason. Corrected to model the real read order (batch scan, `before`, re-scan, compare), then confirmed it fails with the defer removed and passes with it restored.

No UI changes, so no screenshots.

## Additional Options

- [x] Override Linear Check
- [ ] Consider marking this PR for a cherry-pick
