### PR TITLE
refactor(coedit): remove session reuse and purge retention; demote the repair nets

### DIFF
--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -45,15 +45,6 @@ _MAX_INTERVAL_SECONDS = 900
 # Four missed 15-second heartbeats distinguish a departed participant from
 # ordinary event-loop lag.
 _PARTICIPANT_STALE_SECONDS = 60
-# How long a closed viewer session stays purgeable-exempt. A reconnecting
-# client adopts its old row's Yjs lineage, and only a row that still exists
-# can be adopted, so this has to outlast a reconnect by a wide margin — the
-# client retries every ~3s, but a suspended laptop resumes far later. Held
-# well above that; the newest closed row per path is kept regardless of age,
-# so this window only bounds how long the *older* ones linger.
-_VIEWER_SESSION_RETAIN_SECONDS = 3600
-
-
 @coedit_queue.task()
 def checkpoint_coedit_session_task(session_id: int, *, request_id: str | None = None) -> None:
     """Checkpoint one session, then close it if everyone has since left and it
@@ -115,8 +106,6 @@ def scan_coedit_checkpoints() -> None:
     abandoned = coedit.close_abandoned_sessions()
     if abandoned:
         log.info("coedit presence scan: closed %d abandoned session(s)", len(abandoned))
-    purged = coedit.purge_viewer_sessions(
-        retain_seconds=_VIEWER_SESSION_RETAIN_SECONDS
-    )
+    purged = coedit.purge_closed_sessions()
     if purged:
-        log.info("coedit checkpoint scan: purged %d viewer-only session(s)", purged)
+        log.info("coedit checkpoint scan: purged %d closed clean session(s)", purged)

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -38,7 +38,6 @@ from sqlalchemy import Text as SAText, cast, delete, func, literal, or_, select,
 from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, aliased
 
 from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User
 from app.models.wiki import PathMove
@@ -266,46 +265,6 @@ def get_session_for_checkpoint(session_id: int) -> CheckpointSessionRow | None:
         )
 
 
-def _reusable_closed_session(
-    s: Session, path: str, base_sha: str | None
-) -> CoeditSession | None:
-    """The newest closed session for ``path`` whose document still describes
-    the page as committed, or ``None`` when reactivating would be unsafe and
-    the caller should seed a fresh one.
-
-    Three conditions, each ruling out a way the old lineage could disagree with
-    what the next reader expects:
-
-    ``base_sha`` matches the caller's current HEAD for the path
-        A session stamps its own ``base_sha`` with the commit its last
-        checkpoint produced, so equality means nothing has touched the file
-        since — no agent write, no API PUT, no other session. Any commit moves
-        HEAD and disqualifies the row, which is what keeps this from reviving a
-        document that no longer matches the page. ``None`` (a page with no
-        commit of its own yet) never matches.
-    a snapshot exists
-        Without one there is no lineage to preserve, so reuse buys nothing.
-    the session is clean
-        ``ydoc_seq == ydoc_checkpointed_seq``, i.e. every update it holds is
-        already committed. A dirty session was closed with work outstanding
-        (the missing-path close is the one that does this) and reactivating it
-        would resurrect updates against a page state nobody has verified.
-    """
-    if base_sha is None:
-        return None
-    return s.scalar(
-        select(CoeditSession)
-        .where(
-            CoeditSession.path == path,
-            CoeditSession.status == SessionStatus.CLOSED.value,
-            CoeditSession.base_sha == base_sha,
-            CoeditSession.ydoc_snapshot.is_not(None),
-            CoeditSession.ydoc_seq == CoeditSession.ydoc_checkpointed_seq,
-        )
-        .order_by(CoeditSession.id.desc())
-    )
-
-
 def open_session(path: str, *, base_sha: str | None) -> SessionRow:
     """Get-or-create the active session row for ``path``.
 
@@ -316,17 +275,13 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
     history. Concurrent opens race on the partial unique index; the loser
     re-reads the winner's row.
 
-    When no active session exists, a closed one for the same path is
-    *reactivated* in preference to inserting a fresh row, provided it still
-    describes the page as committed (see ``_reusable_closed_session``). This is
-    a correctness requirement, not an optimization: a session's document
-    identity is its Yjs lineage, and a new row means a new snapshot seeded by
-    ``seed_doc_from_markdown``, whose ``Doc()`` carries a fresh random client
-    id. A client that reconnects onto a new lineage answers the server's
-    SYNC_STEP1 with its entire retained document — the two lineages share no
-    item ids, so nothing dedupes and every block ends up in the page twice,
-    compounding on each cycle. Reactivating keeps the lineage, which makes that
-    reply a no-op and also preserves anything typed while disconnected.
+    A fresh row is otherwise inserted — never a reactivated closed one. The
+    page's CRDT lineage doesn't live here: the attach path transplants it
+    from the page's ``wiki_documents`` row into the new session
+    (``transplant_snapshot``; ``_seed_snapshot_sync`` in
+    ``app/api/coedit.py``), so a reconnecting client's retained document
+    always meets the lineage it already holds, whatever became of the old
+    session row.
     """
     with session() as s:
         # The session's binding to the page's document identity, stamped on
@@ -345,28 +300,6 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
                 existing.doc_id = doc_id
             return _session_row(existing)
         now = _iso(_now())
-        reusable = _reusable_closed_session(s, path, base_sha)
-        if reusable is not None:
-            reusable.status = SessionStatus.ACTIVE.value
-            reusable.updated_at = now
-            if reusable.doc_id is None and doc_id is not None:
-                reusable.doc_id = doc_id
-            try:
-                s.flush()
-            except IntegrityError:
-                # Another opener activated a row for this path first — same
-                # race the insert path below handles, same resolution.
-                s.rollback()
-                winner = s.scalar(
-                    select(CoeditSession).where(
-                        CoeditSession.path == path,
-                        CoeditSession.status == SessionStatus.ACTIVE.value,
-                    )
-                )
-                if winner is None:  # pragma: no cover - winner closed in the gap
-                    raise
-                return _session_row(winner)
-            return _session_row(reusable)
         # `now` is stamped in _iso (T-separated, +00:00) rather than letting the
         # space-separated server_default fill it: sessions_due_for_checkpoint
         # compares these against _iso cutoffs, and mixing the two string formats
@@ -938,69 +871,33 @@ def close_abandoned_sessions() -> list[int]:
         )
 
 
-def purge_viewer_sessions(*, retain_seconds: int, limit: int = 500) -> int:
-    """Delete closed sessions that never received an update. Returns the count.
+def purge_closed_sessions(*, limit: int = 500) -> int:
+    """Delete closed sessions whose work is fully checkpointed. Returns the count.
 
-    With join-on-landing, every page view mints a session — a closed
-    ``ydoc_seq == 0`` row carries no updates, no participants (removed on
-    leave; FK cascade catches stragglers), so it is pure dead weight. Runs
-    against *closed* rows only: deleting at the close point instead would
-    race a concurrent join into an FK violation, while a closed session is a
-    soft state joins already tolerate. Bounded so the periodic scan stays
-    cheap; the backlog drains across successive runs.
+    A closed *clean* row is pure dead weight: its updates were pruned by its
+    final checkpoint, its participants left (FK cascade catches stragglers),
+    and the page's lineage lives on its ``wiki_documents`` row — the next
+    open transplants from there (``transplant_snapshot``), so nothing ever
+    reactivates or rebuilds from a closed session. That is what lets this be
+    unconditional: the age gate and the keep-the-newest-row-per-path subquery
+    that used to live here protected the row session *reuse* needed, and
+    reuse is gone with the attach cutover.
 
-    Two conditions keep this off rows ``_reusable_closed_session`` still
-    needs. A deleted row cannot be reactivated, so purging one whose client
-    is about to reconnect forces ``open_session`` to seed a fresh
-    ``Doc()`` — a new Yjs lineage against the retained document the client
-    answers SYNC_STEP1 with, which is exactly the whole-page duplication
-    ``open_session`` describes. The scan closes and purges in the *same*
-    pass, so without these the window was the ~3s a client takes to
-    reconnect, and a "never edited" row is precisely a viewer's — someone
-    with the page merely open.
+    Dirty closed rows are kept — a session closed with uncommitted work (the
+    missing-path close) still holds its unpruned updates for manual recovery,
+    and those are the one thing the document row does not carry.
 
-    ``updated_at`` older than ``retain_seconds``
-        ``close_session``/``close_abandoned_sessions`` both stamp it, so
-        this is time since close.
-    not the row ``_reusable_closed_session`` would pick for its path
-        Kept regardless of age, so a reconnect after any delay still has a
-        lineage to adopt. Bounded at one row per page.
-
-        This mirrors that function's predicate rather than taking the highest
-        id outright: a newer row that is dirty or has no snapshot is *not*
-        reusable, and protecting it would leave an older, eligible row exposed
-        to the age cutoff — deleting the very lineage a reconnect would have
-        adopted. Its ``base_sha == HEAD`` condition has no SQL equivalent
-        (HEAD is per-path git state), but it needs none here: a row's
-        ``base_sha`` is HEAD as of its creation or its last checkpoint, so of
-        two candidates the newer one's is never the staler, and the newest is
-        always the best available match.
+    Runs against *closed* rows only: deleting at the close point instead
+    would race a concurrent join into an FK violation, while a closed session
+    is a soft state joins already tolerate. Bounded so the periodic scan
+    stays cheap; the backlog drains across successive runs.
     """
-    cutoff = _iso(_now() - timedelta(seconds=retain_seconds))
-    newest = aliased(CoeditSession)
-    reusable_for_path = (
-        select(func.max(newest.id))
-        .where(
-            newest.path == CoeditSession.path,
-            newest.status == SessionStatus.CLOSED.value,
-            newest.ydoc_snapshot.is_not(None),
-            newest.ydoc_seq == newest.ydoc_checkpointed_seq,
-        )
-        .correlate(CoeditSession)
-        .scalar_subquery()
-    )
     with session() as s:
         ids = s.scalars(
             select(CoeditSession.id)
             .where(
                 CoeditSession.status == SessionStatus.CLOSED.value,
-                CoeditSession.ydoc_seq == 0,
-                CoeditSession.ydoc_checkpointed_seq == 0,
-                CoeditSession.updated_at <= cutoff,
-                or_(
-                    CoeditSession.id != reusable_for_path,
-                    reusable_for_path.is_(None),
-                ),
+                CoeditSession.ydoc_seq == CoeditSession.ydoc_checkpointed_seq,
             )
             .limit(limit)
         ).all()

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -58,8 +58,9 @@ def _duplicated_block_ids(doc: Doc) -> list[str]:
 
     Two top-level blocks sharing an id is not a thing editing can produce — it
     means the document holds the same block twice under two CRDT lineages that
-    share no item ids and therefore cannot dedupe (``open_session``'s reuse rule
-    exists to stop that arising; this catches any other route to it). Freshly
+    share no item ids and therefore cannot dedupe (the attach path exists to
+    stop that arising: every open transplants the page's one lineage from its
+    ``wiki_documents`` row; this catches any other route to it). Freshly
     typed content carries no id at all and takes ``checkpoint_body``'s
     ``orig is None`` path, so it can't collide.
 
@@ -82,8 +83,25 @@ def _duplicated_block_ids(doc: Doc) -> list[str]:
     return dupes
 
 
-def drop_duplicate_blocks(doc: Doc) -> list[str]:
-    """Repair repeats of a top-level ``_blockId``; return the repeated ids.
+class DuplicateRepair(BaseModel):
+    """What ``drop_duplicate_blocks`` did, split by what the repeat *meant* —
+    the two cases carry very different weight (see that docstring): a deleted
+    identical copy is the "one page, one lineage" invariant broken, while a
+    reidentified differing copy is an ordinary editor race."""
+
+    model_config = ConfigDict(frozen=True)
+
+    deleted: list[str] = []
+    reidentified: list[str] = []
+
+
+def drop_duplicate_blocks(doc: Doc) -> DuplicateRepair:
+    """Repair repeats of a top-level ``_blockId``; return what was repaired.
+
+    A tripwire more than a defense since the attach cutover: every open
+    transplants the page's one lineage from its ``wiki_documents`` row, so
+    the lineage-collision case below should be unreachable — it firing means
+    that invariant broke somewhere, which is exactly why the repair stays.
 
     Two different situations produce a repeated id, and they need different
     repairs:
@@ -120,7 +138,7 @@ def drop_duplicate_blocks(doc: Doc) -> list[str]:
     """
     dupes = _duplicated_block_ids(doc)
     if not dupes:
-        return []
+        return DuplicateRepair()
     root = doc.get(markdown_yjs.ROOT_XML_KEY, type=XmlFragment)
     occurrences: dict[str, list[tuple[int, str]]] = {}
     for i, child in enumerate(root.children):
@@ -129,20 +147,27 @@ def drop_duplicate_blocks(doc: Doc) -> list[str]:
             occurrences.setdefault(block_id, []).append((i, markdown_yjs.serialize_block(child)))
     stale: list[int] = []
     reidentify: list[int] = []
-    for members in occurrences.values():
+    deleted_ids: list[str] = []
+    reidentified_ids: list[str] = []
+    for block_id, members in occurrences.items():
         if len(members) == 1:
             continue
         anchor_text = members[0][1]
         identical = [i for i, text in members if text == anchor_text]
+        differing = [i for i, text in members if text != anchor_text]
         stale.extend(identical[:-1])  # the last identical copy keeps the id
-        reidentify.extend(i for i, text in members if text != anchor_text)
+        reidentify.extend(differing)
+        if len(identical) > 1:
+            deleted_ids.append(block_id)
+        if differing:
+            reidentified_ids.append(block_id)
     # Descending, so each deletion can't shift the index of one still pending.
     with doc.transaction():
         for i in reidentify:
             root.children[i].attributes[markdown_yjs.BLOCK_ID_ATTR] = None
         for i in sorted(stale, reverse=True):
             del root.children[i]
-    return dupes
+    return DuplicateRepair(deleted=deleted_ids, reidentified=reidentified_ids)
 
 
 # A lineage collision restates most of the page; a person can legitimately
@@ -447,28 +472,44 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         # Repaired in place and then committed normally, rather than refused:
         # the checkpoint's closing broadcast carries the deletion to every
         # connected client, so their documents converge too. Refusing instead
-        # would leave the duplication in the browsers that hold it, to be
-        # re-sent on their next reconnect — and closing the session wouldn't
-        # help, since the next one can't reuse a dirty session and would seed
-        # yet another lineage for that same retained document to merge into.
-        dupes = drop_duplicate_blocks(doc)
-        if dupes:
+        # would leave the duplication in the browsers that hold it — and in
+        # the document row the next open transplants from, once a checkpoint
+        # finally did commit it.
+        repair = drop_duplicate_blocks(doc)
+        if repair.deleted:
+            # Tripwire: an identical-copy repeat is two lineages holding the
+            # same block, which the attach path (every open transplants the
+            # page's one lineage) is supposed to make unreachable.
             log.error(
-                "coedit checkpoint: %s (session %s) held duplicate top-level block ids "
-                "%s; dropped the repeats and committing the repaired document. This "
-                "should be unreachable — see open_session's lineage reuse rule.",
+                "coedit checkpoint: %s (session %s) held identical duplicate "
+                "top-level blocks %s; dropped the repeats and committing the "
+                "repaired document. The one-lineage-per-page invariant broke — "
+                "see transplant_snapshot / _seed_snapshot_sync.",
                 path,
                 session_id,
-                dupes,
+                repair.deleted,
+            )
+        elif repair.reidentified:
+            # Benign: ProseMirror's node split copied an id onto both halves
+            # and this checkpoint raced the editor's own fix-up; clearing the
+            # later id is that fix-up. No lineage involvement.
+            log.warning(
+                "coedit checkpoint: %s (session %s) re-identified split block(s) "
+                "%s ahead of the client's own repair",
+                path,
+                session_id,
+                repair.reidentified,
             )
 
         restated = drop_restated_blocks(doc, base_body)
         if restated:
+            # Tripwire, same invariant as above: restatement at this scale is
+            # a second lineage's content re-serialized onto the page.
             log.error(
                 "coedit checkpoint: %s (session %s) held %d block(s) restating the "
                 "page back onto itself; dropped them and committing the repaired "
-                "document. Indicates a second Yjs lineage reached the doc — see "
-                "open_session's reuse rule and purge_viewer_sessions' retention.",
+                "document. The one-lineage-per-page invariant broke — see "
+                "transplant_snapshot / _seed_snapshot_sync.",
                 path,
                 session_id,
                 restated,

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -489,10 +489,12 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 session_id,
                 repair.deleted,
             )
-        elif repair.reidentified:
+        if repair.reidentified:
             # Benign: ProseMirror's node split copied an id onto both halves
             # and this checkpoint raced the editor's own fix-up; clearing the
-            # later id is that fix-up. No lineage involvement.
+            # later id is that fix-up. No lineage involvement. Logged even
+            # when a deletion fired above — the two repairs hit different ids
+            # and operators need the complete account.
             log.warning(
                 "coedit checkpoint: %s (session %s) re-identified split block(s) "
                 "%s ahead of the client's own repair",

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -725,7 +725,8 @@ def test_drop_duplicate_blocks_repairs_the_doc_and_the_client() -> None:
     # The server rebuilds that same state, then repairs it.
     server = seed_doc_from_markdown(body)
     server.apply_update(client.get_update(server.get_state()))
-    assert drop_duplicate_blocks(server) == ["b0"]
+    repair = drop_duplicate_blocks(server)
+    assert repair.deleted == ["b0"] and repair.reidentified == []
     assert _duplicated_block_ids(server) == []
     assert reconstruct_body(server) == body
 
@@ -767,7 +768,8 @@ def test_drop_duplicate_blocks_reidentifies_a_split_instead_of_deleting_it() -> 
         para.children[0].insert(0, "typed ")  # pyright: ignore[reportAttributeAccessIssue]
         para.attributes[BLOCK_ID_ATTR] = dict(lst.attributes)[BLOCK_ID_ATTR]  # pyright: ignore[reportAttributeAccessIssue]
 
-    assert drop_duplicate_blocks(doc) == ["b0"]
+    repair = drop_duplicate_blocks(doc)
+    assert repair.reidentified == ["b0"] and repair.deleted == []
     assert _duplicated_block_ids(doc) == []
     rt = reconstruct_body(doc)
     assert "typed after" in rt  # the person's text survived
@@ -809,7 +811,8 @@ def test_drop_duplicate_blocks_keeps_the_last_identical_copy() -> None:
     with doc.transaction():
         root.children[1].attributes["_probe"] = "later"  # pyright: ignore[reportIndexIssue]
 
-    assert drop_duplicate_blocks(doc) == ["b0"]
+    repair = drop_duplicate_blocks(doc)
+    assert repair.deleted == ["b0"]
     assert _duplicated_block_ids(doc) == []
     assert reconstruct_body(doc) == "a\n"
     survivors = list(root.children)
@@ -848,12 +851,12 @@ def test_drop_duplicate_blocks_repair_converges_across_checkpoints() -> None:
 
 
 def test_drop_duplicate_blocks_is_a_no_op_on_a_healthy_doc() -> None:
-    from app.wiki.coedit_checkpoint import drop_duplicate_blocks
+    from app.wiki.coedit_checkpoint import DuplicateRepair, drop_duplicate_blocks
     from app.wiki.markdown_yjs import reconstruct_body, seed_doc_from_markdown
 
     body = "\n\n".join(f"- line {i}" for i in range(50)) + "\n"
     doc = seed_doc_from_markdown(body)
-    assert drop_duplicate_blocks(doc) == []
+    assert drop_duplicate_blocks(doc) == DuplicateRepair()
     assert reconstruct_body(doc) == body
 
 

--- a/backend/tests/test_coedit_doc_pointers.py
+++ b/backend/tests/test_coedit_doc_pointers.py
@@ -56,7 +56,9 @@ def test_reopen_backfills_a_null_binding(users):
     assert again.doc_id == minted
 
 
-def test_reactivation_backfills_a_null_binding(users):
+def test_open_after_close_stamps_the_fresh_row(users):
+    # A closed session is never reactivated (lineage continuity is the attach
+    # path's job) — the open after a close is a fresh row, stamped from birth.
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
     with db_session() as db:
@@ -64,9 +66,9 @@ def test_reactivation_backfills_a_null_binding(users):
             update(CoeditSession).where(CoeditSession.id == s.id).values(status="closed")
         )
     minted = doc_ids.mint_for_page(_PATH)
-    reused = coedit.open_session(_PATH, base_sha="sha1")
-    assert reused.id == s.id  # reactivated, not fresh
-    assert reused.doc_id == minted
+    fresh = coedit.open_session(_PATH, base_sha="sha1")
+    assert fresh.id != s.id
+    assert fresh.doc_id == minted
 
 
 def test_updates_carry_the_session_binding(users):

--- a/backend/tests/test_coedit_repo.py
+++ b/backend/tests/test_coedit_repo.py
@@ -413,89 +413,44 @@ def test_rename_path(users):
     assert moved.id == s.id
 
 
-def test_purge_viewer_sessions_deletes_only_closed_never_edited(users):
-    # Two viewer-only sessions on one path: opened, seeded, no updates, closed.
-    # Only the older is purgeable — the newest is the row
-    # _reusable_closed_session would reactivate.
-    older = coedit.open_session("viewed.md", base_sha=None)
-    coedit.set_initial_snapshot(older.id, b"snap", "body")
-    coedit.join(older.id, "usr_a")
-    coedit.leave(older.id, "usr_a")
-    coedit.close_session(older.id)
-    newest = coedit.open_session("viewed.md", base_sha=None)
-    coedit.set_initial_snapshot(newest.id, b"snap", "body")
-    coedit.close_session(newest.id)
+def test_purge_closed_sessions_deletes_clean_rows_unconditionally(users):
+    # Closed clean rows purge regardless of age or edit history: the page's
+    # lineage lives on its wiki_documents row and the next open transplants
+    # from there, so nothing ever reactivates a closed session.
+    viewer = coedit.open_session("viewed.md", base_sha=None)
+    coedit.set_initial_snapshot(viewer.id, b"snap", "body")
+    coedit.join(viewer.id, "usr_a")
+    coedit.leave(viewer.id, "usr_a")
+    coedit.close_session(viewer.id)
 
-    # Edited session: has an update, closed after checkpoint — must be
-    # retained (ydoc_seq != 0, regardless of whether advance_checkpoint has
-    # since pruned its coedit_updates rows).
+    # Edited, checkpointed, closed — clean, so equally dead weight.
     edited = coedit.open_session("edited.md", base_sha=None)
     coedit.apply_update(edited.id, update_bytes=b"x", author_user_id="usr_a")
     coedit.advance_checkpoint(edited.id, seq=1, snapshot=b"snap", body="body", base_sha="sha")
     coedit.close_session(edited.id)
 
-    # Active viewer-only session: still occupied — must be retained.
+    # Active session: still occupied — must be retained.
     active = coedit.open_session("open.md", base_sha=None)
 
-    assert coedit.purge_viewer_sessions(retain_seconds=0) == 1
-    assert coedit.get_session(older.id) is None
-    assert coedit.get_session(newest.id) is not None
-    assert coedit.get_session(edited.id) is not None
+    assert coedit.purge_closed_sessions() == 2
+    assert coedit.get_session(viewer.id) is None
+    assert coedit.get_session(edited.id) is None
     assert coedit.get_session(active.id) is not None
     # Idempotent: nothing left to purge.
-    assert coedit.purge_viewer_sessions(retain_seconds=0) == 0
+    assert coedit.purge_closed_sessions() == 0
 
 
-def test_purge_viewer_sessions_retains_recently_closed(users):
-    """A reconnecting client adopts its old row's Yjs lineage, so a row closed
-    moments ago has to survive — deleting it forces a fresh seed and the
-    retained document is then duplicated into the page."""
-    older = coedit.open_session("viewed.md", base_sha=None)
-    coedit.close_session(older.id)
-    newest = coedit.open_session("viewed.md", base_sha=None)
-    coedit.close_session(newest.id)
+def test_purge_closed_sessions_keeps_dirty_rows_for_recovery(users):
+    # A session closed with uncommitted work (the missing-path close) holds
+    # unpruned updates for manual recovery — the one thing the page's
+    # document row does not carry.
+    dirty = coedit.open_session("dirty.md", base_sha=None)
+    coedit.set_initial_snapshot(dirty.id, b"snap", "body")
+    coedit.apply_update(dirty.id, update_bytes=b"lost-work", author_user_id="usr_a")
+    coedit.close_session(dirty.id)
 
-    assert coedit.purge_viewer_sessions(retain_seconds=3600) == 0
-    assert coedit.get_session(older.id) is not None
-    assert coedit.get_session(newest.id) is not None
-
-
-def test_purge_viewer_sessions_protects_the_row_reuse_would_pick(users):
-    """Retention has to mirror ``_reusable_closed_session``, not just take the
-    highest id: a newer snapshotless row isn't reusable, and protecting it
-    instead would expose the older eligible row to the age cutoff — deleting
-    the lineage a reconnect would have adopted."""
-    reusable = coedit.open_session("viewed.md", base_sha=None)
-    coedit.set_initial_snapshot(reusable.id, b"snap", "body")
-    coedit.close_session(reusable.id)
-    # Newer, but never seeded — _reusable_closed_session skips it.
-    snapshotless = coedit.open_session("viewed.md", base_sha=None)
-    coedit.close_session(snapshotless.id)
-
-    assert coedit.purge_viewer_sessions(retain_seconds=0) == 1
-    assert coedit.get_session(reusable.id) is not None
-    assert coedit.get_session(snapshotless.id) is None
-
-
-def test_purge_viewer_sessions_keeps_newest_closed_row_however_old(users):
-    """The reuse candidate is kept regardless of age: a client can reconnect
-    long after closing (a suspended laptop), and one row per page is bounded."""
-    only = coedit.open_session("viewed.md", base_sha=None)
-    coedit.set_initial_snapshot(only.id, b"snap", "body")
-    coedit.close_session(only.id)
-
-    assert coedit.purge_viewer_sessions(retain_seconds=0) == 0
-    assert coedit.get_session(only.id) is not None
-
-
-def test_purge_viewer_sessions_purges_a_never_seeded_row(users):
-    """A row that never got a snapshot holds no lineage, so there is nothing
-    for a reconnect to adopt and nothing to protect."""
-    only = coedit.open_session("viewed.md", base_sha=None)
-    coedit.close_session(only.id)
-
-    assert coedit.purge_viewer_sessions(retain_seconds=0) == 1
-    assert coedit.get_session(only.id) is None
+    assert coedit.purge_closed_sessions() == 0
+    assert coedit.get_session(dirty.id) is not None
 
 
 def test_close_abandoned_sessions_closes_only_clean_empty_ones(users):
@@ -593,54 +548,22 @@ def _close_clean(session_id: int) -> None:
         )
 
 
-def test_open_session_reactivates_a_matching_closed_session(users):
-    """A closed session whose document still describes the committed page is
-    reactivated rather than replaced.
-
-    Replacing it would seed a new Yjs lineage from markdown, and a client that
-    reconnects still holding the old lineage answers the server's sync offer
-    with its whole document — which cannot dedupe against content carrying
-    different item ids, so the page ends up in the doc twice.
-    """
+def test_open_session_never_reactivates_a_closed_session(users):
+    """A closed session stays closed — every open gets a fresh row. Lineage
+    continuity is not this function's job anymore: the attach path
+    transplants the page's document from its wiki_documents row into the new
+    session, whatever became of the old one."""
     first = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(first.id, b"snap0", "hello")
     _close_clean(first.id)
 
     again = coedit.open_session(_PATH, base_sha="sha1")
-    assert again.id == first.id
-    assert again.status == "active"
-    kept = coedit.get_session_for_checkpoint(again.id)
-    assert kept is not None and kept.ydoc_snapshot == b"snap0"
-    assert count_rows(CoeditSession) == 1
-
-
-def test_open_session_does_not_reuse_when_the_page_moved_on(users):
-    """A commit since that session's last checkpoint means its document no
-    longer describes the page, so it must not be revived."""
-    first = coedit.open_session(_PATH, base_sha="sha1")
-    coedit.set_initial_snapshot(first.id, b"snap0", "hello")
-    _close_clean(first.id)
-
-    again = coedit.open_session(_PATH, base_sha="sha2")
     assert again.id != first.id
-    assert again.base_sha == "sha2"
+    assert again.status == "active"
+    assert again.base_sha == "sha1"
+    kept = coedit.get_session_for_checkpoint(again.id)
+    assert kept is not None and kept.ydoc_snapshot is None  # awaits the attach
     assert count_rows(CoeditSession) == 2
-
-
-def test_open_session_does_not_reuse_a_dirty_or_snapshotless_session(users):
-    # Never seeded — no lineage to preserve, nothing to reuse.
-    bare = coedit.open_session(_PATH, base_sha="sha1")
-    _close_clean(bare.id)
-    after_bare = coedit.open_session(_PATH, base_sha="sha1")
-    assert after_bare.id != bare.id
-
-    # Dirty: holds updates that were never committed. Reviving it would
-    # resurrect them against a page state nobody verified.
-    coedit.set_initial_snapshot(after_bare.id, b"snap0", "hello")
-    coedit.apply_update(after_bare.id, update_bytes=b"upd", author_user_id="usr_a")
-    _close_clean(after_bare.id)
-    after_dirty = coedit.open_session(_PATH, base_sha="sha1")
-    assert after_dirty.id != after_bare.id
 
 
 def test_open_session_ignores_a_closed_session_on_another_path(users):


### PR DESCRIPTION
## What

Slice 3 of the one-lineage-per-path plan — the cleanup the attach cutover (#620) earns. Net **−145 lines**.

- **Session reuse goes** (`_reusable_closed_session` + the reactivation branch in `open_session`, from #575). It preserved lineage across a reconnect under three fragile conditions (row still exists, clean, `base_sha` matches). Attach transplants the lineage from the page's `wiki_documents` row on every open, unconditionally — reuse is a strict subset of what attach already does.
- **Purge retention goes** (#585's age gate + newest-reusable-row-per-path subquery — it existed solely so reuse could find a row). `purge_viewer_sessions` → `purge_closed_sessions`: every closed **clean** row deletes on the next scan pass, so sessions stop accumulating (edited-then-checkpointed rows were previously retained forever). Dirty closed rows stay — their unpruned updates (the missing-path close) are the one thing the document row doesn't carry, kept for manual recovery.
- **The repair nets stay in code but demote to tripwires.** `drop_duplicate_blocks` now reports what a repeat *meant*: an identical copy deleted = two lineages held the same block = the one-lineage-per-page invariant broke (still ERROR, message points at the attach path); a differing copy re-identified = an ordinary ProseMirror-split race the checkpoint beat the client's own fix-up to (now WARNING — this was the known-benign path previously logged as ERROR). `drop_restated_blocks` keeps ERROR: restatement at its floors is always a lineage event.

Deliberately **not** dropped: the session snapshot columns. Under the transplant design sessions remain the working copy, so those columns stay load-bearing — the original slice-3 sketch assumed the full re-key cutover that #620 made unnecessary.

## Sequencing

Merge-gated on the #616/#619/#620 prod soak: a few days of both nets staying silent in prod logs is the empirical proof the invariant holds before its backstops' predecessors are deleted. (The nets themselves remain either way.)

## Verified

Reworked tests pin the new contracts: closed clean rows purge unconditionally (viewer and edited alike), dirty rows survive for recovery, opens never reactivate, and the repair split (deleted vs re-identified) asserts per case. Full backend suite + pyright green.