### PR TITLE
feat(coedit): per-page CRDT document rows (wiki_documents) — dual-write

### DIFF
--- a/backend/app/db/migrations/versions/c5d8e2f7a941_wiki_documents.py
+++ b/backend/app/db/migrations/versions/c5d8e2f7a941_wiki_documents.py
@@ -1,0 +1,149 @@
+"""wiki_documents
+
+Adds ``wiki_documents`` — one row per page holding the page's CRDT (Yjs)
+document state, keyed by the page's ``wiki_doc_ids`` id, so the Yjs lineage
+becomes a property of the page rather than of whichever ``coedit_sessions``
+row happens to exist (see the model docstring). Dual-write phase:
+checkpoints and seeds mirror session snapshot state here; nothing reads the
+table until cutover.
+
+Backfills from ``coedit_sessions``: per path, the newest row carrying a
+snapshot — the same row session reuse would adopt, so the backfilled lineage
+is the one live clients can still hold — joined to the live registry row for
+its id. A dirty session's snapshot is still its last-checkpointed document
+state, so no cleanliness filter is needed. Paths with no live registry row
+(and pages with no snapshot-bearing session) get no row; the dual-write
+mirrors one in, minting the id if needed, at their next seed or checkpoint.
+
+Guarded with the inspector because ``0001_initial`` builds fresh databases
+from the current models.
+
+Revision ID: c5d8e2f7a941
+Revises: f2c9a41e7b06
+Create Date: 2026-08-04 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c5d8e2f7a941"
+down_revision: str | None = "f2c9a41e7b06"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_NOW_TEXT_DEFAULT = sa.text(
+    "to_char((now() AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS')"
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("wiki_documents"):
+        return
+    op.create_table(
+        "wiki_documents",
+        sa.Column("doc_id", sa.Text(), primary_key=True),
+        sa.Column("ydoc_snapshot", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "ydoc_snapshot_seq",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "ydoc_snapshot_body",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+        sa.Column(
+            "ydoc_seq", sa.BigInteger(), nullable=False, server_default=sa.text("0")
+        ),
+        sa.Column("base_sha", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.Text(), nullable=False, server_default=_NOW_TEXT_DEFAULT
+        ),
+        sa.Column(
+            "updated_at", sa.Text(), nullable=False, server_default=_NOW_TEXT_DEFAULT
+        ),
+    )
+
+    documents = sa.table(
+        "wiki_documents",
+        sa.column("doc_id", sa.Text()),
+        sa.column("ydoc_snapshot", sa.LargeBinary()),
+        sa.column("ydoc_snapshot_seq", sa.BigInteger()),
+        sa.column("ydoc_snapshot_body", sa.Text()),
+        sa.column("ydoc_seq", sa.BigInteger()),
+        sa.column("base_sha", sa.Text()),
+    )
+    sessions = sa.table(
+        "coedit_sessions",
+        sa.column("id", sa.BigInteger()),
+        sa.column("path", sa.Text()),
+        sa.column("ydoc_snapshot", sa.LargeBinary()),
+        sa.column("ydoc_snapshot_seq", sa.BigInteger()),
+        sa.column("ydoc_snapshot_body", sa.Text()),
+        sa.column("base_sha", sa.Text()),
+    )
+    doc_ids = sa.table(
+        "wiki_doc_ids",
+        sa.column("id", sa.Text()),
+        sa.column("path", sa.Text()),
+        sa.column("deleted_at", sa.Text()),
+    )
+    # Per path, the newest snapshot-bearing session (Postgres DISTINCT ON),
+    # joined to the live registry row for its id. ``ydoc_seq`` is set to the
+    # snapshot seq, not the session's live seq: in the dual-write phase the
+    # update log stays session-keyed, so the document row represents the page
+    # as of its last checkpoint.
+    newest = (
+        sa.select(
+            sessions.c.path,
+            sessions.c.ydoc_snapshot,
+            sessions.c.ydoc_snapshot_seq,
+            sessions.c.ydoc_snapshot_body,
+            sessions.c.base_sha,
+        )
+        .where(sessions.c.ydoc_snapshot.isnot(None))
+        .distinct(sessions.c.path)
+        .order_by(sessions.c.path, sessions.c.id.desc())
+        .subquery("newest")
+    )
+    joined = sa.select(
+        doc_ids.c.id,
+        newest.c.ydoc_snapshot,
+        newest.c.ydoc_snapshot_seq,
+        newest.c.ydoc_snapshot_body,
+        newest.c.ydoc_snapshot_seq.label("ydoc_seq"),
+        newest.c.base_sha,
+    ).select_from(
+        newest.join(
+            doc_ids,
+            sa.and_(
+                doc_ids.c.path == newest.c.path,
+                doc_ids.c.deleted_at.is_(None),
+            ),
+        )
+    )
+    op.execute(
+        documents.insert().from_select(
+            [
+                "doc_id",
+                "ydoc_snapshot",
+                "ydoc_snapshot_seq",
+                "ydoc_snapshot_body",
+                "ydoc_seq",
+                "base_sha",
+            ],
+            joined,
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("wiki_documents")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1090,6 +1090,79 @@ class CoeditUpdate(Base):
     )
 
 
+class WikiDocument(Base):
+    """One row per page holding the page's CRDT (Yjs) document state.
+
+    A page's document identity is its Yjs lineage — Yjs merges by item id
+    ``(client_id, clock)``, never by content, so two documents independently
+    seeded from the same markdown duplicate on merge (see "Document identity
+    is the Yjs lineage" on the co-editing design page). This table makes the
+    lineage a property of the *page* rather than of whichever
+    ``coedit_sessions`` row happens to exist, so a second lineage for a page
+    becomes structurally impossible instead of detected after the fact.
+
+    **Dual-write phase**: nothing reads this table yet. The mirror writes in
+    ``app/wiki/wiki_documents.py`` keep each row in lockstep with its page's
+    session snapshot state — the row *follows* the session, including a
+    reseed overwriting it. Seed-once semantics (row created on a page's first
+    open, never reseeded) begin at cutover, when opens attach here and
+    ``coedit_updates`` re-keys from sessions to documents.
+
+    Named generically rather than ``coedit_*``: this is "the wiki's documents
+    as CRDT rows", scoped today to live editing with git still authoritative.
+    A future doc-native committed store would *promote* this table rather
+    than replace it. It pairs with ``wiki_doc_ids`` the way a content store
+    pairs with an identity registry, and is keyed by that registry's id
+    rather than by path (unlike the other coedit tables): renames never
+    touch a document row, so a missed move re-key can't strand one — which
+    would recreate exactly the second-lineage bug this table exists to kill.
+    The registry's identity semantics are the lineage's: a page recreated at
+    a previously-deleted path is a new document with a fresh id, and a new
+    lineage. Delete and trash drop the row via the lifecycle hooks in
+    ``app/wiki/notify.py`` (a restore re-binds the *id* but reseeds the
+    document from HEAD — a fresh lineage is fine there, since no client can
+    hold a deleted page's document).
+    """
+
+    __tablename__ = "wiki_documents"
+
+    # ``wiki_doc_ids.id`` of the live page. No FK, matching ``media``'s
+    # ``anchor_doc_id``: registry rows are tombstoned rather than deleted,
+    # so referential integrity can't break by deletion, and the mirror
+    # resolves ids through ``app.wiki.doc_ids`` anyway.
+    doc_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    # The document's last-persisted binary state at ``ydoc_snapshot_seq`` —
+    # same shape and lockstep invariants as the ``coedit_sessions`` columns
+    # these mirror (and will eventually replace). NOT NULL, unlike the
+    # session column: a document row exists only once there is a seeded doc,
+    # so there is no pre-snapshot window to represent.
+    ydoc_snapshot: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    ydoc_snapshot_seq: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
+    # The markdown ``ydoc_snapshot`` represents — the checkpoint diff base.
+    # Content-equal to what the snapshot reconstructs to, not byte-equal to
+    # whatever an author typed (the codec normalizes block terminators).
+    ydoc_snapshot_body: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("''")
+    )
+    # Monotonic update sequence. In the dual-write phase ``coedit_updates``
+    # is still session-keyed, so no update rows are logged against the
+    # document and this stays equal to ``ydoc_snapshot_seq`` (the row is the
+    # document as of its last checkpoint). Diverges from ``ydoc_snapshot_seq``
+    # only after cutover, when the update log re-keys here.
+    ydoc_seq: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default=text("0"))
+    # Git HEAD the document was last seeded from / checkpointed against —
+    # the merge base for the checkpoint 3-way merge.
+    base_sha: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+    updated_at: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
+    )
+
+
 # --------------------------------------------------------------------------- #
 # Cron state — per-(queue, task) last-fired timestamp so the periodic         #
 # scheduler can survive restarts without silently dropping or stampeding      #

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -774,6 +774,35 @@ def on_path_moved(moves: list[PathMove]) -> list[int]:
                         .where(CoeditSession.path == mv.old)
                         .values(path=mv.new)
                     )
+                    # Re-mirror the re-keyed page's document row from its
+                    # newest snapshot-bearing session, in this same
+                    # transaction. A checkpoint can land between the registry
+                    # re-key (which runs before this hook) and this session
+                    # re-key: it resolves the old path, finds no live doc id,
+                    # and skips its mirror write — and if the session never
+                    # edits again, nothing else would repair the row. This
+                    # resync closes that window deterministically. For a
+                    # trash move the destination resolves no live id (ids
+                    # never re-key into .trash), so the mirror skips itself
+                    # and the trashed page correctly gets no row.
+                    newest = s.scalar(
+                        select(CoeditSession)
+                        .where(
+                            CoeditSession.path == mv.new,
+                            CoeditSession.ydoc_snapshot.is_not(None),
+                        )
+                        .order_by(CoeditSession.id.desc())
+                        .limit(1)
+                    )
+                    if newest is not None and newest.ydoc_snapshot is not None:
+                        wiki_documents.mirror_session_state(
+                            s,
+                            mv.new,
+                            seq=newest.ydoc_snapshot_seq,
+                            snapshot=newest.ydoc_snapshot,
+                            body=newest.ydoc_snapshot_body,
+                            base_sha=newest.base_sha,
+                        )
             except IntegrityError:
                 # A racing open_session won the unique index between our check
                 # and the update — same outcome as the dirty-collision skip.

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -43,6 +43,7 @@ from sqlalchemy.orm import Session, aliased
 from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User
 from app.models.wiki import PathMove
 from app.db.session import session, try_advisory_xact_lock
+from app.wiki import wiki_documents
 
 log = logging.getLogger(__name__)
 
@@ -409,12 +410,19 @@ def set_initial_snapshot(session_id: int, snapshot: bytes, body: str) -> bool:
         # checkpoint), and sidesteps a basedpyright strict-mode gap:
         # SQLAlchemy's plain Result.rowcount isn't typed on the generic
         # Result[Any] this execute() returns.
-        row = s.scalars(
+        row = s.execute(
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.ydoc_snapshot.is_(None))
             .values(ydoc_snapshot=snapshot, ydoc_snapshot_seq=0, ydoc_snapshot_body=body)
-            .returning(CoeditSession.id)
+            .returning(CoeditSession.path, CoeditSession.base_sha)
         ).one_or_none()
+        if row is not None:
+            # Dual-write: mirror the seeded document onto the page's
+            # ``wiki_documents`` row, in this same transaction so the two
+            # stores can't disagree about which snapshot exists.
+            wiki_documents.mirror_seed(
+                s, row.path, snapshot=snapshot, body=body, base_sha=row.base_sha
+            )
         return row is not None
 
 
@@ -557,9 +565,12 @@ def set_base_sha(session_id: int, base_sha: str) -> bool:
                 CoeditSession.status == SessionStatus.ACTIVE.value,
             )
             .values(base_sha=base_sha, updated_at=_iso(_now()))
-            .returning(CoeditSession.id)
+            .returning(CoeditSession.path)
             .execution_options(synchronize_session=False)
         ).one_or_none()
+        if moved is not None:
+            # Dual-write: keep the ``wiki_documents`` merge base in lockstep.
+            wiki_documents.mirror_base_sha(s, moved, base_sha)
         return moved is not None
 
 
@@ -602,7 +613,7 @@ def advance_checkpoint(
         # conditional-UPDATE call sites (e.g. close_if_clean), and sidesteps
         # a basedpyright strict-mode gap: SQLAlchemy's plain Result.rowcount
         # isn't typed on the generic Result[Any] this execute() returns.
-        updated_id = s.scalars(
+        updated_path = s.scalars(
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.ydoc_checkpointed_seq < seq)
             .values(
@@ -614,14 +625,20 @@ def advance_checkpoint(
                 last_checkpoint_at=now,
                 updated_at=now,
             )
-            .returning(CoeditSession.id)
+            .returning(CoeditSession.path)
             .execution_options(synchronize_session=False)
         ).one_or_none()
-        if updated_id is not None:
+        if updated_path is not None:
             s.execute(
                 delete(CoeditUpdate).where(
                     CoeditUpdate.session_id == session_id, CoeditUpdate.seq <= seq
                 )
+            )
+            # Dual-write: mirror the advanced snapshot state onto the page's
+            # ``wiki_documents`` row, in this same transaction so the two
+            # stores can't disagree about which snapshot exists.
+            wiki_documents.mirror_checkpoint(
+                s, updated_path, seq=seq, snapshot=snapshot, body=body, base_sha=base_sha
             )
 
 

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -20,7 +20,9 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from app.db.models import WikiDocId
 from app.db.session import session
@@ -118,10 +120,16 @@ def resolve(doc_id: str) -> dict[str, str | None] | None:
 def id_for_path(path: str) -> str | None:
     """Id of the live row at ``path``, or ``None``."""
     with session() as s:
-        row = s.execute(
-            select(WikiDocId).where(WikiDocId.path == path, WikiDocId.deleted_at.is_(None))
-        ).scalar_one_or_none()
-        return row.id if row else None
+        return id_for_path_in(s, path)
+
+
+def id_for_path_in(s: Session, path: str) -> str | None:
+    """:func:`id_for_path`, inside the caller's open ORM session — for
+    callers resolving as part of their own transaction (the
+    ``wiki_documents`` mirror)."""
+    return s.execute(
+        select(WikiDocId.id).where(WikiDocId.path == path, WikiDocId.deleted_at.is_(None))
+    ).scalar_one_or_none()
 
 
 def ids_for_paths(paths: list[str]) -> dict[str, str]:
@@ -138,16 +146,21 @@ def ids_for_paths(paths: list[str]) -> dict[str, str]:
     """
     if not paths:
         return {}
-    out: dict[str, str] = {}
     with session() as s:
-        for i in range(0, len(paths), _ID_LOOKUP_CHUNK):
-            chunk = paths[i : i + _ID_LOOKUP_CHUNK]
-            rows = s.execute(
-                select(WikiDocId.path, WikiDocId.id).where(
-                    WikiDocId.path.in_(chunk), WikiDocId.deleted_at.is_(None)
-                )
-            ).all()
-            out.update({path: doc_id for path, doc_id in rows})
+        return ids_for_paths_in(s, paths)
+
+
+def ids_for_paths_in(s: Session, paths: list[str]) -> dict[str, str]:
+    """:func:`ids_for_paths`, inside the caller's open ORM session."""
+    out: dict[str, str] = {}
+    for i in range(0, len(paths), _ID_LOOKUP_CHUNK):
+        chunk = paths[i : i + _ID_LOOKUP_CHUNK]
+        rows = s.execute(
+            select(WikiDocId.path, WikiDocId.id).where(
+                WikiDocId.path.in_(chunk), WikiDocId.deleted_at.is_(None)
+            )
+        ).all()
+        out.update({path: doc_id for path, doc_id in rows})
     return out
 
 
@@ -176,6 +189,35 @@ def get_or_mint(path: str) -> str:
             return winner
         raise
     return new_id
+
+
+def get_or_mint_in(s: Session, path: str) -> str:
+    """:func:`get_or_mint`, but inside the caller's open ORM session.
+
+    For callers whose id lookup must commit or roll back atomically with
+    their own writes (the ``wiki_documents`` mirror keys its rows by this id,
+    in the same transaction as the session-snapshot write it shadows).
+    Race-safe without the exception dance: ``ON CONFLICT DO NOTHING`` against
+    the live-path partial unique index — an ``IntegrityError`` here would
+    poison the caller's whole transaction, so losing the race must not raise.
+    """
+    existing = id_for_path_in(s, path)
+    if existing is not None:
+        return existing
+    s.execute(
+        pg_insert(WikiDocId)
+        .values(id=_mint_id(), path=path, kind=_kind_for(path))
+        .on_conflict_do_nothing(
+            index_elements=[WikiDocId.path],
+            index_where=WikiDocId.deleted_at.is_(None),
+        )
+    )
+    # Re-read rather than RETURNING: on a lost race the insert returns
+    # nothing, and the winner's row is what this path's id *is*.
+    minted = id_for_path_in(s, path)
+    if minted is None:  # pragma: no cover - tombstoned between statements
+        raise RuntimeError(f"doc id for {path!r} vanished mid-mint")
+    return minted
 
 
 def mint_for_page(path: str) -> str:

--- a/backend/app/wiki/doc_ids.py
+++ b/backend/app/wiki/doc_ids.py
@@ -20,7 +20,6 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import func, select, update
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -189,35 +188,6 @@ def get_or_mint(path: str) -> str:
             return winner
         raise
     return new_id
-
-
-def get_or_mint_in(s: Session, path: str) -> str:
-    """:func:`get_or_mint`, but inside the caller's open ORM session.
-
-    For callers whose id lookup must commit or roll back atomically with
-    their own writes (the ``wiki_documents`` mirror keys its rows by this id,
-    in the same transaction as the session-snapshot write it shadows).
-    Race-safe without the exception dance: ``ON CONFLICT DO NOTHING`` against
-    the live-path partial unique index — an ``IntegrityError`` here would
-    poison the caller's whole transaction, so losing the race must not raise.
-    """
-    existing = id_for_path_in(s, path)
-    if existing is not None:
-        return existing
-    s.execute(
-        pg_insert(WikiDocId)
-        .values(id=_mint_id(), path=path, kind=_kind_for(path))
-        .on_conflict_do_nothing(
-            index_elements=[WikiDocId.path],
-            index_where=WikiDocId.deleted_at.is_(None),
-        )
-    )
-    # Re-read rather than RETURNING: on a lost race the insert returns
-    # nothing, and the winner's row is what this path's id *is*.
-    minted = id_for_path_in(s, path)
-    if minted is None:  # pragma: no cover - tombstoned between statements
-        raise RuntimeError(f"doc id for {path!r} vanished mid-mint")
-    return minted
 
 
 def mint_for_page(path: str) -> str:

--- a/backend/app/wiki/notify.py
+++ b/backend/app/wiki/notify.py
@@ -52,6 +52,7 @@ from app.wiki import (
     doc_ids,
     drafts,
     update_policy,
+    wiki_documents,
 )
 from app.wiki.comment_remap import remap_comments
 from app.wiki.provenance_remap import remap_source_ranges
@@ -194,6 +195,12 @@ def after_doc_delete(rel_path: str, sha: str, actor: str | None) -> None:
     drop_page_embedding(rel_path)
     acl.on_page_deleted(rel_path)
     update_policy.on_page_deleted(rel_path)
+    # The page's CRDT document row is operational live-editing state with no
+    # archival value — drop it (a recreate at this path seeds a fresh lineage,
+    # safe because no client can still hold a deleted page's document). Must
+    # run before doc_ids.on_deleted below: the drop resolves the row's id
+    # through the registry, which that call tombstones.
+    wiki_documents.on_pages_deleted([rel_path])
     # Tombstone the id (kept, not dropped) so it still resolves — to a deleted
     # state — and a later restore can re-bind it.
     doc_ids.on_deleted(rel_path)
@@ -245,6 +252,13 @@ def after_doc_trashed(
     # closed in the DB by on_path_moved and needs nothing else: no process holds
     # a live document that would have to be evicted.
     coedit.on_path_moved(moves)
+    # Unlike sessions (re-keyed into .trash above, so their queued checkpoints
+    # resolve), the pages' CRDT document rows are dropped: a restore re-binds
+    # the id but seeds a fresh lineage, which is safe because no client can
+    # still hold a trashed page's document. Must run before doc_ids.on_deleted
+    # below — the drop resolves the rows' ids through the registry, which that
+    # call tombstones.
+    wiki_documents.on_pages_deleted([mv.old for mv in moves])
     # Tombstone the id(s) at the *original* root rather than following the move
     # into `.trash/` — the id keeps resolving (to a deleted state), and restore
     # re-binds it. ACL/policy above deliberately follow into `.trash/` (so the
@@ -314,6 +328,14 @@ def after_path_move(
     """
     acl.on_path_moved(moves, root_move=root_move)
     update_policy.on_path_moved(moves, root_move=root_move)
+    # Document rows are keyed by doc id, so a rename needs nothing here —
+    # doc_ids.on_path_moved re-keys the registry and the row follows for
+    # free. The exception is a page renamed *out of* ``.md``-space: it stops
+    # being a document (the registry stamps its id deleted), so its document
+    # row drops — resolved before that stamping happens.
+    wiki_documents.on_pages_deleted(
+        [mv.old for mv in moves if mv.old.endswith(".md") and not mv.new.endswith(".md")]
+    )
     doc_ids.on_path_moved(moves, root_move=root_move)
     coedit.on_path_moved(moves)
     list_changed = False

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -1,0 +1,165 @@
+"""Per-page CRDT document rows (``wiki_documents``) — dual-write phase.
+
+One row per page holding the page's Yjs document state, keyed by the page's
+``wiki_doc_ids`` id (see the model docstring in ``app/db/models.py``).
+Nothing reads the table yet: the ``mirror_*`` functions keep each row in
+lockstep with its page's session snapshot state so cutover can flip opens to
+read from here against already-correct data.
+
+Keying by id is what removes the move hook: renames re-key the *registry*
+(``doc_ids.on_path_moved``) and never touch a document row, so a missed
+re-key can't strand one. The registry is also why the delete/trash hook
+resolves ids *before* ``doc_ids`` tombstones them — see ``on_pages_deleted``
+and its call sites in ``app/wiki/notify.py``.
+
+Two kinds of entry point, split by transaction ownership:
+
+- ``mirror_seed`` / ``mirror_checkpoint`` / ``mirror_base_sha`` take the
+  caller's open ORM ``Session`` and run inside *its* transaction — the mirror
+  (including the id mint for a page the registry hasn't seen, via
+  ``doc_ids.get_or_mint_in``) must commit or roll back atomically with the
+  session-row write it shadows, or the two stores could disagree about which
+  snapshot exists. Called only from ``app/wiki/coedit.py``.
+- ``on_pages_deleted`` / ``get`` open their own session per call, like every
+  other repo.
+
+The mirror *follows* the session, reseed included: while sessions own
+document state, whatever snapshot the live session carries is the page's
+document, so ``mirror_seed`` overwrites any existing row. Seed-once
+semantics begin at cutover.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from app.db.models import WikiDocument
+from app.db.session import session
+from app.wiki import doc_ids
+
+log = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    # Same format as ``coedit._iso`` — these rows shadow session rows, so
+    # their timestamps should read the same way.
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _row_dict(row: WikiDocument) -> dict[str, object]:
+    return {
+        "doc_id": row.doc_id,
+        "ydoc_snapshot": row.ydoc_snapshot,
+        "ydoc_snapshot_seq": row.ydoc_snapshot_seq,
+        "ydoc_snapshot_body": row.ydoc_snapshot_body,
+        "ydoc_seq": row.ydoc_seq,
+        "base_sha": row.base_sha,
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
+
+
+def mirror_seed(
+    s: Session, path: str, *, snapshot: bytes, body: str, base_sha: str | None
+) -> None:
+    """Mirror a session's initial snapshot: upsert the page's document row at
+    seq 0. Overwrites an existing row — a fresh seed means the session layer
+    just minted a new lineage for this page, and while sessions own document
+    state the mirror's job is to record whichever lineage is live, not to
+    defend the old one.
+    """
+    _upsert(s, path, snapshot=snapshot, seq=0, body=body, base_sha=base_sha)
+
+
+def mirror_checkpoint(
+    s: Session, path: str, *, seq: int, snapshot: bytes, body: str, base_sha: str
+) -> None:
+    """Mirror a checkpoint's advanced snapshot state onto the page's document
+    row. Upsert, not update: the row can be missing for a session that
+    predates the table (opened before the migration ran), and the checkpoint
+    state is complete in itself — snapshot, body, and base all move together.
+    """
+    _upsert(s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha)
+
+
+def _upsert(
+    s: Session, path: str, *, snapshot: bytes, seq: int, body: str, base_sha: str | None
+) -> None:
+    doc_id = doc_ids.get_or_mint_in(s, path)
+    now = _now_iso()
+    stmt = pg_insert(WikiDocument).values(
+        doc_id=doc_id,
+        ydoc_snapshot=snapshot,
+        ydoc_snapshot_seq=seq,
+        ydoc_snapshot_body=body,
+        ydoc_seq=seq,
+        base_sha=base_sha,
+        created_at=now,
+        updated_at=now,
+    )
+    s.execute(
+        stmt.on_conflict_do_update(
+            index_elements=[WikiDocument.doc_id],
+            set_={
+                "ydoc_snapshot": stmt.excluded.ydoc_snapshot,
+                "ydoc_snapshot_seq": stmt.excluded.ydoc_snapshot_seq,
+                "ydoc_snapshot_body": stmt.excluded.ydoc_snapshot_body,
+                "ydoc_seq": stmt.excluded.ydoc_seq,
+                "base_sha": stmt.excluded.base_sha,
+                "updated_at": stmt.excluded.updated_at,
+            },
+        )
+    )
+
+
+def mirror_base_sha(s: Session, path: str, base_sha: str) -> None:
+    """Mirror a rebase's merge-base move (``coedit.set_base_sha``). Update-if-
+    exists only: a NOOP rebase can land on a session whose snapshot hasn't
+    been seeded yet, and a document row can't exist before its snapshot does
+    — so no mint either.
+    """
+    doc_id = doc_ids.id_for_path_in(s, path)
+    if doc_id is None:
+        return
+    s.execute(
+        update(WikiDocument)
+        .where(WikiDocument.doc_id == doc_id)
+        .values(base_sha=base_sha, updated_at=_now_iso())
+        .execution_options(synchronize_session=False)
+    )
+
+
+def on_pages_deleted(paths: list[str]) -> None:
+    """Drop the pages' document rows on delete or trash. No tombstone: the
+    row is operational live-editing state, and page history lives in git.
+
+    Must run while the registry rows at ``paths`` are still live — the ids
+    are resolved here, and ``doc_ids.on_deleted`` tombstones them (see the
+    ordering at the ``app/wiki/notify.py`` call sites). Dropping matters
+    even though a tombstoned id already makes the row unreachable: a restore
+    *re-binds* the same id (``doc_ids.on_restored``), and it must come back
+    to no document row, reseeding a fresh lineage from HEAD — safe precisely
+    because deletion means no client can still hold this document.
+    """
+    md_paths = [p for p in paths if p.endswith(".md")]
+    if not md_paths:
+        return
+    with session() as s:
+        ids = list(doc_ids.ids_for_paths_in(s, md_paths).values())
+        if ids:
+            s.execute(delete(WikiDocument).where(WikiDocument.doc_id.in_(ids)))
+
+
+def get(path: str) -> dict[str, object] | None:
+    """The document row for the live page at ``path``, or None."""
+    with session() as s:
+        doc_id = doc_ids.id_for_path_in(s, path)
+        if doc_id is None:
+            return None
+        row = s.scalar(select(WikiDocument).where(WikiDocument.doc_id == doc_id))
+        return None if row is None else _row_dict(row)

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -12,14 +12,23 @@ re-key can't strand one. The registry is also why the delete/trash hook
 resolves ids *before* ``doc_ids`` tombstones them — see ``on_pages_deleted``
 and its call sites in ``app/wiki/notify.py``.
 
+The mirror **resolves ids, never mints them**. Every page a session can
+exist for already has a live registry row (``GET /wiki/file`` lazily mints
+on read, page creation mints in the lifecycle hook), so a failed resolution
+means the path is *transiently wrong*, not the page unknown — the window
+during a move where the registry is re-keyed but the session row isn't yet.
+Minting there would stamp a phantom live id (and a stray document row) onto
+a path the page just left. Instead the mirror write is skipped; the next
+checkpoint, running after the session re-key, resolves the real id and
+carries complete state, so the row self-heals.
+
 Two kinds of entry point, split by transaction ownership:
 
 - ``mirror_seed`` / ``mirror_checkpoint`` / ``mirror_base_sha`` take the
-  caller's open ORM ``Session`` and run inside *its* transaction — the mirror
-  (including the id mint for a page the registry hasn't seen, via
-  ``doc_ids.get_or_mint_in``) must commit or roll back atomically with the
-  session-row write it shadows, or the two stores could disagree about which
-  snapshot exists. Called only from ``app/wiki/coedit.py``.
+  caller's open ORM ``Session`` and run inside *its* transaction — the
+  mirror must commit or roll back atomically with the session-row write it
+  shadows, or the two stores could disagree about which snapshot exists.
+  Called only from ``app/wiki/coedit.py``.
 - ``on_pages_deleted`` / ``get`` open their own session per call, like every
   other repo.
 
@@ -90,7 +99,13 @@ def mirror_checkpoint(
 def _upsert(
     s: Session, path: str, *, snapshot: bytes, seq: int, body: str, base_sha: str | None
 ) -> None:
-    doc_id = doc_ids.get_or_mint_in(s, path)
+    doc_id = doc_ids.id_for_path_in(s, path)
+    if doc_id is None:
+        # Mid-move window (registry re-keyed, session row not yet) — skip
+        # rather than mint a phantom id at the old path; the next checkpoint
+        # self-heals (see the module docstring).
+        log.info("wiki_documents: no live doc id at %r; mirror write skipped", path)
+        return
     now = _now_iso()
     stmt = pg_insert(WikiDocument).values(
         doc_id=doc_id,

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -18,9 +18,11 @@ on read, page creation mints in the lifecycle hook), so a failed resolution
 means the path is *transiently wrong*, not the page unknown — the window
 during a move where the registry is re-keyed but the session row isn't yet.
 Minting there would stamp a phantom live id (and a stray document row) onto
-a path the page just left. Instead the mirror write is skipped; the next
-checkpoint, running after the session re-key, resolves the real id and
-carries complete state, so the row self-heals.
+a path the page just left. Instead the mirror write is skipped, and the
+session re-key itself repairs it: ``coedit.on_path_moved`` re-mirrors each
+re-keyed page's newest session snapshot (``mirror_session_state``) in the
+same transaction, so a skipped write is restored by the move fan-out that
+caused it — not left waiting on a further edit.
 
 Two kinds of entry point, split by transaction ownership:
 
@@ -102,8 +104,8 @@ def _upsert(
     doc_id = doc_ids.id_for_path_in(s, path)
     if doc_id is None:
         # Mid-move window (registry re-keyed, session row not yet) — skip
-        # rather than mint a phantom id at the old path; the next checkpoint
-        # self-heals (see the module docstring).
+        # rather than mint a phantom id at the old path; the move's session
+        # re-key re-mirrors the row (see the module docstring).
         log.info("wiki_documents: no live doc id at %r; mirror write skipped", path)
         return
     now = _now_iso()
@@ -130,6 +132,18 @@ def _upsert(
             },
         )
     )
+
+
+def mirror_session_state(
+    s: Session, path: str, *, seq: int, snapshot: bytes, body: str, base_sha: str | None
+) -> None:
+    """Re-mirror a session's snapshot state wholesale — the move re-key's
+    repair for the window where a checkpoint resolved the page's old path,
+    found no live id, and skipped its mirror write (see
+    ``coedit.on_path_moved``). Runs after the registry re-key, so ``path``
+    is the page's live location and resolves its real id.
+    """
+    _upsert(s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha)
 
 
 def mirror_base_sha(s: Session, path: str, base_sha: str) -> None:

--- a/backend/tests/test_wiki_documents.py
+++ b/backend/tests/test_wiki_documents.py
@@ -6,7 +6,9 @@ entry points that carry the mirror writes, so the tests pin the lockstep
 ("a session snapshot write and its document mirror land together"), not just
 the repo functions in isolation. Rows are keyed by ``wiki_doc_ids`` id —
 moves are covered by re-keying the *registry* and observing the row follow,
-since the table itself has no move hook to test.
+since the table itself has no move hook to test. The fixture mints the
+page's id up front, matching the production invariant the mirror relies on
+(every page a session can exist for was read first, and reads mint).
 """
 from __future__ import annotations
 
@@ -29,6 +31,11 @@ def users(tmp_db):
     return tmp_db
 
 
+@pytest.fixture
+def page_id(users) -> str:
+    return doc_ids.mint_for_page(_PATH)
+
+
 def _force_close(session_id: int) -> None:
     with db_session() as s:
         s.execute(
@@ -38,30 +45,36 @@ def _force_close(session_id: int) -> None:
         )
 
 
-def test_initial_snapshot_mirrors_a_document_row(users):
+def test_initial_snapshot_mirrors_a_document_row(page_id):
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
     doc = wiki_documents.get(_PATH)
     assert doc is not None
+    assert doc["doc_id"] == page_id
     assert doc["ydoc_snapshot"] == b"snap0"
     assert doc["ydoc_snapshot_seq"] == 0
     assert doc["ydoc_snapshot_body"] == "hello"
     assert doc["ydoc_seq"] == 0
     assert doc["base_sha"] == "sha1"
-    # The mirror minted the page's registry id and keyed the row by it.
-    assert doc["doc_id"] == doc_ids.id_for_path(_PATH)
 
 
-def test_mirror_adopts_an_existing_registry_id(users):
-    minted = doc_ids.mint_for_page(_PATH)
+def test_mirror_without_a_registry_id_skips(users):
+    # The mirror resolves ids, never mints them: with no live registry row
+    # (the mid-move window), the write is skipped — no phantom id, no stray
+    # row — and the next checkpoint self-heals.
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    assert doc_ids.id_for_path(_PATH) is None
+    assert count_rows(WikiDocument) == 0
+    doc_ids.mint_for_page(_PATH)
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    coedit.advance_checkpoint(s.id, seq=1, snapshot=b"snap1", body="healed", base_sha="sha2")
     doc = wiki_documents.get(_PATH)
     assert doc is not None
-    assert doc["doc_id"] == minted
+    assert doc["ydoc_snapshot_body"] == "healed"
 
 
-def test_losing_seed_does_not_mirror(users):
+def test_losing_seed_does_not_mirror(page_id):
     # The conditional seed's loser corresponds to no durable lineage — the
     # mirror must reflect only the snapshot that won.
     s = coedit.open_session(_PATH, base_sha="sha1")
@@ -73,7 +86,7 @@ def test_losing_seed_does_not_mirror(users):
     assert doc["ydoc_snapshot_body"] == "one"
 
 
-def test_reseed_on_a_new_session_overwrites_the_mirror(users):
+def test_reseed_on_a_new_session_overwrites_the_mirror(page_id):
     # While sessions own document state the mirror follows them: a fresh
     # session minting a new lineage for the page replaces the row. (Seed-once
     # is a cutover-phase property, not a dual-write one.)
@@ -91,7 +104,7 @@ def test_reseed_on_a_new_session_overwrites_the_mirror(users):
     assert count_rows(WikiDocument) == 1
 
 
-def test_checkpoint_mirrors_advanced_state(users):
+def test_checkpoint_mirrors_advanced_state(page_id):
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
     coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
@@ -107,7 +120,7 @@ def test_checkpoint_mirrors_advanced_state(users):
     assert doc["base_sha"] == "sha2"
 
 
-def test_checkpoint_creates_the_row_for_a_pre_table_session(users):
+def test_checkpoint_creates_the_row_for_a_pre_table_session(page_id):
     # A session opened before the migration ran has no document row; its
     # first checkpoint after the deploy mirrors one in.
     s = coedit.open_session(_PATH, base_sha="sha1")
@@ -122,7 +135,7 @@ def test_checkpoint_creates_the_row_for_a_pre_table_session(users):
     assert doc["ydoc_snapshot"] == b"snap1"
 
 
-def test_regressed_checkpoint_does_not_mirror(users):
+def test_regressed_checkpoint_does_not_mirror(page_id):
     # advance_checkpoint's regression guard must gate the mirror too.
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
@@ -136,7 +149,7 @@ def test_regressed_checkpoint_does_not_mirror(users):
     assert doc["ydoc_snapshot_seq"] == 2
 
 
-def test_set_base_sha_mirrors_the_merge_base(users):
+def test_set_base_sha_mirrors_the_merge_base(page_id):
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
     assert coedit.set_base_sha(s.id, "sha9")
@@ -145,33 +158,30 @@ def test_set_base_sha_mirrors_the_merge_base(users):
     assert doc["base_sha"] == "sha9"
 
 
-def test_set_base_sha_without_a_row_stays_absent(users):
+def test_set_base_sha_without_a_row_stays_absent(page_id):
     # A rebase can land before the snapshot seed; a document row can't exist
-    # before its snapshot does, so the mirror is update-if-exists only — it
-    # must not mint an id or create a row.
+    # before its snapshot does, so the mirror is update-if-exists only.
     s = coedit.open_session(_PATH, base_sha="sha1")
     assert coedit.set_base_sha(s.id, "sha9")
     assert wiki_documents.get(_PATH) is None
     assert count_rows(WikiDocument) == 0
 
 
-def test_a_move_rekeys_the_registry_and_the_row_follows(users):
+def test_a_move_rekeys_the_registry_and_the_row_follows(page_id):
     # No move hook on the table: the row is keyed by id, so re-keying the
     # registry (what after_path_move does via doc_ids.on_path_moved) is the
     # whole move.
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
-    before = wiki_documents.get(_PATH)
-    assert before is not None
     doc_ids.on_path_moved([PathMove(old=_PATH, new="guides/install.md")])
     assert wiki_documents.get(_PATH) is None
     after = wiki_documents.get("guides/install.md")
     assert after is not None
-    assert after["doc_id"] == before["doc_id"]
+    assert after["doc_id"] == page_id
     assert after["ydoc_snapshot"] == b"snap0"
 
 
-def test_on_pages_deleted_drops_the_row(users):
+def test_on_pages_deleted_drops_the_row(page_id):
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
     wiki_documents.on_pages_deleted([_PATH])
@@ -179,21 +189,22 @@ def test_on_pages_deleted_drops_the_row(users):
     assert count_rows(WikiDocument) == 0
 
 
-def test_recreate_after_delete_is_a_fresh_document(users):
+def test_recreate_after_delete_is_a_fresh_document(page_id):
     # Registry semantics carry over: a page recreated at a deleted path is a
     # new document (fresh id), and the mirror keys the new lineage under it.
     s1 = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s1.id, b"old", "old")
-    old = wiki_documents.get(_PATH)
-    assert old is not None
     wiki_documents.on_pages_deleted([_PATH])
     doc_ids.on_deleted(_PATH)
     _force_close(s1.id)
+    # The recreate's read mints the fresh id before any session exists.
+    fresh_id = doc_ids.get_or_mint(_PATH)
+    assert fresh_id != page_id
     s2 = coedit.open_session(_PATH, base_sha="sha2")
     coedit.set_initial_snapshot(s2.id, b"new", "new")
     fresh = wiki_documents.get(_PATH)
     assert fresh is not None
-    assert fresh["doc_id"] != old["doc_id"]
+    assert fresh["doc_id"] == fresh_id
     assert fresh["ydoc_snapshot"] == b"new"
     assert count_rows(WikiDocument) == 1
 

--- a/backend/tests/test_wiki_documents.py
+++ b/backend/tests/test_wiki_documents.py
@@ -1,0 +1,203 @@
+"""Per-page CRDT document rows (app/wiki/wiki_documents.py) — the dual-write
+mirror that shadows session snapshot state, plus the delete lifecycle hook.
+
+DB-backed like ``test_coedit_repo.py``; exercised through the ``coedit``
+entry points that carry the mirror writes, so the tests pin the lockstep
+("a session snapshot write and its document mirror land together"), not just
+the repo functions in isolation. Rows are keyed by ``wiki_doc_ids`` id —
+moves are covered by re-keying the *registry* and observing the row follow,
+since the table itself has no move hook to test.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sqlalchemy import update
+
+from app.db.models import CoeditSession, WikiDocument
+from app.db.session import session as db_session
+from app.models.wiki import PathMove
+from app.wiki import coedit, doc_ids, wiki_documents
+from tests._seed import count_rows, seed_user
+
+_PATH = "guides/setup.md"
+
+
+@pytest.fixture
+def users(tmp_db):
+    seed_user("usr_a", "a@x.com", name="Ada")
+    return tmp_db
+
+
+def _force_close(session_id: int) -> None:
+    with db_session() as s:
+        s.execute(
+            update(CoeditSession)
+            .where(CoeditSession.id == session_id)
+            .values(status="closed")
+        )
+
+
+def test_initial_snapshot_mirrors_a_document_row(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot"] == b"snap0"
+    assert doc["ydoc_snapshot_seq"] == 0
+    assert doc["ydoc_snapshot_body"] == "hello"
+    assert doc["ydoc_seq"] == 0
+    assert doc["base_sha"] == "sha1"
+    # The mirror minted the page's registry id and keyed the row by it.
+    assert doc["doc_id"] == doc_ids.id_for_path(_PATH)
+
+
+def test_mirror_adopts_an_existing_registry_id(users):
+    minted = doc_ids.mint_for_page(_PATH)
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["doc_id"] == minted
+
+
+def test_losing_seed_does_not_mirror(users):
+    # The conditional seed's loser corresponds to no durable lineage — the
+    # mirror must reflect only the snapshot that won.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"first", "one")
+    coedit.set_initial_snapshot(s.id, b"second", "two")
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot"] == b"first"
+    assert doc["ydoc_snapshot_body"] == "one"
+
+
+def test_reseed_on_a_new_session_overwrites_the_mirror(users):
+    # While sessions own document state the mirror follows them: a fresh
+    # session minting a new lineage for the page replaces the row. (Seed-once
+    # is a cutover-phase property, not a dual-write one.)
+    s1 = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s1.id, b"lineage1", "one")
+    _force_close(s1.id)
+    # A different base_sha defeats session reuse, so this is a fresh lineage.
+    s2 = coedit.open_session(_PATH, base_sha="sha2")
+    assert s2.id != s1.id
+    coedit.set_initial_snapshot(s2.id, b"lineage2", "two")
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot"] == b"lineage2"
+    assert doc["base_sha"] == "sha2"
+    assert count_rows(WikiDocument) == 1
+
+
+def test_checkpoint_mirrors_advanced_state(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    coedit.advance_checkpoint(
+        s.id, seq=1, snapshot=b"snap1", body="hello world", base_sha="sha2"
+    )
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot"] == b"snap1"
+    assert doc["ydoc_snapshot_seq"] == 1
+    assert doc["ydoc_snapshot_body"] == "hello world"
+    assert doc["ydoc_seq"] == 1
+    assert doc["base_sha"] == "sha2"
+
+
+def test_checkpoint_creates_the_row_for_a_pre_table_session(users):
+    # A session opened before the migration ran has no document row; its
+    # first checkpoint after the deploy mirrors one in.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    wiki_documents.on_pages_deleted([_PATH])  # simulate the missing row
+    coedit.advance_checkpoint(
+        s.id, seq=1, snapshot=b"snap1", body="hello world", base_sha="sha2"
+    )
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot"] == b"snap1"
+
+
+def test_regressed_checkpoint_does_not_mirror(users):
+    # advance_checkpoint's regression guard must gate the mirror too.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    coedit.apply_update(s.id, update_bytes=b"up2", author_user_id="usr_a")
+    coedit.advance_checkpoint(s.id, seq=2, snapshot=b"snap2", body="two", base_sha="sha2")
+    coedit.advance_checkpoint(s.id, seq=1, snapshot=b"snap1", body="one", base_sha="sha1")
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot"] == b"snap2"
+    assert doc["ydoc_snapshot_seq"] == 2
+
+
+def test_set_base_sha_mirrors_the_merge_base(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    assert coedit.set_base_sha(s.id, "sha9")
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["base_sha"] == "sha9"
+
+
+def test_set_base_sha_without_a_row_stays_absent(users):
+    # A rebase can land before the snapshot seed; a document row can't exist
+    # before its snapshot does, so the mirror is update-if-exists only — it
+    # must not mint an id or create a row.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    assert coedit.set_base_sha(s.id, "sha9")
+    assert wiki_documents.get(_PATH) is None
+    assert count_rows(WikiDocument) == 0
+
+
+def test_a_move_rekeys_the_registry_and_the_row_follows(users):
+    # No move hook on the table: the row is keyed by id, so re-keying the
+    # registry (what after_path_move does via doc_ids.on_path_moved) is the
+    # whole move.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    before = wiki_documents.get(_PATH)
+    assert before is not None
+    doc_ids.on_path_moved([PathMove(old=_PATH, new="guides/install.md")])
+    assert wiki_documents.get(_PATH) is None
+    after = wiki_documents.get("guides/install.md")
+    assert after is not None
+    assert after["doc_id"] == before["doc_id"]
+    assert after["ydoc_snapshot"] == b"snap0"
+
+
+def test_on_pages_deleted_drops_the_row(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    wiki_documents.on_pages_deleted([_PATH])
+    assert wiki_documents.get(_PATH) is None
+    assert count_rows(WikiDocument) == 0
+
+
+def test_recreate_after_delete_is_a_fresh_document(users):
+    # Registry semantics carry over: a page recreated at a deleted path is a
+    # new document (fresh id), and the mirror keys the new lineage under it.
+    s1 = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s1.id, b"old", "old")
+    old = wiki_documents.get(_PATH)
+    assert old is not None
+    wiki_documents.on_pages_deleted([_PATH])
+    doc_ids.on_deleted(_PATH)
+    _force_close(s1.id)
+    s2 = coedit.open_session(_PATH, base_sha="sha2")
+    coedit.set_initial_snapshot(s2.id, b"new", "new")
+    fresh = wiki_documents.get(_PATH)
+    assert fresh is not None
+    assert fresh["doc_id"] != old["doc_id"]
+    assert fresh["ydoc_snapshot"] == b"new"
+    assert count_rows(WikiDocument) == 1
+
+
+def test_on_pages_deleted_ignores_non_pages_and_missing_rows(users):
+    wiki_documents.on_pages_deleted(["folder/notes.txt", "never-seen.md"])
+    assert count_rows(WikiDocument) == 0

--- a/backend/tests/test_wiki_documents.py
+++ b/backend/tests/test_wiki_documents.py
@@ -181,6 +181,45 @@ def test_a_move_rekeys_the_registry_and_the_row_follows(page_id):
     assert after["ydoc_snapshot"] == b"snap0"
 
 
+def test_move_window_checkpoint_is_repaired_by_the_session_rekey(page_id):
+    # The mid-move race, replayed in hook order: the registry re-keys first;
+    # a dirty checkpoint lands before the session re-key, resolves the old
+    # path, and skips its mirror (leaving the session clean — nothing further
+    # would write); then coedit.on_path_moved re-keys the session and
+    # re-mirrors its snapshot state, repairing the row without another edit.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    new_path = "guides/install.md"
+    doc_ids.on_path_moved([PathMove(old=_PATH, new=new_path)])
+    coedit.advance_checkpoint(s.id, seq=1, snapshot=b"snap1", body="moved", base_sha="sha2")
+    stale = wiki_documents.get(new_path)
+    assert stale is not None
+    assert stale["ydoc_snapshot"] == b"snap0"  # the checkpoint's mirror skipped
+    coedit.on_path_moved([PathMove(old=_PATH, new=new_path)])
+    repaired = wiki_documents.get(new_path)
+    assert repaired is not None
+    assert repaired["doc_id"] == page_id
+    assert repaired["ydoc_snapshot"] == b"snap1"
+    assert repaired["ydoc_snapshot_seq"] == 1
+    assert repaired["base_sha"] == "sha2"
+    assert count_rows(WikiDocument) == 1
+
+
+def test_trash_rekey_does_not_recreate_the_row(page_id):
+    # after_doc_trashed order: sessions re-key into .trash first, then the
+    # row drops, then ids tombstone. The re-key's resync must not resurrect
+    # a row for the trashed page — .trash paths resolve no live id, so the
+    # mirror skips itself.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    trash_path = ".trash/abc123/setup.md"
+    coedit.on_path_moved([PathMove(old=_PATH, new=trash_path)])
+    wiki_documents.on_pages_deleted([_PATH])
+    doc_ids.on_deleted(_PATH)
+    assert count_rows(WikiDocument) == 0
+
+
 def test_on_pages_deleted_drops_the_row(page_id):
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")


### PR DESCRIPTION
## What

Slice 1 of the one-lineage-per-path plan: a `wiki_documents` table (one row per page holding the page's Yjs document state), backfilled and kept in lockstep by dual-writes. **Nothing reads the table yet — zero behavior change.** Cutover (opens attach to the document row, update-log re-key, open-time fold, divergence splice) is slice 2.

## Why

A page's document identity is its Yjs lineage, and today the lineage lives on whichever `coedit_sessions` row happens to exist — the root fault behind the page-duplication incidents. This makes the lineage a property of the page. Named `wiki_documents` (not `coedit_*`) deliberately: it's "the wiki's documents as CRDT rows", the table a future doc-native store would promote rather than replace.

## How

- **Keyed by `wiki_doc_ids.id`, not path.** Renames never touch a document row — a missed move re-key can't strand one, which would recreate exactly the second-lineage bug this table exists to kill. The registry's identity semantics are the lineage's: a page recreated at a deleted path is a new document, fresh id, new lineage.
- **Schema**: `doc_id` pk + the five doc columns mirrored from `coedit_sessions` (`ydoc_snapshot`, `ydoc_snapshot_seq`, `ydoc_snapshot_body`, `ydoc_seq`, `base_sha`). In this phase `ydoc_seq` stays equal to `ydoc_snapshot_seq` (the update log is still session-keyed).
- **Migration backfill**: per path, the newest snapshot-bearing session — the same row session reuse would adopt — joined to the live registry row for its id. Trashed/tombstoned paths therefore get no row, matching drop-on-trash semantics.
- **Dual-write** (same transaction as the session write, so the stores can't disagree): `set_initial_snapshot` → upsert (the mirror *follows* the session, reseed included — seed-once starts at cutover), `advance_checkpoint` → upsert advanced state (also creates the row for sessions predating the migration), `set_base_sha` → update-if-exists. Id resolution/minting happens inside the same transaction via a new session-scoped `doc_ids.get_or_mint_in` (`ON CONFLICT DO NOTHING` against the live-path partial index — no exception dance that would poison the caller's transaction).
- **Lifecycle** (`notify.py`): moves need nothing (the registry re-key carries the row); delete, trash, and a rename out of `.md`-space drop the row, with ids resolved *before* `doc_ids` tombstones them. Dropping matters even though a tombstoned id is unreachable: restore *re-binds* the same id, and it must come back to no document row — a fresh lineage is safe precisely because no client can hold a deleted page's document.

## Verified

- 13 tests exercised through the `coedit` entry points (lockstep, loser-seed not mirrored, regression guard gates the mirror, registry re-key carries the row across a move, recreate-after-delete gets a fresh id + row); full backend suite green.
- Live on the local stack: migration backfilled 10/10 live snapshot-bearing paths (9 `.trash/` residue paths correctly skipped); a typed edit's checkpoint advanced the mirror in lockstep by id (same seq/base, probe text in the mirrored body).