### PR TITLE
fix(coedit): bound the wait for a checkpoint ack

### DIFF
--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -164,16 +164,24 @@ def _deliver_local(coedit_session_id: int, frame: ControlFrame) -> None:
         q.put_nowait(frame)
         notify()
         delivered += 1
-    # A process with no connection for this session is the normal case for a
-    # task worker (it publishes; the socket lives in the web process, reached
-    # via the bus), so this is not an error on its own. It is logged because a
-    # frame delivered to nobody *anywhere* is otherwise invisible: a
+    # A frame delivered to nobody *anywhere* is otherwise invisible: a
     # checkpoint ack that never lands leaves the client's save promise pending,
-    # and until this line there was no trace to distinguish "never published"
-    # from "published, never delivered".
-    log.info(
+    # and without this there is no trace to distinguish "never published" from
+    # "published, never delivered". A process holding no connection for the
+    # session is the normal case rather than a fault — a task worker publishes
+    # while the socket lives in the web process, reached via the bus — so this
+    # records the counts and judges nothing.
+    #
+    # Only the checkpoint ack is worth INFO: it is the one whose loss is known
+    # to strand a client, and it is rare (one per edit burst). Presence frames
+    # go out on every join and leave, which would be noise at this level and
+    # would bury the signal. They stay at DEBUG, where the whole trace is still
+    # available when someone is looking for it.
+    frame_type = frame.get("type", "?")
+    log_at = log.info if frame_type == "checkpoint_result" else log.debug
+    log_at(
         "coedit control frame %s session=%s delivered=%d of %d local conn(s)",
-        frame.get("type", "?"),
+        frame_type,
         coedit_session_id,
         delivered,
         len(targets),

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -157,11 +157,27 @@ def _deliver_local(coedit_session_id: int, frame: ControlFrame) -> None:
             (_queues.get(cid), _notifiers.get(cid))
             for cid in _conns_by_session.get(coedit_session_id, ())
         ]
+    delivered = 0
     for q, notify in targets:
         if q is None or notify is None:
             continue
         q.put_nowait(frame)
         notify()
+        delivered += 1
+    # A process with no connection for this session is the normal case for a
+    # task worker (it publishes; the socket lives in the web process, reached
+    # via the bus), so this is not an error on its own. It is logged because a
+    # frame delivered to nobody *anywhere* is otherwise invisible: a
+    # checkpoint ack that never lands leaves the client's save promise pending,
+    # and until this line there was no trace to distinguish "never published"
+    # from "published, never delivered".
+    log.info(
+        "coedit control frame %s session=%s delivered=%d of %d local conn(s)",
+        frame.get("type", "?"),
+        coedit_session_id,
+        delivered,
+        len(targets),
+    )
 
 
 def _deliver_local_bytes(

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -37,6 +37,7 @@ import * as Y from "yjs";
 import { ApiError } from "@/lib/api";
 import { opaqueId } from "@/lib/editor/ids";
 import {
+  CHECKPOINT_TIMED_OUT,
   checkpointSession,
   closeSession,
   connectSession,
@@ -72,6 +73,18 @@ const STREAM_RECONNECT_MS = 3000;
  * outlasts a reconnect; past that the indicator should stay honest. */
 const SAVE_RETRY_MS = 3000;
 const SAVE_RETRY_LIMIT = 10;
+/** Timeouts get their own, much smaller budget.
+ *
+ * `SAVE_RETRY_LIMIT` above is sized for a failure that returns *instantly*
+ * ("not connected" during a reconnect), where 10 × 3s is a sensible 30-second
+ * window. A `CHECKPOINT_TIMED_OUT` costs a full minute per attempt, so reusing
+ * that budget would mean ~11 minutes of alternating "Saving…"/"Couldn't save".
+ * One retry bounds it to about two minutes and then leaves an honest error.
+ *
+ * Giving up is safe, not lossy: the edits are already in `coedit_updates`, and
+ * the server's periodic scan commits a dirty session on its own (5-min idle /
+ * 15-min overdue). The retry only controls how fast the *indicator* recovers. */
+const SAVE_TIMEOUT_RETRY_LIMIT = 1;
 
 export interface CoeditPeer {
   user_id: string;
@@ -251,6 +264,9 @@ export function useCoeditSession(opts: {
   const [saveError, setSaveError] = useState<string | null>(null);
   const saveRetryTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveRetries = useRef(0);
+  // Counted apart from saveRetries: a timeout and a "not connected" cost two
+  // very different amounts of wall-clock, so they can't share a budget.
+  const saveTimeouts = useRef(0);
   // Guards against overlapping saves — a retry firing while an autosave is
   // still in flight, or the reverse. Coalescing is safe rather than lossy: a
   // checkpoint commits whatever the document currently holds, not a snapshot
@@ -264,14 +280,19 @@ export function useCoeditSession(opts: {
   // not the one captured when the failure happened.
   const checkpointRef = useRef<(() => Promise<void>) | null>(null);
 
-  const armSaveRetry = useCallback(() => {
-    if (saveRetries.current >= SAVE_RETRY_LIMIT) return;
-    saveRetries.current += 1;
+  /** Returns whether a retry was actually armed, so the caller can say so
+   * without promising one the budget won't allow. */
+  const armSaveRetry = useCallback((timedOut = false): boolean => {
+    const used = timedOut ? saveTimeouts : saveRetries;
+    const limit = timedOut ? SAVE_TIMEOUT_RETRY_LIMIT : SAVE_RETRY_LIMIT;
+    if (used.current >= limit) return false;
+    used.current += 1;
     if (saveRetryTimer.current) clearTimeout(saveRetryTimer.current);
     saveRetryTimer.current = setTimeout(() => {
       saveRetryTimer.current = null;
       void checkpointRef.current?.();
     }, SAVE_RETRY_MS);
+    return true;
   }, []);
 
   const sessionId = useRef<number | null>(null);
@@ -317,6 +338,7 @@ export function useCoeditSession(opts: {
     try {
       await checkpointSession(cid);
       saveRetries.current = 0;
+      saveTimeouts.current = 0;
       setSaveError(null);
       setSaveStatus("saved");
     } catch (e) {
@@ -325,13 +347,25 @@ export function useCoeditSession(opts: {
       // and a stack in the console is what makes an intermittent report
       // actionable.
       console.warn("[coedit] save failed", e);
-      setSaveError(reason);
-      setSaveStatus("error");
+      const timedOut = reason === CHECKPOINT_TIMED_OUT;
       // A permission failure is the only terminal one — retrying it just
       // repeats the refusal. Everything else means "no socket right now", which
       // the reconnect loop is already fixing.
       const terminal = reason.toLowerCase().includes("forbidden");
-      if (!terminal) armSaveRetry();
+      const retrying = !terminal && armSaveRetry(timedOut);
+      // A timeout means the ack never came back, which says nothing about
+      // whether the commit happened — the server may well have committed and
+      // only the reply gone missing. So don't claim the save failed, and once
+      // the budget is spent, say what actually happens next: the server's
+      // periodic scan commits a dirty session without the client's help.
+      setSaveError(
+        !timedOut
+          ? reason
+          : retrying
+            ? "Couldn't confirm this save — retrying."
+            : "Couldn't confirm this save. The server will commit it shortly.",
+      );
+      setSaveStatus("error");
     } finally {
       saveInFlight.current = false;
     }

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -146,13 +146,24 @@ export interface UseCoeditSession {
   joinErrorRetryable: boolean;
   /** Clears `joinError` and re-runs the join handshake. */
   retryJoin: () => void;
-  /** Autosave state, for a "Saving…/Saved/Couldn't save" indicator. */
-  saveStatus: "saved" | "saving" | "error";
-  /** Why the last save failed, when `saveStatus` is "error" — the server's own
-   * reason ("forbidden", the task's failure) or "not connected" when there was
-   * no live socket to ask. Surfaced because a bare "Couldn't save" is
-   * undiagnosable: three unrelated faults produce it, and the reason was being
-   * swallowed by a `catch {}` so it reached neither the UI nor the console. */
+  /** Autosave state, for a "Saving…/Saved/Couldn't save" indicator.
+   *
+   * "unconfirmed" is distinct from "error" on purpose: the save's
+   * acknowledgement never came back, which says nothing about whether the
+   * commit happened — the server may well have committed and only the reply
+   * gone missing. Rendering that as a failure would be a claim we can't
+   * support, so it gets its own label. */
+  saveStatus: "saved" | "saving" | "error" | "unconfirmed";
+  /** Detail for the current `saveStatus`, when there is any.
+   *
+   * For "error", why the save failed — the server's own reason ("forbidden",
+   * the task's failure) or "not connected" when there was no live socket to
+   * ask. Surfaced because a bare "Couldn't save" is undiagnosable: three
+   * unrelated faults produce it, and the reason was being swallowed by a
+   * `catch {}` so it reached neither the UI nor the console.
+   *
+   * For "unconfirmed", what happens next rather than what went wrong. Both are
+   * rendered as a suffix to the status label, so neither should repeat it. */
   saveError: string | null;
   /** Wire the underlying Tiptap `Editor` instance once it mounts — needed
    * to resolve peer cursor positions and to drive `setDoc`. Pass directly
@@ -353,19 +364,19 @@ export function useCoeditSession(opts: {
       // the reconnect loop is already fixing.
       const terminal = reason.toLowerCase().includes("forbidden");
       const retrying = !terminal && armSaveRetry(timedOut);
-      // A timeout means the ack never came back, which says nothing about
-      // whether the commit happened — the server may well have committed and
-      // only the reply gone missing. So don't claim the save failed, and once
-      // the budget is spent, say what actually happens next: the server's
-      // periodic scan commits a dirty session without the client's help.
+      // Reported as "unconfirmed", not "error": see saveStatus. The detail says
+      // what happens next rather than what went wrong, and once the budget is
+      // spent that is the server's periodic scan, which commits a dirty session
+      // without the client's help. Neither string repeats the status label —
+      // the indicator prefixes it.
       setSaveError(
         !timedOut
           ? reason
           : retrying
-            ? "Couldn't confirm this save — retrying."
-            : "Couldn't confirm this save. The server will commit it shortly.",
+            ? "retrying"
+            : "the server will commit it shortly",
       );
-      setSaveStatus("error");
+      setSaveStatus(timedOut ? "unconfirmed" : "error");
     } finally {
       saveInFlight.current = false;
     }
@@ -509,6 +520,13 @@ export function useCoeditSession(opts: {
 
         sessionId.current = snap.session_id;
         ownedConnection.current = snap.connectionId;
+        // Both save budgets are per-socket: they exist to stop retrying at a
+        // socket that isn't answering, and this is a different one. Without
+        // resetting, a spent budget outlived the connection whose failures
+        // spent it, so a timeout on a healthy new socket skipped the retry that
+        // would have recovered it and waited for the server's scan instead.
+        saveRetries.current = 0;
+        saveTimeouts.current = 0;
         setCanWrite(snap.can_write);
         setParticipants(snap.participants);
         setActive(true);

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -22,6 +22,28 @@ import {
   handleMessage,
 } from "@/lib/editor/yProtocol";
 
+/** How long to wait for a `checkpoint_result` before giving up on that save.
+ *
+ * A checkpoint is normally tens to low-hundreds of milliseconds, so this only
+ * ever fires on something genuinely wrong. It is sized off the two legitimately
+ * slow paths so it can't fire on a save that is merely working hard: the
+ * server's `_CHECKPOINT_LOCK_TIMEOUT_MS` (30s — how long a duplicate checkpoint
+ * waits for the one in progress), plus room for the AI merge that resolves an
+ * overlap with an agent commit, which the backend measures in seconds. Move the
+ * two together if either changes.
+ *
+ * Without a deadline the promise settles only on the ack or on `onclose`, so an
+ * ack that is published but never delivered left it pending forever — and since
+ * `hooks.ts` holds `saveInFlight` across the await, that silently stopped the
+ * tab autosaving for the rest of the connection while showing "Saving…".
+ */
+const CHECKPOINT_TIMEOUT_MS = 60_000;
+
+/** Marks the timeout rejection so `hooks.ts` can budget its retries
+ * separately: this failure costs a full minute, unlike "not connected", which
+ * fails instantly and is what the 10-attempt budget was written for. */
+export const CHECKPOINT_TIMED_OUT = "checkpoint timed out";
+
 export interface CoeditParticipant {
   user_id: string;
   user_display: string;
@@ -268,7 +290,22 @@ export function checkpointSession(connectionId: number): Promise<void> {
   }
   const requestId = opaqueId();
   return new Promise<void>((resolve, reject) => {
-    entry.pendingCheckpoints.set(requestId, { resolve, reject });
+    const timer = setTimeout(() => {
+      // Drop the correlation first: a late ack must not settle a promise this
+      // has already rejected, and leaving the entry would leak one per save.
+      entry.pendingCheckpoints.delete(requestId);
+      reject(new ApiError(0, CHECKPOINT_TIMED_OUT));
+    }, CHECKPOINT_TIMEOUT_MS);
+    entry.pendingCheckpoints.set(requestId, {
+      resolve: () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      reject: (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    });
     entry.ws.send(
       JSON.stringify({ type: "checkpoint", request_id: requestId }),
     );

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1032,9 +1032,16 @@ export function FileView({ path }: FileViewProps) {
           >
             {coedit.saveStatus === "saving"
               ? "Saving…"
-              : coedit.saveError
-                ? `Couldn't save: ${coedit.saveError}`
-                : "Couldn't save"}
+              : coedit.saveStatus === "unconfirmed"
+                ? // Not a failure: the acknowledgement went missing, so whether
+                  // the commit happened is unknown. Saying "couldn't save"
+                  // here would claim more than we know.
+                  coedit.saveError
+                  ? `Couldn't confirm the save — ${coedit.saveError}`
+                  : "Couldn't confirm the save"
+                : coedit.saveError
+                  ? `Couldn't save: ${coedit.saveError}`
+                  : "Couldn't save"}
           </span>
         )}
         {!viewingVersion && !isMobile && (


### PR DESCRIPTION
## The bug

A tab sat on "Saving…" for 16 minutes. Investigation showed the save had
worked fine:

- the session was **clean** — `ydoc_seq == ydoc_checkpointed_seq`, last
  checkpoint 20:45:27
- the coedit queue was healthy — `xlen=1`, `pending=0`, consumers active
- **no** errors, warnings, or tracebacks in either pod for the whole hour, and
  no `busy; skipping` line, so not even lock contention

The checkpoint committed normally in the usual few hundred milliseconds. The
`checkpoint_result` frame just never reached the browser.

`checkpointSession`'s promise settles on exactly two events — that frame, or
`ws.onclose` rejecting everything pending. Socket open + ack missing = pending
forever.

And the label was the smaller half of it. `checkpoint()` sets
`saveInFlight.current = true` before awaiting and guards with
`if (!canWrite || saveInFlight.current) return`, so a hung promise means **that
tab never autosaves again** for the life of the connection — silently, with no
error and no retry, because the retry only arms on rejection. Work still
reaches git, but only through the server's 5-min-idle / 15-min-overdue scan.

## Changes

**A 60s deadline on the wait.** Sized off the two legitimately slow paths so it
can only fire on something genuinely wrong, never on a slow-but-working save:
the server's `_CHECKPOINT_LOCK_TIMEOUT_MS` (30s — how long a duplicate
checkpoint waits for the one in progress), plus room for the AI merge that
resolves an overlap with an agent commit, which the backend measures in
seconds. A comment ties the two constants together since they can't be shared
across the stack.

**A separate retry budget for timeouts (1).** `SAVE_RETRY_LIMIT = 10` is sized
for "not connected" during a reconnect, which fails instantly — 10 × 3s is a
sensible 30-second window there. At a minute per attempt the same budget means
~11 minutes of alternating "Saving…"/"Couldn't save". One retry bounds it to
about two minutes and then leaves an honest error.

**An honest message.** A missing ack says nothing about whether the commit
happened, so the indicator no longer claims failure; and once the budget is
spent it says what actually happens next — the periodic scan commits it. Giving
up delays the commit, it doesn't lose it: the edits are already in
`coedit_updates`.

**Control-frame delivery logging.** `_deliver_local` silently drops a frame
when no connection for that session is registered in the process — normal for a
task worker (it publishes; the socket lives in the web process, reached via the
bus), but also exactly how an ack goes missing, and it left no trace at all.

## What this does not do

**It does not explain why the frame vanished.** The server side is sound: the
task acks in a `finally`, so even the busy-skip path publishes, and the queue
wasn't backed up. Whether the frame was never fanned out or arrived without
matching is unknown, and after the fact there's nothing to inspect. The logging
above is what makes the next occurrence answerable; I'd rather add the trace
than guess.

What this *does* fix is the amplification — a single lost frame permanently
breaking a tab, versus a blip that self-heals in seconds.

## Testing

Backend: ruff, basedpyright, 130 coedit tests pass. Frontend: `tsc --noEmit`
and prettier clean.

The timeout path itself is **not** covered by an automated test — the frontend
has no test runner configured (`CLAUDE.md` lists Vitest as "when needed"), and
adding one is outside this change. The behaviour wants a runtime check against
a suppressed ack before this is trusted.