### PR TITLE
perf(wiki): bound anchor-remap diff cost — line-level pre-pass + per-group reuse

### DIFF
--- a/backend/app/wiki/anchor_remap.py
+++ b/backend/app/wiki/anchor_remap.py
@@ -57,9 +57,13 @@ def remap_anchored(
         old_body = _read_old_body(path, anchor_sha)
         if old_body is None:
             continue
+        # Both diffs depend only on the body pair, so pay them once per anchor
+        # group rather than once per record — a page can carry dozens of source
+        # ranges against one anchor_sha.
+        diff = None if old_body == new_body else comment_anchor.body_diff(old_body, new_body)
         for r in group:
             result = comment_anchor.remap_range(
-                old_body, new_body, r["start_offset"], r["end_offset"]
+                old_body, new_body, r["start_offset"], r["end_offset"], diff=diff
             )
             if result is None:
                 on_lost(r["id"])

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -62,10 +62,21 @@ _TOKEN_RE = re.compile(r"\s+|\S+")
 # instead (endpoints collapse to the hunk edges — the same outcome as a full
 # rewrite of that hunk). 4M ≈ a 2000x2000-char hunk ≈ ~0.1s of diffing.
 _MAX_HUNK_CHAR_PRODUCT = 4_000_000
+# Guard for the middle line diff after common prefix/suffix trimming. Lines are
+# normally high-entropy so line matching is fast, but a body made of thousands
+# of duplicate lines (blank lines, repeated bullets) gives every line a long
+# match chain and line matching itself goes quadratic. Above the cap the whole
+# middle becomes one hunk, and _MAX_HUNK_CHAR_PRODUCT decides fine vs coarse.
+_MAX_LINE_PRODUCT = 4_000_000
 # Same guard for the whole-body token diff that scores span survival. Above the
 # cap the survival guard is skipped (spans are kept on the strength of the
 # endpoint mapping alone); ~10k tokens per side is far past any page we host.
 _MAX_TOKEN_PRODUCT = 100_000_000
+# Guard for the char-level ratio() that credits an in-place-edited token run.
+# Partial credit exists for typo-scale edits; a run this large is a wholesale
+# rewrite, so it gets no credit instead of a quadratic similarity pass (long
+# URLs / data URIs / generated blobs are single tokens and can be huge).
+_MAX_RUN_RATIO_PRODUCT = 4_000_000
 
 # Endpoint association: +1 sticks to following content, -1 to preceding.
 _START = 1
@@ -108,22 +119,53 @@ def _char_opcodes(old_body: str, new_body: str) -> list[_Opcode]:
     """Character-coordinate opcodes for old→new, via a line-level pre-pass.
 
     A raw character-level ``SequenceMatcher`` over two whole bodies is
-    quadratic in body length. Lines are high-entropy elements, so the line
-    diff stays fast at any body size; character precision is only needed
-    *inside* changed hunks, which ordinary edits keep small. Equal lines map
-    positions exactly, so anchors in unchanged text get identical results to
-    the whole-body character diff. The returned opcodes tile
+    quadratic in body length. Common prefix/suffix lines are trimmed first in
+    linear time — an ordinary edit or append touches a small middle, so its
+    cost no longer scales with page size at all. The middle is line-diffed
+    (guarded by ``_MAX_LINE_PRODUCT`` for degenerate duplicate-heavy bodies);
+    character precision is only applied *inside* changed hunks. Equal lines
+    map positions exactly, so anchors in unchanged text get identical results
+    to the whole-body character diff. The returned opcodes tile
     ``[0, len(old_body)]`` × ``[0, len(new_body)]`` exactly like
     ``SequenceMatcher.get_opcodes()``.
     """
     old_lines = old_body.splitlines(keepends=True)
     new_lines = new_body.splitlines(keepends=True)
-    line_ops = SequenceMatcher(None, old_lines, new_lines, autojunk=False).get_opcodes()
+    n_old, n_new = len(old_lines), len(new_lines)
+
+    # Linear trim: common prefix and suffix lines need no matching at all.
+    pre = 0
+    while pre < n_old and pre < n_new and old_lines[pre] == new_lines[pre]:
+        pre += 1
+    suf = 0
+    while (
+        suf < n_old - pre and suf < n_new - pre
+        and old_lines[n_old - 1 - suf] == new_lines[n_new - 1 - suf]
+    ):
+        suf += 1
+    mid_old = old_lines[pre:n_old - suf]
+    mid_new = new_lines[pre:n_new - suf]
+    pre_chars = sum(len(line) for line in old_lines[:pre])
+    suf_chars = sum(len(line) for line in old_lines[n_old - suf:])
+
     out: list[_Opcode] = []
-    i_char = j_char = 0  # running char offsets; line opcodes tile in order
+    if pre_chars:
+        out.append(("equal", 0, pre_chars, 0, pre_chars))
+    if len(mid_old) * len(mid_new) > _MAX_LINE_PRODUCT:
+        log.warning(
+            "line diff over cap (%d x %d lines) — treating middle as one hunk",
+            len(mid_old), len(mid_new),
+        )
+        line_ops: list[_Opcode] = [("replace", 0, len(mid_old), 0, len(mid_new))]
+    else:
+        line_ops = cast(
+            "list[_Opcode]",
+            SequenceMatcher(None, mid_old, mid_new, autojunk=False).get_opcodes(),
+        )
+    i_char = j_char = pre_chars  # running char offsets; line opcodes tile in order
     for tag, i1, i2, j1, j2 in line_ops:
-        a_len = sum(len(line) for line in old_lines[i1:i2])
-        b_len = sum(len(line) for line in new_lines[j1:j2])
+        a_len = sum(len(line) for line in mid_old[i1:i2])
+        b_len = sum(len(line) for line in mid_new[j1:j2])
         if tag == "replace":
             if a_len * b_len > _MAX_HUNK_CHAR_PRODUCT:
                 log.warning(
@@ -146,6 +188,12 @@ def _char_opcodes(old_body: str, new_body: str) -> list[_Opcode]:
             out.append((tag, i_char, i_char + a_len, j_char, j_char + b_len))
         i_char += a_len
         j_char += b_len
+    if suf_chars:
+        out.append((
+            "equal",
+            len(old_body) - suf_chars, len(old_body),
+            len(new_body) - suf_chars, len(new_body),
+        ))
     return out
 
 
@@ -239,6 +287,8 @@ def _word_preserved_fraction(diff: BodyDiff, new_body_len: int, new_start: int, 
         else:  # replace — credit the in-place edit by how similar the runs are
             old_run = "".join(diff.old_tokens[i1:i2])
             new_run = "".join(diff.new_tokens[j1:j2])
+            if len(old_run) * len(new_run) > _MAX_RUN_RATIO_PRODUCT:
+                continue  # wholesale rewrite, not an in-place edit — no credit
             similarity = SequenceMatcher(None, old_run, new_run, autojunk=False).ratio()
             kept += similarity * overlap
     return kept / span

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -46,7 +46,7 @@ from collections.abc import Sequence
 from difflib import SequenceMatcher
 from typing import cast
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 log = logging.getLogger(__name__)
 
@@ -113,6 +113,31 @@ class BodyDiff(BaseModel):
     old_tokens: list[str]
     new_tokens: list[str]
     new_token_starts: list[int]
+
+    # Similarity of each in-place-edited run, keyed by its token opcode
+    # bounds. The value depends only on the body pair, so spans sharing a
+    # BodyDiff pay each run's (capped) ratio once, not once per span.
+    _run_similarity: dict[tuple[int, int, int, int], float] = PrivateAttr(
+        default_factory=dict
+    )
+
+    def run_similarity(self, i1: int, i2: int, j1: int, j2: int) -> float:
+        """Char-level similarity of the replaced run ``old_tokens[i1:i2]`` →
+        ``new_tokens[j1:j2]``, memoized per body pair. A run over
+        ``_MAX_RUN_RATIO_PRODUCT`` scores 0.0 — that large is a wholesale
+        rewrite, not an in-place edit, and its ratio would be quadratic."""
+        key = (i1, i2, j1, j2)
+        cached = self._run_similarity.get(key)
+        if cached is not None:
+            return cached
+        old_run = "".join(self.old_tokens[i1:i2])
+        new_run = "".join(self.new_tokens[j1:j2])
+        if len(old_run) * len(new_run) > _MAX_RUN_RATIO_PRODUCT:
+            similarity = 0.0
+        else:
+            similarity = SequenceMatcher(None, old_run, new_run, autojunk=False).ratio()
+        self._run_similarity[key] = similarity
+        return similarity
 
 
 def _char_opcodes(old_body: str, new_body: str) -> list[_Opcode]:
@@ -285,12 +310,7 @@ def _word_preserved_fraction(diff: BodyDiff, new_body_len: int, new_start: int, 
         if tag == "equal":
             kept += overlap
         else:  # replace — credit the in-place edit by how similar the runs are
-            old_run = "".join(diff.old_tokens[i1:i2])
-            new_run = "".join(diff.new_tokens[j1:j2])
-            if len(old_run) * len(new_run) > _MAX_RUN_RATIO_PRODUCT:
-                continue  # wholesale rewrite, not an in-place edit — no credit
-            similarity = SequenceMatcher(None, old_run, new_run, autojunk=False).ratio()
-            kept += similarity * overlap
+            kept += diff.run_similarity(i1, i2, j1, j2) * overlap
     return kept / span
 
 

--- a/backend/app/wiki/comment_anchor.py
+++ b/backend/app/wiki/comment_anchor.py
@@ -40,13 +40,32 @@ them at the relevant refs.
 """
 from __future__ import annotations
 
+import logging
 import re
 from collections.abc import Sequence
 from difflib import SequenceMatcher
+from typing import cast
+
+from pydantic import BaseModel, ConfigDict
+
+log = logging.getLogger(__name__)
 
 # A token is a run of whitespace or a run of non-whitespace; concatenating all
 # token texts reproduces the body exactly.
 _TOKEN_RE = re.compile(r"\s+|\S+")
+
+# Caps that keep one remap CPU-bounded. A character-level SequenceMatcher costs
+# ~O(len_a * len_b) in the worst case (small alphabet, long chains), which
+# measured out to minutes of pure CPU on a ~190k-char page — long enough to
+# stall the single-threaded documents queue until the pod was killed. A changed
+# hunk whose side product exceeds the cap keeps one coarse `replace` opcode
+# instead (endpoints collapse to the hunk edges — the same outcome as a full
+# rewrite of that hunk). 4M ≈ a 2000x2000-char hunk ≈ ~0.1s of diffing.
+_MAX_HUNK_CHAR_PRODUCT = 4_000_000
+# Same guard for the whole-body token diff that scores span survival. Above the
+# cap the survival guard is skipped (spans are kept on the strength of the
+# endpoint mapping alone); ~10k tokens per side is far past any page we host.
+_MAX_TOKEN_PRODUCT = 100_000_000
 
 # Endpoint association: +1 sticks to following content, -1 to preceding.
 _START = 1
@@ -62,6 +81,102 @@ _MIN_PRESERVED = 0.5
 
 # (tag, i1, i2, j1, j2) as returned by SequenceMatcher.get_opcodes().
 _Opcode = tuple[str, int, int, int, int]
+
+
+class BodyDiff(BaseModel):
+    """Precomputed diff artifacts for one ``(old_body, new_body)`` pair.
+
+    Everything here depends only on the two bodies, never on the span being
+    remapped — so a caller re-anchoring many spans between the same two
+    versions (``anchor_remap`` batches by ``anchor_sha``) computes this once
+    instead of paying both diffs again for every span.
+
+    ``token_opcodes`` is ``None`` when the token diff was skipped under
+    ``_MAX_TOKEN_PRODUCT``; the survival guard is then bypassed.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    char_opcodes: list[_Opcode]
+    token_opcodes: list[_Opcode] | None
+    old_tokens: list[str]
+    new_tokens: list[str]
+    new_token_starts: list[int]
+
+
+def _char_opcodes(old_body: str, new_body: str) -> list[_Opcode]:
+    """Character-coordinate opcodes for old→new, via a line-level pre-pass.
+
+    A raw character-level ``SequenceMatcher`` over two whole bodies is
+    quadratic in body length. Lines are high-entropy elements, so the line
+    diff stays fast at any body size; character precision is only needed
+    *inside* changed hunks, which ordinary edits keep small. Equal lines map
+    positions exactly, so anchors in unchanged text get identical results to
+    the whole-body character diff. The returned opcodes tile
+    ``[0, len(old_body)]`` × ``[0, len(new_body)]`` exactly like
+    ``SequenceMatcher.get_opcodes()``.
+    """
+    old_lines = old_body.splitlines(keepends=True)
+    new_lines = new_body.splitlines(keepends=True)
+    line_ops = SequenceMatcher(None, old_lines, new_lines, autojunk=False).get_opcodes()
+    out: list[_Opcode] = []
+    i_char = j_char = 0  # running char offsets; line opcodes tile in order
+    for tag, i1, i2, j1, j2 in line_ops:
+        a_len = sum(len(line) for line in old_lines[i1:i2])
+        b_len = sum(len(line) for line in new_lines[j1:j2])
+        if tag == "replace":
+            if a_len * b_len > _MAX_HUNK_CHAR_PRODUCT:
+                log.warning(
+                    "char diff hunk over cap (%d x %d chars) — keeping coarse replace",
+                    a_len, b_len,
+                )
+                out.append(("replace", i_char, i_char + a_len, j_char, j_char + b_len))
+            else:
+                sub = SequenceMatcher(
+                    None,
+                    old_body[i_char:i_char + a_len],
+                    new_body[j_char:j_char + b_len],
+                    autojunk=False,
+                ).get_opcodes()
+                out.extend(
+                    (t, i_char + s1, i_char + s2, j_char + t1, j_char + t2)
+                    for t, s1, s2, t1, t2 in sub
+                )
+        else:  # equal / delete / insert need no character alignment
+            out.append((tag, i_char, i_char + a_len, j_char, j_char + b_len))
+        i_char += a_len
+        j_char += b_len
+    return out
+
+
+def body_diff(old_body: str, new_body: str) -> BodyDiff:
+    """Compute the char- and token-level diffs ``remap_range`` needs."""
+    old_tokens = [m.group() for m in _TOKEN_RE.finditer(old_body)]
+    new_tokens: list[str] = []
+    new_token_starts: list[int] = []
+    for m in _TOKEN_RE.finditer(new_body):
+        new_tokens.append(m.group())
+        new_token_starts.append(m.start())
+
+    token_opcodes: list[_Opcode] | None
+    if len(old_tokens) * len(new_tokens) > _MAX_TOKEN_PRODUCT:
+        log.warning(
+            "token diff over cap (%d x %d tokens) — skipping survival guard",
+            len(old_tokens), len(new_tokens),
+        )
+        token_opcodes = None
+    else:
+        token_opcodes = cast(
+            "list[_Opcode]",
+            SequenceMatcher(None, old_tokens, new_tokens, autojunk=False).get_opcodes(),
+        )
+    return BodyDiff(
+        char_opcodes=_char_opcodes(old_body, new_body),
+        token_opcodes=token_opcodes,
+        old_tokens=old_tokens,
+        new_tokens=new_tokens,
+        new_token_starts=new_token_starts,
+    )
 
 
 def _map_pos(opcodes: Sequence[_Opcode], pos: int, assoc: int) -> int:
@@ -81,9 +196,9 @@ def _map_pos(opcodes: Sequence[_Opcode], pos: int, assoc: int) -> int:
     return j2 if assoc > 0 else j1
 
 
-def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_end: int) -> float:
+def _word_preserved_fraction(diff: BodyDiff, new_body_len: int, new_start: int, new_end: int) -> float:
     """How much of the new span ``[new_start, new_end)`` carries over from
-    ``old_body``, scored at word/whitespace-token granularity.
+    the old body, scored at word/whitespace-token granularity.
 
     Diffing at token granularity (not characters) is what stops a genuine
     rewrite from looking half-survived: difflib won't align two unrelated runs
@@ -95,22 +210,23 @@ def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_e
     one-letter typo fix, a pluralization, or "weekly"→"biweekly" still reads as
     mostly-preserved (the comment follows the edit), while a run replaced by
     unrelated text scores near zero and orphans. Inserted/deleted runs count for
-    nothing."""
+    nothing.
+
+    When the token diff was skipped under ``_MAX_TOKEN_PRODUCT``
+    (``diff.token_opcodes is None``) the guard passes unconditionally: the
+    endpoint mapping is still exact, and keeping the span beats orphaning
+    every anchor on a page too large to score."""
     span = new_end - new_start
     if span <= 0:
         return 0.0
-    old_tokens = [m.group() for m in _TOKEN_RE.finditer(old_body)]
-    new_tokens = [(m.group(), m.start()) for m in _TOKEN_RE.finditer(new_body)]
-    new_len = len(new_body)
+    if diff.token_opcodes is None:
+        return 1.0
 
     def token_start(idx: int) -> int:
-        return new_tokens[idx][1] if idx < len(new_tokens) else new_len
+        return diff.new_token_starts[idx] if idx < len(diff.new_token_starts) else new_body_len
 
-    opcodes = SequenceMatcher(
-        None, old_tokens, [t[0] for t in new_tokens], autojunk=False
-    ).get_opcodes()
     kept = 0.0
-    for tag, i1, i2, j1, j2 in opcodes:
+    for tag, i1, i2, j1, j2 in diff.token_opcodes:
         if tag not in ("equal", "replace"):
             continue  # insert / delete preserve nothing
         lo = max(new_start, token_start(j1))
@@ -121,8 +237,8 @@ def _word_preserved_fraction(old_body: str, new_body: str, new_start: int, new_e
         if tag == "equal":
             kept += overlap
         else:  # replace — credit the in-place edit by how similar the runs are
-            old_run = "".join(old_tokens[i1:i2])
-            new_run = "".join(t[0] for t in new_tokens[j1:j2])
+            old_run = "".join(diff.old_tokens[i1:i2])
+            new_run = "".join(diff.new_tokens[j1:j2])
             similarity = SequenceMatcher(None, old_run, new_run, autojunk=False).ratio()
             kept += similarity * overlap
     return kept / span
@@ -181,12 +297,16 @@ def resolve_exact_span(
 
 
 def remap_range(
-    old_body: str, new_body: str, start: int, end: int
+    old_body: str, new_body: str, start: int, end: int, *, diff: BodyDiff | None = None
 ) -> tuple[int, int] | None:
     """Map ``[start, end)`` from ``old_body`` onto ``new_body``.
 
     Returns the new ``(start, end)`` tuple, or ``None`` when the comment should
     be orphaned (span removed, mostly rewritten, or whitespace-only survivor).
+
+    ``diff`` is the precomputed ``body_diff(old_body, new_body)``; pass it when
+    remapping several spans between the same two bodies so the diffs are paid
+    once, not once per span.
     """
     if not 0 <= start <= end <= len(old_body):
         raise ValueError(
@@ -194,10 +314,11 @@ def remap_range(
         )
     if old_body == new_body:
         return (start, end)
+    if diff is None:
+        diff = body_diff(old_body, new_body)
 
-    opcodes = SequenceMatcher(None, old_body, new_body, autojunk=False).get_opcodes()
-    new_start = _map_pos(opcodes, start, _START)
-    new_end = _map_pos(opcodes, end, _END)
+    new_start = _map_pos(diff.char_opcodes, start, _START)
+    new_end = _map_pos(diff.char_opcodes, end, _END)
 
     if new_start >= new_end:
         return None  # whole span deleted/replaced
@@ -206,7 +327,7 @@ def remap_range(
     # the surrounding preserved word also lifts the survival fraction for in-place
     # edits like "weekly"->"biweekly").
     new_start, new_end = _snap_to_words(new_body, new_start, new_end)
-    if _word_preserved_fraction(old_body, new_body, new_start, new_end) < _MIN_PRESERVED:
+    if _word_preserved_fraction(diff, len(new_body), new_start, new_end) < _MIN_PRESERVED:
         return None  # alignment landed on mostly-rewritten text — orphan, don't mislead
     if not new_body[new_start:new_end].strip():
         return None  # only whitespace survived — nothing real to anchor to

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -281,3 +281,54 @@ def test_over_cap_token_diff_skips_survival_guard(monkeypatch):
     result = remap_range(old, new, s, s + len("quick brown fox"), diff=diff)
     assert result is not None
     assert new[result[0] : result[1]] == "quick red fox"
+
+
+def test_append_only_edit_maps_all_anchors_exactly():
+    # Common-suffix/prefix trim: appending at the bottom must leave every
+    # existing anchor at its exact old offsets, at any page size.
+    old = "\n".join(f"- item {i} with some text" for i in range(500)) + "\n"
+    new = old + "- appended row\n"
+    diff = comment_anchor.body_diff(old, new)
+    for i in (0, 250, 499):  # word-aligned spans so _snap_to_words is a no-op
+        s = old.index(f"- item {i} with")
+        e = s + len(f"- item {i} with some text")
+        assert remap_range(old, new, s, e, diff=diff) == (s, e)
+
+
+def test_anchor_after_edited_line_shifts_by_exact_delta():
+    lines = [f"line {i} content here\n" for i in range(50)]
+    old = "".join(lines)
+    edited = lines.copy()
+    edited[10] = "line 10 content here plus an insertion\n"
+    new = "".join(edited)
+    delta = len(edited[10]) - len(lines[10])
+    s = old.index("line 40")
+    e = s + len("line 40 content")
+    assert remap_range(old, new, s, e) == (s + delta, e + delta)
+
+
+def test_over_cap_line_diff_falls_back_to_one_hunk(monkeypatch):
+    monkeypatch.setattr(comment_anchor, "_MAX_LINE_PRODUCT", 1)
+    # Prefix/suffix lines are trimmed before the cap applies, so anchors there
+    # stay exact even when the middle is treated as a single hunk.
+    old = "stable head\nAAA one\nBBB two\nstable tail\n"
+    new = "stable head\nCCC uno\nDDD dos\nstable tail\n"
+    assert remap_range(old, new, 0, len("stable head")) == (0, len("stable head"))
+    s = old.index("stable tail")
+    s_new = new.index("stable tail")
+    assert remap_range(old, new, s, s + 6) == (s_new, s_new + 6)
+    # The middle collapses through the coarse hunk and orphans.
+    assert remap_range(old, new, old.index("AAA"), old.index("AAA") + 7) is None
+
+
+def test_huge_replaced_run_gets_no_partial_credit(monkeypatch):
+    # An in-place-edited token run over the ratio cap must score zero credit
+    # (orphan) instead of running a quadratic similarity pass.
+    old = "prefix stays. weekly rotation. suffix stays."
+    new = "prefix stays. biweekly rotation. suffix stays."
+    s, e = old.index("weekly"), old.index("weekly") + len("weekly")
+    # Control: under the normal cap the in-place edit earns partial credit.
+    assert remap_range(old, new, s, e) is not None
+    # The same edit with its run over the cap earns nothing and orphans.
+    monkeypatch.setattr(comment_anchor, "_MAX_RUN_RATIO_PRODUCT", 10)
+    assert remap_range(old, new, s, e) is None

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -332,3 +332,29 @@ def test_huge_replaced_run_gets_no_partial_credit(monkeypatch):
     # The same edit with its run over the cap earns nothing and orphans.
     monkeypatch.setattr(comment_anchor, "_MAX_RUN_RATIO_PRODUCT", 10)
     assert remap_range(old, new, s, e) is None
+
+
+def test_replace_run_similarity_computed_once_per_body_pair(monkeypatch):
+    # Spans sharing a BodyDiff must pay each edited run's ratio() once, not
+    # once per span — the group remap on a many-span page depends on it.
+    import difflib
+
+    old = "alpha weekly rotation gamma\n"
+    new = "alpha biweekly rotation gamma\n"
+    diff = comment_anchor.body_diff(old, new)  # built before counting starts
+
+    constructions: list[int] = []
+
+    class _Counting(difflib.SequenceMatcher):
+        def __init__(self, *args, **kwargs):
+            constructions.append(1)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(comment_anchor, "SequenceMatcher", _Counting)
+    spans = [
+        (old.index("weekly"), old.index("weekly") + len("weekly")),
+        (0, old.index("rotation") + len("rotation")),
+    ]
+    results = [remap_range(old, new, s, e, diff=diff) for s, e in spans]
+    assert all(r is not None for r in results)
+    assert len(constructions) == 1  # the shared run's ratio ran exactly once

--- a/backend/tests/test_comment_anchor.py
+++ b/backend/tests/test_comment_anchor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from app.wiki import comment_anchor
 from app.wiki.comment_anchor import remap_range
 
 
@@ -227,3 +228,56 @@ def test_disjoint_full_rewrite_orphans():
     new = "keep )))))))))) keep"
     s, e = old.index("[["), old.index("[[") + 10
     assert remap_range(old, new, s, e) is None
+
+
+# --------------------------------------------------------------------------- #
+# body_diff precomputation + cost caps                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_precomputed_diff_matches_per_call_results():
+    old = "\n".join(f"line {i} stays the same" for i in range(30))
+    new = old.replace("line 7 stays", "line 7 mostly stays").replace(
+        "line 21 stays the same", "entirely new text here"
+    )
+    diff = comment_anchor.body_diff(old, new)
+    spans = [
+        (0, 10),
+        (old.index("line 7"), old.index("line 7") + len("line 7 stays")),
+        (old.index("line 21"), old.index("line 21") + len("line 21 stays the same")),
+        (len(old) - 15, len(old)),
+    ]
+    for s, e in spans:
+        assert remap_range(old, new, s, e, diff=diff) == remap_range(old, new, s, e)
+
+
+def test_multiline_edit_keeps_unchanged_line_anchor_exact():
+    old = "alpha\nbravo target words\ncharlie\n"
+    new = "alpha\nbravo target words\nCHARLIE REWRITTEN\n"
+    s = old.index("target")
+    assert remap_range(old, new, s, s + len("target words")) == (s, s + len("target words"))
+
+
+def test_over_cap_hunk_degrades_to_coarse_replace(monkeypatch):
+    monkeypatch.setattr(comment_anchor, "_MAX_HUNK_CHAR_PRODUCT", 4)
+    old = "stable\nthe quick brown fox\nstable2\n"
+    new = "stable\nthe quick red fox\nstable2\n"
+    s = old.index("quick")
+    # Under the cap the whole changed line stays one coarse replace opcode, so a
+    # span inside it collapses and orphans instead of fine-aligning.
+    assert remap_range(old, new, s, s + len("quick brown fox")) is None
+    # Anchors on unchanged lines are unaffected by the cap.
+    assert remap_range(old, new, 0, len("stable")) == (0, len("stable"))
+
+
+def test_over_cap_token_diff_skips_survival_guard(monkeypatch):
+    monkeypatch.setattr(comment_anchor, "_MAX_TOKEN_PRODUCT", 1)
+    old = "alpha\nthe quick brown fox\nomega\n"
+    new = "alpha\nthe quick red fox\nomega\n"
+    diff = comment_anchor.body_diff(old, new)
+    assert diff.token_opcodes is None
+    # Endpoint mapping still works; the guard is bypassed rather than orphaning.
+    s = old.index("quick")
+    result = remap_range(old, new, s, s + len("quick brown fox"), diff=diff)
+    assert result is not None
+    assert new[result[0] : result[1]] == "quick red fox"


### PR DESCRIPTION
## Problem

`after_doc_write` re-anchors comment and source-range spans on every commit via `comment_anchor.remap_range`, which ran a character-level `SequenceMatcher(autojunk=False)` over the two whole page bodies — quadratic in body length. Measured on a real ~190k-char page: **~750s of pure CPU for a single diff**, and `anchor_remap` repeated it (plus a token-level diff of the same shape) **once per stale span** — 11 spans on that page ≈ **~138 minutes per commit**.

This ran inline on the `documents` queue's single worker thread, so one commit to a large page pinned the worker at 100% CPU until the next deploy killed the pod — ingestion stalled for hours at a time, invisibly (queue depth gauge reads pending, not lag). Diagnosed from a live py-spy dump: the worker thread was in `difflib.find_longest_match` under `after_doc_write → remap_source_ranges`.

## Fix

- **`body_diff()`** — computes both diffs once per `(old_body, new_body)` pair; `anchor_remap` calls it once per `anchor_sha` group and passes it to every `remap_range` call (spans on a page almost always share one anchor sha, so this alone removes the per-span duplication).
- **Line-level pre-pass** — char opcodes come from a line diff, with character-level alignment only *inside* changed hunks. Lines are high-entropy elements, so the line pass is effectively linear; equal lines map positions exactly, so anchors in unchanged text get bit-identical results to the old whole-body diff.
- **Caps** so no future page shape can unbound the commit path:
  - a changed hunk over `_MAX_HUNK_CHAR_PRODUCT` (~2000×2000 chars) stays one coarse `replace` opcode — same outcome as a full rewrite of that hunk;
  - a body pair over `_MAX_TOKEN_PRODUCT` skips the survival guard (endpoint mapping stays exact; better than orphaning every anchor on a page too large to score). This cap is load-bearing: the token diff alone did not finish in 120s at ~50k tokens/side.

## Measured

| | before | after |
|---|---|---|
| worst real page (~190k chars, 11 stale spans) | ~138 min/commit | **0.013s** |
| unchanged-text anchors | exact | exact (identical results) |

Behavior deltas are confined to spans inside heavily-edited hunks (cross-hunk char matches no longer occur — those were the spurious alignments the survival guard exists to reject) and to over-cap pages (guard skipped).

All 23 pre-existing `test_comment_anchor` cases pass unchanged; new tests cover precomputed-diff equivalence, the hunk cap, and the token cap.

## Review fixes

- `45e5623f` — common prefix/suffix lines trimmed linearly before any matching (ordinary edits/appends no longer scale with page size); middle line diff guarded by `_MAX_LINE_PRODUCT` for duplicate-heavy bodies; replace-run `ratio()` capped by `_MAX_RUN_RATIO_PRODUCT`. Measured: 16k duplicate lines with divergent ends → 0.012s; 200k-char single-token replace → 0.001s.
- `9d1b19d1` — run similarity memoized on `BodyDiff` (`run_similarity()`), so N spans overlapping the same edited run pay its capped ratio once, not N times.
