### PR TITLE
feat(editor): /URL command to insert links via a popover

### DIFF
--- a/frontend/src/lib/editor/extensions/commandMenu.ts
+++ b/frontend/src/lib/editor/extensions/commandMenu.ts
@@ -27,6 +27,7 @@ import {
   SvgCode,
   SvgHash,
   SvgImage,
+  SvgLink,
   SvgListTree,
   SvgMinus,
   SvgQuoteStart,
@@ -40,6 +41,7 @@ import {
   canUploadImages,
   promptImageUpload,
 } from "@/lib/editor/extensions/images";
+import { openLinkInput } from "@/lib/editor/extensions/linkInput";
 import type { CommandItem } from "@/lib/editor/extensions/types";
 
 const COMMANDS: CommandItem[] = [
@@ -144,6 +146,17 @@ const COMMANDS: CommandItem[] = [
       // "/image" text would otherwise survive in the doc behind it.
       editor.chain().focus().deleteRange(range).run();
       promptImageUpload(editor.view);
+    },
+  },
+  {
+    title: "URL",
+    icon: SvgLink,
+    run: (editor, range) => {
+      // Clear the "/URL" text first so the caret sits on a clean block, then
+      // open the link popover anchored at that caret — the same delete-then-
+      // prompt shape as Image above.
+      editor.chain().focus().deleteRange(range).run();
+      openLinkInput(editor);
     },
   },
 ];

--- a/frontend/src/lib/editor/extensions/components.tsx
+++ b/frontend/src/lib/editor/extensions/components.tsx
@@ -1,20 +1,35 @@
 "use client";
 
-/** The slash-command menu's UI — the React component the `commandMenu`
- * extension renders through `@tiptap/react`'s `ReactRenderer`. It lives here,
- * beside its extension, rather than in the editor's shared `components.tsx`:
- * it's an implementation detail of the slash command (typed by `CommandItem`,
- * rendered only by that extension's `Suggestion` plugin), not a shared shell
- * component. Keeping it in `extensions/` is also what stops `extensions/` from
- * importing back into the editor shell — the edge that closed a circular
- * dependency (`components.tsx → extensions/index → extensions/commandMenu →
- * components.tsx`). */
-import { useEffect, useImperativeHandle, useState, type Ref } from "react";
+/** The editor extensions' React views — the components their `ReactRenderer`
+ * bridges mount: the slash-command menu (`CommandMenu`, for `commandMenu.ts`)
+ * and the `/URL` link-entry popover (`LinkInputPopover`, for `linkInput.ts`).
+ * They live here, beside their extensions, rather than in the editor's shared
+ * `components.tsx`: each is an implementation detail of one extension, not a
+ * shared shell component. Keeping them in `extensions/` is also what stops
+ * `extensions/` from importing back into the editor shell — the edge that
+ * closed a circular dependency (`components.tsx → extensions/index →
+ * extensions/commandMenu → components.tsx`). */
+import {
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type Ref,
+} from "react";
 import type {
   SuggestionKeyDownProps,
   SuggestionProps,
 } from "@tiptap/suggestion";
-import { LineItemButton } from "@onyx-ai/opal/components";
+import type { EditorView } from "@tiptap/pm/view";
+import {
+  Button,
+  InputTypeIn,
+  LineItemButton,
+  Popover,
+  Text,
+} from "@onyx-ai/opal/components";
 import type { CommandItem } from "@/lib/editor/extensions/types";
 
 export interface CommandMenuHandle {
@@ -80,5 +95,145 @@ export function CommandMenu({ ref, items, command }: CommandMenuProps) {
         </div>
       ))}
     </div>
+  );
+}
+
+/** Prepend a scheme so a bare `example.com` becomes a real link, but leave an
+ * explicit one (`https:`, `mailto:`, …) untouched. Deliberately permissive —
+ * no strict validation gate — because a mistyped link is fixed by unlinking,
+ * not by blocking submit; the only hard stop is an empty URL. */
+function normalizeUrl(raw: string): string {
+  const url = raw.trim();
+  if (!url) return "";
+  return /^[a-z][\w+.-]*:/i.test(url) ? url : `https://${url}`;
+}
+
+export interface LinkInputPopoverProps {
+  open: boolean;
+  /** Doc position the link inserts at; also where the popover anchors. */
+  anchorPos: number | null;
+  view: EditorView;
+  onSubmit: (href: string, text: string) => void;
+  onCancel: () => void;
+}
+
+/** The `/URL` link-entry form (see `linkInput.ts`). Opal `Popover` anchored to
+ * a virtual element at the caret — no trigger button, we open it
+ * programmatically — with URL (autofocused, required) over an optional display
+ * text. Blank text falls back to the URL, matching `[url](url)`. The form
+ * portals to `document.body`, so its keystrokes never reach ProseMirror; focus
+ * handoff back to the editor is the caller's job (`onSubmit`/`onCancel`). */
+export function LinkInputPopover({
+  open,
+  anchorPos,
+  view,
+  onSubmit,
+  onCancel,
+}: LinkInputPopoverProps) {
+  const [url, setUrl] = useState("");
+  const [text, setText] = useState("");
+  const urlRef = useRef<HTMLInputElement>(null);
+
+  // Fresh fields on each open — the previous link's values shouldn't linger.
+  useEffect(() => {
+    if (open) {
+      setUrl("");
+      setText("");
+    }
+  }, [open]);
+
+  // A virtual anchor: Radix measures the caret through `coordsAtPos` on every
+  // reposition, so the popover tracks the caret across scroll. Guarded because
+  // the position can briefly fall out of range mid-edit.
+  const virtualRef = useMemo(() => {
+    if (anchorPos == null) return null;
+    return {
+      current: {
+        getBoundingClientRect: () => {
+          try {
+            const c = view.coordsAtPos(anchorPos);
+            return new DOMRect(c.left, c.top, 0, c.bottom - c.top);
+          } catch {
+            return new DOMRect(0, 0, 0, 0);
+          }
+        },
+      },
+    };
+  }, [view, anchorPos]);
+
+  const submit = () => {
+    const href = normalizeUrl(url);
+    if (!href) return;
+    onSubmit(href, text.trim() || href);
+  };
+
+  const onKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <Popover
+      open={open && virtualRef != null}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      {virtualRef ? <Popover.Anchor virtualRef={virtualRef} /> : null}
+      <Popover.Content
+        align="start"
+        sideOffset={6}
+        width="fit"
+        // We own focus: autofocus the URL field on open, and don't let Radix
+        // yank it to a (non-existent) trigger on close — the caller returns it
+        // to the editor.
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          urlRef.current?.focus();
+        }}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+      >
+        <div className="flex w-[280px] flex-col gap-3 p-1">
+          <div className="flex flex-col gap-1.5">
+            <Text font="main-ui-muted" color="text-03">
+              URL
+            </Text>
+            <InputTypeIn
+              ref={urlRef}
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder="https://…"
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Text font="main-ui-muted" color="text-03">
+              Text
+            </Text>
+            <InputTypeIn
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={onKeyDown}
+              placeholder="Defaults to the URL"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" prominence="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="action"
+              disabled={!url.trim()}
+              onClick={submit}
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+      </Popover.Content>
+    </Popover>
   );
 }

--- a/frontend/src/lib/editor/extensions/index.ts
+++ b/frontend/src/lib/editor/extensions/index.ts
@@ -25,6 +25,7 @@ import {
 import { CommandMenu } from "@/lib/editor/extensions/commandMenu";
 import { AnchoredHighlights } from "@/lib/editor/extensions/highlights";
 import { imageSupport } from "@/lib/editor/extensions/images";
+import { LinkInput } from "@/lib/editor/extensions/linkInput";
 import { presenceExtension } from "@/lib/editor/extensions/presence";
 
 /**
@@ -116,6 +117,7 @@ export function tiptapExtensions(
     AnchoredHighlights,
     presenceExtension(awareness),
     CommandMenu,
+    LinkInput,
     imageSupport(pagePath),
   ];
 }

--- a/frontend/src/lib/editor/extensions/linkInput.ts
+++ b/frontend/src/lib/editor/extensions/linkInput.ts
@@ -1,0 +1,166 @@
+"use client";
+
+/** The `/URL` command's link-entry popover — the extension half. Typing `/`,
+ * picking **URL**, deletes the slash text and opens a small floating form
+ * (URL + optional display text) anchored at the caret; submitting inserts the
+ * text carrying a `link` mark. It's insert-a-new-link only: the slash menu is
+ * `startOfLine`-only (see `commandMenu.ts`), so there's never a selection to
+ * wrap — retargeting/removing an existing link is `MarkdownLink`'s `Mod-k` and
+ * (later) the right-click menu, not this.
+ *
+ * Shape mirrors `highlights.ts`: the open/anchor state lives in a ProseMirror
+ * plugin, poked in and out through `tr.setMeta` by the plain helper functions
+ * below (not Tiptap commands — no module augmentation to carry), and a plugin
+ * `view()` renders the React form (`LinkInputPopover`, in `./components.tsx`)
+ * through `@tiptap/react`'s `ReactRenderer`, the same bridge the slash menu
+ * uses. Positioning is Opal's Radix `Popover` against a virtual caret anchor,
+ * so — unlike the slash menu — there's no Floating UI `mount` here. */
+import { Extension, type Editor } from "@tiptap/core";
+import { Plugin, PluginKey, TextSelection } from "@tiptap/pm/state";
+import { ReactRenderer } from "@tiptap/react";
+import {
+  LinkInputPopover,
+  type LinkInputPopoverProps,
+} from "@/lib/editor/extensions/components";
+
+interface LinkInputState {
+  open: boolean;
+  anchorPos: number | null;
+}
+
+export const linkInputKey = new PluginKey<LinkInputState>("linkInput");
+
+/** Open the popover anchored at the current caret. Callers delete the `/URL`
+ * text first (via the command's range), so `selection.from` is already the
+ * clean insertion point. */
+export function openLinkInput(editor: Editor): void {
+  const { state } = editor.view;
+  editor.view.dispatch(
+    state.tr.setMeta(linkInputKey, {
+      open: true,
+      anchorPos: state.selection.from,
+    } satisfies LinkInputState),
+  );
+}
+
+/** Close without inserting, and hand focus back to the editor. */
+export function closeLinkInput(editor: Editor): void {
+  editor.view.dispatch(
+    editor.view.state.tr.setMeta(linkInputKey, { open: false }),
+  );
+  editor.view.focus();
+}
+
+/** Insert `text` linked to `href` at the stored anchor, then close. Mirrors
+ * `MarkdownLink`'s `[text](url)` input rule exactly — `schema.text` with a
+ * `link` mark, `removeStoredMark` so the next characters typed after the link
+ * don't join it — plus a caret move to just past the inserted run. */
+export function insertLink(
+  editor: Editor,
+  { href, text }: { href: string; text: string },
+): void {
+  const { state } = editor.view;
+  const anchorPos = linkInputKey.getState(state)?.anchorPos;
+  const linkType = state.schema.marks.link;
+  // No anchor (popover already closed) or no link mark in the schema
+  // (StarterKit's `link: false`) would make this a crash, not a no-op.
+  if (anchorPos == null || !linkType) return;
+
+  const node = state.schema.text(text, [linkType.create({ href })]);
+  const tr = state.tr.insert(anchorPos, node);
+  tr.removeStoredMark(linkType);
+  tr.setSelection(TextSelection.create(tr.doc, anchorPos + node.nodeSize));
+  tr.setMeta(linkInputKey, { open: false });
+  editor.view.dispatch(tr);
+  editor.view.focus();
+}
+
+/** Owns the `ReactRenderer` for the popover: mounts it once (rendering nothing
+ * while closed), pushes fresh props only when open/anchor actually change so
+ * ordinary typing doesn't churn it, and tears it down on editor destroy. */
+class LinkInputView {
+  private renderer: ReactRenderer<unknown, LinkInputPopoverProps>;
+  private root: HTMLElement;
+  private last: LinkInputState;
+
+  constructor(private editor: Editor) {
+    this.root = document.createElement("div");
+    document.body.appendChild(this.root);
+    this.last = this.read();
+    this.renderer = new ReactRenderer(LinkInputPopover, {
+      editor,
+      props: this.props(this.last),
+    });
+    this.root.appendChild(this.renderer.element);
+  }
+
+  private read(): LinkInputState {
+    const s = linkInputKey.getState(this.editor.state);
+    return { open: s?.open ?? false, anchorPos: s?.anchorPos ?? null };
+  }
+
+  private props(state: LinkInputState): LinkInputPopoverProps {
+    return {
+      open: state.open,
+      anchorPos: state.anchorPos,
+      view: this.editor.view,
+      onSubmit: (href, text) => insertLink(this.editor, { href, text }),
+      onCancel: () => closeLinkInput(this.editor),
+    };
+  }
+
+  update(): void {
+    const next = this.read();
+    if (
+      next.open === this.last.open &&
+      next.anchorPos === this.last.anchorPos
+    ) {
+      return;
+    }
+    this.last = next;
+    this.renderer.updateProps(this.props(next));
+  }
+
+  destroy(): void {
+    this.renderer.destroy();
+    this.root.remove();
+  }
+}
+
+export const LinkInput = Extension.create({
+  name: "linkInput",
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+    return [
+      new Plugin<LinkInputState>({
+        key: linkInputKey,
+        state: {
+          init: () => ({ open: false, anchorPos: null }),
+          apply(tr, value) {
+            let next = value;
+            const meta = tr.getMeta(linkInputKey) as
+              | Partial<LinkInputState>
+              | undefined;
+            if (meta) {
+              next = {
+                open: meta.open ?? value.open,
+                anchorPos:
+                  meta.anchorPos !== undefined
+                    ? meta.anchorPos
+                    : value.anchorPos,
+              };
+            }
+            // Keep the anchor pinned to its text if an edit lands before it
+            // while the popover is open (e.g. a concurrent co-editor's insert).
+            if (next.anchorPos != null && tr.docChanged) {
+              next = { ...next, anchorPos: tr.mapping.map(next.anchorPos) };
+            }
+            return next;
+          },
+        },
+        view: () => new LinkInputView(editor),
+      }),
+    ];
+  },
+});


### PR DESCRIPTION
## Summary

Adds a UI affordance for authoring links, which until now meant hand-typing the full `[text](url)` markdown.

- New **URL** slash-command (`/` → URL) opens a small Opal `Popover` anchored at the caret: a required URL field (autofocused) over an optional display-text field. Blank text falls back to the URL, matching `[url](url)`.
- On submit it inserts the text carrying a `link` mark, copying `MarkdownLink`'s input-rule exactly (`schema.text` + `removeStoredMark`) so trailing keystrokes don't join the link.
- Kept self-contained in the extensions layer, mirroring the slash menu: open/anchor state in a ProseMirror plugin, the form rendered through a `ReactRenderer`; positioning is Radix against a virtual caret anchor (no Floating UI `mount`).

Scope is deliberately narrow — insert-a-new-link only (the slash menu is `startOfLine`-only, so there's never a selection to wrap). Cmd+click-to-open and `Mod-k`-unlink already exist in `MarkdownLink`.

## Still to clean up (follow-up PRs)

This is the first cut. A bunch of cleanup is still outstanding, including (but not limited to):

- **UI cleanup** — popover chrome/spacing/labels need polish.
- **Preventing _raw_ link-styling from activating** — don't let bare/auto link styling kick in where it shouldn't.
- **Cursoring around the link** — same class of problem we hit with inline code marks; the caret needs to enter/exit the link boundary sanely.
- **Cursor styling while interacting with links** — hover/pointer affordances.

## Screenshots + Videos

<img width="828" height="570" alt="image" src="https://github.com/user-attachments/assets/01604b3a-fa79-421a-9256-7fdd79ce0c23" />

<img width="368" height="282" alt="image" src="https://github.com/user-attachments/assets/754d6039-2257-4ce4-8e8d-000bd932689d" />

<img width="810" height="132" alt="image" src="https://github.com/user-attachments/assets/30ad8962-e325-4393-896f-841d18c18cf9" />