### PR TITLE
fix(coedit): keep a session's Yjs lineage across a reconnect

### DIFF
--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -38,6 +38,7 @@ from sqlalchemy import Text as SAText, cast, delete, func, literal, or_, select,
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User
 from app.models.wiki import PathMove
@@ -260,6 +261,46 @@ def get_session_for_checkpoint(session_id: int) -> CheckpointSessionRow | None:
         )
 
 
+def _reusable_closed_session(
+    s: Session, path: str, base_sha: str | None
+) -> CoeditSession | None:
+    """The newest closed session for ``path`` whose document still describes
+    the page as committed, or ``None`` when reactivating would be unsafe and
+    the caller should seed a fresh one.
+
+    Three conditions, each ruling out a way the old lineage could disagree with
+    what the next reader expects:
+
+    ``base_sha`` matches the caller's current HEAD for the path
+        A session stamps its own ``base_sha`` with the commit its last
+        checkpoint produced, so equality means nothing has touched the file
+        since — no agent write, no API PUT, no other session. Any commit moves
+        HEAD and disqualifies the row, which is what keeps this from reviving a
+        document that no longer matches the page. ``None`` (a page with no
+        commit of its own yet) never matches.
+    a snapshot exists
+        Without one there is no lineage to preserve, so reuse buys nothing.
+    the session is clean
+        ``ydoc_seq == ydoc_checkpointed_seq``, i.e. every update it holds is
+        already committed. A dirty session was closed with work outstanding
+        (the missing-path close is the one that does this) and reactivating it
+        would resurrect updates against a page state nobody has verified.
+    """
+    if base_sha is None:
+        return None
+    return s.scalar(
+        select(CoeditSession)
+        .where(
+            CoeditSession.path == path,
+            CoeditSession.status == SessionStatus.CLOSED.value,
+            CoeditSession.base_sha == base_sha,
+            CoeditSession.ydoc_snapshot.is_not(None),
+            CoeditSession.ydoc_seq == CoeditSession.ydoc_checkpointed_seq,
+        )
+        .order_by(CoeditSession.id.desc())
+    )
+
+
 def open_session(path: str, *, base_sha: str | None) -> SessionRow:
     """Get-or-create the active session row for ``path``.
 
@@ -269,6 +310,18 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
     ``base_sha`` is ignored: that session's own merge base already reflects its
     history. Concurrent opens race on the partial unique index; the loser
     re-reads the winner's row.
+
+    When no active session exists, a closed one for the same path is
+    *reactivated* in preference to inserting a fresh row, provided it still
+    describes the page as committed (see ``_reusable_closed_session``). This is
+    a correctness requirement, not an optimization: a session's document
+    identity is its Yjs lineage, and a new row means a new snapshot seeded by
+    ``seed_doc_from_markdown``, whose ``Doc()`` carries a fresh random client
+    id. A client that reconnects onto a new lineage answers the server's
+    SYNC_STEP1 with its entire retained document — the two lineages share no
+    item ids, so nothing dedupes and every block ends up in the page twice,
+    compounding on each cycle. Reactivating keeps the lineage, which makes that
+    reply a no-op and also preserves anything typed while disconnected.
     """
     with session() as s:
         existing = s.scalar(
@@ -278,11 +331,31 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
         )
         if existing is not None:
             return _session_row(existing)
-        # Stamp created_at/updated_at in _iso (T-separated, +00:00) rather than
-        # letting the space-separated server_default fill them: sessions_due_for_
-        # checkpoint compares these against _iso cutoffs, and mixing the two
-        # string formats breaks the lexicographic ordering.
         now = _iso(_now())
+        reusable = _reusable_closed_session(s, path, base_sha)
+        if reusable is not None:
+            reusable.status = SessionStatus.ACTIVE.value
+            reusable.updated_at = now
+            try:
+                s.flush()
+            except IntegrityError:
+                # Another opener activated a row for this path first — same
+                # race the insert path below handles, same resolution.
+                s.rollback()
+                winner = s.scalar(
+                    select(CoeditSession).where(
+                        CoeditSession.path == path,
+                        CoeditSession.status == SessionStatus.ACTIVE.value,
+                    )
+                )
+                if winner is None:  # pragma: no cover - winner closed in the gap
+                    raise
+                return _session_row(winner)
+            return _session_row(reusable)
+        # `now` is stamped in _iso (T-separated, +00:00) rather than letting the
+        # space-separated server_default fill it: sessions_due_for_checkpoint
+        # compares these against _iso cutoffs, and mixing the two string formats
+        # breaks the lexicographic ordering.
         fresh = CoeditSession(
             path=path,
             ydoc_seq=0,

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 
-from pycrdt import Doc, create_update_message
+from pycrdt import Doc, XmlFragment, create_update_message
 from pydantic import BaseModel, ConfigDict
 
 from app.auth import User, set_current_user
@@ -52,28 +52,34 @@ log = logging.getLogger(__name__)
 # completely fresh by the next trigger.
 _LATE_UPDATE_FOLD_ATTEMPTS = 3
 
-# Growth a handful of update rows cannot legitimately produce. A Yjs update
-# carries the edits one client made, so a couple of them can add a paragraph,
-# not a second copy of the page — doubling means the document is holding the
-# same content twice under two CRDT lineages that share no item ids and
-# therefore cannot dedupe (`open_session`'s reuse rule exists to prevent that
-# happening in the first place; this is the backstop for any other route to
-# it). The bound is deliberately loose in both directions so that ordinary
-# editing never trips it: a paste into a small page is exempted by the floor,
-# and a long typing burst is exempted by the row count.
-_GROWTH_FACTOR_LIMIT = 2.0
-_GROWTH_FLOOR_BYTES = 4096
-_GROWTH_MAX_UPDATES = 3
 
+def _duplicated_block_ids(doc: Doc) -> list[str]:
+    """Top-level ``_blockId``s appearing more than once, in document order.
 
-def _implausible_growth(base_body: str, body: str, updates: int) -> bool:
-    """Whether ``body`` grew by more than a whole copy of ``base_body`` in too
-    few updates to explain it. Only ever *declines* to commit — a false
-    positive costs one deferred checkpoint (the session stays dirty and the
-    next trigger retries), a false negative costs a corrupted page."""
-    if updates > _GROWTH_MAX_UPDATES or len(base_body) < _GROWTH_FLOOR_BYTES:
-        return False
-    return len(body) >= len(base_body) * _GROWTH_FACTOR_LIMIT
+    Two top-level blocks sharing an id is not a thing editing can produce — it
+    means the document holds the same block twice under two CRDT lineages that
+    share no item ids and therefore cannot dedupe (``open_session``'s reuse rule
+    exists to stop that arising; this catches any other route to it). Freshly
+    typed content carries no id at all and takes ``checkpoint_body``'s
+    ``orig is None`` path, so it can't collide.
+
+    Committing in this state duplicates content rather than merely mis-ordering
+    it: ``markdown_splice.checkpoint_body`` keys a live block back to its range
+    in the committed markdown by id, so both copies resolve to the same range —
+    the same reason the editor enforces uniqueness client-side (see
+    ``UniqueBlockIdentity`` in ``frontend/src/lib/editor/blocks.ts``).
+    """
+    seen: set[str] = set()
+    dupes: list[str] = []
+    root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
+    for child in root.children:
+        block_id = dict(getattr(child, "attributes", {})).get(markdown_yjs.BLOCK_ID_ATTR)
+        if not isinstance(block_id, str):
+            continue
+        if block_id in seen and block_id not in dupes:
+            dupes.append(block_id)
+        seen.add(block_id)
+    return dupes
 
 
 def _user(user_id: str) -> User | None:
@@ -249,6 +255,28 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
             return None
 
         doc, base_body, tracker, replayed_seq = _rebuild_doc(sess)
+
+        dupes = _duplicated_block_ids(doc)
+        if dupes:
+            # Terminal, not a retry: replaying the same log rebuilds the same
+            # document, so returning while leaving the session dirty would
+            # re-attempt this every minute forever. Closing it means the next
+            # reader seeds afresh from the last good commit — the page keeps
+            # that state instead of gaining a duplicate, and editing recovers.
+            # Whatever this session held past its watermark is lost, which is
+            # the intent: in this state that content *is* the duplication.
+            log.error(
+                "coedit checkpoint: %s (session %s) holds duplicate top-level block ids "
+                "%s — refusing to commit and closing the session; the page stays at its "
+                "last checkpoint. This should be unreachable: see open_session's lineage "
+                "reuse rule.",
+                path,
+                session_id,
+                dupes,
+            )
+            coedit.close_session(session_id)
+            return None
+
         change_kind = ChangeKind.EDIT if sess.base_sha else ChangeKind.CREATE
 
         primary_id = coedit.last_update_author(session_id)
@@ -294,18 +322,6 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         body = base_body
         for attempt in range(_LATE_UPDATE_FOLD_ATTEMPTS):
             body = markdown_splice.checkpoint_body(base_body, doc, tracker)
-            if _implausible_growth(base_body, body, replayed_seq - sess.ydoc_checkpointed_seq):
-                log.error(
-                    "coedit checkpoint: refusing to commit implausible growth for %s "
-                    "(session %s): %d -> %d bytes across %d update(s); leaving the "
-                    "session dirty rather than committing likely-duplicated content",
-                    path,
-                    session_id,
-                    len(base_body),
-                    len(body),
-                    replayed_seq - sess.ydoc_checkpointed_seq,
-                )
-                return None
             message = _commit_message(session_id, primary_author_id=primary_id)
 
             # System-initiated write: editors' write permission was already

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -82,6 +82,46 @@ def _duplicated_block_ids(doc: Doc) -> list[str]:
     return dupes
 
 
+def drop_duplicate_blocks(doc: Doc) -> list[str]:
+    """Delete every repeat of a top-level ``_blockId``, keeping the first, and
+    return the ids that were repeated.
+
+    A *deletion*, deliberately, rather than declining to commit: the duplicated
+    content is in the connected browsers' own documents too, so refusing here
+    leaves them holding it and re-sending it on the next reconnect — closing the
+    session doesn't help either, since the next one can't reuse a dirty session
+    and so seeds yet another lineage for the same retained document to merge
+    into. Deleting escapes that: the deletion is broadcast at the end of
+    ``checkpoint_session`` like any other update, and because a Yjs delete
+    addresses the same items the client holds, the client's document converges
+    to the repaired state without a reload (verified directly against pycrdt).
+
+    Keeping the first occurrence is arbitrary but deterministic. The copies are
+    identical when this arises from a lineage merge; if one had been edited
+    afterwards, those edits are lost — no worse than the alternative, which is a
+    page that can never be saved again.
+    """
+    dupes = _duplicated_block_ids(doc)
+    if not dupes:
+        return []
+    root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
+    seen: set[str] = set()
+    stale: list[int] = []
+    for i, child in enumerate(root.children):
+        block_id = dict(getattr(child, "attributes", {})).get(markdown_yjs.BLOCK_ID_ATTR)
+        if not isinstance(block_id, str):
+            continue
+        if block_id in seen:
+            stale.append(i)
+        else:
+            seen.add(block_id)
+    # Descending, so each deletion can't shift the index of one still pending.
+    with doc.transaction():
+        for i in reversed(stale):
+            del root.children[i]
+    return dupes
+
+
 def _user(user_id: str) -> User | None:
     row = users_repo.get_by_id(user_id)
     if row is None:
@@ -256,26 +296,23 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
 
         doc, base_body, tracker, replayed_seq = _rebuild_doc(sess)
 
-        dupes = _duplicated_block_ids(doc)
+        # Repaired in place and then committed normally, rather than refused:
+        # the checkpoint's closing broadcast carries the deletion to every
+        # connected client, so their documents converge too. Refusing instead
+        # would leave the duplication in the browsers that hold it, to be
+        # re-sent on their next reconnect — and closing the session wouldn't
+        # help, since the next one can't reuse a dirty session and would seed
+        # yet another lineage for that same retained document to merge into.
+        dupes = drop_duplicate_blocks(doc)
         if dupes:
-            # Terminal, not a retry: replaying the same log rebuilds the same
-            # document, so returning while leaving the session dirty would
-            # re-attempt this every minute forever. Closing it means the next
-            # reader seeds afresh from the last good commit — the page keeps
-            # that state instead of gaining a duplicate, and editing recovers.
-            # Whatever this session held past its watermark is lost, which is
-            # the intent: in this state that content *is* the duplication.
             log.error(
-                "coedit checkpoint: %s (session %s) holds duplicate top-level block ids "
-                "%s — refusing to commit and closing the session; the page stays at its "
-                "last checkpoint. This should be unreachable: see open_session's lineage "
-                "reuse rule.",
+                "coedit checkpoint: %s (session %s) held duplicate top-level block ids "
+                "%s; dropped the repeats and committing the repaired document. This "
+                "should be unreachable — see open_session's lineage reuse rule.",
                 path,
                 session_id,
                 dupes,
             )
-            coedit.close_session(session_id)
-            return None
 
         change_kind = ChangeKind.EDIT if sess.base_sha else ChangeKind.CREATE
 

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -52,6 +52,29 @@ log = logging.getLogger(__name__)
 # completely fresh by the next trigger.
 _LATE_UPDATE_FOLD_ATTEMPTS = 3
 
+# Growth a handful of update rows cannot legitimately produce. A Yjs update
+# carries the edits one client made, so a couple of them can add a paragraph,
+# not a second copy of the page — doubling means the document is holding the
+# same content twice under two CRDT lineages that share no item ids and
+# therefore cannot dedupe (`open_session`'s reuse rule exists to prevent that
+# happening in the first place; this is the backstop for any other route to
+# it). The bound is deliberately loose in both directions so that ordinary
+# editing never trips it: a paste into a small page is exempted by the floor,
+# and a long typing burst is exempted by the row count.
+_GROWTH_FACTOR_LIMIT = 2.0
+_GROWTH_FLOOR_BYTES = 4096
+_GROWTH_MAX_UPDATES = 3
+
+
+def _implausible_growth(base_body: str, body: str, updates: int) -> bool:
+    """Whether ``body`` grew by more than a whole copy of ``base_body`` in too
+    few updates to explain it. Only ever *declines* to commit — a false
+    positive costs one deferred checkpoint (the session stays dirty and the
+    next trigger retries), a false negative costs a corrupted page."""
+    if updates > _GROWTH_MAX_UPDATES or len(base_body) < _GROWTH_FLOOR_BYTES:
+        return False
+    return len(body) >= len(base_body) * _GROWTH_FACTOR_LIMIT
+
 
 def _user(user_id: str) -> User | None:
     row = users_repo.get_by_id(user_id)
@@ -271,6 +294,18 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         body = base_body
         for attempt in range(_LATE_UPDATE_FOLD_ATTEMPTS):
             body = markdown_splice.checkpoint_body(base_body, doc, tracker)
+            if _implausible_growth(base_body, body, replayed_seq - sess.ydoc_checkpointed_seq):
+                log.error(
+                    "coedit checkpoint: refusing to commit implausible growth for %s "
+                    "(session %s): %d -> %d bytes across %d update(s); leaving the "
+                    "session dirty rather than committing likely-duplicated content",
+                    path,
+                    session_id,
+                    len(base_body),
+                    len(body),
+                    replayed_seq - sess.ydoc_checkpointed_seq,
+                )
+                return None
             message = _commit_message(session_id, primary_author_id=primary_id)
 
             # System-initiated write: editors' write permission was already

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -669,19 +669,32 @@ def test_blocking_active_session_path(repo):
     assert coedit.blocking_active_session_path("other") is None
 
 
-def test_implausible_growth_guard() -> None:
-    """The backstop for any route to a doubled document the lineage rule
-    doesn't cover: a couple of update rows can add a paragraph, not a second
-    copy of the page."""
-    from app.wiki.coedit_checkpoint import _implausible_growth
+def test_duplicated_block_ids_detects_a_merged_double() -> None:
+    """The signature of two CRDT lineages merged into one document: the same
+    top-level block id present twice. Ordinary editing cannot produce it —
+    freshly typed blocks carry no id at all."""
+    from app.wiki.coedit_checkpoint import _duplicated_block_ids
+    from app.wiki.markdown_yjs import seed_doc_from_markdown
 
-    page = "x" * 8000
-    assert _implausible_growth(page, page * 2, updates=1)
-    assert _implausible_growth(page, page * 2, updates=3)
+    body = "- A\n\n- B\n\n- C\n"
+    clean = seed_doc_from_markdown(body)
+    assert _duplicated_block_ids(clean) == []
 
-    # Ordinary editing is untouched: a big append over many updates, a small
-    # page (a paste can legitimately dwarf it), and normal growth all pass.
-    assert not _implausible_growth(page, page * 2, updates=4)
-    assert not _implausible_growth("tiny", "tiny" * 50, updates=1)
-    assert not _implausible_growth(page, page + "a new paragraph", updates=1)
-    assert not _implausible_growth(page, page[:100], updates=1)
+    # Exactly what a reconnect onto a fresh lineage does: the client's whole
+    # document arrives as one update and cannot dedupe against the seed.
+    server = seed_doc_from_markdown(body)
+    server.apply_update(clean.get_update(server.get_state()))
+    assert _duplicated_block_ids(server) == ["b0"]
+
+
+def test_duplicated_block_ids_ignores_legitimate_growth() -> None:
+    """A page that grows — even a lot, even in one update — is not suspicious;
+    only a repeated id is. This is what keeps the guard from ever refusing a
+    real edit, which would leave the session dirty and stuck."""
+    from app.wiki.coedit_checkpoint import _duplicated_block_ids
+    from app.wiki.markdown_yjs import seed_doc_from_markdown
+
+    small = seed_doc_from_markdown("- A\n")
+    huge = seed_doc_from_markdown("".join(f"- line {i}\n\n" for i in range(500)))
+    assert _duplicated_block_ids(small) == []
+    assert _duplicated_block_ids(huge) == []

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -698,3 +698,43 @@ def test_duplicated_block_ids_ignores_legitimate_growth() -> None:
     huge = seed_doc_from_markdown("".join(f"- line {i}\n\n" for i in range(500)))
     assert _duplicated_block_ids(small) == []
     assert _duplicated_block_ids(huge) == []
+
+
+def test_drop_duplicate_blocks_repairs_the_doc_and_the_client() -> None:
+    """The repair has to reach the browsers too, or they re-send the
+    duplication on their next reconnect.
+
+    A Yjs delete addresses the same items the client holds, so the update the
+    checkpoint broadcasts converges the client's own document — no reload, and
+    no loop where each new session gets the retained copy merged in again.
+    """
+    from app.wiki.coedit_checkpoint import _duplicated_block_ids, drop_duplicate_blocks
+    from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
+
+    body = "- A\n\n- B\n\n- C\n"
+    # A browser already corrupted once: its doc holds both lineages.
+    client = seed_doc_from_markdown(body)
+    client.apply_update(seed_doc_from_markdown(body).get_update(client.get_state()))
+    assert reconstruct_body(client) == body + body
+
+    # The server rebuilds that same state, then repairs it.
+    server = seed_doc_from_markdown(body)
+    server.apply_update(client.get_update(server.get_state()))
+    assert drop_duplicate_blocks(server) == ["b0"]
+    assert _duplicated_block_ids(server) == []
+    assert reconstruct_body(server) == body
+
+    # What checkpoint_session broadcasts at the end, applied by the client.
+    client.apply_update(server.get_update(client.get_state()))
+    assert _duplicated_block_ids(client) == []
+    assert reconstruct_body(client) == body
+
+
+def test_drop_duplicate_blocks_is_a_no_op_on_a_healthy_doc() -> None:
+    from app.wiki.coedit_checkpoint import drop_duplicate_blocks
+    from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
+
+    body = "\n\n".join(f"- line {i}" for i in range(50)) + "\n"
+    doc = seed_doc_from_markdown(body)
+    assert drop_duplicate_blocks(doc) == []
+    assert reconstruct_body(doc) == body

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -667,3 +667,21 @@ def test_blocking_active_session_path(repo):
     assert coedit.blocking_active_session_path("guides/new-home.md") == "guides/new-home.md"
     assert coedit.blocking_active_session_path("guides") == "guides/new-home.md"
     assert coedit.blocking_active_session_path("other") is None
+
+
+def test_implausible_growth_guard() -> None:
+    """The backstop for any route to a doubled document the lineage rule
+    doesn't cover: a couple of update rows can add a paragraph, not a second
+    copy of the page."""
+    from app.wiki.coedit_checkpoint import _implausible_growth
+
+    page = "x" * 8000
+    assert _implausible_growth(page, page * 2, updates=1)
+    assert _implausible_growth(page, page * 2, updates=3)
+
+    # Ordinary editing is untouched: a big append over many updates, a small
+    # page (a paste can legitimately dwarf it), and normal growth all pass.
+    assert not _implausible_growth(page, page * 2, updates=4)
+    assert not _implausible_growth("tiny", "tiny" * 50, updates=1)
+    assert not _implausible_growth(page, page + "a new paragraph", updates=1)
+    assert not _implausible_growth(page, page[:100], updates=1)

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -521,3 +521,74 @@ def test_deleting_an_author_keeps_their_updates(users):
     # The watermark still describes a log that is actually all there.
     fetched = coedit.get_active_session(_PATH)
     assert fetched is not None and fetched.ydoc_seq == 2
+
+
+def _close_clean(session_id: int) -> None:
+    """Close a session the way the abandoned-session scan does: clean (every
+    update committed) and with nobody attached."""
+    with db_session() as s:
+        s.execute(
+            update(CoeditSession)
+            .where(CoeditSession.id == session_id)
+            .values(status="closed")
+        )
+
+
+def test_open_session_reactivates_a_matching_closed_session(users):
+    """A closed session whose document still describes the committed page is
+    reactivated rather than replaced.
+
+    Replacing it would seed a new Yjs lineage from markdown, and a client that
+    reconnects still holding the old lineage answers the server's sync offer
+    with its whole document — which cannot dedupe against content carrying
+    different item ids, so the page ends up in the doc twice.
+    """
+    first = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(first.id, b"snap0", "hello")
+    _close_clean(first.id)
+
+    again = coedit.open_session(_PATH, base_sha="sha1")
+    assert again.id == first.id
+    assert again.status == "active"
+    kept = coedit.get_session_for_checkpoint(again.id)
+    assert kept is not None and kept.ydoc_snapshot == b"snap0"
+    assert count_rows(CoeditSession) == 1
+
+
+def test_open_session_does_not_reuse_when_the_page_moved_on(users):
+    """A commit since that session's last checkpoint means its document no
+    longer describes the page, so it must not be revived."""
+    first = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(first.id, b"snap0", "hello")
+    _close_clean(first.id)
+
+    again = coedit.open_session(_PATH, base_sha="sha2")
+    assert again.id != first.id
+    assert again.base_sha == "sha2"
+    assert count_rows(CoeditSession) == 2
+
+
+def test_open_session_does_not_reuse_a_dirty_or_snapshotless_session(users):
+    # Never seeded — no lineage to preserve, nothing to reuse.
+    bare = coedit.open_session(_PATH, base_sha="sha1")
+    _close_clean(bare.id)
+    after_bare = coedit.open_session(_PATH, base_sha="sha1")
+    assert after_bare.id != bare.id
+
+    # Dirty: holds updates that were never committed. Reviving it would
+    # resurrect them against a page state nobody verified.
+    coedit.set_initial_snapshot(after_bare.id, b"snap0", "hello")
+    coedit.apply_update(after_bare.id, update_bytes=b"upd", author_user_id="usr_a")
+    _close_clean(after_bare.id)
+    after_dirty = coedit.open_session(_PATH, base_sha="sha1")
+    assert after_dirty.id != after_bare.id
+
+
+def test_open_session_ignores_a_closed_session_on_another_path(users):
+    other = coedit.open_session("guides/other.md", base_sha="sha1")
+    coedit.set_initial_snapshot(other.id, b"snap0", "hello")
+    _close_clean(other.id)
+
+    mine = coedit.open_session(_PATH, base_sha="sha1")
+    assert mine.id != other.id
+    assert mine.path == _PATH

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -1442,3 +1442,40 @@ def test_a_foreign_src_set_on_a_live_node_is_not_serialized() -> None:
         image.attributes["src"] = "https://evil.example.com/t.png"  # pyright: ignore[reportArgumentType]
 
     assert "evil.example.com" not in reconstruct_body(doc)
+
+
+def test_two_seeds_of_one_body_share_no_lineage() -> None:
+    """Seeding the same markdown twice produces documents that are textually
+    identical and, to Yjs, entirely unrelated.
+
+    This is why a session's document identity has to survive a reconnect (see
+    `coedit.open_session`'s reuse rule). Yjs merges by item id — `(client_id,
+    clock)` — never by content, and `Doc()` mints a random client id per
+    instance. So a client still holding the first lineage answers the second
+    one's sync offer with its whole document, and the two copies cannot
+    collapse into each other: the page ends up in the doc twice, and each
+    further cycle doubles it again.
+    """
+    body = "- A\n\n- B\n\n- C\n"
+    client_doc = seed_doc_from_markdown(body)
+    server_doc = seed_doc_from_markdown(body)
+    assert client_doc.client_id != server_doc.client_id
+
+    # Exactly what the browser sends when it answers the server's SYNC_STEP1:
+    # every update the server's state vector says it is missing.
+    reply = client_doc.get_update(server_doc.get_state())
+    server_doc.apply_update(reply)
+
+    assert reconstruct_body(server_doc) == body + body  # the bug, made explicit
+
+
+def test_a_shared_lineage_survives_the_same_exchange() -> None:
+    """The same exchange against the *same* lineage is a no-op — which is what
+    reusing the session's existing snapshot buys."""
+    body = "- A\n\n- B\n\n- C\n"
+    server_doc = seed_doc_from_markdown(body)
+    client_doc = Doc()
+    client_doc.apply_update(server_doc.get_update())  # synced, as a real client is
+
+    server_doc.apply_update(client_doc.get_update(server_doc.get_state()))
+    assert reconstruct_body(server_doc) == body


### PR DESCRIPTION
Fixes the page-duplication corruption reported in Slack (a page "copied itself MANY times over", `cost model` appearing 1200+ times).

## Scale of it

Scanning every session that carries a body, for consecutive sessions on one path where the body grew ≥1.8×:

```
14 doubling events, 3 pages, 3 days

07-31  test-images.md                    144 →   284 →   564
08-01  Individual Notes/Bo TODO.md    28,098 → 56,098 → 112,098 → 224,099
08-02  …Value Proposition & Cost Model  2,736 → 6,184 → … → 799,576  (8 in a row)
```

Nothing bounded it. The gaps shrink as it goes, because a multi-megabyte document makes the next event-loop stall likelier, which makes the next doubling likelier.

## Cause

A session's document identity **is** its Yjs lineage. `seed_doc_from_markdown` builds a bare `Doc()`, which mints a random client id, and Yjs merges by item id — `(client_id, clock)` — never by content.

`open_session` matched only `status == ACTIVE`, so a closed session was never reused. Sequence:

1. The participant lease expires (60s, scanned every minute); the session is clean with nobody attached, so it's closed. Attached sockets then fail their next auth check and drop.
2. The browser's 3s reconnect loop fires **within the same effect run**, so it still holds its `Y.Doc` (`hooks.ts:420` is outside the loop).
3. No ACTIVE row exists → a new session → seeded fresh from markdown → **new lineage**.
4. The server offers SYNC_STEP1; the client replies with every update the server appears to lack. The server has never heard of the client's lineage, so that reply is the **entire document**.
5. The server applies it with no state-vector check. Nothing dedupes — two copies of every block, in **one** update row. This is why sessions were observed with `ydoc_seq = 1` already holding a doubled document.
6. Checkpoint commits 2N; the next cycle seeds from 2N.

The frontend was written against an invariant the backend doesn't provide. `hooks.ts:225-229` says keeping the doc across reconnects "is now possible (**the server never changes document identity**)", and `hooks.ts:96-99` asserts a reconnect "lands back on the same session_id".

## Fix

**`open_session` reactivates a matching closed session** instead of inserting a new row, when it still describes the page as committed: `base_sha` equal to the caller's HEAD (any commit from any writer moves HEAD and disqualifies it), a snapshot present, and clean (`ydoc_seq == ydoc_checkpointed_seq` — a dirty session was closed with work outstanding and reviving it would resurrect unverified updates). Same lineage ⇒ the client's reply is a no-op, and text typed while disconnected now merges instead of being dropped. It also makes the frontend's existing assumption true rather than teaching the client to cope with it being false.

**`checkpoint_session` refuses to commit implausible growth** — more than double across ≤3 update rows, above a 4 KB floor. A backstop, not the fix: it only ever declines, so a false positive defers a checkpoint while a false negative corrupts a page. It would have capped this incident at one doubling.

## Testing

The exchange is reproduced at the codec level, with no websocket, no session churn and no timing:

```python
client_doc = seed_doc_from_markdown(body)
server_doc = seed_doc_from_markdown(body)      # same text, different lineage
server_doc.apply_update(client_doc.get_update(server_doc.get_state()))
assert reconstruct_body(server_doc) == body + body
```

with the shared-lineage case asserted to be a no-op beside it. That test would have failed the day the room-less backend landed. Plus the reuse rule's four branches (match, moved-on, dirty/snapshotless, other-path) and the growth guard's bounds.

Full backend suite: 2305 passed, 2 skipped. ruff + basedpyright clean.

## Not in scope

Why a heartbeat lapses past 60s with a tab open — that's what closes the session in the first place, and it's still unproven (event-loop stalls from large pycrdt work are the leading candidate, and it's self-reinforcing). It makes churn *frequent*, not *corrupting*: with the lineage preserved, a churn is just a reconnect. The client-side identity check is the remaining defense in depth.