### PR TITLE
feat(coedit): opens attach to the page's persistent document

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -59,7 +59,8 @@ from app.models.coedit import (
     ParticipantOut,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session_task
-from app.wiki import acl, coedit, coedit_channel, coedit_live, git
+from app.tasks.coedit_rebase import rebase_coedit_session
+from app.wiki import acl, coedit, coedit_channel, coedit_live, git, wiki_documents
 from app.wiki.markdown_yjs import seed_doc_from_markdown
 
 router = APIRouter()
@@ -442,20 +443,43 @@ def _seed_snapshot_sync(session_id: int, path: str, base_sha: str | None) -> boo
     """Give a brand-new session its initial snapshot; True if the page is
     representable (or already has one).
 
-    Runs entirely in one thread hop, and that is deliberate: the ``Doc`` built
-    here is a PyO3 unsendable type, so it is created, read (``get_update``) and
-    dropped without ever leaving this call. Nothing keeps it — the snapshot
-    bytes plus the update log are the document from here on. The
-    already-seeded check belongs in here for the same reason: it keeps the
-    common case (every connection after the first) to one hop and skips the
-    git read.
+    **Attach first**: when the page has a ``wiki_documents`` row, its snapshot
+    transplants as this session's seq-0 state — a pure byte copy that carries
+    the page's one CRDT lineage across sessions, so a reconnecting client's
+    retained document syncs onto the lineage it already holds and nothing
+    duplicates (see ``coedit.transplant_snapshot``). If the document's
+    ``base_sha`` is behind the page's HEAD (out-of-band commits landed while
+    nobody had the page open), the drift is folded in as an ordinary
+    live-rebase — the same queued fold an agent commit gets mid-session, so
+    the first client may briefly see pre-fold content and then integrate the
+    delta as normal traffic.
 
-    ``set_initial_snapshot`` is conditional on ``ydoc_snapshot IS NULL``, so
-    two processes connecting at once race harmlessly: the loser's snapshot is
-    discarded and both then rebuild from the winner's, which is the same
-    lineage either way.
+    Seeding from markdown is the fallback for a page with no document row
+    (never co-edited, or its row was dropped by delete/trash). The ``Doc``
+    built for it is a PyO3 unsendable type, created, read (``get_update``)
+    and dropped without leaving this call — and the slice-1 mirror creates
+    the page's document row from this seed, so the next session transplants.
+
+    Both writes are conditional on ``ydoc_snapshot IS NULL``, so two
+    processes connecting at once race harmlessly: the loser rebuilds from the
+    winner's snapshot. The already-seeded check keeps the common case (every
+    connection after the first) to one hop.
     """
     if coedit.has_snapshot(session_id):
+        return True
+    doc_row = wiki_documents.get(path)
+    if doc_row is not None:
+        doc_snapshot = doc_row["ydoc_snapshot"]
+        doc_body = doc_row["ydoc_snapshot_body"]
+        doc_base = doc_row["base_sha"]
+        assert isinstance(doc_snapshot, bytes) and isinstance(doc_body, str)
+        assert doc_base is None or isinstance(doc_base, str)
+        coedit.transplant_snapshot(
+            session_id, snapshot=doc_snapshot, body=doc_body, base_sha=doc_base
+        )
+        head = git.head_sha_for_path(path)
+        if head is not None and doc_base != head:
+            rebase_coedit_session(session_id, head)
         return True
     body = git.read_file_opt(path, base_sha or "HEAD") or ""
     try:

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -441,6 +441,44 @@ def set_initial_snapshot(session_id: int, snapshot: bytes, body: str) -> bool:
         return row is not None
 
 
+def transplant_snapshot(
+    session_id: int, *, snapshot: bytes, body: str, base_sha: str | None
+) -> bool:
+    """Adopt the page's persistent document as this session's own seq-0 state
+    — the attach path of the one-lineage-per-page model.
+
+    A pure byte copy from the ``wiki_documents`` row (no ``Doc`` is built):
+    the transplanted snapshot *is* the page's CRDT lineage, so a client
+    reconnecting with a retained document answers the sync handshake on the
+    lineage it already holds and nothing duplicates — for every reconnect
+    shape, not just the same-``base_sha`` clean case ``open_session``'s reuse
+    rule covers. ``base_sha`` is the document's, not the opener's HEAD: it is
+    what the snapshot actually represents, and any drift between it and HEAD
+    is folded in afterwards as an ordinary live-rebase (see
+    ``_seed_snapshot_sync`` in ``app/api/coedit.py``).
+
+    Same conditionality as ``set_initial_snapshot`` (``ydoc_snapshot IS
+    NULL``), so concurrent connectors race harmlessly — and unlike a markdown
+    seed, even the loser lost nothing: both transplant the same lineage.
+
+    No mirror write here, deliberately: the ``wiki_documents`` row is the
+    *source* of this state, already current.
+    """
+    with session() as s:
+        row = s.scalars(
+            update(CoeditSession)
+            .where(CoeditSession.id == session_id, CoeditSession.ydoc_snapshot.is_(None))
+            .values(
+                ydoc_snapshot=snapshot,
+                ydoc_snapshot_seq=0,
+                ydoc_snapshot_body=body,
+                base_sha=base_sha,
+            )
+            .returning(CoeditSession.id)
+        ).one_or_none()
+        return row is not None
+
+
 class UpdateRow(BaseModel):
     """One logged Yjs update from `coedit_updates`."""
 

--- a/backend/tests/test_coedit_attach.py
+++ b/backend/tests/test_coedit_attach.py
@@ -1,0 +1,143 @@
+"""The attach path (``_seed_snapshot_sync`` + ``coedit.transplant_snapshot``)
+— a new session adopts the page's persistent document from ``wiki_documents``
+instead of seeding a fresh lineage from markdown.
+
+This is the cutover that makes a second lineage per page structurally
+impossible: the incident shape (a client retains its document, the session
+row is purged, the reconnect used to get a freshly seeded lineage and the
+retained document re-merged as a full duplicate) now converges, because the
+transplanted snapshot *is* the lineage the client holds.
+"""
+from __future__ import annotations
+
+import pytest
+
+from pycrdt import Doc, XmlFragment
+
+from app.api.coedit import _seed_snapshot_sync
+from app.db.models import CoeditSession
+from app.db.session import session as db_session
+from app.wiki import coedit, doc_ids, wiki_documents
+from app.wiki.markdown_yjs import ROOT_XML_KEY, reconstruct_body, seed_doc_from_markdown
+from tests._seed import seed_user
+
+_PATH = "guides/setup.md"
+_BODY = "# Setup\n\nInstall the thing.\n"
+
+
+@pytest.fixture
+def users(tmp_db):
+    seed_user("usr_a", "a@x.com", name="Ada")
+    return tmp_db
+
+
+def _snapshot(session_id: int) -> bytes:
+    row = coedit.get_session_for_checkpoint(session_id)
+    assert row is not None and row.ydoc_snapshot is not None
+    return row.ydoc_snapshot
+
+
+def _purge(session_id: int) -> None:
+    with db_session() as s:
+        row = s.get(CoeditSession, session_id)
+        assert row is not None
+        s.delete(row)
+
+
+def _seed_first_session(monkeypatch) -> tuple[int, bytes]:
+    """A page's first-ever session, seeded from markdown (no document row
+    exists yet); the slice-1 mirror creates the row from this seed."""
+    doc_ids.mint_for_page(_PATH)
+    monkeypatch.setattr("app.api.coedit.git.read_file_opt", lambda *_a, **_k: _BODY)
+    monkeypatch.setattr("app.api.coedit.git.head_sha_for_path", lambda *_a, **_k: "sha1")
+    s1 = coedit.open_session(_PATH, base_sha="sha1")
+    assert _seed_snapshot_sync(s1.id, _PATH, "sha1")
+    return s1.id, _snapshot(s1.id)
+
+
+def test_first_seed_creates_the_document_row(users, monkeypatch):
+    _seed_first_session(monkeypatch)
+    doc = wiki_documents.get(_PATH)
+    assert doc is not None
+    assert doc["ydoc_snapshot_body"] == _BODY
+
+
+def test_reopen_after_purge_transplants_the_lineage(users, monkeypatch):
+    s1_id, original = _seed_first_session(monkeypatch)
+    _purge(s1_id)  # the incident shape: the row reuse would need is gone
+    s2 = coedit.open_session(_PATH, base_sha="sha1")
+    assert s2.id != s1_id
+    folds: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        "app.api.coedit.rebase_coedit_session", lambda sid, sha: folds.append((sid, sha))
+    )
+    assert _seed_snapshot_sync(s2.id, _PATH, "sha1")
+    assert _snapshot(s2.id) == original  # the same lineage, byte for byte
+    assert folds == []  # base_sha matches HEAD — nothing to fold
+
+
+def test_retained_client_document_does_not_duplicate(users, monkeypatch):
+    # The end-to-end bug kill: a client's retained document, synced into the
+    # session that replaced its purged one, must merge as a no-op — not as a
+    # second copy of every block.
+    s1_id, original = _seed_first_session(monkeypatch)
+    retained = Doc()
+    retained.apply_update(original)  # the browser's copy of the document
+    _purge(s1_id)
+    s2 = coedit.open_session(_PATH, base_sha="sha1")
+    monkeypatch.setattr("app.api.coedit.rebase_coedit_session", lambda *_a: None)
+    assert _seed_snapshot_sync(s2.id, _PATH, "sha1")
+    server = Doc()
+    server.apply_update(_snapshot(s2.id))
+    blocks_before = len(server.get(ROOT_XML_KEY, type=XmlFragment).children)
+    server.apply_update(retained.get_update())  # SYNC_STEP1's full-state reply
+    blocks_after = len(server.get(ROOT_XML_KEY, type=XmlFragment).children)
+    assert blocks_after == blocks_before
+    assert reconstruct_body(server) == reconstruct_body(retained)
+
+
+def test_pre_cutover_reseed_shape_duplicates(users):
+    # The control: two independent seeds of the same markdown DO duplicate on
+    # merge — the behavior the attach path exists to remove. If this ever
+    # starts passing with equal counts, the codec changed and the attach
+    # rationale should be revisited.
+    a = seed_doc_from_markdown(_BODY)
+    b = seed_doc_from_markdown(_BODY)
+    blocks_single = len(a.get(ROOT_XML_KEY, type=XmlFragment).children)
+    a.apply_update(b.get_update())
+    blocks_merged = len(a.get(ROOT_XML_KEY, type=XmlFragment).children)
+    assert blocks_merged == 2 * blocks_single
+
+
+def test_transplant_folds_head_drift(users, monkeypatch):
+    s1_id, original = _seed_first_session(monkeypatch)
+    _purge(s1_id)
+    # An out-of-band commit lands while nobody has the page open: the
+    # document row's base_sha stays at sha1 while HEAD moves to sha2.
+    monkeypatch.setattr("app.api.coedit.git.head_sha_for_path", lambda *_a, **_k: "sha2")
+    s2 = coedit.open_session(_PATH, base_sha="sha2")
+    folds: list[tuple[int, str]] = []
+    monkeypatch.setattr(
+        "app.api.coedit.rebase_coedit_session", lambda sid, sha: folds.append((sid, sha))
+    )
+    assert _seed_snapshot_sync(s2.id, _PATH, "sha2")
+    assert _snapshot(s2.id) == original  # lineage kept even across the drift
+    assert folds == [(s2.id, "sha2")]  # ...and the drift queued as a fold
+    row = coedit.get_session_for_checkpoint(s2.id)
+    assert row is not None
+    assert row.base_sha == "sha1"  # the snapshot's truth, until the fold lands
+
+
+def test_transplant_race_is_harmless(users, monkeypatch):
+    _seed_first_session(monkeypatch)
+    s1 = coedit.get_active_session(_PATH)
+    assert s1 is not None
+    _purge(s1.id)
+    s2 = coedit.open_session(_PATH, base_sha="sha1")
+    monkeypatch.setattr("app.api.coedit.rebase_coedit_session", lambda *_a: None)
+    # Two connections seed concurrently; both transplant the same lineage,
+    # so even the "loser" lost nothing.
+    assert _seed_snapshot_sync(s2.id, _PATH, "sha1")
+    first = _snapshot(s2.id)
+    assert _seed_snapshot_sync(s2.id, _PATH, "sha1")
+    assert _snapshot(s2.id) == first


### PR DESCRIPTION
## What

Slice 2 of the one-lineage-per-path plan, part B — the cutover. A new session **adopts the page's `wiki_documents` snapshot as its own seq-0 state** (a pure byte copy — no `Doc` is built), so the page keeps one CRDT lineage across sessions. Seeding from markdown remains only for pages with no document row, and the slice-1 mirror creates the row from that seed, so the next open transplants.

## Why this shape

A page's document identity is its Yjs lineage; every route where a fresh session seeded a fresh lineage while a client retained the old one has produced page-duplication incidents. The session-reuse rule (#575) covers only the same-`base_sha`, clean, row-still-exists case. The transplant covers **every** reconnect shape — purged rows, moved HEAD, dirty closures — because whatever session exists, its seq-0 state is the same lineage the clients hold.

Notably this needed none of the heavier machinery the original plan sketched (update-log re-key, checkpoint/rebase engine changes): the divergence splice already ships in `checkpoint_session`, and the dual-write mirror keeps the document row current, so attach reduces to a byte copy plus the existing fold path.

## How

- `coedit.transplant_snapshot` — like `set_initial_snapshot` (conditional on `ydoc_snapshot IS NULL`, so concurrent connectors race harmlessly — and here even the loser lost nothing, both transplant the same lineage) but also sets `base_sha` to the *document's*, which is what the snapshot actually represents. No mirror write: the document row is the source.
- `_seed_snapshot_sync` attaches first: transplant when the page has a document row; if the document's `base_sha` is behind HEAD (out-of-band commits landed while nobody had the page open — the last lineage-discard route), the drift folds in as an ordinary queued live-rebase, the same path an agent commit takes mid-session.

## Verified

- 6 tests incl. the end-to-end bug kill (a retained client document syncs into the replacement session as a **no-op**, block counts unchanged) and a control pinning that two independent seeds still duplicate (the behavior this removes). Full backend suite + pyright green.
- Live drill on the local stack, replaying the production incident: opened a page, **deleted** its active session under the connected tab (the purge shape that defeated #575), let the client reconnect — the replacement session's snapshot was byte-identical (same md5) to the document row's lineage, the client's sync reply applied as a small delta, and the page rendered single. Repeated with a cold open after a purge: same lineage, seq relabeled to 0.

## Sequencing

Stacked conceptually on #619 (merged). Per the slice-2 gate agreed with Bo: hold merge until the slice-1 mirror is verified on prod after the next nightly (row count vs live snapshot paths, lockstep on an edited page).