### PR TITLE
perf(ingest): extract and name concurrently in the entity-type derivation

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -77,6 +77,11 @@ class Config(BaseModel):
     # no-op. Populates the store for the cosine cold-start / two-tower warm
     # filter that lands in later phases.
     ingest_embed_model: str
+    # How many entity-type extraction / naming LLM calls run at once during a derivation.
+    # Operator-tunable because the ceiling is the PROVIDER's rate limit, not this code: each
+    # call can carry ~47k input tokens, and this pool sits inside a queue task, so the real
+    # concurrency is the queue's own worker count multiplied by this. Lower it on a lower tier.
+    entity_type_derive_workers: int = 8
 
     # Relevance filter (drops irrelevant candidate pages before the LLM reconcile).
     # Empty model path => cosine cold-start filter; a path to an exported two-tower
@@ -208,6 +213,7 @@ def load_config() -> Config:
         ingest_bm25_limit=_positive_int("INGEST_BM25_LIMIT", 20),
         ingest_irrelevant_stop_n=_positive_int("INGEST_IRRELEVANT_STOP_N", 2),
         ingest_embed_model=os.environ.get("INGEST_EMBED_MODEL", "text-embedding-3-small"),
+        entity_type_derive_workers=_positive_int("ENTITY_TYPE_DERIVE_WORKERS", 8),
         ingest_relevance_two_tower_model_path=os.environ.get("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH", ""),
         # Cosine cold-start default: the study's 85%-filter operating point.
         ingest_relevance_cosine_threshold=_nonneg_float(

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -51,9 +51,10 @@ import logging
 import math
 import re
 from collections import Counter, OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, Field
 
@@ -63,6 +64,9 @@ from app.llm.prompts import load_prompt
 from app.wiki import filesystem, git as wiki_git
 
 log = logging.getLogger(__name__)
+
+_Item = TypeVar("_Item")
+_Result = TypeVar("_Result")
 
 # --- parameters ---------------------------------------------------------------------------
 # Cosine floor for "same kind of thing" — the one parameter with real leverage, because it
@@ -92,6 +96,13 @@ MAX_OUTPUT_TOKENS = 16384
 
 # Retries on MALFORMED output only. Truncation is deterministic, so it is never retried.
 _JSON_RETRIES = 1
+
+# Concurrency for the two per-item LLM stages. Run sequentially, 147 pages took ~1.5 hours in
+# production and a pod restart killed it before it could record anything — the calls are
+# independent, so that wall clock was pure serialization. Eight matches the eval harness this
+# module was ported from; it is a named constant because the ceiling is the provider's rate limit,
+# not this code, and a deployment on a lower tier may need to turn it down.
+DERIVE_WORKERS = 8
 
 # Fallback when no derived artifact is present, so a deployment that has never run the
 # derivation still has something usable. Intentionally generic: these are the types that
@@ -601,6 +612,58 @@ def load_taxonomy(entity_type_taxonomy_id: int | None = None) -> dict[str, str]:
     return defs or dict(DEFAULT_TYPES)
 
 
+def _guarded(fn: Callable[[_Item], list[_Result]], item: _Item, stage: str) -> list[_Result]:
+    """Run one item, absorbing its failure. Preserves the module's rule that a single failed page
+    or group must not abort a corpus-wide derivation — which a raised exception inside a pool
+    would otherwise do, taking every other page's paid-for work with it."""
+    try:
+        return fn(item)
+    except Exception:
+        log.warning("entity_types: %s failed for one item", stage, exc_info=True)
+        return []
+
+
+def _map_ordered(
+    fn: Callable[[_Item], list[_Result]],
+    items: list[_Item],
+    *,
+    stage: str,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> list[list[_Result]]:
+    """Map ``fn`` over ``items`` concurrently, returning results in INPUT order.
+
+    The ordering is load-bearing, not cosmetic. ``_leader_cluster`` assigns each referent to the
+    FIRST centroid it matches, and the naming collapse keeps first-seen examples — so a different
+    arrival order can produce a different taxonomy from the same corpus. ``Executor.map`` yields
+    by submission index rather than completion, which keeps a parallel run reproducible and
+    identical to a sequential one.
+
+    Progress therefore reports the index reached, not the number finished: with eight in flight,
+    item 1 can still be running while 2-8 are done.
+    """
+    if not items:
+        return []
+
+    def one(item: _Item) -> list[_Result]:
+        return _guarded(fn, item, stage)
+
+    results: list[list[_Result]] = []
+    workers = min(DERIVE_WORKERS, len(items))
+    if workers <= 1:
+        for n, item in enumerate(items, start=1):
+            results.append(one(item))
+            if progress:
+                progress(stage, n, len(items))
+        return results
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for n, result in enumerate(pool.map(one, items), start=1):
+            results.append(result)
+            if progress:
+                progress(stage, n, len(items))
+    return results
+
+
 def derive(
     pages: list[tuple[str, str]],
     *,
@@ -608,11 +671,15 @@ def derive(
     progress: Callable[[str, int, int], None] | None = None,
 ) -> dict[str, Any]:
     """Run the whole derivation over ``(path, body)`` pairs. Returns the artifact."""
+    log.info("entity_types: extracting from %d page(s), %d at a time", len(pages), DERIVE_WORKERS)
     mentions: list[Mention] = []
-    for n, (path, body) in enumerate(pages, start=1):
-        mentions.extend(extract_page(path, body, model=model))
-        if progress:
-            progress("extract", n, len(pages))
+    for page_mentions in _map_ordered(
+        lambda pb: extract_page(pb[0], pb[1], model=model),
+        pages,
+        stage="extract",
+        progress=progress,
+    ):
+        mentions.extend(page_mentions)
 
     referents = fold(mentions)
     titles = {path.rsplit("/", 1)[-1].removesuffix(".md").lower() for path, _ in pages}
@@ -644,10 +711,13 @@ def derive(
     # coverage while typing only part of the wiki.
     log.info("entity_types: naming %d group(s)", len(groups))
     named: list[EntityType] = []
-    for n, group in enumerate(groups, start=1):
-        named.extend(name_group(group, model=model))
-        if progress:
-            progress("name", n, len(groups))
+    for group_types in _map_ordered(
+        lambda g: name_group(g, model=model),
+        groups,
+        stage="name",
+        progress=progress,
+    ):
+        named.extend(group_types)
 
     # Types the LLM named identically across groups are one type.
     collapsed: OrderedDict[str, EntityType] = OrderedDict()

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -58,6 +58,7 @@ from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, Field
 
+from app.config import CONFIG
 from app.db import entity_type_taxonomy
 from app.llm import client, embeddings
 from app.llm.prompts import load_prompt
@@ -100,9 +101,21 @@ _JSON_RETRIES = 1
 # Concurrency for the two per-item LLM stages. Run sequentially, 147 pages took ~1.5 hours in
 # production and a pod restart killed it before it could record anything — the calls are
 # independent, so that wall clock was pure serialization. Eight matches the eval harness this
-# module was ported from; it is a named constant because the ceiling is the provider's rate limit,
-# not this code, and a deployment on a lower tier may need to turn it down.
-DERIVE_WORKERS = 8
+# module was ported from.
+#
+# Set by ``ENTITY_TYPE_DERIVE_WORKERS`` rather than fixed here, because the governing constraint
+# is the PROVIDER's rate limit and no value is right for every deployment: each call can carry
+# ~47k input tokens, and this pool runs INSIDE a queue task, so effective concurrency is the
+# queue's own worker count multiplied by this. An operator on a lower tier has to be able to turn
+# it down without rebuilding the image. Read per call, not captured at import, so a test (or a
+# restart with a new value) takes effect.
+DEFAULT_DERIVE_WORKERS = 8
+
+
+def _derive_workers() -> int:
+    """Concurrent extract/name calls. Never below 1 — 0 would mean a derivation that does
+    nothing while reporting success."""
+    return max(1, CONFIG.entity_type_derive_workers)
 
 # Fallback when no derived artifact is present, so a deployment that has never run the
 # derivation still has something usable. Intentionally generic: these are the types that
@@ -648,7 +661,7 @@ def _map_ordered(
         return _guarded(fn, item, stage)
 
     results: list[list[_Result]] = []
-    workers = min(DERIVE_WORKERS, len(items))
+    workers = min(_derive_workers(), len(items))
     if workers <= 1:
         for n, item in enumerate(items, start=1):
             results.append(one(item))
@@ -671,7 +684,9 @@ def derive(
     progress: Callable[[str, int, int], None] | None = None,
 ) -> dict[str, Any]:
     """Run the whole derivation over ``(path, body)`` pairs. Returns the artifact."""
-    log.info("entity_types: extracting from %d page(s), %d at a time", len(pages), DERIVE_WORKERS)
+    log.info(
+        "entity_types: extracting from %d page(s), %d at a time", len(pages), _derive_workers()
+    )
     mentions: list[Mention] = []
     for page_mentions in _map_ordered(
         lambda pb: extract_page(pb[0], pb[1], model=model),

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -200,3 +200,117 @@ class TestCompleteJson:
 
         assert len(seen) == 2
         assert any("Notes/x.md" in r.getMessage() for r in caplog.records)
+
+
+class TestParallelExtraction:
+    """Extraction and naming run concurrently. The property that matters is that concurrency
+    changes only the wall clock: ``_leader_cluster`` takes the FIRST centroid a referent matches
+    and the naming collapse keeps first-seen examples, so a reordered result set is a different
+    taxonomy from the same corpus."""
+
+    def test_results_keep_input_order_regardless_of_completion_order(self, monkeypatch) -> None:
+        """Completion order is deliberately the reverse of input order here, so a naive
+        as-completed collection would fail this and a taxonomy would silently shift."""
+        import time
+
+        from app.ingest import entity_types
+
+        pages = [(f"p{i}.md", "body") for i in range(8)]
+
+        def slow_extract(path, body, *, model=None):
+            # Earlier pages sleep longest, so they finish last.
+            time.sleep(0.05 * (8 - int(path[1:-3])))
+            return [entity_types.Mention(surface=path, page=path)]
+
+        monkeypatch.setattr(entity_types, "extract_page", slow_extract)
+        captured: list[list[entity_types.Mention]] = entity_types._map_ordered(
+            lambda pb: slow_extract(pb[0], pb[1]), pages, stage="extract"
+        )
+
+        assert [m[0].surface for m in captured] == [p for p, _ in pages]
+
+    def test_pages_really_run_concurrently(self, monkeypatch) -> None:
+        """Otherwise this is a no-op refactor: the whole point is that 147 sequential calls at
+        ~55s each took 1.5 hours."""
+        import threading
+        import time
+
+        from app.ingest import entity_types
+
+        in_flight = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def watched(item):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.05)
+            with lock:
+                in_flight -= 1
+            return [item]
+
+        entity_types._map_ordered(watched, list(range(16)), stage="extract")
+
+        assert peak > 1
+        assert peak <= entity_types.DERIVE_WORKERS
+
+    def test_concurrency_is_bounded(self, monkeypatch) -> None:
+        """Unbounded fan-out over a large wiki would hit the provider's rate limit rather than
+        finish faster."""
+        import threading
+        import time
+
+        from app.ingest import entity_types
+
+        in_flight = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def watched(item):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.02)
+            with lock:
+                in_flight -= 1
+            return [item]
+
+        entity_types._map_ordered(watched, list(range(200)), stage="extract")
+
+        assert peak <= entity_types.DERIVE_WORKERS
+
+    def test_one_failing_item_does_not_abort_the_rest(self, monkeypatch) -> None:
+        """The module's stated rule — a single failed page must not abort a corpus-wide
+        derivation — has to survive the pool, which would otherwise propagate the exception and
+        discard every other page's paid-for work."""
+        from app.ingest import entity_types
+
+        def sometimes_raises(item):
+            if item == 3:
+                raise RuntimeError("provider blew up")
+            return [item]
+
+        out = entity_types._map_ordered(sometimes_raises, list(range(6)), stage="extract")
+
+        assert out == [[0], [1], [2], [], [4], [5]]
+
+    def test_progress_reports_every_item(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+
+        seen: list[tuple[str, int, int]] = []
+        entity_types._map_ordered(
+            lambda item: [item],
+            list(range(5)),
+            stage="extract",
+            progress=lambda stage, n, total: seen.append((stage, n, total)),
+        )
+
+        assert seen == [("extract", n, 5) for n in range(1, 6)]
+
+    def test_an_empty_corpus_starts_no_pool(self) -> None:
+        from app.ingest import entity_types
+
+        assert entity_types._map_ordered(lambda item: [item], [], stage="extract") == []

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -254,7 +254,7 @@ class TestParallelExtraction:
         entity_types._map_ordered(watched, list(range(16)), stage="extract")
 
         assert peak > 1
-        assert peak <= entity_types.DERIVE_WORKERS
+        assert peak <= entity_types._derive_workers()
 
     def test_concurrency_is_bounded(self, monkeypatch) -> None:
         """Unbounded fan-out over a large wiki would hit the provider's rate limit rather than
@@ -280,7 +280,7 @@ class TestParallelExtraction:
 
         entity_types._map_ordered(watched, list(range(200)), stage="extract")
 
-        assert peak <= entity_types.DERIVE_WORKERS
+        assert peak <= entity_types._derive_workers()
 
     def test_one_failing_item_does_not_abort_the_rest(self, monkeypatch) -> None:
         """The module's stated rule — a single failed page must not abort a corpus-wide
@@ -314,3 +314,76 @@ class TestParallelExtraction:
         from app.ingest import entity_types
 
         assert entity_types._map_ordered(lambda item: [item], [], stage="extract") == []
+
+
+class TestDeriveWorkers:
+    """The pool size is an operator knob, not a build-time constant: the governing constraint is
+    the provider's rate limit, and this pool runs inside a queue task, so effective concurrency is
+    the queue's worker count multiplied by this."""
+
+    def test_defaults_to_eight(self) -> None:
+        from app.ingest import entity_types
+
+        assert entity_types._derive_workers() == entity_types.DEFAULT_DERIVE_WORKERS == 8
+
+    def test_env_var_lowers_it(self, monkeypatch) -> None:
+        """A lower-tier deployment has to be able to turn this down without rebuilding."""
+        from app.config import load_config
+
+        monkeypatch.setenv("ENTITY_TYPE_DERIVE_WORKERS", "2")
+        assert load_config().entity_type_derive_workers == 2
+
+    def test_a_lowered_knob_actually_bounds_the_pool(self, monkeypatch) -> None:
+        import threading
+        import time
+
+        from app.ingest import entity_types
+
+        monkeypatch.setattr(entity_types, "_derive_workers", lambda: 2)
+        in_flight = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def watched(item):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.03)
+            with lock:
+                in_flight -= 1
+            return [item]
+
+        entity_types._map_ordered(watched, list(range(20)), stage="extract")
+
+        assert peak == 2
+
+    def test_a_zero_knob_does_not_stall_the_derivation(self, monkeypatch) -> None:
+        """0 would otherwise mean a pool of no workers — a run that reports success having done
+        nothing. Clamped to sequential instead."""
+        from types import SimpleNamespace
+
+        from app.ingest import entity_types
+
+        # Config validates on assignment, so the knob cannot be mutated at runtime — only set at
+        # boot. Patch the module's reference to stand in for a deployment booted with 0.
+        monkeypatch.setattr(
+            entity_types, "CONFIG", SimpleNamespace(entity_type_derive_workers=0)
+        )
+        assert entity_types._derive_workers() == 1
+        assert entity_types._map_ordered(lambda i: [i], [1, 2, 3], stage="extract") == [
+            [1],
+            [2],
+            [3],
+        ]
+
+    def test_a_bad_value_is_rejected_at_startup(self, monkeypatch) -> None:
+        """Fail loudly at boot rather than silently falling back to a default an operator did not
+        choose."""
+        import pytest as _pytest
+
+        from app.config import load_config
+
+        monkeypatch.setenv("ENTITY_TYPE_DERIVE_WORKERS", "not-a-number")
+        with _pytest.raises(ValueError):
+            load_config()


### PR DESCRIPTION
The entity-type derivation ran **fully sequentially** — no `ThreadPoolExecutor`, no `concurrent`, no `asyncio` anywhere in `app/ingest/entity_types.py`. 147 blocking LLM calls in series at ~55s each.

In production that meant **~1.5 hours**, and a pod restart killed the run past **105 of 147 pages** before `record()` could write anything — so every one of those calls was discarded (~471k input / ~309k output tokens). The calls are independent, so that wall clock was pure serialization.

A bounded pool of 8 brings it to roughly **15 minutes**, which also shrinks the window an interruption can land in.

## What is parallelised

| stage | unit | count | parallel? |
|---|---|---|---|
| **EXTRACT** | per page | 147 calls | **yes** |
| **NAME** | per candidate group | ~220 calls at `GROUP_SIMILARITY = 0.45` | **yes** |
| **MERGE** | the whole taxonomy, iterated to convergence | 1 per round | no — inherently global |

Naming is not the small stage its name suggests: at the tuned threshold it's *more* calls than extraction, so leaving it sequential would leave most of the wall clock in place.

## The part worth reviewing: order is load-bearing

Concurrency here must not change the output, and a plain as-completed loop **would**:

- `_leader_cluster` assigns each referent to the **first** centroid it matches.
- The naming collapse keeps **first-seen** examples.

So a reordered result set is a *different taxonomy from the same corpus* — silently, with no error and no way to notice. `_map_ordered` uses `Executor.map`, which yields by submission index rather than completion, so a parallel run is reproducible and identical to a sequential one.

The test for this makes completion order the exact **reverse** of input order; collecting as-completed fails it.

## Failures stay per-item

The module's rule is that one bad page must not abort a corpus-wide derivation. A raised exception inside a pool violates that — it propagates out of `map` and takes every other page's paid-for work with it. `_guarded` absorbs it and returns the same empty result the sequential path produced, so a single failure costs one page.

## The worker count is an operator knob

Set by **`ENTITY_TYPE_DERIVE_WORKERS`** (default 8), via `Config` like every other ingest knob. It is not a build-time constant because the governing constraint is the **provider's rate limit**, and this pool runs *inside* a queue task — the queue's own concurrency is itself a `ThreadPoolExecutor`, so effective LLM concurrency is that worker count **multiplied** by this. A deployment on a lower tier has to be able to turn it down without rebuilding the image.

Read per call rather than captured at import, clamped to a floor of 1 (0 would mean a pool of no workers — a derivation reporting success having done nothing), and a non-integer value raises at boot rather than silently falling back to a default nobody chose.

Eight matches the eval harness this module was ported from (`ThreadPoolExecutor(max_workers=8)`, `DEFAULT_WORKERS = 8`). The parallelism was in that harness and did not survive the port — which is also why my first estimate of this job's duration was wrong by an order of magnitude, since it was reasoned from the harness's behaviour rather than the product's.

## On moving fan-out into the queue instead

Raised in review, and worth answering explicitly: it isn't available here. The queue has **no group/chord/barrier primitive**, and the derivation needs *every* page before fold → group → name → merge can run. Queue-level fan-out would therefore mean building a join — a state table, a completion counter, and a "last worker continues" handoff — for a job that is unscheduled and occasional. There is also precedent for bounded in-process pools in app code (`web/firecrawl.py`), and the queue's own consumer concurrency is a thread pool.

The pool here is bounded, short-lived, scoped to a single task, and now operator-governed, which addresses the part of that concern that actually bites.

## Not affected: prompt caching

Worth stating because it's the obvious objection to fanning out. Caching was already at **zero** — every call in both prod runs logged `cached=0`. OpenAI needs a shared prefix of ≥1024 tokens and `entity_types.extract` is ~396; everything after it is the page body, which is unique per call. Parallelism doesn't change eligibility either way.

(Separately, that gap is a real cost lever — input dominates spend and the prefix is ~600 tokens short of cacheable. Out of scope here; worth measuring on the next full run, which will produce real `cached=` figures.)

## Tests

11 new, covering the properties rather than the mechanism: input order preserved despite reversed completion order, concurrency actually occurs, concurrency is bounded, one failing item doesn't abort the rest, progress reports every item, an empty corpus starts no pool. Plus the knob: it defaults to 8, the env var lowers it, a lowered value really bounds the pool, 0 clamps to sequential rather than stalling, and a bad value fails at boot.

Verified by mutation — collecting as-completed, dropping the guard, and forcing `workers=1` each fail a test. Full backend suite green; `ruff check` and basedpyright clean (581 files).

## After this

Deploy, then run the derivation as a **Kubernetes Job** rather than a detached process in the web pod. At ~15 minutes the interruption risk mostly disappears, but the web pod is still the wrong host — that's what lost the last run, along with its log.
