### PR TITLE
fix(editor): show placeholders only while the editor is focused

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -313,8 +313,12 @@
    empty heading names its level, an empty paragraph shows a "/"-shortcut
    prompt — see extensions.ts), so a mid-page prompt is intentional rather than
    the old bug: the content, not the selector, was wrong. No `:first-child`
-   needed — the decoration targets the empty node itself, not a shared wrapper. */
-.editor-prose .is-empty::before {
+   needed — the decoration targets the empty node itself, not a shared wrapper.
+   Gated on `.ProseMirror-focused` (ProseMirror sets it on the editable root
+   while the view holds focus, clears it on blur) so a prompt shows only while
+   the editor is actually focused — a blurred editor renders no placeholder,
+   empty block or not. */
+.editor-prose .ProseMirror-focused .is-empty::before {
   content: attr(data-placeholder);
   color: var(--text-02);
   float: left;


### PR DESCRIPTION
## Summary

An empty block's placeholder prompt (`Start typing or press "/" for
shortcuts`, `Heading N`) stayed visible after the user clicked away from the
editor, reading as stray chrome on a page nobody is editing.

Gate the placeholder `::before` on ProseMirror's own `.ProseMirror-focused`
class (set on the editable root while the view holds focus, cleared on blur),
so a prompt shows **only while the editor is actually focused** and disappears
on blur — for any empty block, not just a blank document.

CSS-only: the Tiptap `Placeholder` extension has no focus option and keeps the
`.is-empty` decoration on the current empty block regardless of focus, so
gating the render in CSS is the idiomatic fix — no JS, no extra state.

## Screenshots + Videos

During focus:

<img width="848" height="258" alt="image" src="https://github.com/user-attachments/assets/48c4ef36-f8d3-43eb-a88e-f83d1e4fe7b0" />

During blur-away:

<img width="832" height="226" alt="image" src="https://github.com/user-attachments/assets/05bdcb40-3f9d-4cd6-bcf8-7dcd4af03f73" />