### PR TITLE
fix(coedit): stop the session purge from cutting a page's Yjs lineage

### DIFF
--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -45,6 +45,13 @@ _MAX_INTERVAL_SECONDS = 900
 # Four missed 15-second heartbeats distinguish a departed participant from
 # ordinary event-loop lag.
 _PARTICIPANT_STALE_SECONDS = 60
+# How long a closed viewer session stays purgeable-exempt. A reconnecting
+# client adopts its old row's Yjs lineage, and only a row that still exists
+# can be adopted, so this has to outlast a reconnect by a wide margin — the
+# client retries every ~3s, but a suspended laptop resumes far later. Held
+# well above that; the newest closed row per path is kept regardless of age,
+# so this window only bounds how long the *older* ones linger.
+_VIEWER_SESSION_RETAIN_SECONDS = 3600
 
 
 @coedit_queue.task()
@@ -108,6 +115,8 @@ def scan_coedit_checkpoints() -> None:
     abandoned = coedit.close_abandoned_sessions()
     if abandoned:
         log.info("coedit presence scan: closed %d abandoned session(s)", len(abandoned))
-    purged = coedit.purge_viewer_sessions()
+    purged = coedit.purge_viewer_sessions(
+        retain_seconds=_VIEWER_SESSION_RETAIN_SECONDS
+    )
     if purged:
         log.info("coedit checkpoint scan: purged %d viewer-only session(s)", purged)

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -859,18 +859,29 @@ def purge_viewer_sessions(*, retain_seconds: int, limit: int = 500) -> int:
     ``updated_at`` older than ``retain_seconds``
         ``close_session``/``close_abandoned_sessions`` both stamp it, so
         this is time since close.
-    not the newest closed row for its path
-        The one ``_reusable_closed_session`` orders to, kept regardless of
-        age so a reconnect after any delay still has a lineage to adopt.
-        Bounded at one row per page.
+    not the row ``_reusable_closed_session`` would pick for its path
+        Kept regardless of age, so a reconnect after any delay still has a
+        lineage to adopt. Bounded at one row per page.
+
+        This mirrors that function's predicate rather than taking the highest
+        id outright: a newer row that is dirty or has no snapshot is *not*
+        reusable, and protecting it would leave an older, eligible row exposed
+        to the age cutoff — deleting the very lineage a reconnect would have
+        adopted. Its ``base_sha == HEAD`` condition has no SQL equivalent
+        (HEAD is per-path git state), but it needs none here: a row's
+        ``base_sha`` is HEAD as of its creation or its last checkpoint, so of
+        two candidates the newer one's is never the staler, and the newest is
+        always the best available match.
     """
     cutoff = _iso(_now() - timedelta(seconds=retain_seconds))
     newest = aliased(CoeditSession)
-    newest_closed_for_path = (
+    reusable_for_path = (
         select(func.max(newest.id))
         .where(
             newest.path == CoeditSession.path,
             newest.status == SessionStatus.CLOSED.value,
+            newest.ydoc_snapshot.is_not(None),
+            newest.ydoc_seq == newest.ydoc_checkpointed_seq,
         )
         .correlate(CoeditSession)
         .scalar_subquery()
@@ -883,7 +894,10 @@ def purge_viewer_sessions(*, retain_seconds: int, limit: int = 500) -> int:
                 CoeditSession.ydoc_seq == 0,
                 CoeditSession.ydoc_checkpointed_seq == 0,
                 CoeditSession.updated_at <= cutoff,
-                CoeditSession.id != newest_closed_for_path,
+                or_(
+                    CoeditSession.id != reusable_for_path,
+                    reusable_for_path.is_(None),
+                ),
             )
             .limit(limit)
         ).all()

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -38,7 +38,7 @@ from sqlalchemy import Text as SAText, cast, delete, func, literal, or_, select,
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, aliased
 
 from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User
 from app.models.wiki import PathMove
@@ -835,18 +835,46 @@ def close_abandoned_sessions() -> list[int]:
         )
 
 
-def purge_viewer_sessions(limit: int = 500) -> int:
+def purge_viewer_sessions(*, retain_seconds: int, limit: int = 500) -> int:
     """Delete closed sessions that never received an update. Returns the count.
 
     With join-on-landing, every page view mints a session — a closed
     ``ydoc_seq == 0`` row carries no updates, no participants (removed on
-    leave; FK cascade catches stragglers), and nothing the update log or
-    checkpoint dedupe ever references, so it is pure dead weight. Runs
+    leave; FK cascade catches stragglers), so it is pure dead weight. Runs
     against *closed* rows only: deleting at the close point instead would
     race a concurrent join into an FK violation, while a closed session is a
     soft state joins already tolerate. Bounded so the periodic scan stays
     cheap; the backlog drains across successive runs.
+
+    Two conditions keep this off rows ``_reusable_closed_session`` still
+    needs. A deleted row cannot be reactivated, so purging one whose client
+    is about to reconnect forces ``open_session`` to seed a fresh
+    ``Doc()`` — a new Yjs lineage against the retained document the client
+    answers SYNC_STEP1 with, which is exactly the whole-page duplication
+    ``open_session`` describes. The scan closes and purges in the *same*
+    pass, so without these the window was the ~3s a client takes to
+    reconnect, and a "never edited" row is precisely a viewer's — someone
+    with the page merely open.
+
+    ``updated_at`` older than ``retain_seconds``
+        ``close_session``/``close_abandoned_sessions`` both stamp it, so
+        this is time since close.
+    not the newest closed row for its path
+        The one ``_reusable_closed_session`` orders to, kept regardless of
+        age so a reconnect after any delay still has a lineage to adopt.
+        Bounded at one row per page.
     """
+    cutoff = _iso(_now() - timedelta(seconds=retain_seconds))
+    newest = aliased(CoeditSession)
+    newest_closed_for_path = (
+        select(func.max(newest.id))
+        .where(
+            newest.path == CoeditSession.path,
+            newest.status == SessionStatus.CLOSED.value,
+        )
+        .correlate(CoeditSession)
+        .scalar_subquery()
+    )
     with session() as s:
         ids = s.scalars(
             select(CoeditSession.id)
@@ -854,6 +882,8 @@ def purge_viewer_sessions(limit: int = 500) -> int:
                 CoeditSession.status == SessionStatus.CLOSED.value,
                 CoeditSession.ydoc_seq == 0,
                 CoeditSession.ydoc_checkpointed_seq == 0,
+                CoeditSession.updated_at <= cutoff,
+                CoeditSession.id != newest_closed_for_path,
             )
             .limit(limit)
         ).all()

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import logging
 
-from pycrdt import Doc, XmlFragment, create_update_message
+from pycrdt import Doc, XmlElement, XmlFragment, create_update_message
 from pydantic import BaseModel, ConfigDict
 
 from app.auth import User, set_current_user
@@ -37,7 +37,7 @@ from app.models.wiki import ChangeKind
 from app.wiki import coedit, coedit_channel, filesystem
 from app.wiki import drafts as wiki_drafts
 from app.wiki import git as wiki_git
-from app.wiki import markdown_splice, markdown_yjs
+from app.wiki import markdown_blocks, markdown_splice, markdown_yjs
 from app.wiki.markdown_splice import TouchedTracker
 
 log = logging.getLogger(__name__)
@@ -120,6 +120,126 @@ def drop_duplicate_blocks(doc: Doc) -> list[str]:
         for i in reversed(stale):
             del root.children[i]
     return dupes
+
+
+# A lineage collision restates most of the page; a person can legitimately
+# retype one line that already exists elsewhere on it. Both floors must clear
+# before anything is deleted, so the small, ordinary case is never touched.
+_RESTATED_MIN_BLOCKS = 5
+_RESTATED_MIN_FRACTION = 0.25
+
+
+class _Restatement(BaseModel):
+    """Where a doc restates the page back onto itself, as child indices.
+
+    ``restated`` is the duplicated content itself, and the only thing the
+    floors are measured against. ``fillers`` are the blank-line blocks the
+    duplicated copy brought with it — the codec makes every newline its own
+    top-level block, so a restated copy arrives interleaved with them.
+    Deleting content without them leaves a run of blank lines behind where the
+    copy was.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    restated: list[int]
+    fillers: list[int]
+
+    def drop_indices(self) -> list[int]:
+        return sorted(self.restated + self.fillers)
+
+
+def _restated_base_blocks(doc: Doc, base_body: str) -> _Restatement:
+    """Child indices holding a second copy of a base block already being
+    emitted by id, in document order.
+
+    Catches the lineage collision that ``_duplicated_block_ids`` cannot see.
+    That one keys on an id repeating *within* the doc, but a foreign lineage's
+    children need not repeat a base id to be duplicated into the page — any id
+    ``base_body`` doesn't know takes ``checkpoint_body``'s ``orig is None``
+    path and is re-serialized as though freshly typed, appended alongside the
+    base copy that is emitted verbatim. That is the 87-insertions/0-deletions
+    shape: nothing conflicts, so nothing dedupes.
+
+    The test is content, not ids, because the ids in this state can't be
+    trusted to any particular shape. Two conditions keep it off legitimate
+    edits:
+
+    the child's id isn't one ``base_body`` carries
+        Those are emitted verbatim from ``base_body`` and are the copy being
+        kept, not a duplicate of it.
+    the base block it restates is still carried by some child
+        So its content is definitely being emitted. Without this, a block the
+        user deleted and retyped identically would be read as a duplicate of a
+        copy that is no longer there, and dropping it would lose the text.
+    """
+    base_ranges = markdown_blocks.top_level_block_ranges(base_body)
+    base_ids = {b.block_id for b in base_ranges}
+    root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
+    children = list(root.children)
+
+    carried_ids: set[str] = set()
+    for child in children:
+        block_id = dict(getattr(child, "attributes", {})).get(markdown_yjs.BLOCK_ID_ATTR)
+        if isinstance(block_id, str):
+            carried_ids.add(block_id)
+
+    emitted_text: set[str] = set()
+    for b in base_ranges:
+        if b.block_id not in carried_ids:
+            continue
+        text = base_body[b.start : b.end].strip()
+        if text:
+            emitted_text.add(text)
+
+    restated: list[int] = []
+    foreign_blanks: list[int] = []
+    for i, child in enumerate(children):
+        if not isinstance(child, XmlElement):
+            continue
+        block_id = dict(child.attributes).get(markdown_yjs.BLOCK_ID_ATTR)
+        if isinstance(block_id, str) and block_id in base_ids:
+            continue
+        text = markdown_yjs.serialize_block(child).strip()
+        if not text:
+            foreign_blanks.append(i)
+        elif text in emitted_text:
+            restated.append(i)
+
+    # Only the blanks sitting within the restated run, so a blank line the
+    # user left elsewhere on the page is untouched.
+    if not restated:
+        return _Restatement(restated=[], fillers=[])
+    first, last = restated[0], restated[-1]
+    fillers = [i for i in foreign_blanks if first < i < last]
+    return _Restatement(restated=restated, fillers=fillers)
+
+
+def drop_restated_blocks(doc: Doc, base_body: str) -> int:
+    """Delete children that restate the page back onto itself; return how many.
+
+    Deleted rather than refused, for the same reason as
+    ``drop_duplicate_blocks``: the duplication is in the connected browsers'
+    documents too, and a Yjs delete addresses the items they hold, so the
+    checkpoint's broadcast converges them. Refusing would leave every client
+    holding it, to be re-sent on the next reconnect.
+
+    Both floors in ``_RESTATED_MIN_BLOCKS``/``_RESTATED_MIN_FRACTION`` must
+    clear. One or two restating blocks is something a person does; half the
+    page is not reachable by editing.
+    """
+    found = _restated_base_blocks(doc, base_body)
+    root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
+    total = len(root.children)
+    if len(found.restated) < _RESTATED_MIN_BLOCKS:
+        return 0
+    if len(found.restated) < total * _RESTATED_MIN_FRACTION:
+        return 0
+    # Descending, so each deletion can't shift the index of one still pending.
+    with doc.transaction():
+        for i in reversed(found.drop_indices()):
+            del root.children[i]
+    return len(found.restated)
 
 
 def _user(user_id: str) -> User | None:
@@ -312,6 +432,18 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 path,
                 session_id,
                 dupes,
+            )
+
+        restated = drop_restated_blocks(doc, base_body)
+        if restated:
+            log.error(
+                "coedit checkpoint: %s (session %s) held %d block(s) restating the "
+                "page back onto itself; dropped them and committing the repaired "
+                "document. Indicates a second Yjs lineage reached the doc — see "
+                "open_session's reuse rule and purge_viewer_sessions' retention.",
+                path,
+                session_id,
+                restated,
             )
 
         change_kind = ChangeKind.EDIT if sess.base_sha else ChangeKind.CREATE

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -165,7 +165,14 @@ def _restated_base_blocks(doc: Doc, base_body: str) -> _Restatement:
     trusted to any particular shape. Two conditions keep it off legitimate
     edits:
 
-    the child's id isn't one ``base_body`` carries
+    the child carries an id at all
+        Freshly typed content carries none (see ``_duplicated_block_ids``),
+        while a foreign lineage's blocks come from a seeded or restamped doc
+        and always have one. So an id-less child is the user's own new
+        content and is never restatement — however much of the page it is,
+        and however exactly it repeats something already there. Five new
+        ``---`` rules or five repeated headings are ordinary editing.
+    the id isn't one ``base_body`` carries
         Those are emitted verbatim from ``base_body`` and are the copy being
         kept, not a duplicate of it.
     the base block it restates is still carried by some child
@@ -198,7 +205,7 @@ def _restated_base_blocks(doc: Doc, base_body: str) -> _Restatement:
         if not isinstance(child, XmlElement):
             continue
         block_id = dict(child.attributes).get(markdown_yjs.BLOCK_ID_ATTR)
-        if isinstance(block_id, str) and block_id in base_ids:
+        if not isinstance(block_id, str) or block_id in base_ids:
             continue
         text = markdown_yjs.serialize_block(child).strip()
         if not text:

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -738,3 +738,51 @@ def test_drop_duplicate_blocks_is_a_no_op_on_a_healthy_doc() -> None:
     doc = seed_doc_from_markdown(body)
     assert drop_duplicate_blocks(doc) == []
     assert reconstruct_body(doc) == body
+
+
+def test_drop_restated_blocks_catches_a_collision_the_id_check_cannot() -> None:
+    """A restamp renumbers a collided doc's children into distinct sequential
+    ids, which is what makes ``_duplicated_block_ids`` blind to it: every id is
+    unique, so the duplicate-id net sees a clean document while
+    ``checkpoint_body`` re-serializes the unknown half onto the end of the page.
+    """
+    from app.wiki.coedit_checkpoint import _duplicated_block_ids, drop_restated_blocks
+    from app.wiki.markdown_splice import restamp_block_ids
+    from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
+
+    body = "\n\n".join(f"para {i}" for i in range(8)) + "\n"
+
+    doc = seed_doc_from_markdown(body)
+    doc.apply_update(seed_doc_from_markdown(body).get_update(doc.get_state()))
+    doubled = reconstruct_body(doc)
+    assert doubled == body + body
+
+    restamp_block_ids(doc, doubled)
+    assert _duplicated_block_ids(doc) == []
+
+    assert drop_restated_blocks(doc, body) == 8
+    assert reconstruct_body(doc) == body
+
+
+def test_drop_restated_blocks_is_a_no_op_on_a_healthy_doc() -> None:
+    from app.wiki.coedit_checkpoint import drop_restated_blocks
+    from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
+
+    body = "\n\n".join(f"para {i}" for i in range(20)) + "\n"
+    doc = seed_doc_from_markdown(body)
+    assert drop_restated_blocks(doc, body) == 0
+    assert reconstruct_body(doc) == body
+
+
+def test_drop_restated_blocks_leaves_a_few_repeated_lines_alone() -> None:
+    """Retyping a line the page already has is something a person does; the
+    floors keep the repair off it. Only a whole-page restatement clears them."""
+    from app.wiki.coedit_checkpoint import drop_restated_blocks
+    from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
+
+    base = "\n\n".join(["alpha", "beta", "gamma", "delta"]) + "\n"
+    # One block beyond what base_body knows, restating a line already on the
+    # page — the shape a collision has, at a scale editing reaches.
+    doc = seed_doc_from_markdown(base + "\nalpha\n")
+    assert drop_restated_blocks(doc, base) == 0
+    assert reconstruct_body(doc) == base + "\nalpha\n"

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -774,6 +774,30 @@ def test_drop_restated_blocks_is_a_no_op_on_a_healthy_doc() -> None:
     assert reconstruct_body(doc) == body
 
 
+def test_drop_restated_blocks_never_touches_freshly_typed_blocks() -> None:
+    """Freshly typed blocks carry no ``_blockId``, and a foreign lineage's
+    always do — so an id-less child is the user's own content and is exempt
+    however much of the page it is. Repeating text already on the page at
+    scale (a run of identical rules, or headings) is ordinary editing, and
+    the count/fraction floors alone would not tell it apart from a collision.
+    """
+    from app.wiki.coedit_checkpoint import drop_restated_blocks
+    from app.wiki.markdown_yjs import ROOT_XML_KEY, reconstruct_body, seed_doc_from_markdown
+
+    base = "\n\n".join(f"para {i}" for i in range(8)) + "\n"
+    doc = seed_doc_from_markdown(base)
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    with doc.transaction():
+        for i in range(6):
+            root.children.append(
+                XmlElement("paragraph", {}, contents=[XmlText(f"para {i}")])
+            )
+
+    before = reconstruct_body(doc)
+    assert drop_restated_blocks(doc, base) == 0
+    assert reconstruct_body(doc) == before
+
+
 def test_drop_restated_blocks_leaves_a_few_repeated_lines_alone() -> None:
     """Retyping a line the page already has is something a person does; the
     floors keep the repair off it. Only a whole-page restatement clears them."""

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -414,14 +414,16 @@ def test_rename_path(users):
 
 
 def test_purge_viewer_sessions_deletes_only_closed_never_edited(users):
-    # Two viewer-only sessions on one path: opened, no updates, closed. Only
-    # the older is purgeable — the newest closed row per path is the one
+    # Two viewer-only sessions on one path: opened, seeded, no updates, closed.
+    # Only the older is purgeable — the newest is the row
     # _reusable_closed_session would reactivate.
     older = coedit.open_session("viewed.md", base_sha=None)
+    coedit.set_initial_snapshot(older.id, b"snap", "body")
     coedit.join(older.id, "usr_a")
     coedit.leave(older.id, "usr_a")
     coedit.close_session(older.id)
     newest = coedit.open_session("viewed.md", base_sha=None)
+    coedit.set_initial_snapshot(newest.id, b"snap", "body")
     coedit.close_session(newest.id)
 
     # Edited session: has an update, closed after checkpoint — must be
@@ -458,14 +460,42 @@ def test_purge_viewer_sessions_retains_recently_closed(users):
     assert coedit.get_session(newest.id) is not None
 
 
+def test_purge_viewer_sessions_protects_the_row_reuse_would_pick(users):
+    """Retention has to mirror ``_reusable_closed_session``, not just take the
+    highest id: a newer snapshotless row isn't reusable, and protecting it
+    instead would expose the older eligible row to the age cutoff — deleting
+    the lineage a reconnect would have adopted."""
+    reusable = coedit.open_session("viewed.md", base_sha=None)
+    coedit.set_initial_snapshot(reusable.id, b"snap", "body")
+    coedit.close_session(reusable.id)
+    # Newer, but never seeded — _reusable_closed_session skips it.
+    snapshotless = coedit.open_session("viewed.md", base_sha=None)
+    coedit.close_session(snapshotless.id)
+
+    assert coedit.purge_viewer_sessions(retain_seconds=0) == 1
+    assert coedit.get_session(reusable.id) is not None
+    assert coedit.get_session(snapshotless.id) is None
+
+
 def test_purge_viewer_sessions_keeps_newest_closed_row_however_old(users):
     """The reuse candidate is kept regardless of age: a client can reconnect
     long after closing (a suspended laptop), and one row per page is bounded."""
     only = coedit.open_session("viewed.md", base_sha=None)
+    coedit.set_initial_snapshot(only.id, b"snap", "body")
     coedit.close_session(only.id)
 
     assert coedit.purge_viewer_sessions(retain_seconds=0) == 0
     assert coedit.get_session(only.id) is not None
+
+
+def test_purge_viewer_sessions_purges_a_never_seeded_row(users):
+    """A row that never got a snapshot holds no lineage, so there is nothing
+    for a reconnect to adopt and nothing to protect."""
+    only = coedit.open_session("viewed.md", base_sha=None)
+    coedit.close_session(only.id)
+
+    assert coedit.purge_viewer_sessions(retain_seconds=0) == 1
+    assert coedit.get_session(only.id) is None
 
 
 def test_close_abandoned_sessions_closes_only_clean_empty_ones(users):

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -414,11 +414,15 @@ def test_rename_path(users):
 
 
 def test_purge_viewer_sessions_deletes_only_closed_never_edited(users):
-    # Viewer-only session: opened, no updates, closed.
-    viewer_only = coedit.open_session("viewed.md", base_sha=None)
-    coedit.join(viewer_only.id, "usr_a")
-    coedit.leave(viewer_only.id, "usr_a")
-    coedit.close_session(viewer_only.id)
+    # Two viewer-only sessions on one path: opened, no updates, closed. Only
+    # the older is purgeable — the newest closed row per path is the one
+    # _reusable_closed_session would reactivate.
+    older = coedit.open_session("viewed.md", base_sha=None)
+    coedit.join(older.id, "usr_a")
+    coedit.leave(older.id, "usr_a")
+    coedit.close_session(older.id)
+    newest = coedit.open_session("viewed.md", base_sha=None)
+    coedit.close_session(newest.id)
 
     # Edited session: has an update, closed after checkpoint — must be
     # retained (ydoc_seq != 0, regardless of whether advance_checkpoint has
@@ -431,12 +435,37 @@ def test_purge_viewer_sessions_deletes_only_closed_never_edited(users):
     # Active viewer-only session: still occupied — must be retained.
     active = coedit.open_session("open.md", base_sha=None)
 
-    assert coedit.purge_viewer_sessions() == 1
-    assert coedit.get_session(viewer_only.id) is None
+    assert coedit.purge_viewer_sessions(retain_seconds=0) == 1
+    assert coedit.get_session(older.id) is None
+    assert coedit.get_session(newest.id) is not None
     assert coedit.get_session(edited.id) is not None
     assert coedit.get_session(active.id) is not None
     # Idempotent: nothing left to purge.
-    assert coedit.purge_viewer_sessions() == 0
+    assert coedit.purge_viewer_sessions(retain_seconds=0) == 0
+
+
+def test_purge_viewer_sessions_retains_recently_closed(users):
+    """A reconnecting client adopts its old row's Yjs lineage, so a row closed
+    moments ago has to survive — deleting it forces a fresh seed and the
+    retained document is then duplicated into the page."""
+    older = coedit.open_session("viewed.md", base_sha=None)
+    coedit.close_session(older.id)
+    newest = coedit.open_session("viewed.md", base_sha=None)
+    coedit.close_session(newest.id)
+
+    assert coedit.purge_viewer_sessions(retain_seconds=3600) == 0
+    assert coedit.get_session(older.id) is not None
+    assert coedit.get_session(newest.id) is not None
+
+
+def test_purge_viewer_sessions_keeps_newest_closed_row_however_old(users):
+    """The reuse candidate is kept regardless of age: a client can reconnect
+    long after closing (a suspended laptop), and one row per page is bounded."""
+    only = coedit.open_session("viewed.md", base_sha=None)
+    coedit.close_session(only.id)
+
+    assert coedit.purge_viewer_sessions(retain_seconds=0) == 0
+    assert coedit.get_session(only.id) is not None
 
 
 def test_close_abandoned_sessions_closes_only_clean_empty_ones(users):


### PR DESCRIPTION
## The bug

A page duplicated itself repeatedly in production, twice — the second time
with #575 already deployed, so #575's fix was necessary but not sufficient.

A page's document identity **is** its Yjs lineage: Yjs merges by item id
(`client_id`, `clock`) and never by content, and `seed_doc_from_markdown`
builds a bare `Doc()` with a random client id. Two documents independently
seeded from the *same* markdown therefore share nothing, and merging them
yields the content twice.

#575 made a reconnect reuse the closed session so the lineage survives. But
reuse can only find a row that still **exists**, and the every-minute scan
deletes the row in the same pass that closes it:

```
expire_stale_participants -> close_abandoned_sessions -> purge_viewer_sessions
```

`purge_viewer_sessions` targets `ydoc_seq == 0` — never edited — which is
precisely a *viewer's* row, and every page view mints a session. So a lapsed
heartbeat on a still-open tab closed the session, deleted it, and the
client's reconnect ~3s later got a fresh `Doc()`: a new lineage facing the
document the browser was still holding. The client answers SYNC_STEP1 with
all of it, nothing dedupes, the next checkpoint commits the page twice, and
the following session seeds from that — geometric.

## Changes

**`purge_viewer_sessions` gains `retain_seconds` and skips the newest closed
row per path.** The age gate covers the reconnect window; keeping the newest
row covers a client that reconnects much later (a suspended laptop), and is
bounded at one row per page.

**`drop_restated_blocks`, a second checkpoint net** for the shape the
existing duplicate-id check structurally cannot see. Once a checkpoint
restamps a collided doc, its children carry *distinct* sequential ids, so no
id repeats — while `checkpoint_body` re-serializes every child whose id
`base_body` doesn't know (`orig is None`, read as "freshly typed") onto the
end of the page. That produced the observed commit shape: 87 insertions, 0
deletions, one hunk at EOF. The new check keys on content instead — children
restating a base block that is still being emitted — behind both a minimum
count and a minimum fraction, so retyping one line the page already has is
never touched. It deletes rather than refuses, like its sibling, so the
checkpoint's broadcast converges the browsers holding the duplication.

## What this does not do

Neither change removes the underlying fault: a lineage is minted ad hoc by
whichever code path needs a document. One lineage per path — moving the
snapshot off `coedit_sessions` onto a per-path row seeded exactly once — is
the structural fix, written up in the design doc and not scheduled yet.

## Testing

Full backend suite green. Four new tests: the collision shape the id check
misses (a restamped doc with distinct ids), a healthy-doc no-op, the floors
holding off a legitimately repeated line, and purge retention (recent rows
retained, newest-per-path kept regardless of age, older ones still purged).