### PR TITLE
fix(coedit): stop the duplicate-id repair from eating a split's new half

### DIFF
--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -101,35 +101,54 @@ def drop_duplicate_blocks(doc: Doc) -> list[str]:
     client holds, the client's document converges to the repaired state
     without a reload (verified directly against pycrdt).
 
-    A repeat with **different content** is an ordinary edit caught
-    mid-flight: ProseMirror's node split copies attrs — the id included —
-    onto both halves, and the editor's ``UniqueBlockIdentity`` clears the
-    second one in a separate follow-up update. A checkpoint landing between
-    the two sees the duplicate the client is about to fix. Deleting here
-    destroys what the person just typed (observed live: a paragraph lifted
-    out of a list, still carrying the list's id, eaten by the checkpoint
-    that raced the fix-up). Instead the later child's id is *cleared* —
-    exactly what the client's own repair would do — which routes it through
-    ``checkpoint_body``'s ``orig is None`` path as the new content it is.
+    A repeat that is **adjacent to, or differs from, its predecessor** is an
+    ordinary edit caught mid-flight: ProseMirror's node split copies attrs —
+    the id included — onto both halves, and the editor's
+    ``UniqueBlockIdentity`` clears the second one in a separate follow-up
+    update. A checkpoint landing between the two sees the duplicate the
+    client is about to fix. Deleting here destroys what the person just
+    typed (observed live: a paragraph lifted out of a list, still carrying
+    the list's id, eaten by the checkpoint that raced the fix-up). Instead
+    the later child's id is *cleared* — exactly what the client's own repair
+    would do — which routes it through ``checkpoint_body``'s ``orig is
+    None`` path as the new content it is.
+
+    Content equality alone cannot separate the two situations: splitting an
+    empty paragraph, or "aa" down the middle, yields halves that serialize
+    identically. The tiebreak is shape. A split's identical halves are
+    adjacent **textblocks** (paragraph or heading — splitting is a textblock
+    operation), and sparing those is safe because adjacent textblocks
+    re-parse into a single block on the next cycle: even a genuine
+    single-paragraph lineage merge spared here converges instead of
+    compounding. Adjacent identical **containers** (two lists, two fences)
+    re-parse as separate blocks that the restamp re-shares an id onto — the
+    compounding loop — and no editing operation splits one into identical
+    halves, so those stay deletions.
     """
     dupes = _duplicated_block_ids(doc)
     if not dupes:
         return []
     root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
-    first_text: dict[str, str] = {}
+    prev: dict[str, tuple[int, str]] = {}
     stale: list[int] = []
     reidentify: list[int] = []
     for i, child in enumerate(root.children):
         block_id = dict(getattr(child, "attributes", {})).get(markdown_yjs.BLOCK_ID_ATTR)
         if not isinstance(block_id, str):
             continue
-        if block_id not in first_text:
-            first_text[block_id] = markdown_yjs.serialize_block(child)
+        text = markdown_yjs.serialize_block(child)
+        if block_id in prev:
+            prev_i, prev_text = prev[block_id]
+            splittable = getattr(child, "tag", None) in ("paragraph", "heading")
+            if text == prev_text and not (splittable and i - prev_i == 1):
+                stale.append(i)
+            else:
+                reidentify.append(i)
+            # Either way this child stops carrying the id, so the retained
+            # first occurrence stays the comparison anchor for any later
+            # repeat of it.
             continue
-        if markdown_yjs.serialize_block(child) == first_text[block_id]:
-            stale.append(i)
-        else:
-            reidentify.append(i)
+        prev[block_id] = (i, text)
     # Descending, so each deletion can't shift the index of one still pending.
     with doc.transaction():
         for i in reidentify:

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -83,40 +83,57 @@ def _duplicated_block_ids(doc: Doc) -> list[str]:
 
 
 def drop_duplicate_blocks(doc: Doc) -> list[str]:
-    """Delete every repeat of a top-level ``_blockId``, keeping the first, and
-    return the ids that were repeated.
+    """Repair repeats of a top-level ``_blockId``, keeping the first of each,
+    and return the ids that were repeated.
 
-    A *deletion*, deliberately, rather than declining to commit: the duplicated
-    content is in the connected browsers' own documents too, so refusing here
-    leaves them holding it and re-sending it on the next reconnect — closing the
-    session doesn't help either, since the next one can't reuse a dirty session
-    and so seeds yet another lineage for the same retained document to merge
-    into. Deleting escapes that: the deletion is broadcast at the end of
-    ``checkpoint_session`` like any other update, and because a Yjs delete
-    addresses the same items the client holds, the client's document converges
-    to the repaired state without a reload (verified directly against pycrdt).
+    Two different situations produce a repeated id, and they need opposite
+    repairs:
 
-    Keeping the first occurrence is arbitrary but deterministic. The copies are
-    identical when this arises from a lineage merge; if one had been edited
-    afterwards, those edits are lost — no worse than the alternative, which is a
-    page that can never be saved again.
+    A **content-identical** repeat is a lineage merge — the same block
+    integrated twice. It is *deleted*, deliberately, rather than declined:
+    the duplicated content is in the connected browsers' own documents too,
+    so refusing here leaves them holding it and re-sending it on the next
+    reconnect — closing the session doesn't help either, since the next one
+    can't reuse a dirty session and so seeds yet another lineage for the
+    same retained document to merge into. Deleting escapes that: the
+    deletion is broadcast at the end of ``checkpoint_session`` like any
+    other update, and because a Yjs delete addresses the same items the
+    client holds, the client's document converges to the repaired state
+    without a reload (verified directly against pycrdt).
+
+    A repeat with **different content** is an ordinary edit caught
+    mid-flight: ProseMirror's node split copies attrs — the id included —
+    onto both halves, and the editor's ``UniqueBlockIdentity`` clears the
+    second one in a separate follow-up update. A checkpoint landing between
+    the two sees the duplicate the client is about to fix. Deleting here
+    destroys what the person just typed (observed live: a paragraph lifted
+    out of a list, still carrying the list's id, eaten by the checkpoint
+    that raced the fix-up). Instead the later child's id is *cleared* —
+    exactly what the client's own repair would do — which routes it through
+    ``checkpoint_body``'s ``orig is None`` path as the new content it is.
     """
     dupes = _duplicated_block_ids(doc)
     if not dupes:
         return []
     root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
-    seen: set[str] = set()
+    first_text: dict[str, str] = {}
     stale: list[int] = []
+    reidentify: list[int] = []
     for i, child in enumerate(root.children):
         block_id = dict(getattr(child, "attributes", {})).get(markdown_yjs.BLOCK_ID_ATTR)
         if not isinstance(block_id, str):
             continue
-        if block_id in seen:
+        if block_id not in first_text:
+            first_text[block_id] = markdown_yjs.serialize_block(child)
+            continue
+        if markdown_yjs.serialize_block(child) == first_text[block_id]:
             stale.append(i)
         else:
-            seen.add(block_id)
+            reidentify.append(i)
     # Descending, so each deletion can't shift the index of one still pending.
     with doc.transaction():
+        for i in reidentify:
+            root.children[i].attributes[markdown_yjs.BLOCK_ID_ATTR] = None
         for i in reversed(stale):
             del root.children[i]
     return dupes
@@ -253,9 +270,7 @@ def _user(user_id: str) -> User | None:
     row = users_repo.get_by_id(user_id)
     if row is None:
         return None
-    return User(
-        id=row["id"], email=row["email"], name=row["name"], is_admin=bool(row["is_admin"])
-    )
+    return User(id=row["id"], email=row["email"], name=row["name"], is_admin=bool(row["is_admin"]))
 
 
 def _commit_message(session_id: int, *, primary_author_id: str | None) -> str:
@@ -552,8 +567,7 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 # Shouldn't happen — a no-op merge implies HEAD exists. Surface
                 # it rather than silently leaving the session dirty forever.
                 log.warning(
-                    "coedit checkpoint: no-op merge but no HEAD for %s (session %s); "
-                    "left dirty",
+                    "coedit checkpoint: no-op merge but no HEAD for %s (session %s); left dirty",
                     path,
                     session_id,
                 )
@@ -608,7 +622,11 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         snapshot = doc.get_update()
 
         coedit.advance_checkpoint(
-            session_id, seq=replayed_seq, snapshot=snapshot, body=result.new_body, base_sha=result.sha
+            session_id,
+            seq=replayed_seq,
+            snapshot=snapshot,
+            body=result.new_body,
+            base_sha=result.sha,
         )
         wiki_drafts.clear_if_diverged(path, result.new_body)
         if diverged:

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -83,77 +83,64 @@ def _duplicated_block_ids(doc: Doc) -> list[str]:
 
 
 def drop_duplicate_blocks(doc: Doc) -> list[str]:
-    """Repair repeats of a top-level ``_blockId``, keeping the first of each,
-    and return the ids that were repeated.
+    """Repair repeats of a top-level ``_blockId``; return the repeated ids.
 
-    Two different situations produce a repeated id, and they need opposite
+    Two different situations produce a repeated id, and they need different
     repairs:
 
-    A **content-identical** repeat is a lineage merge — the same block
-    integrated twice. It is *deleted*, deliberately, rather than declined:
-    the duplicated content is in the connected browsers' own documents too,
-    so refusing here leaves them holding it and re-sending it on the next
-    reconnect — closing the session doesn't help either, since the next one
-    can't reuse a dirty session and so seeds yet another lineage for the
-    same retained document to merge into. Deleting escapes that: the
-    deletion is broadcast at the end of ``checkpoint_session`` like any
-    other update, and because a Yjs delete addresses the same items the
-    client holds, the client's document converges to the repaired state
-    without a reload (verified directly against pycrdt).
+    A **content-identical** repeat is redundancy — a lineage merge, or a
+    split of a block whose halves serialize the same (an empty paragraph,
+    "aa" down the middle). All copies but the **last** are *deleted*,
+    deliberately, rather than declined or re-identified: the duplication is
+    in the connected browsers' own documents too, so refusing leaves them
+    holding it to re-send on the next reconnect, and re-identifying loops —
+    identical neighbours serialize to text that re-parses as one block, the
+    restamp shares one id across the doc's children again, and every cycle
+    appends one more copy. Deletion converges, and the broadcast at the end
+    of ``checkpoint_session`` converges the clients too (a Yjs delete
+    addresses the same items they hold — verified directly against pycrdt).
+    Keeping the *last* copy rather than the first is what makes the raced
+    split of an identical-halves block harmless: the person's cursor is in
+    the later half, so the block they are typing into survives with its
+    identity and only the redundant earlier half goes.
 
-    A repeat that is **adjacent to, or differs from, its predecessor** is an
-    ordinary edit caught mid-flight: ProseMirror's node split copies attrs —
-    the id included — onto both halves, and the editor's
-    ``UniqueBlockIdentity`` clears the second one in a separate follow-up
-    update. A checkpoint landing between the two sees the duplicate the
-    client is about to fix. Deleting here destroys what the person just
-    typed (observed live: a paragraph lifted out of a list, still carrying
-    the list's id, eaten by the checkpoint that raced the fix-up). Instead
-    the later child's id is *cleared* — exactly what the client's own repair
-    would do — which routes it through ``checkpoint_body``'s ``orig is
-    None`` path as the new content it is.
-
-    Content equality alone cannot separate the two situations: splitting an
-    empty paragraph, or "aa" down the middle, yields halves that serialize
-    identically. The tiebreak is shape. A split's identical halves are
-    adjacent **textblocks** (paragraph or heading — splitting is a textblock
-    operation), and sparing those is safe because adjacent textblocks
-    re-parse into a single block on the next cycle: even a genuine
-    single-paragraph lineage merge spared here converges instead of
-    compounding. Adjacent identical **containers** (two lists, two fences)
-    re-parse as separate blocks that the restamp re-shares an id onto — the
-    compounding loop — and no editing operation splits one into identical
-    halves, so those stay deletions.
+    A repeat with **different content** is an ordinary edit caught
+    mid-flight: ProseMirror's node split copies attrs — the id included —
+    onto both halves, and the editor's ``UniqueBlockIdentity`` clears the
+    second one in a separate follow-up update. A checkpoint landing between
+    the two sees the duplicate the client is about to fix. Deleting here
+    destroys what the person just typed (observed live: a paragraph lifted
+    out of a list, still carrying the list's id, eaten by the checkpoint
+    that raced the fix-up). Instead the later child's id is *cleared* —
+    exactly what the client's own repair would do — which routes it through
+    ``checkpoint_body``'s ``orig is None`` path as the new content it is.
+    Differing copies can't loop the way identical ones do: their
+    serializations are distinct blocks that each earn their own id on the
+    next restamp.
     """
     dupes = _duplicated_block_ids(doc)
     if not dupes:
         return []
     root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
-    prev: dict[str, tuple[int, str]] = {}
-    stale: list[int] = []
-    reidentify: list[int] = []
+    occurrences: dict[str, list[tuple[int, str]]] = {}
     for i, child in enumerate(root.children):
         block_id = dict(getattr(child, "attributes", {})).get(markdown_yjs.BLOCK_ID_ATTR)
-        if not isinstance(block_id, str):
+        if isinstance(block_id, str):
+            occurrences.setdefault(block_id, []).append((i, markdown_yjs.serialize_block(child)))
+    stale: list[int] = []
+    reidentify: list[int] = []
+    for members in occurrences.values():
+        if len(members) == 1:
             continue
-        text = markdown_yjs.serialize_block(child)
-        if block_id in prev:
-            prev_i, prev_text = prev[block_id]
-            splittable = getattr(child, "tag", None) in ("paragraph", "heading")
-            if text == prev_text and not (splittable and i - prev_i == 1):
-                stale.append(i)
-            else:
-                reidentify.append(i)
-            # Either way this child stops carrying the id, so the retained
-            # first occurrence stays the comparison anchor for any later
-            # repeat of it.
-            continue
-        prev[block_id] = (i, text)
+        anchor_text = members[0][1]
+        identical = [i for i, text in members if text == anchor_text]
+        stale.extend(identical[:-1])  # the last identical copy keeps the id
+        reidentify.extend(i for i, text in members if text != anchor_text)
     # Descending, so each deletion can't shift the index of one still pending.
     with doc.transaction():
         for i in reidentify:
             root.children[i].attributes[markdown_yjs.BLOCK_ID_ATTR] = None
-        for i in reversed(stale):
+        for i in sorted(stale, reverse=True):
             del root.children[i]
     return dupes
 

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -17,6 +17,7 @@ engine replays them through ``pycrdt``
 which is what a client actually sends — a whole-state payload would converge
 too (CRDT updates are idempotent) but would hide a broken delta.
 """
+
 from __future__ import annotations
 
 import os
@@ -174,7 +175,9 @@ def test_checkpoint_folds_in_late_update_landing_during_its_own_commit(repo, mon
     )
     st = coedit.get_active_session(_PATH)
     assert st is not None
-    assert st.ydoc_checkpointed_seq == st.ydoc_seq, "session must be fully clean, not just partially"
+    assert st.ydoc_checkpointed_seq == st.ydoc_seq, (
+        "session must be fully clean, not just partially"
+    )
 
 
 def test_diverged_checkpoint_reaches_the_editors(repo):
@@ -195,7 +198,9 @@ def test_diverged_checkpoint_reaches_the_editors(repo):
     # commits a distant, non-overlapping change out of band, against the
     # original HEAD, unaware of the human's in-session edit.
     _edit(sess, client, uid, "EDIT-")
-    wiki_git.commit_file(_PATH, "one\ntwo\nthree\nfour\nFIVE\n", "agent edit", author="Agent <a@x.com>")
+    wiki_git.commit_file(
+        _PATH, "one\ntwo\nthree\nfour\nFIVE\n", "agent edit", author="Agent <a@x.com>"
+    )
     sent: list[bytes] = []
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
@@ -241,7 +246,9 @@ def test_late_update_after_a_diverged_checkpoint_is_not_pruned(repo):
     coedit.join(sess.id, uid)
     client = _client(sess, body)
     _edit(sess, client, uid, "EDIT-")
-    wiki_git.commit_file(_PATH, "one\ntwo\nthree\nfour\nFIVE\n", "agent edit", author="Agent <a@x.com>")
+    wiki_git.commit_file(
+        _PATH, "one\ntwo\nthree\nfour\nFIVE\n", "agent edit", author="Agent <a@x.com>"
+    )
 
     outcome = coedit_checkpoint.checkpoint_session(sess.id)
     assert outcome is not None
@@ -486,9 +493,7 @@ def test_checkpoint_lock_times_out_when_held(repo):
     with coedit.checkpoint_lock(base) as acquired:
         assert acquired is True
         with db_session() as s2:
-            got = try_advisory_xact_lock(
-                s2, coedit.checkpoint_lock_key(base), timeout_ms=100
-            )
+            got = try_advisory_xact_lock(s2, coedit.checkpoint_lock_key(base), timeout_ms=100)
         assert got is False  # held elsewhere → bounded wait elapsed
 
 
@@ -730,6 +735,49 @@ def test_drop_duplicate_blocks_repairs_the_doc_and_the_client() -> None:
     assert reconstruct_body(client) == body
 
 
+def test_drop_duplicate_blocks_reidentifies_a_split_instead_of_deleting_it() -> None:
+    """A ProseMirror node split copies attrs — the id included — onto both
+    halves, and the editor clears the second one in a separate follow-up
+    update. A checkpoint landing between the two sees a repeated id whose
+    copies hold *different* content: that is a person's edit mid-flight, not
+    a lineage merge, and deleting it eats what they just typed (observed
+    live). The repair clears the later child's id instead — the same fix the
+    client's own plugin was about to apply — and both texts survive."""
+    from app.wiki.coedit_checkpoint import _duplicated_block_ids, drop_duplicate_blocks
+    from app.wiki.markdown_splice import TouchedTracker, checkpoint_body, restamp_block_ids
+    from app.wiki.markdown_yjs import (
+        BLOCK_ID_ATTR,
+        ROOT_XML_KEY,
+        reconstruct_body,
+        seed_doc_from_markdown,
+        serialize_block,
+    )
+
+    body = "1. item\n\nafter\n"
+    doc = seed_doc_from_markdown(body)
+    tracker = TouchedTracker(doc)
+    restamp_block_ids(doc, body)
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    # The split's copied id: give the freshly typed paragraph the list's id.
+    lst = root.children[0]
+    para = next(
+        c for c in root.children if isinstance(c, XmlElement) and "after" in serialize_block(c)
+    )
+    with doc.transaction():
+        para.children[0].insert(0, "typed ")  # pyright: ignore[reportAttributeAccessIssue]
+        para.attributes[BLOCK_ID_ATTR] = dict(lst.attributes)[BLOCK_ID_ATTR]  # pyright: ignore[reportAttributeAccessIssue]
+
+    assert drop_duplicate_blocks(doc) == ["b0"]
+    assert _duplicated_block_ids(doc) == []
+    rt = reconstruct_body(doc)
+    assert "typed after" in rt  # the person's text survived
+    assert "1. item" in rt  # and so did the block it split from
+
+    out = checkpoint_body(body, doc, tracker)
+    assert "typed after" in out
+    assert out.count("1. item") == 1
+
+
 def test_drop_duplicate_blocks_is_a_no_op_on_a_healthy_doc() -> None:
     from app.wiki.coedit_checkpoint import drop_duplicate_blocks
     from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
@@ -789,9 +837,7 @@ def test_drop_restated_blocks_never_touches_freshly_typed_blocks() -> None:
     root = doc.get(ROOT_XML_KEY, type=XmlFragment)
     with doc.transaction():
         for i in range(6):
-            root.children.append(
-                XmlElement("paragraph", {}, contents=[XmlText(f"para {i}")])
-            )
+            root.children.append(XmlElement("paragraph", {}, contents=[XmlText(f"para {i}")]))
 
     before = reconstruct_body(doc)
     assert drop_restated_blocks(doc, base) == 0

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -778,15 +778,15 @@ def test_drop_duplicate_blocks_reidentifies_a_split_instead_of_deleting_it() -> 
     assert out.count("1. item") == 1
 
 
-def test_drop_duplicate_blocks_spares_identical_adjacent_split_halves() -> None:
-    """Splitting an empty paragraph — or "aa" down the middle — yields halves
-    that serialize identically, so content equality alone would classify the
-    person's new block as a lineage duplicate and delete it. A split's
-    identical halves are adjacent textblocks; those are re-identified
-    instead, and both survive. Adjacent identical *containers* have no
-    editing operation that produces them, and sparing them would compound
-    (their serialization re-parses as separate blocks the restamp re-shares
-    an id onto), so a merged single-list page still repairs by deletion."""
+def test_drop_duplicate_blocks_keeps_the_last_identical_copy() -> None:
+    """Identical copies collapse to one — re-identifying them instead would
+    loop, because identical neighbours serialize to text that re-parses as a
+    single block, the restamp shares one id across the doc's children again,
+    and every checkpoint appends one more copy. The survivor is the *last*
+    copy: in the raced split of an identical-halves block (Enter on an empty
+    paragraph, "aa" down the middle) the person's cursor is in the later
+    half, so the block they are typing into keeps its identity and only the
+    redundant earlier half goes."""
     from app.wiki.coedit_checkpoint import _duplicated_block_ids, drop_duplicate_blocks
     from app.wiki.markdown_splice import restamp_block_ids
     from app.wiki.markdown_yjs import (
@@ -799,30 +799,52 @@ def test_drop_duplicate_blocks_spares_identical_adjacent_split_halves() -> None:
     doc = seed_doc_from_markdown(body)
     restamp_block_ids(doc, body)
     root = _root(doc)
-    # The split's second half: same content, same copied id, adjacent.
+    # The raced split's second half: same content, same copied id.
+    with doc.transaction():
+        root.children.insert(
+            1, XmlElement("paragraph", {BLOCK_ID_ATTR: "b0"}, contents=[XmlText("a")])
+        )
+    # Give the survivor-to-be a distinguishing mark so the test can prove
+    # which copy was kept: a marker attr rides along untouched.
+    with doc.transaction():
+        root.children[1].attributes["_probe"] = "later"  # pyright: ignore[reportIndexIssue]
+
+    assert drop_duplicate_blocks(doc) == ["b0"]
+    assert _duplicated_block_ids(doc) == []
+    assert reconstruct_body(doc) == "a\n"
+    survivors = list(root.children)
+    assert len(survivors) == 1
+    assert dict(survivors[0].attributes).get("_probe") == "later"  # pyright: ignore[reportAttributeAccessIssue]
+    assert dict(survivors[0].attributes).get(BLOCK_ID_ATTR) == "b0"  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_drop_duplicate_blocks_repair_converges_across_checkpoints() -> None:
+    """The full cycle a checkpoint runs — repair, splice, restamp against the
+    committed output — must reach a fixed point. Re-identifying identical
+    copies instead of deleting them fails exactly here: the committed text
+    re-parses as one block, the restamp re-shares its id, and each cycle
+    appends another copy."""
+    from app.wiki.coedit_checkpoint import drop_duplicate_blocks
+    from app.wiki.markdown_splice import TouchedTracker, checkpoint_body, restamp_block_ids
+    from app.wiki.markdown_yjs import BLOCK_ID_ATTR, seed_doc_from_markdown
+
+    body = "a\n"
+    doc = seed_doc_from_markdown(body)
+    tracker = TouchedTracker(doc)
+    restamp_block_ids(doc, body)
+    root = _root(doc)
     with doc.transaction():
         root.children.insert(
             1, XmlElement("paragraph", {BLOCK_ID_ATTR: "b0"}, contents=[XmlText("a")])
         )
 
-    assert drop_duplicate_blocks(doc) == ["b0"]
-    assert _duplicated_block_ids(doc) == []
-    # Both halves survived (adjacent paragraphs carry no blank-line block
-    # between them, and their reparse folds into one block — convergent).
-    assert reconstruct_body(doc) == "a\na\n"
-
-    # The container counterpart: a single-list page merged with itself gives
-    # two adjacent identical lists — that is a lineage duplicate, deleted.
-    list_body = "- A\n- B\n"
-    ldoc = seed_doc_from_markdown(list_body)
-    restamp_block_ids(ldoc, list_body)
-    lroot = _root(ldoc)
-    other = seed_doc_from_markdown(list_body)
-    restamp_block_ids(other, list_body)
-    ldoc.apply_update(other.get_update(ldoc.get_state()))
-    assert len(list(lroot.children)) == 2
-    assert drop_duplicate_blocks(ldoc) == ["b0"]
-    assert reconstruct_body(ldoc) == list_body
+    for _ in range(3):
+        drop_duplicate_blocks(doc)
+        body = checkpoint_body(body, doc, tracker)
+        tracker = TouchedTracker(doc)
+        restamp_block_ids(doc, body)
+    assert body == "a\n"
+    assert len(list(root.children)) == 1
 
 
 def test_drop_duplicate_blocks_is_a_no_op_on_a_healthy_doc() -> None:

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -778,6 +778,53 @@ def test_drop_duplicate_blocks_reidentifies_a_split_instead_of_deleting_it() -> 
     assert out.count("1. item") == 1
 
 
+def test_drop_duplicate_blocks_spares_identical_adjacent_split_halves() -> None:
+    """Splitting an empty paragraph — or "aa" down the middle — yields halves
+    that serialize identically, so content equality alone would classify the
+    person's new block as a lineage duplicate and delete it. A split's
+    identical halves are adjacent textblocks; those are re-identified
+    instead, and both survive. Adjacent identical *containers* have no
+    editing operation that produces them, and sparing them would compound
+    (their serialization re-parses as separate blocks the restamp re-shares
+    an id onto), so a merged single-list page still repairs by deletion."""
+    from app.wiki.coedit_checkpoint import _duplicated_block_ids, drop_duplicate_blocks
+    from app.wiki.markdown_splice import restamp_block_ids
+    from app.wiki.markdown_yjs import (
+        BLOCK_ID_ATTR,
+        reconstruct_body,
+        seed_doc_from_markdown,
+    )
+
+    body = "a\n"
+    doc = seed_doc_from_markdown(body)
+    restamp_block_ids(doc, body)
+    root = _root(doc)
+    # The split's second half: same content, same copied id, adjacent.
+    with doc.transaction():
+        root.children.insert(
+            1, XmlElement("paragraph", {BLOCK_ID_ATTR: "b0"}, contents=[XmlText("a")])
+        )
+
+    assert drop_duplicate_blocks(doc) == ["b0"]
+    assert _duplicated_block_ids(doc) == []
+    # Both halves survived (adjacent paragraphs carry no blank-line block
+    # between them, and their reparse folds into one block — convergent).
+    assert reconstruct_body(doc) == "a\na\n"
+
+    # The container counterpart: a single-list page merged with itself gives
+    # two adjacent identical lists — that is a lineage duplicate, deleted.
+    list_body = "- A\n- B\n"
+    ldoc = seed_doc_from_markdown(list_body)
+    restamp_block_ids(ldoc, list_body)
+    lroot = _root(ldoc)
+    other = seed_doc_from_markdown(list_body)
+    restamp_block_ids(other, list_body)
+    ldoc.apply_update(other.get_update(ldoc.get_state()))
+    assert len(list(lroot.children)) == 2
+    assert drop_duplicate_blocks(ldoc) == ["b0"]
+    assert reconstruct_body(ldoc) == list_body
+
+
 def test_drop_duplicate_blocks_is_a_no_op_on_a_healthy_doc() -> None:
     from app.wiki.coedit_checkpoint import drop_duplicate_blocks
     from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown


### PR DESCRIPTION
Caught **live during end-to-end verification** of #592/#593 on a local stack:
lift a paragraph out of a list, type into it, and the next autosave deleted the
typed text. Worker log: `held duplicate top-level block ids ['b4']; dropped the
repeats`.

## The race

1. ProseMirror's node split copies attrs — `_blockId` included — onto both
   halves, so the freshly created block briefly shares the original's id.
2. The editor's `UniqueBlockIdentity` clears the second id — but that is a
   **separate follow-up update**.
3. An autosave checkpoint landing between the two sees a repeated id.
   `drop_duplicate_blocks` (from #585) assumed repeated id ⇒ lineage merge ⇒
   copies identical ⇒ delete the later one. Here the later one is the
   person's edit. Deleted, broadcast, gone.

The #585 docstring even asserted "freshly typed content carries no id at all"
— false for split-created blocks, for exactly the window before the client's
fix-up lands.

## The fix

Distinguish by content, repair accordingly:

- **identical copy** → still deleted (the lineage-merge case #585 targeted;
  broadcast-converged as before)
- **differing copy** → its id is **cleared** instead — the same repair the
  client's own plugin was about to apply — routing it through
  `checkpoint_body`'s `orig is None` path as the new content it is. Nothing
  lost, id invariant restored either way.

## Testing

New test builds the exact race shape (a paragraph carrying a list's copied id,
with typed text) and asserts both blocks survive the repair and the splice.
The pre-existing lineage-merge tests pass unchanged. Full backend suite green
(2404 passed).

Live re-verification on the local stack follows once this lands in the image.