### PR TITLE
fix(editor): make media selectable and size peer carets to the text

### DIFF
--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -403,28 +403,43 @@ def _map_end(
     return body_len
 
 
-def _subsequence_span(haystack: str, needle: str) -> tuple[int, int] | None:
-    """Span of ``haystack`` holding every character of ``needle`` in order, or
-    None when the alignment is unconvincing.
+def _subsequence_end(haystack: str, needle: str, start: int, limit: int) -> int | None:
+    """Exclusive end of the shortest run from ``start`` holding all of
+    ``needle`` in order, or None if it needs more than ``limit`` characters.
+    Taking each character at its earliest position is what makes it shortest."""
+    stop = min(len(haystack), start + limit)
+    consumed = 0
+    pos = start
+    while pos < stop and consumed < len(needle):
+        if haystack[pos] == needle[consumed]:
+            consumed += 1
+        pos += 1
+    return pos if consumed == len(needle) else None
+
+
+def _subsequence_span(haystack: str, needle: str, near: int) -> tuple[int, int] | None:
+    """Span of ``haystack`` holding every character of ``needle`` in order,
+    closest to ``near``, or None when no alignment is convincing.
 
     A quote drops inline syntax the source keeps (``**bold**`` reaches the
     editor as ``bold``), so it survives as a subsequence of its own source with
     the delimiters interleaved. Requiring *every* character to align, inside a
     region not much longer than the quote, is what separates that from a
-    scatter of coincidental letters across unrelated text.
+    scatter of coincidental letters across unrelated text. Repeated text makes
+    several alignments valid, so the estimate breaks the tie the same way it
+    does for an exact match.
     """
-    blocks = [
-        b
-        for b in SequenceMatcher(None, haystack, needle, autojunk=False).get_matching_blocks()
-        if b.size
-    ]
-    if not blocks or sum(b.size for b in blocks) != len(needle):
+    if not needle:
         return None
-    start = blocks[0].a
-    end = blocks[-1].a + blocks[-1].size
-    if end - start > 2 * len(needle) + _SUBSEQUENCE_SLACK:
-        return None
-    return start, end
+    limit = 2 * len(needle) + _SUBSEQUENCE_SLACK
+    best: tuple[int, int] | None = None
+    start = haystack.find(needle[0])
+    while start != -1:
+        end = _subsequence_end(haystack, needle, start, limit)
+        if end is not None and (best is None or abs(start - near) < abs(best[0] - near)):
+            best = (start, end)
+        start = haystack.find(needle[0], start + 1)
+    return best
 
 
 def _nearest_occurrence(haystack: str, needle: str, near: int) -> int | None:
@@ -486,7 +501,7 @@ def resolve_exact_span(
     best = _nearest_occurrence(body, quoted_text, approx_start)
     if best is not None:
         return best, best + len(quoted_text)
-    aligned = _subsequence_span(projected, quoted_text)
+    aligned = _subsequence_span(projected, quoted_text, approx_start)
     if aligned is not None:
         return (
             _map_start(segments, aligned[0], len(body)),

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -329,6 +329,87 @@ def _snap_to_words(body: str, start: int, end: int) -> tuple[int, int]:
     return start, end
 
 
+# `![alt](dest)`, optionally <>-wrapped with a title. An image this misses stays
+# literal, degrading to the raw search rather than to a wrong span.
+_IMAGE_RE = re.compile(
+    r"!\[(?:\\.|[^\]\\])*\]\(\s*(?:<(?P<angle>(?:\\.|[^<>\\])*)>|(?P<bare>[^\s()]*))"
+    r"(?:\s+(?:\"[^\"]*\"|'[^']*'|\([^)]*\)))?\s*\)"
+)
+
+
+def _project_media(body: str) -> tuple[str, list[tuple[int, int, int, int]]]:
+    """``body`` with each image reduced to its destination, plus a segment map.
+
+    The editor's plain-text projection gives an image its src and nothing else,
+    so a quote spanning text *and* an image only ever matches once the body is
+    reduced the same way. Segments are ``(proj_start, proj_end, body_start,
+    body_end)`` covering the body end to end; a segment is 1:1 exactly when its
+    two lengths agree, which is what lets the mapping below tell a literal run
+    from a collapsed image without a flag.
+    """
+    parts: list[str] = []
+    segments: list[tuple[int, int, int, int]] = []
+    proj = 0
+    last = 0
+    for m in _IMAGE_RE.finditer(body):
+        if m.start() > last:
+            literal = body[last : m.start()]
+            parts.append(literal)
+            segments.append((proj, proj + len(literal), last, m.start()))
+            proj += len(literal)
+        dest = m.group("angle") if m.group("angle") is not None else m.group("bare")
+        parts.append(dest)
+        segments.append((proj, proj + len(dest), m.start(), m.end()))
+        proj += len(dest)
+        last = m.end()
+    if last < len(body):
+        literal = body[last:]
+        parts.append(literal)
+        segments.append((proj, proj + len(literal), last, len(body)))
+    return "".join(parts), segments
+
+
+def _map_start(
+    segments: Sequence[tuple[int, int, int, int]], pos: int, body_len: int
+) -> int:
+    """Projection offset to body offset, opening edge. A position landing inside
+    a collapsed image takes the whole image, so the highlight starts at its
+    ``!`` rather than part-way through the source."""
+    for proj_start, proj_end, body_start, body_end in segments:
+        if proj_start <= pos < proj_end:
+            if proj_end - proj_start == body_end - body_start:
+                return body_start + (pos - proj_start)
+            return body_start
+    return body_len
+
+
+def _map_end(
+    segments: Sequence[tuple[int, int, int, int]], pos: int, body_len: int
+) -> int:
+    """Projection offset to body offset, closing edge. Exclusive, so a position
+    at the end of a collapsed image takes the image's closing paren."""
+    if pos <= 0:
+        return 0
+    for proj_start, proj_end, body_start, body_end in segments:
+        if proj_start < pos <= proj_end:
+            if proj_end - proj_start == body_end - body_start:
+                return body_start + (pos - proj_start)
+            return body_end
+    return body_len
+
+
+def _nearest_occurrence(haystack: str, needle: str, near: int) -> int | None:
+    """Start of the occurrence closest to ``near``, or None when absent."""
+    starts: list[int] = []
+    idx = haystack.find(needle)
+    while idx != -1:
+        starts.append(idx)
+        idx = haystack.find(needle, idx + 1)
+    if not starts:
+        return None
+    return min(starts, key=lambda s: abs(s - near))
+
+
 def resolve_exact_span(
     body: str, approx_start: int, approx_end: int, quoted_text: str
 ) -> tuple[int, int]:
@@ -344,6 +425,12 @@ def resolve_exact_span(
     with no fuzzy matching, so an already-wrong starting span only ever
     compounds through every future remap.
 
+    A quote covering an image carries that image's src and none of the syntax
+    around it, so the body is matched in its media projection first and the hit
+    mapped back — that is what lets such a span cover the whole ``![…](…)``
+    rather than the text beside it. Bodies without images project to themselves
+    and take the raw search directly.
+
     Returns the approximate span unchanged if ``quoted_text`` is empty, or
     isn't found anywhere in ``body`` at all (nothing to correct against —
     never worse than the caller's own estimate). When ``quoted_text``
@@ -355,14 +442,17 @@ def resolve_exact_span(
         return approx_start, approx_end
     if body[approx_start:approx_end] == quoted_text:
         return approx_start, approx_end  # already exact — no syntax preceded it
-    starts: list[int] = []
-    idx = body.find(quoted_text)
-    while idx != -1:
-        starts.append(idx)
-        idx = body.find(quoted_text, idx + 1)
-    if not starts:
+    projected, segments = _project_media(body)
+    if projected != body:
+        hit = _nearest_occurrence(projected, quoted_text, approx_start)
+        if hit is not None:
+            return (
+                _map_start(segments, hit, len(body)),
+                _map_end(segments, hit + len(quoted_text), len(body)),
+            )
+    best = _nearest_occurrence(body, quoted_text, approx_start)
+    if best is None:
         return approx_start, approx_end
-    best = min(starts, key=lambda s: abs(s - approx_start))
     return best, best + len(quoted_text)
 
 

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -90,6 +90,11 @@ _END = -1
 # anchors.
 _MIN_PRESERVED = 0.5
 
+# Characters of inline syntax a subsequence alignment may span beyond the quote
+# itself, on top of doubling it. Generous enough for stacked marks on a short
+# quote, tight enough that a scattered match is rejected.
+_SUBSEQUENCE_SLACK = 16
+
 # (tag, i1, i2, j1, j2) as returned by SequenceMatcher.get_opcodes().
 _Opcode = tuple[str, int, int, int, int]
 
@@ -398,6 +403,30 @@ def _map_end(
     return body_len
 
 
+def _subsequence_span(haystack: str, needle: str) -> tuple[int, int] | None:
+    """Span of ``haystack`` holding every character of ``needle`` in order, or
+    None when the alignment is unconvincing.
+
+    A quote drops inline syntax the source keeps (``**bold**`` reaches the
+    editor as ``bold``), so it survives as a subsequence of its own source with
+    the delimiters interleaved. Requiring *every* character to align, inside a
+    region not much longer than the quote, is what separates that from a
+    scatter of coincidental letters across unrelated text.
+    """
+    blocks = [
+        b
+        for b in SequenceMatcher(None, haystack, needle, autojunk=False).get_matching_blocks()
+        if b.size
+    ]
+    if not blocks or sum(b.size for b in blocks) != len(needle):
+        return None
+    start = blocks[0].a
+    end = blocks[-1].a + blocks[-1].size
+    if end - start > 2 * len(needle) + _SUBSEQUENCE_SLACK:
+        return None
+    return start, end
+
+
 def _nearest_occurrence(haystack: str, needle: str, near: int) -> int | None:
     """Start of the occurrence closest to ``near``, or None when absent."""
     starts: list[int] = []
@@ -431,6 +460,10 @@ def resolve_exact_span(
     rather than the text beside it. Bodies without images project to themselves
     and take the raw search directly.
 
+    A quote also drops inline syntax the source keeps, so one that matches
+    nowhere literally is aligned as a subsequence before giving up. That is
+    what anchors a selection crossing a bold or code run.
+
     Returns the approximate span unchanged if ``quoted_text`` is empty, or
     isn't found anywhere in ``body`` at all (nothing to correct against —
     never worse than the caller's own estimate). When ``quoted_text``
@@ -451,9 +484,15 @@ def resolve_exact_span(
                 _map_end(segments, hit + len(quoted_text), len(body)),
             )
     best = _nearest_occurrence(body, quoted_text, approx_start)
-    if best is None:
-        return approx_start, approx_end
-    return best, best + len(quoted_text)
+    if best is not None:
+        return best, best + len(quoted_text)
+    aligned = _subsequence_span(projected, quoted_text)
+    if aligned is not None:
+        return (
+            _map_start(segments, aligned[0], len(body)),
+            _map_end(segments, aligned[1], len(body)),
+        )
+    return approx_start, approx_end
 
 
 def remap_range(

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -44,8 +44,9 @@ import logging
 import re
 from collections.abc import Sequence
 from difflib import SequenceMatcher
-from typing import cast
+from typing import NamedTuple, cast
 
+from markdown_it.common.normalize_url import normalizeLink
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 log = logging.getLogger(__name__)
@@ -90,9 +91,8 @@ _END = -1
 # anchors.
 _MIN_PRESERVED = 0.5
 
-# Characters of inline syntax a subsequence alignment may span beyond the quote
-# itself, on top of doubling it. Generous enough for stacked marks on a short
-# quote, tight enough that a scattered match is rejected.
+# Inline-syntax characters an alignment may span on top of doubling the quote.
+# Sized for stacked marks around a short quote.
 _SUBSEQUENCE_SLACK = 16
 
 # (tag, i1, i2, j1, j2) as returned by SequenceMatcher.get_opcodes().
@@ -334,79 +334,97 @@ def _snap_to_words(body: str, start: int, end: int) -> tuple[int, int]:
     return start, end
 
 
-# `![alt](dest)`, optionally <>-wrapped with a title. An image this misses stays
-# literal, degrading to the raw search rather than to a wrong span.
+# `![alt](dest)`, optionally <>-wrapped with a title. A regex because markdown-it
+# gives source offsets on block tokens only. It also collapses image syntax
+# inside a code fence, which is why the raw search stays its own tier.
 _IMAGE_RE = re.compile(
-    r"!\[(?:\\.|[^\]\\])*\]\(\s*(?:<(?P<angle>(?:\\.|[^<>\\])*)>|(?P<bare>[^\s()]*))"
+    r"!\[(?:\\.|[^\]\\])*\]\(\s*"
+    r"(?:<(?P<angle>(?:\\.|[^<>\\])*)>|(?P<bare>(?:\\.|[^\s()\\]|\([^\s()]*\))*))"
     r"(?:\s+(?:\"[^\"]*\"|'[^']*'|\([^)]*\)))?\s*\)"
 )
 
 
-def _project_media(body: str) -> tuple[str, list[tuple[int, int, int, int]]]:
+class _Segment(NamedTuple):
+    """One run of the body and where it landed in the projection. ``literal``
+    runs map position for position, images collapse to their destination."""
+
+    proj_start: int
+    proj_end: int
+    body_start: int
+    body_end: int
+    literal: bool
+
+
+def _project_media(body: str) -> tuple[str, list[_Segment]]:
     """``body`` with each image reduced to its destination, plus a segment map.
 
-    The editor's plain-text projection gives an image its src and nothing else,
-    so a quote spanning text *and* an image only ever matches once the body is
-    reduced the same way. Segments are ``(proj_start, proj_end, body_start,
-    body_end)`` covering the body end to end; a segment is 1:1 exactly when its
-    two lengths agree, which is what lets the mapping below tell a literal run
-    from a collapsed image without a flag.
+    The editor gives an image its src and nothing else, so a quote spanning text
+    and an image matches only once the body is reduced the same way. The src it
+    holds is markdown-it's normalized link, which is why the destination is
+    normalized here rather than copied.
     """
     parts: list[str] = []
-    segments: list[tuple[int, int, int, int]] = []
+    segments: list[_Segment] = []
     proj = 0
     last = 0
+
+    def add(text: str, body_start: int, body_end: int, literal: bool) -> None:
+        nonlocal proj
+        parts.append(text)
+        segments.append(_Segment(proj, proj + len(text), body_start, body_end, literal))
+        proj += len(text)
+
     for m in _IMAGE_RE.finditer(body):
         if m.start() > last:
-            literal = body[last : m.start()]
-            parts.append(literal)
-            segments.append((proj, proj + len(literal), last, m.start()))
-            proj += len(literal)
-        dest = m.group("angle") if m.group("angle") is not None else m.group("bare")
-        parts.append(dest)
-        segments.append((proj, proj + len(dest), m.start(), m.end()))
-        proj += len(dest)
+            add(body[last : m.start()], last, m.start(), True)
+        raw = m.group("angle") if m.group("angle") is not None else m.group("bare")
+        add(normalizeLink(raw), m.start(), m.end(), False)
         last = m.end()
     if last < len(body):
-        literal = body[last:]
-        parts.append(literal)
-        segments.append((proj, proj + len(literal), last, len(body)))
+        add(body[last:], last, len(body), True)
     return "".join(parts), segments
 
 
-def _map_start(
-    segments: Sequence[tuple[int, int, int, int]], pos: int, body_len: int
-) -> int:
-    """Projection offset to body offset, opening edge. A position landing inside
-    a collapsed image takes the whole image, so the highlight starts at its
-    ``!`` rather than part-way through the source."""
-    for proj_start, proj_end, body_start, body_end in segments:
-        if proj_start <= pos < proj_end:
-            if proj_end - proj_start == body_end - body_start:
-                return body_start + (pos - proj_start)
-            return body_start
+def _map_start(segments: Sequence[_Segment], pos: int, body_len: int) -> int:
+    """Projection offset to body offset, opening edge. Any position inside a
+    collapsed image takes the whole image, so a highlight starts at its ``!``
+    rather than part-way through the source."""
+    for seg in segments:
+        if seg.proj_start <= pos < seg.proj_end:
+            if seg.literal:
+                return seg.body_start + (pos - seg.proj_start)
+            return seg.body_start
     return body_len
 
 
-def _map_end(
-    segments: Sequence[tuple[int, int, int, int]], pos: int, body_len: int
-) -> int:
-    """Projection offset to body offset, closing edge. Exclusive, so a position
-    at the end of a collapsed image takes the image's closing paren."""
+def _map_end(segments: Sequence[_Segment], pos: int, body_len: int) -> int:
+    """Projection offset to body offset, closing edge. Any position inside a
+    collapsed image takes the whole image. Position 0 needs its own guard, since
+    no segment satisfies ``proj_start < 0``."""
     if pos <= 0:
         return 0
-    for proj_start, proj_end, body_start, body_end in segments:
-        if proj_start < pos <= proj_end:
-            if proj_end - proj_start == body_end - body_start:
-                return body_start + (pos - proj_start)
-            return body_end
-    return body_len
+    for seg in segments:
+        if seg.proj_start < pos <= seg.proj_end:
+            if seg.literal:
+                return seg.body_start + (pos - seg.proj_start)
+            return seg.body_end
+    return body_len  # defensive, segments always tile [0, len(projected)]
+
+
+def _map_span(
+    segments: Sequence[_Segment], proj_start: int, proj_end: int, body_len: int
+) -> tuple[int, int]:
+    """A projection span as a body span, both edges expanded over any image
+    they land inside."""
+    return (
+        _map_start(segments, proj_start, body_len),
+        _map_end(segments, proj_end, body_len),
+    )
 
 
 def _subsequence_end(haystack: str, needle: str, start: int, limit: int) -> int | None:
     """Exclusive end of the shortest run from ``start`` holding all of
-    ``needle`` in order, or None if it needs more than ``limit`` characters.
-    Taking each character at its earliest position is what makes it shortest."""
+    ``needle`` in order, or None if it needs more than ``limit`` characters."""
     stop = min(len(haystack), start + limit)
     consumed = 0
     pos = start
@@ -418,32 +436,35 @@ def _subsequence_end(haystack: str, needle: str, start: int, limit: int) -> int 
 
 
 def _subsequence_span(haystack: str, needle: str, near: int) -> tuple[int, int] | None:
-    """Span of ``haystack`` holding every character of ``needle`` in order,
-    closest to ``near``, or None when no alignment is convincing.
+    """Tightest span of ``haystack`` holding every character of ``needle`` in
+    order, nearest ``near``, or None when no alignment is convincing.
 
-    A quote drops inline syntax the source keeps (``**bold**`` reaches the
-    editor as ``bold``), so it survives as a subsequence of its own source with
-    the delimiters interleaved. Requiring *every* character to align, inside a
-    region not much longer than the quote, is what separates that from a
-    scatter of coincidental letters across unrelated text. Repeated text makes
-    several alignments valid, so the estimate breaks the tie the same way it
-    does for an exact match.
+    A quote drops inline syntax its source keeps (``**bold**`` arrives as
+    ``bold``), so it survives only as a subsequence. The length cap is what
+    keeps a coincidental scatter out. Tightest wins ahead of nearest, since a
+    nearer start can otherwise buy a span several times the quote's length.
     """
     if not needle:
         return None
     limit = 2 * len(needle) + _SUBSEQUENCE_SLACK
-    best: tuple[int, int] | None = None
-    start = haystack.find(needle[0])
-    while start != -1:
+    # The estimate under-counts by the syntax before the span, so the true start
+    # sits near it. Astral characters can push it either way (see the module
+    # docstring on code points), hence a window rather than a forward scan.
+    lo = max(0, near - limit)
+    hi = min(len(haystack), near + limit)
+    best: tuple[tuple[int, int], tuple[int, int]] | None = None
+    start = haystack.find(needle[0], lo)
+    while start != -1 and start <= hi:
         end = _subsequence_end(haystack, needle, start, limit)
-        if end is not None and (best is None or abs(start - near) < abs(best[0] - near)):
-            best = (start, end)
+        if end is not None:
+            rank = (end - start, abs(start - near))
+            if best is None or rank < best[0]:
+                best = (rank, (start, end))
         start = haystack.find(needle[0], start + 1)
-    return best
+    return best[1] if best else None
 
 
 def _nearest_occurrence(haystack: str, needle: str, near: int) -> int | None:
-    """Start of the occurrence closest to ``near``, or None when absent."""
     starts: list[int] = []
     idx = haystack.find(needle)
     while idx != -1:
@@ -469,22 +490,16 @@ def resolve_exact_span(
     with no fuzzy matching, so an already-wrong starting span only ever
     compounds through every future remap.
 
-    A quote covering an image carries that image's src and none of the syntax
-    around it, so the body is matched in its media projection first and the hit
-    mapped back — that is what lets such a span cover the whole ``![…](…)``
-    rather than the text beside it. Bodies without images project to themselves
-    and take the raw search directly.
+    An image reaches the editor as its src alone, so the body is matched in its
+    media projection and the hit mapped back, covering the whole ``![…](…)``.
+    A quote that also drops inline syntax is aligned as a subsequence before
+    giving up.
 
-    A quote also drops inline syntax the source keeps, so one that matches
-    nowhere literally is aligned as a subsequence before giving up. That is
-    what anchors a selection crossing a bold or code run.
-
-    Returns the approximate span unchanged if ``quoted_text`` is empty, or
-    isn't found anywhere in ``body`` at all (nothing to correct against —
-    never worse than the caller's own estimate). When ``quoted_text``
-    occurs more than once, picks the occurrence whose start is closest to
-    ``approx_start``: the estimate is off by the syntax overhead *before*
-    the span, so the true position is always nearby, never far.
+    Returns the approximate span unchanged when the quote is empty, or when
+    neither the literal search nor the alignment places it. Among several
+    candidates it takes the one starting closest to ``approx_start``: the
+    estimate is off by the syntax overhead *before* the span, so the true
+    position is always nearby, never far.
     """
     if not quoted_text:
         return approx_start, approx_end
@@ -494,19 +509,13 @@ def resolve_exact_span(
     if projected != body:
         hit = _nearest_occurrence(projected, quoted_text, approx_start)
         if hit is not None:
-            return (
-                _map_start(segments, hit, len(body)),
-                _map_end(segments, hit + len(quoted_text), len(body)),
-            )
+            return _map_span(segments, hit, hit + len(quoted_text), len(body))
     best = _nearest_occurrence(body, quoted_text, approx_start)
     if best is not None:
         return best, best + len(quoted_text)
     aligned = _subsequence_span(projected, quoted_text, approx_start)
     if aligned is not None:
-        return (
-            _map_start(segments, aligned[0], len(body)),
-            _map_end(segments, aligned[1], len(body)),
-        )
+        return _map_span(segments, aligned[0], aligned[1], len(body))
     return approx_start, approx_end
 
 

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -379,14 +379,17 @@ def test_image_only_quote_covers_syntax_not_just_the_src():
     assert _BODY[start:end] == _IMG
 
 
-def test_quote_ending_at_an_image_keeps_the_closing_paren():
-    quote = "test /api/wiki/media/abc123"
-    _, end = resolve_exact_span(_BODY, 7, 7 + len(quote), quote)
-    assert _BODY[end - 1] == ")"
+def test_quote_ending_inside_an_image_src_takes_the_whole_image():
+    # The end lands strictly inside the collapsed image, which is the arm
+    # `_map_end` exists for.
+    quote = "test /api/wiki/media/abc"
+    start, end = resolve_exact_span(_BODY, 7, 7 + len(quote), quote)
+    assert _BODY[start:end] == f"test {_IMG}"
 
 
 def test_text_quote_beside_an_image_is_unaffected():
-    start, end = resolve_exact_span(_BODY, 0, 5, "intro")
+    # Offset so the equality fast path cannot answer it.
+    start, end = resolve_exact_span(_BODY, 0, 4, "intro")
     assert (start, end) == (0, 5)
 
 
@@ -396,10 +399,26 @@ def test_trailing_text_after_an_image_maps_past_the_syntax():
 
 
 def test_angle_bracketed_destination_is_projected():
+    # The quote carries the editor's src, which is markdown-it's normalized
+    # link, so a space in the source reaches the backend percent-encoded.
     body = "see ![a](</media/x y.png>) here"
-    quote = "see /media/x y.png"
+    quote = "see /media/x%20y.png"
     start, end = resolve_exact_span(body, 0, len(quote), quote)
     assert body[start:end] == "see ![a](</media/x y.png>)"
+
+
+def test_non_ascii_destination_is_projected():
+    body = "a ![i](/media/café.png) b"
+    quote = "a /media/caf%C3%A9.png"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "a ![i](/media/café.png)"
+
+
+def test_nested_parens_in_a_destination_are_projected():
+    body = "test ![a](/m/x(1).png) tail"
+    quote = "test /m/x(1).png"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "test ![a](/m/x(1).png)"
 
 
 def test_image_with_title_is_projected():
@@ -411,7 +430,7 @@ def test_image_with_title_is_projected():
 
 def test_body_without_media_still_picks_nearest_occurrence():
     body = "alpha beta alpha beta"
-    assert resolve_exact_span(body, 11, 16, "alpha") == (11, 16)
+    assert resolve_exact_span(body, 10, 15, "alpha") == (11, 16)
 
 
 def test_quote_absent_from_body_returns_the_estimate():
@@ -448,10 +467,18 @@ def test_quote_with_both_formatting_and_media_anchors_on_the_source():
 
 
 def test_scattered_characters_do_not_count_as_an_alignment():
-    # Every character of the quote exists in order but spread across the whole
-    # body. That is coincidence, not dropped syntax, so keep the estimate.
-    body = "a" * 400 + "zz"
-    assert resolve_exact_span(body, 0, 5, "aaaaa zzz") == (0, 5)
+    # Every character is present in order, but only across a run far longer
+    # than the quote. That is coincidence, not dropped syntax, so keep the
+    # estimate rather than anchoring across the whole line.
+    body = "a...b...c...d...e...f...g...h...i...j... and more"
+    assert resolve_exact_span(body, 0, 10, "abcdefghij") == (0, 10)
+
+
+def test_dropped_syntax_within_the_limit_still_aligns():
+    # Same shape, tight enough to be inline syntax rather than a scatter.
+    body = "a.b.c.d.e.f.g.h.i.j. and more prose"
+    start, end = resolve_exact_span(body, 0, 10, "abcdefghij")
+    assert body[start:end] == "a.b.c.d.e.f.g.h.i.j"
 
 
 def test_alignment_prefers_leaving_the_estimate_when_a_char_is_missing():
@@ -482,3 +509,20 @@ def test_repeated_media_anchors_nearest_the_estimate():
     start, end = resolve_exact_span(body, second, second + len(quote), quote)
     assert body[start:end] == "x ![a](/m/1) y"
     assert start == second
+
+
+def test_image_syntax_in_a_code_fence_falls_back_to_the_raw_search():
+    # The projection collapses this like a real image, so only the raw tier can
+    # place a quote of the literal source.
+    body = "intro\n\n```\n![a](/m/1)\n```\n\ntail"
+    quote = "![a](/m/1)"
+    at = body.index(quote)
+    start, end = resolve_exact_span(body, at - 1, at - 1 + len(quote), quote)
+    assert body[start:end] == quote
+
+
+def test_alignment_prefers_the_tightest_span_over_the_nearest_start():
+    body = "a filler filler a **bold** run"
+    quote = "a bold run"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "a **bold** run"

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import pytest
 
 from app.wiki import comment_anchor
-from app.wiki.comment_anchor import remap_range
+from app.wiki.comment_anchor import remap_range, resolve_exact_span
 
 
 def _slice(new_body: str, result: tuple[int, int] | None) -> str:
@@ -358,3 +358,65 @@ def test_replace_run_similarity_computed_once_per_body_pair(monkeypatch):
     results = [remap_range(old, new, s, e, diff=diff) for s, e in spans]
     assert all(r is not None for r in results)
     assert len(constructions) == 1  # the shared run's ratio ran exactly once
+
+
+# resolve_exact_span: a quote carrying an image's src anchors on the whole
+# `![…](…)`, and a quote without media searches exactly as before.
+
+_IMG = "![shot.png](/api/wiki/media/abc123)"
+_BODY = f"intro\n\ntest {_IMG} tail\n"
+
+
+def test_quote_spanning_text_and_image_covers_the_whole_image():
+    quote = "test /api/wiki/media/abc123"
+    start, end = resolve_exact_span(_BODY, 7, 7 + len(quote), quote)
+    assert _BODY[start:end] == f"test {_IMG}"
+
+
+def test_image_only_quote_covers_syntax_not_just_the_src():
+    quote = "/api/wiki/media/abc123"
+    start, end = resolve_exact_span(_BODY, 12, 12 + len(quote), quote)
+    assert _BODY[start:end] == _IMG
+
+
+def test_quote_ending_at_an_image_keeps_the_closing_paren():
+    quote = "test /api/wiki/media/abc123"
+    _, end = resolve_exact_span(_BODY, 7, 7 + len(quote), quote)
+    assert _BODY[end - 1] == ")"
+
+
+def test_text_quote_beside_an_image_is_unaffected():
+    start, end = resolve_exact_span(_BODY, 0, 5, "intro")
+    assert (start, end) == (0, 5)
+
+
+def test_trailing_text_after_an_image_maps_past_the_syntax():
+    start, end = resolve_exact_span(_BODY, 30, 34, "tail")
+    assert _BODY[start:end] == "tail"
+
+
+def test_angle_bracketed_destination_is_projected():
+    body = "see ![a](</media/x y.png>) here"
+    quote = "see /media/x y.png"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "see ![a](</media/x y.png>)"
+
+
+def test_image_with_title_is_projected():
+    body = 'see ![a](/media/x.png "a title") here'
+    quote = "see /media/x.png"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == 'see ![a](/media/x.png "a title")'
+
+
+def test_body_without_media_still_picks_nearest_occurrence():
+    body = "alpha beta alpha beta"
+    assert resolve_exact_span(body, 11, 16, "alpha") == (11, 16)
+
+
+def test_quote_absent_from_body_returns_the_estimate():
+    assert resolve_exact_span(_BODY, 3, 9, "nowhere") == (3, 9)
+
+
+def test_empty_quote_returns_the_estimate():
+    assert resolve_exact_span(_BODY, 3, 9, "") == (3, 9)

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -458,3 +458,27 @@ def test_alignment_prefers_leaving_the_estimate_when_a_char_is_missing():
     # "xyz" never appears, so no alignment can cover the whole quote.
     body = "some ordinary prose here"
     assert resolve_exact_span(body, 2, 8, "some xyz") == (2, 8)
+
+
+def test_repeated_formatted_text_anchors_nearest_the_estimate():
+    body = "a **bold** run here. filler filler filler. a **bold** run here."
+    quote = "a bold run"
+    second = body.rindex("a **bold** run")
+    start, end = resolve_exact_span(body, second, second + len(quote), quote)
+    assert (start, end) == (second, second + len("a **bold** run"))
+
+
+def test_repeated_formatted_text_still_finds_the_first_when_that_is_nearest():
+    body = "a **bold** run here. filler filler filler. a **bold** run here."
+    quote = "a bold run"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert (start, end) == (0, len("a **bold** run"))
+
+
+def test_repeated_media_anchors_nearest_the_estimate():
+    body = "x ![a](/m/1) y and later x ![a](/m/1) y"
+    quote = "x /m/1 y"
+    second = body.rindex("x ![a](/m/1) y")
+    start, end = resolve_exact_span(body, second, second + len(quote), quote)
+    assert body[start:end] == "x ![a](/m/1) y"
+    assert start == second

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -420,3 +420,41 @@ def test_quote_absent_from_body_returns_the_estimate():
 
 def test_empty_quote_returns_the_estimate():
     assert resolve_exact_span(_BODY, 3, 9, "") == (3, 9)
+
+
+# A quote drops inline syntax the source keeps, so it survives only as a
+# subsequence of its own source. These pin that alignment and its guard.
+
+
+def test_quote_across_a_bold_run_anchors_on_the_source():
+    body = "a **bold** run here"
+    quote = "a bold run"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "a **bold** run"
+
+
+def test_quote_across_a_code_span_anchors_on_the_source():
+    body = "use `code` inline"
+    quote = "use code inline"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "use `code` inline"
+
+
+def test_quote_with_both_formatting_and_media_anchors_on_the_source():
+    body = "see **bold** ![a](/api/wiki/media/x1) tail"
+    quote = "see bold /api/wiki/media/x1"
+    start, end = resolve_exact_span(body, 0, len(quote), quote)
+    assert body[start:end] == "see **bold** ![a](/api/wiki/media/x1)"
+
+
+def test_scattered_characters_do_not_count_as_an_alignment():
+    # Every character of the quote exists in order but spread across the whole
+    # body. That is coincidence, not dropped syntax, so keep the estimate.
+    body = "a" * 400 + "zz"
+    assert resolve_exact_span(body, 0, 5, "aaaaa zzz") == (0, 5)
+
+
+def test_alignment_prefers_leaving_the_estimate_when_a_char_is_missing():
+    # "xyz" never appears, so no alignment can cover the whole quote.
+    body = "some ordinary prose here"
+    assert resolve_exact_span(body, 2, 8, "some xyz") == (2, 8)

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -142,7 +142,7 @@
 .editor-prose ul > li,
 .editor-prose ol > li {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   gap: 0.5rem;
 }
 .editor-prose ol > li {
@@ -179,7 +179,7 @@
    TaskItem renders that and nothing else, no `data-type`. */
 .editor-prose ul[data-type="taskList"] > li[data-checked] {
   display: flex;
-  align-items: flex-start;
+  align-items: baseline;
   gap: 0.5rem;
 }
 /* A plain item in a task list. The list itself is `list-style: none` for the
@@ -372,9 +372,9 @@
   display: inline-block;
   max-width: 100%;
   line-height: 0;
-  /* Top, matching the task-list line. Bottom-aligning drops the image below
-     the text baseline, so a line mixing both reads as two different lines. */
-  vertical-align: top;
+  /* Baseline, so an image sits on the same line as the text and markers beside
+     it rather than defining its own alignment. */
+  vertical-align: baseline;
 }
 .editor-prose .editor-image-img {
   display: block;
@@ -444,7 +444,7 @@
   display: inline-block;
   width: 140px;
   height: 100px;
-  vertical-align: bottom;
+  vertical-align: baseline;
   border-radius: var(--radius-08);
   background: var(--background-tint-02);
   animation: editor-image-pulse 1.2s ease-in-out infinite;

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -304,6 +304,15 @@
   margin-right: -1px;
   border-left: 2px solid;
   border-left-style: solid;
+  /* Sized to the text line, not the line box. An inline-block image makes the
+     box as tall as the image, which otherwise stretches the caret to match and
+     makes it jump between lines. */
+  display: inline-block;
+  height: 1.2em;
+  vertical-align: text-bottom;
+  /* Above the image, which is a positioned inline-block and would paint over
+     a caret sitting beside it. */
+  z-index: 1;
 }
 .editor-prose .ProseMirror-yjs-cursor div {
   position: absolute;
@@ -330,7 +339,9 @@
   display: inline-block;
   max-width: 100%;
   line-height: 0;
-  vertical-align: bottom;
+  /* Top, matching the task-list line. Bottom-aligning drops the image below
+     the text baseline, so a line mixing both reads as two different lines. */
+  vertical-align: top;
 }
 .editor-prose .editor-image-img {
   display: block;

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -128,13 +128,41 @@
 }
 
 /* Lists. */
-.editor-prose ul {
-  list-style: disc;
-  padding-left: 1.5rem;
+/* Markers are flex children, not native `::marker`s, so every list aligns its
+   marker the way the task list already does. A native marker sits on the first
+   line box's baseline, which a tall image pushes to the bottom of the image. */
+.editor-prose ul,
+.editor-prose ol {
+  list-style: none;
+  padding-left: 0.5rem;
 }
 .editor-prose ol {
-  list-style: decimal;
-  padding-left: 1.5rem;
+  counter-reset: editor-ol;
+}
+.editor-prose ul > li,
+.editor-prose ol > li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+.editor-prose ol > li {
+  counter-increment: editor-ol;
+}
+.editor-prose ul:not([data-type="taskList"]) > li::before {
+  content: "•";
+  flex: none;
+  line-height: 1.5rem;
+}
+.editor-prose ol > li::before {
+  content: counter(editor-ol) ".";
+  flex: none;
+  line-height: 1.5rem;
+}
+/* The content beside a marker owns the remaining width, so a long line wraps
+   instead of forcing the row wider than the column. */
+.editor-prose ul > li > *,
+.editor-prose ol > li > * {
+  min-width: 0;
 }
 .editor-prose ul[data-type="taskList"] {
   list-style: none;

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -341,9 +341,10 @@
   content: "";
   position: absolute;
   top: 0;
-  /* Fixed to the prose line-height rather than an em, which would scale with a
-     heading's font size and resize the line as a peer moves through it. */
-  height: 1.5rem;
+  /* Tracks font size, which is what the browser's own caret does (measured 21px
+     at 16px text, 41.5px at 32px). Line-height would misfit headings, whose
+     line-height here is smaller than their font size. */
+  height: 1.3em;
   border-left: 2px solid;
   border-color: inherit;
 }
@@ -360,6 +361,14 @@
 }
 .editor-prose .ProseMirror-yjs-selection {
   opacity: 0.3;
+}
+
+/* Chrome's UA styles make a draggable element unselectable, so a selection
+   covering media highlights the text around it and leaves the media untinted.
+   prosemirror-view ships this override; its stylesheet is not loaded here.
+   Keyed off the attributes, so any later draggable node view inherits it. */
+.editor-prose [draggable][contenteditable="false"] {
+  user-select: text;
 }
 
 /* Inline image node (lib/editor/images.ts). The NodeView renders this raw

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -127,42 +127,16 @@
   color: var(--text-03);
 }
 
-/* Lists. */
-/* Markers are flex children, not native `::marker`s, so every list aligns its
-   marker the way the task list already does. A native marker sits on the first
-   line box's baseline, which a tall image pushes to the bottom of the image. */
-.editor-prose ul,
-.editor-prose ol {
-  list-style: none;
-  padding-left: 0.5rem;
+/* Lists. Native markers, so a nested list stays a block below its parent and an
+   ordered list keeps its `start`. Both depend on the item remaining a
+   `list-item`, which is why the marker is not a flex child here. */
+.editor-prose ul {
+  list-style: disc;
+  padding-left: 1.5rem;
 }
 .editor-prose ol {
-  counter-reset: editor-ol;
-}
-.editor-prose ul > li,
-.editor-prose ol > li {
-  display: flex;
-  align-items: baseline;
-  gap: 0.5rem;
-}
-.editor-prose ol > li {
-  counter-increment: editor-ol;
-}
-.editor-prose ul:not([data-type="taskList"]) > li::before {
-  content: "•";
-  flex: none;
-  line-height: 1.5rem;
-}
-.editor-prose ol > li::before {
-  content: counter(editor-ol) ".";
-  flex: none;
-  line-height: 1.5rem;
-}
-/* The content beside a marker owns the remaining width, so a long line wraps
-   instead of forcing the row wider than the column. */
-.editor-prose ul > li > *,
-.editor-prose ol > li > * {
-  min-width: 0;
+  list-style: decimal;
+  padding-left: 1.5rem;
 }
 .editor-prose ul[data-type="taskList"] {
   list-style: none;
@@ -330,23 +304,20 @@
   position: relative;
   margin-left: -1px;
   margin-right: -1px;
-  /* The bar is the ::before, not this element's own border: an inline element
-     takes the line box's height, which an inline-block image stretches to the
-     image. yCursorPlugin sets border-color inline per user, so that stays here
-     for the ::before to inherit. */
-  border-left: 0 solid;
+  /* The bar is the ::before because this element's height follows the line box,
+     which an image stretches. The per-user color lands inline here, so the
+     ::before inherits it. */
   z-index: 1; /* the image is positioned and would paint over the caret */
 }
 .editor-prose .ProseMirror-yjs-cursor::before {
   content: "";
   position: absolute;
   top: 0;
-  /* Tracks font size, which is what the browser's own caret does (measured 21px
-     at 16px text, 41.5px at 32px). Line-height would misfit headings, whose
-     line-height here is smaller than their font size. */
+  /* Font-relative, matching the browser's own caret. The fixed 1.5rem
+     line-height would undersize it in h1 and h2. */
   height: 1.3em;
   border-left: 2px solid;
-  border-color: inherit;
+  border-left-color: inherit;
 }
 .editor-prose .ProseMirror-yjs-cursor div {
   position: absolute;
@@ -363,10 +334,8 @@
   opacity: 0.3;
 }
 
-/* Chrome's UA styles make a draggable element unselectable, so a selection
-   covering media highlights the text around it and leaves the media untinted.
-   prosemirror-view ships this override; its stylesheet is not loaded here.
-   Keyed off the attributes, so any later draggable node view inherits it. */
+/* Chrome's UA stylesheet makes a draggable element unselectable, so a selection
+   covering media would leave it untinted. */
 .editor-prose [draggable][contenteditable="false"] {
   user-select: text;
 }
@@ -381,8 +350,7 @@
   display: inline-block;
   max-width: 100%;
   line-height: 0;
-  /* Baseline, so an image sits on the same line as the text and markers beside
-     it rather than defining its own alignment. */
+  /* Sits on the text baseline, like the text and markers beside it. */
   vertical-align: baseline;
 }
 .editor-prose .editor-image-img {

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -302,8 +302,6 @@
    small name tag above it. */
 .editor-prose .ProseMirror-yjs-cursor {
   position: relative;
-  margin-left: -1px;
-  margin-right: -1px;
   /* The bar is the ::before because this element's height follows the line box,
      which an image stretches. The per-user color lands inline here, so the
      ::before inherits it. */
@@ -313,8 +311,9 @@
   content: "";
   position: absolute;
   top: 0;
-  /* Font-relative, matching the browser's own caret. The fixed 1.5rem
-     line-height would undersize it in h1 and h2. */
+  left: -1px;
+  /* Font-relative so the caret tracks whatever type size it sits in, which the
+     prose line-height alone does not. */
   height: 1.3em;
   border-left: 2px solid;
   border-left-color: inherit;
@@ -334,8 +333,8 @@
   opacity: 0.3;
 }
 
-/* Chrome's UA stylesheet makes a draggable element unselectable, so a selection
-   covering media would leave it untinted. */
+/* A draggable node is not user-selectable by default, so a selection covering
+   media would leave it untinted. */
 .editor-prose [draggable][contenteditable="false"] {
   user-select: text;
 }
@@ -350,7 +349,6 @@
   display: inline-block;
   max-width: 100%;
   line-height: 0;
-  /* Sits on the text baseline, like the text and markers beside it. */
   vertical-align: baseline;
 }
 .editor-prose .editor-image-img {

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -302,17 +302,22 @@
   position: relative;
   margin-left: -1px;
   margin-right: -1px;
+  /* The bar is the ::before, not this element's own border: an inline element
+     takes the line box's height, which an inline-block image stretches to the
+     image. yCursorPlugin sets border-color inline per user, so that stays here
+     for the ::before to inherit. */
+  border-left: 0 solid;
+  z-index: 1; /* the image is positioned and would paint over the caret */
+}
+.editor-prose .ProseMirror-yjs-cursor::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  /* Fixed to the prose line-height rather than an em, which would scale with a
+     heading's font size and resize the line as a peer moves through it. */
+  height: 1.5rem;
   border-left: 2px solid;
-  border-left-style: solid;
-  /* Sized to the text line, not the line box. An inline-block image makes the
-     box as tall as the image, which otherwise stretches the caret to match and
-     makes it jump between lines. */
-  display: inline-block;
-  height: 1.2em;
-  vertical-align: text-bottom;
-  /* Above the image, which is a positioned inline-block and would paint over
-     a caret sitting beside it. */
-  z-index: 1;
+  border-color: inherit;
 }
 .editor-prose .ProseMirror-yjs-cursor div {
   position: absolute;

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -9,7 +9,9 @@ import {
 } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 
+import { ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
+import { toast } from "@/hooks/useToast";
 import { createComment } from "@/lib/comments";
 import type { CoeditorHandle, CommentDraft } from "@/lib/editor/types";
 import { useIsMobile } from "@/lib/viewport";
@@ -62,6 +64,21 @@ function threadHaystack(t: CommentThreadView): string {
  * search row. Orphaned and resolved threads appear only in list mode.
  * Mobile always lists, the sheet covers the doc the cards would track.
  */
+/** What to show a person when a comment action fails. A server validation
+ * dump names internal files and helps nobody, so anything unrecognized becomes
+ * a plain sentence and the detail stays in the network tab. */
+function commentErrorMessage(e: unknown): string {
+  if (e instanceof ApiError) {
+    if (e.status === 403) return "You do not have permission to comment here.";
+    if (e.status === 404) return "That page or comment no longer exists.";
+    if (e.status === 409) return "The page changed. Reload and try again.";
+    if (e.status < 500 && !/\n|{|validation error/i.test(e.message)) {
+      return e.message;
+    }
+  }
+  return "Could not save that comment. Try again.";
+}
+
 export function CommentsPanel({
   path,
   headSha,
@@ -80,7 +97,6 @@ export function CommentsPanel({
 }: Props) {
   const { user } = useAuth();
   const isMobile = useIsMobile();
-  const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [query, setQuery] = useState("");
   const listMode = listView || isMobile || !editorRef;
@@ -95,7 +111,7 @@ export function CommentsPanel({
         await onChanged();
         return true;
       } catch (e) {
-        setError(e instanceof Error ? e.message : "action failed");
+        toast.error(commentErrorMessage(e));
         return false;
       } finally {
         setBusy(false);
@@ -159,7 +175,7 @@ export function CommentsPanel({
   const submitDraft = async (body: string) => {
     if (!draft) return;
     if (!headSha) {
-      setError("page version unknown, reload and retry");
+      toast.error("Page version unknown. Reload and try again.");
       return;
     }
     const ok = await run(() =>
@@ -214,11 +230,6 @@ export function CommentsPanel({
         <div className="shrink-0 rounded-(--radius-12) border border-(--border-01) p-1">
           {searchRow}
         </div>
-        {error && (
-          <div className="px-2 py-1 text-xs text-(--status-text-error-05)">
-            {error}
-          </div>
-        )}
         <CommentMarginRail
           inPanel
           threads={searched}
@@ -257,12 +268,6 @@ export function CommentsPanel({
         gap={0.25}
         className="scroll-fade-bottom scroll-y-hidden min-h-0 flex-1 overflow-y-auto"
       >
-        {error && (
-          <div className="px-2 py-1 text-xs text-(--status-text-error-05)">
-            {error}
-          </div>
-        )}
-
         {draft && (
           <NewCommentComposer
             selfName={user?.name || user?.email || "You"}

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -9,10 +9,9 @@ import {
 } from "@onyx-ai/opal/components";
 import { Section } from "@onyx-ai/opal/layouts";
 
-import { ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
 import { toast } from "@/hooks/useToast";
-import { createComment } from "@/lib/comments";
+import { commentErrorMessage, createComment } from "@/lib/comments";
 import type { CoeditorHandle, CommentDraft } from "@/lib/editor/types";
 import { useIsMobile } from "@/lib/viewport";
 import type { CommentThreadView } from "@/types";
@@ -64,21 +63,6 @@ function threadHaystack(t: CommentThreadView): string {
  * search row. Orphaned and resolved threads appear only in list mode.
  * Mobile always lists, the sheet covers the doc the cards would track.
  */
-/** What to show a person when a comment action fails. A server validation
- * dump names internal files and helps nobody, so anything unrecognized becomes
- * a plain sentence and the detail stays in the network tab. */
-function commentErrorMessage(e: unknown): string {
-  if (e instanceof ApiError) {
-    if (e.status === 403) return "You do not have permission to comment here.";
-    if (e.status === 404) return "That page or comment no longer exists.";
-    if (e.status === 409) return "The page changed. Reload and try again.";
-    if (e.status < 500 && !/\n|{|validation error/i.test(e.message)) {
-      return e.message;
-    }
-  }
-  return "Could not save that comment. Try again.";
-}
-
 export function CommentsPanel({
   path,
   headSha,

--- a/frontend/src/components/wiki/CommentsPanel.tsx
+++ b/frontend/src/components/wiki/CommentsPanel.tsx
@@ -11,7 +11,11 @@ import { Section } from "@onyx-ai/opal/layouts";
 
 import { useAuth } from "@/lib/auth";
 import { toast } from "@/hooks/useToast";
-import { commentErrorMessage, createComment } from "@/lib/comments";
+import {
+  NO_HEAD_SHA_MESSAGE,
+  commentErrorMessage,
+  createComment,
+} from "@/lib/comments";
 import type { CoeditorHandle, CommentDraft } from "@/lib/editor/types";
 import { useIsMobile } from "@/lib/viewport";
 import type { CommentThreadView } from "@/types";
@@ -159,7 +163,7 @@ export function CommentsPanel({
   const submitDraft = async (body: string) => {
     if (!draft) return;
     if (!headSha) {
-      toast.error("Page version unknown. Reload and try again.");
+      toast.error(NO_HEAD_SHA_MESSAGE);
       return;
     }
     const ok = await run(() =>

--- a/frontend/src/lib/comments.ts
+++ b/frontend/src/lib/comments.ts
@@ -1,18 +1,18 @@
 import { ApiError, apiFetch } from "./api";
 import type { CommentThreadView, CommentView } from "@/types";
 
-/** What to show a person when a comment action fails.
-
- * Allowlisted by status rather than by inspecting the text: a server body can
- * be a validation dump naming internal files, or HTML from a proxy, and
- * neither belongs on screen. */
+/** What to show a person when a comment action fails. Mapped by status, not by
+ * the server's text: a 400 carries the raw validation dump. Wording stays
+ * action-neutral, since every comment mutation reports through here. */
 export function commentErrorMessage(e: unknown): string {
   if (e instanceof ApiError) {
     switch (e.status) {
       case 400:
-        return "That selection cannot be commented on.";
+        return "That comment could not be applied.";
+      case 401:
+        return "Your session expired. Sign in and try again.";
       case 403:
-        return "You do not have permission to comment here.";
+        return "You do not have permission to do that.";
       case 404:
         return "That page or comment no longer exists.";
       case 409:
@@ -23,8 +23,13 @@ export function commentErrorMessage(e: unknown): string {
         return "Too many requests. Wait a moment and try again.";
     }
   }
-  return "Could not save that comment. Try again.";
+  return "That did not go through. Try again.";
 }
+
+/** Shown when a draft is submitted before the page's version is known, which is
+ * what anchors the comment to a revision. */
+export const NO_HEAD_SHA_MESSAGE =
+  "Page version unknown. Reload and try again.";
 
 /** List a page's comments, grouped into threads (root + replies). */
 export async function listComments(path: string): Promise<CommentThreadView[]> {

--- a/frontend/src/lib/comments.ts
+++ b/frontend/src/lib/comments.ts
@@ -1,5 +1,30 @@
-import { apiFetch } from "./api";
+import { ApiError, apiFetch } from "./api";
 import type { CommentThreadView, CommentView } from "@/types";
+
+/** What to show a person when a comment action fails.
+
+ * Allowlisted by status rather than by inspecting the text: a server body can
+ * be a validation dump naming internal files, or HTML from a proxy, and
+ * neither belongs on screen. */
+export function commentErrorMessage(e: unknown): string {
+  if (e instanceof ApiError) {
+    switch (e.status) {
+      case 400:
+        return "That selection cannot be commented on.";
+      case 403:
+        return "You do not have permission to comment here.";
+      case 404:
+        return "That page or comment no longer exists.";
+      case 409:
+        return "The page changed. Reload and try again.";
+      case 413:
+        return "That comment is too long.";
+      case 429:
+        return "Too many requests. Wait a moment and try again.";
+    }
+  }
+  return "Could not save that comment. Try again.";
+}
 
 /** List a page's comments, grouped into threads (root + replies). */
 export async function listComments(path: string): Promise<CommentThreadView[]> {

--- a/frontend/src/lib/comments.ts
+++ b/frontend/src/lib/comments.ts
@@ -1,9 +1,9 @@
 import { ApiError, apiFetch } from "./api";
 import type { CommentThreadView, CommentView } from "@/types";
 
-/** What to show a person when a comment action fails. Mapped by status, not by
- * the server's text: a 400 carries the raw validation dump. Wording stays
- * action-neutral, since every comment mutation reports through here. */
+/** What to show a person when a comment action fails. Keyed on status because
+ * the server's text can be a raw pydantic dump. Action-neutral wording, so it
+ * fits any comment mutation. */
 export function commentErrorMessage(e: unknown): string {
   if (e instanceof ApiError) {
     switch (e.status) {
@@ -15,12 +15,8 @@ export function commentErrorMessage(e: unknown): string {
         return "You do not have permission to do that.";
       case 404:
         return "That page or comment no longer exists.";
-      case 409:
-        return "The page changed. Reload and try again.";
       case 413:
         return "That comment is too long.";
-      case 429:
-        return "Too many requests. Wait a moment and try again.";
     }
   }
   return "That did not go through. Try again.";

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -3,6 +3,7 @@
 /** Tiptap-based live editor. Replaces `frontend/src/lib/editor/` (the
  * CodeMirror/OT-era editor, deleted once this cutover lands). */
 import { posToDOMRect } from "@tiptap/core";
+import type { Node as PMNode } from "@tiptap/pm/model";
 import { EditorContent, useEditor } from "@tiptap/react";
 import {
   forwardRef,
@@ -30,6 +31,16 @@ import type {
   CommentDraft,
   TiptapEditorProps,
 } from "@/lib/editor/types";
+
+/** Text a leaf contributes to a comment's quote. A leaf holds no text, so an
+ * image-only selection would quote nothing, and the server re-anchors by
+ * searching the markdown source for the quote. Its markdown is what is there. */
+function leafQuotedText(leaf: PMNode): string {
+  if (leaf.type.name !== "image") return "";
+  const alt = (leaf.attrs.alt as string) ?? "";
+  const src = (leaf.attrs.src as string) ?? "";
+  return `![${alt}](${src})`;
+}
 
 /** Highlight ids whose spans contain a collapsed caret or intersect a
  * selection, half-open at span ends so a caret just past a span misses —
@@ -186,13 +197,24 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
           lastSelectionForComment.current = selKey;
           const cb = onSelectionForCommentRef.current;
           if (cb) {
-            if (from === to) {
+            const quotedText =
+              from === to
+                ? ""
+                : editor.state.doc.textBetween(
+                    from,
+                    to,
+                    "\n\n",
+                    leafQuotedText,
+                  );
+            // A quote is what the server re-anchors by, so a selection holding
+            // no quotable content offers nothing to comment on.
+            if (!quotedText) {
               cb(null, null);
             } else {
               const draft: CommentDraft = {
                 startOffset: pmPosToTextOffset(editor, from),
                 endOffset: pmPosToTextOffset(editor, to),
-                quotedText: editor.state.doc.textBetween(from, to, "\n\n"),
+                quotedText,
               };
               const coords = editor.view.coordsAtPos(to);
               cb(draft, { x: coords.left, y: coords.top });

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -3,7 +3,6 @@
 /** Tiptap-based live editor. Replaces `frontend/src/lib/editor/` (the
  * CodeMirror/OT-era editor, deleted once this cutover lands). */
 import { posToDOMRect } from "@tiptap/core";
-import type { Node as PMNode } from "@tiptap/pm/model";
 import { EditorContent, useEditor } from "@tiptap/react";
 import {
   forwardRef,
@@ -23,7 +22,11 @@ import {
 import type { CoeditPeer } from "@/lib/editor/hooks";
 import { colorFor } from "@/lib/editor/presence";
 import type { CoeditParticipant } from "@/lib/editor/svc";
-import { pmPosToTextOffset, textOffsetToPmPos } from "@/lib/editor/textOffsets";
+import {
+  leafText,
+  pmPosToTextOffset,
+  textOffsetToPmPos,
+} from "@/lib/editor/textOffsets";
 import { opaqueId } from "@/lib/editor/ids";
 import type {
   AnchoredHighlightTarget,
@@ -31,16 +34,6 @@ import type {
   CommentDraft,
   TiptapEditorProps,
 } from "@/lib/editor/types";
-
-/** Text a leaf contributes to a comment's quote. A leaf holds no text, so an
- * image-only selection would quote nothing, and the server re-anchors by
- * searching the markdown source for the quote. Its markdown is what is there. */
-function leafQuotedText(leaf: PMNode): string {
-  if (leaf.type.name !== "image") return "";
-  const alt = (leaf.attrs.alt as string) ?? "";
-  const src = (leaf.attrs.src as string) ?? "";
-  return `![${alt}](${src})`;
-}
 
 /** Highlight ids whose spans contain a collapsed caret or intersect a
  * selection, half-open at span ends so a caret just past a span misses —
@@ -200,12 +193,7 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
             const quotedText =
               from === to
                 ? ""
-                : editor.state.doc.textBetween(
-                    from,
-                    to,
-                    "\n\n",
-                    leafQuotedText,
-                  );
+                : editor.state.doc.textBetween(from, to, "\n\n", leafText);
             // A quote is what the server re-anchors by, so a selection holding
             // no quotable content offers nothing to comment on.
             if (!quotedText) {

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -23,7 +23,7 @@ import type { CoeditPeer } from "@/lib/editor/hooks";
 import { colorFor } from "@/lib/editor/presence";
 import type { CoeditParticipant } from "@/lib/editor/svc";
 import {
-  leafText,
+  docTextBetween,
   pmPosToTextOffset,
   textOffsetToPmPos,
 } from "@/lib/editor/textOffsets";
@@ -190,13 +190,10 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
           lastSelectionForComment.current = selKey;
           const cb = onSelectionForCommentRef.current;
           if (cb) {
-            const quotedText =
-              from === to
-                ? ""
-                : editor.state.doc.textBetween(from, to, "\n\n", leafText);
-            // A quote is what the server re-anchors by, so a selection holding
-            // no quotable content offers nothing to comment on.
-            if (!quotedText) {
+            const quotedText = docTextBetween(editor, from, to);
+            // A quote is what the server re-anchors by, and block separators
+            // alone match anywhere, so neither is something to comment on.
+            if (!quotedText.trim()) {
               cb(null, null);
             } else {
               const draft: CommentDraft = {

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -191,8 +191,8 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
           const cb = onSelectionForCommentRef.current;
           if (cb) {
             const quotedText = docTextBetween(editor, from, to);
-            // A quote is what the server re-anchors by, and block separators
-            // alone match anywhere, so neither is something to comment on.
+            // The server re-anchors by the quote, and a whitespace-only quote
+            // matches anywhere.
             if (!quotedText.trim()) {
               cb(null, null);
             } else {

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -23,7 +23,7 @@ import type { CoeditPeer } from "@/lib/editor/hooks";
 import { colorFor } from "@/lib/editor/presence";
 import type { CoeditParticipant } from "@/lib/editor/svc";
 import {
-  docTextBetween,
+  commentQuote,
   pmPosToTextOffset,
   textOffsetToPmPos,
 } from "@/lib/editor/textOffsets";
@@ -190,7 +190,7 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
           lastSelectionForComment.current = selKey;
           const cb = onSelectionForCommentRef.current;
           if (cb) {
-            const quotedText = docTextBetween(editor, from, to);
+            const quotedText = commentQuote(editor, from, to);
             // A quote is what the server re-anchors by, and block separators
             // alone match anywhere, so neither is something to comment on.
             if (!quotedText.trim()) {

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -23,7 +23,7 @@ import type { CoeditPeer } from "@/lib/editor/hooks";
 import { colorFor } from "@/lib/editor/presence";
 import type { CoeditParticipant } from "@/lib/editor/svc";
 import {
-  commentQuote,
+  docTextBetween,
   pmPosToTextOffset,
   textOffsetToPmPos,
 } from "@/lib/editor/textOffsets";
@@ -190,7 +190,7 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
           lastSelectionForComment.current = selKey;
           const cb = onSelectionForCommentRef.current;
           if (cb) {
-            const quotedText = commentQuote(editor, from, to);
+            const quotedText = docTextBetween(editor, from, to);
             // A quote is what the server re-anchors by, and block separators
             // alone match anywhere, so neither is something to comment on.
             if (!quotedText.trim()) {

--- a/frontend/src/lib/editor/images.ts
+++ b/frontend/src/lib/editor/images.ts
@@ -335,8 +335,6 @@ function imageUploadPlugin(pagePath: string): Plugin<DecorationSet> {
   const startUpload = (view: EditorView, file: File, rawPos: number): void => {
     const imageType = view.state.schema.nodes.image;
     if (!imageType) return;
-    // Refused before the bytes leave the browser: a proxy rejects an oversized
-    // body first, and its reply carries no message worth showing.
     if (file.size > MAX_UPLOAD_BYTES) {
       toast.error(`${file.name} is larger than ${MAX_UPLOAD_LABEL}.`);
       return;

--- a/frontend/src/lib/editor/images.ts
+++ b/frontend/src/lib/editor/images.ts
@@ -17,6 +17,8 @@ import type { EditorView, NodeView } from "@tiptap/pm/view";
 import { ApiError, apiUpload } from "@/lib/api";
 import { toast } from "@/hooks/useToast";
 import {
+  MAX_UPLOAD_BYTES,
+  MAX_UPLOAD_LABEL,
   isSameOriginSrc,
   parseMediaWidth,
   srcWithoutFragment,
@@ -333,6 +335,12 @@ function imageUploadPlugin(pagePath: string): Plugin<DecorationSet> {
   const startUpload = (view: EditorView, file: File, rawPos: number): void => {
     const imageType = view.state.schema.nodes.image;
     if (!imageType) return;
+    // Refused before the bytes leave the browser: a proxy rejects an oversized
+    // body first, and its reply carries no message worth showing.
+    if (file.size > MAX_UPLOAD_BYTES) {
+      toast.error(`${file.name} is larger than ${MAX_UPLOAD_LABEL}.`);
+      return;
+    }
     // Land the placeholder (and later the node) at the nearest position an
     // inline image is actually allowed, so a drop at a block boundary still
     // produces a valid document.

--- a/frontend/src/lib/editor/media.ts
+++ b/frontend/src/lib/editor/media.ts
@@ -7,6 +7,14 @@ function stripFragment(src: string): string {
   return hash === -1 ? src : src.slice(0, hash);
 }
 
+/** Largest upload the server stores, mirroring `media_upload.UPLOAD_CAP_BYTES`.
+ * Enforced here too because a proxy in front of the app answers an oversized
+ * body first, with an HTML page carrying no message this client can show. */
+export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+/** How that cap reads to a person. */
+export const MAX_UPLOAD_LABEL = "10 MB";
+
 /** A base that exists only to resolve against. Any origin works, since the
  * question is whether `src` escapes whatever base it is resolved from. */
 const RESOLUTION_BASE = "http://same-origin.invalid";

--- a/frontend/src/lib/editor/media.ts
+++ b/frontend/src/lib/editor/media.ts
@@ -8,12 +8,11 @@ function stripFragment(src: string): string {
 }
 
 /** Largest upload the server stores, mirroring `media_upload.UPLOAD_CAP_BYTES`.
- * Enforced here too because a proxy in front of the app answers an oversized
- * body first, with an HTML page carrying no message this client can show. */
+ * Checked here so an oversized file is refused at once, not after the upload. */
 export const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 
-/** How that cap reads to a person. */
-export const MAX_UPLOAD_LABEL = "10 MB";
+/** How that cap reads to a person, in the server's own units. */
+export const MAX_UPLOAD_LABEL = "10 MiB";
 
 /** A base that exists only to resolve against. Any origin works, since the
  * question is whether `src` escapes whatever base it is resolved from. */

--- a/frontend/src/lib/editor/textOffsets.ts
+++ b/frontend/src/lib/editor/textOffsets.ts
@@ -36,10 +36,19 @@
  * attempted here.
  */
 import type { Editor } from "@tiptap/core";
+import type { Node as PMNode } from "@tiptap/pm/model";
+
+/** Text a leaf contributes, so it occupies offsets instead of collapsing to
+ * nothing. An image gives its src, which the codec carries into the markdown
+ * source verbatim, so that same string locates it there. */
+export function leafText(leaf: PMNode): string {
+  if (leaf.type.name !== "image") return "";
+  return (leaf.attrs.src as string | null) ?? "";
+}
 
 export function pmPosToTextOffset(editor: Editor, pos: number): number {
   const clamped = Math.max(0, Math.min(pos, editor.state.doc.content.size));
-  return editor.state.doc.textBetween(0, clamped, "\n\n").length;
+  return editor.state.doc.textBetween(0, clamped, "\n\n", leafText).length;
 }
 
 /** Inverse of `pmPosToTextOffset`, via binary search rather than a

--- a/frontend/src/lib/editor/textOffsets.ts
+++ b/frontend/src/lib/editor/textOffsets.ts
@@ -30,25 +30,34 @@
  * `hello **world**`) matches nothing in the body, and `resolve_exact_span`
  * falls back to this mapper's own estimate. Selections without formatting
  * inside them are corrected exactly; selections across a bold/italic/code run
- * are not. Closing it needs either a markdown serializer here (mirroring
- * `app/wiki/markdown_yjs.py`, which is also what a precise offset mapper
- * needs) or delimiter-insensitive matching in `comment_anchor.py`. Neither is
- * attempted here.
+ * are not. A selection holding an image misses too when the codec respells its
+ * src, which it does for cross-origin, escaped and percent-encoded srcs.
  */
 import type { Editor } from "@tiptap/core";
 import type { Node as PMNode } from "@tiptap/pm/model";
 
 /** Text a leaf contributes, so it occupies offsets instead of collapsing to
- * nothing. An image gives its src, which the codec carries into the markdown
- * source verbatim, so that same string locates it there. */
-export function leafText(leaf: PMNode): string {
+ * nothing. An image gives its src, which usually reaches the markdown source
+ * unchanged. A cross-origin or respelled src does not, and a quote holding one
+ * falls back to the estimated span. */
+function leafText(leaf: PMNode): string {
   if (leaf.type.name !== "image") return "";
   return (leaf.attrs.src as string | null) ?? "";
 }
 
+/** The plain-text projection offsets are counted in. Comment quotes are built
+ * from it too, so a quote always describes the string the offsets measure. */
+export function docTextBetween(
+  editor: Editor,
+  from: number,
+  to: number,
+): string {
+  return editor.state.doc.textBetween(from, to, "\n\n", leafText);
+}
+
 export function pmPosToTextOffset(editor: Editor, pos: number): number {
   const clamped = Math.max(0, Math.min(pos, editor.state.doc.content.size));
-  return editor.state.doc.textBetween(0, clamped, "\n\n", leafText).length;
+  return docTextBetween(editor, 0, clamped).length;
 }
 
 /** Inverse of `pmPosToTextOffset`, via binary search rather than a

--- a/frontend/src/lib/editor/textOffsets.ts
+++ b/frontend/src/lib/editor/textOffsets.ts
@@ -30,34 +30,38 @@
  * `hello **world**`) matches nothing in the body, and `resolve_exact_span`
  * falls back to this mapper's own estimate. Selections without formatting
  * inside them are corrected exactly; selections across a bold/italic/code run
- * are not. A selection holding an image misses too when the codec respells its
- * src, which it does for cross-origin, escaped and percent-encoded srcs.
+ * are not.
  */
 import type { Editor } from "@tiptap/core";
 import type { Node as PMNode } from "@tiptap/pm/model";
 
-/** Text a leaf contributes, so it occupies offsets instead of collapsing to
- * nothing. An image gives its src, which usually reaches the markdown source
- * unchanged. A cross-origin or respelled src does not, and a quote holding one
- * falls back to the estimated span. */
-function leafText(leaf: PMNode): string {
-  if (leaf.type.name !== "image") return "";
-  return (leaf.attrs.src as string | null) ?? "";
-}
-
-/** The plain-text projection offsets are counted in. Comment quotes are built
- * from it too, so a quote always describes the string the offsets measure. */
+/** The plain-text projection offsets are counted in. */
 export function docTextBetween(
   editor: Editor,
   from: number,
   to: number,
 ): string {
-  return editor.state.doc.textBetween(from, to, "\n\n", leafText);
+  return editor.state.doc.textBetween(from, to, "\n\n");
 }
 
 export function pmPosToTextOffset(editor: Editor, pos: number): number {
   const clamped = Math.max(0, Math.min(pos, editor.state.doc.content.size));
   return docTextBetween(editor, 0, clamped).length;
+}
+
+/** What the server re-anchors a comment by, searched for literally in the
+ * markdown source. Text when there is any, since the source carries it
+ * verbatim, and otherwise a src, which it carries inside the image syntax. */
+export function commentQuote(editor: Editor, from: number, to: number): string {
+  const text = docTextBetween(editor, from, to);
+  if (text.trim()) return text;
+  let src = "";
+  editor.state.doc.nodesBetween(from, to, (node: PMNode) => {
+    if (!src && node.type.name === "image") {
+      src = (node.attrs.src as string | null) ?? "";
+    }
+  });
+  return src;
 }
 
 /** Inverse of `pmPosToTextOffset`, via binary search rather than a

--- a/frontend/src/lib/editor/textOffsets.ts
+++ b/frontend/src/lib/editor/textOffsets.ts
@@ -24,16 +24,15 @@
  * quoted text — so this mapper only has to get the creation-time request into
  * the right neighborhood.
  *
- * The quote is plain text, so it never matches a source carrying inline syntax
- * literally. `resolve_exact_span` aligns it as a subsequence to close that, and
- * this estimate stands only when that alignment is refused.
+ * `resolve_exact_span` recovers a quote from the media projection or as a
+ * subsequence. Both still refuse one crossing blocks, or whose link URL dwarfs
+ * it, and this estimate is what gets stored then.
  */
 import type { Editor } from "@tiptap/core";
 import type { Node as PMNode } from "@tiptap/pm/model";
 
-/** Text a leaf contributes, so it occupies offsets rather than collapsing to
- * nothing. The src must stay in step with `comment_anchor._project_media`,
- * which reduces the source the same way. */
+/** An image occupies offsets by its src, so a quote covering one matches the
+ * body only where `comment_anchor._project_media` reduces to the same string. */
 function leafText(leaf: PMNode): string {
   if (leaf.type.name !== "image") return "";
   return (leaf.attrs.src as string | null) ?? "";

--- a/frontend/src/lib/editor/textOffsets.ts
+++ b/frontend/src/lib/editor/textOffsets.ts
@@ -35,33 +35,26 @@
 import type { Editor } from "@tiptap/core";
 import type { Node as PMNode } from "@tiptap/pm/model";
 
-/** The plain-text projection offsets are counted in. */
+/** Text a leaf contributes, so it occupies offsets rather than collapsing to
+ * nothing. The src must stay in step with `comment_anchor._project_media`,
+ * which reduces the source the same way. */
+function leafText(leaf: PMNode): string {
+  if (leaf.type.name !== "image") return "";
+  return (leaf.attrs.src as string | null) ?? "";
+}
+
+/** The plain-text projection offsets and comment quotes are counted in. */
 export function docTextBetween(
   editor: Editor,
   from: number,
   to: number,
 ): string {
-  return editor.state.doc.textBetween(from, to, "\n\n");
+  return editor.state.doc.textBetween(from, to, "\n\n", leafText);
 }
 
 export function pmPosToTextOffset(editor: Editor, pos: number): number {
   const clamped = Math.max(0, Math.min(pos, editor.state.doc.content.size));
   return docTextBetween(editor, 0, clamped).length;
-}
-
-/** What the server re-anchors a comment by, searched for literally in the
- * markdown source. Text when there is any, since the source carries it
- * verbatim, and otherwise a src, which it carries inside the image syntax. */
-export function commentQuote(editor: Editor, from: number, to: number): string {
-  const text = docTextBetween(editor, from, to);
-  if (text.trim()) return text;
-  let src = "";
-  editor.state.doc.nodesBetween(from, to, (node: PMNode) => {
-    if (!src && node.type.name === "image") {
-      src = (node.attrs.src as string | null) ?? "";
-    }
-  });
-  return src;
 }
 
 /** Inverse of `pmPosToTextOffset`, via binary search rather than a

--- a/frontend/src/lib/editor/textOffsets.ts
+++ b/frontend/src/lib/editor/textOffsets.ts
@@ -24,13 +24,9 @@
  * quoted text — so this mapper only has to get the creation-time request into
  * the right neighborhood.
  *
- * That correction has a gap worth knowing about, because it is the one case
- * where a *wrong span gets stored*: the quote we send is plain text, so a
- * selection containing inline formatting ("hello world" over a source
- * `hello **world**`) matches nothing in the body, and `resolve_exact_span`
- * falls back to this mapper's own estimate. Selections without formatting
- * inside them are corrected exactly; selections across a bold/italic/code run
- * are not.
+ * The quote is plain text, so it never matches a source carrying inline syntax
+ * literally. `resolve_exact_span` aligns it as a subsequence to close that, and
+ * this estimate stands only when that alignment is refused.
  */
 import type { Editor } from "@tiptap/core";
 import type { Node as PMNode } from "@tiptap/pm/model";

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -64,7 +64,11 @@ import {
 import { apiFetch } from "@/lib/api";
 import { deleteTrigger, useTriggers, type Trigger } from "@/lib/triggers";
 import { wikiHref, resolveIds, revalidateWiki } from "@/lib/wikiHref";
-import { createComment, listComments } from "@/lib/comments";
+import {
+  commentErrorMessage,
+  createComment,
+  listComments,
+} from "@/lib/comments";
 import type { CommentDraft, CommentHighlightTarget } from "@/lib/editor/types";
 import { pageTitle } from "@/lib/wiki/utils";
 import { useAuth } from "@/lib/auth";
@@ -528,7 +532,7 @@ export function FileView({ path }: FileViewProps) {
         await refreshComments();
         return true;
       } catch (e) {
-        toast.error(e instanceof Error ? e.message : "Comment action failed");
+        toast.error(commentErrorMessage(e));
         return false;
       } finally {
         setMarginBusy(false);

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -65,6 +65,7 @@ import { apiFetch } from "@/lib/api";
 import { deleteTrigger, useTriggers, type Trigger } from "@/lib/triggers";
 import { wikiHref, resolveIds, revalidateWiki } from "@/lib/wikiHref";
 import {
+  NO_HEAD_SHA_MESSAGE,
   commentErrorMessage,
   createComment,
   listComments,
@@ -546,7 +547,7 @@ export function FileView({ path }: FileViewProps) {
       const draft = commentDraft;
       if (!draft) return;
       if (!headSha) {
-        toast.error("Page version unknown, reload and retry");
+        toast.error(NO_HEAD_SHA_MESSAGE);
         return;
       }
       const ok = await runMargin(() =>


### PR DESCRIPTION
## Description

Fixes from the post-deploy feedback, plus two regressions the review caught.

**Selecting text and an image looked broken.** The selection always spanned the image, but the image showed no highlight, so it read as a failure. Chrome's UA styles make a `draggable` element unselectable. prosemirror-view ships an override for exactly this, which never applied because the app does not import its stylesheet.

**Peer caret.** It was pinned to the prose line-height, so it ballooned on a line an image made tall and fell short on a heading. The browser's own caret tracks font size: measured 21px at 16px text, 41.5px at 32px, and 21px on a 71px-tall line. `1.3em` matches all three within a fifth of a pixel.

**Also:** comment failures now toast a plain sentence instead of rendering a raw validation dump; an image-only selection can be commented on; oversized uploads are refused before uploading.

**Regressions fixed:** the earlier flex list markers laid nested lists to the *right* of their parent and renumbered `<ol start="3">` from 1. Reverted to native markers, which align correctly now that images sit on the baseline.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check