### PR TITLE
feat(ingest): capture each need's stated update instruction

### DIFF
--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2102,7 +2102,7 @@ class PageNeeds(Base):
     entity_type_taxonomy_id: Mapped[int | None] = mapped_column(
         Integer, ForeignKey("entity_type_taxonomies.id", ondelete="SET NULL")
     )
-    # [{need_name, need_kind, description, detail_level, current_content,
+    # [{need_name, need_kind, description, detail_level, update_instruction, current_content,
     #   entities: [{canonical_name, entity_type, primary}], focus}, ...]
     # JSONB and free-form for the same reason as ``EntityTypeTaxonomy.types``: the shape is owned
     # by ``app.ingest.needs``, read whole, and never queried by field.

--- a/backend/app/ingest/needs.py
+++ b/backend/app/ingest/needs.py
@@ -1,8 +1,8 @@
 """Infer each wiki page's INFORMATION NEEDS — what it keeps track of, and how closely.
 
 A need is not a fact on the page. It is a statement of what the page maintains: a stable
-spec (``description``, ``detail_level``) plus a snapshot of the state it currently holds
-(``current_content``). One page yields a handful, typically 1-5.
+spec (``description``, ``detail_level``, ``update_instruction``) plus a snapshot of the state it
+currently holds (``current_content``). One page yields a handful, typically 1-5.
 
 Why that framing pays: a page tracking "current deal status and blockers" has a need whose
 *shape* is stable even as its content churns. An incoming document can then be judged against
@@ -122,6 +122,15 @@ class InformationNeed(BaseModel):
     need_kind: NeedKind
     description: str
     detail_level: str = ""
+    # The page's OWN stated rule for maintaining this, quoted verbatim; empty when the page
+    # states none. Distinct from ``detail_level``, which is inferred from the entries already
+    # there: an instruction is a directive its author wrote, and it can constrain things no
+    # amount of looking at content reveals — where a new entry goes ("newest first"), which
+    # sources are admissible ("only from the customer; deal status from the CRM"), what a row
+    # must carry. Verbatim because paraphrasing a directive can change what it permits, and
+    # empty rather than inferred because a fabricated instruction would be obeyed as if a human
+    # had written it.
+    update_instruction: str = ""
     # The state the page holds right now — what an incoming document gets diffed against. A
     # description of what the page *tracks* is therefore a failure, not a shorter answer.
     current_content: str = ""
@@ -219,6 +228,7 @@ def parse_need(obj: object, ctx: str, type_defs: dict[str, str]) -> InformationN
         need_kind=need_kind,
         description=description,
         detail_level=str(entry.get("detail_level") or "").strip(),
+        update_instruction=str(entry.get("update_instruction") or "").strip(),
         current_content=str(entry.get("current_content") or "").strip(),
         entities=_parse_entities(entry.get("entities"), type_defs),
         focus=focus,

--- a/backend/app/ingest/needs.py
+++ b/backend/app/ingest/needs.py
@@ -166,6 +166,25 @@ def build_prompt(type_defs: dict[str, str]) -> str:
     return load_prompt("needs.extract").replace("ENTITY_TYPES", block)
 
 
+def _text(value: object, *, field: str, ctx: str) -> str:
+    """Free text from an LLM payload, or "" when the value is not text.
+
+    A non-string is dropped rather than coerced. ``str(42)`` would store "42" and
+    ``str(["a"])`` would store "['a']" as though the page had said it, which is worst for
+    ``update_instruction`` — that field is kept verbatim precisely so it can be treated as the
+    author's own directive — but no field wants a repr of a list as its value.
+
+    Dropping rather than raising keeps the failure proportionate for the optional fields: losing
+    one advisory value beats discarding a whole page's needs. The REQUIRED fields still reach the
+    retry path, because "" is exactly what their existing emptiness check rejects.
+    """
+    if isinstance(value, str):
+        return value.strip()
+    if value is not None:
+        log.debug("needs: %s.%s was %s, not text; dropped", ctx, field, type(value).__name__)
+    return ""
+
+
 def _parse_entities(raw: object, type_defs: dict[str, str]) -> list[EntityMention]:
     """Structural validation, plus a check that the type came from the menu.
 
@@ -181,10 +200,12 @@ def _parse_entities(raw: object, type_defs: dict[str, str]) -> list[EntityMentio
         if not isinstance(item, dict):
             continue
         entry = cast(dict[str, Any], item)
-        name = str(entry.get("canonical_name") or entry.get("name") or "").strip()
+        name = _text(entry.get("canonical_name"), field="canonical_name", ctx="entity") or _text(
+            entry.get("name"), field="name", ctx="entity"
+        )
         if not name:
             continue
-        etype = str(entry.get("entity_type") or "").strip().lower()
+        etype = _text(entry.get("entity_type"), field="entity_type", ctx="entity").lower()
         if etype and etype not in type_defs:
             log.debug("needs: dropping off-menu entity_type %r", etype)
             etype = ""
@@ -202,14 +223,17 @@ def parse_need(obj: object, ctx: str, type_defs: dict[str, str]) -> InformationN
         raise SchemaError(f"{ctx} must be an object")
     entry = cast(dict[str, Any], obj)
 
-    need_name = str(entry.get("need_name") or "").strip()
+    # "must be a non-empty string" rather than "is required": it is accurate whether the field was
+    # missing, blank, or the wrong type, and a message that says "required" for a value the model
+    # DID send would send it looking for the wrong fix on the retry.
+    need_name = _text(entry.get("need_name"), field="need_name", ctx=ctx)
     if not need_name:
-        raise SchemaError(f"{ctx}.need_name is required")
-    description = str(entry.get("description") or "").strip()
+        raise SchemaError(f"{ctx}.need_name must be a non-empty string")
+    description = _text(entry.get("description"), field="description", ctx=ctx)
     if not description:
-        raise SchemaError(f"{ctx}.description is required")
+        raise SchemaError(f"{ctx}.description must be a non-empty string")
 
-    raw_kind = str(entry.get("need_kind") or "").strip().lower()
+    raw_kind = _text(entry.get("need_kind"), field="need_kind", ctx=ctx).lower()
     try:
         need_kind = NeedKind(raw_kind)
     except ValueError:
@@ -219,7 +243,7 @@ def parse_need(obj: object, ctx: str, type_defs: dict[str, str]) -> InformationN
     # Unlike need_kind, an unusable focus is defaulted rather than rejected: it narrows what the
     # need may absorb, so getting it wrong costs a missed entity, not a misapplied fact.
     try:
-        focus = Focus(str(entry.get("focus") or "").strip().lower())
+        focus = Focus(_text(entry.get("focus"), field="focus", ctx=ctx).lower())
     except ValueError:
         focus = DEFAULT_FOCUS
 
@@ -227,9 +251,11 @@ def parse_need(obj: object, ctx: str, type_defs: dict[str, str]) -> InformationN
         need_name=need_name,
         need_kind=need_kind,
         description=description,
-        detail_level=str(entry.get("detail_level") or "").strip(),
-        update_instruction=str(entry.get("update_instruction") or "").strip(),
-        current_content=str(entry.get("current_content") or "").strip(),
+        detail_level=_text(entry.get("detail_level"), field="detail_level", ctx=ctx),
+        update_instruction=_text(
+            entry.get("update_instruction"), field="update_instruction", ctx=ctx
+        ),
+        current_content=_text(entry.get("current_content"), field="current_content", ctx=ctx),
         entities=_parse_entities(entry.get("entities"), type_defs),
         focus=focus,
     )

--- a/backend/app/llm/prompts/needs.extract.md
+++ b/backend/app/llm/prompts/needs.extract.md
@@ -12,6 +12,12 @@ Use no other value for need_kind.
 
 Infer detail_level from BOTH the page's own instructions/headers AND its existing instances/examples (how granular are the entries that are already there?).
 
+ALSO capture update_instruction: the page's OWN stated rule for how this need is maintained, QUOTED VERBATIM from the page.
+  - This is different from detail_level. detail_level is what you infer from the entries already there; an update_instruction is a directive the page's author WROTE, and it can say things the existing content never shows: where a new entry goes ("Add each Friday's notes as a new dated section below, newest first"), which sources are admissible ("all information should come here either through the customer, or from internal sources explicitly referencing the customer; overall deal status should come from a CRM"), or what every row must carry ("each line should include the source, which customer, the date, and what the issue is").
+  - Quote it, do not paraphrase — a reworded directive can permit or forbid something the original did not.
+  - Use "" when the page states no such rule. MOST PAGES DO NOT. Do NOT infer one from how the content happens to look, and do NOT invent a reasonable-sounding one: a fabricated instruction gets obeyed as though a human wrote it, which is worse than having none.
+  - Only include a rule about MAINTAINING the page. Instructions that are the page's subject matter (a runbook's steps, a design doc's guidance to engineers) are content, not update rules.
+
 If one page tracks several things (e.g. a section per customer), emit one need per thing. If it tracks a single thing, emit one need.
 
 For current_content, LIST THE ACTUAL TRACKED CONTENT: the concrete facts, values, names, dates, versions, and entries that are on the page right now.
@@ -39,6 +45,7 @@ OUTPUT: a single JSON object, no prose:
       "need_kind": "entity_status",
       "description": "current deal status, open blockers, and primary contact",
       "detail_level": "one status line + a short blockers list",
+      "update_instruction": "",
       "current_content": "Status: negotiation. Blocker: security review. Contact: J. Doe.",
       "entities": [{"canonical_name": "Acme", "entity_type": "<one of the types listed above>", "primary": true}],
       "focus": "specific"

--- a/backend/tests/test_needs.py
+++ b/backend/tests/test_needs.py
@@ -53,6 +53,14 @@ class TestBuildPrompt:
         assert "- aircraft_model: A named aircraft type." in prompt
         assert "organization" not in prompt
 
+    def test_asks_for_a_verbatim_update_instruction(self) -> None:
+        prompt = needs.build_prompt(TYPE_DEFS)
+
+        assert "update_instruction" in prompt
+        assert "VERBATIM" in prompt
+        # The guard that matters: an invented instruction would be obeyed as a human directive.
+        assert "do NOT invent" in prompt
+
     def test_does_not_cap_how_many_entities_a_need_may_have(self) -> None:
         """The prompt used to hint "usually 0-3", which suppresses entities on exactly the pages
         that name many — a tracker with a row per customer is about every one of them."""
@@ -90,6 +98,43 @@ class TestParseNeed:
 
     def test_generic_focus_survives(self) -> None:
         assert needs.parse_need(_need(focus="generic"), "n", TYPE_DEFS).focus is Focus.GENERIC
+
+    def test_captures_an_update_instruction(self) -> None:
+        need = needs.parse_need(
+            _need(update_instruction="Add each Friday's notes as a new dated section, newest first."),
+            "n",
+            TYPE_DEFS,
+        )
+
+        assert need.update_instruction == "Add each Friday's notes as a new dated section, newest first."
+
+    def test_no_instruction_is_empty_not_invented(self) -> None:
+        """Most pages state no maintenance rule, and a fabricated one would be obeyed as though a
+        human wrote it — worse than having none. Absence must survive parsing as absence."""
+        assert needs.parse_need(_need(), "n", TYPE_DEFS).update_instruction == ""
+        assert needs.parse_need(_need(update_instruction=None), "n", TYPE_DEFS).update_instruction == ""
+        assert needs.parse_need(_need(update_instruction="   "), "n", TYPE_DEFS).update_instruction == ""
+
+    def test_an_instruction_is_independent_of_detail_level(self) -> None:
+        """They answer different questions: detail_level is inferred from the entries already
+        there, an instruction is the author's directive and can constrain placement or admissible
+        sources, which no amount of reading the content reveals."""
+        need = needs.parse_need(
+            _need(
+                detail_level="one line per report",
+                update_instruction="Each line should include the source, the customer, and the date.",
+            ),
+            "n",
+            TYPE_DEFS,
+        )
+
+        assert need.detail_level == "one line per report"
+        assert need.update_instruction.startswith("Each line should include")
+
+    def test_the_instruction_reaches_stored_json(self) -> None:
+        need = needs.parse_need(_need(update_instruction="Newest first."), "n", TYPE_DEFS)
+
+        assert need.model_dump(mode="json")["update_instruction"] == "Newest first."
 
     def test_ignores_fields_the_schema_no_longer_carries(self) -> None:
         """``cadence`` was dropped: it was populated on 9-18% of needs, missed 30/43 timelines

--- a/backend/tests/test_needs.py
+++ b/backend/tests/test_needs.py
@@ -136,6 +136,41 @@ class TestParseNeed:
 
         assert need.model_dump(mode="json")["update_instruction"] == "Newest first."
 
+    @pytest.mark.parametrize("bad", [42, True, ["a", "b"], {"k": "v"}, 3.5])
+    def test_a_non_string_instruction_is_dropped_not_stringified(self, bad) -> None:
+        """str(42) would store "42" and str(["a"]) "['a']" as though the page had written it. This
+        field is kept verbatim so it can be treated as the author's own directive, which makes a
+        coerced value worse than no value."""
+        need = needs.parse_need(_need(update_instruction=bad), "n", TYPE_DEFS)
+
+        assert need.update_instruction == ""
+
+    @pytest.mark.parametrize("field", ["detail_level", "current_content"])
+    def test_a_non_string_optional_field_is_dropped(self, field) -> None:
+        """Dropped rather than raised: losing one advisory value beats discarding a whole page's
+        needs."""
+        need = needs.parse_need(_need(**{field: ["x"]}), "n", TYPE_DEFS)
+
+        assert getattr(need, field) == ""
+
+    @pytest.mark.parametrize("field", ["need_name", "description"])
+    def test_a_non_string_required_field_reaches_the_retry_path(self, field) -> None:
+        """The required fields already reject emptiness, so a dropped non-string lands there — and
+        the message says "non-empty string" rather than "required", which would send the model
+        looking for a field it did send."""
+        with pytest.raises(needs.SchemaError, match="non-empty string"):
+            needs.parse_need(_need(**{field: 42}), "n", TYPE_DEFS)
+
+    def test_a_non_string_entity_name_is_skipped(self) -> None:
+        """Same coercion in the entity list would have minted an entity literally named "42"."""
+        need = needs.parse_need(
+            _need(entities=[{"canonical_name": 42}, {"canonical_name": "Acme"}]),
+            "n",
+            TYPE_DEFS,
+        )
+
+        assert [e.canonical_name for e in need.entities] == ["Acme"]
+
     def test_ignores_fields_the_schema_no_longer_carries(self) -> None:
         """``cadence`` was dropped: it was populated on 9-18% of needs, missed 30/43 timelines
         on a weaker model, leaked onto kinds where it means nothing, and restated


### PR DESCRIPTION
A page often writes down **how it is to be maintained**, and nothing in the need schema held that.

`detail_level` is *inferred* from the entries already present. An update instruction is a directive the author **wrote**, and it constrains things no amount of reading content reveals. Three real examples from this wiki:

| kind | instruction |
|---|---|
| **placement** | *"Add each Friday's notes as a new dated section below, newest first."* |
| **admission** | *"all information should come here either through the customer, or from internal sources explicitly referencing information provided by the customer. Overall deal status should come from a CRM system."* |
| **format** | *"Each line should include the source type where it came from, which customer it is (or Unknown), the date, and what the issue is."* |

The **admission** rule is the argument for the field: it decides whether an incoming document is eligible at all — something `detail_level` cannot express, and exactly the judgment a reconciler needs before it edits a page.

Worth noting the eval saw these only **incidentally**, in a free-text `evidence` field on 12 of 205 needs. The information was visible and had nowhere to live.

## Two deliberate constraints

**Verbatim, not paraphrased.** A reworded directive can permit or forbid something the original didn't. This field is meant to be authoritative, so it quotes.

**Empty when absent, and the prompt says so twice.** Most pages state no rule. A fabricated instruction would be obeyed as though a human wrote it — worse than having none. Same reasoning that led to dropping organization-name detection: being wrong here is silent and compounds, while being absent costs nothing.

Also scoped to rules about *maintaining the page*: a runbook's steps or a design doc's guidance to engineers are content, not update rules.

## Re-extraction required

This makes every stored need stale, and the prompt is deliberately **not** part of the staleness guard (stored needs are only comparable when they came from the same prompt). So the re-run needs `force=True` — 148 pages, ~6 min on the ingestion model.

## Tests

5 new: the instruction is captured; absence stays absent across `""`/`None`/whitespace; it's independent of `detail_level`; it reaches stored JSON; and the prompt asks for it verbatim *and* warns against inventing one.

Verified by mutation — dropping the field, or softening the do-not-invent rule, each fails a test. `ruff check` and basedpyright clean, full suite green.

## Context

Prior run for comparison, on the current schema: 255 needs from 148 pages in 6m06s, 2,903 entities all typed against taxonomy id=3, zero truncations, `current_content` enumerating real values rather than describing pages. This adds one field to that.