### PR TITLE
fix(wiki): restore the doc scrollbar outside the anchored panel

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -159,6 +159,33 @@ body {
   overflow: clip;
 }
 
+/* Doc scroller: thumb only, no track. A full-height rail down the page reads as
+   a border rather than a scroll affordance, and it appears on any system set to
+   show scroll bars always (an overlay-scrollbar system never paints the track,
+   so this is invisible there). Still the native scrollbar, restyled — the
+   `::-webkit-*` pair is the fallback for engines that don't honour the standard
+   properties; where both are understood the standard ones win.
+   `.panel-anchored` hides this bar entirely in favour of EditorEdgeScrollbar
+   (see below). */
+.editor-prose::-webkit-scrollbar {
+  width: 0.625rem;
+}
+.editor-prose::-webkit-scrollbar-track {
+  background: transparent;
+}
+.editor-prose::-webkit-scrollbar-thumb {
+  background: var(--border-04);
+  border-radius: var(--radius-04);
+  /* Inset the thumb off both edges without shrinking the hit area. */
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+.editor-prose {
+  scrollbar-width: thin;
+  /* thumb, then track */
+  scrollbar-color: var(--border-04) transparent;
+}
+
 /* ── Doc panel tab transitions ────────────────────────────────────────────
    Enter-only fade + directional slide for the incoming tab surface, matched
    to the underline indicator's travel (DocPanel keys the body by tab). No

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -159,18 +159,6 @@ body {
   overflow: clip;
 }
 
-/* The editor hides its scroll chrome per the mocks; EditorEdgeScrollbar's tick
-   rail is the intended indicator surface. `.editor-prose` is the editor's own
-   scroll container (css/editor.css) — the CodeMirror `.cm-scroller` this
-   replaces. */
-.editor-prose {
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-.editor-prose::-webkit-scrollbar {
-  display: none;
-}
-
 /* ── Doc panel tab transitions ────────────────────────────────────────────
    Enter-only fade + directional slide for the incoming tab surface, matched
    to the underline indicator's travel (DocPanel keys the body by tab). No


### PR DESCRIPTION
The wiki page had no scroll indicator at all, and once restored it painted a full-height rail. Two commits: make the bar exist, then make it a thumb only.

## 1. No scrollbar at all

Two rules hid `.editor-prose`'s native scrollbar:

| rule | scope | correct? |
|---|---|---|
| `.panel-anchored .editor-prose` | only when `panelScrollDocked` is true | **yes** — same condition that mounts `EditorEdgeScrollbar` (`FileView.tsx:1439`), where the native bar would sit at the doc/panel boundary instead of the viewport edge |
| `.editor-prose` | unscoped — every state | **no** |

The unscoped rule's comment named `EditorEdgeScrollbar` as the replacement indicator, but that component only renders inside the panel branch. With no panel open there was neither a native bar nor a custom one. Measured on the default page state:

```
scrollbarWidth: "none"   overflowY: "auto"    scrollable: true
gutterPx: 0              panelAnchored: false  edgeScrollbarMounted: false
```

Removed the unscoped rule; kept the scoped one. Verified against a built image that `panel-anchored` still resolves to `none` and the normal state to `auto`, so the case the scoped rule exists for is untouched.

## 2. Thumb, not a rail

On a system set to show scroll bars *always*, the native bar paints its track too — a thin line down the full page height that reads as a border, not an affordance:

`gutterPx: 15` with no separate strip element in the DOM confirmed the line was the scrollbar track rather than some other element.

So: track transparent, thumb a token grey inset off both edges with a transparent border plus `background-clip: content-box`, which keeps the hit area full width. Standard properties (`scrollbar-width` / `scrollbar-color`) alongside the `::-webkit-*` pair — the latter is the fallback for engines that don't honour the former, and where both are understood the standard ones win. Still the native scrollbar, restyled, not a custom control. Invisible on overlay-scrollbar systems, which never paint a track anyway.

One correction along the way: I first used `--border-05`, which is `#000` — a pure-black thumb. Reading the resolved token values showed `--border-04` (`gray`) is the medium grey that matches the platform bar.

## Verification

Confirmed three ways rather than from the stylesheet: deleting only the offending rules at runtime in a live page made the bar appear; a rebuilt image reproduces it; and a zoomed capture of the right edge shows the grey thumb with no rail behind it. `scrollbar-color` resolves to `rgb(128,128,128) rgba(0,0,0,0)` — grey thumb, transparent track.
