### PR TITLE
feat(health): render served queue labels and backlog descriptions

### DIFF
--- a/frontend/src/app/admin/health/page.tsx
+++ b/frontend/src/app/admin/health/page.tsx
@@ -10,12 +10,6 @@ import { useIsMobile } from "@/lib/viewport";
 
 const POLL_MS = 5000;
 
-const QUEUE_LABELS: Record<string, string> = {
-  documents: "Document update processing",
-  triggers: "Trigger evaluations",
-  lightweight_maintenance: "Lightweight maintenance",
-};
-
 export default function AdminHealthPage() {
   const isMobile = useIsMobile();
   const {
@@ -110,9 +104,14 @@ export default function AdminHealthPage() {
                   key={q.name}
                   className="mb-[10px] rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) px-4 py-[14px]"
                 >
-                  <div className="mb-2 flex items-baseline justify-between">
-                    <div className="text-sm">
-                      {QUEUE_LABELS[q.name] ?? q.name}
+                  <div className="mb-2 flex items-baseline justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-sm">{q.label || q.name}</div>
+                      {q.description && (
+                        <div className="mt-[2px] text-[11px] text-(--text-03)">
+                          {q.description}
+                        </div>
+                      )}
                     </div>
                     <div className="text-xs text-(--text-04)">
                       {haveCounts && pending != null ? (
@@ -141,8 +140,8 @@ export default function AdminHealthPage() {
                   </div>
                   {haveCounts && (
                     <div className="flex gap-4 text-[11px] text-(--text-03)">
-                      <span>
-                        ready{" "}
+                      <span title="Tasks a worker can pick up right now.">
+                        waiting{" "}
                         <strong className="text-(--text-05)">{q.ready}</strong>
                       </span>
                       <span title="Tasks scheduled for a future run time — waiting their turn, not stuck.">
@@ -151,8 +150,8 @@ export default function AdminHealthPage() {
                           {q.delayed}
                         </strong>
                       </span>
-                      <span>
-                        in flight{" "}
+                      <span title="Tasks a worker is running right now.">
+                        running{" "}
                         <strong className="text-(--text-05)">
                           {q.in_flight}
                         </strong>

--- a/frontend/src/lib/health.ts
+++ b/frontend/src/lib/health.ts
@@ -4,9 +4,9 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 
 export interface QueueHealth {
   name: string;
-  // Human name + what a backlog means, served from the queue's own
-  // definition (backend `app/tasks/queues.py`). Optional so this page
-  // renders against a backend that predates them.
+  // Human name and what a backlog means, served from the queue's own
+  // definition (backend `app/tasks/queues.py`). Optional: callers fall
+  // back to the queue name when the metadata is unavailable.
   label?: string;
   description?: string;
   // Per-state breakdown. `ready` is what a worker can pick up right now;

--- a/frontend/src/lib/health.ts
+++ b/frontend/src/lib/health.ts
@@ -4,6 +4,11 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 
 export interface QueueHealth {
   name: string;
+  // Human name + what a backlog means, served from the queue's own
+  // definition (backend `app/tasks/queues.py`). Optional so this page
+  // renders against a backend that predates them.
+  label?: string;
+  description?: string;
   // Per-state breakdown. `ready` is what a worker can pick up right now;
   // `delayed` is scheduled for a future fire time; `in_flight` is held
   // by a worker. `ready + delayed` is the figure the cap gates on. All


### PR DESCRIPTION
Frontend half of #608. The Status page's queue cards now render the label and what-a-backlog-means line each queue serves about itself, replacing the local `QUEUE_LABELS` map that had drifted (three entries; `coedit` and both `automanage` queues rendered as raw ids). Stat wording becomes person-first: `waiting / scheduled / running` (with title tooltips) instead of `ready / scheduled / in flight`.

The new response fields are optional in the client type and the card falls back to the queue name, so this renders correctly against a backend that predates #608 — deploy order doesn't matter.
<img width="414" height="940" alt="Screenshot 2026-08-04 at 1 27 15 PM" src="https://github.com/user-attachments/assets/01e2c62e-d78f-4880-8cb1-b0a801406e2a" />

