### PR TITLE
feat(health): queues describe themselves for the admin status page

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -36,6 +36,8 @@ def _build() -> HealthResponse:
             error = str(e)
         queues.append(QueueHealth(
             name=name,
+            label=queue.label or name,
+            description=queue.description,
             ready=ready,
             delayed=delayed,
             in_flight=in_flight,

--- a/backend/app/models/health.py
+++ b/backend/app/models/health.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel
 
 class QueueHealth(BaseModel):
     name: str
+    # Human name + what a backlog on this queue means for a person, from
+    # the queue's own definition (``app/tasks/queues.py``).
+    label: str
+    description: str
     # Per-state breakdown. ``ready`` is what a worker can pick up right
     # now; ``delayed`` is messages scheduled for a future fire time
     # (``schedule(..., eta=...)``); ``in_flight`` is currently held by a

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -265,6 +265,12 @@ class TaskQueue(BaseModel):
 
     name: str
     max_size: int
+    # Display metadata for the admin health page — defined beside each
+    # queue in ``queues.py`` so a new queue carries its own label and
+    # backlog meaning, rather than a frontend map that drifts. ``label``
+    # falls back to ``name`` at the API boundary when unset.
+    label: str = ""
+    description: str = ""
     immediate: bool = False
     handlers: dict[str, Callable[..., Any]] = Field(default_factory=dict)
     periodic: list[_PeriodicEntry] = Field(default_factory=list)

--- a/backend/app/tasks/queue.py
+++ b/backend/app/tasks/queue.py
@@ -265,10 +265,9 @@ class TaskQueue(BaseModel):
 
     name: str
     max_size: int
-    # Display metadata for the admin health page — defined beside each
-    # queue in ``queues.py`` so a new queue carries its own label and
-    # backlog meaning, rather than a frontend map that drifts. ``label``
-    # falls back to ``name`` at the API boundary when unset.
+    # Display metadata for the admin health page, defined beside each queue
+    # in ``queues.py``. ``label`` falls back to ``name`` at the API boundary
+    # when unset.
     label: str = ""
     description: str = ""
     immediate: bool = False

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -109,16 +109,53 @@ __all__ = [
 ]
 
 
-def _make(name: str) -> TaskQueue:
-    return TaskQueue(name=name, max_size=CONFIG.max_queue_size)
+def _make(name: str, label: str, description: str) -> TaskQueue:
+    return TaskQueue(
+        name=name,
+        label=label,
+        description=description,
+        max_size=CONFIG.max_queue_size,
+    )
 
 
-documents_queue = _make("documents")
-triggers_queue = _make("triggers")
-coedit_queue = _make("coedit")
-automanage_offline_queue = _make("automanage_offline")
-automanage_nearline_queue = _make("automanage_nearline")
-lightweight_maintenance_queue = _make("lightweight_maintenance")
+# The label says what the work is; the description says what a backlog
+# means for a person — that pair is what the admin health page renders.
+documents_queue = _make(
+    "documents",
+    "Document updates",
+    "AI reconciliation of ingested source changes into wiki pages. "
+    "A backlog means the wiki lags its sources.",
+)
+triggers_queue = _make(
+    "triggers",
+    "Watcher evaluations",
+    "Page watchers and scheduled triggers. A backlog means late "
+    "notifications.",
+)
+coedit_queue = _make(
+    "coedit",
+    "Editor saves",
+    "Live editing sessions checkpointing to git. A backlog means edits "
+    "stay uncommitted a little longer; nothing is lost.",
+)
+automanage_offline_queue = _make(
+    "automanage_offline",
+    "Auto Organize sweeps",
+    "Background housekeeping scans that propose cleanups. A backlog "
+    "here is harmless.",
+)
+automanage_nearline_queue = _make(
+    "automanage_nearline",
+    "Auto Organize approvals",
+    "Applies proposals a person just approved. A backlog keeps someone "
+    "waiting.",
+)
+lightweight_maintenance_queue = _make(
+    "lightweight_maintenance",
+    "Indexing & cleanup",
+    "Search reindexing and small upkeep. A backlog means stale search "
+    "results.",
+)
 
 # Map queue-name → instance, used by run_worker.py to launch the right
 # consumer per worker container.

--- a/backend/app/tasks/queues.py
+++ b/backend/app/tasks/queues.py
@@ -123,14 +123,15 @@ def _make(name: str, label: str, description: str) -> TaskQueue:
 documents_queue = _make(
     "documents",
     "Document updates",
-    "AI reconciliation of ingested source changes into wiki pages. "
-    "A backlog means the wiki lags its sources.",
+    "AI edits to wiki pages — reconciling ingested source changes and "
+    "applying direct agent edits. A backlog means the wiki lags its "
+    "sources and AI edits land late.",
 )
 triggers_queue = _make(
     "triggers",
     "Watcher evaluations",
-    "Page watchers and scheduled triggers. A backlog means late "
-    "notifications.",
+    "Page watchers, scheduled triggers, and Onyx Craft launches. A "
+    "backlog means late notifications and slow Craft starts.",
 )
 coedit_queue = _make(
     "coedit",
@@ -141,8 +142,9 @@ coedit_queue = _make(
 automanage_offline_queue = _make(
     "automanage_offline",
     "Auto Organize sweeps",
-    "Background housekeeping scans that propose cleanups. A backlog "
-    "here is harmless.",
+    "Unattended batch work: housekeeping sweeps, their AI-approved "
+    "auto-applies, and taxonomy derivation. Nobody is actively "
+    "waiting, but automatic changes land late while it backs up.",
 )
 automanage_nearline_queue = _make(
     "automanage_nearline",
@@ -153,7 +155,8 @@ automanage_nearline_queue = _make(
 lightweight_maintenance_queue = _make(
     "lightweight_maintenance",
     "Indexing & cleanup",
-    "Search reindexing and small upkeep. A backlog means stale search "
+    "Search reindexing and other fast upkeep (expiries, media sweeps, "
+    "session cleanup). A backlog most visibly means stale search "
     "results.",
 )
 

--- a/backend/tests/test_health_api.py
+++ b/backend/tests/test_health_api.py
@@ -33,4 +33,16 @@ def test_health_response_shape(client):
     assert isinstance(body["queues"], list)
     assert len(body["queues"]) > 0
     for q in body["queues"]:
-        assert {"name", "ready", "delayed", "in_flight", "limit", "ok", "error"} <= set(q)
+        assert {
+            "name",
+            "label",
+            "description",
+            "ready",
+            "delayed",
+            "in_flight",
+            "limit",
+            "ok",
+            "error",
+        } <= set(q)
+        assert q["label"], f"queue {q['name']} has no label"
+        assert q["description"], f"queue {q['name']} has no description"


### PR DESCRIPTION
The admin Status page labels queues from a frontend map that has drifted: it has three entries, so the three queues added since (`coedit`, `automanage_offline`, `automanage_nearline`) render as raw internal ids.

This moves the display contract to the source: `TaskQueue` gains `label` and `description` fields, each queue defines its own beside its registration in `app/tasks/queues.py` (the description says what a backlog means for a person — "a human is waiting" vs "harmless"), and `GET /health` serves them per queue. A future queue can't silently regress the page: the health test asserts every queue ships a non-empty label and description.

Additive response change — the current frontend ignores the new fields. The frontend PR that renders them follows separately.

Labels shipped: Document updates / Watcher evaluations / Editor saves / Auto Organize sweeps / Auto Organize approvals / Indexing & cleanup.