### PR TITLE
feat(wiki): brand-new wikis seed the root policy defaults

### DIFF
--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -126,8 +126,13 @@ def _seed_root_policy_defaults() -> None:
 
     A visible root policy row rather than a code default, so a customer
     changes it like any folder policy and the choice sticks — this runs
-    only on the boot that seeded the wiki, never on a restored or
-    pre-existing install."""
+    only on the boot that seeds the wiki, never on a restored or
+    pre-existing install. It runs *before* the pages are written: an
+    interrupted first boot then recovers on the next one — either the
+    seed branch re-runs (the ``get("")`` guard skips the existing row) or
+    the committed pages route the boot down the pre-existing-content
+    branch with the row already durably in place. After the pages or the
+    marker, a crash could strand the wiki seeded but defaultless."""
     if update_policy.get("") is not None:
         return
     update_policy.set_policy(
@@ -166,9 +171,9 @@ def seed_if_empty(target_dir: str) -> bool:
         _stamp_seed_marker()
         return False
     log.info("seeding empty wiki at %s from %s", target_dir, SEED_SOURCE_DIR)
+    _seed_root_policy_defaults()
     written = write_seed_pages(Path(target_dir), overwrite_existing=False)
     if written > 0:
         _stamp_seed_marker()
-        _seed_root_policy_defaults()
         reindex_all_inline()
     return written > 0

--- a/backend/app/wiki/seed.py
+++ b/backend/app/wiki/seed.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from app.db.session import session
 from app.models.wiki import ChangeKind
+from app.wiki import update_policy
 from app.wiki.git import commit_file, list_paths
 from app.wiki.notify import after_doc_write
 import logging
@@ -119,6 +120,22 @@ def _stamp_seed_marker() -> None:
     log.info("wiki_seed_state marker stamped at %s", now_iso)
 
 
+def _seed_root_policy_defaults() -> None:
+    """Org-policy defaults for a brand-new wiki: the AI may organize pages
+    everywhere, and connector ingestion updates are opt-in per scope.
+
+    A visible root policy row rather than a code default, so a customer
+    changes it like any folder policy and the choice sticks — this runs
+    only on the boot that seeded the wiki, never on a restored or
+    pre-existing install."""
+    if update_policy.get("") is not None:
+        return
+    update_policy.set_policy(
+        "", ingestion_auto_update_disabled=True, ai_management_allowed=True
+    )
+    log.info("seeded root update-policy defaults (organize on, auto-update off)")
+
+
 def seed_if_empty(target_dir: str) -> bool:
     """If this DB has never been seeded, populate the wiki from the bundled seed.
 
@@ -152,5 +169,6 @@ def seed_if_empty(target_dir: str) -> bool:
     written = write_seed_pages(Path(target_dir), overwrite_existing=False)
     if written > 0:
         _stamp_seed_marker()
+        _seed_root_policy_defaults()
         reindex_all_inline()
     return written > 0

--- a/backend/tests/test_wiki_seed.py
+++ b/backend/tests/test_wiki_seed.py
@@ -45,6 +45,14 @@ def test_seed_if_empty_writes_pages_and_stamps_marker(tmp_repo):
     assert sorted(_list_md_paths()) == sorted(expected_paths)
     assert _read_marker() is not None
 
+    # A seeded wiki carries the org-policy defaults on the root scope:
+    # AI organization allowed, ingestion auto-update opt-in per scope.
+    from app.wiki import update_policy
+
+    resolved = update_policy.resolve_for_path("Any Folder/any-page.md")
+    assert resolved.ai_management_allowed is True
+    assert resolved.ingestion_auto_update_disabled is True
+
 
 def test_seed_if_empty_is_idempotent_when_marker_set(tmp_repo):
     """Second call must skip without writing anything new."""
@@ -87,6 +95,18 @@ def test_seed_does_not_run_again_after_user_wipes_wiki(tmp_repo):
 
     assert re_seeded is False
     assert _list_md_paths() == []
+
+
+def test_pre_existing_wiki_defaults_untouched(tmp_repo):
+    """A boot over pre-existing content must not install the root policy
+    defaults — an upgraded or restored deployment keeps its behavior."""
+    from app.wiki import update_policy
+    from app.wiki.git import commit_file
+    from app.wiki.seed import seed_if_empty
+
+    commit_file("existing.md", "hello", "pre-existing page")
+    assert seed_if_empty(tmp_repo.wiki_dir) is False
+    assert update_policy.get("") is None
 
 
 def test_pre_existing_wiki_content_just_stamps_marker(tmp_repo):


### PR DESCRIPTION
Makes the intended org defaults — **Auto Organize on, ingestion Auto Update off (opt-in per scope)** — hold on every new customer deployment, not just environments where someone set the root row by hand.

Mechanism: `seed_if_empty`'s did-seed branch (the one that only runs on the boot that seeds a brand-new wiki) also writes the root (`""`) update-policy row. Properties that fall out of using this seam:

- **Fresh installs only.** A boot over pre-existing content (restored volume, upgrade, migration) stamps the seed marker without touching policy — no existing deployment changes behavior on image pull. Covered by a test.
- **A visible, editable row, not a code default.** A customer who disagrees flips it in the normal Updates panel / API like any folder policy, and the choice sticks — seeding never reruns on a marked database.
- Guarded on "no root row exists", so a bootstrap that somehow raced a policy write never overwrites it.

Pairs with #617 (new-template form defaults Auto Organize on). 5/5 seed tests pass, including the new pre-existing-content guard test.