### PR TITLE
feat(codec): one marker is enough to make a list a task list

### DIFF
--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -12,10 +12,11 @@ sibling ``XmlElement``, not to a text mark, since a break is a node boundary,
 not formatting), ``bulletList``/``orderedList``/``listItem`` (arbitrarily
 nested — CommonMark's own grammar is already recursive here, so supporting
 depth costs about the same as supporting one level), ``taskList``/
-``taskItem`` (a GFM checkbox list — a plain bullet list whose items *all*
-start with a ``[ ]``/``[x]`` marker; a mixed list stays a regular
-``bulletList`` since a taskList's children must be uniformly taskItems — see
-``_build_list``), ``blockquote`` (a sequence of paragraph/list/blockquote
+``taskItem`` (a GFM checkbox list — a bullet list where *at least one* item
+starts with a ``[ ]``/``[x]`` marker; items without one stay plain
+``listItem`` children of the same ``taskList``, since GFM lets a list mix the
+two and the editor's schema holds that mix — see ``_build_list``),
+``blockquote`` (a sequence of paragraph/list/blockquote
 children, so multi-paragraph quotes and quotes containing lists work), and
 ``codeBlock`` (a ``language`` attribute + plain text content, fence syntax
 stripped — not stored as opaque markup). Tables get row-level structure
@@ -671,15 +672,17 @@ def _build_list(
             continue
         raise NotImplementedError(f"unexpected token inside list: {t.type!r}")
 
-    # A bullet list becomes a task list only when *every* item carries a
-    # checkbox marker — a taskList schema requires uniform taskItem
-    # children, so a mixed list (some items marked, some not) can't become
-    # one; it stays a plain bulletList with the literal "[ ] "/"[x] " text
-    # visible.
+    # A bullet list becomes a task list as soon as *any* item carries a
+    # checkbox marker, and the unmarked items ride along as plain listItems —
+    # which is how GFM reads it, and what the editor's widened `taskList`
+    # holds (see `MixedTaskList`). Requiring every item to be marked instead
+    # demoted the whole list to a bulletList over one unmarked entry, so every
+    # "[ ] "/"[x] " in it rendered as literal text; on a list mixing tasks with
+    # section labels ("Phase 2") that is the common case, not a rare one.
     task_matches = (
         None if ordered else [_list_item_task_marker(tokens, s, e) for s, e in item_ranges]
     )
-    is_task_list = bool(item_ranges) and task_matches is not None and all(task_matches)
+    is_task_list = bool(item_ranges) and task_matches is not None and any(task_matches)
 
     attrs = dict(extra_attrs or {})
     if is_task_list:
@@ -692,9 +695,8 @@ def _build_list(
     items: list[XmlElement] = []
     finishers: list[Any] = []
     for idx, (item_start, item_end) in enumerate(item_ranges):
-        if is_task_list:
-            match = task_matches[idx]  # type: ignore[index]
-            assert match is not None
+        match = task_matches[idx] if is_task_list else None  # type: ignore[index]
+        if match is not None:
             checked = match.group(1).lower() == "x"
             first_text = tokens[item_start + 1].children[0]
             first_text.content = first_text.content[match.end() :]
@@ -984,11 +986,13 @@ def _serialize_list(node: XmlElement) -> str:
     (``markdown_splice.py``), which never calls this serializer at all.
     """
     ordered = node.tag == "orderedList"
-    is_task = node.tag == "taskList"
     attrs = dict(node.attributes)
     start = int(attrs.get("start", "1")) if ordered else 1
     lines: list[str] = []
     for idx, item in enumerate(node.children):
+        # Per item, not per list: a taskList holds plain listItems alongside
+        # taskItems (see `_build_list`), and each one carries its own marker.
+        is_task = item.tag == "taskItem"
         if is_task:
             checked = _is_checked(dict(item.attributes).get("checked"))
             marker = f"- [{'x' if checked else ' '}] "
@@ -1009,9 +1013,9 @@ def _serialize_list(node: XmlElement) -> str:
         body = _serialize_block_sequence(list(item.children), indent)  # type: ignore[arg-type]
         if not is_task:
             # A literal "[x] " opening a plain list item is a checkbox marker
-            # the parse declined to promote — the list is mixed (a taskList's
-            # children must be uniformly taskItems, see `_build_list`) or it's
-            # ordered — not decorative text. `_escape_inline_text` escapes every
+            # the parse declined to promote — the item is in an ordered list,
+            # which is never promoted (see `_build_list`) — not decorative
+            # text. `_escape_inline_text` escapes every
             # "["/"]" it sees, which here would rewrite a marker that GFM
             # readers and a later uniform version of this same list still act on
             # into permanently inert text, an edit nothing in the editor shows

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -672,13 +672,13 @@ def _build_list(
             continue
         raise NotImplementedError(f"unexpected token inside list: {t.type!r}")
 
-    # A bullet list becomes a task list as soon as *any* item carries a
-    # checkbox marker, and the unmarked items ride along as plain listItems —
-    # which is how GFM reads it, and what the editor's widened `taskList`
-    # holds (see `MixedTaskList`). Requiring every item to be marked instead
-    # demoted the whole list to a bulletList over one unmarked entry, so every
-    # "[ ] "/"[x] " in it rendered as literal text; on a list mixing tasks with
-    # section labels ("Phase 2") that is the common case, not a rare one.
+    # A bullet list is a task list when at least one item carries a checkbox
+    # marker. Marked items become taskItem children, with the marker consumed
+    # into the `checked` attribute; unmarked items stay plain listItem
+    # children of that same taskList, markers being the only thing that
+    # distinguishes the two. GFM lets a list mix them, and the editor's
+    # taskList schema holds both (`MixedTaskList`). An ordered list is never
+    # a task list.
     task_matches = (
         None if ordered else [_list_item_task_marker(tokens, s, e) for s, e in item_ranges]
     )

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -357,9 +357,7 @@ def test_task_list_structure_and_checked_attribute() -> None:
 
 def test_mixed_task_and_plain_items_becomes_a_task_list() -> None:
     """One marker is enough to make the list a taskList; the unmarked items
-    ride along as plain listItems. That mix is what GFM reads and what the
-    editor's widened taskList holds, so the marker stays a checkbox instead
-    of decaying to literal text over an unmarked sibling."""
+    are plain listItems in that same list."""
     doc = seed_doc_from_markdown("- [ ] marked\n- unmarked\n")
     root = _root(doc)
     lst = root.children[0]

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -355,16 +355,39 @@ def test_task_list_structure_and_checked_attribute() -> None:
     assert items[0].children[0].children[0].to_py() == "todo"
 
 
-def test_mixed_task_and_plain_items_stays_plain_bullet_list() -> None:
-    """A taskList schema requires uniformly-taskItem children — a list
-    where only some items carry a checkbox marker can't become one, so it
-    stays a plain bulletList (the marker text is then literal, same as
-    pre-checkbox-support behavior)."""
+def test_mixed_task_and_plain_items_becomes_a_task_list() -> None:
+    """One marker is enough to make the list a taskList; the unmarked items
+    ride along as plain listItems. That mix is what GFM reads and what the
+    editor's widened taskList holds, so the marker stays a checkbox instead
+    of decaying to literal text over an unmarked sibling."""
     doc = seed_doc_from_markdown("- [ ] marked\n- unmarked\n")
     root = _root(doc)
     lst = root.children[0]
+    assert lst.tag == "taskList"
+    assert [i.tag for i in lst.children] == ["taskItem", "listItem"]
+    # The marker is consumed for the task item and left alone for the plain
+    # one — a listItem's text is its own content, markers and all.
+    assert lst.children[0].children[0].children[0].to_py() == "marked"
+    assert lst.children[1].children[0].children[0].to_py() == "unmarked"
+
+
+def test_a_list_with_no_markers_stays_a_bullet_list() -> None:
+    doc = seed_doc_from_markdown("- one\n- two\n")
+    lst = _root(doc).children[0]
     assert lst.tag == "bulletList"
     assert [i.tag for i in lst.children] == ["listItem", "listItem"]
+
+
+def test_mixed_list_round_trips_byte_identically() -> None:
+    """The serializer picks the marker per item rather than per list, so a
+    mixed list survives a round trip unchanged in both directions."""
+    for body in (
+        "- [x] marked\n\n- unmarked\n",
+        "- [x] top\n\n- mid\n\n  - [ ] nested\n\n  - also plain\n",
+    ):
+        once = reconstruct_body(seed_doc_from_markdown(body))
+        assert once == body
+        assert once == reconstruct_body(seed_doc_from_markdown(once))
 
 
 def test_mixed_list_keeps_its_checkbox_markers() -> None:


### PR DESCRIPTION
**Do not merge before #572.** That PR teaches the editor the schema this one starts emitting. In the other order, a client on the old bundle hard-rejects a `taskList` containing a `listItem` and renders the page blank — the #562 failure mode.

## Why

`_build_list` promoted a bullet list to a `taskList` only when **every** item carried a `[ ]`/`[x]` marker, because a `taskList`'s children had to be uniformly `taskItem`s. A single unmarked sibling demoted the whole list to a `bulletList`, and every marker in it became literal text.

On a TODO page mixing tasks with section labels (`Phase 2`, `@ mention someone in a comment`) that is the ordinary shape — so most of the checkboxes on such a page weren't checkboxes. #567 stopped those markers being *destroyed* on save; this makes them render.

## What changes

- `all(task_matches)` → `any(task_matches)`. Unmarked items become plain `listItem` children of the same `taskList`.
- `_serialize_list` picks the marker per item from the item's own tag instead of per list from the list's tag, so `- [x] ` and `- ` interleave correctly.
- The escape exemption from #567 narrows accordingly: with mixed bullet lists now promoted, the only list whose items still carry a literal marker is an ordered one, which is never promoted.

## Testing

Five list shapes — mixed, uniform, unmarked, ordered, nested-mixed — all round-trip **byte-identically** and idempotently.

Against the real 28,070-char page body from the bug report: 120 lines in / 120 out, idempotent, zero unexplained structural drift, zero empty `- [ ]` stubs, and all 49 escaped markers restored to live ones. Verified through a real editor checkpoint on a local stack with #572 applied, not only the codec in isolation.

One existing test asserted the old behavior (`test_mixed_task_and_plain_items_stays_plain_bullet_list`) and is replaced by its inverse, plus a no-marker case and a byte-identity round trip. Full codec, splice, blocks and checkpoint suites pass; ruff and basedpyright clean.