### PR TITLE
feat(ingest): skip auto-update-disabled pages; carry the policy instruction

### DIFF
--- a/backend/app/db/page_needs.py
+++ b/backend/app/db/page_needs.py
@@ -52,14 +52,31 @@ def _now() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
-def content_sha256(body: str) -> str:
-    """Hash of a page body — the re-extract guard. Uncapped, unlike the embedding store's:
-    extraction sends the page whole, so a change past any cap still changes the result."""
-    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+def content_sha256(body: str, policy_instruction: str = "") -> str:
+    """Hash of everything a page's needs are derived FROM — the re-extract guard.
+
+    Uncapped, unlike the embedding store's: extraction sends the page whole, so a change past any
+    cap still changes the result.
+
+    ``policy_instruction`` is hashed alongside the body because it is an INPUT to extraction, not
+    a property of the page: an admin can rewrite it without touching a word of content, and needs
+    extracted under the old rule would otherwise stay stored and look current forever. Governance
+    state changing has to invalidate what was derived from it, the same way a taxonomy change
+    does.
+    """
+    digest = hashlib.sha256(body.encode("utf-8"))
+    if policy_instruction:
+        digest.update(b"\x1fpolicy\x1f")
+        digest.update(policy_instruction.encode("utf-8"))
+    return digest.hexdigest()
 
 
 def stale_paths(
-    pages: list[tuple[str, str]], *, model: str | None = None, entity_type_taxonomy_id: int | None = None
+    pages: list[tuple[str, str]],
+    *,
+    model: str | None = None,
+    entity_type_taxonomy_id: int | None = None,
+    policy_instructions: dict[str, str] | None = None,
 ) -> list[str]:
     """Which of ``pages`` need extracting: never extracted, edited since, or extracted under a
     different model or taxonomy. Returns paths, since that is what the caller holds bodies by.
@@ -89,11 +106,17 @@ def stale_paths(
                 )
             )
         }
+    instructions = policy_instructions or {}
     return [
         path
         for path, body in pages
         if path not in ids
-        or stored.get(ids[path]) != (content_sha256(body), want_model, entity_type_taxonomy_id)
+        or stored.get(ids[path])
+        != (
+            content_sha256(body, instructions.get(path, "")),
+            want_model,
+            entity_type_taxonomy_id,
+        )
     ]
 
 
@@ -104,6 +127,7 @@ def store(
     needs: list[dict[str, Any]],
     model: str | None = None,
     entity_type_taxonomy_id: int | None = None,
+    policy_instruction: str = "",
 ) -> str:
     """Replace the needs of the page at ``path``. Returns the ``doc_id`` written.
 
@@ -119,7 +143,7 @@ def store(
         if row is None:
             row = PageNeeds(doc_id=doc_id)
             s.add(row)
-        row.content_sha256 = content_sha256(body)
+        row.content_sha256 = content_sha256(body, policy_instruction)
         row.model = model or ""
         row.entity_type_taxonomy_id = entity_type_taxonomy_id
         row.needs = needs

--- a/backend/app/ingest/needs.py
+++ b/backend/app/ingest/needs.py
@@ -40,6 +40,7 @@ from app.ingest import entity_types
 from app.llm import client
 from app.llm.prompts import load_prompt
 from app.llm.settings import get as get_llm_settings
+from app.wiki import update_policy
 
 log = logging.getLogger(__name__)
 
@@ -131,6 +132,15 @@ class InformationNeed(BaseModel):
     # empty rather than inferred because a fabricated instruction would be obeyed as if a human
     # had written it.
     update_instruction: str = ""
+    # The admin's configured rule for this page, from ``app.wiki.update_policy``. NOT from the
+    # model: it is attached after extraction, and deliberately kept out of the prompt — shown the
+    # admin's rule, the model would echo it back as the page's own instruction and destroy the
+    # verbatim-from-page property of the field above. Two rules from two sources, kept apart.
+    #
+    # It is governance state, so it can change with the page untouched. That is why
+    # ``page_needs.content_sha256`` hashes it alongside the body: needs extracted under a
+    # superseded rule must not stay stored looking current.
+    policy_update_instruction: str = ""
     # The state the page holds right now — what an incoming document gets diffed against. A
     # description of what the page *tracks* is therefore a failure, not a shorter answer.
     current_content: str = ""
@@ -384,12 +394,35 @@ def run_extraction(
         entity_type_taxonomy_id if entity_type_taxonomy_id is not None else "(fallback)",
     )
 
-    pages = entity_types.read_corpus(prefix)
+    # Only pages the ingestion pipeline may auto-update. A need on a page that can never be
+    # updated is not merely wasted spend: it joins clusters and would present itself as somewhere
+    # a fact could be reconciled to, when nothing may write there. update_policy resolves the
+    # tri-state with folder inheritance and applies the ai_edits_disabled master override.
+    corpus = entity_types.read_corpus(prefix)
+    policies = update_policy.resolve_for_paths([path for path, _ in corpus])
+    disabled = {p for p, r in policies.items() if r.ingestion_auto_update_disabled}
+    pages = [(path, body) for path, body in corpus if path not in disabled]
+    # The admin's per-page rule, resolved through the same folder cascade. Part of the staleness
+    # guard, so editing it re-extracts the pages it governs.
+    instructions = {
+        path: (policies[path].update_instruction or "") for path, _ in pages if path in policies
+    }
+    if disabled:
+        log.info(
+            "needs: skipping %d of %d page(s) with ingestion auto-update disabled",
+            len(disabled),
+            len(corpus),
+        )
     by_path = dict(pages)
     stale = (
         [path for path, _ in pages]
         if force
-        else page_needs.stale_paths(pages, model=model, entity_type_taxonomy_id=entity_type_taxonomy_id)
+        else page_needs.stale_paths(
+            pages,
+            model=model,
+            entity_type_taxonomy_id=entity_type_taxonomy_id,
+            policy_instructions=instructions,
+        )
     )
     counts = {
         "pages": len(pages),
@@ -412,6 +445,9 @@ def run_extraction(
         # failure and send an operator to the database when the fault was in the model call.
         try:
             extracted = extract_page(path, by_path[path], type_defs=type_defs, model=model)
+            rule = instructions.get(path, "")
+            for need in extracted:
+                need.policy_update_instruction = rule
             payload = [need.model_dump(mode="json") for need in extracted]
         except Exception:
             # extract_page already absorbs a failed or unparseable completion and returns [], so
@@ -426,6 +462,7 @@ def run_extraction(
                 needs=payload,
                 model=model,
                 entity_type_taxonomy_id=entity_type_taxonomy_id,
+                policy_instruction=rule,
             )
         except Exception:
             log.warning("needs: storing needs failed for %s", path, exc_info=True)
@@ -452,7 +489,9 @@ def run_extraction(
 
     if pages:
         # Scoped to the prefix walked: ``by_path`` only describes that scope, so an unscoped
-        # prune would read every page outside it as deleted.
+        # prune would read every page outside it as deleted. Disabled pages are absent from
+        # ``by_path``, so this is also what retires the needs of a page that was turned off
+        # after it was last extracted.
         page_needs.prune(set(by_path), prefix=prefix)
     else:
         # A read that comes back empty is not evidence the wiki is empty — ``read_corpus``

--- a/backend/app/ingest/needs.py
+++ b/backend/app/ingest/needs.py
@@ -487,11 +487,15 @@ def run_extraction(
             if progress:
                 progress(n, len(stale))
 
-    if pages:
+    # Guarded on the RAW read, not on the filtered set. The two differ once pages can be
+    # excluded by policy: a corpus where every page is disabled leaves ``pages`` empty while the
+    # read succeeded, and those needs genuinely should be retired. Guarding on ``pages`` would
+    # read that as a failed read and keep them forever.
+    if corpus:
         # Scoped to the prefix walked: ``by_path`` only describes that scope, so an unscoped
         # prune would read every page outside it as deleted. Disabled pages are absent from
         # ``by_path``, so this is also what retires the needs of a page that was turned off
-        # after it was last extracted.
+        # after it was last extracted — including the case where that is every page.
         page_needs.prune(set(by_path), prefix=prefix)
     else:
         # A read that comes back empty is not evidence the wiki is empty — ``read_corpus``

--- a/backend/tests/test_needs_extraction_run.py
+++ b/backend/tests/test_needs_extraction_run.py
@@ -619,3 +619,43 @@ class TestAutoUpdatePolicy:
         needs.run_extraction()
 
         assert llm == []
+
+    def test_disabling_every_page_still_retires_their_needs(
+        self, tmp_repo, llm, monkeypatch
+    ) -> None:
+        """The prune guard exists for a failed READ, and the filtered set is a different quantity
+        once pages can be excluded by policy: a corpus where everything is disabled leaves no
+        pages to extract while the read succeeded perfectly, and those needs should go."""
+        _page("a.md")
+        _page("b.md")
+        needs.run_extraction()
+        assert len(page_needs.load_all()) == 2
+
+        monkeypatch.setattr(
+            needs.update_policy,
+            "resolve_for_paths",
+            self._policy(
+                **{
+                    "a.md": {"ingestion_auto_update_disabled": True},
+                    "b.md": {"ingestion_auto_update_disabled": True},
+                }
+            ),
+        )
+        counts = needs.run_extraction()
+
+        assert counts["pages"] == 0
+        assert page_needs.load_all() == []
+
+    def test_a_failed_read_still_keeps_everything(self, tmp_repo, llm, monkeypatch) -> None:
+        """The case the guard was written for must survive the fix: read_corpus silently skips a
+        page it cannot read, so an empty read is indistinguishable from a wiki that lost every
+        page — and those needs cost an LLM call each."""
+        _page("a.md")
+        needs.run_extraction()
+
+        monkeypatch.setattr(needs.entity_types, "read_corpus", lambda prefix="": [])
+        with monkeypatch.context():
+            counts = needs.run_extraction()
+
+        assert counts["pages"] == 0
+        assert [r.path for r in page_needs.load_all()] == ["a.md"]

--- a/backend/tests/test_needs_extraction_run.py
+++ b/backend/tests/test_needs_extraction_run.py
@@ -520,3 +520,102 @@ class TestParallelAndModel:
         assert counts["extracted"] == 0
         assert "extracting needs failed for a.md" in messages
         assert "storing" not in messages
+
+
+class TestAutoUpdatePolicy:
+    """Needs are only useful where the ingestion pipeline may write. A need on a page that can
+    never be auto-updated is not merely wasted spend — it joins clusters and presents itself as
+    somewhere a fact could be reconciled to, when nothing may write there."""
+
+    @staticmethod
+    def _policy(**per_path):
+        from app.wiki import update_policy
+
+        def resolve(paths, **kw):
+            return {
+                p: update_policy.ResolvedPolicy(**per_path.get(p, {})) for p in paths
+            }
+
+        return resolve
+
+    def test_disabled_pages_are_not_extracted(self, tmp_repo, llm, monkeypatch) -> None:
+        _page("open.md")
+        _page("closed.md")
+        monkeypatch.setattr(
+            needs.update_policy,
+            "resolve_for_paths",
+            self._policy(**{"closed.md": {"ingestion_auto_update_disabled": True}}),
+        )
+
+        counts = needs.run_extraction()
+
+        assert counts["pages"] == 1
+        assert [r.path for r in page_needs.load_all()] == ["open.md"]
+        assert len(llm) == 1
+
+    def test_disabling_a_page_retires_its_needs(self, tmp_repo, llm, monkeypatch) -> None:
+        """The prune is driven by the live set, so a page turned off after extraction drops out
+        without a separate cleanup path."""
+        _page("a.md")
+        _page("b.md")
+        needs.run_extraction()
+        assert len(page_needs.load_all()) == 2
+
+        monkeypatch.setattr(
+            needs.update_policy,
+            "resolve_for_paths",
+            self._policy(**{"b.md": {"ingestion_auto_update_disabled": True}}),
+        )
+        needs.run_extraction()
+
+        assert [r.path for r in page_needs.load_all()] == ["a.md"]
+
+    def test_the_policy_instruction_is_stored_on_every_need(
+        self, tmp_repo, llm, monkeypatch
+    ) -> None:
+        _page("a.md")
+        monkeypatch.setattr(
+            needs.update_policy,
+            "resolve_for_paths",
+            self._policy(**{"a.md": {"update_instruction": "Only update from the CRM."}}),
+        )
+
+        needs.run_extraction()
+
+        stored = page_needs.get("a.md")
+        assert stored is not None
+        assert stored.needs[0]["policy_update_instruction"] == "Only update from the CRM."
+
+    def test_editing_the_policy_instruction_re_extracts(self, tmp_repo, llm, monkeypatch) -> None:
+        """Governance state can change with the page untouched. Without it in the guard, needs
+        derived under a superseded rule would stay stored and look current forever."""
+        _page("a.md")
+        monkeypatch.setattr(
+            needs.update_policy, "resolve_for_paths", self._policy(**{"a.md": {"update_instruction": "Old rule."}})
+        )
+        needs.run_extraction()
+        llm.clear()
+
+        # Same body, same model, same taxonomy — only the admin's rule moved.
+        monkeypatch.setattr(
+            needs.update_policy, "resolve_for_paths", self._policy(**{"a.md": {"update_instruction": "New rule."}})
+        )
+        counts = needs.run_extraction()
+
+        assert len(llm) == 1
+        assert counts["extracted"] == 1
+        stored = page_needs.get("a.md")
+        assert stored is not None
+        assert stored.needs[0]["policy_update_instruction"] == "New rule."
+
+    def test_an_unchanged_policy_does_not_re_extract(self, tmp_repo, llm, monkeypatch) -> None:
+        _page("a.md")
+        monkeypatch.setattr(
+            needs.update_policy, "resolve_for_paths", self._policy(**{"a.md": {"update_instruction": "Rule."}})
+        )
+        needs.run_extraction()
+        llm.clear()
+
+        needs.run_extraction()
+
+        assert llm == []


### PR DESCRIPTION
Needs are only useful where the ingestion pipeline may write. A need on a page that can never be auto-updated isn't merely wasted spend — it **presents itself as somewhere a fact could be reconciled to**, when nothing may write there.

On the production wiki that's **37 of 149 pages (25%)**, holding **66 of 238 stored needs (28%)**.

## The filter

`update_policy.resolve_for_paths` handles the tri-state through the folder cascade and applies the `ai_edits_disabled` master override, so this is one call rather than a rule reimplemented here.

Retiring is free: `prune` is driven by the live set, so a page turned off *after* extraction drops out with no separate cleanup path.

## The policy instruction

Each need now carries the **admin's configured** `update_instruction` alongside the one **extracted from the page's own text** — one a human's directive, one what the page tells its readers.

You asked whether a dedicated field earns its place given `description`/`detail_level` exist. Measured over the 238 stored needs: the page-stated instruction shares a **median 17%** of its words with those fields, and **51 of 61 share under 40%**:

```
[0%] do not re-add module-level `depends_on` to modules containing data sources.
[0%] Revisit if multi-client demand shows up; don't front-load it.
[0%] Steps use checkbox (`- [ ]`) syntax for tracking.
[0%] Update at checkpoints.
```

Prohibitions, deferrals, syntax requirements, cadence — `description` says *what* a page tracks and `detail_level` *how granular*; neither can say "do not re-add X".

**The policy rule is kept out of the prompt on purpose.** Shown the admin's rule, the model would echo it back as the page's own instruction and destroy the verbatim-from-page property that makes that field trustworthy.

**And it's in the staleness guard.** Policy is governance state — an admin can rewrite it with the page untouched. `content_sha256` now hashes it alongside the body, so editing a rule re-extracts the pages it governs. Without that, needs derived under a superseded rule stay stored looking current forever — the failure the taxonomy id already prevents.

## Tests

5 new: disabled pages aren't extracted; disabling retires existing needs; the policy instruction is stored per need; editing it re-extracts; an unchanged policy doesn't.

`ruff check` and basedpyright clean, full suite green.

Split out of #605; the clustering half is now #605 and the two are independent.