### PR TITLE
feat(coedit): bind sessions and updates to document identity

### DIFF
--- a/backend/app/db/migrations/versions/b6f3a1d8c2e7_coedit_doc_pointers.py
+++ b/backend/app/db/migrations/versions/b6f3a1d8c2e7_coedit_doc_pointers.py
@@ -1,0 +1,99 @@
+"""coedit doc pointers
+
+Binds the live-session layer to document identity, ahead of the cutover that
+moves document state to ``wiki_documents``:
+
+- ``coedit_sessions.doc_id`` — the page's ``wiki_doc_ids`` id, stamped at
+  open; backfilled here from the live registry row at each session's path.
+- ``coedit_updates.doc_id`` — the document-keyed view of the update log,
+  copied from the session's binding at write time; backfilled here from each
+  row's session. Indexed on (doc_id, seq) for the document-keyed rebuild.
+- ``wiki_documents.last_checkpoint_at`` — overdue-detection input for the
+  post-cutover checkpoint scan; starts NULL.
+
+Sessions whose path has no live registry row (trashed paths, never-read
+pages) keep a NULL ``doc_id``, as do their updates — the same resolve-only
+rule as the ``wiki_documents`` mirror.
+
+Guarded with the inspector because ``0001_initial`` builds fresh databases
+from the current models.
+
+Revision ID: b6f3a1d8c2e7
+Revises: c5d8e2f7a941
+Create Date: 2026-08-04 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b6f3a1d8c2e7"
+down_revision: str | None = "c5d8e2f7a941"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    sessions_cols = {c["name"] for c in inspector.get_columns("coedit_sessions")}
+    updates_cols = {c["name"] for c in inspector.get_columns("coedit_updates")}
+    documents_cols = {c["name"] for c in inspector.get_columns("wiki_documents")}
+
+    if "doc_id" not in sessions_cols:
+        op.add_column("coedit_sessions", sa.Column("doc_id", sa.Text(), nullable=True))
+        sessions = sa.table(
+            "coedit_sessions",
+            sa.column("path", sa.Text()),
+            sa.column("doc_id", sa.Text()),
+        )
+        doc_ids = sa.table(
+            "wiki_doc_ids",
+            sa.column("id", sa.Text()),
+            sa.column("path", sa.Text()),
+            sa.column("deleted_at", sa.Text()),
+        )
+        live_id = (
+            sa.select(doc_ids.c.id)
+            .where(
+                doc_ids.c.path == sessions.c.path,
+                doc_ids.c.deleted_at.is_(None),
+            )
+            .scalar_subquery()
+        )
+        op.execute(sessions.update().values(doc_id=live_id))
+
+    if "doc_id" not in updates_cols:
+        op.add_column("coedit_updates", sa.Column("doc_id", sa.Text(), nullable=True))
+        updates = sa.table(
+            "coedit_updates",
+            sa.column("session_id", sa.BigInteger()),
+            sa.column("doc_id", sa.Text()),
+        )
+        sessions_for_updates = sa.table(
+            "coedit_sessions",
+            sa.column("id", sa.BigInteger()),
+            sa.column("doc_id", sa.Text()),
+        )
+        session_doc = (
+            sa.select(sessions_for_updates.c.doc_id)
+            .where(sessions_for_updates.c.id == updates.c.session_id)
+            .scalar_subquery()
+        )
+        op.execute(updates.update().values(doc_id=session_doc))
+        op.create_index("idx_coedit_updates_doc_seq", "coedit_updates", ["doc_id", "seq"])
+
+    if "last_checkpoint_at" not in documents_cols:
+        op.add_column(
+            "wiki_documents", sa.Column("last_checkpoint_at", sa.Text(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("wiki_documents", "last_checkpoint_at")
+    op.drop_index("idx_coedit_updates_doc_seq", table_name="coedit_updates")
+    op.drop_column("coedit_updates", "doc_id")
+    op.drop_column("coedit_sessions", "doc_id")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -989,6 +989,14 @@ class CoeditSession(Base):
     # checkpoint 3-way merge. Null until the session is seeded from a page's
     # HEAD (or, for a brand-new page, until the first checkpoint).
     base_sha: Mapped[str | None] = mapped_column(Text)
+    # ``wiki_doc_ids.id`` of the page this session serves, stamped at open —
+    # the session's binding to the page's document identity (see
+    # ``wiki_documents``). Resolved once, so later readers don't re-resolve
+    # through the path (which can be transiently wrong mid-move). Nullable:
+    # rows predating the column, and sessions whose path had no live registry
+    # row at open (never-read pages in tests/seed scripts), carry NULL until
+    # the next open stamps them.
+    doc_id: Mapped[str | None] = mapped_column(Text)
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'active'"))
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
@@ -1078,6 +1086,15 @@ class CoeditUpdate(Base):
     # (a user with two tabs shares one user id). Nullable: non-collab writers
     # don't set it.
     client_id: Mapped[str | None] = mapped_column(Text)
+    # ``wiki_doc_ids.id`` of the page whose document this update belongs to,
+    # copied from the session's own ``doc_id`` at write time. The document-
+    # keyed view of this log: cutover re-reads updates by document rather
+    # than by session, so the lineage survives session churn. Nullable for
+    # rows written before the column (or under a NULL session ``doc_id``);
+    # ``seq`` stays session-scoped until cutover, so (doc_id, seq) is
+    # deliberately NOT unique — surviving rows from two sessions of one page
+    # can share a seq.
+    doc_id: Mapped[str | None] = mapped_column(Text)
     update_payload: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
@@ -1087,6 +1104,9 @@ class CoeditUpdate(Base):
         # One update per produced seq, in order — also the lookup for
         # "updates since seq N" catch-up.
         UniqueConstraint("session_id", "seq", name="idx_coedit_updates_session_seq"),
+        # The document-keyed catch-up/rebuild lookup ("updates for doc since
+        # seq N"), live once cutover reads this log by document.
+        Index("idx_coedit_updates_doc_seq", "doc_id", "seq"),
     )
 
 
@@ -1155,6 +1175,10 @@ class WikiDocument(Base):
     # Git HEAD the document was last seeded from / checkpointed against —
     # the merge base for the checkpoint 3-way merge.
     base_sha: Mapped[str | None] = mapped_column(Text)
+    # When the document last checkpointed to git — the overdue-detection
+    # input once the checkpoint scan reads document state (cutover). NULL for
+    # a document that has never checkpointed.
+    last_checkpoint_at: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
     )

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -43,7 +43,7 @@ from sqlalchemy.orm import Session, aliased
 from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User
 from app.models.wiki import PathMove
 from app.db.session import session, try_advisory_xact_lock
-from app.wiki import wiki_documents
+from app.wiki import doc_ids, wiki_documents
 
 log = logging.getLogger(__name__)
 
@@ -86,6 +86,7 @@ class SessionRow(BaseModel):
     ydoc_seq: int
     ydoc_checkpointed_seq: int
     base_sha: str | None
+    doc_id: str | None
     status: str
     created_at: str
     updated_at: str
@@ -120,6 +121,7 @@ def _session_row(s: CoeditSession) -> SessionRow:
         ydoc_seq=s.ydoc_seq,
         ydoc_checkpointed_seq=s.ydoc_checkpointed_seq,
         base_sha=s.base_sha,
+        doc_id=s.doc_id,
         status=s.status,
         created_at=s.created_at,
         updated_at=s.updated_at,
@@ -233,6 +235,7 @@ class CheckpointSessionRow(BaseModel):
     path: str
     status: str
     base_sha: str | None
+    doc_id: str | None
     ydoc_seq: int
     ydoc_checkpointed_seq: int
     ydoc_snapshot: bytes | None
@@ -254,6 +257,7 @@ def get_session_for_checkpoint(session_id: int) -> CheckpointSessionRow | None:
             path=row.path,
             status=row.status,
             base_sha=row.base_sha,
+            doc_id=row.doc_id,
             ydoc_seq=row.ydoc_seq,
             ydoc_checkpointed_seq=row.ydoc_checkpointed_seq,
             ydoc_snapshot=row.ydoc_snapshot,
@@ -325,18 +329,28 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
     reply a no-op and also preserves anything typed while disconnected.
     """
     with session() as s:
+        # The session's binding to the page's document identity, stamped on
+        # every open (see the ``doc_id`` column comment): fresh rows carry it
+        # from birth, and rows predating the column pick it up on their next
+        # open. Resolve-only, like the ``wiki_documents`` mirror — an open on
+        # a page the registry has never seen leaves NULL rather than minting.
+        doc_id = doc_ids.id_for_path_in(s, path)
         existing = s.scalar(
             select(CoeditSession).where(
                 CoeditSession.path == path, CoeditSession.status == SessionStatus.ACTIVE.value
             )
         )
         if existing is not None:
+            if existing.doc_id is None and doc_id is not None:
+                existing.doc_id = doc_id
             return _session_row(existing)
         now = _iso(_now())
         reusable = _reusable_closed_session(s, path, base_sha)
         if reusable is not None:
             reusable.status = SessionStatus.ACTIVE.value
             reusable.updated_at = now
+            if reusable.doc_id is None and doc_id is not None:
+                reusable.doc_id = doc_id
             try:
                 s.flush()
             except IntegrityError:
@@ -361,6 +375,7 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
             path=path,
             ydoc_seq=0,
             base_sha=base_sha,
+            doc_id=doc_id,
             status=SessionStatus.ACTIVE.value,
             created_at=now,
             updated_at=now,
@@ -494,25 +509,29 @@ def apply_update(
     """
     now = _iso(_now())
     with session() as s:
-        new_seq = s.scalars(
+        bumped = s.execute(
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.status == SessionStatus.ACTIVE.value)
             .values(ydoc_seq=CoeditSession.ydoc_seq + 1, updated_at=now)
-            .returning(CoeditSession.ydoc_seq)
+            .returning(CoeditSession.ydoc_seq, CoeditSession.doc_id)
             .execution_options(synchronize_session=False)
         ).one_or_none()
-        if new_seq is None:
+        if bumped is None:
             return None
         s.add(
             CoeditUpdate(
                 session_id=session_id,
-                seq=new_seq,
+                seq=bumped.ydoc_seq,
                 author_user_id=author_user_id,
                 client_id=client_id,
+                # The row's document-keyed identity, carried from the session's
+                # own binding rather than re-resolved through the path (which
+                # can be transiently wrong mid-move).
+                doc_id=bumped.doc_id,
                 update_payload=update_bytes,
             )
         )
-        return new_seq
+        return bumped.ydoc_seq
 
 
 def updates_since(session_id: int, after_seq: int) -> UpdatesSince:

--- a/backend/tests/test_coedit_doc_pointers.py
+++ b/backend/tests/test_coedit_doc_pointers.py
@@ -1,0 +1,83 @@
+"""The session layer's document-identity binding (``coedit_sessions.doc_id``,
+``coedit_updates.doc_id``) — stamped at open, carried onto every logged
+update. Transition plumbing for the cutover that moves document state to
+``wiki_documents``: nothing reads these pointers yet.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sqlalchemy import select, update
+
+from app.db.models import CoeditSession, CoeditUpdate
+from app.db.session import session as db_session
+from app.wiki import coedit, doc_ids
+from tests._seed import seed_user
+
+_PATH = "guides/setup.md"
+
+
+@pytest.fixture
+def users(tmp_db):
+    seed_user("usr_a", "a@x.com", name="Ada")
+    return tmp_db
+
+
+def _update_doc_ids(session_id: int) -> list[str | None]:
+    with db_session() as s:
+        return list(
+            s.scalars(
+                select(CoeditUpdate.doc_id)
+                .where(CoeditUpdate.session_id == session_id)
+                .order_by(CoeditUpdate.seq)
+            )
+        )
+
+
+def test_open_stamps_the_page_doc_id(users):
+    minted = doc_ids.mint_for_page(_PATH)
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    assert s.doc_id == minted
+
+
+def test_open_without_a_registry_row_leaves_null(users):
+    # Resolve-only, like the wiki_documents mirror: no live registry row, no
+    # mint — the binding stays NULL until an open after the page is read.
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    assert s.doc_id is None
+
+
+def test_reopen_backfills_a_null_binding(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    assert s.doc_id is None
+    minted = doc_ids.mint_for_page(_PATH)
+    again = coedit.open_session(_PATH, base_sha="sha1")
+    assert again.id == s.id
+    assert again.doc_id == minted
+
+
+def test_reactivation_backfills_a_null_binding(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    with db_session() as db:
+        db.execute(
+            update(CoeditSession).where(CoeditSession.id == s.id).values(status="closed")
+        )
+    minted = doc_ids.mint_for_page(_PATH)
+    reused = coedit.open_session(_PATH, base_sha="sha1")
+    assert reused.id == s.id  # reactivated, not fresh
+    assert reused.doc_id == minted
+
+
+def test_updates_carry_the_session_binding(users):
+    minted = doc_ids.mint_for_page(_PATH)
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    coedit.apply_update(s.id, update_bytes=b"up2", author_user_id="usr_a")
+    assert _update_doc_ids(s.id) == [minted, minted]
+
+
+def test_updates_under_a_null_binding_stay_null(users):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.apply_update(s.id, update_bytes=b"up1", author_user_id="usr_a")
+    assert _update_doc_ids(s.id) == [None]


### PR DESCRIPTION
## What

Slice 2 of the one-lineage-per-path plan, part A of two: the transition plumbing that binds the live-session layer to document identity. **Nothing reads the new pointers yet — zero behavior change.** Part B (the actual cutover: opens attach to `wiki_documents`, rebuilds/checkpoints/folds run against the document row) stacks on this.

## How

- **`coedit_sessions.doc_id`** — the page's `wiki_doc_ids` id, stamped at open (fresh rows from birth; pre-existing rows backfilled on their next open/reactivation, and by the migration). This is the session's binding to the page's document identity, resolved once — so post-cutover reads go `session.doc_id` directly instead of re-resolving through the path, which can be transiently wrong mid-move.
- **`coedit_updates.doc_id`** — the document-keyed view of the update log, copied from the session's binding inside the same `RETURNING` round-trip that assigns the seq. Backfilled from each row's session. Indexed on `(doc_id, seq)` for the document-keyed rebuild. `(doc_id, seq)` is deliberately not unique yet: `seq` stays session-scoped until cutover, so surviving rows from two sessions of one page can share a seq.
- **`wiki_documents.last_checkpoint_at`** — overdue-detection input for the post-cutover checkpoint scan; starts NULL.
- Resolve-only, same rule as the `wiki_documents` mirror: a page the registry has never seen leaves the binding NULL (trashed paths, never-read pages) rather than minting a phantom id.

## Verified

- 6 new tests (stamp at open, NULL without a registry row, reopen/reactivation backfill, updates carry the binding, NULL propagates); full backend suite + pyright green.