### PR TITLE
perf(ingest): extract needs concurrently, on the ingestion model

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -82,6 +82,10 @@ class Config(BaseModel):
     # call can carry ~47k input tokens, and this pool sits inside a queue task, so the real
     # concurrency is the queue's own worker count multiplied by this. Lower it on a lower tier.
     entity_type_derive_workers: int = 8
+    # How many need-extraction LLM calls run at once. Separate from the derivation's knob because
+    # the token profile differs: a need response enumerates a page's tracked entries, so it is far
+    # larger than a referent list, and an operator may want the two rates set differently.
+    need_extract_workers: int = 8
 
     # Relevance filter (drops irrelevant candidate pages before the LLM reconcile).
     # Empty model path => cosine cold-start filter; a path to an exported two-tower
@@ -214,6 +218,7 @@ def load_config() -> Config:
         ingest_irrelevant_stop_n=_positive_int("INGEST_IRRELEVANT_STOP_N", 2),
         ingest_embed_model=os.environ.get("INGEST_EMBED_MODEL", "text-embedding-3-small"),
         entity_type_derive_workers=_positive_int("ENTITY_TYPE_DERIVE_WORKERS", 8),
+        need_extract_workers=_positive_int("NEED_EXTRACT_WORKERS", 8),
         ingest_relevance_two_tower_model_path=os.environ.get("INGEST_RELEVANCE_TWO_TOWER_MODEL_PATH", ""),
         # Cosine cold-start default: the study's 85%-filter operating point.
         ingest_relevance_cosine_threshold=_nonneg_float(

--- a/backend/app/ingest/needs.py
+++ b/backend/app/ingest/needs.py
@@ -28,11 +28,13 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Any, cast
 
 from pydantic import BaseModel, Field
 
+from app.config import CONFIG
 from app.db import page_needs
 from app.ingest import entity_types
 from app.llm import client
@@ -86,6 +88,13 @@ MAX_VALIDATION_RETRIES = 1
 # measured worst case with headroom while staying inside current models' output limits; the cap
 # costs nothing when unused, since billing follows tokens generated.
 MAX_OUTPUT_TOKENS = 16384
+
+
+def _workers() -> int:
+    """Concurrent page extractions. Pages are independent and each is stored as it finishes, so
+    there is no ordering constraint and no barrier — unlike the taxonomy's grouping, where arrival
+    order changes the result. Set by ``NEED_EXTRACT_WORKERS``; never below 1."""
+    return max(1, CONFIG.need_extract_workers)
 
 
 class EntityMention(BaseModel):
@@ -320,13 +329,16 @@ def run_extraction(
     The entity-type menu is read ONCE per run and its taxonomy id stored with every need set,
     so a later re-derivation that renames a type leaves these mentions resolvable.
     """
-    # Resolve the model to a NAME once, rather than storing "" for "whatever the default was".
-    # Both callers use the deployment default, so an unresolved model would make every row's
-    # model column empty — and the staleness guard would then compare "" to "" and conclude
-    # nothing changed after an admin switched models, silently keeping needs written by the old
-    # one. Resolved once per run for the same reason the taxonomy id is: a switch landing
+    # Default to the admin's ingestion-pipeline model: this is ingest-side work, and it keeps
+    # needs on the same model the taxonomy they are labelled against was derived with.
+    #
+    # Resolved to a NAME, never left as None or "": the staleness guard compares this column, so
+    # an unresolved value would make every row's model empty, and a later model switch would then
+    # compare "" to "" and conclude nothing changed — silently keeping needs written by the old
+    # model. Resolved ONCE per run for the same reason the taxonomy id is: a switch landing
     # mid-run must not leave one batch labelled two ways.
-    model = model or get_llm_settings().model
+    settings = get_llm_settings()
+    model = model or settings.ingest_selector_model or settings.model
     entity_type_taxonomy_id = entity_types.active_entity_type_taxonomy_id()
     type_defs = entity_types.load_taxonomy(entity_type_taxonomy_id)
     log.info(
@@ -351,25 +363,46 @@ def run_extraction(
         "empty": 0,
     }
 
-    for n, path in enumerate(stale, start=1):
-        needs = extract_page(path, by_path[path], type_defs=type_defs, model=model)
-        if not needs:
-            # "empty", not "failed": a page that tracks nothing durable and a page the model
-            # could not parse both land here, and this layer cannot tell them apart —
-            # extract_page logs the ones that were real failures. Either way the empty result
-            # is STORED, which is what stops the page being re-extracted on every run.
-            counts["empty"] += 1
-        page_needs.store(
-            path,
-            body=by_path[path],
-            needs=[need.model_dump(mode="json") for need in needs],
-            model=model,
-            entity_type_taxonomy_id=entity_type_taxonomy_id,
-        )
-        counts["extracted"] += 1
-        counts["needs"] += len(needs)
-        if progress:
-            progress(n, len(stale))
+    def extract_and_store(path: str) -> int | None:
+        """One page, extracted and stored. ``None`` means it could not be stored.
+
+        The store stays INSIDE the worker rather than being collected for a single write at the
+        end: that is what makes an interrupted run resumable — every finished page is already
+        durable, and the content-hash guard skips it next time. The taxonomy derivation wrote once
+        at the end and lost 105 pages to a pod restart; this cannot.
+        """
+        try:
+            extracted = extract_page(path, by_path[path], type_defs=type_defs, model=model)
+            page_needs.store(
+                path,
+                body=by_path[path],
+                needs=[need.model_dump(mode="json") for need in extracted],
+                model=model,
+                entity_type_taxonomy_id=entity_type_taxonomy_id,
+            )
+            return len(extracted)
+        except Exception:
+            # One page must not abort the corpus — an exception escaping the pool would take
+            # every other page's paid-for work with it.
+            log.warning("needs: could not store needs for %s", path, exc_info=True)
+            return None
+
+    workers = min(_workers(), len(stale)) if stale else 1
+    log.info("needs: extracting %d page(s), %d at a time", len(stale), workers)
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        for n, result in enumerate(pool.map(extract_and_store, stale), start=1):
+            if result is None:
+                continue
+            counts["extracted"] += 1
+            counts["needs"] += result
+            if result == 0:
+                # "empty", not "failed": a page that tracks nothing durable and a page the model
+                # could not parse both land here, and this layer cannot tell them apart —
+                # extract_page logs the ones that were real failures. Either way the empty result
+                # is STORED, which is what stops the page being re-extracted on every run.
+                counts["empty"] += 1
+            if progress:
+                progress(n, len(stale))
 
     if pages:
         # Scoped to the prefix walked: ``by_path`` only describes that scope, so an unscoped

--- a/backend/app/ingest/needs.py
+++ b/backend/app/ingest/needs.py
@@ -371,21 +371,31 @@ def run_extraction(
         durable, and the content-hash guard skips it next time. The taxonomy derivation wrote once
         at the end and lost 105 pages to a pod restart; this cannot.
         """
+        # Two boundaries, not one: an exception escaping the pool would take every other page's
+        # paid-for work with it, but a single handler would also report every failure as a storage
+        # failure and send an operator to the database when the fault was in the model call.
         try:
             extracted = extract_page(path, by_path[path], type_defs=type_defs, model=model)
+            payload = [need.model_dump(mode="json") for need in extracted]
+        except Exception:
+            # extract_page already absorbs a failed or unparseable completion and returns [], so
+            # reaching here means something unexpected — a serialization fault, or a bug.
+            log.warning("needs: extracting needs failed for %s", path, exc_info=True)
+            return None
+
+        try:
             page_needs.store(
                 path,
                 body=by_path[path],
-                needs=[need.model_dump(mode="json") for need in extracted],
+                needs=payload,
                 model=model,
                 entity_type_taxonomy_id=entity_type_taxonomy_id,
             )
-            return len(extracted)
         except Exception:
-            # One page must not abort the corpus — an exception escaping the pool would take
-            # every other page's paid-for work with it.
-            log.warning("needs: could not store needs for %s", path, exc_info=True)
+            log.warning("needs: storing needs failed for %s", path, exc_info=True)
             return None
+
+        return len(extracted)
 
     workers = min(_workers(), len(stale)) if stale else 1
     log.info("needs: extracting %d page(s), %d at a time", len(stale), workers)

--- a/backend/tests/test_needs_extraction_run.py
+++ b/backend/tests/test_needs_extraction_run.py
@@ -372,3 +372,130 @@ class TestBookkeeping:
 
         assert counts == {"pages": 0, "extracted": 0, "skipped": 0, "needs": 0, "empty": 0}
         assert llm == []
+
+
+class TestParallelAndModel:
+    """Extraction runs concurrently, and each page is durable as soon as it finishes."""
+
+    def test_pages_extract_concurrently(self, tmp_repo, monkeypatch) -> None:
+        import threading
+        import time
+
+        in_flight = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def slow(messages, **kwargs):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.05)
+            with lock:
+                in_flight -= 1
+            return CompletionResult(text=json.dumps({"needs": []}))
+
+        monkeypatch.setattr(needs.client, "complete", slow)
+        for i in range(12):
+            _page(f"p{i}.md")
+
+        needs.run_extraction()
+
+        assert peak > 1
+        assert peak <= needs._workers()
+
+    def test_concurrency_is_bounded(self, tmp_repo, monkeypatch) -> None:
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(needs, "CONFIG", SimpleNamespace(need_extract_workers=2))
+        import threading
+        import time
+
+        in_flight = 0
+        peak = 0
+        lock = threading.Lock()
+
+        def slow(messages, **kwargs):
+            nonlocal in_flight, peak
+            with lock:
+                in_flight += 1
+                peak = max(peak, in_flight)
+            time.sleep(0.03)
+            with lock:
+                in_flight -= 1
+            return CompletionResult(text=json.dumps({"needs": []}))
+
+        monkeypatch.setattr(needs.client, "complete", slow)
+        for i in range(10):
+            _page(f"p{i}.md")
+
+        needs.run_extraction()
+
+        assert peak == 2
+
+    def test_every_page_is_stored_not_just_counted(self, tmp_repo, llm) -> None:
+        """Each page is written inside its own worker, so an interrupted run resumes instead of
+        losing everything — the failure that cost the taxonomy derivation 105 pages."""
+        for i in range(6):
+            _page(f"p{i}.md")
+
+        counts = needs.run_extraction()
+
+        assert counts["extracted"] == 6
+        assert len(page_needs.load_all()) == 6
+
+    def test_one_unstorable_page_does_not_abort_the_rest(self, tmp_repo, llm, monkeypatch) -> None:
+        real_store = page_needs.store
+
+        def flaky(path, **kwargs):
+            if path == "p2.md":
+                raise RuntimeError("db hiccup")
+            return real_store(path, **kwargs)
+
+        monkeypatch.setattr(needs.page_needs, "store", flaky)
+        for i in range(5):
+            _page(f"p{i}.md")
+
+        counts = needs.run_extraction()
+
+        assert counts["extracted"] == 4
+        assert sorted(r.path for r in page_needs.load_all()) == [
+            "p0.md",
+            "p1.md",
+            "p3.md",
+            "p4.md",
+        ]
+
+    def test_uses_the_ingestion_model(self, tmp_repo, llm, monkeypatch) -> None:
+        from app.llm import settings as llm_settings
+
+        monkeypatch.setattr(
+            needs,
+            "get_llm_settings",
+            lambda: llm_settings.LLMSettings(model="main", ingest_selector_model="ingest-cheap"),
+        )
+        _page("a.md")
+
+        needs.run_extraction()
+
+        stored = page_needs.get("a.md")
+        assert stored is not None
+        assert stored.model == "ingest-cheap"
+
+    def test_falls_back_to_the_main_model_by_name(self, tmp_repo, llm, monkeypatch) -> None:
+        """Never "" — the staleness guard compares this column, so an empty value would make a
+        later model switch invisible."""
+        from app.llm import settings as llm_settings
+
+        monkeypatch.setattr(
+            needs,
+            "get_llm_settings",
+            lambda: llm_settings.LLMSettings(model="main", ingest_selector_model=""),
+        )
+        _page("a.md")
+
+        needs.run_extraction()
+
+        stored = page_needs.get("a.md")
+        assert stored is not None
+        assert stored.model == "main"

--- a/backend/tests/test_needs_extraction_run.py
+++ b/backend/tests/test_needs_extraction_run.py
@@ -499,3 +499,24 @@ class TestParallelAndModel:
         stored = page_needs.get("a.md")
         assert stored is not None
         assert stored.model == "main"
+
+    def test_an_extraction_failure_is_not_reported_as_a_storage_failure(
+        self, tmp_repo, llm, monkeypatch, caplog
+    ) -> None:
+        """The two stages fail for different reasons and need different fixes, so a shared
+        handler that always blamed storage would send an operator to the database for a fault in
+        the model call."""
+
+        def boom(path, body, *, type_defs, model=None):
+            raise RuntimeError("unexpected")
+
+        monkeypatch.setattr(needs, "extract_page", boom)
+        _page("a.md")
+
+        with caplog.at_level("WARNING"):
+            counts = needs.run_extraction()
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert counts["extracted"] == 0
+        assert "extracting needs failed for a.md" in messages
+        assert "storing" not in messages


### PR DESCRIPTION
Readies need extraction for its first production run. Two changes.

## Concurrency

Extraction was sequential — 148 pages at ~45s each is roughly **two hours**. Pages are independent and there is **no ordering constraint** here (unlike the taxonomy's grouping, where arrival order changes the result), so a bounded pool of 8 brings it to about **20 minutes**.

`NEED_EXTRACT_WORKERS` sets it, kept separate from the derivation's knob because the token profiles differ: a need response enumerates a page's tracked entries and is far larger than a referent list, so an operator may want the two rates set differently.

**The store stays inside the worker**, rather than collecting results for one write at the end. That's what makes an interrupted run resumable — every finished page is already durable, and the content-hash guard skips it next time. The taxonomy derivation wrote once at the end and lost 105 pages to a pod restart; this can't. A page that fails to store is logged and skipped rather than aborting the pool.

## Model

Needs now default to the **ingestion-pipeline model**, so they run on the same model the taxonomy they're labelled against was derived with (`gpt-5.6-luna` in prod).

Resolved to a **name**, never `None` or `""`: the staleness guard compares that column, so an empty value would make a later model switch invisible. Falls back to the main model's name when no ingestion model is nominated.

Worth flagging as a risk rather than hiding it: the earlier eval found weaker models did poorly on need extraction **for large pages specifically** — a stronger constraint here than for mention extraction, since `current_content` has to enumerate a page's entries rather than summarise them. Truncation now names the page, so if the ingestion model struggles we'll see it rather than infer it.

## Readiness check that prompted this

Audited `needs.py` against the failure modes the derivation hit. It already carried: output cap passed (16384), truncation surfaced, retry on malformed JSON, model recorded by name, prune scoped by prefix and guarded against an empty read. Sequential execution was the only gap.

Verified against prod: taxonomy `id=3` resolves, all 14 types splice into the prompt, task registered, 148 pages queued. One incidental find — the prompt is ~1,715 tokens, above OpenAI's 1024-token minimum shared prefix, so unlike entity extraction (~396 tokens, 0% cache hits) this should actually get cache discounts.

## Tests

6 new: pages extract concurrently; concurrency is bounded by the knob; every page is stored rather than just counted; one unstorable page doesn't abort the rest; the ingestion model is used; and it falls back to the main model *by name*.

Verified by mutation — forcing sequential, using the main model, or narrowing the per-page guard each fails a test. `ruff check` and basedpyright clean, full suite green.