### PR TITLE
fix(wiki): drop the Update History card from a folder's Updates panel

### DIFF
--- a/frontend/src/components/wiki/UpdatePolicyPanel.tsx
+++ b/frontend/src/components/wiki/UpdatePolicyPanel.tsx
@@ -109,8 +109,13 @@ export function UpdatePolicyPanel({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Live health poll backs the history card. A failure never blocks the
-  // policy card, null just hides the history card.
-  const { health, refresh: refreshHealth } = useUpdateHealth(path);
+  // policy card, null just hides the history card. Pages only: the card's
+  // whole job is reading a 24h count against a threshold and a cap, and both
+  // of those are per-page. A folder's count is its subtree's, so measuring it
+  // against a single page's cap says nothing — see the card below.
+  const { health, refresh: refreshHealth } = useUpdateHealth(
+    kind === "page" ? path : null,
+  );
   const { user } = useAuth();
 
   // Drop the previous scope's unsaved editor state and stale save error.
@@ -416,7 +421,13 @@ export function UpdatePolicyPanel({
               </div>
             </Section>
 
-            {health !== null && (
+            {/* Page-only. There is no folder-level alert threshold or
+                auto-edit limit for the bar to plot a count against, and the
+                folder surfaces pass no history expander or total-edit count
+                either, so on a folder this card is a bare number with nothing
+                to read it against. `health` is already null there (the poll is
+                skipped); the explicit check keeps the intent at the card. */}
+            {kind === "page" && health !== null && (
               <Section
                 justifyContent="start"
                 alignItems="stretch"


### PR DESCRIPTION
## Problem

A folder's **Updates** panel showed the Update History card — a 24h auto-edit count, a usage bar, and `Alert: 30` / `Auto-Edit Limit: 100` chips. None of that is a folder-level concept:

- The **alert threshold** and the **auto-edit limit** are per-page. A folder has neither.
- The **count** comes from `git log -- <dir>`, so on a folder it covers the whole subtree. Plotting a subtree's count against a single page's cap says nothing — a folder with five busy pages trivially "exceeds" a limit that applies to none of them.
- The folder surfaces (`WikiPage.tsx`, both the right-panel and mobile-drawer mounts) pass no `onShowHistory` and no `totalEdits`, so the card had no expander and no Total Edits column either.

What was left on a folder was a bare number with nothing to read it against, plus two chips describing limits that don't exist at that scope.

## Change

`UpdatePolicyPanel` renders the card for pages only. The `useUpdateHealth` poll is gated the same way, so a folder scope no longer runs a 15s request whose only consumer was this card. Everything else in the panel — AI Auto-Edits / Update / Organize toggles and Page Instructions — is unchanged and still folder-aware.

`kind` already existed in this component (`pathKind(path)`), and `kind === "page"` already gated the clickable limit-modal trigger; this extends the same distinction to the card as a whole.

## Verification

Built and run against the local stack:

- **Folder** (`Engineering Projects`) — Updates panel shows the three toggles + Page Instructions, no history card.
- **Page** — card still renders in full: count, Total Edits, usage bar, Alert/Auto-Edit Limit chips, expander.
- `bun run typecheck` clean; prettier + tsc pre-commit hooks pass.