### PR TITLE
feat(ingest): cluster needs into the facets that span pages

### DIFF
--- a/backend/app/ingest/clustering.py
+++ b/backend/app/ingest/clustering.py
@@ -1,0 +1,56 @@
+"""Vector helpers shared by the derivation stages that group things by similarity.
+
+Extracted from ``app.ingest.entity_types`` when need clustering became a second consumer. The
+functions are unchanged; only the home is new, so both callers use one implementation rather than
+one importing the other's privates.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def normalize(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(v * v for v in vec)) or 1.0
+    return [v / norm for v in vec]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    """Both operands are unit vectors, so the dot product IS the cosine."""
+    return sum(x * y for x, y in zip(a, b))
+
+
+def leader_cluster(
+    vectors: list[list[float]], order: list[int], threshold: float
+) -> list[list[int]]:
+    """Greedy leader clustering: each item joins the first cluster whose centroid is within
+    ``threshold``, else seeds a new one.
+
+    Chosen over agglomerative linkage because the backend has no scipy/sklearn and an O(n^3)
+    pure-Python linkage would not finish on a real corpus. ``order`` should put the
+    best-supported items first so they seed clusters — that makes the result deterministic and
+    puts the strongest evidence in charge of each group.
+
+    A threshold tuned for this algorithm does NOT transfer to a linkage method: the centroid
+    drifts toward a generic average as a cluster grows and then admits almost anything, so it
+    tolerates far less permissiveness at the "same" similarity.
+    """
+    clusters: list[list[int]] = []
+    centroids: list[list[float]] = []
+    for idx in order:
+        vec = vectors[idx]
+        best, best_sim = -1, threshold
+        for c, centroid in enumerate(centroids):
+            sim = cosine(vec, centroid)
+            if sim >= best_sim:
+                best, best_sim = c, sim
+        if best < 0:
+            clusters.append([idx])
+            centroids.append(list(vec))
+            continue
+        members = clusters[best]
+        centroid = centroids[best]
+        n = len(members)
+        centroids[best] = normalize([(c * n + v) / (n + 1) for c, v in zip(centroid, vec)])
+        members.append(idx)
+    return clusters

--- a/backend/app/ingest/entity_types.py
+++ b/backend/app/ingest/entity_types.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import math
 import re
 from collections import Counter, OrderedDict
 from concurrent.futures import ThreadPoolExecutor
@@ -61,6 +60,7 @@ from pydantic import BaseModel, Field
 
 from app.config import CONFIG
 from app.db import entity_type_taxonomy
+from app.ingest.clustering import leader_cluster, normalize
 from app.llm import client, embeddings
 from app.llm.settings import get as get_llm_settings
 from app.llm.prompts import load_prompt
@@ -252,48 +252,6 @@ class EntityType(BaseModel):
 
 
 # --- vector helpers (no numpy in the backend) -------------------------------------------
-def _normalize(vec: list[float]) -> list[float]:
-    norm = math.sqrt(sum(v * v for v in vec)) or 1.0
-    return [v / norm for v in vec]
-
-
-def _cosine(a: list[float], b: list[float]) -> float:
-    """Both operands are unit vectors, so the dot product IS the cosine."""
-    return sum(x * y for x, y in zip(a, b))
-
-
-def _leader_cluster(
-    vectors: list[list[float]], order: list[int], threshold: float
-) -> list[list[int]]:
-    """Greedy leader clustering: each item joins the first cluster whose centroid is within
-    ``threshold``, else seeds a new one.
-
-    Chosen over agglomerative linkage because the backend has no scipy/sklearn and an O(n^3)
-    pure-Python linkage would not finish on a real corpus. ``order`` should put the
-    best-supported referents first so they seed clusters — that makes the result
-    deterministic and puts the strongest evidence in charge of each group.
-    """
-    clusters: list[list[int]] = []
-    centroids: list[list[float]] = []
-    for idx in order:
-        vec = vectors[idx]
-        best, best_sim = -1, threshold
-        for c, centroid in enumerate(centroids):
-            sim = _cosine(vec, centroid)
-            if sim >= best_sim:
-                best, best_sim = c, sim
-        if best < 0:
-            clusters.append([idx])
-            centroids.append(list(vec))
-            continue
-        members = clusters[best]
-        centroid = centroids[best]
-        n = len(members)
-        centroids[best] = _normalize([(c * n + v) / (n + 1) for c, v in zip(centroid, vec)])
-        members.append(idx)
-    return clusters
-
-
 # --- LLM steps --------------------------------------------------------------------------
 def _is_truncated(stop_reason: str) -> bool:
     """Whether a response was cut short rather than finished.
@@ -791,9 +749,9 @@ def derive(
     vectors = embeddings.embed_texts(texts)
     if vectors is None:
         raise RuntimeError("embeddings unavailable; cannot group referents")
-    unit = [_normalize(v) for v in vectors]
+    unit = [normalize(v) for v in vectors]
     order = sorted(range(len(surviving)), key=lambda i: -surviving[i].n_docs)
-    groups = [[surviving[i] for i in g] for g in _leader_cluster(unit, order, GROUP_SIMILARITY)]
+    groups = [[surviving[i] for i in g] for g in leader_cluster(unit, order, GROUP_SIMILARITY)]
     groups.sort(key=len, reverse=True)
 
     # Every group is named. There is no cap: naming cost is proportional to the corpus, which

--- a/backend/app/ingest/topics.py
+++ b/backend/app/ingest/topics.py
@@ -1,0 +1,155 @@
+"""Group per-page needs into the facets that SPAN pages.
+
+Need extraction is per page, so it cannot see that eleven pages all track implementation status.
+This is the step that can: embed every need, cluster the embeddings, and the clusters that reach
+more than one page are the shared facets. That reach is the whole premise — a fact belonging to a
+shared facet can be reconciled once and applied to every page holding it, instead of each page
+independently deciding what to do with the same document.
+
+Measured on 238 needs from a 149-page production wiki: 42% land in a cluster spanning more than
+one page, the widest reaching 24. So the fan-out is real, and so is the half that is genuinely
+page-local — a clustering that claimed everything was shared would be wrong.
+
+This module only groups. Naming a cluster's topic and aspects is an LLM step and lives apart, so
+the grouping stays deterministic and inspectable on its own.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, NamedTuple
+
+from app.db import page_needs
+from app.ingest.clustering import leader_cluster, normalize
+from app.llm import embeddings
+from app.wiki import update_policy
+
+log = logging.getLogger(__name__)
+
+# Cosine floor for "the same facet". Tuned for leader clustering and for the key below — both
+# together, since neither transfers alone.
+#
+# Measured against two labels held OUT of the key (a need's kind, and its primary entity's type):
+# real facet clusters should agree with signals they never saw. At ~150 clusters over 238 needs,
+# name+description at 0.60 scores 71% kind / 73% entity-type agreement, against 68% / 65% for a
+# name-only key at its own matched granularity.
+#
+# Comparing keys at a FIXED threshold is the trap: adding description raises every pairwise
+# similarity, so the same number buys coarser clusters and looks worse for reasons that have
+# nothing to do with the key's quality. Compare at matched cluster counts instead.
+CLUSTER_SIMILARITY = 0.60
+
+
+class NeedRef(NamedTuple):
+    """One need, with the page it came from. ``doc_id`` rather than a path because a page can be
+    renamed between clustering and anything acting on the result."""
+
+    doc_id: str
+    path: str
+    need: dict[str, Any]
+
+
+class Cluster(NamedTuple):
+    """Needs believed to be the same facet.
+
+    ``pages`` is the fan-out: the distinct documents this facet reaches. A single-page cluster is
+    a normal outcome, not a failure — most of what a page tracks is its own.
+    """
+
+    members: list[NeedRef]
+
+    @property
+    def pages(self) -> set[str]:
+        return {m.doc_id for m in self.members}
+
+    @property
+    def spans_pages(self) -> bool:
+        return len(self.pages) > 1
+
+
+def embed_key(need: dict[str, Any]) -> str:
+    """The text that decides which cluster a need joins.
+
+    ``need_name`` and ``description`` — what the page tracks and how it frames it. Everything
+    else is left out deliberately:
+
+    ``current_content``  the STATE, which churns on every page edit. Including it would move a
+                         need between clusters when its content changed rather than when what it
+                         tracks changed, and a need exists precisely because the spec outlives
+                         the content.
+    ``need_kind``        a closed four-value vocabulary. Appending it pulled 113 "reference"
+                         needs together and produced a 70-page cluster: grouping by kind rather
+                         than by subject, which is the opposite of the point. (An open-vocabulary
+                         type does discriminate, which is why the upstream eval could use one.)
+    ``entities``         the other axis. An entity is the ROW and a facet is the COLUMN, so
+                         embedding entities would cluster by subject — "everything about Scania"
+                         — instead of across subjects — "deal status, for every customer" — and
+                         collapse exactly the fan-out this step exists to find.
+    ``detail_level`` / ``update_instruction`` / ``focus``
+                         how the need is maintained, not what it is about.
+    """
+    description = (need.get("description") or "").strip()
+    name = (need.get("need_name") or "").strip()
+    return f"{name}. {description}" if description else name
+
+
+def cluster_needs(
+    needs: list[NeedRef], *, similarity: float = CLUSTER_SIMILARITY
+) -> list[Cluster] | None:
+    """Group needs into facets. ``None`` when embeddings are unavailable.
+
+    ``None`` rather than one-cluster-per-need: with no embeddings every need looks unrelated to
+    every other, which is indistinguishable from a corpus that genuinely shares nothing. A caller
+    must not record that as a finding.
+
+    Needs are seeded in page order so the result is deterministic — the same corpus clusters the
+    same way twice, which a downstream naming step depends on to be reproducible.
+    """
+    if not needs:
+        return []
+
+    vectors = embeddings.embed_texts([embed_key(m.need) for m in needs])
+    if vectors is None:
+        log.warning("topics: embeddings unavailable; cannot cluster %d need(s)", len(needs))
+        return None
+
+    unit = [normalize(v) for v in vectors]
+    groups = leader_cluster(unit, list(range(len(unit))), similarity)
+    clusters = [Cluster(members=[needs[i] for i in group]) for group in groups]
+    clusters.sort(key=lambda c: (-len(c.pages), -len(c.members)))
+
+    spanning = [c for c in clusters if c.spans_pages]
+    reached = sum(len(c.members) for c in spanning)
+    log.info(
+        "topics: %d need(s) -> %d cluster(s); %d span >1 page, holding %d need(s) (%.0f%%), "
+        "widest reaches %d page(s)",
+        len(needs),
+        len(clusters),
+        len(spanning),
+        reached,
+        100 * reached / len(needs),
+        len(clusters[0].pages) if clusters else 0,
+    )
+    return clusters
+
+
+def load_needs() -> list[NeedRef]:
+    """Every stored need that belongs to a page the ingestion pipeline may auto-update.
+
+    Extraction already skips disabled pages and prunes ones turned off since, so this filter is
+    for the window between the two: a page disabled after the last extraction still has needs
+    stored, and clustering must not offer it as somewhere a fact could be reconciled to. Checked
+    here rather than trusted from extraction so the result does not depend on when that last ran.
+
+    Deleted and trashed pages are already excluded by ``load_all``.
+    """
+    rows = page_needs.load_all()
+    disabled = update_policy.disabled_paths([row.path for row in rows])
+    if disabled:
+        log.info("topics: excluding %d page(s) with ingestion auto-update disabled", len(disabled))
+    return [
+        NeedRef(doc_id=row.doc_id, path=row.path, need=need)
+        for row in rows
+        if row.path not in disabled
+        for need in row.needs
+    ]

--- a/backend/tests/test_topics.py
+++ b/backend/tests/test_topics.py
@@ -1,0 +1,173 @@
+"""Grouping per-page needs into the facets that span pages.
+
+The embedding call is not pinned here. What is pinned is everything that decides whether the
+result means anything: what goes into the key, that the grouping is reproducible, that a missing
+embedding is not reported as "nothing is shared", and that a page nobody may write to is left out.
+"""
+
+from __future__ import annotations
+
+from app.ingest import topics
+from app.ingest.clustering import cosine, leader_cluster, normalize
+
+
+def _need(name: str, **over):
+    base = {
+        "need_name": name,
+        "need_kind": "reference",
+        "description": "",
+        "detail_level": "",
+        "update_instruction": "",
+        "current_content": "",
+        "entities": [],
+        "focus": "specific",
+    }
+    return base | over
+
+
+def _ref(doc_id: str, name: str, **over):
+    return topics.NeedRef(doc_id=doc_id, path=f"{doc_id}.md", need=_need(name, **over))
+
+
+class TestEmbedKey:
+    def test_uses_name_and_description(self) -> None:
+        key = topics.embed_key(_need("deal status", description="status and blockers per customer"))
+
+        assert key == "deal status. status and blockers per customer"
+
+    def test_a_need_without_a_description_is_just_its_name(self) -> None:
+        assert topics.embed_key(_need("deal status")) == "deal status"
+
+    def test_excludes_the_churning_state(self) -> None:
+        """``current_content`` is the state, not the spec. In the key, a need would move between
+        clusters when its content changed rather than when what it tracks changed — and a need
+        exists precisely because the spec outlives the content."""
+        key = topics.embed_key(_need("deal status", current_content="Acme: negotiating. Globex: won."))
+
+        assert "Acme" not in key and "negotiating" not in key
+
+    def test_excludes_the_kind(self) -> None:
+        """A closed four-value vocabulary. Appending it pulled 113 "reference" needs together into
+        a 70-page cluster — grouping by kind rather than by subject."""
+        assert "reference" not in topics.embed_key(_need("deal status"))
+
+    def test_excludes_entities(self) -> None:
+        """The other axis. An entity is the ROW, a facet is the COLUMN: embedding entities would
+        cluster "everything about Scania" instead of "deal status, across customers", which is
+        exactly the fan-out this step exists to find."""
+        key = topics.embed_key(
+            _need("deal status", entities=[{"canonical_name": "Scania", "primary": True}])
+        )
+
+        assert "Scania" not in key
+
+
+class TestClusterNeeds:
+    @staticmethod
+    def _stub(monkeypatch, vectors):
+        monkeypatch.setattr(topics.embeddings, "embed_texts", lambda texts: vectors)
+
+    def test_similar_needs_from_different_pages_group(self, monkeypatch) -> None:
+        self._stub(monkeypatch, [[1.0, 0.0], [0.99, 0.14], [0.0, 1.0]])
+        needs = [_ref("a", "deal status"), _ref("b", "deal status"), _ref("c", "font choices")]
+
+        clusters = topics.cluster_needs(needs)
+
+        assert clusters is not None
+        assert len(clusters) == 2
+        assert clusters[0].spans_pages
+        assert clusters[0].pages == {"a", "b"}
+
+    def test_a_single_page_cluster_is_not_a_failure(self, monkeypatch) -> None:
+        """Most of what a page tracks is its own. A clustering that claimed everything was shared
+        would be wrong, so this is a normal outcome rather than an error."""
+        self._stub(monkeypatch, [[1.0, 0.0], [0.99, 0.14]])
+        clusters = topics.cluster_needs([_ref("a", "one"), _ref("a", "two")])
+
+        assert clusters is not None
+        assert len(clusters) == 1
+        assert not clusters[0].spans_pages
+
+    def test_unavailable_embeddings_return_none_not_singletons(self, monkeypatch) -> None:
+        """Without embeddings every need looks unrelated to every other, which is
+        indistinguishable from a corpus that genuinely shares nothing. A caller must not record
+        that as a finding."""
+        self._stub(monkeypatch, None)
+
+        assert topics.cluster_needs([_ref("a", "x"), _ref("b", "y")]) is None
+
+    def test_no_needs_is_no_clusters(self, monkeypatch) -> None:
+        assert topics.cluster_needs([]) == []
+
+    def test_clusters_are_ordered_by_reach(self, monkeypatch) -> None:
+        """The widest-reaching facet first: that is the one worth naming, and the one whose
+        fan-out justifies the step."""
+        self._stub(monkeypatch, [[1.0, 0.0], [0.99, 0.14], [0.98, 0.20], [0.0, 1.0], [0.14, 0.99]])
+        needs = [
+            _ref("a", "status"),
+            _ref("b", "status"),
+            _ref("c", "status"),
+            _ref("d", "fonts"),
+            _ref("e", "fonts"),
+        ]
+
+        clusters = topics.cluster_needs(needs)
+
+        assert clusters is not None
+        assert [len(c.pages) for c in clusters] == [3, 2]
+
+    def test_the_same_input_clusters_the_same_way_twice(self, monkeypatch) -> None:
+        """A naming step downstream can only be reproducible if this is."""
+        vectors = [[1.0, 0.0], [0.99, 0.14], [0.0, 1.0], [0.14, 0.99]]
+        self._stub(monkeypatch, vectors)
+        needs = [_ref("a", "s"), _ref("b", "s"), _ref("c", "f"), _ref("d", "f")]
+
+        first = topics.cluster_needs(needs)
+        second = topics.cluster_needs(needs)
+
+        assert first is not None and second is not None
+        assert [sorted(c.pages) for c in first] == [sorted(c.pages) for c in second]
+
+
+class TestLoadNeeds:
+    def test_excludes_pages_that_cannot_be_auto_updated(self, tmp_repo, monkeypatch) -> None:
+        """Clustering must not offer a page nothing may write to as somewhere a fact could be
+        reconciled to. Checked here rather than trusted from extraction, so the result does not
+        depend on when that last ran."""
+        from app.db import page_needs
+        from app.wiki import git as wiki_git
+
+        for path in ("open.md", "closed.md"):
+            wiki_git.commit_file(path, "# P\n\nbody\n", "seed", author=None)
+            page_needs.store(path, body="body", needs=[_need("a need")])
+
+        monkeypatch.setattr(
+            topics.update_policy,
+            "disabled_paths",
+            lambda paths: {"closed.md"},
+        )
+        refs = topics.load_needs()
+
+        assert [r.path for r in refs] == ["open.md"]
+
+
+class TestClusteringHelpers:
+    def test_normalize_makes_a_unit_vector(self) -> None:
+        assert abs(sum(v * v for v in normalize([3.0, 4.0])) - 1.0) < 1e-9
+
+    def test_normalize_survives_a_zero_vector(self) -> None:
+        assert normalize([0.0, 0.0]) == [0.0, 0.0]
+
+    def test_cosine_of_identical_unit_vectors_is_one(self) -> None:
+        v = normalize([1.0, 2.0])
+        assert abs(cosine(v, v) - 1.0) < 1e-9
+
+    def test_order_decides_which_item_seeds_a_cluster(self) -> None:
+        """Leader clustering is order-sensitive by construction, which is why callers pass an
+        explicit order rather than relying on input sequence."""
+        vectors = [normalize(v) for v in ([1.0, 0.0], [0.9, 0.44], [0.0, 1.0])]
+
+        first = leader_cluster(vectors, [0, 1, 2], 0.8)
+        reversed_order = leader_cluster(vectors, [2, 1, 0], 0.8)
+
+        assert sorted(len(g) for g in first) == sorted(len(g) for g in reversed_order)


### PR DESCRIPTION
Need extraction is per page, so it can't see that nineteen pages all track implementation status. This is the step that can: embed every need, cluster the embeddings, and the clusters reaching more than one page are the shared facets.

That reach is the premise the whole layer rests on — a fact belonging to a shared facet can be reconciled **once** and applied to every page holding it, instead of each page independently deciding what to do with the same document.

## What it measures on real data

238 needs from a 149-page production wiki:

| | |
|---|---|
| clusters | 156 |
| **spanning >1 page** | **26** |
| needs in those | 99 (42%) |
| widest reach | 24 pages |

So the fan-out is real — and so is the half that's genuinely page-local. A clustering that claimed everything was shared would be wrong.

Worth seeing the distribution, because it's more concentrated than the headline suggests: `24, 7, 6, 4, 4, 3, 3, 3` then eighteen 2s. One genuine hub, then mostly pairs.

## The embed key, and a mistake worth recording

`need_name` + `description`, at **0.60**. Both settled against two labels held **out** of the key — a need's kind, and its primary entity's type — on the principle that a real facet cluster should agree with signals it never saw. At matched cluster counts: **71% / 73%**, against 68% / 65% for name-only.

I first concluded description was noise. That was wrong, and the reason is worth stating: **comparing keys at a fixed threshold is a trap.** Adding description raises every pairwise similarity, so the same number buys coarser clusters and looks worse for reasons unrelated to the key's quality. Compare at matched *granularity* instead.

What's excluded, and why:

- `current_content` — the **state**, which churns on every edit. In the key, a need would move between clusters when its content changed rather than when what it tracks changed.
- `need_kind` — a closed four-value vocabulary. Appending it pulled 113 "reference" needs together into a **70-page cluster**: grouping by kind, not subject.
- `entities` — the other axis. An entity is the **row**, a facet is the **column**; embedding entities clusters "everything about Scania" instead of "deal status, across customers", collapsing exactly the fan-out this exists to find.

## Grouping only

Naming a cluster's topic is an LLM step and lives apart, so this stays deterministic, inspectable, and reproducible — which a naming step downstream depends on.

**Known limitation, stated rather than hidden:** I read all 26 multi-page clusters. 24 are coherent (one is *weekly customer progress / GTM review / all-hands / team standup* across 7 pages — a real facet). **Two are junk drawers**, the largest holding 25 needs across 24 pages joined only by being *about Agent Wiki* — a subject, not a facet. That's centroid drift, and raising the threshold breaks the good pairs before it fixes them (at 0.65 the widest only drops 24→13 while multi-page clusters fall 26→15). The designed answer is the partition step in naming, which splits a mixed cluster — but that's an assumption I'd rather test than assert.

## Also here

`app/ingest/clustering.py` — the vector helpers extracted from `entity_types` now that this is a second consumer, so neither module imports the other's privates. No behaviour change to entity-type derivation.

## Tests

16 new: the key includes name+description and excludes state/kind/entities; similar needs across pages group; a single-page cluster isn't a failure; **unavailable embeddings return `None` rather than singletons** (otherwise "no embeddings" is indistinguishable from "nothing is shared"); clusters order by reach; the same input clusters the same way twice; disabled pages are excluded; plus the helpers.

Mutation-verified. `ruff check` and basedpyright clean, full suite green.

Split from the policy-filter work, which is now its own PR and independent of this.