### PR TITLE
feat(editor): let a task list hold plain items alongside checkbox items

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -140,16 +140,27 @@
   list-style: none;
   padding-left: 0;
 }
-/* Direct children only. A task item's own `li` is a flex row so the checkbox
-   sits beside its content, but a plain `li` renders as `<li><p>text</p><ul>
-   …</ul></li>` — flexed, its paragraph and its nested list become two
-   side-by-side columns instead of a list under a line of text. A descendant
-   selector hits every nested plain item under a task list, which on a page
-   that mixes the two is most of the page. */
-.editor-prose ul[data-type="taskList"] > li {
+/* Task items only, and direct children only. The flex row is what puts the
+   checkbox beside its content, so it belongs to `taskItem` rather than to
+   anything sitting in a task list: a plain `li` renders as
+   `<li><p>text</p><ul>…</ul></li>`, and flexed, its paragraph and its nested
+   list become two side-by-side columns instead of a list under a line of
+   text. A task list can now hold both kinds (see `MixedTaskList`), and a
+   descendant selector would additionally hit every nested plain item further
+   down. `data-checked` is what marks a task item in the DOM — the installed
+   TaskItem renders that and nothing else, no `data-type`. */
+.editor-prose ul[data-type="taskList"] > li[data-checked] {
   display: flex;
   align-items: flex-start;
   gap: 0.5rem;
+}
+/* A plain item in a task list. The list itself is `list-style: none` for the
+   checkbox rows, so this restores an ordinary bullet, and the indent puts its
+   text on the same column as a task item's (checkbox 1rem + 0.5rem gap) so a
+   mixed list reads as one list rather than two interleaved ones. */
+.editor-prose ul[data-type="taskList"] > li:not([data-checked]) {
+  list-style: disc;
+  margin-left: 1.5rem;
 }
 /* A nested task list carries no bullet or marker to sit under, so without an
    indent of its own it starts at the parent's text column and the nesting

--- a/frontend/src/lib/editor/blocks.ts
+++ b/frontend/src/lib/editor/blocks.ts
@@ -46,6 +46,7 @@ import {
 } from "@tiptap/core";
 import { Fragment } from "@tiptap/pm/model";
 import { Plugin, TextSelection, type Transaction } from "@tiptap/pm/state";
+import { TaskList } from "@tiptap/extension-task-list";
 import { isSameOriginSrc } from "./media";
 
 /** Internal bookkeeping attrs never rendered into the DOM (`rendered:
@@ -225,6 +226,33 @@ export const HeadingBackspace = Extension.create({
  * the well-tested primitive for exactly this "exit the list" operation,
  * and it's available as a core command regardless of whether `ListKeymap`
  * is installed. */
+/** `taskList` widened to hold plain `listItem`s alongside `taskItem`s.
+ *
+ * GFM lets a single list mix checkbox and non-checkbox items freely — a TODO
+ * page where some bullets are tasks and some are section labels ("Phase 2",
+ * "@ mention someone") is the ordinary case, not an edge one. Tiptap's stock
+ * `taskList` is `taskItem+`, which cannot represent that, so the backend codec
+ * has to demote any mixed list to a plain `bulletList` and every `[x]` in it
+ * renders as literal text instead of a checkbox (see `_build_list`'s uniformity
+ * rule).
+ *
+ * The item types already coexist cleanly: `listItem` and `taskItem` both hold
+ * `paragraph block*`, so nesting, lifting and splitting behave the same in
+ * either, and `prosemirror-schema-list`'s commands operate on whichever type
+ * they're given. The only thing the stock spec adds is the uniformity
+ * constraint itself.
+ *
+ * The rendered `li` carries `data-checked` on task items and no attributes at
+ * all on plain ones, which is what the stylesheet keys the checkbox row off —
+ * a plain item in a task list gets an ordinary bullet, aligned to the same
+ * text column so a mixed list reads as one list rather than two interleaved
+ * ones. */
+export const MixedTaskList = TaskList.extend({
+  content() {
+    return `(${this.options.itemTypeName}|listItem)+`;
+  },
+});
+
 export const TaskItemBackspace = Extension.create({
   name: "taskItemBackspace",
   priority: 200,

--- a/frontend/src/lib/editor/extensions.ts
+++ b/frontend/src/lib/editor/extensions.ts
@@ -1,7 +1,6 @@
 import type { AnyExtension } from "@tiptap/core";
 import { Collaboration } from "@tiptap/extension-collaboration";
 import { TaskItem } from "@tiptap/extension-task-item";
-import { TaskList } from "@tiptap/extension-task-list";
 import { Placeholder } from "@tiptap/extensions";
 import { StarterKit } from "@tiptap/starter-kit";
 import type { Awareness } from "y-protocols/awareness";
@@ -13,6 +12,7 @@ import {
   Image,
   InlineCode,
   MarkdownLink,
+  MixedTaskList,
   OtherBlock,
   Table,
   TableRow,
@@ -63,7 +63,7 @@ export function tiptapExtensions(
       // reconcile it against, so it's just a wrong extra block.
       trailingNode: false,
     }),
-    TaskList,
+    MixedTaskList,
     TaskItem.configure({ nested: true }),
     TaskItemBackspace,
     BlockIdentity,


### PR DESCRIPTION
**Merge this before the backend half.** It widens the editor's schema to accept a shape nothing produces yet, which is inert on its own. The reverse order is not safe: a client on the old bundle would hard-reject a `taskList` containing a `listItem` and render the page blank — the #562 failure.

## Why

Tiptap's stock `taskList` is `taskItem+`, so a list cannot mix checkbox and non-checkbox items. GFM has no such rule. The cost lands in the codec: a `taskList`'s children must be uniformly `taskItem`s, so `_build_list` demotes any mixed list to a plain `bulletList`, and every `[ ]`/`[x]` in it renders as literal text.

On a TODO page that shape is the norm — some bullets are tasks, some are section labels (`Phase 2`, `@ mention someone in a comment`) — so most checkboxes on such a page don't render as checkboxes:

## What changes

`MixedTaskList` extends `TaskList` to `(taskItem|listItem)+`. The two item types already coexist — both hold `paragraph block*`, so nesting, lifting and splitting behave identically in either, and `prosemirror-schema-list`'s commands act on whichever type they're handed. The uniformity constraint is the only thing the stock spec contributes.

Styling moves from the list to the item. The flex row that puts a checkbox beside its content is keyed on `data-checked` — the attribute the installed TaskItem actually renders; it emits no `data-type`, verified against the live DOM rather than the package source, which claims otherwise. A plain item in a task list gets an ordinary bullet indented to the same text column, so a mixed list reads as one list rather than two interleaved ones.

## Testing

Verified end to end on a local stack against the real page body from the bug report, with the backend half applied locally: mixed lists render checkboxes for marked items and bullets for unmarked ones, single column, nesting intact. A live edit + checkpoint round-trips the full 28k-char body with 120 lines in / 120 out, zero structural drift, zero empty `- [ ]` stubs, and all 49 escaped markers restored to live ones.

`tsc` and prettier clean.
