### PR TITLE
fix(automanage): show the LLM detectors a tree of pages, not every tracked file

### DIFF
--- a/backend/app/wiki/automanage/detectors/misplaced_page.py
+++ b/backend/app/wiki/automanage/detectors/misplaced_page.py
@@ -129,7 +129,13 @@ class _MisplacedPageDetector:
     def _agent_pass(
         self, scope: Scope, candidates: list[str]
     ) -> list[dict[str, str]]:
-        tree = "\n".join(sorted(p for p in scope.paths))
+        # Pages only. The scope also carries the `.gitkeep` markers that
+        # materialize folders and any `.trigger_*.yaml` — the folder
+        # detectors need those, but they are not content the model can
+        # reason about, and a marker-only folder is not a destination
+        # `_folders` would accept anyway. Folders holding pages still
+        # appear, since a page path carries its prefix.
+        tree = "\n".join(sorted(p for p in scope.paths if is_page(p)))
         system = load_prompt("misplaced_page_detect.system").replace(
             "{max_proposals}", str(MAX_PROPOSALS)
         )

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -127,7 +127,13 @@ class _StalePageDetector:
     def _agent_pass(
         self, scope: Scope, candidates: list[str]
     ) -> list[dict[str, str]]:
-        tree = "\n".join(sorted(p for p in scope.paths))
+        # Pages only. The scope also carries the `.gitkeep` markers that
+        # materialize folders and any `.trigger_*.yaml` — the folder
+        # detectors need those, but they are not content the model can
+        # reason about, and on a real wiki they were a quarter of every
+        # tree it read. Folders holding pages still appear, since a page
+        # path carries its prefix.
+        tree = "\n".join(sorted(p for p in scope.paths if is_page(p)))
         ages: list[str] = []
         for p in candidates:
             meta = git.last_commit_meta_for_path(p)

--- a/backend/app/wiki/automanage/detectors/stale_page.py
+++ b/backend/app/wiki/automanage/detectors/stale_page.py
@@ -130,8 +130,7 @@ class _StalePageDetector:
         # Pages only. The scope also carries the `.gitkeep` markers that
         # materialize folders and any `.trigger_*.yaml` — the folder
         # detectors need those, but they are not content the model can
-        # reason about, and on a real wiki they were a quarter of every
-        # tree it read. Folders holding pages still appear, since a page
+        # reason about. Folders holding pages still appear, since a page
         # path carries its prefix.
         tree = "\n".join(sorted(p for p in scope.paths if is_page(p)))
         ages: list[str] = []

--- a/backend/tests/test_misplaced_page_detector.py
+++ b/backend/tests/test_misplaced_page_detector.py
@@ -148,6 +148,38 @@ def test_confirmed_stray_emits_a_move_draft(monkeypatch, tmp_repo):
     assert meta is not None and draft.premise == meta[0]
 
 
+def test_prompt_tree_holds_pages_only(monkeypatch, tmp_repo):
+    """The scope carries `.gitkeep` markers and folder-scoped trigger YAMLs for
+    the folder detectors' benefit. They are not content the model can reason
+    about, and a marker-only folder is not even a destination this detector
+    would accept (`_folders` counts pages), so showing them offered options the
+    guards then reject."""
+    _seed_home()
+    _backdated_commit("stray.md", _BODY)
+    calls = _script(
+        monkeypatch,
+        _finish({"path": "stray.md", "dest_folder": "Runbooks", "evidence": "x"}),
+    )
+
+    _MisplacedPageDetector().detect(
+        _scope(
+            "stray.md",
+            "Runbooks/restore.md",
+            "Runbooks/rotate.md",
+            "Empty Folder/.gitkeep",
+            "Runbooks/.trigger_abc.yaml",
+        )
+    )
+
+    prompt = "".join(
+        str(m.get("content", "")) for m in calls[0] if m.get("role") == "user"
+    )
+    assert "Runbooks/restore.md" in prompt  # folders with pages still show
+    assert ".gitkeep" not in prompt
+    assert ".trigger_abc.yaml" not in prompt
+    assert "Empty Folder" not in prompt  # marker-only folder: not a destination
+
+
 def test_invented_destination_is_dropped(monkeypatch, tmp_repo):
     _seed_home()
     _backdated_commit("stray.md", _BODY)

--- a/backend/tests/test_stale_page_detector.py
+++ b/backend/tests/test_stale_page_detector.py
@@ -140,6 +140,36 @@ def test_young_tracking_gates_unviewed_pages(monkeypatch, tmp_repo):
 # ---- agent pass ------------------------------------------------------------ #
 
 
+def test_prompt_tree_holds_pages_only(monkeypatch, tmp_repo):
+    """The scope carries `.gitkeep` markers and folder-scoped trigger YAMLs for
+    the folder detectors' benefit; they are not content this model can reason
+    about. Mirrors the misplaced-page assertion — the two detectors build their
+    tree independently, so one-sided coverage would let a regression through."""
+    _age_tracking()
+    _backdated_commit("notes/old.md", _OLD_BODY)
+    calls = _script(
+        monkeypatch,
+        _finish({"path": "notes/old.md", "evidence": "agenda for a past event"}),
+    )
+
+    _StalePageDetector().detect(
+        _scope(
+            "notes/old.md",
+            "anchor/tracked.md",
+            "Empty Folder/.gitkeep",
+            "notes/.trigger_abc.yaml",
+        )
+    )
+
+    prompt = "".join(
+        str(m.get("content", "")) for m in calls[0] if m.get("role") == "user"
+    )
+    assert "notes/old.md" in prompt  # folders with pages still show
+    assert ".gitkeep" not in prompt
+    assert ".trigger_abc.yaml" not in prompt
+    assert "Empty Folder" not in prompt
+
+
 def test_confirmed_stale_page_emits_a_deletion_draft(monkeypatch, tmp_repo):
     _age_tracking()
     _backdated_commit("notes/old.md", _OLD_BODY)


### PR DESCRIPTION
## Problem

Follow-up to #569. Both LLM detectors build their prompt's "Wiki file tree" from the raw scope:

```python
tree = "\n".join(sorted(p for p in scope.paths))   # stale_page.py:129, misplaced_page.py:143
```

So the model reads every `.gitkeep` marker and `.trigger_*.yaml` in the wiki. On dev-wiki that's **45 of 193 lines — roughly a quarter of the tree** — on every LLM pass of every sweep. None of it is content the model can reason about.

`misplaced_page` had a sharper version of the problem: `_folders()` counts *pages* per folder, so a folder that exists only through a marker is never an accepted destination — yet it appeared in the tree the model was choosing from. The guard at `misplaced_page.py:158` dropped the pick with a warning, i.e. after paying for the round trip. The model was shown options it wasn't allowed to pick.

## Change

Filter both trees through `is_page` (the util from #569). Folders holding pages still appear — a page path carries its prefix — and marker-only folders drop out, which is exactly the set `misplaced_page` refuses anyway.

The **scope is unchanged**. `empty_folder` and `folder_chain` still read the unfiltered list, because a marker is their only evidence a folder exists. This is about what the model is shown, not what the sweep covers.

## Testing

- New `test_prompt_tree_holds_pages_only`: seeds a scope holding a marker-only folder and a folder-scoped trigger, captures the prompt through the existing `client.complete` stub, and asserts pages are present while `.gitkeep`, the trigger YAML, and the marker-only folder are not.
- Confirmed the test isn't vacuous — reverted the change and watched it fail on the `.gitkeep` assertion before restoring.
- Full backend suite green (2276 passed, 2 skipped); ruff and basedpyright clean.

## Not verified

The prompt input changes, so the detectors deserve a live run against the real model before this is trusted in production — the same live verification #532 and #543 each got. I don't have provider credentials in this environment, so that check is outstanding.