### PR TITLE
fix(wiki): keep a continuing emphasis mark open across run boundaries

### DIFF
--- a/backend/app/wiki/markdown_yjs.py
+++ b/backend/app/wiki/markdown_yjs.py
@@ -88,6 +88,10 @@ _KNOWN_INLINE_TYPES = {
 # semantically nest (or be nested inside) other marks anyway.
 _NESTING_MARK_ORDER = ("link", "bold", "strike", "italic")
 _SYMMETRIC_MARK_DELIMS = {"italic": "*", "bold": "**", "strike": "~~"}
+# The equivalent underscore spellings, used only when an emphasis opener
+# would directly abut a same-character closer (see the delimiter-collision
+# fallback in ``_serialize_inline_text``).
+_ALT_EMPHASIS_DELIMS = {"*": "_", "**": "__"}
 
 # A text segment or a leaf segment. The 4th slot carries a leaf's attrs
 # dict, used for images and ``None`` for text runs or hard breaks.
@@ -322,15 +326,20 @@ def _close_delim(key: _MarkKey) -> str:
     return _SYMMETRIC_MARK_DELIMS[key]
 
 
-def _close_after(out: str, keys: Iterable[_MarkKey]) -> str:
+def _close_after(out: str, closers: Iterable[str]) -> str:
     """Append closing delimiters, keeping trailing whitespace outside them.
 
     CommonMark only closes emphasis on a delimiter preceded by non-whitespace,
     so `*before *` is literal text, not emphasis. A leaf (an image, a hard
     break) splitting a marked run forces a close mid-run, which is exactly
     where that trailing space appears.
+
+    Takes the closer strings themselves rather than mark keys: openers are
+    chosen per instance (an emphasis mark can open with either spelling —
+    see the collision fallback in ``_serialize_inline_text``), and only the
+    caller's stack knows which one to match.
     """
-    closing = "".join(_close_delim(key) for key in keys)
+    closing = "".join(closers)
     if not closing:
         return out
     body = out.rstrip()
@@ -352,44 +361,70 @@ def _serialize_inline_text(xt: XmlText) -> str:
 
     Fixed by tracking a single stack of currently-open marks across the
     *whole* run sequence — the standard "properly nested delimiters"
-    approach: at each run boundary, find the longest common prefix between
-    what's currently open and what the next run wants (both in
-    ``_NESTING_MARK_ORDER``, outer to inner), close everything after that
-    prefix (innermost first — a mark can't close while something opened
-    after it is still open, that's what "nested" means), then open
-    whatever the next run newly wants. A mark that's genuinely continuous
-    across runs never closes at all.
+    approach: at each run boundary, keep the longest prefix of the open
+    stack that the next run still carries, close everything after it
+    (innermost first — a mark can't close while something opened after it
+    is still open, that's what "nested" means), then open whatever the
+    next run newly wants, in ``_NESTING_MARK_ORDER``. Which mark nests
+    outside which is this serializer's own choice, so a mark carried by
+    both neighbouring runs stays open in the position it already holds —
+    continuity, not a fixed order — and a genuinely continuous mark never
+    closes at all.
 
     "code" is handled separately, per run (``_wrap_code_run``) — a code
     span's own fence is already self-delimiting per its own text and
     doesn't participate in this cross-run nesting.
     """
-    open_keys: list[_MarkKey] = []
+    # Each open mark remembers the closer it was opened with, because the
+    # opener is chosen per instance (see the delimiter-collision fallback
+    # below) and the closer must match it.
+    open_marks: list[tuple[_MarkKey, str]] = []
     out = ""
     for text, attrs in xt.diff():
         attrs = attrs or {}
-        target = [_mark_key(m, attrs) for m in _NESTING_MARK_ORDER if m in attrs]
+        ordered = [_mark_key(m, attrs) for m in _NESTING_MARK_ORDER if m in attrs]
+        want = set(ordered)
+        # Keep every already-open mark this run still carries, in the order
+        # they are open — not in ``_NESTING_MARK_ORDER``. The order marks
+        # nest in is this serializer's own choice, and continuity is the
+        # correct choice: for italic text with a bold word inside, closing
+        # the italic to reopen it bold-first abuts the two spans' delimiter
+        # runs into one (``***Status****.*``), which CommonMark reads as a
+        # single unmatchable run — the emphasis is lost and the asterisks
+        # go literal on the next parse. Keeping the continuing mark open
+        # reproduces the nesting the source actually had.
         common = 0
-        while (
-            common < len(open_keys) and common < len(target) and open_keys[common] == target[common]
-        ):
+        while common < len(open_marks) and open_marks[common][0] in want:
             common += 1
-        out = _close_after(out, reversed(open_keys[common:]))
-        open_keys = target
+        out = _close_after(out, (close for _, close in reversed(open_marks[common:])))
+        open_marks = open_marks[:common]
+        kept = {key for key, _ in open_marks}
         # Inline code spans are verbatim — CommonMark never processes
         # escapes inside them, so escaping here would corrupt the code's
         # actual text (a literal backslash would become part of the
         # visible content).
         rendered = _wrap_code_run(text) if "code" in attrs else _escape_inline_text(text)
-        opening = "".join(_open_delim(key) for key in target[common:])
-        if opening:
-            # An opener must be followed by non-whitespace, so any leading
-            # space stays in front of it.
-            lead = len(rendered) - len(rendered.lstrip())
-            out += rendered[:lead] + opening + rendered[lead:]
-        else:
-            out += rendered
-    return _close_after(out, reversed(open_keys))
+        # An opener must be followed by non-whitespace, so any leading
+        # space stays in front of it.
+        lead = len(rendered) - len(rendered.lstrip())
+        prefix = out + rendered[:lead]
+        opening = ""
+        for key in ordered:
+            if key in kept:
+                continue
+            delim = _open_delim(key)
+            # A genuine mark crossing (one span ends exactly where another
+            # begins) still abuts a closer and an opener of the same
+            # character into one ambiguous delimiter run. Emphasis has an
+            # equivalent spelling to break the tie with; a strike run has
+            # no alternate and keeps its (pre-existing) ambiguity.
+            last = (prefix + opening)[-1:]
+            if delim[0] == last and delim in _ALT_EMPHASIS_DELIMS:
+                delim = _ALT_EMPHASIS_DELIMS[delim]
+            opening += delim
+            open_marks.append((key, delim if not isinstance(key, tuple) else _close_delim(key)))
+        out = prefix + opening + rendered[lead:]
+    return _close_after(out, (close for _, close in reversed(open_marks)))
 
 
 def _escape_title(title: str) -> str:

--- a/backend/tests/test_markdown_yjs.py
+++ b/backend/tests/test_markdown_yjs.py
@@ -468,6 +468,38 @@ def test_list_reserialization_is_content_correct_and_idempotent() -> None:
     assert "item one" in once and "item two" in once and "item three" in once
 
 
+def test_nested_emphasis_keeps_the_continuing_mark_open() -> None:
+    """A mark carried by both neighbouring runs stays open in the position
+    it already holds, whatever ``_NESTING_MARK_ORDER`` says — italic around
+    a bold word round-trips as written instead of closing and reopening the
+    italic at each boundary, whose abutted delimiters (``****``) CommonMark
+    reads as one unmatchable run."""
+    for body in (
+        "*a **b** c*\n",
+        "**a *b* c**\n",
+        "*a **b***\n",
+        "**a *b***\n",
+        "**bold [link](x) more**\n",
+        "~~a *b* c~~\n",
+        "> *the **Design** section is under **Status**.*\n",
+    ):
+        assert reconstruct_body(seed_doc_from_markdown(body)) == body
+
+
+def test_emphasis_crossing_opens_with_the_underscore_spelling() -> None:
+    """When one emphasis span ends exactly where another begins, the opener
+    would abut a same-character closer into an ambiguous delimiter run — it
+    opens with the underscore spelling instead, which re-parses to the same
+    marks and is byte-stable from then on."""
+    for src, want in (
+        ("**a***b*\n", "**a**_b_\n"),
+        ("*a***b**\n", "*a*__b__\n"),
+    ):
+        one = reconstruct_body(seed_doc_from_markdown(src))
+        assert one == want
+        assert reconstruct_body(seed_doc_from_markdown(one)) == one
+
+
 def test_tight_list_round_trips_byte_identically() -> None:
     """A tight list (no blank lines between items) keeps its shape, so a
     checkpoint that touches one commits only the edit, never a whole-list


### PR DESCRIPTION
Third symmetry fix, from the corpus sweep after #592/#593: one page's round
trip never stabilized because of how the inline serializer handles nested
emphasis.

## The bug

Marks opened in a fixed nesting order (`bold` outside `italic`), so italic
text containing a bold word closed the italic and reopened it inside the
bold: `*a **b** c*` → `*a* ***b*** *c*`. At a boundary with no intervening
space, the closer and the reopened opener abut into a single delimiter run —
`***Status****.*` — which CommonMark cannot match. The next parse drops the
emphasis and the asterisks go literal, escaped: content mutation on every
touch of the block.

## The fix

- **Continuity over fixed order.** Which mark nests outside which is the
  serializer's own choice, so a mark carried by both neighbouring runs stays
  open in the position it already holds. `*a **b** c*` round-trips
  byte-identically; so does the production line that surfaced this.
- **Underscore fallback for genuine crossings.** One span ending exactly
  where another begins still abuts same-character delimiters; the opener
  switches to the equivalent underscore spelling — `**a***b*` → `**a**_b_` —
  which re-parses to the same marks and is byte-stable after. Strike has no
  alternate spelling and keeps its (pre-existing, rare) ambiguity.
- Open marks now carry the closer they were opened with, since openers are
  chosen per instance.

## Verification

- Full production corpus round-trip: **0 non-converging pages** (1 before),
  27 byte-stable, everything else converges in one pass.
- New tests: nesting continuity in both directions (incl. links and strike),
  the crossing fallback and its stability.
- All 166 existing codec/splice/checkpoint tests pass **unmodified**, full
  backend suite green (2405 passed).