### PR TITLE
fix(llm): surface truncated responses instead of returning partial text

### DIFF
--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -82,6 +82,17 @@ log = logging.getLogger(__name__)
 GROUP_SIMILARITY = 0.45
 MERGE_ROUNDS = 3  # merge exits on convergence; this only bounds the loop
 
+# Output cap, well above the client's 4096 default. Extraction lists every referent on a page, so
+# the response scales with the page — and on a 205k-char page it overflowed 4096, which cut the
+# JSON off mid-list. Every one of the eight largest pages in a real 147-page wiki failed that way,
+# contributing zero referents each. The cap costs nothing when unused, since billing follows
+# tokens generated. It is a ceiling, not a guarantee: a page can still overflow it, which is why
+# ``_complete_json`` now reports truncation instead of mistaking it for malformed JSON.
+MAX_OUTPUT_TOKENS = 16384
+
+# Retries on MALFORMED output only. Truncation is deterministic, so it is never retried.
+_JSON_RETRIES = 1
+
 # Fallback when no derived artifact is present, so a deployment that has never run the
 # derivation still has something usable. Intentionally generic: these are the types that
 # recur across corpora, not a customer's.
@@ -253,33 +264,102 @@ def _leader_cluster(
 
 
 # --- LLM steps --------------------------------------------------------------------------
-def _complete_json(system: str, user: str, *, model: str | None) -> dict[str, Any] | None:
+def _is_truncated(stop_reason: str) -> bool:
+    """Whether a response was cut short rather than finished.
+
+    Each provider passes its own vocabulary through: "max_tokens" (anthropic, bedrock, and
+    gemini's MAX_TOKENS), "length" (ollama, custom), and "incomplete" — what the OpenAI Responses
+    API reports via status, and what ``client.complete`` reports when a stream ends with no
+    terminal event at all.
+    """
+    lowered = stop_reason.lower()
+    return any(token in lowered for token in ("max_token", "length", "incomplete"))
+
+
+def _complete_json(
+    system: str, user: str, *, model: str | None, ctx: str = ""
+) -> dict[str, Any] | None:
     """One completion parsed as a JSON object. Returns None rather than raising — a single
-    failed page or group must not abort a corpus-wide derivation."""
-    try:
-        result = client.complete(
-            [{"role": "system", "content": system}, {"role": "user", "content": user}],
-            model=model,
+    failed page or group must not abort a corpus-wide derivation.
+
+    ``ctx`` names what was being extracted (a page path, a group) so a failure is attributable.
+    Without it the log said only "unparseable JSON (N chars)", which cannot be acted on: it
+    identifies neither the page nor the reason.
+
+    Retries once on malformed JSON, feeding the error back — but NOT on truncation, which is
+    deterministic. A retry there pays for the same overflowing response twice and needs a bigger
+    cap, not a re-prompt.
+    """
+    label = ctx or "(unknown)"
+    messages = [{"role": "system", "content": system}, {"role": "user", "content": user}]
+    last_error: str | None = None
+
+    for attempt in range(_JSON_RETRIES + 1):
+        convo = (
+            messages
+            if last_error is None
+            else [
+                *messages[:-1],
+                {
+                    "role": "user",
+                    "content": (
+                        f"{user}\n\nYOUR PREVIOUS OUTPUT WAS REJECTED: {last_error}\n"
+                        "Return corrected JSON."
+                    ),
+                },
+            ]
         )
-    except Exception:
-        log.warning("entity_types: completion failed", exc_info=True)
-        return None
-    text = (result.text or "").strip()
-    start, end = text.find("{"), text.rfind("}")
-    if start == -1 or end <= start:
-        return None
-    try:
-        parsed = cast(object, json.loads(text[start : end + 1]))
-    except json.JSONDecodeError:
-        log.warning("entity_types: unparseable JSON (%d chars)", len(text))
-        return None
-    return cast(dict[str, Any], parsed) if isinstance(parsed, dict) else None
+        try:
+            result = client.complete(convo, model=model, max_tokens=MAX_OUTPUT_TOKENS)
+        except Exception:
+            log.warning("entity_types: completion failed for %s", label, exc_info=True)
+            return None
+
+        text = (result.text or "").strip()
+        if _is_truncated(result.stop_reason):
+            # Distinct from a parse failure because the fix is distinct: raise the cap (or split
+            # the input), rather than ask again. Returning here also spares the retry, which
+            # would truncate identically.
+            log.warning(
+                "entity_types: response for %s was cut off at the %d-token output cap "
+                "(stop_reason=%r, %d chars) — its referents are incomplete and were dropped",
+                label,
+                MAX_OUTPUT_TOKENS,
+                result.stop_reason,
+                len(text),
+            )
+            return None
+
+        start, end = text.find("{"), text.rfind("}")
+        if start == -1 or end <= start:
+            last_error = "response was not a JSON object"
+        else:
+            try:
+                parsed = cast(object, json.loads(text[start : end + 1]))
+            except json.JSONDecodeError as exc:
+                last_error = f"invalid JSON ({exc.msg})"
+            else:
+                if isinstance(parsed, dict):
+                    return cast(dict[str, Any], parsed)
+                last_error = "top-level JSON value was not an object"
+
+        if attempt == _JSON_RETRIES:
+            log.warning(
+                "entity_types: giving up on %s after %d attempt(s) — %s (%d chars)",
+                label,
+                attempt + 1,
+                last_error,
+                len(text),
+            )
+    return None
 
 
 def extract_page(path: str, body: str, *, model: str | None = None) -> list[Mention]:
     """Open extraction over one whole page. No type menu — see module docstring."""
     system = load_prompt("entity_types.extract")
-    data = _complete_json(system, f"path:\n{path}\ncontent:\n{body}", model=model)
+    data = _complete_json(
+        system, f"path:\n{path}\ncontent:\n{body}", model=model, ctx=path
+    )
     if not data or not isinstance(data.get("referents"), list):
         return []
     out: list[Mention] = []
@@ -318,7 +398,12 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
         + f"  (on {r.n_docs} page{'s' if r.n_docs != 1 else ''})"
         for i, r in enumerate(group, start=1)
     )
-    data = _complete_json(system, f"Referents in this group:\n\n{listing}", model=model)
+    data = _complete_json(
+        system,
+        f"Referents in this group:\n\n{listing}",
+        model=model,
+        ctx=f"naming a group of {len(group)} referent(s)",
+    )
 
     # The prompt requires a partition: every member in exactly one type. Enforce it. A
     # response that omits members would silently drop referents, and one that repeats them
@@ -397,7 +482,12 @@ def _merge_once(types: list[EntityType], *, model: str | None) -> list[EntityTyp
         f"     e.g. {', '.join(t.examples[:5])}"
         for i, t in enumerate(types, start=1)
     )
-    data = _complete_json(system, f"Derived types to consolidate:\n\n{listing}", model=model)
+    data = _complete_json(
+        system,
+        f"Derived types to consolidate:\n\n{listing}",
+        model=model,
+        ctx=f"merging {len(types)} type(s)",
+    )
     raw = (data or {}).get("types")
     if not isinstance(raw, list) or not raw:
         return types

--- a/backend/app/llm/client.py
+++ b/backend/app/llm/client.py
@@ -240,6 +240,7 @@ def complete(
     tool_calls: list[ToolCall] = []
     stop_reason = ""
     usage = Usage()
+    saw_terminal = False
     for ev in stream(messages, model=model, tools=tools, max_tokens=max_tokens):
         t = ev["type"]
         if t == "text_delta":
@@ -249,8 +250,24 @@ def complete(
                 ToolCall(id=ev["id"], name=ev["name"], arguments=ev["arguments"])
             )
         elif t == "done":
+            saw_terminal = True
             stop_reason = ev["stop_reason"]
             usage = Usage(**ev["usage"])
+    if not saw_terminal:
+        # A stream that ends with no terminal event delivered an answer nobody said was
+        # finished — a dropped connection, or a provider status this layer doesn't translate.
+        # Returning it with an empty ``stop_reason`` presents it as a normal result, which is
+        # how truncated entity-type extractions read as "the model emitted bad JSON".
+        # Reported as "incomplete" so callers that already test for truncation catch this too
+        # rather than having to know one more sentinel.
+        stop_reason = "incomplete"
+        log.warning(
+            "llm stream ended with no terminal event (model=%s, %d char(s) of text, %d tool "
+            "call(s)) — reporting the response as incomplete",
+            model or "(default)",
+            sum(len(part) for part in text_parts),
+            len(tool_calls),
+        )
     return CompletionResult(
         text="".join(text_parts),
         tool_calls=tool_calls,

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -186,18 +186,29 @@ class OpenAIProvider:
                     reason = getattr(incomplete, "reason", "") or ""
                     if etype == "response.failed" or status == "failed":
                         err = getattr(resp, "error", None)
-                        detail = str(getattr(err, "message", "") or "").strip()
+                        # ``code`` is a short, stable identifier ("server_error"); ``message`` is
+                        # free-form upstream text. Only the code reaches the user, because
+                        # LLMError.message is user-presentable by contract and free text from a
+                        # provider can carry request ids, org detail, or echoed input. The
+                        # message is still worth having when diagnosing, so it goes to DEBUG —
+                        # the same split ``_debug_dump`` makes for request/response payloads.
+                        code = str(getattr(err, "code", "") or "").strip()
                         log.error(
-                            "llm failed provider=openai model=%s tokens=%d/%d detail=%s",
+                            "llm failed provider=openai model=%s tokens=%d/%d code=%s",
                             model,
                             in_tok,
                             out_tok,
-                            detail or "(none given)",
+                            code or "(none given)",
                         )
+                        if log.isEnabledFor(logging.DEBUG):
+                            log.debug(
+                                "llm failed provider=openai detail=%s",
+                                str(getattr(err, "message", "") or "").strip() or "(none given)",
+                            )
                         raise LLMError(
                             "provider",
-                            f"OpenAI reported the response failed: {detail}"
-                            if detail
+                            f"OpenAI reported the response failed ({code})."
+                            if code
                             else "OpenAI reported the response failed.",
                         )
                     log_at = log.info if status == "completed" else log.warning

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -152,7 +152,15 @@ class OpenAIProvider:
                             "name": rec["name"],
                             "arguments": safe_json_loads(rec["args_buf"]),
                         }
-                elif etype == "response.completed":
+                # EVERY terminal status, not just success. A run that hits
+                # ``max_output_tokens`` ends with ``response.incomplete``; a server-side failure
+                # ends with ``response.failed``. Handling only ``response.completed`` meant those
+                # two yielded no terminal event at all, so ``client.complete`` returned the
+                # partial text with an empty ``stop_reason`` and zero usage — a truncated answer
+                # indistinguishable from a whole one, and no exception raised. That is how
+                # entity-type extraction silently lost every large page: the model emitted valid
+                # JSON, was cut off mid-list, and the caller saw only "malformed JSON".
+                elif etype in ("response.completed", "response.incomplete", "response.failed"):
                     resp = event.response
                     usage = getattr(resp, "usage", None)
                     in_tok = getattr(usage, "input_tokens", 0) if usage else 0
@@ -165,10 +173,16 @@ class OpenAIProvider:
                     in_details = getattr(usage, "input_tokens_details", None) if usage else None
                     cached_tok = getattr(in_details, "cached_tokens", 0) if in_details else 0
                     status = getattr(resp, "status", "") or ""
-                    log.info(
-                        "llm done provider=openai model=%s status=%s tokens=%d/%d cached=%d",
+                    # Why it stopped, when the API says: "max_output_tokens" or "content_filter".
+                    # Worth logging because the fix differs — a bigger cap versus a changed prompt.
+                    incomplete = getattr(resp, "incomplete_details", None)
+                    reason = getattr(incomplete, "reason", "") or ""
+                    log_at = log.info if status == "completed" else log.warning
+                    log_at(
+                        "llm done provider=openai model=%s status=%s%s tokens=%d/%d cached=%d",
                         model,
-                        status,
+                        status or "(none)",
+                        f" reason={reason}" if reason else "",
                         in_tok,
                         out_tok,
                         cached_tok or 0,

--- a/backend/app/llm/providers/openai.py
+++ b/backend/app/llm/providers/openai.py
@@ -160,6 +160,13 @@ class OpenAIProvider:
                 # indistinguishable from a whole one, and no exception raised. That is how
                 # entity-type extraction silently lost every large page: the model emitted valid
                 # JSON, was cut off mid-list, and the caller saw only "malformed JSON".
+                #
+                # The two are NOT handled alike. An incomplete response is a real, usable answer
+                # that stopped early, so it is returned with its status for the caller to judge.
+                # A failed one is an upstream error, and returning its partial text — even
+                # labelled — would let a caller persist a broken turn as a finished one, since
+                # nothing downstream inspects ``stop_reason``. So that one raises, like every
+                # other provider error here.
                 elif etype in ("response.completed", "response.incomplete", "response.failed"):
                     resp = event.response
                     usage = getattr(resp, "usage", None)
@@ -177,6 +184,22 @@ class OpenAIProvider:
                     # Worth logging because the fix differs — a bigger cap versus a changed prompt.
                     incomplete = getattr(resp, "incomplete_details", None)
                     reason = getattr(incomplete, "reason", "") or ""
+                    if etype == "response.failed" or status == "failed":
+                        err = getattr(resp, "error", None)
+                        detail = str(getattr(err, "message", "") or "").strip()
+                        log.error(
+                            "llm failed provider=openai model=%s tokens=%d/%d detail=%s",
+                            model,
+                            in_tok,
+                            out_tok,
+                            detail or "(none given)",
+                        )
+                        raise LLMError(
+                            "provider",
+                            f"OpenAI reported the response failed: {detail}"
+                            if detail
+                            else "OpenAI reported the response failed.",
+                        )
                     log_at = log.info if status == "completed" else log.warning
                     log_at(
                         "llm done provider=openai model=%s status=%s%s tokens=%d/%d cached=%d",

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -99,3 +99,104 @@ class TestMemberIndices:
     def test_missing_or_malformed_is_empty(self) -> None:
         assert _member_indices({}, 3) == []
         assert _member_indices({"member_indices": "1,2"}, 3) == []
+
+
+class TestCompleteJson:
+    """The LLM boundary of the derivation. Every rule here exists because a large wiki page
+    broke it in production: extraction overflowed the client's 4096-token default, the response
+    came back cut off mid-list, and the truncation was reported as "unparseable JSON" naming
+    neither the page nor the reason. Eight of eight of the largest pages failed that way,
+    contributing zero referents each."""
+
+    def _stub(self, monkeypatch, *results):
+        from app.ingest import entity_types
+
+        seen: list[dict] = []
+
+        def fake_complete(messages, **kwargs):
+            seen.append({"messages": messages, "kwargs": kwargs})
+            return results[min(len(seen) - 1, len(results) - 1)]
+
+        monkeypatch.setattr(entity_types.client, "complete", fake_complete)
+        return seen
+
+    def test_asks_for_more_than_the_client_default(self) -> None:
+        from app.ingest.entity_types import MAX_OUTPUT_TOKENS
+        from app.llm.client import DEFAULT_MAX_TOKENS
+
+        assert MAX_OUTPUT_TOKENS > DEFAULT_MAX_TOKENS
+
+    def test_passes_the_cap_on_every_call(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+        from app.llm.client import CompletionResult
+
+        seen = self._stub(
+            monkeypatch, CompletionResult(text='{"referents":[]}', stop_reason="completed")
+        )
+
+        entity_types.extract_page("a.md", "body")
+
+        assert seen[0]["kwargs"]["max_tokens"] == entity_types.MAX_OUTPUT_TOKENS
+
+    def test_truncation_is_reported_as_truncation_and_names_the_page(
+        self, monkeypatch, caplog
+    ) -> None:
+        from app.ingest import entity_types
+        from app.llm.client import CompletionResult
+
+        self._stub(
+            monkeypatch,
+            CompletionResult(text='{"referents":[{"name":"Acme"}', stop_reason="incomplete"),
+        )
+
+        with caplog.at_level("WARNING"):
+            assert entity_types.extract_page("Customers/Big Page.md", "body") == []
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("cut off" in m for m in messages)
+        assert any("Customers/Big Page.md" in m for m in messages)
+
+    def test_truncation_does_not_burn_the_retry(self, monkeypatch) -> None:
+        """Truncation is deterministic — re-asking pays for the same overflowing response twice.
+        What it needs is a bigger cap, not another prompt."""
+        from app.ingest import entity_types
+        from app.llm.client import CompletionResult
+
+        seen = self._stub(
+            monkeypatch, CompletionResult(text='{"referents":[{"name":"A"}', stop_reason="incomplete")
+        )
+
+        entity_types.extract_page("a.md", "body")
+
+        assert len(seen) == 1
+
+    def test_malformed_json_is_retried_with_the_reason(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+        from app.llm.client import CompletionResult
+
+        seen = self._stub(
+            monkeypatch,
+            CompletionResult(text="not json at all", stop_reason="completed"),
+            CompletionResult(
+                text='{"referents":[{"name":"Acme","what":"a customer"}]}',
+                stop_reason="completed",
+            ),
+        )
+
+        out = entity_types.extract_page("a.md", "body")
+
+        assert [m.surface for m in out] == ["Acme"]
+        assert len(seen) == 2
+        assert "REJECTED" in seen[1]["messages"][-1]["content"]
+
+    def test_gives_up_after_the_retry_and_names_the_page(self, monkeypatch, caplog) -> None:
+        from app.ingest import entity_types
+        from app.llm.client import CompletionResult
+
+        seen = self._stub(monkeypatch, CompletionResult(text="never json", stop_reason="completed"))
+
+        with caplog.at_level("WARNING"):
+            assert entity_types.extract_page("Notes/x.md", "body") == []
+
+        assert len(seen) == 2
+        assert any("Notes/x.md" in r.getMessage() for r in caplog.records)

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -184,6 +184,22 @@ def _o_completed(*, status="completed", input_tokens=10, output_tokens=20, cache
     )
 
 
+def _o_terminal(etype, *, status, reason="", input_tokens=10, output_tokens=20, cached=0):
+    """A terminal Responses event of any kind — ``response.incomplete`` / ``response.failed``
+    carry the same payload shape as ``response.completed``, only a different status."""
+    response = SimpleNamespace(
+        status=status,
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            input_tokens_details=SimpleNamespace(cached_tokens=cached),
+        ),
+    )
+    if reason:
+        response.incomplete_details = SimpleNamespace(reason=reason)
+    return SimpleNamespace(type=etype, response=response)
+
+
 def _o_tool_call_events(*, item_id, call_id, name, arg_chunks):
     events = [
         SimpleNamespace(
@@ -890,3 +906,79 @@ def test_openai_usage_splits_cached_and_uncached(configure_openai, fake_openai):
     assert out.usage.input_tokens == 100
     assert out.usage.cached_input_tokens == 80
     assert out.usage.uncached_input_tokens == 20
+
+
+# --------------------------------------------------------------------------- #
+# Truncated / abnormal responses
+#
+# A response cut short at ``max_output_tokens`` ends with ``response.incomplete``, not
+# ``response.completed``. Handling only the latter returned the partial text with an empty
+# stop_reason and zero usage — indistinguishable from a whole answer, and no exception — which is
+# how entity-type extraction silently lost every large wiki page. Verified against the live API:
+# the SDK's final event was ``response.incomplete`` while the caller saw stop_reason=''.
+# --------------------------------------------------------------------------- #
+
+
+def test_openai_reports_a_truncated_response_as_incomplete(configure_openai, fake_openai):
+    fake_openai(
+        [
+            _o_text_delta('{"referents":[{"name":"Acme"}'),
+            _o_terminal("response.incomplete", status="incomplete", reason="max_output_tokens"),
+        ]
+    )
+
+    result = llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert result.stop_reason == "incomplete"
+    assert result.text == '{"referents":[{"name":"Acme"}'
+
+
+def test_openai_reports_usage_for_a_truncated_response(configure_openai, fake_openai):
+    """Usage is on the terminal event whatever its status, so dropping the event also lost the
+    token counts — which is what made a truncated call look like it had never happened."""
+    fake_openai(
+        [
+            _o_text_delta("partial"),
+            _o_terminal(
+                "response.incomplete", status="incomplete", input_tokens=51000, output_tokens=4096
+            ),
+        ]
+    )
+
+    result = llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert result.usage.input_tokens == 51000
+    assert result.usage.output_tokens == 4096
+
+
+def test_openai_reports_a_failed_response(configure_openai, fake_openai):
+    fake_openai([_o_text_delta("half"), _o_terminal("response.failed", status="failed")])
+
+    result = llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert result.stop_reason == "failed"
+
+
+def test_openai_still_reports_a_completed_response(configure_openai, fake_openai):
+    """The success path must be untouched by widening the terminal branch."""
+    fake_openai([_o_text_delta("done"), _o_completed()])
+
+    result = llm_client.complete([{"role": "user", "content": "hi"}])
+
+    assert result.stop_reason == "completed"
+    assert result.usage.input_tokens == 10
+
+
+def test_a_stream_with_no_terminal_event_is_reported_incomplete(
+    configure_openai, fake_openai, caplog
+):
+    """The safety net under the provider fix: a dropped connection, or any future status this
+    layer does not translate, must not present partial text as a finished answer."""
+    fake_openai([_o_text_delta("cut off here")])
+
+    with caplog.at_level("WARNING"):
+        result = llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert result.stop_reason == "incomplete"
+    assert result.text == "cut off here"
+    assert any("no terminal event" in r.getMessage() for r in caplog.records)

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -951,12 +951,43 @@ def test_openai_reports_usage_for_a_truncated_response(configure_openai, fake_op
     assert result.usage.output_tokens == 4096
 
 
-def test_openai_reports_a_failed_response(configure_openai, fake_openai):
+def test_openai_raises_on_a_failed_response(configure_openai, fake_openai):
+    """A failure is not a short answer. Returning its partial text — even labelled "failed" —
+    would let a caller persist a broken turn as a finished one, because nothing downstream
+    inspects ``stop_reason``. So it raises, like every other provider error."""
     fake_openai([_o_text_delta("half"), _o_terminal("response.failed", status="failed")])
+
+    with pytest.raises(LLMError) as excinfo:
+        llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert excinfo.value.code == "provider"
+
+
+def test_openai_failure_message_carries_the_provider_detail(configure_openai, fake_openai):
+    event = _o_terminal("response.failed", status="failed")
+    event.response.error = SimpleNamespace(message="upstream capacity exceeded")
+    fake_openai([_o_text_delta("half"), event])
+
+    with pytest.raises(LLMError) as excinfo:
+        llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert "upstream capacity exceeded" in excinfo.value.message
+
+
+def test_a_truncated_response_is_not_treated_as_a_failure(configure_openai, fake_openai):
+    """The distinction the two branches turn on: an incomplete answer is real and usable, so it
+    comes back rather than raising."""
+    fake_openai(
+        [
+            _o_text_delta("usable partial"),
+            _o_terminal("response.incomplete", status="incomplete", reason="max_output_tokens"),
+        ]
+    )
 
     result = llm_client.complete([{"role": "user", "content": "extract"}])
 
-    assert result.stop_reason == "failed"
+    assert result.text == "usable partial"
+    assert result.stop_reason == "incomplete"
 
 
 def test_openai_still_reports_a_completed_response(configure_openai, fake_openai):

--- a/backend/tests/test_llm_client.py
+++ b/backend/tests/test_llm_client.py
@@ -963,15 +963,32 @@ def test_openai_raises_on_a_failed_response(configure_openai, fake_openai):
     assert excinfo.value.code == "provider"
 
 
-def test_openai_failure_message_carries_the_provider_detail(configure_openai, fake_openai):
+def test_openai_failure_names_the_code_not_the_upstream_text(configure_openai, fake_openai):
+    """``LLMError.message`` is user-presentable by contract, and this one travels to HTTP, SSE and
+    agent-tool responses. So the stable ``code`` goes to the user and the free-form upstream
+    ``message`` — which can carry request ids, org detail, or echoed input — does not."""
     event = _o_terminal("response.failed", status="failed")
-    event.response.error = SimpleNamespace(message="upstream capacity exceeded")
+    event.response.error = SimpleNamespace(
+        code="server_error", message="request 7f3a for org-XYZ echoed: <internal detail>"
+    )
     fake_openai([_o_text_delta("half"), event])
 
     with pytest.raises(LLMError) as excinfo:
         llm_client.complete([{"role": "user", "content": "extract"}])
 
-    assert "upstream capacity exceeded" in excinfo.value.message
+    assert "server_error" in excinfo.value.message
+    assert "org-XYZ" not in excinfo.value.message
+    assert "internal detail" not in excinfo.value.message
+
+
+def test_openai_failure_without_a_code_still_raises(configure_openai, fake_openai):
+    fake_openai([_o_text_delta("half"), _o_terminal("response.failed", status="failed")])
+
+    with pytest.raises(LLMError) as excinfo:
+        llm_client.complete([{"role": "user", "content": "extract"}])
+
+    assert excinfo.value.code == "provider"
+    assert "failed" in excinfo.value.message
 
 
 def test_a_truncated_response_is_not_treated_as_a_failure(configure_openai, fake_openai):


### PR DESCRIPTION
Entity-type derivation lost **every large wiki page** in production. The cause was three layers deep, and the outermost symptom pointed at the wrong layer.

## What actually happened

1. A page's referent list overflowed the client's `DEFAULT_MAX_TOKENS = 4096` (the derivation passed no cap, so it got the default — prod logs show `max_tokens=4096`).
2. OpenAI stopped generating and ended the run with **`response.incomplete`**.
3. `app/llm/providers/openai.py` handled exactly one terminal event — `response.completed` — so that event was **dropped**. The generator ended yielding nothing terminal.
4. `client.complete()` only assigns `stop_reason`/`usage` inside its `done` branch, so it returned the partial text with `stop_reason=''`, zero usage, and **no exception**.
5. `_complete_json` brace-sliced valid-JSON-cut-off-mid-list into invalid JSON and logged `unparseable JSON (N chars)` — naming neither the page nor the reason.

Result: **8 of the 8 largest pages** in a 147-page wiki contributed **zero** referents each, and the log said the model had emitted bad JSON. It hadn't — the model emitted valid JSON and was cut off mid-sentence.

## Confirmed, not inferred

I first concluded "not truncation" from the derivation log showing `status=completed` on every line. That was wrong, and instructively so: the log line lives *inside* the `response.completed` branch, so truncated calls emit **no line at all**. The 19 lines were the successes. Absence of evidence read as evidence of absence.

Settled by wrapping the SDK stream and logging raw event types against the live API:

```
raw SDK event types (non-delta):
   response.incomplete    1        <-- the final event
   ...
delta events: 2021
result: chars=9838 stop_reason='' usage_in=0 usage_out=0
```

The API reported truncation; the caller saw nothing.

## The fix

| file | change |
|---|---|
| `providers/openai.py` | treat `response.incomplete` and `response.failed` as terminal too. **Incomplete** returns with its status and usage — it is a real, usable answer that stopped early. **Failed** raises `LLMError("provider", ...)` carrying the API's error message, like every other provider failure here; returning its partial text even labelled would let a caller persist a broken turn as a finished one, since nothing downstream inspects `stop_reason`. Non-completed statuses log with the API's own `incomplete_details.reason` (`max_output_tokens` / `content_filter`) — the fix differs per reason. |
| `client.py` | a stream ending with **no** terminal event now reports `stop_reason="incomplete"` and warns, instead of presenting partial text as finished. Covers dropped connections and any future status this layer doesn't translate. Uses `"incomplete"` rather than a new sentinel so callers already testing for truncation catch it. |
| `ingest/entity_types.py` | cap raised to 16384 (extraction lists every referent, so output scales with the page); every failure log names the page or group; retry once on **malformed** JSON feeding the error back, but **never** on truncation. |

**Why truncation is never retried:** it's deterministic. Re-asking pays for the same overflowing response twice. What it needs is a bigger cap, not another prompt.

**The cap is a ceiling, not a guarantee.** A large enough page still overflows 16384. That's precisely why the other two changes matter — when it happens it now says so, naming the page, instead of silently yielding nothing. If it recurs, the structural answer is to chunk *mention* extraction: unlike need extraction (where slices can't reveal what a page tracks), "what named things appear in this text?" is genuinely local and the results union cleanly — which is what the fold/dedup stage already does.

## Blast radius

`client.py` and `providers/openai.py` are shared by every LLM call path in the product. Both changes are **additive**: the `completed` path is untouched (pinned by a test), and the client change only fills in a `stop_reason` that was previously empty. Nothing that worked before behaves differently; calls that were silently truncated now report it.

## Tests

13 new. Provider: `incomplete` returns with the right status and usage (and is explicitly *not* treated as a failure), `failed` raises with the provider's detail, and `completed` is unchanged. Client: a stream with no terminal event is reported incomplete and warns. `entity_types`: the cap is passed, truncation is logged as truncation naming the page, truncation doesn't burn the retry, malformed JSON is retried with the reason fed back.

Every fix verified by mutation — reverting it fails a test. Full backend suite green; `ruff check` and `basedpyright` clean.

## After this

Deploy, then a clean derivation run (~147 pages, ~40 min). That's the first run that will tell us what cap the corpus actually needs, since we've never yet seen a complete response for the largest pages.
