### PR TITLE
refactor(automanage): one is_page() instead of ten inline .md checks

### DIFF
--- a/backend/app/wiki/automanage/detectors/body_dup.py
+++ b/backend/app/wiki/automanage/detectors/body_dup.py
@@ -31,6 +31,7 @@ from typing import Any
 from app.wiki import git
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
 from app.wiki.automanage.detectors.template_echo import template_body_blob_shas
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ class _BodyDupDetector:
         return trigger in (TriggerKind.SWEEP, TriggerKind.ON_CREATE)
 
     def detect(self, scope: Scope) -> list[ProposalDraft]:
-        in_scope = {p for p in scope.paths if p.endswith(".md")}
+        in_scope = {p for p in scope.paths if is_page(p)}
         if len(in_scope) < 2:
             return []
         by_blob: dict[str, list[str]] = defaultdict(list)

--- a/backend/app/wiki/automanage/detectors/case_collision.py
+++ b/backend/app/wiki/automanage/detectors/case_collision.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from app.wiki import git
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ class _CaseCollisionDetector:
         return trigger in (TriggerKind.SWEEP, TriggerKind.ON_CREATE)
 
     def detect(self, scope: Scope) -> list[ProposalDraft]:
-        pages = {p for p in scope.paths if p.endswith(".md")}
+        pages = {p for p in scope.paths if is_page(p)}
         if len(pages) < 2:
             return []
         by_lower: dict[str, list[str]] = defaultdict(list)

--- a/backend/app/wiki/automanage/detectors/folder_chain.py
+++ b/backend/app/wiki/automanage/detectors/folder_chain.py
@@ -39,6 +39,7 @@ from typing import Any
 
 from app.wiki import git
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -125,7 +126,7 @@ def _plan_moves(
     while stack:
         d = stack.pop()
         for f in sorted(tree.plain_files.get(d, ())):
-            if not f.endswith(".md"):
+            if not is_page(f):
                 return None
             pages.append(f)
         stack.extend(tree.subdirs.get(d, ()))
@@ -207,8 +208,8 @@ class _FolderChainDetector:
         stranded half-flattened), and every destination still free. Body
         edits to the pages don't break the premise; moves stay content-
         preserving."""
-        folders = [s for s in proposal["source_paths"] if not s.endswith(".md")]
-        pages = [s for s in proposal["source_paths"] if s.endswith(".md")]
+        folders = [s for s in proposal["source_paths"] if not is_page(s)]
+        pages = [s for s in proposal["source_paths"] if is_page(s)]
         if not folders:
             return "proposal is missing its chain folders"
         head, tail = min(folders, key=len), max(folders, key=len)

--- a/backend/app/wiki/automanage/detectors/misplaced_page.py
+++ b/backend/app/wiki/automanage/detectors/misplaced_page.py
@@ -30,6 +30,7 @@ from app.llm.prompts import load_prompt
 from app.wiki import git
 from app.wiki.automanage.detectors import llm_agent
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class _MisplacedPageDetector:
         already hold real pages)."""
         counts: dict[str, int] = {}
         for p in scope.paths:
-            if not p.endswith(".md") or "/" not in p:
+            if not is_page(p) or "/" not in p:
                 continue
             folder = p.rsplit("/", 1)[0]
             counts[folder] = counts.get(folder, 0) + 1
@@ -106,7 +107,7 @@ class _MisplacedPageDetector:
 
     def _candidates(self, scope: Scope) -> list[str]:
         root_pages = sorted(
-            p for p in scope.paths if p.endswith(".md") and "/" not in p
+            p for p in scope.paths if is_page(p) and "/" not in p
         )
         root_pages = [
             p

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -30,6 +30,7 @@ from app.llm.prompts import load_prompt
 from app.wiki import git, page_views
 from app.wiki.automanage.detectors import llm_agent
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ class _StalePageDetector:
     # ---- mechanical prefilter ------------------------------------------
 
     def _candidates(self, scope: Scope) -> list[str]:
-        pages = sorted(p for p in scope.paths if p.endswith(".md"))
+        pages = sorted(p for p in scope.paths if is_page(p))
         if not pages:
             return []
         floor_dt = _now() - timedelta(days=self._floor_days)

--- a/backend/app/wiki/automanage/detectors/stub_page.py
+++ b/backend/app/wiki/automanage/detectors/stub_page.py
@@ -36,6 +36,7 @@ from app.wiki.automanage.detectors.template_echo import (
     blob_sha,
     template_body_blob_shas,
 )
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class _StubPageDetector:
     def detect(self, scope: Scope) -> list[ProposalDraft]:
         if not self.applicable(scope.trigger):
             return []
-        pages = sorted(p for p in scope.paths if p.endswith(".md"))
+        pages = sorted(p for p in scope.paths if is_page(p))
         if not pages:
             return []
         echoes = template_body_blob_shas()

--- a/backend/app/wiki/automanage/detectors/template_echo.py
+++ b/backend/app/wiki/automanage/detectors/template_echo.py
@@ -28,6 +28,7 @@ from typing import Any
 
 from app.wiki import git, templates
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import ProposalOp
 
 log = logging.getLogger(__name__)
@@ -81,7 +82,7 @@ class _TemplateEchoDetector:
         echoes = template_body_blob_shas()
         if not echoes:
             return []
-        in_scope = {p for p in scope.paths if p.endswith(".md")}
+        in_scope = {p for p in scope.paths if is_page(p)}
         if not in_scope:
             return []
         now = datetime.now(UTC)

--- a/backend/app/wiki/automanage/executor.py
+++ b/backend/app/wiki/automanage/executor.py
@@ -35,7 +35,7 @@ from app.wiki import change_proposals, doc_ids, git, notify, trash
 from app.wiki.automanage import fingerprint, settings
 from app.wiki.automanage.detectors import DETECTORS_BY_NAME
 from app.wiki.change_proposals import ProposalOp, ProposalStatus
-from app.wiki.filesystem import TRASH_PREFIX
+from app.wiki.filesystem import TRASH_PREFIX, is_page
 
 log = logging.getLogger(__name__)
 
@@ -220,7 +220,7 @@ def _reconverge_after_revert(
     live = set(git.list_paths())
     doc_ids.on_restored([path for path in sorted(allowed) if path in live])
     for path in sorted(allowed):
-        if not path.endswith(".md"):
+        if not is_page(path):
             continue
         if path in live:
             notify.after_doc_write(

--- a/backend/app/wiki/automanage/runner.py
+++ b/backend/app/wiki/automanage/runner.py
@@ -42,6 +42,7 @@ from app.wiki.automanage import (
 )
 from app.wiki.automanage.detectors import DETECTORS
 from app.wiki.automanage.detectors.base import ProposalDraft, Scope, TriggerKind
+from app.wiki.filesystem import is_page
 from app.wiki.change_proposals import (
     ProposalCreatedVia,
     ProposalStatus,
@@ -102,7 +103,7 @@ def _partition_by_audience(scope: Scope) -> list[Scope]:
     single page are dropped — nothing to pair. Most wikis are default-public,
     so this usually returns one big bucket and the partition costs one batched
     fingerprint pass."""
-    pages = [p for p in scope.paths if p.endswith(".md")]
+    pages = [p for p in scope.paths if is_page(p)]
     if not pages:
         return []
     fps = fingerprint.fingerprints_for_paths(pages)
@@ -429,7 +430,7 @@ def run_detection(
         # 148 pages read as 193. Folders join this count when they become
         # scanned units; the scope size stays in the log line, where it is the
         # useful cost signal.
-        scanned = sum(1 for p in paths if p.endswith(".md"))
+        scanned = sum(1 for p in paths if is_page(p))
         runs.mark_completed(run_id, paths_scanned=scanned, proposals_emitted=emitted)
         log.info(
             "detection run %s (%s): scanned %d pages (%d files in scope), emitted %d proposals",

--- a/backend/app/wiki/filesystem.py
+++ b/backend/app/wiki/filesystem.py
@@ -19,6 +19,20 @@ log = logging.getLogger(__name__)
 TRASH_DIR = ".trash"
 TRASH_PREFIX = TRASH_DIR + "/"
 
+# What makes a tracked file a wiki *page*. A path listing also carries files
+# that exist to represent structure rather than content — the `.gitkeep`
+# markers that materialize folders (git can't track an empty directory) and
+# the `.trigger_*.yaml` files that sit beside the scope they act on. Those are
+# neither editable nor visible in the tree, so most callers want pages only.
+PAGE_SUFFIX = ".md"
+
+
+def is_page(rel_path: str) -> bool:
+    """Whether ``rel_path`` is a wiki page, as opposed to a folder path or one
+    of the structural files that share the tree with pages (see
+    ``PAGE_SUFFIX``)."""
+    return rel_path.endswith(PAGE_SUFFIX)
+
 
 def is_trash_path(rel_path: str) -> bool:
     """Whether ``rel_path`` lives in the reserved ``.trash/`` area."""


### PR DESCRIPTION
## Why

Follow-up to #565. Every consumer that wants pages was re-deriving the rule inline — `p.endswith(".md")`, ten times across the detectors, the runner and the executor. That's what made "wait, do we filter those out?" hard to answer from the code.

The rule is a wiki concept, not an automanage one: a path listing carries structural files (`.gitkeep` markers that materialize folders, `.trigger_*.yaml` beside the scope they act on) alongside pages, and most callers want pages only.

## Change

`is_page()` + `PAGE_SUFFIX` in `app/wiki/filesystem.py`, next to `TRASH_DIR` / `is_trash_path()` — that module already owns this kind of single definition ("This is the single definition; git.py and trash.py import it").

Converted the ten automanage sites:

| file | sites |
|---|---|
| `detectors/folder_chain.py` | 3 |
| `detectors/misplaced_page.py` | 2 |
| `runner.py` | 2 |
| `detectors/{body_dup,case_collision,stale_page,stub_page,template_echo}.py` | 1 each |
| `executor.py` | 1 |

**Filtering stays per consumer** — that shape is deliberate and unchanged. `empty_folder` and `folder_chain` still read the *unfiltered* scope, because a `.gitkeep` is the only evidence an empty folder exists. This only stops each consumer spelling the predicate out again.

Mechanical, no behavior change. The other ~58 `.endswith(".md")` sites elsewhere (`api/wiki.py`, `triggers/`, `tasks/`, …) are left alone; they can migrate as they're touched, rather than inflating this diff into subsystems it has no reason to enter.

## Testing

Full backend suite green on top of merged main (2275 passed, 2 skipped); ruff and basedpyright clean.

Note on formatting: `ruff format` would also rewrite unrelated parts of `filesystem.py` and `executor.py`, but that drift is pre-existing on `main` (55 files repo-wide), so I left it rather than mixing it into this diff.