### PR TITLE
fix(wiki): applied changes reach every open view

### DIFF
--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -71,6 +71,18 @@ function displayPath(path: string, budget = 28): string {
   return head ? `${head}/…/${leaf}` : `…/${leaf}`;
 }
 
+/** The reason clause of a backend summary — the text after the " — " that
+ * follows the quoted path (`Remove “x.md” — still identical to …`). The
+ * first closing quote ends the path, so a quote inside the reason itself
+ * doesn't confuse the split; summaries with no quoted path fall back to
+ * the first separator. Null when the summary carries no reason. */
+function proposalReason(summary: string): string | null {
+  const afterPath = summary.indexOf("”");
+  const i = summary.indexOf(" — ", afterPath >= 0 ? afterPath : 0);
+  if (i < 0) return null;
+  return summary.slice(i + 3).trim() || null;
+}
+
 /** Short, path-free row title — the folder tag right under it already
  * shows the path, so repeating it here (the backend summary quotes it in
  * full) only forced long rows to overflow. Unknown ops fall back to the
@@ -141,6 +153,12 @@ export function SuggestionsCard({
   const [outcomes, setOutcomes] = useState<Partial<Record<number, Outcome>>>(
     {},
   );
+  // Rows the local user acted on, kept rendered until their outcome has
+  // been shown — the proposals list now revalidates in the background
+  // (another reviewer's action must reach this screen), and an acted row
+  // leaves `pending` server-side immediately, so without this copy the
+  // refresh would yank the row before its "Applied ✓" was ever visible.
+  const [acted, setActed] = useState<Partial<Record<number, Proposal>>>({});
   const alive = useRef(true);
   useEffect(() => {
     alive.current = true;
@@ -159,8 +177,14 @@ export function SuggestionsCard({
       if (!alive.current) return;
       try {
         const fresh = await fetchProposal(id);
-        if (fresh.status === "applied") return setOutcome(id, "applied");
-        if (fresh.status === "stale") return setOutcome(id, "stale");
+        if (fresh.status === "applied") {
+          setOutcome(id, "applied");
+          return fadeActed(id);
+        }
+        if (fresh.status === "stale") {
+          setOutcome(id, "stale");
+          return fadeActed(id);
+        }
       } catch {
         // transient failure (or the row was purged) — keep polling
       }
@@ -170,7 +194,28 @@ export function SuggestionsCard({
     if (alive.current) void refresh();
   }
 
+  // Terminal outcomes linger briefly so the human sees the result, then
+  // the local copy drops; the background revalidation has removed the row
+  // from the server list by then.
+  function fadeActed(id: number) {
+    setTimeout(() => {
+      if (!alive.current) return;
+      setActed((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      setOutcomes((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+    }, 4000);
+  }
+
   async function act(id: number, kind: "approve" | "reject") {
+    const row = proposals.find((x) => x.id === id);
+    if (row) setActed((prev) => ({ ...prev, [id]: row }));
     setOutcome(id, "working");
     try {
       if (kind === "approve") {
@@ -179,6 +224,7 @@ export function SuggestionsCard({
       } else {
         await rejectProposal(id);
         setOutcome(id, "rejected");
+        fadeActed(id);
       }
     } catch (e) {
       if (!alive.current) return;
@@ -192,12 +238,22 @@ export function SuggestionsCard({
           delete next[id];
           return next;
         });
+        setActed((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
         void refresh();
         return;
       }
       setOutcome(id, "error");
     }
   }
+
+  const actedOnly = Object.values(acted).filter(
+    (a): a is Proposal => !!a && !proposals.some((p) => p.id === a.id),
+  );
+  const rows = [...proposals, ...actedOnly];
 
   const pendingIds = proposals
     .filter((p) => {
@@ -216,8 +272,8 @@ export function SuggestionsCard({
   // Once every row is handled, leave the outcomes visible briefly, then
   // refresh so the settled rows drop out (they have left `pending`).
   const allHandled =
-    proposals.length > 0 &&
-    proposals.every((p) => {
+    rows.length > 0 &&
+    rows.every((p) => {
       const o = outcomes[p.id];
       return !!o && HANDLED.has(o);
     });
@@ -229,8 +285,8 @@ export function SuggestionsCard({
     return () => clearTimeout(t);
   }, [allHandled, refresh]);
 
-  if (proposals.length === 0) return null;
-  const n = proposals.length;
+  if (rows.length === 0) return null;
+  const n = rows.length;
 
   return (
     <Section
@@ -274,7 +330,7 @@ export function SuggestionsCard({
       </Section>
       {open && (
         <Section gap={0.25} height="fit" alignItems="stretch" className="mt-1">
-          {proposals.map((p) => (
+          {rows.map((p) => (
             <SuggestionRow
               key={p.id}
               proposal={p}
@@ -426,11 +482,22 @@ function SuggestionRow({
           title={proposal.summary}
         >
           <Text font="main-ui-action" color="text-04">
-            {opTitle(
-              proposal.op,
-              proposal.source_paths[0] ?? "",
-              proposal.summary,
-            )}
+            {/* The reason rides the visible title — the "why" is what the
+                approve decision needs, and hover-only detail never reaches
+                keyboard or touch users. Long reasons wrap; nothing here
+                truncates. */}
+            {(() => {
+              const title = opTitle(
+                proposal.op,
+                proposal.source_paths[0] ?? "",
+                proposal.summary,
+              );
+              const reason =
+                title === proposal.summary
+                  ? null
+                  : proposalReason(proposal.summary);
+              return reason ? `${title} — ${reason}` : title;
+            })()}
           </Text>
         </span>
         <span className="block w-full min-w-0">

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -27,6 +27,7 @@ import {
 import type { IconFunctionComponent } from "@onyx-ai/opal/types";
 import { SvgFolderDashed, SvgSlashCircle } from "@/components/wiki/icons";
 import { pathKind } from "@/lib/wiki/utils";
+import { revalidateWiki } from "@/lib/wikiHref";
 
 import { ApiError } from "@/lib/api";
 import { useAuth } from "@/lib/auth";
@@ -179,6 +180,10 @@ export function SuggestionsCard({
         const fresh = await fetchProposal(id);
         if (fresh.status === "applied") {
           setOutcome(id, "applied");
+          // The change just landed in the wiki (a move, a deletion): the
+          // tree and listings this tab shows are now wrong — refresh them
+          // rather than waiting out their poll interval.
+          void revalidateWiki();
           return fadeActed(id);
         }
         if (fresh.status === "stale") {
@@ -249,6 +254,23 @@ export function SuggestionsCard({
       setOutcome(id, "error");
     }
   }
+
+  // Rows that disappear from the server list without a local outcome were
+  // acted on by someone else — their change may have landed in the wiki,
+  // so the structural views deserve the same immediate refresh the acting
+  // client gives itself.
+  const prevIds = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    const ids = new Set(proposals.map((p) => p.id));
+    const vanishedElsewhere = [...prevIds.current].some(
+      (id) => !ids.has(id) && !outcomes[id],
+    );
+    prevIds.current = ids;
+    if (vanishedElsewhere) void revalidateWiki();
+    // outcomes intentionally unlisted: this reacts to the server list
+    // changing, not to local action state.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [proposals]);
 
   const actedOnly = Object.values(acted).filter(
     (a): a is Proposal => !!a && !proposals.some((p) => p.id === a.id),

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -160,6 +160,18 @@ export function SuggestionsCard({
   // leaves `pending` server-side immediately, so without this copy the
   // refresh would yank the row before its "Applied ✓" was ever visible.
   const [acted, setActed] = useState<Partial<Record<number, Proposal>>>({});
+  // Server-list ids as of the previous render — the vanished-elsewhere
+  // detector below diffs against it.
+  const prevIds = useRef<Set<number>>(new Set());
+  // All row state is per path. The card instance survives navigation (the
+  // panel stays mounted while `path` changes under it), so without this a
+  // row acted on in the previous folder would merge into the next folder's
+  // list — displayed, counted, and actionable where it doesn't belong.
+  useEffect(() => {
+    setActed({});
+    setOutcomes({});
+    prevIds.current = new Set();
+  }, [path]);
   const alive = useRef(true);
   useEffect(() => {
     alive.current = true;
@@ -259,7 +271,6 @@ export function SuggestionsCard({
   // acted on by someone else — their change may have landed in the wiki,
   // so the structural views deserve the same immediate refresh the acting
   // client gives itself.
-  const prevIds = useRef<Set<number>>(new Set());
   useEffect(() => {
     const ids = new Set(proposals.map((p) => p.id));
     const vanishedElsewhere = [...prevIds.current].some(

--- a/frontend/src/components/wiki/SuggestionsCard.tsx
+++ b/frontend/src/components/wiki/SuggestionsCard.tsx
@@ -127,14 +127,12 @@ interface SuggestionsCardProps {
    * stay pending (mock annotation). */
   onClose?: () => void;
   /** Row click, with the proposal's source paths (mock: highlight folder). */
-  onHighlight?: (paths: string[]) => void;
 }
 
 export function SuggestionsCard({
   path,
   onOpenPanel,
   onClose,
-  onHighlight,
 }: SuggestionsCardProps) {
   const router = useRouter();
   const { user } = useAuth();
@@ -283,9 +281,14 @@ export function SuggestionsCard({
               outcome={outcomes[p.id]}
               onApprove={() => void act(p.id, "approve")}
               onDismiss={() => void act(p.id, "reject")}
-              onClick={
-                onHighlight ? () => onHighlight(p.source_paths) : undefined
-              }
+              // Click opens the affected page/folder — the proposal may
+              // target something nested well below the current view, and
+              // inspecting a page is how you decide on its proposal. The
+              // path URL redirects to the canonical id URL.
+              onClick={() => {
+                const target = p.source_paths[0] ?? p.target_paths[0];
+                if (target) router.push(`/app/wiki/${target}`);
+              }}
             />
           ))}
           <Section

--- a/frontend/src/components/wiki/WikiTree.tsx
+++ b/frontend/src/components/wiki/WikiTree.tsx
@@ -316,7 +316,11 @@ export function WikiTree() {
   const router = useRouter();
   const { toggleTree } = useLeftPanel();
   const actions = useRowActions();
-  const { data } = useSWR<{ entries: Entry[] }>("/wiki");
+  // Same key + polling rationale as useWikiTree: the sidebar must track
+  // changes other people/agents make while this tab stays focused.
+  const { data } = useSWR<{ entries: Entry[] }>("/wiki", {
+    refreshInterval: 60_000,
+  });
   const entries = data?.entries ?? [];
 
   const [query, setQuery] = useState("");

--- a/frontend/src/lib/autoOrganize.ts
+++ b/frontend/src/lib/autoOrganize.ts
@@ -102,11 +102,17 @@ export interface Proposal {
 export function useProposalsByPath(path: string, enabled = true) {
   const { data, error, isLoading, mutate } = useSWR<{ proposals: Proposal[] }>(
     enabled ? SWR_KEYS.automanageProposals(path) : null,
-    // Don't auto-revalidate on focus/reconnect: an acted-on proposal leaves
-    // `pending`, so a background revalidation would drop its row and cancel the
-    // in-flight applied/went-stale poll. The banner refreshes explicitly (via
-    // `refresh`) once a row has shown its outcome.
-    { revalidateOnFocus: false, revalidateOnReconnect: false },
+    // Background revalidation is what lets another reviewer's approve/reject
+    // reach every open view of the path — without it the card only ever
+    // changed for the person acting. Consumers that show per-row outcomes
+    // keep a local copy of acted rows (see SuggestionsCard), so a
+    // revalidation dropping a just-acted row from this list cannot yank it
+    // off screen mid-outcome.
+    {
+      refreshInterval: 30_000,
+      revalidateOnFocus: true,
+      revalidateOnReconnect: true,
+    },
   );
   return {
     proposals: data?.proposals ?? [],

--- a/frontend/src/lib/wiki/hooks.ts
+++ b/frontend/src/lib/wiki/hooks.ts
@@ -57,10 +57,18 @@ export async function saveUpdatePolicy(
 }
 
 /** The full flat wiki listing — backs the folder Explorer and the New Doc
- * destination picker. */
+ * destination picker.
+ *
+ * Polled: the listing changes under a focused tab all the time — agents
+ * write, ingestion lands, a colleague approves a proposal — and focus
+ * revalidation only helps the tab being returned to. A minute is fresh
+ * enough for structure (page bodies are live through the co-edit session),
+ * and proposal applies additionally force an immediate refresh
+ * (SuggestionsCard). */
 export function useWikiTree() {
   const { data, error, isLoading, mutate } = useSWR<ListResponse>(
     SWR_KEYS.wikiTree,
+    { refreshInterval: 60_000 },
   );
   return { entries: data?.entries ?? [], error, isLoading, mutate };
 }

--- a/frontend/src/views/wiki/WikiPage.tsx
+++ b/frontend/src/views/wiki/WikiPage.tsx
@@ -460,26 +460,6 @@ function Explorer({ dir }: ExplorerProps) {
   }, [dir]);
   // Mock annotation "Click to highlight folder": flash the listing row for
   // the proposal's first path segment under this folder.
-  const highlightPath = useCallback(
-    (paths: string[]) => {
-      const target = paths.find((x) => x.startsWith(dir ? dir + "/" : ""));
-      if (!target) return;
-      const rel = dir ? target.slice(dir.length + 1) : target;
-      const childPath = (dir ? dir + "/" : "") + rel.split("/")[0];
-      const el = document.querySelector(
-        `[data-wiki-row="${CSS.escape(childPath)}"]`,
-      );
-      if (!el) return;
-      el.scrollIntoView({ block: "center", behavior: "smooth" });
-      el.classList.add("wiki-row-flash");
-      el.addEventListener(
-        "animationend",
-        () => el.classList.remove("wiki-row-flash"),
-        { once: true },
-      );
-    },
-    [dir],
-  );
 
   const headerActions = (
     <>
@@ -832,7 +812,6 @@ function Explorer({ dir }: ExplorerProps) {
                   // Wrapped: the prop is wired to onClick, so a bare reference
                   // would pass the MouseEvent as the opts argument.
                   onOpenPanel={() => openSidePanel()}
-                  onHighlight={highlightPath}
                 />
               )}
             </Section>
@@ -861,9 +840,7 @@ function Explorer({ dir }: ExplorerProps) {
                   onInstructionEditorOpened={clearInstructionEditorRequest}
                 />
                 {/* Not at root — a wiki-wide review is the admin queue's job. */}
-                {dir && (
-                  <SuggestionsCard path={dir} onHighlight={highlightPath} />
-                )}
+                {dir && <SuggestionsCard path={dir} />}
               </div>
             ) : (
               <div


### PR DESCRIPTION
## Recovery note

#607 was merged while its last two commits were still in flight — the squash
contains only the first two. This PR carries the orphaned pair verbatim
(cherry-picked from the closed branch) plus the new staleness fix:

1. **Row click navigates to the affected page/folder** (was `3fadc40a`) — a
   proposal can target something nested below the current view, and deciding
   on a proposal usually starts with looking at the thing.
2. **Background revalidation + reason in the title** (was `af126385`) — the
   proposals list refreshes every 30s and on focus so another reviewer's
   action reaches open views (acted rows kept locally so outcomes stay
   visible), and the summary's reason clause rides the row title, wrapping
   over lines.

## New: applied changes reach every open view

The reported staleness: someone applies a change and a colleague's focused tab
never updates — tree and listings only revalidated on focus. Three layers:

- the shared `/wiki` listing **polls every 60s** (structure changes constantly
  under focused tabs — agents, ingestion, colleagues; page bodies are already
  live via the co-edit session, so structure was the gap);
- **the actor refreshes instantly**: an "applied" outcome triggers
  `revalidateWiki()` the moment it lands;
- **viewers follow within the proposals poll**: proposals vanishing without
  local action (someone else acted) trigger the same refresh.

`tsc`, prettier, editor Vitest suite green. Live-verified on a local stack.

@nikolas-garza same surface as #602/#607.