### PR TITLE
fix(ingest): accept partial naming responses instead of discarding them

### DIFF
--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -414,6 +414,18 @@ def _member_indices(entry: dict[str, Any], upper: int) -> list[int]:
     return out
 
 
+def _placeholder_name(members: list[Referent]) -> str:
+    """A name unique to THESE members.
+
+    ``derive`` collapses types that share a name, on the premise that the model named them
+    identically. A placeholder does not carry that premise, so two groups each leaving one
+    unassigned member must not become one type with their referents and examples pooled.
+    Canonicals are distinct after folding, so the first member's is enough to keep them apart.
+    """
+    slug = _TOKENS.sub("_", members[0].canonical.lower()).strip("_")
+    return f"unnamed_{slug or 'group'}"[:60]
+
+
 def name_group(group: list[Referent], *, model: str | None = None) -> list[EntityType]:
     """Name the kind a group shares. May split a group that turns out to be mixed."""
     system = load_prompt("entity_types.name")
@@ -431,12 +443,8 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
     )
 
     # The prompt requires a partition: every member in exactly one type. Both ways it can break
-    # are handled by taking what is valid rather than discarding the response, because
-    # all-or-nothing costs far more than the flaw it guards against — a group of 261 referents
-    # was rejected over ONE uncovered member, and the whole group then fell through to a
-    # placeholder that the merge step had to place from examples with no definition. Losing one
-    # referent's type beats losing the name of 260. (Same conclusion the merge step reached; see
-    # ``merge_types``.)
+    # take what is valid instead of discarding the response — losing one referent's type beats
+    # losing the name of the whole group. Same rule as ``merge_types``.
     out: list[EntityType] = []
     claimed: set[int] = set()
     for raw_entry in cast(list[Any], (data or {}).get("types") or []):
@@ -471,9 +479,8 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
             )
         )
 
-    # Members the response never assigned are carried as their own remainder rather than dropped
-    # silently. They stay visible to the merge step, which can place a handful from examples far
-    # better than it can place a whole group.
+    # Unassigned members are carried as their own remainder rather than dropped silently: merge
+    # places a handful from examples better than it places a whole group.
     uncovered = [i for i in range(len(group)) if i not in claimed]
     if out and uncovered:
         log.warning(
@@ -487,7 +494,7 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
         members = [group[i] for i in uncovered]
         out.append(
             EntityType(
-                name=f"unnamed_{len(uncovered)}",
+                name=_placeholder_name(members),
                 definition="(uncovered by naming)",
                 examples=[r.canonical for r in members[:8]],
                 n_referents=len(members),
@@ -499,7 +506,7 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
     # A group we could not name is still evidence; keep it visible rather than dropping it.
     return [
         EntityType(
-            name=f"unnamed_{len(group)}",
+            name=_placeholder_name(group),
             definition="(naming failed)",
             examples=[r.canonical for r in group[:8]],
             n_referents=len(group),

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -430,10 +430,13 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
         ctx=f"naming a group of {len(group)} referent(s)",
     )
 
-    # The prompt requires a partition: every member in exactly one type. Enforce it. A
-    # response that omits members would silently drop referents, and one that repeats them
-    # would inflate the support counts a type is judged on — so a partial answer is treated
-    # as no answer, not as a smaller one.
+    # The prompt requires a partition: every member in exactly one type. Both ways it can break
+    # are handled by taking what is valid rather than discarding the response, because
+    # all-or-nothing costs far more than the flaw it guards against — a group of 261 referents
+    # was rejected over ONE uncovered member, and the whole group then fell through to a
+    # placeholder that the merge step had to place from examples with no definition. Losing one
+    # referent's type beats losing the name of 260. (Same conclusion the merge step reached; see
+    # ``merge_types``.)
     out: list[EntityType] = []
     claimed: set[int] = set()
     for raw_entry in cast(list[Any], (data or {}).get("types") or []):
@@ -444,12 +447,20 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
         indices = _member_indices(entry, len(group))
         if not name or not indices:
             continue
-        if claimed & set(indices):
-            log.warning("entity_types: naming returned overlapping members; ignoring response")
-            out = []
-            break
-        claimed.update(indices)
-        members = [group[i] for i in indices]
+        # A repeated member would inflate the support counts a type is judged on, so the FIRST
+        # claim wins and later duplicates are dropped — not the entry, and not the response.
+        fresh = [i for i in indices if i not in claimed]
+        if len(fresh) != len(indices):
+            log.warning(
+                "entity_types: naming claimed %d already-assigned member(s) for %r; keeping the "
+                "first assignment",
+                len(indices) - len(fresh),
+                name,
+            )
+        if not fresh:
+            continue
+        claimed.update(fresh)
+        members = [group[i] for i in fresh]
         out.append(
             EntityType(
                 name=name,
@@ -459,13 +470,30 @@ def name_group(group: list[Referent], *, model: str | None = None) -> list[Entit
                 n_docs=len({p for r in members for p in r.pages}),
             )
         )
-    if out and len(claimed) < len(group):
+
+    # Members the response never assigned are carried as their own remainder rather than dropped
+    # silently. They stay visible to the merge step, which can place a handful from examples far
+    # better than it can place a whole group.
+    uncovered = [i for i in range(len(group)) if i not in claimed]
+    if out and uncovered:
         log.warning(
-            "entity_types: naming covered %d of %d member(s); ignoring response",
+            "entity_types: naming covered %d of %d member(s); keeping the %d named type(s) and "
+            "carrying %d uncovered member(s)",
             len(claimed),
             len(group),
+            len(out),
+            len(uncovered),
         )
-        out = []
+        members = [group[i] for i in uncovered]
+        out.append(
+            EntityType(
+                name=f"unnamed_{len(uncovered)}",
+                definition="(uncovered by naming)",
+                examples=[r.canonical for r in members[:8]],
+                n_referents=len(members),
+                n_docs=len({p for r in members for p in r.pages}),
+            )
+        )
     if out:
         return out
     # A group we could not name is still evidence; keep it visible rather than dropping it.

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -46,6 +46,7 @@ type list, the same degradation as the relevance scorer without its model file.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import math
@@ -415,15 +416,21 @@ def _member_indices(entry: dict[str, Any], upper: int) -> list[int]:
 
 
 def _placeholder_name(members: list[Referent]) -> str:
-    """A name unique to THESE members.
+    """A name unique to THIS member set.
 
     ``derive`` collapses types that share a name, on the premise that the model named them
-    identically. A placeholder does not carry that premise, so two groups each leaving one
-    unassigned member must not become one type with their referents and examples pooled.
-    Canonicals are distinct after folding, so the first member's is enough to keep them apart.
+    identically — which a placeholder does not carry. So the name must not be reachable by any
+    other set of members, or two groups' referents and examples get pooled into one type.
+
+    A digest over every member's canonical, rather than a readable slug alone: a slug has to be
+    truncated somewhere, and two long names sharing a prefix would then collide. The leading slug
+    is kept only so the name is legible to the merge step.
     """
-    slug = _TOKENS.sub("_", members[0].canonical.lower()).strip("_")
-    return f"unnamed_{slug or 'group'}"[:60]
+    digest = hashlib.sha256(
+        "\x1f".join(r.canonical for r in members).encode("utf-8")
+    ).hexdigest()[:10]
+    slug = _TOKENS.sub("_", members[0].canonical.lower()).strip("_")[:32]
+    return f"unnamed_{slug}_{digest}" if slug else f"unnamed_{digest}"
 
 
 def name_group(group: list[Referent], *, model: str | None = None) -> list[EntityType]:

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -478,10 +478,8 @@ class TestDerivationTaskModel:
 
 
 class TestNamingPartialAcceptance:
-    """Naming used to discard a whole response over one unassigned member. On the production
-    corpus that rejected the three LARGEST groups (261, 119 and 94 referents) — each for a single
-    uncovered member — and merge then had to place them from a placeholder with no definition,
-    which is how `organization` and `person` referents ended up inside `software`."""
+    """A partition violation costs only what is invalid: the named types survive, and uncovered or
+    double-claimed members are handled without discarding the response."""
 
     @staticmethod
     def _group(n: int):
@@ -498,12 +496,11 @@ class TestNamingPartialAcceptance:
 
         monkeypatch.setattr(entity_types, "_complete_json", lambda *a, **k: payload)
 
-    def test_one_uncovered_member_no_longer_discards_the_group(self, monkeypatch, caplog) -> None:
+    def test_one_uncovered_member_does_not_discard_the_group(self, monkeypatch, caplog) -> None:
         from app.ingest import entity_types
 
         group = self._group(10)
-        # Covers members 1-9 of 10, omitting the last — the shape seen in production.
-        # Indices are 1-based in the payload (see ``_member_indices``).
+        # Covers members 1-9 of 10. Indices are 1-based (see ``_member_indices``).
         self._stub(
             monkeypatch,
             {
@@ -520,10 +517,10 @@ class TestNamingPartialAcceptance:
         with caplog.at_level("WARNING"):
             out = entity_types.name_group(group)
 
-        assert [t.name for t in out] == ["organization", "unnamed_1"]
+        assert out[0].name == "organization"
         assert out[0].n_referents == 9
+        assert out[1].name.startswith("unnamed")
         assert out[1].n_referents == 1
-        assert not any(t.name.startswith("unnamed_10") for t in out)
 
     def test_a_full_partition_is_unchanged(self, monkeypatch) -> None:
         from app.ingest import entity_types
@@ -572,7 +569,38 @@ class TestNamingPartialAcceptance:
 
         out = entity_types.name_group(self._group(5))
 
-        assert [t.name for t in out] == ["unnamed_5"]
+        assert len(out) == 1
+        assert out[0].name.startswith("unnamed")
+        assert out[0].n_referents == 5
+
+    def test_remainders_from_different_groups_get_different_names(self, monkeypatch) -> None:
+        """``derive`` collapses types sharing a name, so identically-sized remainders from
+        unrelated groups would otherwise pool their referents and examples into one type."""
+        from app.ingest import entity_types
+
+        names = []
+        for offset in (0, 100):
+            group = [
+                entity_types.Referent(canonical=f"r{offset + i}", pages={f"p{i}.md"})
+                for i in range(3)
+            ]
+            self._stub(
+                monkeypatch,
+                {"types": [{"type_name": "person", "definition": "d", "member_indices": [1, 2]}]},
+            )
+            out = entity_types.name_group(group)
+            names.append([t.name for t in out if t.name.startswith("unnamed")])
+
+        assert names[0] != names[1], names
+
+    def test_a_whole_group_fallback_is_also_named_per_group(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+
+        self._stub(monkeypatch, {"types": []})
+        first = entity_types.name_group([entity_types.Referent(canonical="alpha", pages={"a.md"})])
+        second = entity_types.name_group([entity_types.Referent(canonical="beta", pages={"b.md"})])
+
+        assert first[0].name != second[0].name
 
     def test_referent_counts_stay_exact(self, monkeypatch) -> None:
         """The counts are what a type's support is judged on downstream, so they must sum to the

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -475,3 +475,120 @@ class TestDerivationTaskModel:
         entity_types.run_derivation()
 
         assert seen["model"] is None
+
+
+class TestNamingPartialAcceptance:
+    """Naming used to discard a whole response over one unassigned member. On the production
+    corpus that rejected the three LARGEST groups (261, 119 and 94 referents) — each for a single
+    uncovered member — and merge then had to place them from a placeholder with no definition,
+    which is how `organization` and `person` referents ended up inside `software`."""
+
+    @staticmethod
+    def _group(n: int):
+        from app.ingest.entity_types import Referent
+
+        return [
+            Referent(canonical=f"r{i}", variants=[f"r{i}"], pages={f"p{i}.md"})
+            for i in range(n)
+        ]
+
+    @staticmethod
+    def _stub(monkeypatch, payload):
+        from app.ingest import entity_types
+
+        monkeypatch.setattr(entity_types, "_complete_json", lambda *a, **k: payload)
+
+    def test_one_uncovered_member_no_longer_discards_the_group(self, monkeypatch, caplog) -> None:
+        from app.ingest import entity_types
+
+        group = self._group(10)
+        # Covers members 1-9 of 10, omitting the last — the shape seen in production.
+        # Indices are 1-based in the payload (see ``_member_indices``).
+        self._stub(
+            monkeypatch,
+            {
+                "types": [
+                    {
+                        "type_name": "organization",
+                        "definition": "d",
+                        "member_indices": list(range(1, 10)),
+                    }
+                ]
+            },
+        )
+
+        with caplog.at_level("WARNING"):
+            out = entity_types.name_group(group)
+
+        assert [t.name for t in out] == ["organization", "unnamed_1"]
+        assert out[0].n_referents == 9
+        assert out[1].n_referents == 1
+        assert not any(t.name.startswith("unnamed_10") for t in out)
+
+    def test_a_full_partition_is_unchanged(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+
+        self._stub(
+            monkeypatch,
+            {
+                "types": [
+                    {"type_name": "person", "definition": "d", "member_indices": [1, 2]},
+                    {"type_name": "organization", "definition": "d", "member_indices": [3]},
+                ]
+            },
+        )
+
+        out = entity_types.name_group(self._group(3))
+
+        assert [t.name for t in out] == ["person", "organization"]
+        assert sum(t.n_referents for t in out) == 3
+
+    def test_a_repeated_member_keeps_the_first_assignment(self, monkeypatch, caplog) -> None:
+        """A double-claimed member would inflate the support counts a type is judged on, so the
+        duplicate is dropped — not the entry, and not the response."""
+        from app.ingest import entity_types
+
+        self._stub(
+            monkeypatch,
+            {
+                "types": [
+                    {"type_name": "person", "definition": "d", "member_indices": [1, 2]},
+                    {"type_name": "organization", "definition": "d", "member_indices": [2, 3]},
+                ]
+            },
+        )
+
+        with caplog.at_level("WARNING"):
+            out = entity_types.name_group(self._group(3))
+
+        assert [t.name for t in out] == ["person", "organization"]
+        assert [t.n_referents for t in out] == [2, 1]
+        assert sum(t.n_referents for t in out) == 3
+
+    def test_an_unusable_response_still_falls_back_to_the_whole_group(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+
+        self._stub(monkeypatch, {"types": []})
+
+        out = entity_types.name_group(self._group(5))
+
+        assert [t.name for t in out] == ["unnamed_5"]
+
+    def test_referent_counts_stay_exact(self, monkeypatch) -> None:
+        """The counts are what a type's support is judged on downstream, so they must sum to the
+        group with nothing double-counted and nothing lost."""
+        from app.ingest import entity_types
+
+        self._stub(
+            monkeypatch,
+            {
+                "types": [
+                    {"type_name": "a", "definition": "d", "member_indices": [1, 2, 3]},
+                    {"type_name": "b", "definition": "d", "member_indices": [3, 4]},
+                ]
+            },
+        )
+
+        out = entity_types.name_group(self._group(6))
+
+        assert sum(t.n_referents for t in out) == 6

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -593,6 +593,51 @@ class TestNamingPartialAcceptance:
 
         assert names[0] != names[1], names
 
+    def test_names_survive_truncation_of_long_canonicals(self, monkeypatch) -> None:
+        """A readable slug has to be cut somewhere, so two long names sharing a prefix would
+        collide on length alone. The digest is what keeps them apart."""
+        from app.ingest import entity_types
+
+        self._stub(monkeypatch, {"types": []})
+        shared = "x" * 80
+        first = entity_types.name_group(
+            [entity_types.Referent(canonical=shared + "alpha", pages={"a.md"})]
+        )
+        second = entity_types.name_group(
+            [entity_types.Referent(canonical=shared + "beta", pages={"b.md"})]
+        )
+
+        assert first[0].name != second[0].name
+
+    def test_names_distinguish_canonicals_that_differ_only_by_punctuation(
+        self, monkeypatch
+    ) -> None:
+        """Folding already merges these, so they should never be two referents — but the name
+        must not depend on that invariant holding."""
+        from app.ingest import entity_types
+
+        self._stub(monkeypatch, {"types": []})
+        first = entity_types.name_group(
+            [entity_types.Referent(canonical="Acme-Foo", pages={"a.md"})]
+        )
+        second = entity_types.name_group(
+            [entity_types.Referent(canonical="Acme Foo", pages={"b.md"})]
+        )
+
+        assert first[0].name != second[0].name
+
+    def test_the_same_member_set_names_deterministically(self, monkeypatch) -> None:
+        from app.ingest import entity_types
+
+        self._stub(monkeypatch, {"types": []})
+
+        def once():
+            return entity_types.name_group(
+                [entity_types.Referent(canonical="alpha", pages={"a.md"})]
+            )[0].name
+
+        assert once() == once()
+
     def test_a_whole_group_fallback_is_also_named_per_group(self, monkeypatch) -> None:
         from app.ingest import entity_types
 


### PR DESCRIPTION
The naming stage enforced a strict partition and treated any violation as no answer at all. On the production derivation that rejected the **three largest groups — 261, 119 and 94 referents — each for a single uncovered member**:

```
naming covered 260 of 261 member(s); ignoring response
naming covered 118 of 119 member(s); ignoring response
naming covered  93 of  94 member(s); ignoring response
```

Those groups fell through to the whole-group placeholder (`unnamed_261`, definition `"(naming failed)"`), so the merge step had to place **474 referents** from example lists with no definition to constrain them.

**That is visible in the recorded taxonomy.** `software` is the largest type at 1012 referents, and its examples include `OpenAI` and `Braintrust` (organizations) and `Bo` (a person). The vocabulary's biggest type is absorbing referents that belong elsewhere.

The guarding intent was right; the remedy was inverted. Discarding the response drops **all 261** members to avoid silently dropping **1**.

## The fix

Both ways the partition can break now take what is valid:

| violation | before | after |
|---|---|---|
| **omitted** members | discard the whole response | keep the named types; carry the uncovered members as their own small remainder, so nothing is dropped silently |
| **repeated** members | discard the whole response | first claim wins, later duplicates dropped — support counts stay exact, which is what the original guard protected |

Merge can place a handful of leftover referents from examples far better than it can place an entire group.

This is the same conclusion `merge_types` already reached one stage over — its docstring notes *"a single conflict used to discard the entire response."* Naming kept the old rule.

## Placeholder names are per group

Raised in review: `derive` collapses types that **share a name**, on the premise that the model named them identically — a premise a placeholder doesn't carry. Sized names meant every group leaving one unassigned member produced `unnamed_1`, so the collapse pooled unrelated referents and examples into one type and merge then placed them together.

Partial acceptance makes small remainders common, so this would have fired often — a miniature of the very misplacement this PR set out to fix. Names now derive from the first member's canonical, which folding has already made distinct. The whole-group fallback had the same flaw and is fixed too.

## Tests

7 new: one uncovered member no longer discards the group; a full partition is unchanged; a repeated member keeps the first assignment; a genuinely unusable response still falls back to the whole-group placeholder; referent counts sum to the group with nothing double-counted or lost; and remainders from different groups (and whole-group fallbacks) get different names.

Verified by mutation — restoring either all-or-nothing rule, or the sized placeholder names, fails a test. `ruff check` and basedpyright clean.

## After this

Re-derive. It's cheap now (~8 minutes on `gpt-5.6-luna` after #578), and re-deriving later would invalidate every extracted need anyway, since the taxonomy id is part of need extraction's staleness guard. Better to settle the vocabulary before anything labels against it.

Worth comparing the re-derived taxonomy against the current one: if `software` shrinks and `organization`/`person` grow, that confirms this was the cause of the misplacement.
