### PR TITLE
fix(tasks): reclaim orphaned stream entries + truthful queue gauges

### DIFF
--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -133,10 +133,10 @@ ingest_llm_calls_per_doc = Histogram(
     buckets=[0, 1, 2, 3, 5, 8, 10, 15, 20],
 )
 
-ingest_queue_depth = Gauge(
-    "ingest_queue_depth",
-    "Current number of pending tasks in the documents queue",
-)
+# ingest_queue_depth is exported by _TaskQueueCollector below — sampled at
+# scrape time so it stays truthful while the worker is stalled or freshly
+# restarted (a handler-set gauge freezes at its last write and resets to 0 on
+# every worker boot, which is how a fully stalled queue once read as 0).
 
 # --------------------------------------------------------------------------- #
 # Wiki media                                                                 #
@@ -232,19 +232,34 @@ class _TaskQueueCollector:
             "Pending messages (ready + delayed) per task queue",
             labels=["queue"],
         )
+        in_flight = GaugeMetricFamily(
+            "task_queue_in_flight",
+            "Delivered-but-unacked messages per task queue (stuck deliveries show here)",
+            labels=["queue"],
+        )
         age = GaugeMetricFamily(
             "task_queue_oldest_age_seconds",
             "Age of the oldest ready message per task queue (0 when empty)",
             labels=["queue"],
         )
+        ingest_depth = GaugeMetricFamily(
+            "ingest_queue_depth",
+            "Current number of pending tasks in the documents queue",
+        )
         for name, q in QUEUES.items():
             try:
-                depth.add_metric([name], q.depth().pending)
+                d = q.depth()
+                depth.add_metric([name], d.pending)
+                in_flight.add_metric([name], d.in_flight)
                 age.add_metric([name], q.oldest_age_seconds() or 0.0)
+                if name == "documents":
+                    ingest_depth.add_metric([], d.pending)
             except Exception:
                 log.warning("metrics: queue stats failed for %s", name, exc_info=True)
         yield depth
+        yield in_flight
         yield age
+        yield ingest_depth
 
 
 REGISTRY.register(_TaskQueueCollector())

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -737,8 +737,11 @@ def _process_one(
             "queue %s: task %s failed (entry=%s retry=%d)",
             queue.name, task_name, stream_entry_id, retry_count,
         )
-        # Drop the entry, then re-enqueue a fresh copy if retries remain.
-        _drop_entry(queue, r, stream_entry_id)
+        # Persist the retry copy BEFORE dropping the entry. If any step after
+        # the persist fails partway, the original entry is still (or again)
+        # deliverable and the worst case is a duplicate retry, bounded by the
+        # delivery cap — whereas drop-then-persist failing between the two
+        # would leave no copy anywhere and lose the task outright.
         if retry_count < max_retries:
             backoff = _retry_backoff_seconds(retry_count + 1)
             log.info(
@@ -757,6 +760,7 @@ def _process_one(
                 "queue %s: task %s exceeded %d retries — dropping entry %s",
                 queue.name, task_name, max_retries, stream_entry_id,
             )
+        _drop_entry(queue, r, stream_entry_id)
         return
 
     _drop_entry(queue, r, stream_entry_id)

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -48,7 +48,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any, Callable, Generator
+from typing import Any, Callable, Generator, cast
 
 import redis as redis_lib
 from croniter import croniter
@@ -66,6 +66,11 @@ log = logging.getLogger(__name__)
 _DEFAULT_VT_SECONDS = 300       # visibility timeout — how long a worker holds a message
 _POLL_IDLE_SLEEP = 1.0          # seconds to sleep when the stream is empty
 _MAX_RETRIES = 3
+# An entry claimed this many times without being acked is dropped as poison:
+# each delivery means a consumer took it and died/stalled before finishing, so
+# handing it to a fourth consumer would just wedge that one too.
+_MAX_DELIVERIES = 3
+_RECLAIM_BATCH = 10             # stale entries adopted per idle reclaim pass
 _RETRY_BASE_SECONDS = 30
 _RETRY_MAX_SECONDS = 600
 _LEADER_RETRY_SECONDS = 30
@@ -582,26 +587,99 @@ def _worker_loop(
             continue
 
         if not results:
+            _reclaim_stale(queue, consumer_name, r, vt_seconds, max_retries)
             continue
 
-        for _stream, messages in results:
-            for stream_entry_id, fields in messages:
-                payload_json = fields.get("payload", "{}")
-                try:
-                    body: dict[str, Any] = json.loads(payload_json)
-                except (ValueError, TypeError):
-                    log.error(
-                        "queue %s: malformed payload at %s — acking and skipping",
-                        queue.name, stream_entry_id,
-                    )
-                    r.xack(_stream_key(queue.name), "workers", stream_entry_id)
-                    r.xdel(_stream_key(queue.name), stream_entry_id)
-                    continue
-                _process_one(
-                    queue, stream_entry_id, body, r, max_retries=max_retries,
-                )
+        try:
+            for _stream, messages in results:
+                for stream_entry_id, fields in messages:
+                    _handle_entry(queue, stream_entry_id, fields, r, max_retries)
+        except Exception:
+            # _process_one contains handler failures, but anything escaping it
+            # (a Redis error on ack, a malformed message shape) must not kill
+            # this thread: its exception would land in a Future nobody reads,
+            # and the queue would silently stop consuming until pod restart.
+            log.exception("queue %s: worker loop error — continuing", queue.name)
 
     log.debug("queue %s: worker %s stopped", queue.name, consumer_name)
+
+
+def _handle_entry(
+    queue: TaskQueue, stream_entry_id: str, fields: dict[str, Any], r: Any, max_retries: int
+) -> None:
+    payload_json = fields.get("payload", "{}")
+    try:
+        body: dict[str, Any] = json.loads(payload_json)
+    except (ValueError, TypeError):
+        log.error(
+            "queue %s: malformed payload at %s — acking and skipping",
+            queue.name, stream_entry_id,
+        )
+        r.xack(_stream_key(queue.name), "workers", stream_entry_id)
+        r.xdel(_stream_key(queue.name), stream_entry_id)
+        return
+    _process_one(queue, stream_entry_id, body, r, max_retries=max_retries)
+
+
+def _reclaim_stale(
+    queue: TaskQueue, consumer_name: str, r: Any, vt_seconds: int, max_retries: int
+) -> None:
+    """Adopt pending entries whose consumer died or stalled past ``vt_seconds``.
+
+    ``XREADGROUP ">"`` never re-reads another consumer's pending entries, and
+    every worker start mints a fresh consumer name — so an entry in flight when
+    its worker was killed would otherwise sit in the PEL forever, invisible to
+    all future consumers. Runs only when this consumer is idle, so a busy
+    single-consumer queue never steals its own in-flight work.
+
+    Reclaim makes delivery at-least-once: a handler that outlives ``vt_seconds``
+    while another consumer is idle can run twice. Entries delivered more than
+    ``_MAX_DELIVERIES`` times are dropped as poison rather than wedging every
+    successive consumer.
+    """
+    sk = _stream_key(queue.name)
+    try:
+        resp = r.xautoclaim(
+            sk, "workers", consumer_name,
+            min_idle_time=vt_seconds * 1000, start_id="0-0", count=_RECLAIM_BATCH,
+        )
+    except Exception:
+        log.exception("queue %s: xautoclaim failed", queue.name)
+        return
+    # redis-py returns (next_start_id, messages[, deleted_ids]) depending on
+    # server version; index 1 is the claimed messages in every shape.
+    try:
+        messages = cast("list[tuple[str, dict[str, Any] | None]]", resp[1])
+    except (IndexError, TypeError):
+        return
+    for stream_entry_id, fields in messages:
+        if fields is None:
+            continue  # entry was XDELed while still pending — nothing to run
+        delivered = 1
+        try:
+            info = r.xpending_range(
+                sk, "workers", min=stream_entry_id, max=stream_entry_id, count=1,
+            )
+            if info:
+                delivered = int(info[0].get("times_delivered", 1))
+        except Exception:
+            log.warning("queue %s: xpending_range failed for %s", queue.name, stream_entry_id)
+        if delivered > _MAX_DELIVERIES:
+            log.warning(
+                "queue %s: entry %s delivered %d times without completing — dropping as poison",
+                queue.name, stream_entry_id, delivered,
+            )
+            r.xack(sk, "workers", stream_entry_id)
+            r.xdel(sk, stream_entry_id)
+            continue
+        log.info(
+            "queue %s: reclaimed stale entry %s (delivery %d)",
+            queue.name, stream_entry_id, delivered,
+        )
+        try:
+            _handle_entry(queue, stream_entry_id, fields, r, max_retries)
+        except Exception:
+            log.exception("queue %s: reclaimed entry %s failed", queue.name, stream_entry_id)
 
 
 def _process_one(

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -71,6 +71,12 @@ _MAX_RETRIES = 3
 # handing it to a fourth consumer would just wedge that one too.
 _MAX_DELIVERIES = 3
 _RECLAIM_BATCH = 10             # stale entries adopted per idle reclaim pass
+# Reclaim fires at vt * factor, not vt itself. Reclaiming an entry whose
+# consumer is merely *slow* (not dead) runs it twice, and several handlers have
+# non-idempotent side effects (trigger notifications, wiki commits) — so the
+# reclaim horizon sits well past any handler's legitimate runtime while still
+# recovering orphans within minutes. 3 x 300s = 15 min.
+_RECLAIM_IDLE_FACTOR = 3
 _RETRY_BASE_SECONDS = 30
 _RETRY_MAX_SECONDS = 600
 _LEADER_RETRY_SECONDS = 30
@@ -632,16 +638,19 @@ def _reclaim_stale(
     all future consumers. Runs only when this consumer is idle, so a busy
     single-consumer queue never steals its own in-flight work.
 
-    Reclaim makes delivery at-least-once: a handler that outlives ``vt_seconds``
-    while another consumer is idle can run twice. Entries delivered more than
+    Reclaim makes delivery at-least-once: a handler still running past the
+    reclaim horizon (``vt_seconds * _RECLAIM_IDLE_FACTOR``) while another
+    consumer is idle runs twice. Entries delivered more than
     ``_MAX_DELIVERIES`` times are dropped as poison rather than wedging every
-    successive consumer.
+    successive consumer. Never raises — this runs on the consumer thread's
+    idle path, outside the message-handling guard.
     """
     sk = _stream_key(queue.name)
     try:
         resp = r.xautoclaim(
             sk, "workers", consumer_name,
-            min_idle_time=vt_seconds * 1000, start_id="0-0", count=_RECLAIM_BATCH,
+            min_idle_time=vt_seconds * _RECLAIM_IDLE_FACTOR * 1000,
+            start_id="0-0", count=_RECLAIM_BATCH,
         )
     except Exception:
         log.exception("queue %s: xautoclaim failed", queue.name)
@@ -653,32 +662,31 @@ def _reclaim_stale(
     except (IndexError, TypeError):
         return
     for stream_entry_id, fields in messages:
-        if fields is None:
-            continue  # entry was XDELed while still pending — nothing to run
-        delivered = 1
         try:
+            if fields is None:
+                continue  # entry was XDELed while still pending — nothing to run
+            delivered = 1
             info = r.xpending_range(
                 sk, "workers", min=stream_entry_id, max=stream_entry_id, count=1,
             )
             if info:
                 delivered = int(info[0].get("times_delivered", 1))
-        except Exception:
-            log.warning("queue %s: xpending_range failed for %s", queue.name, stream_entry_id)
-        if delivered > _MAX_DELIVERIES:
-            log.warning(
-                "queue %s: entry %s delivered %d times without completing — dropping as poison",
+            if delivered > _MAX_DELIVERIES:
+                log.warning(
+                    "queue %s: entry %s delivered %d times without completing — dropping as poison",
+                    queue.name, stream_entry_id, delivered,
+                )
+                r.xack(sk, "workers", stream_entry_id)
+                r.xdel(sk, stream_entry_id)
+                continue
+            log.info(
+                "queue %s: reclaimed stale entry %s (delivery %d)",
                 queue.name, stream_entry_id, delivered,
             )
-            r.xack(sk, "workers", stream_entry_id)
-            r.xdel(sk, stream_entry_id)
-            continue
-        log.info(
-            "queue %s: reclaimed stale entry %s (delivery %d)",
-            queue.name, stream_entry_id, delivered,
-        )
-        try:
             _handle_entry(queue, stream_entry_id, fields, r, max_retries)
         except Exception:
+            # One bad entry (or a Redis hiccup on its ack/delete) must not
+            # abort the remaining claims or escape to kill the consumer.
             log.exception("queue %s: reclaimed entry %s failed", queue.name, stream_entry_id)
 
 

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -621,10 +621,25 @@ def _handle_entry(
             "queue %s: malformed payload at %s — acking and skipping",
             queue.name, stream_entry_id,
         )
-        r.xack(_stream_key(queue.name), "workers", stream_entry_id)
-        r.xdel(_stream_key(queue.name), stream_entry_id)
+        _drop_entry(queue, r, stream_entry_id)
         return
     _process_one(queue, stream_entry_id, body, r, max_retries=max_retries)
+
+
+
+def _drop_entry(queue: TaskQueue, r: Any, stream_entry_id: str) -> None:
+    """Remove a finished (or discarded) entry: XDEL first, then XACK.
+
+    The failure modes between the two calls are asymmetric. Delete-then-ack
+    failing halfway leaves a dangling PEL reference to a deleted entry, which
+    the next XAUTOCLAIM pass cleans up (Redis returns such entries with no
+    fields; the reclaim loop skips them). Ack-then-delete failing halfway
+    leaves an acked entry in the stream forever — never deliverable again,
+    invisible to reclaim, but still counted by depth().ready and pinning
+    oldest_age_seconds(): a zombie backlog that cannot drain.
+    """
+    r.xdel(_stream_key(queue.name), stream_entry_id)
+    r.xack(_stream_key(queue.name), "workers", stream_entry_id)
 
 
 def _reclaim_stale(
@@ -676,8 +691,7 @@ def _reclaim_stale(
                     "queue %s: entry %s delivered %d times without completing — dropping as poison",
                     queue.name, stream_entry_id, delivered,
                 )
-                r.xack(sk, "workers", stream_entry_id)
-                r.xdel(sk, stream_entry_id)
+                _drop_entry(queue, r, stream_entry_id)
                 continue
             log.info(
                 "queue %s: reclaimed stale entry %s (delivery %d)",
@@ -709,8 +723,7 @@ def _process_one(
             "queue %s: no handler for task %r — discarding entry %s",
             queue.name, task_name, stream_entry_id,
         )
-        r.xack(_stream_key(queue.name), "workers", stream_entry_id)
-        r.xdel(_stream_key(queue.name), stream_entry_id)
+        _drop_entry(queue, r, stream_entry_id)
         return
 
     try:
@@ -724,9 +737,8 @@ def _process_one(
             "queue %s: task %s failed (entry=%s retry=%d)",
             queue.name, task_name, stream_entry_id, retry_count,
         )
-        # Ack first (remove from PEL), then re-enqueue if retries remain.
-        r.xack(_stream_key(queue.name), "workers", stream_entry_id)
-        r.xdel(_stream_key(queue.name), stream_entry_id)
+        # Drop the entry, then re-enqueue a fresh copy if retries remain.
+        _drop_entry(queue, r, stream_entry_id)
         if retry_count < max_retries:
             backoff = _retry_backoff_seconds(retry_count + 1)
             log.info(
@@ -747,8 +759,7 @@ def _process_one(
             )
         return
 
-    r.xack(_stream_key(queue.name), "workers", stream_entry_id)
-    r.xdel(_stream_key(queue.name), stream_entry_id)
+    _drop_entry(queue, r, stream_entry_id)
 
 
 # --------------------------------------------------------------------------- #

--- a/backend/app/tasks/wiki_update.py
+++ b/backend/app/tasks/wiki_update.py
@@ -45,7 +45,6 @@ from app.metrics import (
     ingest_document_results_total,
     ingest_llm_calls_per_doc,
     ingest_outcomes_total,
-    ingest_queue_depth,
     ingest_requests_total,
     ingest_selector_candidates_filtered,
     ingest_selector_duration_seconds,
@@ -306,7 +305,6 @@ def _reconcile_pushed_document(push: dict[str, Any]) -> None:
 
     ingest_requests_total.labels(source_type=source_type or "unknown").inc()
     ingest_document_chars.labels(source_type=source_type or "unknown").observe(len(content))
-    ingest_queue_depth.set(documents_queue.depth().pending)
 
     if is_filtered(source_type):
         log.debug("process_pushed_document: filtered source %s, dropping", source_type)

--- a/backend/tests/test_task_queue_metrics.py
+++ b/backend/tests/test_task_queue_metrics.py
@@ -93,7 +93,12 @@ def test_task_queue_collector_labels_every_queue(monkeypatch):
     monkeypatch.setattr(queue_mod, "get_redis", lambda: fake)
 
     families = {f.name: f for f in metrics._TaskQueueCollector().collect()}
-    assert set(families) == {"task_queue_depth", "task_queue_oldest_age_seconds"}
+    assert set(families) == {
+        "task_queue_depth",
+        "task_queue_in_flight",
+        "task_queue_oldest_age_seconds",
+        "ingest_queue_depth",
+    }
 
     depth = families["task_queue_depth"]
     seen = {s.labels["queue"] for s in depth.samples}

--- a/backend/tests/test_task_queue_reclaim.py
+++ b/backend/tests/test_task_queue_reclaim.py
@@ -188,3 +188,64 @@ def test_poison_drop_ordering_and_partial_failure_leaves_no_zombie():
     _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)  # contained
     assert ("xdel", "1-0") in r.ops  # stream entry removed despite the ack failure
     assert r.deleted == ["1-0"]
+
+
+def test_failed_handler_persists_retry_before_dropping_entry():
+    # Retry-copy persistence must precede the drop: if the drop half-fails
+    # after XDEL, the already-persisted retry is what keeps the task alive.
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+
+    def _boom():
+        raise RuntimeError("handler failed")
+
+    q.handlers["boom"] = _boom
+
+    class _OrderedRetry(_OpOrderRedis):
+        def incr(self, key):
+            self.ops.append(("incr", key))
+            return 1
+
+        def hset(self, key, field, value):
+            self.ops.append(("hset", field))
+            return 1
+
+        def zadd(self, key, mapping):
+            self.ops.append(("zadd", next(iter(mapping))))
+            return 1
+
+    r = _OrderedRetry(claimed=[("1-0", _payload("boom"))], delivered={"1-0": 1})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    names = [op for op, _ in r.ops]
+    assert names.index("zadd") < names.index("xdel")  # retry persisted first
+
+
+def test_retry_survives_ack_failure_after_delete():
+    # The reported loss scenario: handler fails, XDEL succeeds, XACK raises.
+    # The retry copy must already be in the delay structures.
+    q = TaskQueue(name="reclaimq", max_size=10)
+
+    def _boom():
+        raise RuntimeError("handler failed")
+
+    q.handlers["boom"] = _boom
+    persisted: list[str] = []
+
+    class _AckBoomAfterDel(_OpOrderRedis):
+        def incr(self, key):
+            return 7
+
+        def hset(self, key, field, value):
+            persisted.append(field)
+            return 1
+
+        def zadd(self, key, mapping):
+            return 1
+
+        def xack(self, key, group, entry_id):
+            raise RuntimeError("redis down")
+
+    r = _AckBoomAfterDel(claimed=[("1-0", _payload("boom"))], delivered={"1-0": 1})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)  # contained
+    assert persisted == ["7"]  # the retry body exists despite the failed ack
+    assert ("xdel", "1-0") in r.ops

--- a/backend/tests/test_task_queue_reclaim.py
+++ b/backend/tests/test_task_queue_reclaim.py
@@ -18,8 +18,10 @@ class _FakeRedis:
         self.delivered = delivered  # entry id -> times_delivered after the claim
         self.acked: list[str] = []
         self.deleted: list[str] = []
+        self.min_idle_seen: int | None = None
 
     def xautoclaim(self, key, group, consumer, min_idle_time, start_id, count):
+        self.min_idle_seen = min_idle_time
         return ("0-0", self.claimed, [])
 
     def xpending_range(self, key, group, min, max, count):
@@ -80,3 +82,65 @@ def test_reclaim_survives_xautoclaim_failure():
             raise RuntimeError("redis down")
 
     _reclaim_stale(q, "worker-x", _Boom([], {}), vt_seconds=300, max_retries=3)  # no raise
+
+
+def test_reclaim_horizon_is_vt_times_factor():
+    # A merely-slow consumer must keep its entry until well past vt: reclaim
+    # asks Redis for entries idle >= vt * _RECLAIM_IDLE_FACTOR, not vt itself.
+    q = _queue_with_handler([])
+    r = _FakeRedis(claimed=[], delivered={})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert r.min_idle_seen == 300 * queue_mod._RECLAIM_IDLE_FACTOR * 1000
+
+
+def test_poison_drop_redis_failure_contained_and_next_entry_still_runs():
+    # xack raising on the poison entry must neither escape _reclaim_stale nor
+    # abort the rest of the claimed batch.
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+    over = queue_mod._MAX_DELIVERIES + 1
+
+    class _AckBoom(_FakeRedis):
+        def xack(self, key, group, entry_id):
+            if entry_id == "1-0":
+                raise RuntimeError("redis down")
+            return super().xack(key, group, entry_id)
+
+    r = _AckBoom(
+        claimed=[("1-0", _payload("record")), ("2-0", _payload("record"))],
+        delivered={"1-0": over, "2-0": 2},
+    )
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert calls == ["ran"]  # poison entry never ran; the good one did
+    assert "2-0" in r.acked and "2-0" in r.deleted
+
+
+def test_handler_exception_does_not_abort_batch():
+    # A reclaimed entry whose handler raises is retried via _process_one's own
+    # path; the failure must not stop later entries from being claimed and run.
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+
+    def _boom():
+        raise RuntimeError("handler failed")
+
+    q.handlers["boom"] = _boom
+
+    class _RetryCapture(_FakeRedis):
+        def incr(self, key):
+            return 1
+
+        def hset(self, key, field, value):
+            return 1
+
+        def zadd(self, key, mapping):
+            return 1
+
+    r = _RetryCapture(
+        claimed=[("1-0", _payload("boom")), ("2-0", _payload("record"))],
+        delivered={"1-0": 2, "2-0": 2},
+    )
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert calls == ["ran"]
+    # the failing entry was acked+deleted by _process_one's retry path
+    assert "1-0" in r.acked and "1-0" in r.deleted

--- a/backend/tests/test_task_queue_reclaim.py
+++ b/backend/tests/test_task_queue_reclaim.py
@@ -1,0 +1,82 @@
+"""Stale-entry reclaim (queue._reclaim_stale): adopting PEL entries whose
+consumer died, and the poison-message delivery cap. Redis is faked so the
+claim/ack/delete choreography is tested deterministically without a broker."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.tasks import queue as queue_mod
+from app.tasks.queue import TaskQueue, _reclaim_stale
+
+
+class _FakeRedis:
+    """Stand-in for the calls _reclaim_stale + _process_one make."""
+
+    def __init__(self, claimed: list[tuple[str, dict[str, Any] | None]], delivered: dict[str, int]):
+        self.claimed = claimed
+        self.delivered = delivered  # entry id -> times_delivered after the claim
+        self.acked: list[str] = []
+        self.deleted: list[str] = []
+
+    def xautoclaim(self, key, group, consumer, min_idle_time, start_id, count):
+        return ("0-0", self.claimed, [])
+
+    def xpending_range(self, key, group, min, max, count):
+        n = self.delivered.get(min)
+        return [{"times_delivered": n}] if n is not None else []
+
+    def xack(self, key, group, entry_id):
+        self.acked.append(entry_id)
+        return 1
+
+    def xdel(self, key, entry_id):
+        self.deleted.append(entry_id)
+        return 1
+
+
+def _payload(task: str) -> dict[str, str]:
+    return {"payload": json.dumps({"task": task, "args": [], "kwargs": {}})}
+
+
+def _queue_with_handler(calls: list[str]) -> TaskQueue:
+    q = TaskQueue(name="reclaimq", max_size=10)
+    q.handlers["record"] = lambda: calls.append("ran")
+    return q
+
+
+def test_reclaimed_entry_runs_and_completes():
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+    r = _FakeRedis(claimed=[("1-0", _payload("record"))], delivered={"1-0": 2})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert calls == ["ran"]
+    assert r.acked == ["1-0"] and r.deleted == ["1-0"]
+
+
+def test_entry_over_delivery_cap_dropped_without_running():
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+    over = queue_mod._MAX_DELIVERIES + 1
+    r = _FakeRedis(claimed=[("1-0", _payload("record"))], delivered={"1-0": over})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert calls == []  # poison — never handed to the handler
+    assert r.acked == ["1-0"] and r.deleted == ["1-0"]
+
+
+def test_concurrently_deleted_entry_skipped():
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+    r = _FakeRedis(claimed=[("1-0", None)], delivered={})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert calls == [] and r.acked == [] and r.deleted == []
+
+
+def test_reclaim_survives_xautoclaim_failure():
+    q = _queue_with_handler([])
+
+    class _Boom(_FakeRedis):
+        def xautoclaim(self, *a, **k):
+            raise RuntimeError("redis down")
+
+    _reclaim_stale(q, "worker-x", _Boom([], {}), vt_seconds=300, max_retries=3)  # no raise

--- a/backend/tests/test_task_queue_reclaim.py
+++ b/backend/tests/test_task_queue_reclaim.py
@@ -144,3 +144,47 @@ def test_handler_exception_does_not_abort_batch():
     assert calls == ["ran"]
     # the failing entry was acked+deleted by _process_one's retry path
     assert "1-0" in r.acked and "1-0" in r.deleted
+
+
+class _OpOrderRedis(_FakeRedis):
+    """Records the relative order of xdel/xack per entry."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ops: list[tuple[str, str]] = []
+
+    def xack(self, key, group, entry_id):
+        self.ops.append(("xack", entry_id))
+        return super().xack(key, group, entry_id)
+
+    def xdel(self, key, entry_id):
+        self.ops.append(("xdel", entry_id))
+        return super().xdel(key, entry_id)
+
+
+def test_drop_deletes_from_stream_before_acking():
+    # XDEL-then-XACK ordering: a failure between the calls must leave a
+    # dangling PEL ref (cleaned by the next reclaim pass), never an acked
+    # entry stranded in the stream where depth()/oldest_age count it forever.
+    calls: list[str] = []
+    q = _queue_with_handler(calls)
+    r = _OpOrderRedis(claimed=[("1-0", _payload("record"))], delivered={"1-0": 2})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)
+    assert r.ops == [("xdel", "1-0"), ("xack", "1-0")]
+
+
+def test_poison_drop_ordering_and_partial_failure_leaves_no_zombie():
+    # Even if XACK fails after XDEL succeeded, the entry is gone from the
+    # stream — the dangling PEL ref is the recoverable half.
+    q = _queue_with_handler([])
+    over = queue_mod._MAX_DELIVERIES + 1
+
+    class _AckAlwaysBoom(_OpOrderRedis):
+        def xack(self, key, group, entry_id):
+            self.ops.append(("xack", entry_id))
+            raise RuntimeError("redis down")
+
+    r = _AckAlwaysBoom(claimed=[("1-0", _payload("record"))], delivered={"1-0": over})
+    _reclaim_stale(q, "worker-x", r, vt_seconds=300, max_retries=3)  # contained
+    assert ("xdel", "1-0") in r.ops  # stream entry removed despite the ack failure
+    assert r.deleted == ["1-0"]


### PR DESCRIPTION
## Problem

Three compounding gaps in the Redis Streams queue layer, found while diagnosing week-long invisible ingestion stalls:

1. **Orphaned deliveries.** A worker killed mid-task (deploy SIGTERM, OOM) leaves its message in the `workers` group PEL under a consumer name that never returns — every start mints a fresh `worker-{i}-{uuid}` name, and `XREADGROUP \">\"` never re-reads another consumer's pending entries. `vt_seconds` has been plumbed through `run_consumer` since the Streams migration but **nothing consumed it** — the visibility timeout the boot log advertises (`vt=300s`) did not exist. Prod accumulated 31 such orphans since May, one per worker kill.
2. **Silent consumer death.** `run_consumer` submits `_worker_loop` to a pool and never inspects the futures; the message-handling section ran outside the loop's `try`. An exception escaping `_process_one` (a Redis error on ack, a malformed message shape) would kill the consumer thread with zero log output while the pod stayed `1/1 Ready`.
3. **Lying dashboard gauge.** `ingest_queue_depth` was `.set()` only inside `process_pushed_document` — so a stalled worker froze it at its last value and a fresh pod reset it to 0. During a real multi-day stall with 53 undelivered + 30 pending entries, the panel read **0**.

## Fix

- **`_reclaim_stale`** — when a consumer polls and finds nothing new, it `XAUTOCLAIM`s entries idle past `vt_seconds` and runs them. Entries delivered more than `_MAX_DELIVERIES` (3) times are dropped as poison — each prior delivery means a consumer took it and died/stalled, so a fourth attempt would just wedge again. Running reclaim only when idle means a busy single-consumer queue never steals its own in-flight work. Delivery is now at-least-once (documented on the function); handlers were already written for retry semantics.
- **Exception containment** — message handling moved inside a `try` that logs and continues; the extracted `_handle_entry` is shared by the normal and reclaim paths.
- **Scrape-time gauges** — `ingest_queue_depth` moves into `_TaskQueueCollector` (sampled at scrape, truthful during stalls and across restarts); new `task_queue_in_flight` per-queue gauge makes stuck deliveries visible next to the existing depth/oldest-age families.

## Tests

New `test_task_queue_reclaim.py` (fake-Redis, same style as `test_task_queue_metrics`): reclaimed entry runs + acks, poison cap drops without running, concurrently-deleted entries skipped, xautoclaim failure contained. Full backend suite: 2300 passed.

## Review fixes

- `0c84d07a` — the per-entry reclaim body (delivery lookup, poison drop, handler) is inside one guard, so a Redis error skips that entry and continues the batch instead of escaping the idle path; reclaim horizon raised to `vt * _RECLAIM_IDLE_FACTOR` (3× = 15 min) so a merely-slow consumer on a multi-threaded queue isn't double-run at 5 minutes.
- `59654a65` — all five completion sites drop entries XDEL-first via a shared `_drop_entry` helper: a partial failure now leaves a dangling PEL ref that the next `XAUTOCLAIM` pass cleans, instead of an acked zombie that inflates `depth().ready` and pins `oldest_age_seconds` forever.

- `992f5cd7` — the retry copy is persisted before `_drop_entry` in the handler-failure path, so a partial drop failure degrades to redelivery (duplicate retry at worst, delivery-capped) instead of silently losing the task.
