### PR TITLE
fix(automanage): don't count unmanaged files in a sweep's scanned stat

### DIFF
--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -23,6 +23,7 @@ pages with different audiences are never named together in one proposal.
 Single-path detectors (empty-folder) see the whole scope. Every emitted
 proposal is stamped with the combined audience fingerprint of its path-set.
 """
+
 from __future__ import annotations
 
 import logging
@@ -80,9 +81,7 @@ def _resolve_management(drafts: list[ProposalDraft]) -> dict[str, bool | None]:
     return update_policy.resolve_ai_management_for_paths(paths)
 
 
-def _base_shas(
-    source_paths: list[str], target_paths: list[str]
-) -> dict[str, str] | None:
+def _base_shas(source_paths: list[str], target_paths: list[str]) -> dict[str, str] | None:
     """Drift anchors: every affected path that has history gets one. Paths
     without history are reserved/new names (a rename option, a move
     destination) — nothing to anchor. A draft none of whose paths can be
@@ -166,9 +165,7 @@ def run_detection(
             }
         run_id = acquired
     else:
-        run_id = runs.start(
-            trigger=trigger, triggered_by_user_id=triggered_by_user_id
-        )
+        run_id = runs.start(trigger=trigger, triggered_by_user_id=triggered_by_user_id)
     try:
         scope = Scope(trigger=trigger, paths=tuple(paths), run_id=run_id)
         deduper = dedup.Deduper(paths)
@@ -196,9 +193,7 @@ def run_detection(
                 drafts = [
                     d
                     for d in drafts
-                    if any(
-                        p in focus_paths for p in d.source_paths + d.target_paths
-                    )
+                    if any(p in focus_paths for p in d.source_paths + d.target_paths)
                 ]
             # One policy query per detector, not one per path per draft.
             mgmt = _resolve_management(drafts)
@@ -250,25 +245,19 @@ def run_detection(
         # Carried pendings were just re-confirmed against current wiki
         # state — stamp them so the banner's freshness line ("confirmed by
         # the last scan …") reflects this run, not the original emit.
-        touch_last_emitted(
-            [row["id"] for row in pending_rows if row["id"] in carried_ids]
-        )
+        touch_last_emitted([row["id"] for row in pending_rows if row["id"] in carried_ids])
         if trigger is TriggerKind.SWEEP:
             revive_ids = {
-                d.existing_id for _, _, d, _ in candidates
-                if d.action is dedup.DedupAction.REVIVE
+                d.existing_id for _, _, d, _ in candidates if d.action is dedup.DedupAction.REVIVE
             }
             for row in pending_rows:
                 if row["id"] in carried_ids or row["id"] in revive_ids:
                     continue
-                if mark_stale(
-                    row["id"], reason=f"not re-detected by run {run_id}"
-                ):
+                if mark_stale(row["id"], reason=f"not re-detected by run {run_id}"):
                     invalidated += 1
             if invalidated:
                 log.info(
-                    "detection run %s: invalidated %d pending proposal(s) "
-                    "no longer detected",
+                    "detection run %s: invalidated %d pending proposal(s) no longer detected",
                     run_id,
                     invalidated,
                 )
@@ -284,9 +273,7 @@ def run_detection(
             blocked |= selection.claim_of(row["source_paths"] + row["target_paths"])
         for row in pending_rows:
             if row["id"] in carried_ids:
-                blocked |= selection.claim_of(
-                    row["source_paths"] + row["target_paths"]
-                )
+                blocked |= selection.claim_of(row["source_paths"] + row["target_paths"])
 
         emitted = 0
         persisted_invalid = 0
@@ -347,8 +334,7 @@ def run_detection(
             if until is not None:
                 if decision.action is dedup.DedupAction.CREATE:
                     _persist_invalid(
-                        f"in cooldown until {until} — these pages were "
-                        "recently declined"
+                        f"in cooldown until {until} — these pages were recently declined"
                     )
                     persisted_invalid += 1
                 # REVIVE: the row already rests as persisted-invalid.
@@ -356,8 +342,7 @@ def run_detection(
             if selection.conflicts(frozenset(claim), frozenset(blocked)):
                 if decision.action is dedup.DedupAction.CREATE:
                     _persist_invalid(
-                        f"not selected by run {run_id} — a live proposal "
-                        "holds the page"
+                        f"not selected by run {run_id} — a live proposal holds the page"
                     )
                     persisted_invalid += 1
                 # A REVIVE candidate stays at rest (stale/expired) — its
@@ -369,8 +354,7 @@ def run_detection(
                     # Unreachable: DedupDecision enforces this at
                     # construction. Skip loudly rather than crash a run.
                     log.error(
-                        "detection run %s: REVIVE decision without a row "
-                        "(%s) — skipped",
+                        "detection run %s: REVIVE decision without a row (%s) — skipped",
                         run_id,
                         decision.dedup_key,
                     )
@@ -423,9 +407,7 @@ def run_detection(
             # consent (`auto_approvable`) — probabilistic detectors emit
             # False so their proposals always get a human even in
             # AI-managed scopes.
-            if auto_ok and not review.auto_approve(
-                proposal["id"], acting_user_id=AI_USER_ID
-            ):
+            if auto_ok and not review.auto_approve(proposal["id"], acting_user_id=AI_USER_ID):
                 # Shouldn't happen for a just-created proposal; if a race
                 # transitioned it out of pending, it stays pending (a
                 # human can still action it) — surface the anomaly loudly.
@@ -436,13 +418,24 @@ def run_detection(
                     proposal["id"],
                     decision.dedup_key,
                 )
-        runs.mark_completed(
-            run_id, paths_scanned=len(paths), proposals_emitted=emitted
-        )
+        # Wiki paths, not files in scope. `paths` also carries the `.gitkeep`
+        # markers that materialize folders and any `.trigger_*.yaml`, because
+        # the folder detectors read them as facts about a folder (a marker IS
+        # the folder — git can't track an empty directory). Neither is ever a
+        # candidate: every page detector filters to `.md`, empty-folder names
+        # the folder rather than its marker, and folder-chain bails on a chain
+        # holding any non-page file. They aren't shown in the tree either, so
+        # counting them reported work on objects nobody manages or can see —
+        # 148 pages read as 193. Folders join this count when they become
+        # scanned units; the scope size stays in the log line, where it is the
+        # useful cost signal.
+        scanned = sum(1 for p in paths if p.endswith(".md"))
+        runs.mark_completed(run_id, paths_scanned=scanned, proposals_emitted=emitted)
         log.info(
-            "detection run %s (%s): scanned %d paths, emitted %d proposals",
+            "detection run %s (%s): scanned %d pages (%d files in scope), emitted %d proposals",
             run_id,
             trigger.value,
+            scanned,
             len(paths),
             emitted,
         )
@@ -452,7 +445,7 @@ def run_detection(
         raise
     return {
         "run_id": run_id,
-        "paths_scanned": len(paths),
+        "paths_scanned": scanned,
         "proposals_emitted": emitted,
     }
 

--- a/backend/tests/test_detection_runner.py
+++ b/backend/tests/test_detection_runner.py
@@ -5,6 +5,7 @@ Uses a zero-age empty-folder detector (via monkeypatched ``DETECTORS``) so the
 fresh tmp-repo commits qualify without forging commit dates; the age gate
 itself is covered in ``test_empty_folder_detector.py``.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -42,6 +43,24 @@ def _eager_detector(monkeypatch):
     monkeypatch.setattr(runner, "DETECTORS", [_EmptyFolderDetector(min_age_days=0)])
 
 
+def test_scanned_count_excludes_folder_markers_and_trigger_files(repo):
+    """`.gitkeep` markers and `.trigger_*.yaml` stay in the scope — the folder
+    detectors read them as facts about a folder, and a marker *is* the folder
+    as far as git is concerned. They are never candidates, though (every page
+    detector filters to `.md`, empty-folder names the folder rather than its
+    marker, folder-chain bails on a chain holding any non-page file) and they
+    aren't shown in the tree, so counting them reported work on objects nobody
+    manages or can see."""
+    wiki_git.commit_file("team/.trigger_abc.yaml", "id: abc\n", "add trigger", author=None)
+    wiki_git.commit_file("team/roadmap.md", "# Roadmap\n", "seed", author=None)
+
+    result = runner.run_sweep(triggered_by_user_id=None)
+
+    # Scope is unchanged: 2 pages + 2 .gitkeep + 1 trigger.
+    assert len(wiki_git.list_paths()) == 5
+    assert result["paths_scanned"] == 2
+
+
 def test_sweep_emits_proposals_and_records_run(repo):
     result = runner.run_sweep(triggered_by_user_id=None)
 
@@ -61,7 +80,8 @@ def test_sweep_emits_proposals_and_records_run(repo):
     assert run["status"] == "completed"
     assert run["trigger"] == "sweep"
     assert run["proposals_emitted"] == 2
-    assert run["paths_scanned"] >= 3
+    # Three tracked files, two of them .gitkeep markers — one page counts.
+    assert run["paths_scanned"] == 1
     assert run["finished_at"] is not None
 
 
@@ -186,7 +206,5 @@ def test_emitted_proposal_carries_acl_fingerprint(repo):
     runner.run_sweep(triggered_by_user_id=None)
 
     for p in list_by_status(ProposalStatus.PENDING):
-        expected = fingerprint.combined_fingerprint(
-            p["source_paths"] + p["target_paths"]
-        )
+        expected = fingerprint.combined_fingerprint(p["source_paths"] + p["target_paths"])
         assert p["acl_fingerprint_before"] == expected

--- a/frontend/src/components/admin/AutoOrganize.tsx
+++ b/frontend/src/components/admin/AutoOrganize.tsx
@@ -149,10 +149,16 @@ function proposalsCell(_value: number, row: DetectionRun) {
   );
 }
 
+// Paths, not pages: a run's scope is every tracked file, so the count also
+// covers the `.gitkeep` markers that materialize folders and any
+// `.trigger_*.yaml`. Detectors need those — empty-folder finds a folder by its
+// marker, and a folder-scoped trigger is what keeps that folder from counting
+// as empty — so the count is right; calling them pages was not (148 pages read
+// as 193). "Paths" also still fits once folders are scanned as units.
 function scannedCell(_value: number, row: DetectionRun) {
   return (
     <Text font="main-ui-body" color="text-03">
-      {row.status === "completed" ? `${row.paths_scanned} pages` : "—"}
+      {row.status === "completed" ? `${row.paths_scanned} paths` : "—"}
     </Text>
   );
 }


### PR DESCRIPTION
## Problem

The Auto Organize table reported **193 pages scanned** on a wiki with **148 pages**. Against prod's own path list:

| | count |
|---|---|
| `.md` pages | 148 |
| `.gitkeep` folder markers | 37 |
| `.trigger_*.yaml` | 8 |
| **total files in scope** | **193** |

The extra 45 are objects nobody manages: they never become proposal candidates, and the tree doesn't show them. Counting them reported work on things a user can neither see nor act on.

## They are never candidates — verified per detector

- `body_dup`, `case_collision`, `stub_page`, `template_echo`, `stale_page`, `misplaced_page` — all filter `p.endswith(".md")` before doing anything.
- `empty_folder` — emits `source_paths=[folder]`, the folder path, never its marker.
- `folder_chain` — `_plan_moves` returns `None` on any non-`.md` file under the tail, so a chain holding a trigger or attachment is skipped entirely; its instruction also says to leave `.gitkeep` markers in place.

## Why the scope still keeps them

They're read as facts *about* a folder, not as candidates. Git can't track an empty directory, so a `.gitkeep` **is** the folder: `_maximal_empty_folders` derives folders from `_ancestor_dirs` over the paths it's given, and a folder whose only tracked file is its marker contributes nothing if markers are filtered out — `empty_folder` and `folder_chain` would simply stop finding empty folders. Keeping them costs nothing either; they're already in the single `git ls-files` the sweep runs anyway.

So `run_sweep` still passes every tracked path. Only the reported number changes.

## Change

`paths_scanned` records the count of wiki paths — `.md` today. The column keeps its name because folders join this count when they become scanned units, at which point "paths" still reads true and no stored value changes meaning. The scope size moves into the run log (`scanned 148 pages (193 files in scope)`), where it's the useful cost signal. The admin table's cell label goes from "pages" to "paths" to match.

## Note for the folder follow-up

Folders are not the `.gitkeep` count. Prod has **59** distinct folders but only **37** markers — a folder containing pages needs none. Counting folders as units means deriving them from path prefixes, not counting marker files.

## Historical rows

The two existing rows recorded 193 and will keep reading 193; the file mix behind an old number isn't recoverable from the row, so they aren't back-computed.

## Testing

- New `test_scanned_count_excludes_folder_markers_and_trigger_files`: 5 files in scope (2 pages, 2 markers, 1 trigger), asserts the scope is still 5 and the recorded count is 2.
- Tightened the existing sweep assertion from `>= 3` to exactly `1` — that fixture's three tracked files include two markers.
- Full backend suite green (2182 passed, 2 skipped); ruff, basedpyright, prettier, tsc all clean.