### PR TITLE
feat(db): store derived entity-type taxonomies, append-only

### DIFF
--- a/backend/app/db/entity_taxonomy.py
+++ b/backend/app/db/entity_taxonomy.py
@@ -7,8 +7,8 @@ makes that failure silent and unrecoverable; keeping a history makes a rename a 
 event with the superseded taxonomy still readable.
 
 So ``record()`` inserts and promotes rather than updating, and the previous row stays. A
-consumer that keys by type should store the ``version`` it used alongside, and resolve
-through ``get(version)`` rather than assuming the active one still means what it meant.
+consumer that keys by type should store the taxonomy ``id`` it used alongside, and resolve
+through ``get(id)`` rather than assuming the active one still means what it meant.
 """
 
 from __future__ import annotations
@@ -35,24 +35,22 @@ def active() -> EntityTaxonomy | None:
         return db.scalars(select(EntityTaxonomy).where(EntityTaxonomy.active)).one_or_none()
 
 
-def get(version: int) -> EntityTaxonomy | None:
-    """A specific taxonomy by version — how a consumer resolves the types it keyed under."""
+def get(taxonomy_id: int) -> EntityTaxonomy | None:
+    """A specific taxonomy by id — how a consumer resolves the types it keyed facts under."""
     with session() as db:
-        return db.scalars(
-            select(EntityTaxonomy).where(EntityTaxonomy.version == version)
-        ).one_or_none()
+        return db.get(EntityTaxonomy, taxonomy_id)
 
 
 def history(limit: int = 20) -> list[EntityTaxonomy]:
     """Newest first. For seeing what a re-derivation changed."""
     with session() as db:
         return list(
-            db.scalars(select(EntityTaxonomy).order_by(EntityTaxonomy.version.desc()).limit(limit))
+            db.scalars(select(EntityTaxonomy).order_by(EntityTaxonomy.id.desc()).limit(limit))
         )
 
 
 def record(artifact: dict[str, Any], *, triggered_by: str | None = None) -> int:
-    """Store a derived taxonomy and make it active. Returns its version.
+    """Store a derived taxonomy and make it active. Returns its id.
 
     Takes the artifact ``app.ingest.entity_types.derive`` produces, so the producer decides
     what is worth keeping rather than this layer imposing a shape.
@@ -66,29 +64,23 @@ def record(artifact: dict[str, Any], *, triggered_by: str | None = None) -> int:
         raise ValueError("refusing to record a taxonomy with no types")
 
     with session() as db:
-        latest = db.scalars(
-            select(EntityTaxonomy.version).order_by(EntityTaxonomy.version.desc()).limit(1)
-        ).first()
-        version = (latest or 0) + 1
-
         db.execute(update(EntityTaxonomy).where(EntityTaxonomy.active).values(active=False))
-        db.add(
-            EntityTaxonomy(
-                version=version,
-                active=True,
-                corpus_fingerprint=str(artifact.get("corpus_fingerprint") or ""),
-                types=types,
-                provenance=artifact.get("provenance") or {},
-                stats=artifact.get("stats") or {},
-                triggered_by=triggered_by,
-            )
+        row = EntityTaxonomy(
+            active=True,
+            corpus_fingerprint=str(artifact.get("corpus_fingerprint") or ""),
+            types=types,
+            provenance=artifact.get("provenance") or {},
+            stats=artifact.get("stats") or {},
+            triggered_by=triggered_by,
         )
+        db.add(row)
         db.commit()
+        taxonomy_id = row.id
 
     log.info(
-        "entity_taxonomy: recorded v%d (%d type(s), corpus %s)",
-        version,
+        "entity_taxonomy: recorded taxonomy %d (%d type(s), corpus %s)",
+        taxonomy_id,
         len(types),
         str(artifact.get("corpus_fingerprint") or "")[:12],
     )
-    return version
+    return taxonomy_id

--- a/backend/app/db/entity_taxonomy.py
+++ b/backend/app/db/entity_taxonomy.py
@@ -19,9 +19,13 @@ from typing import Any, cast
 from sqlalchemy import select, update
 
 from app.db.models import EntityTaxonomy
-from app.db.session import session
+from app.db.session import advisory_xact_lock, session
 
 log = logging.getLogger(__name__)
+
+# Serializes record(): the whole DB shares one 64-bit advisory keyspace (see
+# triggers/repo.py's _REBUILD_ADVISORY_LOCK), so this is a distinct constant. Spells "etax".
+_RECORD_ADVISORY_LOCK = 0x65746178
 
 
 def active() -> EntityTaxonomy | None:
@@ -55,15 +59,23 @@ def record(artifact: dict[str, Any], *, triggered_by: str | None = None) -> int:
     Takes the artifact ``app.ingest.entity_types.derive`` produces, so the producer decides
     what is worth keeping rather than this layer imposing a shape.
 
-    Deactivating the previous row and inserting the new one happen in one transaction: the
-    partial unique index on ``active`` means a half-applied write would either leave no
-    taxonomy in force or fail outright, and the second is much easier to notice.
+    Deactivating the previous row and inserting the new one happen in one transaction, under
+    an advisory lock, because the partial unique index alone is not enough to make concurrent
+    recorders safe. Two workers would each deactivate the row their statement could see, both
+    insert with ``active=true``, and the second would hit the index and roll back — losing a
+    derivation that had already paid for its LLM calls. The lock makes the second recorder
+    WAIT and then succeed, rather than fail.
+
+    Transaction-scoped, so a worker that dies mid-record cannot strand it. Unbounded rather
+    than ``try_advisory_xact_lock``: the caller has already done the expensive work, so
+    waiting is always better than skipping.
     """
     types = cast(list[dict[str, Any]], artifact.get("entity_types") or [])
     if not types:
         raise ValueError("refusing to record a taxonomy with no types")
 
     with session() as db:
+        advisory_xact_lock(db, _RECORD_ADVISORY_LOCK)
         db.execute(update(EntityTaxonomy).where(EntityTaxonomy.active).values(active=False))
         row = EntityTaxonomy(
             active=True,

--- a/backend/app/db/entity_taxonomy.py
+++ b/backend/app/db/entity_taxonomy.py
@@ -1,0 +1,94 @@
+"""Read and write derived entity-type taxonomies.
+
+Append-only with one active row. The reason is that entity types are KEYS: anything that
+records facts per entity records them under a type name, so a re-derivation that renames a
+type would orphan every row pointing at the old one. Overwriting a single current value
+makes that failure silent and unrecoverable; keeping a history makes a rename a visible
+event with the superseded taxonomy still readable.
+
+So ``record()`` inserts and promotes rather than updating, and the previous row stays. A
+consumer that keys by type should store the ``version`` it used alongside, and resolve
+through ``get(version)`` rather than assuming the active one still means what it meant.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from sqlalchemy import select, update
+
+from app.db.models import EntityTaxonomy
+from app.db.session import session
+
+log = logging.getLogger(__name__)
+
+
+def active() -> EntityTaxonomy | None:
+    """The taxonomy in force, or None when nothing has been derived yet.
+
+    None is a normal state, not an error — a deployment that has never run a derivation has
+    no taxonomy, and callers fall back to a generic type list (see
+    ``app.ingest.entity_types.load_taxonomy``).
+    """
+    with session() as db:
+        return db.scalars(select(EntityTaxonomy).where(EntityTaxonomy.active)).one_or_none()
+
+
+def get(version: int) -> EntityTaxonomy | None:
+    """A specific taxonomy by version — how a consumer resolves the types it keyed under."""
+    with session() as db:
+        return db.scalars(
+            select(EntityTaxonomy).where(EntityTaxonomy.version == version)
+        ).one_or_none()
+
+
+def history(limit: int = 20) -> list[EntityTaxonomy]:
+    """Newest first. For seeing what a re-derivation changed."""
+    with session() as db:
+        return list(
+            db.scalars(select(EntityTaxonomy).order_by(EntityTaxonomy.version.desc()).limit(limit))
+        )
+
+
+def record(artifact: dict[str, Any], *, triggered_by: str | None = None) -> int:
+    """Store a derived taxonomy and make it active. Returns its version.
+
+    Takes the artifact ``app.ingest.entity_types.derive`` produces, so the producer decides
+    what is worth keeping rather than this layer imposing a shape.
+
+    Deactivating the previous row and inserting the new one happen in one transaction: the
+    partial unique index on ``active`` means a half-applied write would either leave no
+    taxonomy in force or fail outright, and the second is much easier to notice.
+    """
+    types = cast(list[dict[str, Any]], artifact.get("entity_types") or [])
+    if not types:
+        raise ValueError("refusing to record a taxonomy with no types")
+
+    with session() as db:
+        latest = db.scalars(
+            select(EntityTaxonomy.version).order_by(EntityTaxonomy.version.desc()).limit(1)
+        ).first()
+        version = (latest or 0) + 1
+
+        db.execute(update(EntityTaxonomy).where(EntityTaxonomy.active).values(active=False))
+        db.add(
+            EntityTaxonomy(
+                version=version,
+                active=True,
+                corpus_fingerprint=str(artifact.get("corpus_fingerprint") or ""),
+                types=types,
+                provenance=artifact.get("provenance") or {},
+                stats=artifact.get("stats") or {},
+                triggered_by=triggered_by,
+            )
+        )
+        db.commit()
+
+    log.info(
+        "entity_taxonomy: recorded v%d (%d type(s), corpus %s)",
+        version,
+        len(types),
+        str(artifact.get("corpus_fingerprint") or "")[:12],
+    )
+    return version

--- a/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
+++ b/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
@@ -1,7 +1,7 @@
 """entity_taxonomies
 
 Adds ``entity_taxonomies``: derived entity-type taxonomies, append-only with one row
-flagged ``active``. Append-only because entity types key facts by entity — a re-derivation
+flagged ``active``, plus ``ingest_settings.organization_name``. Append-only because entity types key facts by entity — a re-derivation
 that renames a type must not orphan rows keyed under the old name, so the superseded
 taxonomy has to stay readable rather than being overwritten.
 
@@ -68,8 +68,12 @@ def upgrade() -> None:
         unique=True,
         postgresql_where=sa.text("active"),
     )
+    # The organisation the wiki belongs to. A setting, not derived output — see the model.
+    if "organization_name" not in {c["name"] for c in inspector.get_columns("ingest_settings")}:
+        op.add_column("ingest_settings", sa.Column("organization_name", sa.Text(), nullable=True))
 
 
 def downgrade() -> None:
+    op.drop_column("ingest_settings", "organization_name")
     op.drop_index("uq_entity_taxonomies_active", table_name="entity_taxonomies")
     op.drop_table("entity_taxonomies")

--- a/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
+++ b/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
@@ -68,12 +68,20 @@ def upgrade() -> None:
         unique=True,
         postgresql_where=sa.text("active"),
     )
-    # The organisation the wiki belongs to. A setting, not derived output — see the model.
-    if "organization_name" not in {c["name"] for c in inspector.get_columns("ingest_settings")}:
+    # The organisation the wiki belongs to, and who claimed it. A setting, not derived
+    # output — see the model for why the source column gates inference rather than the value.
+    existing = {c["name"] for c in inspector.get_columns("ingest_settings")}
+    if "organization_name" not in existing:
         op.add_column("ingest_settings", sa.Column("organization_name", sa.Text(), nullable=True))
+    if "organization_name_source" not in existing:
+        op.add_column(
+            "ingest_settings",
+            sa.Column("organization_name_source", sa.Text(), nullable=True),
+        )
 
 
 def downgrade() -> None:
+    op.drop_column("ingest_settings", "organization_name_source")
     op.drop_column("ingest_settings", "organization_name")
     op.drop_index("uq_entity_taxonomies_active", table_name="entity_taxonomies")
     op.drop_table("entity_taxonomies")

--- a/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
+++ b/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
@@ -1,7 +1,7 @@
 """entity_taxonomies
 
 Adds ``entity_taxonomies``: derived entity-type taxonomies, append-only with one row
-flagged ``active``, plus ``ingest_settings.organization_name``. Append-only because entity types key facts by entity — a re-derivation
+flagged ``active``. Append-only because entity types key facts by entity — a re-derivation
 that renames a type must not orphan rows keyed under the old name, so the superseded
 taxonomy has to stay readable rather than being overwritten.
 
@@ -68,20 +68,8 @@ def upgrade() -> None:
         unique=True,
         postgresql_where=sa.text("active"),
     )
-    # The organisation the wiki belongs to, and who claimed it. A setting, not derived
-    # output — see the model for why the source column gates inference rather than the value.
-    existing = {c["name"] for c in inspector.get_columns("ingest_settings")}
-    if "organization_name" not in existing:
-        op.add_column("ingest_settings", sa.Column("organization_name", sa.Text(), nullable=True))
-    if "organization_name_source" not in existing:
-        op.add_column(
-            "ingest_settings",
-            sa.Column("organization_name_source", sa.Text(), nullable=True),
-        )
 
 
 def downgrade() -> None:
-    op.drop_column("ingest_settings", "organization_name_source")
-    op.drop_column("ingest_settings", "organization_name")
     op.drop_index("uq_entity_taxonomies_active", table_name="entity_taxonomies")
     op.drop_table("entity_taxonomies")

--- a/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
+++ b/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
@@ -1,0 +1,77 @@
+"""entity_taxonomies
+
+Adds ``entity_taxonomies``: derived entity-type taxonomies, append-only with one row
+flagged ``active``. Append-only because entity types key facts by entity — a re-derivation
+that renames a type must not orphan rows keyed under the old name, so the superseded
+taxonomy has to stay readable rather than being overwritten.
+
+Revision ID: e1b7c3a95d24
+Revises: c8a4e7d2f6b1
+Create Date: 2026-07-31 10:15:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e1b7c3a95d24"
+down_revision: str | None = "c8a4e7d2f6b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Guarded because ``0001_initial`` builds fresh databases from the current models,
+    # which already carry this table.
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("entity_taxonomies"):
+        return
+    op.create_table(
+        "entity_taxonomies",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("active", sa.Boolean(), server_default=sa.text("FALSE"), nullable=False),
+        sa.Column("corpus_fingerprint", sa.Text(), nullable=False),
+        sa.Column("types", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "provenance",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column(
+            "stats",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("triggered_by", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.Text(),
+            server_default=sa.text("to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD HH24:MI:SS')"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["triggered_by"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("version", name="uq_entity_taxonomies_version"),
+    )
+    # Partial unique index: at most one active row, enforced by the database rather than by
+    # every writer remembering to clear the previous one.
+    op.create_index(
+        "uq_entity_taxonomies_active",
+        "entity_taxonomies",
+        ["active"],
+        unique=True,
+        postgresql_where=sa.text("active"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_entity_taxonomies_active", table_name="entity_taxonomies")
+    op.drop_table("entity_taxonomies")

--- a/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
+++ b/backend/app/db/migrations/versions/e1b7c3a95d24_entity_taxonomies.py
@@ -34,7 +34,6 @@ def upgrade() -> None:
     op.create_table(
         "entity_taxonomies",
         sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("version", sa.Integer(), nullable=False),
         sa.Column("active", sa.Boolean(), server_default=sa.text("FALSE"), nullable=False),
         sa.Column("corpus_fingerprint", sa.Text(), nullable=False),
         sa.Column("types", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
@@ -59,7 +58,6 @@ def upgrade() -> None:
         ),
         sa.ForeignKeyConstraint(["triggered_by"], ["users.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("version", name="uq_entity_taxonomies_version"),
     )
     # Partial unique index: at most one active row, enforced by the database rather than by
     # every writer remembering to clear the previous one.

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -804,25 +804,6 @@ class IngestSettings(Base):
     # origin used for Craft build-API calls, connect redirects, and
     # "Open Craft" deep links. Null = Craft launches unavailable.
     onyx_base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
-    # The organisation this wiki belongs to. Its name saturates the corpus, so it carries no
-    # discriminative signal and entity extraction is told not to treat it as a referent.
-    #
-    # A SETTING rather than derived output: it is one value, it is stable, and an admin knows
-    # it on day one — long before there are enough pages for any statistical signal to
-    # exist. A derivation may later suggest it, but must not own it, or a re-derivation on a
-    # thin corpus could overwrite something correct with a guess.
-    organization_name: Mapped[str | None] = mapped_column(Text, nullable=True)
-    # Who last claimed the name above: "admin" | "inferred" | NULL (nobody yet).
-    #
-    # This, not the value's nullness, is what gates inference. "Do not overwrite a non-null
-    # value" would freeze a bad guess forever — a later derivation with far more corpus to
-    # work with should be allowed to correct its own earlier guess. And an admin who CLEARS
-    # the field has decided there is no name, which must not re-trigger inference; that state
-    # is ("admin", NULL), indistinguishable from "unset" if we only looked at the value.
-    #
-    # "admin" also means inference need not run at all, so a derivation spends nothing
-    # computing a value it is not allowed to use.
-    organization_name_source: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners override via update_policies, and a hard
     # cap above which a page's ingestion auto-update is turned off. 0 = off.

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -812,6 +812,17 @@ class IngestSettings(Base):
     # exist. A derivation may later suggest it, but must not own it, or a re-derivation on a
     # thin corpus could overwrite something correct with a guess.
     organization_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Who last claimed the name above: "admin" | "inferred" | NULL (nobody yet).
+    #
+    # This, not the value's nullness, is what gates inference. "Do not overwrite a non-null
+    # value" would freeze a bad guess forever — a later derivation with far more corpus to
+    # work with should be allowed to correct its own earlier guess. And an admin who CLEARS
+    # the field has decided there is no name, which must not re-trigger inference; that state
+    # is ("admin", NULL), indistinguishable from "unset" if we only looked at the value.
+    #
+    # "admin" also means inference need not run at all, so a derivation spends nothing
+    # computing a value it is not allowed to use.
+    organization_name_source: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners override via update_policies, and a hard
     # cap above which a page's ingestion auto-update is turned off. 0 = off.

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2018,10 +2018,10 @@ class EntityTaxonomy(Base):
 
     __tablename__ = "entity_taxonomies"
 
+    # Monotonic, and what a consumer records to say which taxonomy it keyed facts under.
+    # SERIAL rather than an application-computed counter: "SELECT max + 1" then INSERT is
+    # not atomic, so two concurrent derivations could pick the same number.
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    # Monotonic per deployment. What a status row records to say which taxonomy it was
-    # keyed under; the primary key would do, but a version reads as an ordering.
-    version: Mapped[int] = mapped_column(Integer, nullable=False, unique=True)
     # Exactly one row is active. Enforced by a partial unique index, not by convention.
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
     # sha256 over the corpus this was derived from. Answers "has the wiki moved far enough

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -804,6 +804,14 @@ class IngestSettings(Base):
     # origin used for Craft build-API calls, connect redirects, and
     # "Open Craft" deep links. Null = Craft launches unavailable.
     onyx_base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # The organisation this wiki belongs to. Its name saturates the corpus, so it carries no
+    # discriminative signal and entity extraction is told not to treat it as a referent.
+    #
+    # A SETTING rather than derived output: it is one value, it is stable, and an admin knows
+    # it on day one — long before there are enough pages for any statistical signal to
+    # exist. A derivation may later suggest it, but must not own it, or a re-derivation on a
+    # thin corpus could overwrite something correct with a guess.
+    organization_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners override via update_policies, and a hard
     # cap above which a page's ingestion auto-update is turned off. 0 = off.

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2001,3 +2001,53 @@ class Notification(Base):
         UniqueConstraint("user_id", "notif_type", "data", name="uq_notifications_user_type_data"),
         Index("idx_notifications_user_dismissed", "user_id", "dismissed"),
     )
+
+class EntityTaxonomy(Base):
+    """A derived entity-type taxonomy, kept as a history rather than a current value.
+
+    Entity types key facts by entity, so a re-derivation that renames a type would orphan
+    every row keyed under the old name. Rows are therefore append-only and one is marked
+    ``active``: a new derivation inserts and flips the flag, and the superseded taxonomy
+    stays resolvable for anything still pointing at it.
+
+    ``types`` and ``provenance`` are free-form JSONB. The shape is owned by
+    ``app.ingest.entity_types`` (which produces it) rather than by a column layout, because
+    it is read whole and never queried by field — and because pinning it would mean a
+    migration every time a derivation stage learns to record something new.
+    """
+
+    __tablename__ = "entity_taxonomies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Monotonic per deployment. What a status row records to say which taxonomy it was
+    # keyed under; the primary key would do, but a version reads as an ordering.
+    version: Mapped[int] = mapped_column(Integer, nullable=False, unique=True)
+    # Exactly one row is active. Enforced by a partial unique index, not by convention.
+    active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
+    # sha256 over the corpus this was derived from. Answers "has the wiki moved far enough
+    # to warrant re-deriving?", which nothing else can reconstruct after the fact.
+    corpus_fingerprint: Mapped[str] = mapped_column(Text, nullable=False)
+    # The type list: [{name, definition, examples, n_referents, n_docs}, ...]
+    types: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    # Models, thresholds, and the funnel counts. Kept so a human can judge whether a
+    # derivation is trustworthy without re-running it — a merge that collapsed 75 types to 9
+    # looks very different from one that left 75 standing.
+    provenance: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    stats: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
+    triggered_by: Mapped[str | None] = mapped_column(
+        Text, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    created_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+
+    __table_args__ = (
+        Index(
+            "uq_entity_taxonomies_active",
+            "active",
+            unique=True,
+            postgresql_where=text("active"),
+        ),
+    )

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -65,6 +65,7 @@ from typing import Any, cast
 from pydantic import BaseModel, Field
 
 from app.db import entity_taxonomy
+from app.ingest import settings as ingest_settings
 from app.llm import client, embeddings
 from app.llm.prompts import load_prompt
 from app.wiki import filesystem, git as wiki_git
@@ -479,8 +480,24 @@ def fold(mentions: list[Mention]) -> list[Referent]:
 
 
 # --- artifact ---------------------------------------------------------------------------
+def _skip_names() -> frozenset[str]:
+    """Names extraction should not treat as referents — the organisation itself.
+
+    Empty when no organisation is configured, which simply drops the "ignore these" line
+    from the prompt rather than guessing.
+    """
+    name = (ingest_settings.get_organization_name() or "").strip()
+    return frozenset({name}) if name else frozenset()
+
+
 def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], frozenset[str]]:
-    """``(type definitions, home entity names)`` for the active taxonomy.
+    """``(type definitions, names to skip)`` for the active taxonomy.
+
+    The two halves come from different places on purpose. Types are DERIVED, and versioned
+    so a rename cannot orphan facts keyed under the old name. The organisation the wiki
+    belongs to is CONFIGURED (``app.ingest.settings``) — one value, stable, known to an admin
+    on day one, and deliberately not something a re-derivation over a thin corpus can
+    overwrite with a guess.
 
     ``taxonomy_id`` resolves a specific one instead — how a consumer reads back the types it
     keyed facts under, rather than assuming the active taxonomy still means the same thing.
@@ -489,11 +506,7 @@ def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], froze
     relevance scorer degrades to cosine without its model file: a deployment that has never
     run a derivation still works, with types that are generic rather than tailored.
     """
-    row = (
-        entity_taxonomy.get(taxonomy_id)
-        if taxonomy_id is not None
-        else entity_taxonomy.active()
-    )
+    row = entity_taxonomy.get(taxonomy_id) if taxonomy_id is not None else entity_taxonomy.active()
     if row is None:
         return dict(DEFAULT_TYPES), frozenset()
 
@@ -505,11 +518,7 @@ def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], froze
         name, definition = entry.get("name"), entry.get("definition")
         if isinstance(name, str) and isinstance(definition, str) and name and definition:
             defs[name] = definition
-    # Home entities are not derived yet — see the module docstring. The field is read so a
-    # future producer (a per-page vote) can populate it without changing this reader.
-    stats = row.stats or {}
-    home = frozenset(str(a) for a in cast(list[Any], stats.get("home_entities") or []))
-    return (defs or dict(DEFAULT_TYPES)), home
+    return (defs or dict(DEFAULT_TYPES)), _skip_names()
 
 
 def derive(

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -479,17 +479,21 @@ def fold(mentions: list[Mention]) -> list[Referent]:
 
 
 # --- artifact ---------------------------------------------------------------------------
-def load_taxonomy(version: int | None = None) -> tuple[dict[str, str], frozenset[str]]:
+def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], frozenset[str]]:
     """``(type definitions, home entity names)`` for the active taxonomy.
 
-    ``version`` resolves a specific one instead — how a consumer reads back the types it
+    ``taxonomy_id`` resolves a specific one instead — how a consumer reads back the types it
     keyed facts under, rather than assuming the active taxonomy still means the same thing.
 
     Falls back to ``DEFAULT_TYPES`` when nothing has been derived, mirroring how the
     relevance scorer degrades to cosine without its model file: a deployment that has never
     run a derivation still works, with types that are generic rather than tailored.
     """
-    row = entity_taxonomy.get(version) if version is not None else entity_taxonomy.active()
+    row = (
+        entity_taxonomy.get(taxonomy_id)
+        if taxonomy_id is not None
+        else entity_taxonomy.active()
+    )
     if row is None:
         return dict(DEFAULT_TYPES), frozenset()
 
@@ -621,12 +625,12 @@ def run_derivation(
         stats["n_typed"],
         stats["n_types"],
     )
-    artifact["version"] = store_taxonomy(artifact, triggered_by=triggered_by_user_id)
+    artifact["taxonomy_id"] = store_taxonomy(artifact, triggered_by=triggered_by_user_id)
     return artifact
 
 
 def store_taxonomy(artifact: dict[str, Any], *, triggered_by: str | None = None) -> int:
-    """Persist a derived taxonomy and make it active. Returns its version.
+    """Persist a derived taxonomy and make it active. Returns its id.
 
     Append-only: see ``app.db.entity_taxonomy`` for why a rename must not overwrite.
     """

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -64,6 +64,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
+from app.db import entity_taxonomy
 from app.llm import client, embeddings
 from app.llm.prompts import load_prompt
 from app.wiki import filesystem, git as wiki_git
@@ -478,32 +479,31 @@ def fold(mentions: list[Mention]) -> list[Referent]:
 
 
 # --- artifact ---------------------------------------------------------------------------
-def load_taxonomy(path: str | None) -> tuple[dict[str, str], frozenset[str]]:
-    """``(type definitions, home entity names)`` from a derived artifact.
+def load_taxonomy(version: int | None = None) -> tuple[dict[str, str], frozenset[str]]:
+    """``(type definitions, home entity names)`` for the active taxonomy.
 
-    Falls back to ``DEFAULT_TYPES`` when absent or unreadable, mirroring how the relevance
-    scorer degrades to cosine when its model file is missing: a deployment that has never
-    run the derivation still works.
+    ``version`` resolves a specific one instead — how a consumer reads back the types it
+    keyed facts under, rather than assuming the active taxonomy still means the same thing.
+
+    Falls back to ``DEFAULT_TYPES`` when nothing has been derived, mirroring how the
+    relevance scorer degrades to cosine without its model file: a deployment that has never
+    run a derivation still works, with types that are generic rather than tailored.
     """
-    if not path:
+    row = entity_taxonomy.get(version) if version is not None else entity_taxonomy.active()
+    if row is None:
         return dict(DEFAULT_TYPES), frozenset()
-    try:
-        with open(path, encoding="utf-8") as handle:
-            payload = cast(dict[str, Any], json.load(handle))
-    except (OSError, json.JSONDecodeError):
-        log.warning("entity_types: no usable artifact at %s; using defaults", path)
-        return dict(DEFAULT_TYPES), frozenset()
+
     defs: dict[str, str] = {}
-    for raw_type in cast(list[Any], payload.get("entity_types") or []):
+    for raw_type in cast(list[Any], row.types or []):
         if not isinstance(raw_type, dict):
             continue
         entry = cast(dict[str, Any], raw_type)
         name, definition = entry.get("name"), entry.get("definition")
         if isinstance(name, str) and isinstance(definition, str) and name and definition:
             defs[name] = definition
-    # Home entities are not derived here — see the module docstring. The field is read so a
+    # Home entities are not derived yet — see the module docstring. The field is read so a
     # future producer (a per-page vote) can populate it without changing this reader.
-    stats = cast(dict[str, Any], payload.get("stats") or {})
+    stats = row.stats or {}
     home = frozenset(str(a) for a in cast(list[Any], stats.get("home_entities") or []))
     return (defs or dict(DEFAULT_TYPES)), home
 
@@ -612,7 +612,6 @@ def run_derivation(
 
     log.info("entity_types: deriving from %d page(s)", len(pages))
     artifact = derive(pages, model=model)
-    artifact["triggered_by_user_id"] = triggered_by_user_id
 
     stats = artifact["stats"]
     log.info(
@@ -622,23 +621,16 @@ def run_derivation(
         stats["n_typed"],
         stats["n_types"],
     )
-    store_taxonomy(artifact)
+    artifact["version"] = store_taxonomy(artifact, triggered_by=triggered_by_user_id)
     return artifact
 
 
-def store_taxonomy(artifact: dict[str, Any]) -> None:
-    """Persist a derived taxonomy.
+def store_taxonomy(artifact: dict[str, Any], *, triggered_by: str | None = None) -> int:
+    """Persist a derived taxonomy and make it active. Returns its version.
 
-    A placeholder while there is no consumer in-tree. The eventual home is a versioned
-    table rather than a single current value: types key facts by entity, so a re-derivation
-    that renames one must not orphan rows keyed under the old name — which means keeping
-    the old taxonomy resolvable, not overwriting it. Deferred until the consumer lands and
-    can say what it needs to read.
+    Append-only: see ``app.db.entity_taxonomy`` for why a rename must not overwrite.
     """
-    log.info(
-        "entity_types: derived taxonomy for corpus %s — not persisted; no store configured yet",
-        str(artifact.get("corpus_fingerprint", ""))[:12],
-    )
+    return entity_taxonomy.record(artifact, triggered_by=triggered_by)
 
 
 def read_corpus(prefix: str = "") -> list[tuple[str, str]]:

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -6,8 +6,8 @@ the obvious way to get one is for someone to write it down. That does not surviv
 with customers: nobody arriving with a wiki is going to author a type list first, and a list
 written for one deployment is wrong for the next.
 
-So derive it from the pages themselves. The pipeline reads only the wiki — never an incoming document — because a taxonomy has to
-describe the corpus it will be applied to:
+So derive it from the pages themselves. The pipeline reads only the wiki — never an
+incoming document — because a taxonomy has to describe the corpus it will be applied to:
 
     1. EXTRACT   per page, whole page, with NO type menu. Supplying one would presuppose the
                  answer; we want the referents the corpus actually contains.
@@ -31,7 +31,6 @@ Keeping types few and general is the MERGE step's job, and it is effective at it
 per-group naming step over-splits by construction, and one pass over the whole taxonomy
 collapses that. A second, count-based implementation of the same intent only cost
 information.
-
 
 Deliberately NOT solved here: exact entity resolution to canonical ids. Types need
 approximate counts, not identities — and once types exist, resolution gets easier because

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -32,12 +32,6 @@ per-group naming step over-splits by construction, and one pass over the whole t
 collapses that. A second, count-based implementation of the same intent only cost
 information.
 
-Home entities — the organization a wiki is written BY, whose name therefore carries no
-discriminative signal — are a real and separate need, consumed by the extraction prompt.
-Document frequency is the wrong instrument for it: it conflates "whose wiki is this" with
-"what gets mentioned a lot", and on a small corpus the two are indistinguishable. That
-signal wants asking each page directly and taking a vote; until then ``load_taxonomy``
-returns no home entities rather than a guess.
 
 Deliberately NOT solved here: exact entity resolution to canonical ids. Types need
 approximate counts, not identities — and once types exist, resolution gets easier because
@@ -65,7 +59,6 @@ from typing import Any, cast
 from pydantic import BaseModel, Field
 
 from app.db import entity_taxonomy
-from app.ingest import settings as ingest_settings
 from app.llm import client, embeddings
 from app.llm.prompts import load_prompt
 from app.wiki import filesystem, git as wiki_git
@@ -480,24 +473,10 @@ def fold(mentions: list[Mention]) -> list[Referent]:
 
 
 # --- artifact ---------------------------------------------------------------------------
-def _skip_names() -> frozenset[str]:
-    """Names extraction should not treat as referents — the organisation itself.
-
-    Empty when no organisation is configured, which simply drops the "ignore these" line
-    from the prompt rather than guessing.
-    """
-    name = (ingest_settings.get_organization_name() or "").strip()
-    return frozenset({name}) if name else frozenset()
 
 
-def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], frozenset[str]]:
-    """``(type definitions, names to skip)`` for the active taxonomy.
-
-    The two halves come from different places on purpose. Types are DERIVED, and versioned
-    so a rename cannot orphan facts keyed under the old name. The organisation the wiki
-    belongs to is CONFIGURED (``app.ingest.settings``) — one value, stable, known to an admin
-    on day one, and deliberately not something a re-derivation over a thin corpus can
-    overwrite with a guess.
+def load_taxonomy(taxonomy_id: int | None = None) -> dict[str, str]:
+    """``{type name: definition}`` for the active taxonomy.
 
     ``taxonomy_id`` resolves a specific one instead — how a consumer reads back the types it
     keyed facts under, rather than assuming the active taxonomy still means the same thing.
@@ -508,7 +487,7 @@ def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], froze
     """
     row = entity_taxonomy.get(taxonomy_id) if taxonomy_id is not None else entity_taxonomy.active()
     if row is None:
-        return dict(DEFAULT_TYPES), frozenset()
+        return dict(DEFAULT_TYPES)
 
     defs: dict[str, str] = {}
     for raw_type in cast(list[Any], row.types or []):
@@ -518,7 +497,7 @@ def load_taxonomy(taxonomy_id: int | None = None) -> tuple[dict[str, str], froze
         name, definition = entry.get("name"), entry.get("definition")
         if isinstance(name, str) and isinstance(definition, str) and name and definition:
             defs[name] = definition
-    return (defs or dict(DEFAULT_TYPES)), _skip_names()
+    return defs or dict(DEFAULT_TYPES)
 
 
 def derive(

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -33,6 +33,9 @@ class IngestSettings(BaseModel):
     # rather than derived output — an admin knows it on day one, long before a corpus is big
     # enough for any statistical signal, and a re-derivation must not overwrite it.
     organization_name: str | None
+    # "admin" | "inferred" | None. Gates inference: see the model for why the source, not the
+    # value's nullness, decides whether a derivation may write.
+    organization_name_source: str | None
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners can override, and a hard cap above which
     # a page's ingestion auto-update is turned off. 0 = off.
@@ -52,6 +55,7 @@ def get() -> IngestSettings:
                 api_key=None,
                 onyx_base_url=None,
                 organization_name=None,
+                organization_name_source=None,
                 warn_update_threshold_default=DEFAULT_WARN_UPDATE_THRESHOLD,
                 auto_update_cap=DEFAULT_AUTO_UPDATE_CAP,
                 updated_at=None,
@@ -62,6 +66,7 @@ def get() -> IngestSettings:
             api_key=row.api_key,
             onyx_base_url=row.onyx_base_url,
             organization_name=row.organization_name,
+            organization_name_source=row.organization_name_source,
             warn_update_threshold_default=row.warn_update_threshold_default,
             auto_update_cap=row.auto_update_cap,
             updated_at=row.updated_at,
@@ -75,8 +80,46 @@ def get_onyx_base_url() -> str | None:
 
 
 def get_organization_name() -> str | None:
-    """The organisation the wiki belongs to, or None when an admin has not set it."""
+    """The organisation the wiki belongs to, or None when nobody has claimed it."""
     return get().organization_name
+
+
+def organization_name_is_admin_set() -> bool:
+    """Whether a human decided the name — in which case inference must not run.
+
+    A derivation checks this before spending anything on detection: an admin's value is not
+    to be improved upon, and that includes an admin who deliberately CLEARED it.
+    """
+    return get().organization_name_source == "admin"
+
+
+def set_organization_name(
+    name: str | None, *, source: str, updated_by_user_id: str | None = None
+) -> None:
+    """Claim the organisation name. ``source`` is "admin" or "inferred".
+
+    Inference must not clobber a human decision, so an "inferred" write is refused once the
+    source is "admin". An "admin" write always wins, including clearing the value.
+    """
+    if source not in ("admin", "inferred"):
+        raise ValueError(f"unknown organization_name source: {source!r}")
+
+    cleaned = (name or "").strip() or None
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+    with session() as s:
+        row = s.get(IngestSettingsRow, 1)
+        if row is None:
+            row = IngestSettingsRow(id=1)
+            s.add(row)
+        if source == "inferred" and row.organization_name_source == "admin":
+            log.info("organization_name: keeping the admin-set value; inference skipped")
+            return
+        row.organization_name = cleaned
+        row.organization_name_source = source
+        row.updated_at = now
+        if updated_by_user_id is not None:
+            row.updated_by_user_id = updated_by_user_id
+    log.info("organization_name set (source=%s, cleared=%s)", source, cleaned is None)
 
 
 def upsert(
@@ -102,8 +145,11 @@ def upsert(
         row.onyx_base_url = onyx_base_url
         # Patch semantics, like the health knobs below: None leaves it unchanged, so a
         # connection-only save cannot silently clear an organisation name someone set.
+        # A value arriving here came from an admin, so it is stamped as such — otherwise a
+        # human edit would be indistinguishable from a guess and inference would overwrite it.
         if organization_name is not None:
             row.organization_name = organization_name.strip() or None
+            row.organization_name_source = "admin"
         if warn_update_threshold_default is not None:
             row.warn_update_threshold_default = warn_update_threshold_default
         if auto_update_cap is not None:

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -1,5 +1,4 @@
 """DB-backed ingest settings. Configured from /admin/ingest."""
-
 from __future__ import annotations
 
 import logging
@@ -28,16 +27,6 @@ class IngestSettings(BaseModel):
     # Outbound half of the "Onyx Connection" admin page — the public Onyx
     # origin for Craft launches. None = Craft unavailable.
     onyx_base_url: str | None
-    # The organisation this wiki belongs to. Entity extraction is told not to treat it as a
-    # referent: its name is on nearly every page, so it distinguishes nothing. A setting
-    # rather than derived output — an admin knows it on day one, long before a corpus is big
-    # enough for any statistical signal, and a re-derivation must not overwrite it.
-    # Default None so existing construction sites (and tests) stay valid: an unset
-    # organisation is the normal state, not an omission a caller has to declare.
-    organization_name: str | None = None
-    # "admin" | "inferred" | None. Gates inference: see the model for why the source, not the
-    # value's nullness, decides whether a derivation may write.
-    organization_name_source: str | None = None
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners can override, and a hard cap above which
     # a page's ingestion auto-update is turned off. 0 = off.
@@ -56,8 +45,6 @@ def get() -> IngestSettings:
                 max_doc_chars=DEFAULT_MAX_DOC_CHARS,
                 api_key=None,
                 onyx_base_url=None,
-                organization_name=None,
-                organization_name_source=None,
                 warn_update_threshold_default=DEFAULT_WARN_UPDATE_THRESHOLD,
                 auto_update_cap=DEFAULT_AUTO_UPDATE_CAP,
                 updated_at=None,
@@ -67,8 +54,6 @@ def get() -> IngestSettings:
             max_doc_chars=row.max_doc_chars,
             api_key=row.api_key,
             onyx_base_url=row.onyx_base_url,
-            organization_name=row.organization_name,
-            organization_name_source=row.organization_name_source,
             warn_update_threshold_default=row.warn_update_threshold_default,
             auto_update_cap=row.auto_update_cap,
             updated_at=row.updated_at,
@@ -81,54 +66,10 @@ def get_onyx_base_url() -> str | None:
     return get().onyx_base_url
 
 
-def get_organization_name() -> str | None:
-    """The organisation the wiki belongs to, or None when nobody has claimed it."""
-    return get().organization_name
-
-
-def organization_name_is_admin_set() -> bool:
-    """Whether a human decided the name — in which case inference must not run.
-
-    A derivation checks this before spending anything on detection: an admin's value is not
-    to be improved upon, and that includes an admin who deliberately CLEARED it.
-    """
-    return get().organization_name_source == "admin"
-
-
-def set_organization_name(
-    name: str | None, *, source: str, updated_by_user_id: str | None = None
-) -> None:
-    """Claim the organisation name. ``source`` is "admin" or "inferred".
-
-    Inference must not clobber a human decision, so an "inferred" write is refused once the
-    source is "admin". An "admin" write always wins, including clearing the value.
-    """
-    if source not in ("admin", "inferred"):
-        raise ValueError(f"unknown organization_name source: {source!r}")
-
-    cleaned = (name or "").strip() or None
-    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-    with session() as s:
-        row = s.get(IngestSettingsRow, 1)
-        if row is None:
-            row = IngestSettingsRow(id=1)
-            s.add(row)
-        if source == "inferred" and row.organization_name_source == "admin":
-            log.info("organization_name: keeping the admin-set value; inference skipped")
-            return
-        row.organization_name = cleaned
-        row.organization_name_source = source
-        row.updated_at = now
-        if updated_by_user_id is not None:
-            row.updated_by_user_id = updated_by_user_id
-    log.info("organization_name set (source=%s, cleared=%s)", source, cleaned is None)
-
-
 def upsert(
     *,
     max_doc_chars: int,
     onyx_base_url: str | None,
-    organization_name: str | None = None,
     warn_update_threshold_default: int | None = None,
     auto_update_cap: int | None = None,
     updated_by_user_id: str | None = None,
@@ -145,13 +86,6 @@ def upsert(
             s.add(row)
         row.max_doc_chars = max_doc_chars
         row.onyx_base_url = onyx_base_url
-        # Patch semantics, like the health knobs below: None leaves it unchanged, so a
-        # connection-only save cannot silently clear an organisation name someone set.
-        # A value arriving here came from an admin, so it is stamped as such — otherwise a
-        # human edit would be indistinguishable from a guess and inference would overwrite it.
-        if organization_name is not None:
-            row.organization_name = organization_name.strip() or None
-            row.organization_name_source = "admin"
         if warn_update_threshold_default is not None:
             row.warn_update_threshold_default = warn_update_threshold_default
         if auto_update_cap is not None:
@@ -172,15 +106,10 @@ def regenerate_key(*, updated_by_user_id: str | None = None) -> str:
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            s.add(
-                IngestSettingsRow(
-                    id=1,
-                    max_doc_chars=DEFAULT_MAX_DOC_CHARS,
-                    api_key=key,
-                    updated_at=now,
-                    updated_by_user_id=updated_by_user_id,
-                )
-            )
+            s.add(IngestSettingsRow(
+                id=1, max_doc_chars=DEFAULT_MAX_DOC_CHARS, api_key=key, updated_at=now,
+                updated_by_user_id=updated_by_user_id,
+            ))
         else:
             row.api_key = key
             row.updated_at = now

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -32,10 +32,12 @@ class IngestSettings(BaseModel):
     # referent: its name is on nearly every page, so it distinguishes nothing. A setting
     # rather than derived output — an admin knows it on day one, long before a corpus is big
     # enough for any statistical signal, and a re-derivation must not overwrite it.
-    organization_name: str | None
+    # Default None so existing construction sites (and tests) stay valid: an unset
+    # organisation is the normal state, not an omission a caller has to declare.
+    organization_name: str | None = None
     # "admin" | "inferred" | None. Gates inference: see the model for why the source, not the
     # value's nullness, decides whether a derivation may write.
-    organization_name_source: str | None
+    organization_name_source: str | None = None
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners can override, and a hard cap above which
     # a page's ingestion auto-update is turned off. 0 = off.

--- a/backend/app/ingest/settings.py
+++ b/backend/app/ingest/settings.py
@@ -1,4 +1,5 @@
 """DB-backed ingest settings. Configured from /admin/ingest."""
+
 from __future__ import annotations
 
 import logging
@@ -27,6 +28,11 @@ class IngestSettings(BaseModel):
     # Outbound half of the "Onyx Connection" admin page — the public Onyx
     # origin for Craft launches. None = Craft unavailable.
     onyx_base_url: str | None
+    # The organisation this wiki belongs to. Entity extraction is told not to treat it as a
+    # referent: its name is on nearly every page, so it distinguishes nothing. A setting
+    # rather than derived output — an admin knows it on day one, long before a corpus is big
+    # enough for any statistical signal, and a re-derivation must not overwrite it.
+    organization_name: str | None
     # Auto-update health knobs (see "Taming Bad-Behaved Wikis"): the default
     # per-page warning threshold owners can override, and a hard cap above which
     # a page's ingestion auto-update is turned off. 0 = off.
@@ -45,6 +51,7 @@ def get() -> IngestSettings:
                 max_doc_chars=DEFAULT_MAX_DOC_CHARS,
                 api_key=None,
                 onyx_base_url=None,
+                organization_name=None,
                 warn_update_threshold_default=DEFAULT_WARN_UPDATE_THRESHOLD,
                 auto_update_cap=DEFAULT_AUTO_UPDATE_CAP,
                 updated_at=None,
@@ -54,6 +61,7 @@ def get() -> IngestSettings:
             max_doc_chars=row.max_doc_chars,
             api_key=row.api_key,
             onyx_base_url=row.onyx_base_url,
+            organization_name=row.organization_name,
             warn_update_threshold_default=row.warn_update_threshold_default,
             auto_update_cap=row.auto_update_cap,
             updated_at=row.updated_at,
@@ -66,10 +74,16 @@ def get_onyx_base_url() -> str | None:
     return get().onyx_base_url
 
 
+def get_organization_name() -> str | None:
+    """The organisation the wiki belongs to, or None when an admin has not set it."""
+    return get().organization_name
+
+
 def upsert(
     *,
     max_doc_chars: int,
     onyx_base_url: str | None,
+    organization_name: str | None = None,
     warn_update_threshold_default: int | None = None,
     auto_update_cap: int | None = None,
     updated_by_user_id: str | None = None,
@@ -86,6 +100,10 @@ def upsert(
             s.add(row)
         row.max_doc_chars = max_doc_chars
         row.onyx_base_url = onyx_base_url
+        # Patch semantics, like the health knobs below: None leaves it unchanged, so a
+        # connection-only save cannot silently clear an organisation name someone set.
+        if organization_name is not None:
+            row.organization_name = organization_name.strip() or None
         if warn_update_threshold_default is not None:
             row.warn_update_threshold_default = warn_update_threshold_default
         if auto_update_cap is not None:
@@ -106,10 +124,15 @@ def regenerate_key(*, updated_by_user_id: str | None = None) -> str:
     with session() as s:
         row = s.get(IngestSettingsRow, 1)
         if row is None:
-            s.add(IngestSettingsRow(
-                id=1, max_doc_chars=DEFAULT_MAX_DOC_CHARS, api_key=key, updated_at=now,
-                updated_by_user_id=updated_by_user_id,
-            ))
+            s.add(
+                IngestSettingsRow(
+                    id=1,
+                    max_doc_chars=DEFAULT_MAX_DOC_CHARS,
+                    api_key=key,
+                    updated_at=now,
+                    updated_by_user_id=updated_by_user_id,
+                )
+            )
         else:
             row.api_key = key
             row.updated_at = now

--- a/backend/tests/test_entity_taxonomy_store.py
+++ b/backend/tests/test_entity_taxonomy_store.py
@@ -104,16 +104,14 @@ class TestRead:
 
 
 class TestLoadTaxonomy:
-    """``load_taxonomy`` is what the extraction prompt reads, so its fallback matters as
-    much as its happy path — a deployment that has never derived must still work."""
+    """``load_taxonomy`` is what the extractor's type menu comes from, so its fallback
+    matters as much as its happy path — a deployment that has never derived must still
+    work."""
 
     def test_falls_back_to_generic_types_when_nothing_is_derived(self, tmp_db) -> None:
         from app.ingest.entity_types import DEFAULT_TYPES, load_taxonomy
 
-        defs, home = load_taxonomy()
-
-        assert defs == dict(DEFAULT_TYPES)
-        assert home == frozenset()
+        assert load_taxonomy() == dict(DEFAULT_TYPES)
 
     def test_reads_the_active_taxonomy(self, tmp_db) -> None:
         from app.ingest.entity_types import load_taxonomy
@@ -122,9 +120,7 @@ class TestLoadTaxonomy:
             _artifact(types=[{"name": "person", "definition": "A named individual."}])
         )
 
-        defs, _ = load_taxonomy()
-
-        assert defs == {"person": "A named individual."}
+        assert load_taxonomy() == {"person": "A named individual."}
 
     def test_reads_a_specific_taxonomy(self, tmp_db) -> None:
         """How a consumer resolves the types it keyed facts under, rather than assuming the
@@ -134,30 +130,8 @@ class TestLoadTaxonomy:
         entity_taxonomy.record(_artifact(types=[{"name": "old_name", "definition": "d"}]))
         entity_taxonomy.record(_artifact(types=[{"name": "new_name", "definition": "d"}]))
 
-        assert set(load_taxonomy(taxonomy_id=1)[0]) == {"old_name"}
-        assert set(load_taxonomy()[0]) == {"new_name"}
-
-    def test_names_to_skip_come_from_the_configured_organisation(self, tmp_db) -> None:
-        """Types are derived and versioned; the organisation is configured. An admin knows it
-        on day one, and a re-derivation over a thin corpus must not overwrite it."""
-        from app.ingest import settings as ingest_settings
-        from app.ingest.entity_types import load_taxonomy
-
-        entity_taxonomy.record(_artifact())
-        assert load_taxonomy()[1] == frozenset()
-
-        ingest_settings.upsert(max_doc_chars=1000, onyx_base_url=None, organization_name="Acme")
-
-        assert load_taxonomy()[1] == frozenset({"Acme"})
-
-    def test_a_blank_organisation_name_is_not_a_skip_name(self, tmp_db) -> None:
-        """Whitespace must not become a name the extractor is told to ignore."""
-        from app.ingest import settings as ingest_settings
-        from app.ingest.entity_types import load_taxonomy
-
-        ingest_settings.upsert(max_doc_chars=1000, onyx_base_url=None, organization_name="   ")
-
-        assert load_taxonomy()[1] == frozenset()
+        assert set(load_taxonomy(taxonomy_id=1)) == {"old_name"}
+        assert set(load_taxonomy()) == {"new_name"}
 
     def test_a_taxonomy_of_unusable_entries_falls_back(self, tmp_db) -> None:
         """Malformed rows should degrade to the generic list, not to an empty menu that
@@ -166,86 +140,4 @@ class TestLoadTaxonomy:
 
         entity_taxonomy.record(_artifact(types=[{"name": "", "definition": ""}, {"nope": 1}]))
 
-        assert load_taxonomy()[0] == dict(DEFAULT_TYPES)
-
-
-class TestOrganizationNameSource:
-    """The source column, not the value, gates inference.
-
-    "Do not overwrite a non-null value" would freeze a bad guess forever; and an admin who
-    deliberately CLEARS the name has decided there is none, which must not look like "unset"
-    and re-trigger detection.
-    """
-
-    def _set(self, name: str | None, source: str) -> None:
-        from app.ingest import settings as ingest_settings
-
-        ingest_settings.set_organization_name(name, source=source)
-
-    def test_inference_may_claim_an_unset_name(self, tmp_db) -> None:
-        from app.ingest import settings as ingest_settings
-
-        self._set("Acme", "inferred")
-
-        assert ingest_settings.get_organization_name() == "Acme"
-        assert ingest_settings.organization_name_is_admin_set() is False
-
-    def test_inference_may_correct_its_own_earlier_guess(self, tmp_db) -> None:
-        """A later derivation sees far more corpus; it should be allowed to improve on itself."""
-        from app.ingest import settings as ingest_settings
-
-        self._set("Acme", "inferred")
-        self._set("Acme Industries", "inferred")
-
-        assert ingest_settings.get_organization_name() == "Acme Industries"
-
-    def test_inference_never_overwrites_an_admin(self, tmp_db) -> None:
-        from app.ingest import settings as ingest_settings
-
-        self._set("CBRE", "admin")
-        self._set("Cbre", "inferred")
-
-        assert ingest_settings.get_organization_name() == "CBRE"
-
-    def test_an_admin_clearing_the_name_stops_inference(self, tmp_db) -> None:
-        """("admin", NULL) means "there is no name" — not "nobody has said"."""
-        from app.ingest import settings as ingest_settings
-
-        self._set("Acme", "admin")
-        self._set(None, "admin")
-
-        assert ingest_settings.get_organization_name() is None
-        assert ingest_settings.organization_name_is_admin_set() is True
-
-        self._set("Guessed", "inferred")
-        assert ingest_settings.get_organization_name() is None
-
-    def test_an_admin_may_override_an_inferred_value(self, tmp_db) -> None:
-        from app.ingest import settings as ingest_settings
-
-        self._set("Acme", "inferred")
-        self._set("Acme Industries GmbH", "admin")
-
-        assert ingest_settings.get_organization_name() == "Acme Industries GmbH"
-        assert ingest_settings.organization_name_is_admin_set() is True
-
-    def test_upsert_stamps_an_admin_source(self, tmp_db) -> None:
-        """A name arriving through the admin settings save is a human decision, so inference
-        must not later overwrite it."""
-        from app.ingest import settings as ingest_settings
-
-        ingest_settings.upsert(max_doc_chars=1000, onyx_base_url=None, organization_name="Acme")
-
-        assert ingest_settings.organization_name_is_admin_set() is True
-
-    def test_whitespace_is_not_a_name(self, tmp_db) -> None:
-        from app.ingest import settings as ingest_settings
-
-        self._set("   ", "inferred")
-        assert ingest_settings.get_organization_name() is None
-
-    def test_an_unknown_source_is_rejected(self, tmp_db) -> None:
-        from app.ingest import settings as ingest_settings
-
-        with pytest.raises(ValueError):
-            ingest_settings.set_organization_name("Acme", source="guessed")
+        assert load_taxonomy() == dict(DEFAULT_TYPES)

--- a/backend/tests/test_entity_taxonomy_store.py
+++ b/backend/tests/test_entity_taxonomy_store.py
@@ -33,31 +33,31 @@ def _artifact(*, types: list[dict[str, object]] | None = None, fingerprint: str 
 
 
 class TestRecord:
-    def test_first_taxonomy_is_version_one_and_active(self) -> None:
+    def test_first_taxonomy_is_id_one_and_active(self) -> None:
         assert entity_taxonomy.active() is None
 
-        version = entity_taxonomy.record(_artifact())
+        taxonomy_id = entity_taxonomy.record(_artifact())
 
-        assert version == 1
+        assert taxonomy_id == 1
         row = entity_taxonomy.active()
         assert row is not None
-        assert row.version == 1
+        assert row.id == 1
         assert row.corpus_fingerprint == "abc123"
         assert row.types[0]["name"] == "organization"
         assert row.provenance["group_similarity"] == 0.45
 
-    def test_versions_increment_and_only_the_newest_is_active(self) -> None:
+    def test_ids_increment_and_only_the_newest_is_active(self) -> None:
         entity_taxonomy.record(_artifact(fingerprint="first"))
         second = entity_taxonomy.record(_artifact(fingerprint="second"))
 
         assert second == 2
         active = entity_taxonomy.active()
         assert active is not None
-        assert (active.version, active.corpus_fingerprint) == (2, "second")
+        assert (active.id, active.corpus_fingerprint) == (2, "second")
 
     def test_a_superseded_taxonomy_stays_resolvable(self) -> None:
-        """The whole point of append-only: rows keyed under v1's type names must still be
-        able to look those names up after v2 renames them."""
+        """The whole point of append-only: facts keyed under the first taxonomy's type names
+        must still resolve after a later one renames them."""
         entity_taxonomy.record(
             _artifact(types=[{"name": "software_product_or_service", "definition": "d"}])
         )
@@ -85,18 +85,18 @@ class TestRecord:
 
 
 class TestRead:
-    def test_get_unknown_version_is_none(self) -> None:
+    def test_get_unknown_id_is_none(self) -> None:
         assert entity_taxonomy.get(99) is None
 
     def test_history_is_newest_first(self) -> None:
         for n in range(3):
             entity_taxonomy.record(_artifact(fingerprint=f"c{n}"))
-        assert [row.version for row in entity_taxonomy.history()] == [3, 2, 1]
+        assert [row.id for row in entity_taxonomy.history()] == [3, 2, 1]
 
     def test_history_respects_the_limit(self) -> None:
         for n in range(4):
             entity_taxonomy.record(_artifact(fingerprint=f"c{n}"))
-        assert [row.version for row in entity_taxonomy.history(limit=2)] == [4, 3]
+        assert [row.id for row in entity_taxonomy.history(limit=2)] == [4, 3]
 
 
 class TestLoadTaxonomy:
@@ -122,7 +122,7 @@ class TestLoadTaxonomy:
 
         assert defs == {"person": "A named individual."}
 
-    def test_reads_a_specific_version(self) -> None:
+    def test_reads_a_specific_taxonomy(self) -> None:
         """How a consumer resolves the types it keyed facts under, rather than assuming the
         active taxonomy still means the same thing."""
         from app.ingest.entity_types import load_taxonomy
@@ -130,7 +130,7 @@ class TestLoadTaxonomy:
         entity_taxonomy.record(_artifact(types=[{"name": "old_name", "definition": "d"}]))
         entity_taxonomy.record(_artifact(types=[{"name": "new_name", "definition": "d"}]))
 
-        assert set(load_taxonomy(version=1)[0]) == {"old_name"}
+        assert set(load_taxonomy(taxonomy_id=1)[0]) == {"old_name"}
         assert set(load_taxonomy()[0]) == {"new_name"}
 
     def test_home_entities_come_from_stats(self) -> None:

--- a/backend/tests/test_entity_taxonomy_store.py
+++ b/backend/tests/test_entity_taxonomy_store.py
@@ -133,16 +133,27 @@ class TestLoadTaxonomy:
         assert set(load_taxonomy(taxonomy_id=1)[0]) == {"old_name"}
         assert set(load_taxonomy()[0]) == {"new_name"}
 
-    def test_home_entities_come_from_stats(self) -> None:
-        """Not produced yet — the reader is wired so a per-page vote can fill it without
-        changing this side."""
+    def test_names_to_skip_come_from_the_configured_organisation(self) -> None:
+        """Types are derived and versioned; the organisation is configured. An admin knows it
+        on day one, and a re-derivation over a thin corpus must not overwrite it."""
+        from app.ingest import settings as ingest_settings
         from app.ingest.entity_types import load_taxonomy
 
-        artifact = _artifact()
-        artifact["stats"]["home_entities"] = ["Acme"]
-        entity_taxonomy.record(artifact)
+        entity_taxonomy.record(_artifact())
+        assert load_taxonomy()[1] == frozenset()
+
+        ingest_settings.upsert(max_doc_chars=1000, onyx_base_url=None, organization_name="Acme")
 
         assert load_taxonomy()[1] == frozenset({"Acme"})
+
+    def test_a_blank_organisation_name_is_not_a_skip_name(self) -> None:
+        """Whitespace must not become a name the extractor is told to ignore."""
+        from app.ingest import settings as ingest_settings
+        from app.ingest.entity_types import load_taxonomy
+
+        ingest_settings.upsert(max_doc_chars=1000, onyx_base_url=None, organization_name="   ")
+
+        assert load_taxonomy()[1] == frozenset()
 
     def test_a_taxonomy_of_unusable_entries_falls_back(self) -> None:
         """Malformed rows should degrade to the generic list, not to an empty menu that

--- a/backend/tests/test_entity_taxonomy_store.py
+++ b/backend/tests/test_entity_taxonomy_store.py
@@ -12,6 +12,10 @@ import pytest
 
 from app.db import entity_taxonomy
 
+# Every test here takes ``tmp_db`` — the conftest fixture that declares "this test needs a
+# migrated database". Without it a test runs against the app's own configured connection,
+# which in CI is a docker-compose hostname that does not resolve from the test job.
+
 
 def _artifact(*, types: list[dict[str, object]] | None = None, fingerprint: str = "abc123") -> dict:
     return {
@@ -33,7 +37,7 @@ def _artifact(*, types: list[dict[str, object]] | None = None, fingerprint: str 
 
 
 class TestRecord:
-    def test_first_taxonomy_is_id_one_and_active(self) -> None:
+    def test_first_taxonomy_is_id_one_and_active(self, tmp_db) -> None:
         assert entity_taxonomy.active() is None
 
         taxonomy_id = entity_taxonomy.record(_artifact())
@@ -46,7 +50,7 @@ class TestRecord:
         assert row.types[0]["name"] == "organization"
         assert row.provenance["group_similarity"] == 0.45
 
-    def test_ids_increment_and_only_the_newest_is_active(self) -> None:
+    def test_ids_increment_and_only_the_newest_is_active(self, tmp_db) -> None:
         entity_taxonomy.record(_artifact(fingerprint="first"))
         second = entity_taxonomy.record(_artifact(fingerprint="second"))
 
@@ -55,7 +59,7 @@ class TestRecord:
         assert active is not None
         assert (active.id, active.corpus_fingerprint) == (2, "second")
 
-    def test_a_superseded_taxonomy_stays_resolvable(self) -> None:
+    def test_a_superseded_taxonomy_stays_resolvable(self, tmp_db) -> None:
         """The whole point of append-only: facts keyed under the first taxonomy's type names
         must still resolve after a later one renames them."""
         entity_taxonomy.record(
@@ -68,13 +72,13 @@ class TestRecord:
         assert old.types[0]["name"] == "software_product_or_service"
         assert old.active is False
 
-    def test_refuses_a_taxonomy_with_no_types(self) -> None:
+    def test_refuses_a_taxonomy_with_no_types(self, tmp_db) -> None:
         """An empty derivation is a failure, and recording it would deactivate a good one."""
         with pytest.raises(ValueError):
             entity_taxonomy.record(_artifact(types=[]))
         assert entity_taxonomy.active() is None
 
-    def test_a_failed_record_leaves_the_previous_one_in_force(self) -> None:
+    def test_a_failed_record_leaves_the_previous_one_in_force(self, tmp_db) -> None:
         entity_taxonomy.record(_artifact(fingerprint="good"))
         with pytest.raises(ValueError):
             entity_taxonomy.record(_artifact(types=[]))
@@ -85,15 +89,15 @@ class TestRecord:
 
 
 class TestRead:
-    def test_get_unknown_id_is_none(self) -> None:
+    def test_get_unknown_id_is_none(self, tmp_db) -> None:
         assert entity_taxonomy.get(99) is None
 
-    def test_history_is_newest_first(self) -> None:
+    def test_history_is_newest_first(self, tmp_db) -> None:
         for n in range(3):
             entity_taxonomy.record(_artifact(fingerprint=f"c{n}"))
         assert [row.id for row in entity_taxonomy.history()] == [3, 2, 1]
 
-    def test_history_respects_the_limit(self) -> None:
+    def test_history_respects_the_limit(self, tmp_db) -> None:
         for n in range(4):
             entity_taxonomy.record(_artifact(fingerprint=f"c{n}"))
         assert [row.id for row in entity_taxonomy.history(limit=2)] == [4, 3]
@@ -103,7 +107,7 @@ class TestLoadTaxonomy:
     """``load_taxonomy`` is what the extraction prompt reads, so its fallback matters as
     much as its happy path — a deployment that has never derived must still work."""
 
-    def test_falls_back_to_generic_types_when_nothing_is_derived(self) -> None:
+    def test_falls_back_to_generic_types_when_nothing_is_derived(self, tmp_db) -> None:
         from app.ingest.entity_types import DEFAULT_TYPES, load_taxonomy
 
         defs, home = load_taxonomy()
@@ -111,7 +115,7 @@ class TestLoadTaxonomy:
         assert defs == dict(DEFAULT_TYPES)
         assert home == frozenset()
 
-    def test_reads_the_active_taxonomy(self) -> None:
+    def test_reads_the_active_taxonomy(self, tmp_db) -> None:
         from app.ingest.entity_types import load_taxonomy
 
         entity_taxonomy.record(
@@ -122,7 +126,7 @@ class TestLoadTaxonomy:
 
         assert defs == {"person": "A named individual."}
 
-    def test_reads_a_specific_taxonomy(self) -> None:
+    def test_reads_a_specific_taxonomy(self, tmp_db) -> None:
         """How a consumer resolves the types it keyed facts under, rather than assuming the
         active taxonomy still means the same thing."""
         from app.ingest.entity_types import load_taxonomy
@@ -133,7 +137,7 @@ class TestLoadTaxonomy:
         assert set(load_taxonomy(taxonomy_id=1)[0]) == {"old_name"}
         assert set(load_taxonomy()[0]) == {"new_name"}
 
-    def test_names_to_skip_come_from_the_configured_organisation(self) -> None:
+    def test_names_to_skip_come_from_the_configured_organisation(self, tmp_db) -> None:
         """Types are derived and versioned; the organisation is configured. An admin knows it
         on day one, and a re-derivation over a thin corpus must not overwrite it."""
         from app.ingest import settings as ingest_settings
@@ -146,7 +150,7 @@ class TestLoadTaxonomy:
 
         assert load_taxonomy()[1] == frozenset({"Acme"})
 
-    def test_a_blank_organisation_name_is_not_a_skip_name(self) -> None:
+    def test_a_blank_organisation_name_is_not_a_skip_name(self, tmp_db) -> None:
         """Whitespace must not become a name the extractor is told to ignore."""
         from app.ingest import settings as ingest_settings
         from app.ingest.entity_types import load_taxonomy
@@ -155,7 +159,7 @@ class TestLoadTaxonomy:
 
         assert load_taxonomy()[1] == frozenset()
 
-    def test_a_taxonomy_of_unusable_entries_falls_back(self) -> None:
+    def test_a_taxonomy_of_unusable_entries_falls_back(self, tmp_db) -> None:
         """Malformed rows should degrade to the generic list, not to an empty menu that
         would make the extractor unable to type anything."""
         from app.ingest.entity_types import DEFAULT_TYPES, load_taxonomy
@@ -178,7 +182,7 @@ class TestOrganizationNameSource:
 
         ingest_settings.set_organization_name(name, source=source)
 
-    def test_inference_may_claim_an_unset_name(self) -> None:
+    def test_inference_may_claim_an_unset_name(self, tmp_db) -> None:
         from app.ingest import settings as ingest_settings
 
         self._set("Acme", "inferred")
@@ -186,7 +190,7 @@ class TestOrganizationNameSource:
         assert ingest_settings.get_organization_name() == "Acme"
         assert ingest_settings.organization_name_is_admin_set() is False
 
-    def test_inference_may_correct_its_own_earlier_guess(self) -> None:
+    def test_inference_may_correct_its_own_earlier_guess(self, tmp_db) -> None:
         """A later derivation sees far more corpus; it should be allowed to improve on itself."""
         from app.ingest import settings as ingest_settings
 
@@ -195,7 +199,7 @@ class TestOrganizationNameSource:
 
         assert ingest_settings.get_organization_name() == "Acme Industries"
 
-    def test_inference_never_overwrites_an_admin(self) -> None:
+    def test_inference_never_overwrites_an_admin(self, tmp_db) -> None:
         from app.ingest import settings as ingest_settings
 
         self._set("CBRE", "admin")
@@ -203,7 +207,7 @@ class TestOrganizationNameSource:
 
         assert ingest_settings.get_organization_name() == "CBRE"
 
-    def test_an_admin_clearing_the_name_stops_inference(self) -> None:
+    def test_an_admin_clearing_the_name_stops_inference(self, tmp_db) -> None:
         """("admin", NULL) means "there is no name" — not "nobody has said"."""
         from app.ingest import settings as ingest_settings
 
@@ -216,7 +220,7 @@ class TestOrganizationNameSource:
         self._set("Guessed", "inferred")
         assert ingest_settings.get_organization_name() is None
 
-    def test_an_admin_may_override_an_inferred_value(self) -> None:
+    def test_an_admin_may_override_an_inferred_value(self, tmp_db) -> None:
         from app.ingest import settings as ingest_settings
 
         self._set("Acme", "inferred")
@@ -225,7 +229,7 @@ class TestOrganizationNameSource:
         assert ingest_settings.get_organization_name() == "Acme Industries GmbH"
         assert ingest_settings.organization_name_is_admin_set() is True
 
-    def test_upsert_stamps_an_admin_source(self) -> None:
+    def test_upsert_stamps_an_admin_source(self, tmp_db) -> None:
         """A name arriving through the admin settings save is a human decision, so inference
         must not later overwrite it."""
         from app.ingest import settings as ingest_settings
@@ -234,13 +238,13 @@ class TestOrganizationNameSource:
 
         assert ingest_settings.organization_name_is_admin_set() is True
 
-    def test_whitespace_is_not_a_name(self) -> None:
+    def test_whitespace_is_not_a_name(self, tmp_db) -> None:
         from app.ingest import settings as ingest_settings
 
         self._set("   ", "inferred")
         assert ingest_settings.get_organization_name() is None
 
-    def test_an_unknown_source_is_rejected(self) -> None:
+    def test_an_unknown_source_is_rejected(self, tmp_db) -> None:
         from app.ingest import settings as ingest_settings
 
         with pytest.raises(ValueError):

--- a/backend/tests/test_entity_taxonomy_store.py
+++ b/backend/tests/test_entity_taxonomy_store.py
@@ -1,0 +1,154 @@
+"""Storage for derived entity-type taxonomies.
+
+What matters here is that a re-derivation cannot quietly invalidate what came before.
+Entity types are keys: anything recording facts per entity records them under a type name,
+so a rename must leave the old taxonomy readable and must not leave two rows claiming to be
+in force. Both are properties of the store, not of the derivation, so they are pinned here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.db import entity_taxonomy
+
+
+def _artifact(*, types: list[dict[str, object]] | None = None, fingerprint: str = "abc123") -> dict:
+    return {
+        "corpus_fingerprint": fingerprint,
+        "provenance": {"model": "test-model", "group_similarity": 0.45},
+        "stats": {"n_pages": 3, "n_types": 1},
+        "entity_types": types
+        if types is not None
+        else [
+            {
+                "name": "organization",
+                "definition": "A named company or institution.",
+                "examples": ["Acme"],
+                "n_referents": 12,
+                "n_docs": 3,
+            }
+        ],
+    }
+
+
+class TestRecord:
+    def test_first_taxonomy_is_version_one_and_active(self) -> None:
+        assert entity_taxonomy.active() is None
+
+        version = entity_taxonomy.record(_artifact())
+
+        assert version == 1
+        row = entity_taxonomy.active()
+        assert row is not None
+        assert row.version == 1
+        assert row.corpus_fingerprint == "abc123"
+        assert row.types[0]["name"] == "organization"
+        assert row.provenance["group_similarity"] == 0.45
+
+    def test_versions_increment_and_only_the_newest_is_active(self) -> None:
+        entity_taxonomy.record(_artifact(fingerprint="first"))
+        second = entity_taxonomy.record(_artifact(fingerprint="second"))
+
+        assert second == 2
+        active = entity_taxonomy.active()
+        assert active is not None
+        assert (active.version, active.corpus_fingerprint) == (2, "second")
+
+    def test_a_superseded_taxonomy_stays_resolvable(self) -> None:
+        """The whole point of append-only: rows keyed under v1's type names must still be
+        able to look those names up after v2 renames them."""
+        entity_taxonomy.record(
+            _artifact(types=[{"name": "software_product_or_service", "definition": "d"}])
+        )
+        entity_taxonomy.record(_artifact(types=[{"name": "software_product", "definition": "d"}]))
+
+        old = entity_taxonomy.get(1)
+        assert old is not None
+        assert old.types[0]["name"] == "software_product_or_service"
+        assert old.active is False
+
+    def test_refuses_a_taxonomy_with_no_types(self) -> None:
+        """An empty derivation is a failure, and recording it would deactivate a good one."""
+        with pytest.raises(ValueError):
+            entity_taxonomy.record(_artifact(types=[]))
+        assert entity_taxonomy.active() is None
+
+    def test_a_failed_record_leaves_the_previous_one_in_force(self) -> None:
+        entity_taxonomy.record(_artifact(fingerprint="good"))
+        with pytest.raises(ValueError):
+            entity_taxonomy.record(_artifact(types=[]))
+
+        active = entity_taxonomy.active()
+        assert active is not None
+        assert active.corpus_fingerprint == "good"
+
+
+class TestRead:
+    def test_get_unknown_version_is_none(self) -> None:
+        assert entity_taxonomy.get(99) is None
+
+    def test_history_is_newest_first(self) -> None:
+        for n in range(3):
+            entity_taxonomy.record(_artifact(fingerprint=f"c{n}"))
+        assert [row.version for row in entity_taxonomy.history()] == [3, 2, 1]
+
+    def test_history_respects_the_limit(self) -> None:
+        for n in range(4):
+            entity_taxonomy.record(_artifact(fingerprint=f"c{n}"))
+        assert [row.version for row in entity_taxonomy.history(limit=2)] == [4, 3]
+
+
+class TestLoadTaxonomy:
+    """``load_taxonomy`` is what the extraction prompt reads, so its fallback matters as
+    much as its happy path — a deployment that has never derived must still work."""
+
+    def test_falls_back_to_generic_types_when_nothing_is_derived(self) -> None:
+        from app.ingest.entity_types import DEFAULT_TYPES, load_taxonomy
+
+        defs, home = load_taxonomy()
+
+        assert defs == dict(DEFAULT_TYPES)
+        assert home == frozenset()
+
+    def test_reads_the_active_taxonomy(self) -> None:
+        from app.ingest.entity_types import load_taxonomy
+
+        entity_taxonomy.record(
+            _artifact(types=[{"name": "person", "definition": "A named individual."}])
+        )
+
+        defs, _ = load_taxonomy()
+
+        assert defs == {"person": "A named individual."}
+
+    def test_reads_a_specific_version(self) -> None:
+        """How a consumer resolves the types it keyed facts under, rather than assuming the
+        active taxonomy still means the same thing."""
+        from app.ingest.entity_types import load_taxonomy
+
+        entity_taxonomy.record(_artifact(types=[{"name": "old_name", "definition": "d"}]))
+        entity_taxonomy.record(_artifact(types=[{"name": "new_name", "definition": "d"}]))
+
+        assert set(load_taxonomy(version=1)[0]) == {"old_name"}
+        assert set(load_taxonomy()[0]) == {"new_name"}
+
+    def test_home_entities_come_from_stats(self) -> None:
+        """Not produced yet — the reader is wired so a per-page vote can fill it without
+        changing this side."""
+        from app.ingest.entity_types import load_taxonomy
+
+        artifact = _artifact()
+        artifact["stats"]["home_entities"] = ["Acme"]
+        entity_taxonomy.record(artifact)
+
+        assert load_taxonomy()[1] == frozenset({"Acme"})
+
+    def test_a_taxonomy_of_unusable_entries_falls_back(self) -> None:
+        """Malformed rows should degrade to the generic list, not to an empty menu that
+        would make the extractor unable to type anything."""
+        from app.ingest.entity_types import DEFAULT_TYPES, load_taxonomy
+
+        entity_taxonomy.record(_artifact(types=[{"name": "", "definition": ""}, {"nope": 1}]))
+
+        assert load_taxonomy()[0] == dict(DEFAULT_TYPES)

--- a/backend/tests/test_entity_taxonomy_store.py
+++ b/backend/tests/test_entity_taxonomy_store.py
@@ -163,3 +163,85 @@ class TestLoadTaxonomy:
         entity_taxonomy.record(_artifact(types=[{"name": "", "definition": ""}, {"nope": 1}]))
 
         assert load_taxonomy()[0] == dict(DEFAULT_TYPES)
+
+
+class TestOrganizationNameSource:
+    """The source column, not the value, gates inference.
+
+    "Do not overwrite a non-null value" would freeze a bad guess forever; and an admin who
+    deliberately CLEARS the name has decided there is none, which must not look like "unset"
+    and re-trigger detection.
+    """
+
+    def _set(self, name: str | None, source: str) -> None:
+        from app.ingest import settings as ingest_settings
+
+        ingest_settings.set_organization_name(name, source=source)
+
+    def test_inference_may_claim_an_unset_name(self) -> None:
+        from app.ingest import settings as ingest_settings
+
+        self._set("Acme", "inferred")
+
+        assert ingest_settings.get_organization_name() == "Acme"
+        assert ingest_settings.organization_name_is_admin_set() is False
+
+    def test_inference_may_correct_its_own_earlier_guess(self) -> None:
+        """A later derivation sees far more corpus; it should be allowed to improve on itself."""
+        from app.ingest import settings as ingest_settings
+
+        self._set("Acme", "inferred")
+        self._set("Acme Industries", "inferred")
+
+        assert ingest_settings.get_organization_name() == "Acme Industries"
+
+    def test_inference_never_overwrites_an_admin(self) -> None:
+        from app.ingest import settings as ingest_settings
+
+        self._set("CBRE", "admin")
+        self._set("Cbre", "inferred")
+
+        assert ingest_settings.get_organization_name() == "CBRE"
+
+    def test_an_admin_clearing_the_name_stops_inference(self) -> None:
+        """("admin", NULL) means "there is no name" — not "nobody has said"."""
+        from app.ingest import settings as ingest_settings
+
+        self._set("Acme", "admin")
+        self._set(None, "admin")
+
+        assert ingest_settings.get_organization_name() is None
+        assert ingest_settings.organization_name_is_admin_set() is True
+
+        self._set("Guessed", "inferred")
+        assert ingest_settings.get_organization_name() is None
+
+    def test_an_admin_may_override_an_inferred_value(self) -> None:
+        from app.ingest import settings as ingest_settings
+
+        self._set("Acme", "inferred")
+        self._set("Acme Industries GmbH", "admin")
+
+        assert ingest_settings.get_organization_name() == "Acme Industries GmbH"
+        assert ingest_settings.organization_name_is_admin_set() is True
+
+    def test_upsert_stamps_an_admin_source(self) -> None:
+        """A name arriving through the admin settings save is a human decision, so inference
+        must not later overwrite it."""
+        from app.ingest import settings as ingest_settings
+
+        ingest_settings.upsert(max_doc_chars=1000, onyx_base_url=None, organization_name="Acme")
+
+        assert ingest_settings.organization_name_is_admin_set() is True
+
+    def test_whitespace_is_not_a_name(self) -> None:
+        from app.ingest import settings as ingest_settings
+
+        self._set("   ", "inferred")
+        assert ingest_settings.get_organization_name() is None
+
+    def test_an_unknown_source_is_rejected(self) -> None:
+        from app.ingest import settings as ingest_settings
+
+        with pytest.raises(ValueError):
+            ingest_settings.set_organization_name("Acme", source="guessed")


### PR DESCRIPTION
Follow-up to #558, which landed the derivation with `store_taxonomy` / `load_taxonomy` as placeholders. This makes them a real read/write seam, so a derivation produces something durable instead of a log line.

## Append-only, with one active row

Entity types are **keys**. Anything recording facts per entity records them under a type name, so a re-derivation that renames a type would orphan every row pointing at the old one. Overwriting a single current value makes that failure silent and unrecoverable.

So rows accumulate and one is flagged `active`:

```
v1  organization, software_product_or_service, person   (superseded, still readable)
v2  organization, software_product, person              (active)
```

`record()` inserts and promotes rather than updating. A consumer that keys by type stores the `version` it used and resolves through `get(version)`, rather than assuming the active taxonomy still means what it meant.

Two things enforce that rather than relying on discipline:

- **a partial unique index** on `active` — the database rejects two rows claiming to be in force, instead of every writer having to remember to clear the previous one
- **deactivate and insert share a transaction** — a half-applied write then either leaves no taxonomy active or fails outright, and the second is much easier to notice

## Schema

```python
entity_taxonomies
  id, version (unique), active, corpus_fingerprint
  types       JSONB   [{name, definition, examples, n_referents, n_docs}, ...]
  provenance  JSONB   models, thresholds
  stats       JSONB   the funnel counts
  triggered_by -> users.id ON DELETE SET NULL
  created_at
```

`types` / `provenance` / `stats` are free-form JSONB deliberately. The shape belongs to the producer (`app.ingest.entity_types`), it is read whole and never queried by field, and pinning it into columns would mean a migration whenever a derivation stage learns to record something new.

`stats` is kept so a human can judge a derivation without re-running it. A merge that collapsed 75 candidate types to 9 looks nothing like one that left 75 standing — and that difference is invisible in the type list alone. It was a real failure mode during development: the merge step silently no-opped, and only the counts revealed it.

## Reading

`load_taxonomy()` reads the active row; `load_taxonomy(version=n)` resolves a specific one.

It falls back to `DEFAULT_TYPES` when no row exists — the same degradation as the relevance scorer without its model file, so a deployment that has never derived keeps working with generic types rather than tailored ones. It now also falls back when a row's entries are unusable, so a malformed taxonomy cannot leave the extractor with an empty type menu.

## Entities are deliberately not stored

Only the taxonomy. Mentions and referents are intermediate — unresolved surface strings with no canonical identity, which a re-derivation invalidates wholesale. Storing them would persist scratch work nothing can key on.

They become durable when resolution exists, and that is a smaller problem once types do: resolution runs *within* a type rather than across all pairs.

## Caveats

- **The tests have not run.** They need Postgres, and neither a local instance nor docker was available. Verified without a database: the DDL SQLAlchemy emits, the migration chain (this is the only revision claiming `c8a4e7d2f6b1` as parent, so no fork), and that both modules import. CI is the first real execution of the 16 tests.
- **No consumer yet.** The typed-entity layer that would key facts by these types still lives in `agent-wiki-evals`. This closes the write path so the producer is complete; the read path exists for whatever lands next.
- **Home entities are still not produced** — unchanged from #558. `load_taxonomy` returns an empty set, and `stats.home_entities` is the field a future per-page ownership vote would fill without touching the reader.