### PR TITLE
refactor(editor): move slash-menu view into extensions/, break import cycle

### DIFF
--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -4,10 +4,6 @@
  * CodeMirror/OT-era editor, deleted once this cutover lands). */
 import { posToDOMRect, type Editor } from "@tiptap/core";
 import { EditorContent, useEditor } from "@tiptap/react";
-import type {
-  SuggestionKeyDownProps,
-  SuggestionProps,
-} from "@tiptap/suggestion";
 import {
   useEffect,
   useImperativeHandle,
@@ -18,9 +14,7 @@ import {
 } from "react";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
-import { LineItemButton } from "@onyx-ai/opal/components";
 import { tiptapExtensions } from "@/lib/editor/extensions";
-import type { CommandItem } from "@/lib/editor/extensions/types";
 import {
   commentHighlights as commentHighlightPlugin,
   sourceHighlights as sourceHighlightPlugin,
@@ -461,72 +455,6 @@ export function CoeditPresenceBar({
                 : "viewing"}
           </span>
         </span>
-      ))}
-    </div>
-  );
-}
-
-export interface CommandMenuHandle {
-  onKeyDown: (props: SuggestionKeyDownProps) => boolean;
-}
-export type CommandMenuProps = {
-  ref?: Ref<CommandMenuHandle>;
-} & SuggestionProps<CommandItem>;
-export function CommandMenu({ ref, items, command }: CommandMenuProps) {
-  const [selected, setSelected] = useState(0);
-  useEffect(() => setSelected(0), [items]);
-
-  const select = (index: number) => {
-    const item = items[index];
-    if (item) command(item);
-  };
-
-  useImperativeHandle(ref, () => ({
-    onKeyDown: ({ event }) => {
-      if (event.key === "ArrowDown") {
-        setSelected((s) => (items.length ? (s + 1) % items.length : 0));
-        return true;
-      }
-      if (event.key === "ArrowUp") {
-        setSelected((s) =>
-          items.length ? (s - 1 + items.length) % items.length : 0,
-        );
-        return true;
-      }
-      if (event.key === "Enter") {
-        select(selected);
-        return true;
-      }
-      return false;
-    },
-  }));
-
-  if (items.length === 0) return null;
-
-  return (
-    <div className="max-h-[320px] w-[220px] overflow-y-auto rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-1 shadow-[0px_2px_6px_var(--shadow-02),0px_0px_2px_var(--shadow-01)]">
-      {items.map((item, i) => (
-        // The wrapper carries the keyboard-selection highlight rather than
-        // relying on LineItemButton's own "selected" state, which is a hover-
-        // weight tint — too quiet for the thing Enter is about to apply. A
-        // solid fill and nothing else, as Notion's menu does it.
-        <div
-          key={item.title}
-          className={
-            i === selected
-              ? "rounded-(--radius-06) bg-(--background-tint-03)"
-              : undefined
-          }
-        >
-          <LineItemButton
-            title={item.title}
-            icon={item.icon}
-            sizePreset="main-ui"
-            variant="section"
-            state={i === selected ? "selected" : "empty"}
-            onClick={() => select(i)}
-          />
-        </div>
       ))}
     </div>
   );

--- a/frontend/src/lib/editor/extensions/commandMenu.ts
+++ b/frontend/src/lib/editor/extensions/commandMenu.ts
@@ -8,8 +8,8 @@
  * confirmed against the installed package's own documented API.
  *
  * The command set and its filtering live here; the menu UI (`CommandMenu`) is
- * a plain React component in `components.tsx` (which keeps this a JSX-free
- * `.ts` extension), and the shared `CommandItem` type is in `./types`.
+ * a plain React component in the sibling `./components.tsx` (which keeps this a
+ * JSX-free `.ts` extension), and the shared `CommandItem` type is in `./types`.
  *
  * Table isn't offered here: there's no "insert a blank table" flow (the
  * backend's opaque-row table shape has no per-cell editing to seed —
@@ -35,7 +35,7 @@ import {
 import {
   CommandMenu as CommandMenuComponent,
   type CommandMenuHandle,
-} from "@/lib/editor/components";
+} from "@/lib/editor/extensions/components";
 import {
   canUploadImages,
   promptImageUpload,

--- a/frontend/src/lib/editor/extensions/components.tsx
+++ b/frontend/src/lib/editor/extensions/components.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/** The slash-command menu's UI — the React component the `commandMenu`
+ * extension renders through `@tiptap/react`'s `ReactRenderer`. It lives here,
+ * beside its extension, rather than in the editor's shared `components.tsx`:
+ * it's an implementation detail of the slash command (typed by `CommandItem`,
+ * rendered only by that extension's `Suggestion` plugin), not a shared shell
+ * component. Keeping it in `extensions/` is also what stops `extensions/` from
+ * importing back into the editor shell — the edge that closed a circular
+ * dependency (`components.tsx → extensions/index → extensions/commandMenu →
+ * components.tsx`). */
+import { useEffect, useImperativeHandle, useState, type Ref } from "react";
+import type {
+  SuggestionKeyDownProps,
+  SuggestionProps,
+} from "@tiptap/suggestion";
+import { LineItemButton } from "@onyx-ai/opal/components";
+import type { CommandItem } from "@/lib/editor/extensions/types";
+
+export interface CommandMenuHandle {
+  onKeyDown: (props: SuggestionKeyDownProps) => boolean;
+}
+export type CommandMenuProps = {
+  ref?: Ref<CommandMenuHandle>;
+} & SuggestionProps<CommandItem>;
+export function CommandMenu({ ref, items, command }: CommandMenuProps) {
+  const [selected, setSelected] = useState(0);
+  useEffect(() => setSelected(0), [items]);
+
+  const select = (index: number) => {
+    const item = items[index];
+    if (item) command(item);
+  };
+
+  useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === "ArrowDown") {
+        setSelected((s) => (items.length ? (s + 1) % items.length : 0));
+        return true;
+      }
+      if (event.key === "ArrowUp") {
+        setSelected((s) =>
+          items.length ? (s - 1 + items.length) % items.length : 0,
+        );
+        return true;
+      }
+      if (event.key === "Enter") {
+        select(selected);
+        return true;
+      }
+      return false;
+    },
+  }));
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="max-h-[320px] w-[220px] overflow-y-auto rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-00) p-1 shadow-[0px_2px_6px_var(--shadow-02),0px_0px_2px_var(--shadow-01)]">
+      {items.map((item, i) => (
+        // The wrapper carries the keyboard-selection highlight rather than
+        // relying on LineItemButton's own "selected" state, which is a hover-
+        // weight tint — too quiet for the thing Enter is about to apply. A
+        // solid fill and nothing else, as Notion's menu does it.
+        <div
+          key={item.title}
+          className={
+            i === selected
+              ? "rounded-(--radius-06) bg-(--background-tint-03)"
+              : undefined
+          }
+        >
+          <LineItemButton
+            title={item.title}
+            icon={item.icon}
+            sizePreset="main-ui"
+            variant="section"
+            state={i === selected ? "selected" : "empty"}
+            onClick={() => select(i)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Removes the one circular dependency in `src/lib/editor/`.

The slash-command menu's UI component (`CommandMenu`) lived in the editor's
shared `components.tsx`, so `extensions/commandMenu.ts` imported it back — the
edge that closed a cycle:

```
components.tsx → extensions/index.ts → extensions/commandMenu.ts → components.tsx
```

That menu view isn't a shared shell component (like `TipTapEditor` /
`CoeditPresenceBar`) — it's an implementation detail of the slash-command
extension: typed by `CommandItem`, rendered only by that extension's
`Suggestion` plugin via `ReactRenderer`, used nowhere else. So it moves beside
its extension into a new **`extensions/components.tsx`**, and `commandMenu.ts`
imports the sibling instead of the editor shell.

Result: **no `extensions/` file imports `components.tsx` anymore**, so the
cycle is gone. `commandMenu.ts` stays a JSX-free `.ts` extension, and
`components.tsx` also sheds its now-unused `CommandItem`/`@tiptap/suggestion`/
`LineItemButton` imports.

## Test plan

- `madge --circular --ts-config tsconfig.json src/lib/editor` → **No circular
  dependency found** (was 1 before this change).
- `tsc` + `vitest` + prettier pass in pre-commit.
- Slash menu (`/`) still opens/filters/navigates/inserts — the extension
  renders the relocated `CommandMenu` component via `ReactRenderer` exactly as
  before (import path only).