### PR TITLE
feat(editor): node-aware placeholders; rename TiptapEditor -> TipTapEditor

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -6,7 +6,7 @@
    the DOM ProseMirror actually produces, not Tailwind utilities on our own
    JSX. Opal tokens throughout, same as the rest of the app.
 
-   .editor-prose is the scroll wrapper TiptapEditor renders
+   .editor-prose is the scroll wrapper TipTapEditor renders
    (frontend/src/lib/editor/components.tsx) — every other selector below is
    scoped under it. */
 
@@ -302,17 +302,19 @@
   border-top: 1px solid var(--border-02);
 }
 
-/* Placeholder (@tiptap/extensions' Placeholder), keyed on `.is-editor-empty`
-   rather than `.is-empty`. Both land on the same decoration — the empty
-   textblock holding the cursor — but per the installed extension's source
-   only `.is-editor-empty` is conditional on `editor.isEmpty`, i.e. the whole
-   document being blank.
-   `.is-empty` alone matches any empty block, so pressing Enter part-way down a
-   written page put "Start typing, or pick a template above…" in the middle of
-   it: wrong twice over, since there is nothing to start and a template can't be
-   applied to a page that already has content. No `:first-child` needed — the
-   decoration targets the empty node itself, not a shared wrapper. */
-.editor-prose .is-editor-empty::before {
+/* Placeholder (@tiptap/extensions' Placeholder), keyed on `.is-empty` — any
+   current empty block — so a per-block, node-aware placeholder can render
+   (e.g. "Heading 1" on the empty heading you're in). `.is-editor-empty` is the
+   narrower whole-document-blank case; the empty first paragraph carries both
+   classes, so keying on `.is-empty` still covers it.
+   Keying on `.is-empty` was previously wrong only because the copy was a fixed
+   whole-document message ("Start typing, or pick a template above…") that made
+   no sense part-way down a written page. The placeholder is now node-aware (an
+   empty heading names its level, an empty paragraph shows a "/"-shortcut
+   prompt — see extensions.ts), so a mid-page prompt is intentional rather than
+   the old bug: the content, not the selector, was wrong. No `:first-child`
+   needed — the decoration targets the empty node itself, not a shared wrapper. */
+.editor-prose .is-empty::before {
   content: attr(data-placeholder);
   color: var(--text-02);
   float: left;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -32,7 +32,7 @@ import type {
   AnchoredHighlightTarget,
   CoeditorHandle,
   CommentDraft,
-  TiptapEditorProps,
+  TipTapEditorProps,
 } from "@/lib/editor/types";
 
 /** Highlight ids whose spans contain a collapsed caret or intersect a
@@ -54,15 +54,14 @@ function caretHitIds(
   return ids;
 }
 
-export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
-  function TiptapEditor(
+export const TipTapEditor = forwardRef<CoeditorHandle, TipTapEditorProps>(
+  function TipTapEditor(
     {
       doc: docProp,
       awareness: awarenessProp,
       userId,
       userDisplay,
       readOnly,
-      placeholder,
       pagePath,
       commentHighlights,
       activeCommentIds,
@@ -72,7 +71,7 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
       onSourceCaret,
       onSelectionForComment,
       onEditorReady,
-    }: TiptapEditorProps,
+    }: TipTapEditorProps,
     ref,
   ) {
     // A caller-supplied doc (a real live session, or two relayed docs for
@@ -120,7 +119,7 @@ export const TiptapEditor = forwardRef<CoeditorHandle, TiptapEditorProps>(
       // the client's hydration pass. Tiptap's documented fix for SSR.
       immediatelyRender: false,
       editable: !readOnly,
-      extensions: tiptapExtensions(doc, awareness, placeholder, pagePath),
+      extensions: tiptapExtensions(doc, awareness, pagePath),
     });
 
     useEffect(() => {

--- a/frontend/src/lib/editor/extensions.ts
+++ b/frontend/src/lib/editor/extensions.ts
@@ -38,7 +38,6 @@ import { presenceExtension } from "@/lib/editor/presence";
 export function tiptapExtensions(
   doc: Y.Doc,
   awareness: Awareness,
-  placeholder?: string,
   pagePath?: string,
 ): AnyExtension[] {
   return [
@@ -93,7 +92,26 @@ export function tiptapExtensions(
       // locally-constructed docs never exercised the mismatch.
       field: "prosemirror",
     }),
-    Placeholder.configure({ placeholder: placeholder ?? "" }),
+    Placeholder.configure({
+      // Node-aware, shown on the current empty block (the extension's
+      // showOnlyCurrent default). An empty heading names its own level; an
+      // empty paragraph — including the blank document — shows the regular-text
+      // prompt; every other empty block stays silent. A prompt on a mid-page
+      // empty paragraph is intended, which is why the CSS keys on `.is-empty`
+      // (any current empty block) rather than `.is-editor-empty` (whole doc
+      // blank): the reason it couldn't before was the copy, not the mechanism
+      // (see editor.css). Copy lives here, at the config site — the editor's
+      // placeholder is intrinsic, not a per-caller prop.
+      placeholder: ({ node }) => {
+        if (node.type.name === "heading") {
+          return `Heading ${node.attrs.level as number}`;
+        }
+        if (node.type.name === "paragraph") {
+          return 'Start typing or press "/" for shortcuts';
+        }
+        return "";
+      },
+    }),
     MarkdownLink,
     AnchoredHighlights,
     presenceExtension(awareness),

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -17,7 +17,7 @@
  *
  * On `enabled` it opens the session's WebSocket for `path`, binding a
  * `Y.Doc`/`Awareness` pair this hook owns for the connection's lifetime —
- * pass them to `<TiptapEditor doc={coedit.doc} awareness={coedit.awareness}
+ * pass them to `<TipTapEditor doc={coedit.doc} awareness={coedit.awareness}
  * .../>`. Teardown (checkpoint, then close, in that order — closing before
  * a final edit's checkpoint has landed would let the server's last-leave
  * forced commit race ahead of it) happens entirely inside the hook's own
@@ -109,7 +109,7 @@ export interface UseCoeditSession {
   /** True once the join handshake completes. */
   active: boolean;
   /** Bump count for `doc`/`awareness`'s identity — pass as
-   * `<TiptapEditor key={coedit.connectionId}>`. Required, not cosmetic:
+   * `<TipTapEditor key={coedit.connectionId}>`. Required, not cosmetic:
    * Tiptap's `useEditor` defaults to building the editor once and never
    * rebuilding it from new `doc`/`awareness` props (confirmed against the
    * installed `@tiptap/react` — `deps = []` unless the caller opts in), so
@@ -119,10 +119,10 @@ export interface UseCoeditSession {
    * (the session outlives any one socket), so that id alone can't be used as
    * the key the way the old hook's `session.id` was. */
   connectionId: number;
-  /** This connection's Yjs doc — pass to `<TiptapEditor doc={...}>`. A
+  /** This connection's Yjs doc — pass to `<TipTapEditor doc={...}>`. A
    * fresh instance every time `connectionId` bumps. */
   doc: Y.Doc;
-  /** This connection's Awareness — pass to `<TiptapEditor awareness={...}>`. */
+  /** This connection's Awareness — pass to `<TipTapEditor awareness={...}>`. */
   awareness: Awareness;
   /** Whether the user may edit this page (`can_write` from the join
    * response). False joins as a pure viewer: presence + live updates flow
@@ -175,7 +175,7 @@ export interface UseCoeditSession {
   saveError: string | null;
   /** Wire the underlying Tiptap `Editor` instance once it mounts — needed
    * to resolve peer cursor positions and to drive `setDoc`. Pass directly
-   * as `<TiptapEditor onEditorReady={coedit.onEditorReady}>`. */
+   * as `<TipTapEditor onEditorReady={coedit.onEditorReady}>`. */
   onEditorReady: (editor: Editor) => void;
   /** Replace the whole document with plain text, split into paragraphs on
    * blank lines — used by template-picking. A deliberate simplification:

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -37,7 +37,7 @@ export interface CommentDraft {
   quotedText: string;
 }
 
-export interface TiptapEditorProps {
+export interface TipTapEditorProps {
   /** The Yjs doc this editor's content lives in. Defaults to a fresh local
    * `Y.Doc` if omitted (P1's scaffold behavior — never synced anywhere).
    * Real live sessions (Track B) and multi-client verification (two editors
@@ -57,8 +57,6 @@ export interface TiptapEditorProps {
   userDisplay?: string;
   /** Render without accepting edits. */
   readOnly?: boolean;
-  /** Placeholder text shown on an empty document. */
-  placeholder?: string;
   /** The wiki page path this editor is editing, used to scope image uploads
    * (`POST /api/wiki/media?path=...`). Omitted by the scaffold/multi-client
    * verification harness, which has no real page - image paste/drop then

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -67,7 +67,7 @@ import {
 import type { CommentDraft, CommentHighlightTarget } from "@/lib/editor/types";
 import { pageTitle } from "@/lib/wiki/utils";
 import { useAuth } from "@/lib/auth";
-import { CoeditPresenceBar, TiptapEditor } from "@/lib/editor/components";
+import { CoeditPresenceBar, TipTapEditor } from "@/lib/editor/components";
 import { useCoeditSession } from "@/lib/editor/hooks";
 import type { CoeditorHandle } from "@/lib/editor/types";
 import {
@@ -512,7 +512,7 @@ export function FileView({ path }: FileViewProps) {
   ]);
 
   // Selecting text in the editor offers a floating "Comment" affordance
-  // anchored above the selection — fed by TiptapEditor's onSelectionForComment
+  // anchored above the selection — fed by TipTapEditor's onSelectionForComment
   // instead of a DOM `mouseup`/`selectionchange` handler.
   // The margin rail's mutation runner mirrors the panel's success gate;
   // failures surface as toasts since the rail has no error slot.
@@ -1368,7 +1368,7 @@ export function FileView({ path }: FileViewProps) {
                 </div>
                 {coedit.active ? (
                   <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-                    <TiptapEditor
+                    <TipTapEditor
                       key={coedit.connectionId}
                       ref={coeditorRef}
                       doc={coedit.doc}
@@ -1385,7 +1385,6 @@ export function FileView({ path }: FileViewProps) {
                       activeSourceIds={activeSourceIds}
                       onSourceCaret={setCaretSourceKeys}
                       onSelectionForComment={handleSelectionForComment}
-                      placeholder="Start typing, or pick a template above…"
                     />
                   </div>
                 ) : coedit.joinError ? (


### PR DESCRIPTION
## Summary

Two small editor changes.

**Node-aware placeholders.** The empty-block placeholder was a single
document-level string (`Start typing, or pick a template above…`) shown only
on a wholly blank document. It's now node-aware:

- empty **heading** → `Heading 1` / `Heading 2` / … (names its own level)
- empty **paragraph** (including a blank page) → `Start typing or press "/" for shortcuts`
- any other empty block → silent

Because a mid-page prompt is now intentional, the CSS moves from
`.is-editor-empty` (whole doc blank) to `.is-empty` (the current empty
block). That selector was only ever wrong because the *copy* made no sense
part-way down a page — node-aware copy fixes the content, which was the real
bug. The copy is intrinsic editor behavior (not page-specific), so it lives
at the `Placeholder.configure` site and the now-pointless `placeholder` prop
+ `tiptapExtensions` param are removed (single caller, never varied).

**Rename.** `TiptapEditor` → `TipTapEditor` (and `TiptapEditorProps` →
`TipTapEditorProps`) for house casing. Identifier-only; library references
(`Tiptap` / `@tiptap`) are untouched.

## Screenshots + Videos

Regular text editing:

<img width="346" height="90" alt="image" src="https://github.com/user-attachments/assets/a8dbb4de-0b88-49be-b804-a78f32bd522b" />

Heading editing:

<img width="286" height="144" alt="image" src="https://github.com/user-attachments/assets/781d91ba-b5da-4880-9fdf-23405cce6202" />

<img width="231" height="117" alt="image" src="https://github.com/user-attachments/assets/4fa4f87c-5096-4a4c-a1a5-7299a50ac397" />