### PR TITLE
fix(editor): task lists — nested items rendered as columns, checkbox markers escaped away

### DIFF
--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -1018,6 +1018,16 @@ def _serialize_list(node: XmlElement) -> str:
             # (the item renders identically either way). Bare, it re-parses to
             # exactly the text it was serialized from, so the round trip stays
             # byte-stable *and* the marker survives.
+            #
+            # This also normalizes a marker the source deliberately escaped,
+            # and can't do otherwise: markdown-it resolves "\[x\]" to the text
+            # "[x]" before this codec sees a token, so by here the two
+            # spellings are one string and one of them has to be picked for
+            # both. Live is the same choice `_build_list` makes on the other
+            # side of the fork — a list whose items *all* carry an escaped
+            # marker promotes to real taskItems — so the two paths agree
+            # rather than making escaping mean opposite things in a mixed
+            # list and a uniform one.
             body = _ESCAPED_TASK_MARKER_RE.sub(r"[\1]\2", body, count=1)
         lines.append(marker + body)
     return "\n\n".join(lines) + "\n"

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -630,6 +630,11 @@ def _build_block_sequence(
 # inline text and matched by hand rather than via a token type.
 _TASK_MARKER_RE = re.compile(r"^\[([ xX])\](?:\s+|$)")
 
+# The same marker in the spelling `_escape_inline_text` gives it, which is how
+# it reaches the front of a plain list item's serialized body. See the
+# un-escaping call site in `_serialize_list`.
+_ESCAPED_TASK_MARKER_RE = re.compile(r"^\\\[([ xX])\\\](\s|$)")
+
 
 def _list_item_task_marker(
     tokens: list[Any], item_start: int, item_end: int
@@ -1002,6 +1007,18 @@ def _serialize_list(node: XmlElement) -> str:
             marker = f"{start + idx}. " if ordered else "- "
             indent = " " * len(marker)
         body = _serialize_block_sequence(list(item.children), indent)  # type: ignore[arg-type]
+        if not is_task:
+            # A literal "[x] " opening a plain list item is a checkbox marker
+            # the parse declined to promote — the list is mixed (a taskList's
+            # children must be uniformly taskItems, see `_build_list`) or it's
+            # ordered — not decorative text. `_escape_inline_text` escapes every
+            # "["/"]" it sees, which here would rewrite a marker that GFM
+            # readers and a later uniform version of this same list still act on
+            # into permanently inert text, an edit nothing in the editor shows
+            # (the item renders identically either way). Bare, it re-parses to
+            # exactly the text it was serialized from, so the round trip stays
+            # byte-stable *and* the marker survives.
+            body = _ESCAPED_TASK_MARKER_RE.sub(r"[\1]\2", body, count=1)
         lines.append(marker + body)
     return "\n\n".join(lines) + "\n"
 

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -367,6 +367,30 @@ def test_mixed_task_and_plain_items_stays_plain_bullet_list() -> None:
     assert [i.tag for i in lst.children] == ["listItem", "listItem"]
 
 
+def test_mixed_list_keeps_its_checkbox_markers() -> None:
+    """The marker text a mixed list can't promote to a taskItem still has to
+    come back out as a marker: escaping it ("\\[x\\]") is a content edit that
+    no longer reads as a checkbox to anything, here or downstream."""
+    body = "- [x] marked\n\n- unmarked\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == body
+    assert once == reconstruct_body(seed_doc_from_markdown(once))
+
+
+def test_ordered_list_keeps_its_checkbox_markers() -> None:
+    body = "1. [ ] marked\n\n2. unmarked\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == body
+
+
+def test_only_a_leading_marker_escapes_differently_from_other_brackets() -> None:
+    """The exemption is positional — a bracket run anywhere else in the item,
+    including one that would re-parse as a link, still escapes."""
+    body = "- text \\[x\\] mid\n\n- \\[see\\](/a) not a link\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == body
+
+
 def test_task_list_reserialization_is_content_correct_and_idempotent() -> None:
     body = "- [ ] buy milk\n- [x] walk dog\n"
     once = reconstruct_body(seed_doc_from_markdown(body))

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -391,6 +391,28 @@ def test_only_a_leading_marker_escapes_differently_from_other_brackets() -> None
     assert once == body
 
 
+def test_a_uniform_list_of_escaped_markers_promotes_to_task_items() -> None:
+    """markdown-it resolves "\\[x\\]" to the text "[x]" before the codec sees a
+    token, so an escaped marker and a live one are the same string by the time
+    promotion is decided, and an all-escaped list becomes real taskItems.
+    Pinned because it's what makes the serializer's choice below consistent
+    rather than arbitrary."""
+    doc = seed_doc_from_markdown("- \\[x\\] a\n\n- \\[x\\] b\n")
+    lst = _root(doc).children[0]
+    assert lst.tag == "taskList"
+    assert [i.tag for i in lst.children] == ["taskItem", "taskItem"]
+
+
+def test_an_escaped_marker_in_a_mixed_list_normalizes_to_a_live_one() -> None:
+    """Same erasure one fork over: the item stays a plain listItem, and its
+    text is indistinguishable from an item that was written "[x]" bare, so
+    both serialize to the live marker. A single normalization pass — the
+    output is then stable."""
+    once = reconstruct_body(seed_doc_from_markdown("- \\[x\\] a\n\n- plain\n"))
+    assert once == "- [x] a\n\n- plain\n"
+    assert once == reconstruct_body(seed_doc_from_markdown(once))
+
+
 def test_task_list_reserialization_is_content_correct_and_idempotent() -> None:
     body = "- [ ] buy milk\n- [x] walk dog\n"
     once = reconstruct_body(seed_doc_from_markdown(body))

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -140,10 +140,22 @@
   list-style: none;
   padding-left: 0;
 }
-.editor-prose ul[data-type="taskList"] li {
+/* Direct children only. A task item's own `li` is a flex row so the checkbox
+   sits beside its content, but a plain `li` renders as `<li><p>text</p><ul>
+   …</ul></li>` — flexed, its paragraph and its nested list become two
+   side-by-side columns instead of a list under a line of text. A descendant
+   selector hits every nested plain item under a task list, which on a page
+   that mixes the two is most of the page. */
+.editor-prose ul[data-type="taskList"] > li {
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
+}
+/* A nested task list carries no bullet or marker to sit under, so without an
+   indent of its own it starts at the parent's text column and the nesting
+   reads as flat. Matches what the base `ul` rule gives a nested bullet list. */
+.editor-prose li ul[data-type="taskList"] {
+  padding-left: 1.5rem;
 }
 .editor-prose ul[data-type="taskList"] input {
   /* Native control, deliberately: `accent-color` keeps the design system's


### PR DESCRIPTION
Two independent bugs that compound on the same content: a page mixing checkbox items with plain ones renders as a grid of side-by-side columns, and the markers themselves decay into literal text. Reported against a TODO page whose sections had turned into two-column blocks with literal `[x]` text down the middle.

## Layout

`.editor-prose ul[data-type="taskList"] li` is a **descendant** selector, so every nested plain `li` under a task list gets `display: flex` too. A task item wants that — the checkbox sits beside its content — but a plain item renders as `<li><p>text</p><ul>…</ul></li>`, and flexed, its paragraph and its nested list become two columns side by side instead of a list underneath a line of text. On a page that mixes the two, that is most of the page.

Scoped to `> li`. Nested task lists then need an indent of their own: unlike a bullet list they carry no marker to sit under, so they would start at the parent's text column and the nesting would read flat. The added rule matches what the base `ul` rule already gives a nested bullet list.

Page view goes through the same single `.editor-prose` wrapper (`lib/editor/components.tsx`), so this is one change for both surfaces.

## Markers

`_escape_inline_text` escapes every `[` and `]`, so a `[x] ` opening a plain list item comes back out as `\[x\] `. That item's list is one the parse declined to promote — a taskList's children must be uniformly taskItems, so a list mixing marked and unmarked items stays a plain `bulletList` with the marker as ordinary text (`_build_list`), and an ordered list is never promoted at all. The escape then rewrites a marker that GFM readers, and a later uniform version of that same list, still act on into text nothing will ever read as a checkbox again.

It is invisible while it happens — the item renders identically either way — so the first checkpoint of any page with a mixed list quietly spends its checkboxes.

Serialize is now the inverse of parse for that position: a leading marker is emitted bare, and `_ESCAPED_TASK_MARKER_RE` sits next to `_TASK_MARKER_RE` so the pair reads as one rule. Positional and single-shot — brackets anywhere else in the item, including a run that would re-parse as a link, still escape.

## Scope

This does **not** make a mixed list *render* checkboxes; those markers stay literal text until a taskList can hold non-task items, which is a schema change across both sides. It stops the loss, and it leaves the markers in the file for that change to pick up. It also doesn't repair pages already carrying `\[x\]` — that wants a restore from a pre-damage revision.

## Testing

Three new codec tests. Mixed and ordered lists now round-trip **byte-identically** (`once == body`) rather than merely idempotently, which is the property that was broken; the third asserts the exemption doesn't over-reach, and passes with or without the fix by design. Verified the two marker tests fail with the change stubbed out.

`test_markdown_yjs` / `test_markdown_splice` / `test_markdown_blocks` / `test_coedit_checkpoint` pass, ruff + basedpyright + prettier clean.