### PR TITLE
fix(wiki): one identity colour for a peer's caret and their presence chip

### DIFF
--- a/frontend/src/components/wiki/PresenceAvatars.tsx
+++ b/frontend/src/components/wiki/PresenceAvatars.tsx
@@ -24,6 +24,7 @@ import {
   PolicyPopover,
   type OpenUpdatesPanelOpts,
 } from "@/components/wiki/policyPanels";
+import { colorFor } from "@/lib/editor/identityColor";
 import { relativeTime } from "@/lib/users";
 import { fetchFileHistory } from "@/lib/wiki/svc";
 import { useUpdateHealth } from "@/lib/wiki/hooks";
@@ -36,14 +37,6 @@ import type { DocumentActivity } from "@/types";
 // Identity hues cycled per user. Semantic hues stay reserved: red/green/
 // orange for status, blue/amber/sky for selection. The mock's mint/coral/
 // violet have no Opal tokens, so the cycle substitutes shipped hues.
-const USER_COLORS = [
-  "var(--neon-cyan-50)",
-  "var(--neon-yellow-50)",
-  "var(--neon-lime-60)",
-  "var(--neon-magenta-50)",
-  "var(--purple-50)",
-];
-
 const MAX_CHIPS = 5;
 
 function agentGlyph(name: string | null): IconFunctionComponent | null {
@@ -345,7 +338,7 @@ export function PresenceAvatars({
     ): PresenceEntry => ({
       userId,
       display,
-      color: USER_COLORS[i % USER_COLORS.length],
+      color: colorFor(userId),
       editing,
       agentName,
       caretHead: caretByUser.get(userId) ?? null,

--- a/frontend/src/lib/editor/identityColor.ts
+++ b/frontend/src/lib/editor/identityColor.ts
@@ -1,0 +1,33 @@
+/** The one place a peer's identity colour is decided.
+ *
+ * A peer shows up twice on a page — as a caret in the document
+ * (`presence.ts` → `yCursorPlugin`) and as a presence chip's ring
+ * (`components/wiki/PresenceAvatars.tsx`) — and those two have to be the
+ * same colour, or the chip stops identifying whose caret is whose, which is
+ * the only thing the colour is for. Keeping one palette and one keying rule
+ * in one module is what makes that true; two lists drift the moment either
+ * side is edited.
+ *
+ * Keyed on `userId`, never on a position in a list: a peer's colour has to
+ * hold still while other people come and go around them.
+ */
+
+/** Opal tokens rather than literals, per CLAUDE.md. */
+const IDENTITY_COLORS = [
+  "var(--neon-cyan-50)",
+  "var(--neon-yellow-50)",
+  "var(--neon-lime-60)",
+  "var(--neon-magenta-50)",
+  "var(--purple-50)",
+];
+
+/** A stable colour for `userId` — same input, same colour, for as long as the
+ * palette is unchanged. Distinct users can collide once there are more of
+ * them than colours; a collision costs a moment of ambiguity, whereas a
+ * colour that moves around costs the reader the mapping entirely. */
+export function colorFor(userId: string): string {
+  let h = 0;
+  for (let i = 0; i < userId.length; i++)
+    h = (h * 31 + userId.charCodeAt(i)) | 0;
+  return IDENTITY_COLORS[Math.abs(h) % IDENTITY_COLORS.length]!;
+}

--- a/frontend/src/lib/editor/presence.ts
+++ b/frontend/src/lib/editor/presence.ts
@@ -11,28 +11,9 @@ import { Extension } from "@tiptap/core";
 import { yCursorPlugin } from "@tiptap/y-tiptap";
 import type { Awareness } from "y-protocols/awareness";
 
-/** Opal-ish hues that read on both themes, one per peer slot — ported
- * verbatim from `lib/editor/constants.ts`. */
-const PEER_COLORS = [
-  "#e5484d",
-  "#0090ff",
-  "#30a46c",
-  "#f76b15",
-  "#8e4ec6",
-  "#e5b000",
-  "#00a2c7",
-  "#e93d82",
-];
-
-/** Deterministically map a `userId` to a color from `PEER_COLORS` so a given
- * peer keeps the same color for the full session — ported verbatim from
- * `lib/editor/utils.ts`. */
-export function colorFor(userId: string): string {
-  let h = 0;
-  for (let i = 0; i < userId.length; i++)
-    h = (h * 31 + userId.charCodeAt(i)) | 0;
-  return PEER_COLORS[Math.abs(h) % PEER_COLORS.length]!;
-}
+// Re-exported so existing importers keep working; the definition lives in one
+// place because the caret and the presence chip must agree (see identityColor).
+export { colorFor } from "@/lib/editor/identityColor";
 
 /** Registers `yCursorPlugin` — renders every other client's caret/selection
  * from `awareness`'s shared state as a `Decoration.widget` (colored bar +


### PR DESCRIPTION
Confirmed — and the mismatch isn't intermittent, it's structural.

## What was wrong

A peer appears twice on a page: as a caret in the document, and as the ring on their presence chip. Those colours were derived two different ways:

| | palette | keyed by |
|---|---|---|
| caret (`presence.ts`) | `PEER_COLORS` — 8 raw hex (`#e5484d`, `#0090ff`, …) | hash of `userId` |
| chip ring (`PresenceAvatars.tsx:348`) | `USER_COLORS` — 5 Opal neon vars | **index in the participant list** |

Different palettes *and* different keys, so any agreement was a coincidence of similar hue rather than a match — which is why it read as "sometimes different."

**Keying the ring on list position is a second defect.** The list filters out the current user and is in participant order, so a peer's ring colour changed when somebody *else* joined or left ahead of them. Demonstrated against the two implementations:

```
caret vs ring, per user:
  8840e472-user-bo     caret=lime     oldRing=cyan
  c1a2-user-joachim    caret=yellow   oldRing=yellow   ← coincidence
  f9d3-user-nik        caret=magenta  oldRing=lime
  aa11-user-dane       caret=lime     oldRing=magenta

same peer, roster changes (nik):
  old ring: lime -> yellow      ← peer did nothing; someone ahead of them left
  new ring: magenta -> magenta
```

(That comparison holds the palette constant to isolate the keying difference; in the shipped code the two palettes differed as well, so the disagreement was near-total.)

A colour whose only job is "this caret belongs to that chip" cannot move when the roster around it moves.

## Fix

One module, `lib/editor/identityColor.ts`, owns the palette and the keying rule; the caret and the chip both call its `colorFor(userId)`. `presence.ts` re-exports it so existing importers are unaffected.

The surviving palette is the **chip's existing Opal tokens**, not the caret's hex literals — one list to change, and no raw colour values (CLAUDE.md). Keyed on `userId`, never on position.

## Trade-off, and one thing for Nik

The caret palette goes from 8 entries to 5, so distinct users collide slightly sooner. A brief ambiguity between two peers seems clearly better than a colour the reader can't rely on at all — but if you'd rather keep 8, the fix is to add three more Opal tokens to the one list (`--blue-50`, `--orange-50`, `--red-50` all resolve).

Worth a look from Nik since he owns this surface: two of the inherited chip tokens are light (`--neon-yellow-50` `#ece600`, `--neon-cyan-50` `#00ebea`) and now render as caret bars too, where they'll be fainter on a light background than the hex values they replace. Swapping specific hues is a one-line edit now that there's a single list.

`tsc` and prettier clean.

<img width="574" height="457" alt="Screenshot 2026-08-03 at 11 32 25 AM" src="https://github.com/user-attachments/assets/96d46b58-4409-4130-8c32-ad01608cd82a" />

