### PR TITLE
feat(admin): new templates default Auto Organize on

### DIFF
--- a/frontend/src/app/admin/templates/page.tsx
+++ b/frontend/src/app/admin/templates/page.tsx
@@ -258,11 +258,12 @@ function TemplateModal({
   const [updateInstruction, setUpdateInstruction] = useState(
     initial?.update_instruction ?? "",
   );
-  // Whether pages created from this template start opted into AI
-  // auto-management. Defaults to off; a template author enables it
-  // deliberately (e.g. team spaces the AI should keep organized).
+  // Whether pages created from this template start opted into Auto
+  // Organize. New templates default to on — the product encourages
+  // AI-managed pages — and a template author opts out deliberately
+  // (e.g. records that must never be reorganized).
   const [aiManagedOn, setAiManagedOn] = useState<boolean>(
-    initial?.ai_management_allowed === true,
+    initial == null ? true : initial.ai_management_allowed === true,
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
Part of making Auto Organize the encouraged default: the new-template form now starts with the Auto Organize toggle on, so pages created from new templates opt into AI management unless the template author deliberately opts out. Existing templates keep their stored value; the effective per-page value still resolves most-granular-wins through the update-policy chain, so any page/folder row overrides the template seed.

(The other half of the default is environment data, not code: an `ai_management_allowed=true` policy row on the root scope, set per environment via the update-policy API.)