### PR TITLE
fix(coedit): support code blocks, headings, breaks and tables inside list items

### DIFF
--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -27,13 +27,20 @@ padding, and still achieves the byte-stability goal for every row that isn't
 touched — cells aren't decomposed or individually editable. Thematic break
 and html block stay opaque verbatim, tagged ``_raw="1"``.
 
+A list item or blockquote holds a sequence of these same blocks — not just
+paragraphs and nested lists, but a code block, heading, thematic break or
+table too, since CommonMark nests all of them and a code block inside a
+bullet is ordinary on a docs page. The nested forms are built from tokens
+rather than source slices, so two of them normalize (a thematic break to
+``---``, a table's cell padding to one space) — see ``_build_block_sequence``.
+
 Unrecognized inline constructs (anything this module doesn't have an
 explicit encoder for) raise ``NotImplementedError`` rather than
 silently drop or mis-serialize content — the byte-stability
 requirement this whole engine exists for is only meaningful if failures are
-loud, never silent. Same for a list item that isn't a clean sequence of
-paragraph/list/blockquote children (e.g. a list item containing a table) —
-unsupported, raises rather than mis-encodes.
+loud, never silent. Same for any block construct nested in a list item or
+blockquote that has no branch in ``_build_block_sequence`` — unsupported,
+raises rather than mis-encodes.
 """
 
 from __future__ import annotations
@@ -363,9 +370,7 @@ def _serialize_inline_text(xt: XmlText) -> str:
         target = [_mark_key(m, attrs) for m in _NESTING_MARK_ORDER if m in attrs]
         common = 0
         while (
-            common < len(open_keys)
-            and common < len(target)
-            and open_keys[common] == target[common]
+            common < len(open_keys) and common < len(target) and open_keys[common] == target[common]
         ):
             common += 1
         out = _close_after(out, reversed(open_keys[common:]))
@@ -374,9 +379,7 @@ def _serialize_inline_text(xt: XmlText) -> str:
         # escapes inside them, so escaping here would corrupt the code's
         # actual text (a literal backslash would become part of the
         # visible content).
-        rendered = (
-            _wrap_code_run(text) if "code" in attrs else _escape_inline_text(text)
-        )
+        rendered = _wrap_code_run(text) if "code" in attrs else _escape_inline_text(text)
         opening = "".join(_open_delim(key) for key in target[common:])
         if opening:
             # An opener must be followed by non-whitespace, so any leading
@@ -551,12 +554,26 @@ def _build_paragraph_from_inline(inline_token: Any) -> tuple[XmlElement, list[An
 def _build_block_sequence(
     tokens: list[Any], start: int, end: int
 ) -> tuple[list[XmlElement], list[Any]]:
-    """Build a sequence of paragraph/list/blockquote child elements from a
-    flat markdown-it token range ``[start, end)`` — used for list-item and
-    blockquote content, recursing into ``_build_list``/``_build_blockquote``
-    for nested containers. This is what lets a list item contain multiple
-    paragraphs or a nested list, and a blockquote contain multiple
-    paragraphs or a list, with the same code path either way."""
+    """Build a sequence of child block elements from a flat markdown-it token
+    range ``[start, end)`` — used for list-item and blockquote content,
+    recursing into ``_build_list``/``_build_blockquote`` for nested
+    containers. This is what lets a list item contain multiple paragraphs or
+    a nested list, and a blockquote contain multiple paragraphs or a list,
+    with the same code path either way.
+
+    Every block construct CommonMark can nest here has a branch, so the set
+    matches ``serialize_block``'s (the inverse direction) rather than being a
+    subset of it: a page is only openable in the live editor if this function
+    can represent all of it, and a code block or heading inside a bullet is
+    ordinary markdown. Unlike the top-level path, nested constructs are built
+    from tokens alone, never from a source slice: the same token ``.map``
+    line numbers address the *undecorated* source, so inside a blockquote a
+    slice would carry the ``> `` prefixes along with the content. That costs
+    verbatim fidelity for the two constructs the top level stores as opaque
+    source text — a nested thematic break normalizes to ``---`` and a nested
+    table's cells are re-emitted with single-space padding — the same
+    correct-not-byte-identical tradeoff ``_serialize_list`` already makes for
+    a touched list."""
     children: list[XmlElement] = []
     finishers: list[Any] = []
     i = start
@@ -580,6 +597,27 @@ def _build_block_sequence(
             el, bq_finishers = _build_blockquote(tokens, i, close_idx + 1)
             children.append(el)
             finishers.extend(bq_finishers)
+            i = close_idx + 1
+            continue
+        if t.type in ("fence", "code_block"):
+            children.append(_code_block_from_token(t, {}))
+            i += 1
+            continue
+        if t.type == "heading_open":
+            el, heading_finishers = _element_from_segments(
+                "heading", {"level": str(int(t.tag[1:]))}, _inline_runs(tokens[i + 1])
+            )
+            children.append(el)
+            finishers.extend(heading_finishers)
+            i += 3  # heading_open, inline, heading_close
+            continue
+        if t.type == "hr":
+            children.append(_thematic_break_element({}))
+            i += 1
+            continue
+        if t.type == "table_open":
+            close_idx = _matching_close(tokens, i, "table_close")
+            children.append(_build_nested_table(tokens, i, close_idx + 1))
             i = close_idx + 1
             continue
         raise NotImplementedError(f"unsupported nested block construct: {t.type!r}")
@@ -656,11 +694,7 @@ def _build_list(
             first_text = tokens[item_start + 1].children[0]
             first_text.content = first_text.content[match.end() :]
             item_children, item_finishers = _build_block_sequence(tokens, item_start, item_end)
-            items.append(
-                XmlElement(
-                    "taskItem", {"checked": checked}, contents=item_children
-                )
-            )
+            items.append(XmlElement("taskItem", {"checked": checked}, contents=item_children))
         else:
             item_children, item_finishers = _build_block_sequence(tokens, item_start, item_end)
             items.append(XmlElement("listItem", {}, contents=item_children))
@@ -676,10 +710,89 @@ def _build_blockquote(
     return XmlElement("blockquote", dict(extra_attrs or {}), contents=children), finishers
 
 
-def _build_code_block(raw: str, attrs: dict[str, str]) -> XmlElement:
-    tok = next(t for t in gfm_parser().parse(raw) if t.type in ("fence", "code_block"))
+def _code_block_from_token(tok: Any, attrs: dict[str, str]) -> XmlElement:
+    """An already-tokenized code block as a ``codeBlock`` element. The token
+    carries the content already stripped of whichever syntax produced it —
+    the fence lines, or an indented block's 4-column indent — so this works
+    the same for a top-level block and one nested in a list item, where no
+    source slice is available (see ``_build_block_sequence``)."""
     language = tok.info.strip() if tok.type == "fence" else ""
     return XmlElement("codeBlock", {**attrs, "language": language}, contents=[XmlText(tok.content)])
+
+
+def _build_code_block(raw: str, attrs: dict[str, str]) -> XmlElement:
+    tok = next(t for t in gfm_parser().parse(raw) if t.type in ("fence", "code_block"))
+    return _code_block_from_token(tok, attrs)
+
+
+def _thematic_break_element(attrs: dict[str, str]) -> XmlElement:
+    """A thematic break as an opaque verbatim block holding the canonical
+    ``---`` spelling. The top-level path keeps the source's own spelling
+    (``***``, ``___``, a longer dash run) by storing its raw slice; a nested
+    one has no slice to store, and a thematic break carries no content, so
+    every spelling is the same block."""
+    return XmlElement(
+        BlockKind.THEMATIC_BREAK.value, {**attrs, _RAW_ATTR: "1"}, contents=[XmlText("---\n")]
+    )
+
+
+# GFM delimiter-row cell per column alignment, keyed by the ``style``
+# attribute markdown-it-py puts on a ``th``/``td`` token. A column with no
+# alignment gets no style attribute at all.
+_ALIGNMENT_DELIMITERS = {
+    "text-align:left": ":---",
+    "text-align:center": ":---:",
+    "text-align:right": "---:",
+}
+
+
+def _table_row_line(cells: list[str]) -> str:
+    return "| " + " | ".join(cells) + " |\n"
+
+
+def _build_nested_table(tokens: list[Any], start: int, end: int) -> XmlElement:
+    """A table nested in a list item or blockquote, as the same row-level
+    ``table`` element the top-level path builds.
+
+    Rows are re-emitted from their cells with single-space padding rather
+    than sliced verbatim out of the source (which would carry a blockquote's
+    ``> `` prefixes — see ``_build_block_sequence``), so a nested table's
+    original column padding is not preserved. Column alignment is, via the
+    delimiter row this reconstructs from the cells' own style attributes.
+
+    Rows carry no ``_rowId``: those ids are positional within a *top-level*
+    block (``<block_id>:r<n>``), and a nested table has no block id of its
+    own to derive them from. Only ``find_by_row_id`` — the targeted
+    single-row splice path — needs them, and it looks at top-level tables
+    only; a touched nested table reserializes through its whole enclosing
+    block instead.
+    """
+    rows: list[list[str]] = []
+    alignments: list[str] = []
+    for i in range(start, end):
+        t = tokens[i]
+        if t.type == "tr_open":
+            rows.append([])
+            continue
+        if t.type in ("th_open", "td_open"):
+            # A literal "|" in cell text arrives here with its source
+            # backslash already consumed by the table tokenizer; re-emitting
+            # it bare would split the cell in two on the next parse.
+            content = tokens[i + 1].content.replace("|", "\\|")
+            rows[-1].append(content)
+            if t.type == "th_open":
+                alignments.append(str((t.attrs or {}).get("style", "")))
+    header, *body_rows = rows
+    delimiter = [_ALIGNMENT_DELIMITERS.get(style, "---") for style in alignments]
+    children = [
+        XmlElement("tableRow", {}, contents=[XmlText(_table_row_line(header))]),
+        XmlElement("tableSeparator", {}, contents=[XmlText(_table_row_line(delimiter))]),
+        *(
+            XmlElement("tableRow", {}, contents=[XmlText(_table_row_line(row))])
+            for row in body_rows
+        ),
+    ]
+    return XmlElement("table", {}, contents=children)
 
 
 def _build_heading(raw: str, attrs: dict[str, str]) -> tuple[XmlElement, list[Any]]:
@@ -835,25 +948,20 @@ def serialize_row(row: XmlElement) -> str:
 
 
 def _serialize_block_sequence(children: list[XmlElement], indent: str) -> str:
-    """Inverse of ``_build_block_sequence``: paragraph/list/blockquote
-    children joined by blank lines, with every line after the very first
-    indented by ``indent`` so continuation lines / nested constructs align
-    under the parent marker or blockquote ``>``."""
-    parts: list[str] = []
-    for child in children:
-        if child.tag == "paragraph":
-            # Same block-start ambiguity as a top-level paragraph
-            # (serialize_block) — a list item or blockquote's own first
-            # line is just as much a fresh block-start position as the
-            # top of the document, so a literal leading "-"/">"/"#"/"---"
-            # needs the same escaping, not just the top-level case.
-            parts.append(_serialize_paragraph_text(list(child.children)))
-        elif child.tag in ("bulletList", "orderedList", "taskList"):
-            parts.append(_serialize_list(child).rstrip("\n"))
-        elif child.tag == "blockquote":
-            parts.append(_serialize_blockquote(child).rstrip("\n"))
-        else:
-            raise NotImplementedError(f"unsupported nested block in sequence: tag={child.tag!r}")
+    """Inverse of ``_build_block_sequence``: block children joined by blank
+    lines, with every line after the very first indented by ``indent`` so
+    continuation lines / nested constructs align under the parent marker or
+    blockquote ``>``.
+
+    Each child goes through ``serialize_block``, the same function the top
+    level uses, so the two directions can't drift apart into a nested
+    construct that seeds but won't serialize. That includes a paragraph's
+    block-start escaping: a list item or blockquote's own first line is just
+    as much a fresh block-start position as the top of the document, so a
+    literal leading ``-``/``>``/``#``/``---`` needs the same escaping there.
+    Each block's own trailing newline is dropped here because the blank-line
+    join below supplies the separation instead."""
+    parts = [serialize_block(child).rstrip("\n") for child in children]
     combined = "\n\n".join(parts)
     lines = combined.split("\n")
     indented = [lines[0]] + [(indent + line if line else line) for line in lines[1:]]
@@ -879,11 +987,21 @@ def _serialize_list(node: XmlElement) -> str:
         if is_task:
             checked = _is_checked(dict(item.attributes).get("checked"))
             marker = f"- [{'x' if checked else ' '}] "
-        elif ordered:
-            marker = f"{start + idx}. "
+            # A task item's continuation indent is the width of "- " alone,
+            # not of the whole marker: `gfm_parser()` runs no task-list
+            # plugin, so "[x] " is the first paragraph's own text (see
+            # `_list_item_task_marker`) and CommonMark puts the item's
+            # content column right after the bullet. Indenting the item's
+            # later blocks under the checkbox instead put them 4 columns
+            # past that content column — an indented code block on the next
+            # parse, which is a live round trip: a task item with a nested
+            # list or a second paragraph got rewritten into code the first
+            # time anything on the page was checkpointed.
+            indent = " " * len("- ")
         else:
-            marker = "- "
-        body = _serialize_block_sequence(list(item.children), " " * len(marker))  # type: ignore[arg-type]
+            marker = f"{start + idx}. " if ordered else "- "
+            indent = " " * len(marker)
+        body = _serialize_block_sequence(list(item.children), indent)  # type: ignore[arg-type]
         lines.append(marker + body)
     return "\n\n".join(lines) + "\n"
 

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -417,6 +417,95 @@ def test_blockquote_containing_list() -> None:
     assert len(list(inner_list.children)) == 2
 
 
+def test_task_item_continuation_indents_to_the_bullet_not_the_checkbox() -> None:
+    """A task item's later blocks belong at the item's CommonMark content
+    column — right after "- ". Indenting them under the whole "- [x] "
+    marker instead put them 4 columns further out, which is an indented
+    code block on the next parse: a checkpoint rewrote a task item's nested
+    list into code, and the page then wouldn't open at all (the codec had
+    no support for a code block inside a list item). The indentation of the
+    output is what matters here — the blank line the first case gains is
+    this module's usual tight->loose list normalization."""
+    assert reconstruct_body(seed_doc_from_markdown("- [ ] top\n  - [x] nested\n")) == (
+        "- [ ] top\n\n  - [x] nested\n"
+    )
+    for body in (
+        "- [ ] top\n\n  a second paragraph\n",
+        "- [ ] top\n\n  ```py\n  x = 1\n  ```\n",
+    ):
+        assert reconstruct_body(seed_doc_from_markdown(body)) == body
+
+
+def test_code_block_inside_a_list_item_round_trips() -> None:
+    body = "- item\n\n  ```py\n  x = 1\n  ```\n"
+    doc = seed_doc_from_markdown(body)
+    item = _root(doc).children[0].children[0]
+    assert [c.tag for c in item.children] == ["paragraph", "codeBlock"]
+    assert dict(list(item.children)[1].attributes)["language"] == "py"
+    assert reconstruct_body(doc) == body
+
+
+def test_indented_code_block_inside_a_list_item_becomes_fenced() -> None:
+    """Sub-bullets indented 4+ columns past their item's content column are
+    an indented code block, not a nested list — what CommonMark says, and
+    what a real page in the wiki turned out to contain."""
+    body = "- item\n\n      - not a nested bullet\n"
+    doc = seed_doc_from_markdown(body)
+    item = _root(doc).children[0].children[0]
+    assert [c.tag for c in item.children] == ["paragraph", "codeBlock"]
+    got = reconstruct_body(doc)
+    assert got == "- item\n\n  ```\n  - not a nested bullet\n  ```\n"
+    assert reconstruct_body(seed_doc_from_markdown(got)) == got
+
+
+def test_heading_and_thematic_break_inside_a_list_item() -> None:
+    body = "- item\n\n  ## nested heading\n\n  ---\n"
+    doc = seed_doc_from_markdown(body)
+    item = _root(doc).children[0].children[0]
+    assert [c.tag for c in item.children] == ["paragraph", "heading", "thematic_break"]
+    assert dict(list(item.children)[1].attributes)["level"] == "2"
+    assert reconstruct_body(doc) == body
+
+
+def test_nested_thematic_break_normalizes_to_dashes() -> None:
+    # A nested break is rebuilt from tokens, not from a source slice (a
+    # blockquote's would carry its "> " prefixes), so it loses the source's
+    # own spelling. It carries no content, so every spelling is the same
+    # block — but the result still has to be stable, not drift each pass.
+    got = reconstruct_body(seed_doc_from_markdown("> quote\n>\n> ***\n"))
+    assert got == "> quote\n>\n> ---\n"
+    assert reconstruct_body(seed_doc_from_markdown(got)) == got
+
+
+def test_table_inside_a_list_item_keeps_rows_and_alignment() -> None:
+    body = "- item\n\n  | a | b |\n  | :--- | ---: |\n  | 1 | 2 |\n"
+    doc = seed_doc_from_markdown(body)
+    item = _root(doc).children[0].children[0]
+    table = list(item.children)[1]
+    assert table.tag == "table"
+    assert [c.tag for c in table.children] == ["tableRow", "tableSeparator", "tableRow"]
+    assert reconstruct_body(doc) == body
+
+
+def test_table_inside_a_blockquote_re_pads_cells() -> None:
+    # Cells are re-emitted with single-space padding — a nested table's rows
+    # are rebuilt from their cells rather than sliced verbatim out of the
+    # source, which inside a blockquote would carry the "> " prefixes.
+    got = reconstruct_body(
+        seed_doc_from_markdown("> |  a  |  b  |\n> | --- | --- |\n> | 1 | 2 |\n")
+    )
+    assert got == "> | a | b |\n> | --- | --- |\n> | 1 | 2 |\n"
+    assert reconstruct_body(seed_doc_from_markdown(got)) == got
+
+
+def test_pipe_in_a_nested_table_cell_stays_escaped() -> None:
+    body = "- item\n\n  | a \\| b | c |\n  | --- | --- |\n  | 1 | 2 |\n"
+    doc = seed_doc_from_markdown(body)
+    table = list(_root(doc).children[0].children[0].children)[1]
+    assert serialize_row(list(table.children)[0]) == "| a \\| b | c |\n"
+    assert reconstruct_body(doc) == body
+
+
 def test_code_block_language_and_content_stored_without_fence_syntax() -> None:
     doc = seed_doc_from_markdown("```python\nx = 1\ny = 2\n```\n")
     root = _root(doc)
@@ -634,11 +723,9 @@ def test_escaped_block_start_markers_inside_list_item_stay_literal() -> None:
     # call _serialize_inline_children directly, bypassing
     # _escape_block_start_ambiguity entirely — a list item or blockquote's
     # own first line is just as much a fresh block-start position as the
-    # top of the document. Without the fix, these reactivate as a nested
-    # list/blockquote; a nested heading attempt doesn't just misparse, it
-    # crashes outright (_build_block_sequence has no heading support at
-    # all), since escaping is also what prevents ever attempting that
-    # parse in the first place.
+    # top of the document. Without the escaping, each of these reactivates
+    # as a real nested list/heading/break — the literal text the author
+    # typed silently becomes a different block.
     cases = [
         "- \\- nested item text\n",
         "- \\# nested heading text\n",
@@ -693,10 +780,8 @@ def test_escaped_block_start_marker_on_a_later_soft_break_line() -> None:
     # doubly so once a list item's continuation indent or a blockquote's
     # per-line "> " prefix (_serialize_blockquote adds that to *every*
     # line, including a paragraph's internal soft breaks) gets added on
-    # top. The "#" case is the sharpest: reactivating it doesn't just
-    # misparse, it crashes outright the next time the checkpointed body is
-    # seeded (_build_block_sequence has no heading support inside a list
-    # item/blockquote at all).
+    # top. Reactivating any of these turns text the author typed literally
+    # into a different block on the next seed of the checkpointed body.
     cases = [
         "first line\n\\# second line\n",
         "first line\n\\- second line\n",
@@ -707,8 +792,6 @@ def test_escaped_block_start_marker_on_a_later_soft_break_line() -> None:
     for raw in cases:
         once = reconstruct_body(seed_doc_from_markdown(raw))
         assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
-        # The real regression: seeding the checkpointed output a second
-        # time must not raise (it did, for "#", before this fix).
         twice = reconstruct_body(seed_doc_from_markdown(once))
         assert twice == once
 
@@ -731,9 +814,6 @@ def test_escaped_setext_underline_on_a_later_line_stays_literal() -> None:
     for raw in cases:
         once = reconstruct_body(seed_doc_from_markdown(raw))
         assert once == raw, f"expected stable round-trip for {raw!r}, got {once!r}"
-        # Confirms no crash on re-seed for the nested cases (same failure
-        # mode as the "#" case: _build_block_sequence has no heading
-        # support inside a list item/blockquote at all).
         twice = reconstruct_body(seed_doc_from_markdown(once))
         assert twice == once
 
@@ -774,8 +854,7 @@ def test_paragraph_reactivates_as_table_without_escaping() -> None:
     # is escaped as a thematic break, which also blocks the delimiter-row
     # read, coincidentally but correctly).
     assert tags == ["paragraph", "paragraph"], (
-        f"expected two paragraphs, no table reactivation, "
-        f"got tags={tags} for body={once!r}"
+        f"expected two paragraphs, no table reactivation, got tags={tags} for body={once!r}"
     )
 
 
@@ -786,8 +865,7 @@ def test_table_delimiter_row_escaping_is_stable() -> None:
         twice = reconstruct_body(seed_doc_from_markdown(once))
         assert once == twice
         tags = [
-            c.tag
-            for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+            c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
         ]
         assert tags == ["paragraph", "paragraph"]
 
@@ -803,7 +881,9 @@ def test_paragraph_line_of_tildes_does_not_reactivate_as_a_fence() -> None:
     once = reconstruct_body(doc)
     twice = reconstruct_body(seed_doc_from_markdown(once))
     assert once == twice
-    tags = [c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children]
+    tags = [
+        c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+    ]
     # Every newline is its own block boundary now - three lines, three
     # paragraphs, none of them reactivating as a fence.
     assert tags == ["paragraph", "paragraph", "paragraph"]
@@ -816,7 +896,9 @@ def test_paragraph_line_of_backticks_does_not_reactivate_as_a_fence() -> None:
     # relying on that being obvious from reading _serialize_inline_text alone.
     doc = _build_live_paragraph("some text:\n```\nmore text")
     once = reconstruct_body(doc)
-    tags = [c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children]
+    tags = [
+        c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+    ]
     assert tags == ["paragraph", "paragraph", "paragraph"]
 
 
@@ -911,7 +993,9 @@ def test_indented_continuation_line_stays_safe_without_escaping() -> None:
     doc = _build_live_paragraph(text)
     once = reconstruct_body(doc)
     assert once == text + "\n"
-    tags = [c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children]
+    tags = [
+        c.tag for c in seed_doc_from_markdown(once).get(ROOT_XML_KEY, type=XmlFragment).children
+    ]
     # Every newline is its own block boundary now - the continuation line
     # becomes its own paragraph. It stays safe without any backslash escape
     # (there's nothing to escape - the ambiguity is 4+ leading columns of

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from pycrdt import Doc, XmlElement, XmlFragment, XmlText
 
+from app.wiki.markdown_blocks import gfm_parser
 from app.wiki.markdown_yjs import (
     BLOCK_ID_ATTR,
     ROOT_XML_KEY,
@@ -504,6 +505,28 @@ def test_pipe_in_a_nested_table_cell_stays_escaped() -> None:
     table = list(_root(doc).children[0].children[0].children)[1]
     assert serialize_row(list(table.children)[0]) == "| a \\| b | c |\n"
     assert reconstruct_body(doc) == body
+
+
+def test_pipe_inside_a_code_span_in_a_nested_table_cell_gains_no_backslash() -> None:
+    """GFM requires a cell's pipe to be escaped even inside a code span, and
+    the table tokenizer unescapes it while splitting cells — before inline
+    parsing runs. So a cell's token content holds source-level text with bare
+    pipes either way, and re-escaping every one of them reproduces the source
+    spelling exactly rather than leaking a backslash into the code span."""
+    body = "- item\n\n  | h1 | h2 |\n  | --- | --- |\n  | b `\\|` az | y |\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == body
+    # The rendered code span still holds one bare pipe, and repeated
+    # checkpoints don't accumulate backslashes in front of it.
+    code_spans = [
+        child.content
+        for token in gfm_parser().parse(once)
+        if token.type == "inline"
+        for child in (token.children or [])
+        if child.type == "code_inline"
+    ]
+    assert code_spans == ["|"]
+    assert reconstruct_body(seed_doc_from_markdown(once)) == once
 
 
 def test_code_block_language_and_content_stored_without_fence_syntax() -> None:

--- a/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
+++ b/docs/AGENT_WIKI_MARKDOWN_STANDARD.md
@@ -94,3 +94,12 @@ preserve it byte-for-byte:
    the line's block type is unchanged by the next parse — escaping just the
    marker and leaving the whitespace in front of it round-trips the marker
    characters as literal text but not the indentation that preceded them.
+
+2. A block nested inside a list item or blockquote is rebuilt from parsed
+   tokens, not from a slice of the source: the same token line numbers
+   address the undecorated source, so a slice taken inside a blockquote
+   would carry its `> ` prefixes into the content. Content MUST survive
+   unchanged; the syntax that spelled it MAY not. Specifically, a nested
+   thematic break MAY be re-emitted as `---` whatever spelling the source
+   used, and a nested table's cells MAY be re-emitted with single-space
+   padding.


### PR DESCRIPTION
## Problem

A page whose markdown nests a code block, heading, thematic break or table inside a bullet or blockquote could not be opened **at all** — the body rendered blank with *"This page uses formatting the live editor doesn't support yet."* Page view is the live editor, so this isn't a degraded edit experience; the content is invisible.

`_build_block_sequence` in `markdown_yjs.py` handled exactly three nested block types (paragraph, nested list, blockquote) and raised `NotImplementedError` on anything else, which `api/coedit.py` turns into that refusal frame. A fenced code block inside a bullet is ordinary markdown on a docs page.

## Root cause of the page that surfaced this

The bad markdown was **our own output**. `_serialize_list` indented a task item's continuation blocks by the width of the full `- [x] ` marker (6 columns), but `gfm_parser()` runs no task-list plugin: `[x] ` is the item's own paragraph text, so CommonMark puts the item's content column right after the bullet, at 2. Six columns is four past that — an indented code block on the next parse.

So a task item holding a nested list or a second paragraph was silently rewritten into code the first time anything on that page was checkpointed, and the page then wouldn't open. Round trip, on a real page:

```
- [ ] top            ->  - [ ] top            ->  - [ ] top
  - [x] nested                                        ```
                             - [x] nested             - [x] nested
                                                      ```
```

Continuation now indents to the bullet, so this round-trips.

## Changes

- `_build_block_sequence` gains branches for `fence` / `code_block`, `heading_open`, `hr` and `table_open`, so the nested set matches what `serialize_block` can emit rather than being a subset of it.
- `_serialize_block_sequence` now delegates each child to `serialize_block` instead of keeping its own three-way dispatch — the two directions can't drift into a construct that seeds but won't serialize.
- `_serialize_list` indents a task item's continuation to `- `, not to the checkbox.
- Nested blocks are built from tokens, never from a source slice: token line numbers address the undecorated source, so a slice taken inside a blockquote would carry its `> ` prefixes into the content. Two constructs lose verbatim fidelity as a result — a nested thematic break normalizes to `---`, and a nested table's cells are re-emitted with single-space padding (alignment preserved). Both are now written down in `docs/AGENT_WIKI_MARKDOWN_STANDARD.md` §6.

## Testing

- Seven new codec tests: nested fenced/indented code, nested heading + break, nested table with alignment and with an escaped pipe, blockquote cell re-padding, and the task-item indent regression. Every case asserts a stable (mostly byte-identical) round trip.
- `pytest` green across the backend suite, including `test_coedit_checkpoint`, `test_coedit_rebase` and `test_markdown_splice`.
- Verified directly against the real body of the production page that reported the error: it previously raised `NotImplementedError`, now seeds and round-trips idempotently.

## Follow-up (not in this PR)

The page that surfaced this still holds the mangled 6-space indentation, so it now opens showing its goal tree as a code block — faithful to what the markdown literally says. It needs a one-off dedent back to a real nested list.
<img width="1187" height="825" alt="Screenshot 2026-07-31 at 11 47 48 AM" src="https://github.com/user-attachments/assets/4a1cdf36-b0d6-4658-a962-fd40d11619b5" />

