### PR TITLE
fix(editor): restore heading-bottom and list-row breathing room

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -94,12 +94,11 @@
   color: var(--text-05);
 }
 
-/* Breathing room the Tailwind reset removed. Kept deliberately small: the
-   doc's larger rhythm is the author's own blank lines — the codec models
-   each one as an empty paragraph (see markdown_yjs) — so real block
-   margins here would double-space every existing page. Headings get a
-   bottom margin (a heading directly above a list sat flush on it), list
-   rows get 2px each side so a tight list isn't a solid brick. */
+/* Kept deliberately small: the doc's larger rhythm is the author's own
+   blank lines — the codec models each one as an empty paragraph (see
+   markdown_yjs) — so real block margins here would double-space every
+   page. Headings carry the separation from the block that follows them;
+   list rows get 2px each side so a tight list reads as distinct rows. */
 .editor-prose h1,
 .editor-prose h2,
 .editor-prose h3,

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -94,6 +94,25 @@
   color: var(--text-05);
 }
 
+/* Breathing room the Tailwind reset removed. Kept deliberately small: the
+   doc's larger rhythm is the author's own blank lines — the codec models
+   each one as an empty paragraph (see markdown_yjs) — so real block
+   margins here would double-space every existing page. Headings get a
+   bottom margin (a heading directly above a list sat flush on it), list
+   rows get 2px each side so a tight list isn't a solid brick. */
+.editor-prose h1,
+.editor-prose h2,
+.editor-prose h3,
+.editor-prose h4,
+.editor-prose h5,
+.editor-prose h6 {
+  margin-bottom: 0.25em;
+}
+.editor-prose li {
+  margin-top: 0.125rem;
+  margin-bottom: 0.125rem;
+}
+
 /* Marks. */
 .editor-prose strong {
   font-weight: bold;


### PR DESCRIPTION
A heading directly above a list sat flush on it (the Tailwind reset zeroes all margins and the editor only restores heading `margin-top`), and rows inside a tight list rendered with exactly 0px between them.

Scanned before styling: the codec models every authored blank line as an empty paragraph (`markdown_yjs` — an inter-block blank line is a first-class 24px node), so the doc's larger rhythm is already the author's blank lines. Standard prose margins (like the read-view `.markdown` rules) would double-space every existing page on top of those. Verified against the live DOM: computed margins on `ul`/`li`/`p` are all 0 and the item-to-item gap is 0px.

So the change is deliberately minimal:
- `h1`–`h6` get `margin-bottom: 0.25em` — fixes the reported heading-hugs-list case;
- `li` gets 2px top/bottom — a tight list reads as rows, not a brick, without touching the blank-line rhythm.

Verified in the browser on a heading + tight-bullet page: clear gap under the heading, small even row gaps, blank-line-spaced content unchanged.
Before
<img width="165" height="74" alt="Screenshot 2026-08-03 at 4 42 31 PM" src="https://github.com/user-attachments/assets/bebe8e4f-2e63-4d30-b5b7-f115f79bc7cb" />
after
<img width="93" height="71" alt="Screenshot 2026-08-03 at 4 43 02 PM" src="https://github.com/user-attachments/assets/19af0d26-107c-41ce-8488-44383ff83fb7" />
