### PR TITLE
feat(ingest): derive the taxonomy with the ingestion model

### DIFF
--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -61,6 +61,7 @@ from pydantic import BaseModel, Field
 from app.config import CONFIG
 from app.db import entity_type_taxonomy
 from app.llm import client, embeddings
+from app.llm.settings import get as get_llm_settings
 from app.llm.prompts import load_prompt
 from app.wiki import filesystem, git as wiki_git
 
@@ -784,6 +785,10 @@ def run_derivation(
     the caller decides whether that is fatal (nothing is stored, so the previous taxonomy,
     or the fallback, stays in force).
     """
+    # Default to the admin's ingestion-pipeline model: this job is ingest-side and does not need
+    # the main model. Unset means none was nominated, so fall through to the deployment default.
+    model = model or get_llm_settings().ingest_selector_model or None
+
     pages = read_corpus(prefix)
     if not pages:
         raise RuntimeError("no wiki pages to derive from")

--- a/backend/app/tasks/entity_types.py
+++ b/backend/app/tasks/entity_types.py
@@ -33,17 +33,8 @@ def derive_entity_types(
     ``triggered_by_user_id`` is the admin who asked (NULL for a system run),
     matching ``run_detection_sweep``.
 
-    ``model`` overrides the deployment default for this derivation only. Worth
-    having because this job does not need the deployment's strongest model: the
-    validated 9-type taxonomy for the reference wiki was produced by
-    ``gpt-5.4-mini``, which is cheaper, faster, and materially less verbose —
-    and verbosity is the risk here, since a stronger model came within 12% of
-    the output cap on one page and truncation costs that page's referents
-    entirely.
-
-    Deliberately NOT wired to ``ingest_selector_model``: an empty value there
-    means "skip the ingest pre-filter", so reusing it would let an admin turn
-    off that filter and silently change which model builds the taxonomy.
+    ``model`` overrides the default for this run. Unset, ``run_derivation``
+    uses the ingestion-pipeline model.
     """
     entity_types.run_derivation(
         triggered_by_user_id=triggered_by_user_id, model=model

--- a/backend/app/tasks/entity_types.py
+++ b/backend/app/tasks/entity_types.py
@@ -25,10 +25,26 @@ log = logging.getLogger(__name__)
 
 
 @automanage_offline_queue.task()
-def derive_entity_types(triggered_by_user_id: str | None = None) -> None:
+def derive_entity_types(
+    triggered_by_user_id: str | None = None, model: str | None = None
+) -> None:
     """Derive the taxonomy from the current wiki and store it.
 
     ``triggered_by_user_id`` is the admin who asked (NULL for a system run),
     matching ``run_detection_sweep``.
+
+    ``model`` overrides the deployment default for this derivation only. Worth
+    having because this job does not need the deployment's strongest model: the
+    validated 9-type taxonomy for the reference wiki was produced by
+    ``gpt-5.4-mini``, which is cheaper, faster, and materially less verbose —
+    and verbosity is the risk here, since a stronger model came within 12% of
+    the output cap on one page and truncation costs that page's referents
+    entirely.
+
+    Deliberately NOT wired to ``ingest_selector_model``: an empty value there
+    means "skip the ingest pre-filter", so reusing it would let an admin turn
+    off that filter and silently change which model builds the taxonomy.
     """
-    entity_types.run_derivation(triggered_by_user_id=triggered_by_user_id)
+    entity_types.run_derivation(
+        triggered_by_user_id=triggered_by_user_id, model=model
+    )

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -390,9 +390,9 @@ class TestDeriveWorkers:
 
 
 class TestDerivationTaskModel:
-    """The task can pin a model. This job does not need the deployment's strongest one — the
-    validated taxonomy for the reference wiki came from gpt-5.4-mini — and a less verbose model
-    is safer here, since truncation costs a page's referents outright."""
+    """Which model the derivation runs on. It defaults to the ingestion-pipeline model rather
+    than the main one: this job is ingest-side, and the validated 9-type taxonomy for the
+    reference wiki came from gpt-5.4-mini."""
 
     def test_the_model_reaches_run_derivation(self, monkeypatch) -> None:
         from app.ingest import entity_types as ingest_entity_types
@@ -423,20 +423,55 @@ class TestDerivationTaskModel:
 
         assert seen["model"] is None
 
-    def test_the_task_does_not_read_llm_settings(self) -> None:
-        """The model is passed in, never inferred from settings. Specifically it must not read
-        ``ingest_selector_model``: that field is EMPTY when the ingest pre-filter is off, so
-        deriving the taxonomy model from it would let an unrelated switch silently change which
-        model builds the taxonomy. Checked against imports rather than text, so a docstring that
-        explains the reasoning cannot satisfy it."""
-        import ast
-        import pathlib
+    @staticmethod
+    def _stub(monkeypatch, *, ingest_model: str) -> dict:
+        """Stub the derivation down to the one thing under test: which model it resolves."""
+        from app.ingest import entity_types
+        from app.llm import settings as llm_settings
 
-        tree = ast.parse(pathlib.Path("app/tasks/entity_types.py").read_text())
-        imported = {
-            alias.name if isinstance(node, ast.Import) else f"{node.module}.{alias.name}"
-            for node in ast.walk(tree)
-            if isinstance(node, (ast.Import, ast.ImportFrom))
-            for alias in node.names
+        seen: dict = {}
+        artifact = {
+            "entity_types": [{"name": "t", "definition": "d"}],
+            "stats": {"n_mentions": 1, "n_referents": 1, "n_typed": 1, "n_types": 1},
         }
-        assert not any("llm" in name for name in imported), imported
+        monkeypatch.setattr(
+            entity_types,
+            "get_llm_settings",
+            lambda: llm_settings.LLMSettings(model="main", ingest_selector_model=ingest_model),
+        )
+        monkeypatch.setattr(entity_types, "read_corpus", lambda prefix="": [("a.md", "body")])
+        monkeypatch.setattr(
+            entity_types,
+            "derive",
+            lambda pages, model=None: (seen.update(model=model), artifact)[1],
+        )
+        monkeypatch.setattr(entity_types, "store_taxonomy", lambda artifact, triggered_by=None: 1)
+        return seen
+
+    def test_defaults_to_the_ingestion_model(self, monkeypatch) -> None:
+        """The wiring that makes the option useful: with nothing passed, the admin's
+        ingestion-pipeline model is what runs."""
+        from app.ingest import entity_types
+
+        seen = self._stub(monkeypatch, ingest_model="ingest-cheap")
+        entity_types.run_derivation()
+
+        assert seen["model"] == "ingest-cheap"
+
+    def test_an_explicit_model_wins(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+
+        seen = self._stub(monkeypatch, ingest_model="ingest-cheap")
+        entity_types.run_derivation(model="pinned")
+
+        assert seen["model"] == "pinned"
+
+    def test_no_ingestion_model_falls_back_to_the_deployment_default(self, monkeypatch) -> None:
+        """Unset means no cheaper model was nominated: pass None so client.complete resolves the
+        main model, rather than "" which would read as configured-but-blank."""
+        from app.ingest import entity_types
+
+        seen = self._stub(monkeypatch, ingest_model="")
+        entity_types.run_derivation()
+
+        assert seen["model"] is None

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -387,3 +387,56 @@ class TestDeriveWorkers:
         monkeypatch.setenv("ENTITY_TYPE_DERIVE_WORKERS", "not-a-number")
         with _pytest.raises(ValueError):
             load_config()
+
+
+class TestDerivationTaskModel:
+    """The task can pin a model. This job does not need the deployment's strongest one — the
+    validated taxonomy for the reference wiki came from gpt-5.4-mini — and a less verbose model
+    is safer here, since truncation costs a page's referents outright."""
+
+    def test_the_model_reaches_run_derivation(self, monkeypatch) -> None:
+        from app.ingest import entity_types as ingest_entity_types
+        from app.tasks import entity_types as task_module
+
+        seen: dict[str, object] = {}
+
+        def fake_run(**kwargs):
+            seen.update(kwargs)
+            return {}
+
+        monkeypatch.setattr(ingest_entity_types, "run_derivation", fake_run)
+        task_module.derive_entity_types.fn(triggered_by_user_id="usr_1", model="gpt-5.4-mini")
+
+        assert seen == {"triggered_by_user_id": "usr_1", "model": "gpt-5.4-mini"}
+
+    def test_no_model_keeps_the_deployment_default(self, monkeypatch) -> None:
+        """None must reach run_derivation as None, so client.complete resolves llm_settings —
+        not be turned into an empty string, which would read as a configured-but-blank model."""
+        from app.ingest import entity_types as ingest_entity_types
+        from app.tasks import entity_types as task_module
+
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            ingest_entity_types, "run_derivation", lambda **kw: seen.update(kw) or {}
+        )
+        task_module.derive_entity_types.fn()
+
+        assert seen["model"] is None
+
+    def test_the_task_does_not_read_llm_settings(self) -> None:
+        """The model is passed in, never inferred from settings. Specifically it must not read
+        ``ingest_selector_model``: that field is EMPTY when the ingest pre-filter is off, so
+        deriving the taxonomy model from it would let an unrelated switch silently change which
+        model builds the taxonomy. Checked against imports rather than text, so a docstring that
+        explains the reasoning cannot satisfy it."""
+        import ast
+        import pathlib
+
+        tree = ast.parse(pathlib.Path("app/tasks/entity_types.py").read_text())
+        imported = {
+            alias.name if isinstance(node, ast.Import) else f"{node.module}.{alias.name}"
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.Import, ast.ImportFrom))
+            for alias in node.names
+        }
+        assert not any("llm" in name for name in imported), imported


### PR DESCRIPTION
The taxonomy derivation ran on the main model. It's ingest-side work, so it should use the model an admin picks for the ingestion pipeline.

`run_derivation` now defaults to `llm_settings.ingest_selector_model`. Unset means no cheaper model was nominated, so it falls through to the deployment default; an explicit `model=` still wins. `derive_entity_types(model=...)` passes through for one-off runs.

**Why mini is enough here:** the validated 9-type taxonomy for the reference wiki was produced by `gpt-5.4-mini` — same corpus, one model for every stage.

**Why it's also safer:** on the production run with the main model (`gpt-5.5`), one page produced **14,453 output tokens against the 16,384 cap**. Truncation in this stage drops that page's referents outright rather than degrading them, so a less verbose model widens a margin that is currently thin.

## Tests

3 new: the ingestion model is used by default, an explicit model overrides it, and an unset ingestion model passes `None` (not `""`, which would read as configured-but-blank). Verified by mutation — dropping the default fails the first.

`ruff check` and basedpyright clean.

## Note

Need extraction (`app/ingest/needs.py`) still resolves the **main** model. It's also ingest-side, so the same argument may apply — but it's a separate change with its own cost/quality trade-off, and switching it would make every stored page stale and force a full re-extraction. Left alone deliberately.
