### PR TITLE
fix(ingest): raise the merge round bound clear of real runs

### DIFF
--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -87,11 +87,12 @@ _Result = TypeVar("_Result")
 # generic average as a group grows and then admits almost anything, so it tolerates far less
 # permissiveness than a linkage-based method at the "same" threshold.
 GROUP_SIMILARITY = 0.45
-# Safety bound on the merge loop, which exits as soon as a round stops collapsing anything.
-# Three was too low to be that bound: naming emitted 204 candidate types on a real corpus and
-# the loop stopped mid-descent, leaving single-referent types the merge prompt explicitly asks
-# to fold. One round is one LLM call, so a generous cap costs nothing when convergence is early.
-MERGE_ROUNDS = 8
+# Runaway guard on the merge loop, not a working limit: the loop exits as soon as a round stops
+# collapsing anything, so this only bounds a pathological case. Kept well clear of what real runs
+# need — a 148-page corpus converged in 6 rounds, most of it in the first (221 -> 34), then a slow
+# tail. One round is one LLM call, so headroom is nearly free, and running out is worse than
+# paying for a round that finds nothing.
+MERGE_ROUNDS = 20
 
 # Output cap, well above the client's 4096 default. Extraction lists every referent on a page, so
 # the response scales with the page — and on a 205k-char page it overflowed 4096, which cut the


### PR DESCRIPTION
`MERGE_ROUNDS` 8 → 20.

The 148-page corpus converged in **6** rounds, so 8 left only 25% headroom on a number that grows with the corpus. The loop already exits the moment a round collapses nothing, so the cap is a runaway guard, not a working limit — one round is one LLM call, so headroom is nearly free, while running out leaves the taxonomy over-split.

Observed descent: `[221, 34, 28, 20, 15, 14, 14]` — round 1 does 85% of the work, then a slow tail.

## The ceiling that binds first (not fixed here)

Round 1 must emit `member_indices` for every candidate type, and **221 types cost 5,569 output tokens** (~25/type). Against `MAX_OUTPUT_TOKENS = 16384` that saturates near **650 candidates** — roughly **435 pages** at the observed 1.5 candidates/page.

Past that, round 1 truncates. It now fails visibly (truncation → `None` → `NOT converged` warning) rather than silently, but the taxonomy would come out essentially unmerged. The fix there is chunking that first pass — which the eval harness had (`max_component`) and the port dropped — not more rounds. Left for when it's needed.

## One fix I investigated and dropped

`information_artifact` (99 referents) contains `Customers`, `Prospects`, `Random Ideas #2` — wiki structure, not tracked things. `is_corpus_artifact` only compares **leaf filenames**, so the obvious fix was to include directory names.

Checking the actual directories killed it: they include `Opal` (a real product, in the `software` examples), `scania` (a customer, in `organization`), `joachim`, `roshan`, `big man ronnie` (people), `Two Tower Model`. Filtering directory names would delete real entities — worse than the leak.

And only `Customers` is actually a directory; `Prospects` and `Random Ideas #2` are neither directories nor page names, so they came from **headings inside pages**. Filtering those is a design question, not a small fix.

No behaviour change beyond the bound. `ruff check` and basedpyright clean; existing merge tests unchanged and passing.