### PR TITLE
fix(editor): keep the doc text on the title's gutter at narrow widths

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -40,10 +40,19 @@
      edge) — matching DocTitle/the banners' width (--app-container-sm-md,
      Opal's sizes.css) so the title, banners, and doc text all share one
      column. The old CM6 editor capped this internally via its own theme;
-     ProseMirror has no equivalent, hence doing it here. */
+     ProseMirror has no equivalent, hence doing it here.
+
+     The wrapper is full-bleed (FileView cancels <main>'s padding so the
+     scrollbar hugs the window edge) and sets --cm-gutter to that padding;
+     consuming it here keeps the text on DocTitle's left edge when the
+     width cap stops binding — otherwise a narrow window lets the text run
+     past the title toward the window edge. Border-box, so the cap grows
+     by the gutters and the wide layout's text width is unchanged. */
   margin-left: auto;
   margin-right: auto;
-  max-width: var(--app-container-sm-md);
+  max-width: calc(var(--app-container-sm-md) + 2 * var(--cm-gutter, 0rem));
+  padding-left: var(--cm-gutter, 0rem);
+  padding-right: var(--cm-gutter, 0rem);
 }
 
 /* Headings — same size scale as the old CM6 WYSIWYG decorations. */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -470,10 +470,17 @@ body {
    visibly out of alignment, which is what happened when the editor moved to
    Tiptap and this rule kept pointing at CodeMirror's DOM. */
 @container (min-width: 920px) {
-  .rail-reserved .editor-prose .ProseMirror,
   .rail-reserved .rail-inset {
     max-width: calc(768px + 360px);
     padding-right: 360px;
+  }
+  /* Same geometry, plus the side gutters the full-bleed editor column
+     carries (see .editor-prose .ProseMirror in css/editor.css) — without
+     them this override re-loses the gutter and the doc text slides off
+     DocTitle's edge whenever the lane is reserved. */
+  .rail-reserved .editor-prose .ProseMirror {
+    max-width: calc(768px + 360px + 2 * var(--cm-gutter, 0rem));
+    padding-right: calc(360px + var(--cm-gutter, 0rem));
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,7 +471,7 @@ body {
    Tiptap and this rule kept pointing at CodeMirror's DOM. */
 @container (min-width: 920px) {
   .rail-reserved .rail-inset {
-    max-width: calc(768px + 360px);
+    max-width: calc(var(--app-container-sm-md) + 360px);
     padding-right: 360px;
   }
   /* Same geometry, plus the side gutters the full-bleed editor column
@@ -479,7 +479,9 @@ body {
      them this override re-loses the gutter and the doc text slides off
      DocTitle's edge whenever the lane is reserved. */
   .rail-reserved .editor-prose .ProseMirror {
-    max-width: calc(768px + 360px + 2 * var(--cm-gutter, 0rem));
+    max-width: calc(
+      var(--app-container-sm-md) + 360px + 2 * var(--cm-gutter, 0rem)
+    );
     padding-right: calc(360px + var(--cm-gutter, 0rem));
   }
 }


### PR DESCRIPTION
On a narrow window (especially with a side panel open), the doc body slid ~32px left of the page title, running toward the window edge while the title kept its inset.

Root cause: the editor's scroll wrapper is deliberately full-bleed — FileView cancels `<main>`'s padding with `-mx-8`/`-mx-3` so the scrollbar hugs the window edge — and defines `--cm-gutter` to mirror that padding so the text column keeps the title's side gutter. The old CodeMirror theme consumed that variable; the Tiptap migration's `.editor-prose .ProseMirror` column never did. While the width cap binds, centering happens to align both columns, so the bug only appears once the row gets narrow enough for the cap to stop binding.

Fix: `.ProseMirror` now consumes `--cm-gutter` as horizontal padding, with the cap grown by both gutters (border-box) so wide-layout text width is unchanged — narrow widths leave the text exactly on DocTitle's edge with the gutter as the minimum side space. The margin-comments-lane override (`.rail-reserved`, which re-declares the same geometry) grows by the gutters the same way, so reserving the lane no longer re-loses them.

Verified in the browser at 1130px with the Updates panel open (the reported repro): title and body share one left edge; wide layout unchanged.