### PR TITLE
fix(editor): outline-style markers for nested ordered lists

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -138,6 +138,24 @@
   list-style: decimal;
   padding-left: 1.5rem;
 }
+/* Nested ordered lists step through Notion's outline sequence — decimal,
+   lower-alpha, lower-roman — repeating from the fourth level. Without this
+   every level renders "1." and the nesting depth is illegible. */
+.editor-prose ol ol {
+  list-style: lower-alpha;
+}
+.editor-prose ol ol ol {
+  list-style: lower-roman;
+}
+.editor-prose ol ol ol ol {
+  list-style: decimal;
+}
+.editor-prose ol ol ol ol ol {
+  list-style: lower-alpha;
+}
+.editor-prose ol ol ol ol ol ol {
+  list-style: lower-roman;
+}
 .editor-prose ul[data-type="taskList"] {
   list-style: none;
   padding-left: 0;


### PR DESCRIPTION
Nested ordered lists in the editor rendered `1.` at every depth, so nesting levels were illegible.

This steps nested `<ol>` markers through the outline sequence Notion uses — decimal → lower-alpha → lower-roman — repeating the cycle from the fourth level (capped at six levels of selectors; deeper stays roman). Pure CSS on `.editor-prose`, keyed on `<ol>` nesting depth: the markdown source keeps plain `1.` numbering at every level, only the rendered marker changes, and both edit and read view pick it up. An ordered list nested inside a bulleted list still starts at `1.`, since only ordered ancestors count.

Bullet markers (`ul`) are unchanged — Notion's disc → circle → square cycling can be a follow-up if we want full parity.