### PR TITLE
chore(ingest): record the largest type's share of referents

### DIFF
--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -844,10 +844,11 @@ def derive(
             "n_groups": len(groups),
             "n_types_named": len(collapsed),
             "n_types": len(final),
-            # Share of typed referents under the single largest type. A taxonomy is a key space,
-            # so this is the number that says whether it discriminates: a label most referents
-            # share carries almost no information for a consumer, however sound its definition.
-            # Recorded because it is otherwise only visible by inspecting the type list by hand.
+            # Share of typed referents under the single largest type. Recorded, not judged: a
+            # dominant type is what an accurate taxonomy looks like when the corpus really is
+            # mostly one kind of thing, and forcing a split would distort it. Useful as a
+            # tripwire — a share that MOVES between runs on the same corpus says the merge is
+            # unstable — which needs the number visible without reading the type list by hand.
             "largest_type_share": (
                 round(max(t.n_referents for t in final) / len(surviving), 3) if final else 0.0
             ),
@@ -878,18 +879,14 @@ def run_derivation(
     artifact = derive(pages, model=model)
 
     stats = artifact["stats"]
-    if stats.get("largest_type_share", 0) >= 0.4:
-        log.warning(
-            "entity_types: the largest type holds %.0f%% of typed referents — a label that many "
-            "share tells a consumer little; the taxonomy may be over-merged",
-            100 * stats["largest_type_share"],
-        )
     log.info(
-        "entity_types: %d mention(s) -> %d referent(s) -> %d typed -> %d type(s)",
+        "entity_types: %d mention(s) -> %d referent(s) -> %d typed -> %d type(s); "
+        "largest type holds %.0f%%",
         stats["n_mentions"],
         stats["n_referents"],
         stats["n_typed"],
         stats["n_types"],
+        100 * stats.get("largest_type_share", 0),
     )
     artifact["entity_type_taxonomy_id"] = store_taxonomy(artifact, triggered_by=triggered_by_user_id)
     return artifact

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -844,6 +844,13 @@ def derive(
             "n_groups": len(groups),
             "n_types_named": len(collapsed),
             "n_types": len(final),
+            # Share of typed referents under the single largest type. A taxonomy is a key space,
+            # so this is the number that says whether it discriminates: a label most referents
+            # share carries almost no information for a consumer, however sound its definition.
+            # Recorded because it is otherwise only visible by inspecting the type list by hand.
+            "largest_type_share": (
+                round(max(t.n_referents for t in final) / len(surviving), 3) if final else 0.0
+            ),
         },
         "entity_types": [t.model_dump() for t in final],
     }
@@ -871,6 +878,12 @@ def run_derivation(
     artifact = derive(pages, model=model)
 
     stats = artifact["stats"]
+    if stats.get("largest_type_share", 0) >= 0.4:
+        log.warning(
+            "entity_types: the largest type holds %.0f%% of typed referents — a label that many "
+            "share tells a consumer little; the taxonomy may be over-merged",
+            100 * stats["largest_type_share"],
+        )
     log.info(
         "entity_types: %d mention(s) -> %d referent(s) -> %d typed -> %d type(s)",
         stats["n_mentions"],

--- a/backend/app/llm/prompts/entity_types.merge.md
+++ b/backend/app/llm/prompts/entity_types.merge.md
@@ -5,8 +5,7 @@ You see every type at once, with how many referents and pages each covers.
 TASK: merge types that denote the same KIND of thing.
   - Merge a narrow type into a broader one when the broader one already covers its members: "medical_organization", "telecommunications_company" and "nonprofit_organization" are all "organization".
   - Merge synonyms: types whose definitions are interchangeable are one type, even when the names differ ("software_product" / "software_service" / "software_application").
-  - PREFER FEW, GENERAL types — but fewness is not free. A taxonomy of 5-10 types a later extractor can apply consistently beats 40 it cannot choose between; a type that ends up holding most of the referents is no better, because a label half of them share tells that extractor nothing. When a merge would produce such a type, keep the distinction instead.
-  - The two counts mean different things. PAGES is the evidence that a kind is real and worth telling apart: a kind appearing on 30 pages is established across the corpus, while 200 referents confined to 2 pages is one page's list. A type with a single referent usually belongs inside a larger one — but not when it is thin in referents yet spread across many pages.
+  - PREFER FEW, GENERAL types. A taxonomy of 5-10 types that a later extractor can apply consistently beats 40 precise ones it cannot choose between. Referent counts are your guide: a type with 1 referent almost always belongs inside a larger one.
   - Do NOT merge kinds that a later extractor would need to tell apart — a person is not an organization, a protocol is not a product.
   - Reject a type whose basis is not the KIND of thing:
       * FORM-based: "abbreviation" classifies how a name is SPELLED, not what it denotes. Every acronym would qualify, so it steals members from every real type.

--- a/backend/app/llm/prompts/entity_types.merge.md
+++ b/backend/app/llm/prompts/entity_types.merge.md
@@ -5,7 +5,8 @@ You see every type at once, with how many referents and pages each covers.
 TASK: merge types that denote the same KIND of thing.
   - Merge a narrow type into a broader one when the broader one already covers its members: "medical_organization", "telecommunications_company" and "nonprofit_organization" are all "organization".
   - Merge synonyms: types whose definitions are interchangeable are one type, even when the names differ ("software_product" / "software_service" / "software_application").
-  - PREFER FEW, GENERAL types. A taxonomy of 5-10 types that a later extractor can apply consistently beats 40 precise ones it cannot choose between. Referent counts are your guide: a type with 1 referent almost always belongs inside a larger one.
+  - PREFER FEW, GENERAL types — but fewness is not free. A taxonomy of 5-10 types a later extractor can apply consistently beats 40 it cannot choose between; a type that ends up holding most of the referents is no better, because a label half of them share tells that extractor nothing. When a merge would produce such a type, keep the distinction instead.
+  - The two counts mean different things. PAGES is the evidence that a kind is real and worth telling apart: a kind appearing on 30 pages is established across the corpus, while 200 referents confined to 2 pages is one page's list. A type with a single referent usually belongs inside a larger one — but not when it is thin in referents yet spread across many pages.
   - Do NOT merge kinds that a later extractor would need to tell apart — a person is not an organization, a protocol is not a product.
   - Reject a type whose basis is not the KIND of thing:
       * FORM-based: "abbreviation" classifies how a name is SPELLED, not what it denotes. Every acronym would qualify, so it steals members from every real type.

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -765,3 +765,99 @@ class TestMergeConvergence:
         messages = " ".join(r.getMessage() for r in caplog.records)
         assert "50 -> 30" in messages and "30 -> 12" in messages
         assert "converged" in messages
+
+
+class TestLargestTypeShare:
+    """A taxonomy is a key space, so the share held by its biggest type is what says whether it
+    discriminates. The recorded run had 51% under one type and nothing reported it."""
+
+    def test_share_is_recorded(self, monkeypatch) -> None:
+        artifact = self._derive(monkeypatch, sizes=[6, 3, 1])
+
+        assert artifact["stats"]["largest_type_share"] == 0.6
+
+    def test_a_dominant_type_warns(self, monkeypatch, caplog) -> None:
+        from app.ingest import entity_types
+
+        monkeypatch.setattr(entity_types, "read_corpus", lambda prefix="": [("a.md", "b")])
+        monkeypatch.setattr(entity_types, "store_taxonomy", lambda a, triggered_by=None: 1)
+        monkeypatch.setattr(
+            entity_types,
+            "derive",
+            lambda pages, model=None: {
+                "entity_types": [{"name": "software", "definition": "d"}],
+                "stats": {
+                    "n_mentions": 1,
+                    "n_referents": 1,
+                    "n_typed": 1,
+                    "n_types": 1,
+                    "largest_type_share": 0.51,
+                },
+            },
+        )
+        monkeypatch.setattr(entity_types, "get_llm_settings", lambda: _Settings())
+
+        with caplog.at_level("WARNING"):
+            entity_types.run_derivation()
+
+        assert any("51% of typed referents" in r.getMessage() for r in caplog.records)
+
+    def test_a_balanced_taxonomy_does_not_warn(self, monkeypatch, caplog) -> None:
+        from app.ingest import entity_types
+
+        monkeypatch.setattr(entity_types, "read_corpus", lambda prefix="": [("a.md", "b")])
+        monkeypatch.setattr(entity_types, "store_taxonomy", lambda a, triggered_by=None: 1)
+        monkeypatch.setattr(
+            entity_types,
+            "derive",
+            lambda pages, model=None: {
+                "entity_types": [{"name": "software", "definition": "d"}],
+                "stats": {
+                    "n_mentions": 1,
+                    "n_referents": 1,
+                    "n_typed": 1,
+                    "n_types": 1,
+                    "largest_type_share": 0.25,
+                },
+            },
+        )
+        monkeypatch.setattr(entity_types, "get_llm_settings", lambda: _Settings())
+
+        with caplog.at_level("WARNING"):
+            entity_types.run_derivation()
+
+        assert not any("typed referents" in r.getMessage() for r in caplog.records)
+
+    @staticmethod
+    def _derive(monkeypatch, *, sizes: list[int]) -> dict:
+        """Drive derive() with stubbed LLM stages so only the arithmetic is under test."""
+        from app.ingest import entity_types
+        from app.ingest.entity_types import EntityType, Mention
+
+        total = sum(sizes)
+        monkeypatch.setattr(
+            entity_types,
+            "extract_page",
+            lambda path, body, model=None: [
+                Mention(surface=f"r{i}", page=path) for i in range(total)
+            ],
+        )
+        monkeypatch.setattr(entity_types, "_leader_cluster", lambda unit, order, sim: [order])
+        monkeypatch.setattr(
+            entity_types,
+            "name_group",
+            lambda group, model=None: [
+                EntityType(name=f"t{n}", definition="d", n_referents=size, n_docs=1)
+                for n, size in enumerate(sizes)
+            ],
+        )
+        monkeypatch.setattr(entity_types, "merge_types", lambda types, model=None: types)
+        monkeypatch.setattr(
+            entity_types.embeddings, "embed_texts", lambda texts: [[1.0, 0.0] for _ in texts]
+        )
+        return entity_types.derive([("a.md", "body")])
+
+
+class _Settings:
+    model = "m"
+    ingest_selector_model = ""

--- a/backend/tests/test_entity_types.py
+++ b/backend/tests/test_entity_types.py
@@ -768,65 +768,24 @@ class TestMergeConvergence:
 
 
 class TestLargestTypeShare:
-    """A taxonomy is a key space, so the share held by its biggest type is what says whether it
-    discriminates. The recorded run had 51% under one type and nothing reported it."""
+    """The share held by the biggest type is RECORDED, not policed. A dominant type is what an
+    accurate taxonomy looks like when the corpus really is mostly one kind of thing. The number is
+    kept as a tripwire: one that moves between runs on the same corpus says the merge is unstable,
+    which is a defect — unlike being large."""
 
     def test_share_is_recorded(self, monkeypatch) -> None:
         artifact = self._derive(monkeypatch, sizes=[6, 3, 1])
 
         assert artifact["stats"]["largest_type_share"] == 0.6
 
-    def test_a_dominant_type_warns(self, monkeypatch, caplog) -> None:
-        from app.ingest import entity_types
+    def test_a_dominant_type_is_not_treated_as_a_fault(self, monkeypatch, caplog) -> None:
+        """No warning, no suppression: 51% under one type was the taxonomy being right about an
+        engineering wiki, and forcing a split would manufacture boundaries a later extractor has
+        to guess at."""
+        artifact = self._derive(monkeypatch, sizes=[9, 1])
 
-        monkeypatch.setattr(entity_types, "read_corpus", lambda prefix="": [("a.md", "b")])
-        monkeypatch.setattr(entity_types, "store_taxonomy", lambda a, triggered_by=None: 1)
-        monkeypatch.setattr(
-            entity_types,
-            "derive",
-            lambda pages, model=None: {
-                "entity_types": [{"name": "software", "definition": "d"}],
-                "stats": {
-                    "n_mentions": 1,
-                    "n_referents": 1,
-                    "n_typed": 1,
-                    "n_types": 1,
-                    "largest_type_share": 0.51,
-                },
-            },
-        )
-        monkeypatch.setattr(entity_types, "get_llm_settings", lambda: _Settings())
-
-        with caplog.at_level("WARNING"):
-            entity_types.run_derivation()
-
-        assert any("51% of typed referents" in r.getMessage() for r in caplog.records)
-
-    def test_a_balanced_taxonomy_does_not_warn(self, monkeypatch, caplog) -> None:
-        from app.ingest import entity_types
-
-        monkeypatch.setattr(entity_types, "read_corpus", lambda prefix="": [("a.md", "b")])
-        monkeypatch.setattr(entity_types, "store_taxonomy", lambda a, triggered_by=None: 1)
-        monkeypatch.setattr(
-            entity_types,
-            "derive",
-            lambda pages, model=None: {
-                "entity_types": [{"name": "software", "definition": "d"}],
-                "stats": {
-                    "n_mentions": 1,
-                    "n_referents": 1,
-                    "n_typed": 1,
-                    "n_types": 1,
-                    "largest_type_share": 0.25,
-                },
-            },
-        )
-        monkeypatch.setattr(entity_types, "get_llm_settings", lambda: _Settings())
-
-        with caplog.at_level("WARNING"):
-            entity_types.run_derivation()
-
-        assert not any("typed referents" in r.getMessage() for r in caplog.records)
+        assert artifact["stats"]["largest_type_share"] == 0.9
+        assert len(artifact["entity_types"]) == 2
 
     @staticmethod
     def _derive(monkeypatch, *, sizes: list[int]) -> dict:
@@ -856,8 +815,3 @@ class TestLargestTypeShare:
             entity_types.embeddings, "embed_texts", lambda texts: [[1.0, 0.0] for _ in texts]
         )
         return entity_types.derive([("a.md", "body")])
-
-
-class _Settings:
-    model = "m"
-    ingest_selector_model = ""


### PR DESCRIPTION
Records `largest_type_share` in the derivation's `stats` and reports it in the summary line. No behaviour change.

## Why only this

I originally added two merge-prompt rules to push back on `software` holding **51% of typed referents**. That was wrong, and I've reverted them — the merge prompt now shows no diff against main.

A dominant type is not a defect. If the corpus really is mostly one kind of thing — and an engineering company's wiki really is mostly software — then a type holding half the referents is the taxonomy being **accurate**. Two arguments I should have weighed before writing the rules:

- **Broader types are easier for a later extractor to apply, not harder.** Splitting `software` into `our_product` / `third_party_tool` / `library` manufactures boundaries it has to guess at silently — the *"40 precise ones it cannot choose between"* failure the prompt already warns about.
- **I never showed the 51% harmed anything downstream.** It was a balance heuristic with no evidence, which is the same class as the six speculative parameters this module has already had removed.

The evidence pointed the same way: when I checked the odd-looking members of `software`, they were legitimate — `Jara` and `Kunchan` are customer systems, `Clank` is an agent.

## What the number is for

Not policing the share — a tripwire for the defect that *is* real: a share that **moves between runs on the same corpus**. It was 45% / 53% / 51% across three identical-input runs, alongside type counts of 18 / 23 / 14. That instability matters because type names are keys stored in `page_needs`; the size of a type doesn't.

Previously the share was only discoverable by reading the type list by hand.

2 tests: the share is computed correctly, and a 90%-dominant type is passed through untouched rather than warned about or split.

`ruff check` and basedpyright clean, full suite green.