### PR TITLE
fix(wiki): preserve list tightness through the markdown-Yjs round trip

### DIFF
--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -692,6 +692,25 @@ def _build_list(
         if ordered:
             attrs["start"] = str(open_tok.attrs.get("start", 1))
 
+    # Tight vs. loose is recorded, not discarded: markdown-it hides a tight
+    # item's paragraph tokens (CommonMark makes looseness a whole-list
+    # property, so they're all hidden or all visible per list). The direct
+    # item paragraphs sit exactly two levels below this list's open token —
+    # a nested list's paragraphs are deeper and carry that list's own flag,
+    # judged by its own recursive ``_build_list`` call. Without this
+    # attribute every touched list re-serialized loose, so editing one item
+    # rewrote the whole list's spacing — phantom formatting churn in every
+    # co-edit checkpoint that touched a tight list.
+    para_level = open_tok.level + 2
+    direct_paras = [
+        t
+        for s, e in item_ranges
+        for t in tokens[s:e]
+        if t.type == "paragraph_open" and t.level == para_level
+    ]
+    if all(t.hidden for t in direct_paras):
+        attrs["tight"] = "true"
+
     items: list[XmlElement] = []
     finishers: list[Any] = []
     for idx, (item_start, item_end) in enumerate(item_ranges):
@@ -954,7 +973,7 @@ def serialize_row(row: XmlElement) -> str:
     return kids[0].to_py() if kids else ""  # type: ignore[return-value]
 
 
-def _serialize_block_sequence(children: list[XmlElement], indent: str) -> str:
+def _serialize_block_sequence(children: list[XmlElement], indent: str, sep: str = "\n\n") -> str:
     """Inverse of ``_build_block_sequence``: block children joined by blank
     lines, with every line after the very first indented by ``indent`` so
     continuation lines / nested constructs align under the parent marker or
@@ -966,28 +985,72 @@ def _serialize_block_sequence(children: list[XmlElement], indent: str) -> str:
     block-start escaping: a list item or blockquote's own first line is just
     as much a fresh block-start position as the top of the document, so a
     literal leading ``-``/``>``/``#``/``---`` needs the same escaping there.
-    Each block's own trailing newline is dropped here because the blank-line
-    join below supplies the separation instead."""
+    Each block's own trailing newline is dropped here because the join
+    below supplies the separation instead.
+
+    ``sep`` is ``"\\n"`` for a tight list item's blocks (no blank between a
+    tight item's paragraph and its nested list — see ``_serialize_list``,
+    which only passes it when ``_tight_item_safe`` proved the reparse keeps
+    the blocks apart) and the default blank-line join everywhere else."""
     parts = [serialize_block(child).rstrip("\n") for child in children]
-    combined = "\n\n".join(parts)
+    combined = sep.join(parts)
     lines = combined.split("\n")
     indented = [lines[0]] + [(indent + line if line else line) for line in lines[1:]]
     return "\n".join(indented)
 
 
+# Blocks that may directly follow a tight item's first paragraph with no
+# blank line and still reparse as their own block: constructs CommonMark
+# lets interrupt a paragraph. Notably absent: ``paragraph`` (two need a
+# blank between them or they merge), ``horizontalRule`` (``---`` under a
+# paragraph line is a setext heading, not a rule), ``table`` (a delimiter
+# row can't interrupt), and ``orderedList`` unless it starts at 1 (checked
+# separately — only ``1.`` may interrupt).
+_TIGHT_INTERRUPTERS = frozenset({"bulletList", "taskList", "codeBlock", "heading", "blockquote"})
+
+
+def _tight_item_safe(item: XmlElement) -> bool:
+    """Whether this item's blocks survive a tight (no-blank-line) join.
+
+    A tight list parsed from markdown always satisfies this — a blank line
+    inside an item would have made the whole list loose. What can't is a doc
+    the editor mutated after parsing: the ``tight`` attribute lives on the
+    list node, so nothing clears it when an edit gives an item a second
+    paragraph. Serializing that tightly would merge the paragraphs on the
+    next parse; the caller falls back to loose for the whole list instead
+    (one visible reflow, after which the reparse records ``loose`` and the
+    round trip is stable again)."""
+    blocks = [c for c in item.children if isinstance(c, XmlElement)]
+    for later in blocks[1:]:
+        if later.tag == "orderedList":
+            if dict(later.attributes).get("start", "1") != "1":
+                return False
+            continue
+        if later.tag not in _TIGHT_INTERRUPTERS:
+            return False
+    return True
+
+
 def _serialize_list(node: XmlElement) -> str:
-    """Serializes every list as CommonMark "loose" style (blank line between
-    items), even if the source was "tight" (no blank lines) — tight vs.
-    loose is purely an HTML-rendering distinction (whether item content gets
-    wrapped in ``<p>``); the item *text* is identical either way, so this
-    never changes a page's actual content. Not byte-identical for a touched
-    list, same accepted tradeoff as ordered-list renumbering — only
+    """Serializes a list in the style its ``tight`` attribute records —
+    single newlines between a tight list's items, blank lines for a loose
+    one — so an edit to one item no longer reflows the whole list's
+    spacing. A list with no attribute (built by the editor rather than the
+    parser) serializes loose, the safe direction. Still not byte-identical
+    for every touched list (ordered-list renumbering, marker style) — only
     untouched blocks carry the byte-stability guarantee
     (``markdown_splice.py``), which never calls this serializer at all.
     """
     ordered = node.tag == "orderedList"
     attrs = dict(node.attributes)
     start = int(attrs.get("start", "1")) if ordered else 1
+    tight = _is_tight(attrs.get("tight")) and all(
+        _tight_item_safe(item)  # type: ignore[arg-type]
+        for item in node.children
+        if isinstance(item, XmlElement)
+    )
+    item_sep = "\n" if tight else "\n\n"
+    block_sep = "\n" if tight else "\n\n"
     lines: list[str] = []
     for idx, item in enumerate(node.children):
         # Per item, not per list: a taskList holds plain listItems alongside
@@ -1010,7 +1073,7 @@ def _serialize_list(node: XmlElement) -> str:
         else:
             marker = f"{start + idx}. " if ordered else "- "
             indent = " " * len(marker)
-        body = _serialize_block_sequence(list(item.children), indent)  # type: ignore[arg-type]
+        body = _serialize_block_sequence(list(item.children), indent, block_sep)  # type: ignore[arg-type]
         if not is_task:
             # A literal "[x] " opening a plain list item is a checkbox marker
             # the parse declined to promote — the item is in an ordered list,
@@ -1034,7 +1097,17 @@ def _serialize_list(node: XmlElement) -> str:
             # list and a uniform one.
             body = _ESCAPED_TASK_MARKER_RE.sub(r"[\1]\2", body, count=1)
         lines.append(marker + body)
-    return "\n\n".join(lines) + "\n"
+    return item_sep.join(lines) + "\n"
+
+
+def _is_tight(value: object) -> bool:
+    """Whether a list's ``tight`` attribute means tight. Same two-writer
+    tolerance as ``_is_checked`` below: this codec writes the string
+    ``"true"``; a node that round-tripped through a y-prosemirror client can
+    hand back a real bool."""
+    if isinstance(value, bool):
+        return value
+    return isinstance(value, str) and value == "true"
 
 
 def _is_checked(value: object) -> bool:

--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -692,15 +692,16 @@ def _build_list(
         if ordered:
             attrs["start"] = str(open_tok.attrs.get("start", 1))
 
-    # Tight vs. loose is recorded, not discarded: markdown-it hides a tight
-    # item's paragraph tokens (CommonMark makes looseness a whole-list
-    # property, so they're all hidden or all visible per list). The direct
-    # item paragraphs sit exactly two levels below this list's open token —
-    # a nested list's paragraphs are deeper and carry that list's own flag,
-    # judged by its own recursive ``_build_list`` call. Without this
-    # attribute every touched list re-serialized loose, so editing one item
-    # rewrote the whole list's spacing — phantom formatting churn in every
-    # co-edit checkpoint that touched a tight list.
+    # A tight list is recorded as such so ``_serialize_list`` can keep its
+    # shape. The signal is markdown-it's: a tight item's paragraph tokens
+    # are hidden, and CommonMark makes looseness a whole-list property, so
+    # per list they are all hidden or all visible. Only paragraphs exactly
+    # two levels below this list's open token count — a nested list's
+    # paragraphs are deeper and carry that list's own flag, judged by its
+    # own recursive ``_build_list`` call. A list with no direct paragraphs
+    # at all (items holding only nested blocks, e.g. fenced code) has no
+    # signal to read and stays unstamped — serialized loose, the safe
+    # direction, since a wrongly-tight stamp would strip its blank lines.
     para_level = open_tok.level + 2
     direct_paras = [
         t
@@ -708,7 +709,7 @@ def _build_list(
         for t in tokens[s:e]
         if t.type == "paragraph_open" and t.level == para_level
     ]
-    if all(t.hidden for t in direct_paras):
+    if direct_paras and all(t.hidden for t in direct_paras):
         attrs["tight"] = "true"
 
     items: list[XmlElement] = []
@@ -1034,10 +1035,10 @@ def _tight_item_safe(item: XmlElement) -> bool:
 def _serialize_list(node: XmlElement) -> str:
     """Serializes a list in the style its ``tight`` attribute records —
     single newlines between a tight list's items, blank lines for a loose
-    one — so an edit to one item no longer reflows the whole list's
-    spacing. A list with no attribute (built by the editor rather than the
-    parser) serializes loose, the safe direction. Still not byte-identical
-    for every touched list (ordered-list renumbering, marker style) — only
+    one — so editing one item leaves the rest of the list's spacing as
+    written. A list with no attribute (built by the editor rather than the
+    parser) serializes loose, the safe direction. Not byte-identical for
+    every touched list (ordered-list renumbering, marker style) — only
     untouched blocks carry the byte-stability guarantee
     (``markdown_splice.py``), which never calls this serializer at all.
     """

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -469,11 +469,9 @@ def test_list_reserialization_is_content_correct_and_idempotent() -> None:
 
 
 def test_tight_list_round_trips_byte_identically() -> None:
-    """A tight list (no blank lines between items) keeps its shape. Every
-    touched list used to re-serialize loose, so editing one item rewrote the
-    whole list's spacing — phantom formatting churn in each co-edit
-    checkpoint that brushed a tight list, which is exactly the "saves not
-    from a human" a reader sees in the page history."""
+    """A tight list (no blank lines between items) keeps its shape, so a
+    checkpoint that touches one commits only the edit, never a whole-list
+    spacing reflow."""
     for body in (
         "- one\n- two\n- three\n",
         "- [ ] todo\n- [x] done\n- [ ] later\n",
@@ -491,6 +489,20 @@ def test_loose_list_round_trips_byte_identically() -> None:
         "1. first\n\n2. second\n",
     ):
         assert reconstruct_body(seed_doc_from_markdown(body)) == body
+
+
+def test_paragraphless_list_stays_unstamped_and_serializes_loose() -> None:
+    """A list whose items hold only nested blocks (no direct paragraphs)
+    carries no tight/loose signal — markdown-it's marker is paragraph
+    hiddenness — so it stays unstamped and serializes loose, the safe
+    direction. A wrongly-tight stamp would strip a loose source's blank
+    lines."""
+    loose = "- ```py\n  x\n  ```\n\n- ```py\n  y\n  ```\n"
+    doc = seed_doc_from_markdown(loose)
+    lst = _root(doc).children[0]
+    assert isinstance(lst, XmlElement)
+    assert dict(lst.attributes).get("tight") is None
+    assert reconstruct_body(doc) == loose
 
 
 def test_mixed_spacing_normalizes_loose_and_converges() -> None:

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -459,14 +459,70 @@ def test_task_list_nesting_and_inside_blockquote() -> None:
 
 
 def test_list_reserialization_is_content_correct_and_idempotent() -> None:
-    """The tight->loose list normalization (see markdown_yjs.py) means
-    output isn't byte-identical to a tight-list source, but re-parsing the
-    output must be a no-op (a well-defined normal form, not drift)."""
+    """Re-parsing the output must be a no-op (a well-defined normal form,
+    not drift)."""
     body = "- item one\n- item two\n- item three\n"
     once = reconstruct_body(seed_doc_from_markdown(body))
     twice = reconstruct_body(seed_doc_from_markdown(once))
     assert once == twice
     assert "item one" in once and "item two" in once and "item three" in once
+
+
+def test_tight_list_round_trips_byte_identically() -> None:
+    """A tight list (no blank lines between items) keeps its shape. Every
+    touched list used to re-serialize loose, so editing one item rewrote the
+    whole list's spacing — phantom formatting churn in each co-edit
+    checkpoint that brushed a tight list, which is exactly the "saves not
+    from a human" a reader sees in the page history."""
+    for body in (
+        "- one\n- two\n- three\n",
+        "- [ ] todo\n- [x] done\n- [ ] later\n",
+        "1. first\n2. second\n",
+        "- top\n  - nested tight\n- next\n",
+        "- [ ] top\n  - [x] nested\n- [ ] after\n",
+    ):
+        assert reconstruct_body(seed_doc_from_markdown(body)) == body
+
+
+def test_loose_list_round_trips_byte_identically() -> None:
+    for body in (
+        "- one\n\n- two\n",
+        "- [ ] todo\n\n- [x] done\n",
+        "1. first\n\n2. second\n",
+    ):
+        assert reconstruct_body(seed_doc_from_markdown(body)) == body
+
+
+def test_mixed_spacing_normalizes_loose_and_converges() -> None:
+    """CommonMark makes looseness a whole-list property: one blank line
+    anywhere makes the entire list loose, so mixed spacing has no faithful
+    representation. It normalizes to uniform loose in one pass and is
+    byte-stable from then on."""
+    body = "- one\n- two\n\n- three\n"
+    once = reconstruct_body(seed_doc_from_markdown(body))
+    assert once == "- one\n\n- two\n\n- three\n"
+    assert reconstruct_body(seed_doc_from_markdown(once)) == once
+
+
+def test_editor_added_second_paragraph_falls_back_to_loose() -> None:
+    """The tight attribute lives on the list node, so nothing clears it when
+    an edit gives an item a second paragraph. Serializing that tightly would
+    merge the paragraphs on the next parse — the serializer must fall back
+    to loose for the whole list instead, and the result must re-parse to the
+    same two paragraphs."""
+    doc = seed_doc_from_markdown("- one\n- two\n")
+    lst = _root(doc).children[0]
+    assert isinstance(lst, XmlElement)
+    assert dict(lst.attributes).get("tight") == "true"
+    with doc.transaction():
+        item = lst.children[0]
+        item.children.append(XmlElement("paragraph", {}, contents=[XmlText("second para")]))  # pyright: ignore[reportAttributeAccessIssue]
+    out = reconstruct_body(doc)
+    assert out == "- one\n\n  second para\n\n- two\n"
+    reparsed = _root(seed_doc_from_markdown(out)).children[0]
+    assert isinstance(reparsed, XmlElement)
+    first_item_tags = [c.tag for c in reparsed.children[0].children]  # pyright: ignore[reportAttributeAccessIssue]
+    assert first_item_tags == ["paragraph", "paragraph"]
 
 
 def test_blockquote_multi_paragraph_round_trips_exactly() -> None:
@@ -492,10 +548,10 @@ def test_task_item_continuation_indents_to_the_bullet_not_the_checkbox() -> None
     code block on the next parse: a checkpoint rewrote a task item's nested
     list into code, and the page then wouldn't open at all (the codec had
     no support for a code block inside a list item). The indentation of the
-    output is what matters here — the blank line the first case gains is
-    this module's usual tight->loose list normalization."""
+    output is what matters here — and the first case is tight, so it keeps
+    its no-blank-line shape byte-for-byte."""
     assert reconstruct_body(seed_doc_from_markdown("- [ ] top\n  - [x] nested\n")) == (
-        "- [ ] top\n\n  - [x] nested\n"
+        "- [ ] top\n  - [x] nested\n"
     )
     for body in (
         "- [ ] top\n\n  a second paragraph\n",
@@ -1350,7 +1406,7 @@ def test_checkbox_accepts_the_legacy_string_attribute() -> None:
         lst.children[0].attributes["checked"] = "true"  # pyright: ignore[reportAttributeAccessIssue]
         lst.children[1].attributes["checked"] = "false"  # pyright: ignore[reportAttributeAccessIssue]
 
-    assert reconstruct_body(doc) == "- [x] one\n\n- [ ] two\n"
+    assert reconstruct_body(doc) == "- [x] one\n- [ ] two\n"
 
 
 def test_code_block_closing_fence_starts_its_own_line() -> None:


### PR DESCRIPTION
## The asymmetry

The codec serialized every list loose (blank line between items) regardless of
how the source was written — documented as a rendering-only distinction. It is
content-preserving, but it means the file and the document permanently disagree
about every tight list's bytes: the first checkpoint that touches one rewrites
the whole list's spacing. In a co-edited page's history that reads as machine
commits nobody typed, and it erodes the byte-stable diff base the splice's
verbatim emission depends on.

This was found while root-causing today's task-list self-duplication incident:
the round trip `file → doc → file` was not the identity, and each touched-list
checkpoint committed the drift.

## The fix

- **Parse** records the distinction. markdown-it hides a tight item's paragraph
  tokens (CommonMark makes looseness a whole-list property, so per list they
  are all hidden or all visible); `_build_list` stamps `tight="true"` when
  hidden. Nested lists judge their own tokens at their own depth.
- **Serialize** joins a tight list's items — and each item's own blocks — with
  single newlines.
- **Safety valve** (`_tight_item_safe`): the attribute lives on the list node,
  so an editor mutation can hand the serializer a "tight" list whose item now
  holds a second paragraph; serializing that tightly would merge the paragraphs
  on reparse. Any block sequence that can't reparse tightly (paragraph after
  paragraph, `---` that would read as a setext heading, an ordered list not
  starting at 1, a table) drops the whole list to loose — one visible reflow,
  then stable.

Docs seeded before this change carry no attribute and keep the old loose
behaviour until their session reseeds — the safe direction.

## Verification

Replayed against the production page that surfaced it (a fresh-seeded doc,
touching each list block in turn, splicing against the committed body):

| touched block | before | after |
|---|---|---|
| tight 19-item task list | +17B (blank per item) | −2B (trailing-space trim) |
| tight 9-item task list | +8B | ±0 |
| loose task list | ±0 | ±0 |
| 2-item task list | +1B | ±0 |
| nested QA checklist | −57B | −128B (marker canonicalization, converges) |

Remaining diffs are one-time parse-level normalizations (trailing-space trims,
mixed-spacing lists normalizing to uniform loose per CommonMark, nested-marker
indent) — each converges in one pass and is byte-stable after.

New tests: tight/loose/nested byte-identical round trips, mixed-spacing
convergence, and the editor-added-second-paragraph fallback. Two existing tests
asserted the old lossy behaviour and were updated. Full backend suite green.

## What this does not fix

The duplication loop itself (a split task list fighting the id restamp) — that
is the companion frontend PR. This PR removes the formatting churn and restores
`file → doc → file` symmetry.