### PR TITLE
fix(wiki): comment box opens three lines tall and grows with the comment

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -455,18 +455,26 @@ body {
    (566:19918), so the textarea itself goes chromeless. The wrapper owns
    the border, focus ring, and padding. */
 .comment-input textarea {
-  /* block, not inline: the inline baseline gap would grow the field past
-     the mock's 36px total height */
+  /* block, not inline: an inline baseline gap would add height the line-height
+     arithmetic below doesn't account for */
   display: block;
   border: none;
   background: transparent;
   box-shadow: none;
   outline: none;
   padding: 2px;
-  min-height: 24px;
   width: 100%;
   font-size: 14px;
   line-height: 20px;
+  /* Three lines open, so a comment starts with room to write in rather than a
+     single line that scrolls under itself. Both bounds are line-height
+     arithmetic: 3 lines + the 2px padding on each edge, and 12 lines the same
+     way. Between them MentionTextarea sets an inline height per keystroke; the
+     floor wins while that measurement is smaller, the ceiling wins once it's
+     larger and the field scrolls instead of growing without limit. */
+  min-height: calc(3 * 20px + 4px);
+  max-height: calc(12 * 20px + 4px);
+  overflow-y: auto;
   resize: none;
 }
 .comment-input textarea::placeholder {

--- a/frontend/src/components/wiki/MentionTextarea.tsx
+++ b/frontend/src/components/wiki/MentionTextarea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { activeMentionQuery } from "@/lib/commentMentions";
 import { displayName, initials, useUserSearch } from "@/lib/users";
@@ -35,6 +35,21 @@ export function MentionTextarea({
 
   const { users } = useUserSearch(query ?? "", query !== null);
   const open = query !== null && users.length > 0;
+
+  // A textarea does not grow with its content, so without this it stays at
+  // whatever height CSS gives it and long comments scroll inside one cramped
+  // line. Measuring needs the height released first: `scrollHeight` on an
+  // element already stretched by an inline height reports that height, so it
+  // could never shrink again after a delete. The floor and ceiling stay in CSS
+  // (`.comment-input textarea`) — `min-height` holds the field open at three
+  // lines while it's short, and `max-height` takes over once it's long enough
+  // to scroll, so neither bound has to be duplicated here as a magic number.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [value]);
 
   // Recompute the active `@query` from the current caret position.
   const sync = (v: string, caret: number) => {


### PR DESCRIPTION
The comment composer was one line high with no growth — `rows={1}` plus a 24px `min-height` — so anything past a few words scrolled inside a field the height of its own text, hiding what you'd already written while you typed.

## Change

- **Floor of three lines**, in CSS.
- **Growth past that**: `MentionTextarea` sets an inline height from the content on each change.

Measuring releases the inline height first. `scrollHeight` on an element already stretched by an inline height reports *that* height, so without the reset the field could grow but never shrink again after a delete.

Both bounds stay in CSS as line-height arithmetic (`calc(3 * 20px + 4px)` and `calc(12 * 20px + 4px)` — three and twelve lines plus the 2px padding on each edge) rather than as numbers in the component: the floor wins while the measurement is smaller, the ceiling wins once it's larger, and past twelve lines the field scrolls instead of growing without limit.

## Verified on a running build

Driven through React's own change path, measuring the rendered element:

| content | height |
|---|---|
| empty / 1 line / 3 lines | **64px** — the floor |
| 5 lines | 104px |
| 8 lines | 164px |
| 30 lines | 244px, and `scrollHeight > clientHeight` |
| deleted back to 1 line, then cleared | 64px |

## One thing I added that you didn't ask for

**The twelve-line cap.** An uncapped composer in a floating card would eventually outgrow the viewport, so leaving it unbounded seemed worse than picking a number — but twelve is a starting point, not a considered design value. Say the word and I'll change or remove it.

I also updated a stale comment on the CSS rule: it explained `display: block` in terms of "the mock's 36px total height", which this change makes untrue.

`tsc` and prettier clean; only consumer of `MentionTextarea` is the comment composer, so nothing else is affected.
<img width="946" height="259" alt="Screenshot 2026-08-03 at 12 00 09 PM" src="https://github.com/user-attachments/assets/7054110e-1e43-4965-a605-d48ac0a98cdf" />

