### PR TITLE
feat(ingest): aspect states — each aspect's current state, unified from its needs

### DIFF
--- a/backend/app/db/aspect_states.py
+++ b/backend/app/db/aspect_states.py
@@ -1,0 +1,87 @@
+"""Aspect states — what each aspect's needs say right now, unified.
+
+The read/write seam for ``aspect_states`` (see the model docstring for what a
+row means and how it goes stale). Same boundary rules as ``page_needs``:
+NamedTuple records out, no ORM objects, each function its own session.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from sqlalchemy import select
+
+from app.db.models import Aspect, AspectState
+from app.db.session import session
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+
+class StoredAspectState(NamedTuple):
+    """One aspect's stored state."""
+
+    aspect_id: int
+    state: str
+    conflict: bool
+    conflict_note: str
+    model: str
+    updated_at: str
+
+
+def record(
+    aspect_id: int,
+    *,
+    state: str,
+    conflict: bool,
+    conflict_note: str,
+    model: str,
+) -> None:
+    """Upsert one aspect's state. Per aspect, so a generation pass that dies
+    keeps everything it already produced — same shape as ``page_needs.store``."""
+    with session() as s:
+        stmt = pg_insert(AspectState).values(
+            aspect_id=aspect_id,
+            state=state,
+            conflict=conflict,
+            conflict_note=conflict_note,
+            model=model,
+        )
+        s.execute(
+            stmt.on_conflict_do_update(
+                index_elements=[AspectState.aspect_id],
+                set_={
+                    "state": stmt.excluded.state,
+                    "conflict": stmt.excluded.conflict,
+                    "conflict_note": stmt.excluded.conflict_note,
+                    "model": stmt.excluded.model,
+                    "updated_at": stmt.excluded.updated_at,
+                },
+            )
+        )
+
+
+def get(aspect_id: int) -> StoredAspectState | None:
+    with session() as s:
+        row = s.get(AspectState, aspect_id)
+        return _record(row) if row is not None else None
+
+
+def load_for_map(need_map_id: int) -> list[StoredAspectState]:
+    """Every stored state whose aspect belongs to ``need_map_id``."""
+    with session() as s:
+        rows = s.scalars(
+            select(AspectState)
+            .join(Aspect, Aspect.id == AspectState.aspect_id)
+            .where(Aspect.need_map_id == need_map_id)
+        ).all()
+        return [_record(r) for r in rows]
+
+
+def _record(row: AspectState) -> StoredAspectState:
+    return StoredAspectState(
+        aspect_id=row.aspect_id,
+        state=row.state,
+        conflict=row.conflict,
+        conflict_note=row.conflict_note,
+        model=row.model,
+        updated_at=row.updated_at,
+    )

--- a/backend/app/db/migrations/versions/d7e4b9a2c1f6_aspect_states.py
+++ b/backend/app/db/migrations/versions/d7e4b9a2c1f6_aspect_states.py
@@ -1,0 +1,58 @@
+"""aspect_states
+
+Adds ``aspect_states`` — one row per aspect holding the aspect's current
+state: what its member needs say right now, unified, plus the conflict flag a
+multi-page unification can raise when the pages disagree (see the model
+docstring). Scoped to the aspect and CASCADEd from it, so a map re-derivation
+tears states down with the aspects they describe.
+
+Guarded with the inspector because ``0001_initial`` builds fresh databases
+from the current models.
+
+Revision ID: d7e4b9a2c1f6
+Revises: a4d92e1c7f38
+Create Date: 2026-08-07 00:00:00.000000+00:00
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "d7e4b9a2c1f6"
+down_revision: str | None = "a4d92e1c7f38"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if inspector.has_table("aspect_states"):
+        return
+    op.create_table(
+        "aspect_states",
+        sa.Column(
+            "aspect_id",
+            sa.Integer(),
+            sa.ForeignKey("aspects.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("state", sa.Text(), nullable=False),
+        sa.Column("conflict", sa.Boolean(), nullable=False, server_default=sa.text("FALSE")),
+        sa.Column("conflict_note", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column("model", sa.Text(), nullable=False, server_default=sa.text("''")),
+        sa.Column(
+            "updated_at",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text(
+                "to_char((now() AT TIME ZONE 'UTC'), 'YYYY-MM-DD HH24:MI:SS')"
+            ),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("aspect_states")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2322,6 +2322,46 @@ class AspectPage(Base):
     )
 
 
+class AspectState(Base):
+    """What one aspect's needs say right now, unified — the aspect's current state.
+
+    The comparison target reconciliation reads: an incoming fact is judged against this before
+    any page is touched, and no delta means no page write. One row per aspect, so identity is
+    scoped to the aspect's own run — the cross-derivation identity problem the need-map docstring
+    defers never arises here, because a re-derivation mints new aspects and their states are
+    generated fresh against the new rows.
+
+    Current-valued against a snapshot map, like ``page_needs`` against the page: the map says
+    which needs compose the aspect, this row says what they currently amount to. It goes stale
+    two ways — a member page's needs were re-extracted since this was generated (detected by
+    comparing ``updated_at`` against the members' ``page_needs.updated_at``; no stored
+    fingerprint, deliberately — it would duplicate what those timestamps already say), or the
+    map itself is replaced (caught by CASCADE: the aspect row dies and takes this with it).
+
+    ``conflict`` is the fan-out's free by-product: unifying needs that live on more than one page
+    is exactly where two pages can be found disagreeing about the same facet, and that
+    disagreement is a wiki inconsistency worth surfacing, not an error in the unification.
+    Single-page aspects are unified mechanically (their needs' snapshots verbatim) and can never
+    conflict.
+    """
+
+    __tablename__ = "aspect_states"
+
+    aspect_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("aspects.id", ondelete="CASCADE"), primary_key=True
+    )
+    # The unified current state, prose — same register as the member needs' ``current_content``.
+    state: Mapped[str] = mapped_column(Text, nullable=False)
+    # The member pages disagree about this facet. Only a multi-page unification can set it.
+    conflict: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))
+    # What disagrees, when ``conflict`` — written for a human triaging the inconsistency.
+    conflict_note: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    # The completion model used for a unified (multi-page) state; empty for the mechanical
+    # single-page copy, which no model produced.
+    model: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("''"))
+    updated_at: Mapped[str] = mapped_column(Text, nullable=False, server_default=_NOW_TEXT_DEFAULT)
+
+
 class PageNeeds(Base):
     """What one wiki page keeps track of — its information needs.
 

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -2350,7 +2350,8 @@ class AspectState(Base):
     aspect_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("aspects.id", ondelete="CASCADE"), primary_key=True
     )
-    # The unified current state, prose — same register as the member needs' ``current_content``.
+    # The unified current state: compact fact-dense fragments (the register the extraction's
+    # own ``current_content`` uses), unioning every distinct fact across the member needs.
     state: Mapped[str] = mapped_column(Text, nullable=False)
     # The member pages disagree about this facet. Only a multi-page unification can set it.
     conflict: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))

--- a/backend/app/ingest/aspect_state.py
+++ b/backend/app/ingest/aspect_state.py
@@ -54,7 +54,12 @@ class _Member(NamedTuple):
 
 
 class _Job(NamedTuple):
-    """One aspect with its resolved members — everything a state needs."""
+    """One aspect with its resolved members — everything a state needs.
+
+    ``links`` is kept alongside the resolved ``members`` because freshness is
+    judged against the links: a link whose need no longer resolves is itself
+    evidence the inputs moved (see ``_fresh``).
+    """
 
     aspect_id: int
     topic_name: str
@@ -62,6 +67,7 @@ class _Job(NamedTuple):
     name: str
     description: str
     members: list[_Member]
+    links: list[need_map.NeedLink]
 
 
 def _resolve_members(
@@ -139,19 +145,38 @@ def _unify(job: _Job, *, model: str | None) -> tuple[str, bool, str] | None:
     return state, conflict, note
 
 
-def _fresh(aspect_id: int, members: list[_Member], *, force: bool) -> bool:
+def _fresh(
+    aspect_id: int,
+    links: list[need_map.NeedLink],
+    by_doc: dict[str, page_needs.StoredNeeds],
+    *,
+    force: bool,
+) -> bool:
     """Whether the stored state already reflects every member's current needs.
 
-    Timestamp comparison, both sides written second-precision by the same clock discipline:
-    a state generated after every member's last re-extraction has seen everything the members
-    currently say.
+    Judged against the aspect's LINKS, not just the members that still resolve: a link whose
+    page has no stored needs anymore, or whose need was renamed away, dangles precisely
+    *because* that page was re-extracted — and a state generated before that re-extraction may
+    still be carrying the vanished need's claims. Any link whose page can't vouch for the
+    stored state means regenerate.
+
+    Strict ``<`` on the second-precision timestamps: a member re-extracted in the same second
+    the state was recorded is indistinguishable from one re-extracted just after it, so it
+    counts as moved. Worst case is one redundant regeneration, which stamps a later timestamp
+    and settles.
     """
     if force:
         return False
     existing = aspect_states.get(aspect_id)
     if existing is None:
         return False
-    return all(m.needs_updated_at <= existing.updated_at for m in members)
+    for link in links:
+        stored = by_doc.get(link.doc_id)
+        if stored is None:
+            return False
+        if not stored.updated_at < existing.updated_at:
+            return False
+    return True
 
 
 def run_generation(
@@ -192,6 +217,7 @@ def run_generation(
                     name=aspect.name,
                     description=aspect.description,
                     members=members,
+                    links=list(aspect.needs),
                 )
             )
     if dangling:
@@ -202,7 +228,7 @@ def run_generation(
             record.need_map_id,
         )
 
-    todo = [j for j in jobs if not _fresh(j.aspect_id, j.members, force=force)]
+    todo = [j for j in jobs if not _fresh(j.aspect_id, j.links, by_doc, force=force)]
     mech = [j for j in todo if len({m.doc_id for m in j.members}) == 1]
     fan = [j for j in todo if len({m.doc_id for m in j.members}) > 1]
     log.info(

--- a/backend/app/ingest/aspect_state.py
+++ b/backend/app/ingest/aspect_state.py
@@ -1,0 +1,254 @@
+"""Generate each aspect's CURRENT STATE — what its member needs say right now, unified.
+
+The need map says which needs compose an aspect; the needs' own ``current_content`` snapshots
+say what each page currently records. This step folds those snapshots into one answer per
+aspect (``aspect_states``) — the comparison target reconciliation reads before touching any
+page, and the place where two pages get caught disagreeing about the same facet.
+
+Two paths, split by fan-out:
+
+    single page   the aspect's state IS its needs' snapshots — copied mechanically, no LLM
+    multi page    one completion unifies the per-page snapshots and flags disagreement
+
+Only the second can set ``conflict``: unifying needs from more than one page is exactly where
+incompatible claims surface, and that disagreement is a wiki inconsistency worth surfacing
+(one page moved, its sibling did not), not a unification error. On the measured corpus the
+split is ~234 mechanical to ~10 unified, so a full pass costs about ten calls.
+
+Per aspect and resumable, like need extraction: each state is recorded as it is produced, and
+an aspect is skipped when its stored state is already newer than every member's
+``page_needs.updated_at`` — no stored fingerprint, deliberately; the timestamps already say
+whether the inputs moved. A quiet corpus therefore costs a pass nothing.
+
+States are scoped to their map: ``aspect_states`` CASCADEs from ``aspects``, and a derivation
+mints new aspect rows, so a re-derivation starts stateless and a full pass re-pays the unified
+calls. That is the price of map-scoped identity, accepted until the map itself becomes
+patch-in-place.
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, NamedTuple
+
+from app.db import aspect_states, need_map, page_needs
+from app.ingest import json_completion
+from app.llm.prompts import load_prompt
+from app.llm.settings import get as get_llm_settings
+
+log = logging.getLogger(__name__)
+
+# Same bound and rationale as the other corpus steps (see ``need_map.DEFAULT_WORKERS``).
+DEFAULT_WORKERS = 8
+
+
+class _Member(NamedTuple):
+    """One member need, resolved from its (doc_id, need_name) link."""
+
+    doc_id: str
+    path: str
+    need_name: str
+    current_content: str
+    needs_updated_at: str
+
+
+class _Job(NamedTuple):
+    """One aspect with its resolved members — everything a state needs."""
+
+    aspect_id: int
+    topic_name: str
+    topic_description: str
+    name: str
+    description: str
+    members: list[_Member]
+
+
+def _resolve_members(
+    links: list[need_map.NeedLink], by_doc: dict[str, page_needs.StoredNeeds]
+) -> list[_Member]:
+    """The member needs an aspect's links still resolve to.
+
+    A link can dangle: the map is a snapshot, and a re-extraction since it was derived can have
+    renamed or dropped the need it points at. Dangling links are skipped rather than failing the
+    aspect — the state describes what the corpus still says, and the staleness of the map itself
+    is the fingerprint's question (``need_maps.corpus_fingerprint``), not this step's.
+    """
+    members: list[_Member] = []
+    for link in links:
+        stored = by_doc.get(link.doc_id)
+        if stored is None:
+            continue
+        for needdict in stored.needs:
+            if str(needdict.get("need_name") or "") == link.need_name:
+                members.append(
+                    _Member(
+                        doc_id=link.doc_id,
+                        path=stored.path,
+                        need_name=link.need_name,
+                        current_content=str(needdict.get("current_content") or ""),
+                        needs_updated_at=stored.updated_at,
+                    )
+                )
+                break
+    return members
+
+
+def _mechanical_state(members: list[_Member]) -> str:
+    """A single-page aspect's state: its needs' snapshots, verbatim.
+
+    Usually one member; two needs of one page landing in one aspect is legitimate (see
+    ``AspectPage``), and their snapshots are simply carried together.
+    """
+    return "\n\n".join(m.current_content for m in members if m.current_content.strip())
+
+
+def _listing(members: list[_Member]) -> str:
+    """The unification call's input: one block per member, attributed to its page."""
+    blocks: list[str] = []
+    for m in members:
+        blocks.append(f"Page: {m.path}\nTracks: {m.need_name}\nCurrent snapshot: {m.current_content}")
+    return "\n\n".join(blocks)
+
+
+def _unify(job: _Job, *, model: str | None) -> tuple[str, bool, str] | None:
+    """One completion: the aspect's unified state plus the disagreement verdict.
+
+    None when the call fails — the aspect is skipped and counted, never guessed: a wrong
+    "the pages agree" is worse than no state at all.
+    """
+    user = (
+        f"Subject: {job.topic_name} — {job.topic_description}\n"
+        f"Aspect: {job.name} — {job.description}\n\n"
+        f"{_listing(job.members)}"
+    )
+    data = json_completion.complete_json(
+        load_prompt("aspect_state.system"),
+        user,
+        model=model,
+        ctx=f"aspect {job.name!r} across {len({m.doc_id for m in job.members})} page(s)",
+        module="aspect_state",
+    )
+    if data is None:
+        return None
+    state = str(data.get("state") or "").strip()
+    if not state:
+        return None
+    conflict = bool(data.get("conflict"))
+    note = str(data.get("conflict_note") or "").strip() if conflict else ""
+    return state, conflict, note
+
+
+def _fresh(aspect_id: int, members: list[_Member], *, force: bool) -> bool:
+    """Whether the stored state already reflects every member's current needs.
+
+    Timestamp comparison, both sides written second-precision by the same clock discipline:
+    a state generated after every member's last re-extraction has seen everything the members
+    currently say.
+    """
+    if force:
+        return False
+    existing = aspect_states.get(aspect_id)
+    if existing is None:
+        return False
+    return all(m.needs_updated_at <= existing.updated_at for m in members)
+
+
+def run_generation(
+    need_map_id: int | None = None,
+    *,
+    model: str | None = None,
+    workers: int | None = None,
+    force: bool = False,
+) -> dict[str, Any] | None:
+    """Generate states for one map's aspects (the active map when unnamed).
+
+    Returns the pass's counts, or None when there is nothing to work on — no map, or a map
+    with no aspects. Never partial-failure-fatal: one aspect's failed unification is counted
+    and skipped, the same rule as every other corpus step.
+    """
+    record = need_map.get(need_map_id) if need_map_id is not None else need_map.active()
+    if record is None or not record.topics:
+        log.info("aspect_state: no need map to generate states for")
+        return None
+
+    llm = get_llm_settings()
+    model = model or llm.ingest_selector_model or llm.model or None
+
+    by_doc = {row.doc_id: row for row in page_needs.load_all()}
+    jobs: list[_Job] = []
+    dangling = 0
+    for topic in record.topics:
+        for aspect in topic.aspects:
+            members = _resolve_members(aspect.needs, by_doc)
+            if not members:
+                dangling += 1
+                continue
+            jobs.append(
+                _Job(
+                    aspect_id=aspect.aspect_id,
+                    topic_name=topic.name,
+                    topic_description=topic.description,
+                    name=aspect.name,
+                    description=aspect.description,
+                    members=members,
+                )
+            )
+    if dangling:
+        log.warning(
+            "aspect_state: %d aspect(s) had no resolvable members and got no state "
+            "(needs re-extracted since map %d was derived)",
+            dangling,
+            record.need_map_id,
+        )
+
+    todo = [j for j in jobs if not _fresh(j.aspect_id, j.members, force=force)]
+    mech = [j for j in todo if len({m.doc_id for m in j.members}) == 1]
+    fan = [j for j in todo if len({m.doc_id for m in j.members}) > 1]
+    log.info(
+        "aspect_state: map %d — %d aspect(s): %d fresh, %d mechanical, %d to unify",
+        record.need_map_id,
+        len(jobs),
+        len(jobs) - len(todo),
+        len(mech),
+        len(fan),
+    )
+
+    for job in mech:
+        aspect_states.record(
+            job.aspect_id,
+            state=_mechanical_state(job.members),
+            conflict=False,
+            conflict_note="",
+            model="",
+        )
+
+    def one(job: _Job) -> str:
+        result = _unify(job, model=model)
+        if result is None:
+            return "failed"
+        state, conflict, note = result
+        aspect_states.record(
+            job.aspect_id, state=state, conflict=conflict, conflict_note=note, model=model or ""
+        )
+        return "conflict" if conflict else "ok"
+
+    outcomes: list[str] = []
+    if fan:
+        with ThreadPoolExecutor(max_workers=workers or DEFAULT_WORKERS) as pool:
+            outcomes = list(pool.map(one, fan))
+    failed = outcomes.count("failed")
+    conflicts = outcomes.count("conflict")
+
+    stats = {
+        "need_map_id": record.need_map_id,
+        "aspects": len(jobs),
+        "fresh": len(jobs) - len(todo),
+        "mechanical": len(mech),
+        "unified": len(fan) - failed,
+        "failed": failed,
+        "conflicts": conflicts,
+        "dangling": dangling,
+    }
+    log.info("aspect_state: done — %s", stats)
+    return stats

--- a/backend/app/llm/prompts/aspect_state.system.md
+++ b/backend/app/llm/prompts/aspect_state.system.md
@@ -1,0 +1,32 @@
+You are consolidating what a wiki currently says about one FACET of one subject.
+
+You are given an aspect — a facet of a subject that several wiki pages track — and, per page,
+a snapshot of what that page currently records for it. The pages are supposed to be describing
+the same underlying reality at possibly different levels of detail.
+
+Produce the aspect's unified CURRENT STATE, and say whether the pages disagree.
+
+Rules:
+
+- **State only what the snapshots say.** The unified state is a faithful merge of the inputs,
+  not your judgment of what is probably true. Never add facts, never resolve a disagreement by
+  picking a side.
+- **Different detail is not disagreement.** One page saying "slice 3 merged" and another
+  listing the PRs in that slice agree; unify them at the more informative level. Disagreement
+  is when the snapshots make INCOMPATIBLE claims about the same thing — different status for
+  the same item, different owner, different date for the same event, one says shipped and the
+  other says in review.
+- **When they disagree**, still produce the best unified state you can (carry both claims,
+  attributed to their pages), set `conflict` to true, and write `conflict_note`: one or two
+  sentences naming exactly what disagrees and which page says what — written for a person
+  deciding which page needs the fix.
+- **Stay in the inputs' register**: plain prose, compact, present tense. No headers, no
+  markdown structure. A reader should get the facet's current answer in one breath.
+
+Respond with a single JSON object, nothing else:
+
+{
+  "state": "<the unified current state, one short paragraph>",
+  "conflict": <true|false>,
+  "conflict_note": "<empty string when conflict is false; otherwise what disagrees and which page says what>"
+}

--- a/backend/app/llm/prompts/aspect_state.system.md
+++ b/backend/app/llm/prompts/aspect_state.system.md
@@ -6,27 +6,31 @@ the same underlying reality at possibly different levels of detail.
 
 Produce the aspect's unified CURRENT STATE, and say whether the pages disagree.
 
-Rules:
+Rules for the state:
 
-- **State only what the snapshots say.** The unified state is a faithful merge of the inputs,
-  not your judgment of what is probably true. Never add facts, never resolve a disagreement by
-  picking a side.
+- **UNION the distinct facts across all pages.** Preserve every non-conflicting detail even if
+  only one page has it — do NOT drop information. State only what the snapshots say; never add
+  facts.
+- **Complete but compact and fact-dense.** Terse facts and values — `key: value` fragments or
+  short semicolon-joined clauses — not narrative prose, no filler. Not a lossy one-liner
+  either: every distinct fact survives. Example register: "Late-stage POC; security review
+  pending; contact Jane Doe."
 - **Different detail is not disagreement.** One page saying "slice 3 merged" and another
-  listing the PRs in that slice agree; unify them at the more informative level. Disagreement
-  is when the snapshots make INCOMPATIBLE claims about the same thing — different status for
-  the same item, different owner, different date for the same event, one says shipped and the
-  other says in review.
-- **When they disagree**, still produce the best unified state you can (carry both claims,
-  attributed to their pages), set `conflict` to true, and write `conflict_note`: one or two
-  sentences naming exactly what disagrees and which page says what — written for a person
-  deciding which page needs the fix.
-- **Stay in the inputs' register**: plain prose, compact, present tense. No headers, no
-  markdown structure. A reader should get the facet's current answer in one breath.
+  listing the PRs in that slice agree; keep the more informative level. Disagreement is when
+  the snapshots make INCOMPATIBLE claims about the same thing — different status for the same
+  item, different owner, different date for the same event, one says shipped and the other
+  says in review.
+- **When they disagree**, reconcile the disagreement INTO the state — carry both claims,
+  attributed to their pages inline where it matters ("merged per eng page; in review per
+  TODO") — never resolve it by picking a side. Also set `conflict` to true and write
+  `conflict_note`: one or two sentences naming exactly what disagrees and which page says
+  what, written for a person deciding which page needs the fix. The note is the queryable
+  record; the inline attribution keeps the state self-contained.
 
 Respond with a single JSON object, nothing else:
 
 {
-  "state": "<the unified current state, one short paragraph>",
+  "state": "<the unified current state: compact, fact-dense, unions every distinct fact>",
   "conflict": <true|false>,
   "conflict_note": "<empty string when conflict is false; otherwise what disagrees and which page says what>"
 }

--- a/backend/app/tasks/aspect_state.py
+++ b/backend/app/tasks/aspect_state.py
@@ -1,0 +1,25 @@
+"""Aspect-state generation — one pass unifying each aspect's member needs.
+
+Thin binding, like the other task modules: the work lives in
+``app.ingest.aspect_state``; this only says which queue it runs on.
+
+``automanage_offline_queue`` for the same reasons as need extraction and map
+derivation: batch, nobody waiting, LLM-bound for the fan-out aspects. Safe to
+re-run — the pass skips every aspect whose stored state is already newer than
+its members' needs, so a run over a quiet corpus costs nothing.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from app.ingest import aspect_state
+from app.tasks.queues import automanage_offline_queue
+
+log = logging.getLogger(__name__)
+
+
+@automanage_offline_queue.task()
+def generate_aspect_states(need_map_id: int | None = None, force: bool = False) -> None:
+    """Generate states for one map's aspects (the active map when unnamed)."""
+    aspect_state.run_generation(need_map_id, force=force)

--- a/backend/app/tasks/run_worker.py
+++ b/backend/app/tasks/run_worker.py
@@ -46,6 +46,7 @@ _TASK_MODULES = (
     "app.tasks.coedit_checkpoint",
     "app.tasks.coedit_rebase",
     "app.tasks.need_map",
+    "app.tasks.aspect_state",
     "app.tasks.craft",
     "app.tasks.wiki_update",
     "app.tasks.entity_types",

--- a/backend/tests/test_aspect_state.py
+++ b/backend/tests/test_aspect_state.py
@@ -118,6 +118,11 @@ def test_fan_out_aspect_unifies_and_flags_conflict(corpus, monkeypatch):
 
 
 def test_fresh_states_are_skipped(corpus, monkeypatch):
+    from sqlalchemy import update as sa_update
+
+    from app.db.models import AspectState
+    from app.db.session import session as db_session
+
     monkeypatch.setattr(
         aspect_state.json_completion,
         "complete_json",
@@ -125,6 +130,12 @@ def test_fresh_states_are_skipped(corpus, monkeypatch):
     )
     first = aspect_state.run_generation(corpus)
     assert first is not None and first["fresh"] == 0
+
+    # The whole test runs inside one second, and a same-second member counts
+    # as moved (see _fresh) — age the states one minute past the needs so the
+    # freshness this test is about is unambiguous.
+    with db_session() as s:
+        s.execute(sa_update(AspectState).values(updated_at="2999-01-01 00:00:00"))
 
     def boom(*_a, **_k):
         raise AssertionError("a fresh corpus must not reach the LLM")
@@ -176,3 +187,67 @@ def test_dangling_links_resolve_to_what_remains(corpus, monkeypatch):
     assert stored is not None
     assert stored.state == "slice 3 merged; watch until Friday"
     assert stored.model == ""
+
+
+def test_a_dangling_member_makes_the_stored_state_stale(corpus, monkeypatch):
+    # Generate a unified two-page state, then rename one member's need. The
+    # dropped member's page can no longer vouch for the stored state, so the
+    # next pass must regenerate (to the mechanical state of what remains) —
+    # not report the old unified state, which still carries the vanished
+    # need's claims, as fresh.
+    monkeypatch.setattr(
+        aspect_state.json_completion,
+        "complete_json",
+        lambda *a, **k: {"state": "old unified answer", "conflict": False, "conflict_note": ""},
+    )
+    assert aspect_state.run_generation(corpus) is not None
+    ids = _aspect_ids(corpus)
+    record = need_map.get(corpus)
+    assert record is not None
+    b_doc = next(
+        n.doc_id
+        for t in record.topics
+        for a in t.aspects
+        if a.name == "delivery status"
+        for n in a.needs
+        if n.need_name == "delivery progress"
+    )
+    b_row = page_needs.get_by_doc_id(b_doc)
+    assert b_row is not None
+    page_needs.store(
+        b_row.path, body="changed body", needs=[_need("renamed need", "different now")], model="test-model"
+    )
+    stats = aspect_state.run_generation(corpus)
+    assert stats is not None
+    stored = aspect_states.get(ids["delivery status"])
+    assert stored is not None
+    assert stored.state == "slice 3 merged; watch until Friday"  # regenerated, mechanical
+    assert stored.model == ""
+
+
+def test_same_second_reextraction_counts_as_moved(corpus, monkeypatch):
+    from sqlalchemy import update as sa_update
+
+    from app.db.models import AspectState
+    from app.db.session import session as db_session
+
+    monkeypatch.setattr(
+        aspect_state.json_completion,
+        "complete_json",
+        lambda *a, **k: {"state": "unified", "conflict": False, "conflict_note": ""},
+    )
+    assert aspect_state.run_generation(corpus) is not None
+    ids = _aspect_ids(corpus)
+    # Pin the stored state's timestamp to exactly a member's needs timestamp —
+    # the same-second race, made deterministic.
+    row = page_needs.get("eng/status.md")
+    assert row is not None
+    with db_session() as s:
+        s.execute(
+            sa_update(AspectState)
+            .where(AspectState.aspect_id == ids["delivery status"])
+            .values(updated_at=row.updated_at)
+        )
+    stats = aspect_state.run_generation(corpus)
+    assert stats is not None
+    assert stats["unified"] == 1  # regenerated, not reported fresh

--- a/backend/tests/test_aspect_state.py
+++ b/backend/tests/test_aspect_state.py
@@ -1,0 +1,178 @@
+"""Aspect-state generation (app/ingest/aspect_state.py) — the mechanical
+single-page path, the unified fan-out path with its conflict verdict, the
+timestamp staleness skip, and dangling-link tolerance.
+
+DB-backed via ``tmp_db``. The LLM is mocked at the house seam
+(``json_completion.complete_json`` — itself a wrapper over
+``app.llm.client.complete``); the mechanical path asserts the seam is never
+touched at all.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.db import aspect_states, need_map, page_needs
+from app.ingest import aspect_state
+
+
+def _seed_page(path: str, needs: list[dict[str, Any]], *, body: str = "") -> str:
+    return page_needs.store(path, body=body or ("body of " + path), needs=needs, model="test-model")
+
+
+def _need(name: str, content: str) -> dict[str, Any]:
+    return {"need_name": name, "current_content": content}
+
+
+def _seed_map(topics: list[dict[str, Any]]) -> int:
+    map_id = need_map.record(
+        {
+            "corpus_fingerprint": "fp",
+            "entity_type_taxonomy_id": None,
+            "provenance": {},
+            "stats": {},
+            "topics": topics,
+        }
+    )
+    return map_id
+
+
+@pytest.fixture
+def corpus(tmp_db):
+    a = _seed_page("eng/status.md", [_need("delivery status", "slice 3 merged; watch until Friday")])
+    b = _seed_page("notes/todo.md", [_need("delivery progress", "slice 3 still in review")])
+    c = _seed_page("eng/design.md", [_need("architecture", "attach-by-transplant; sessions stay the working copy")])
+    map_id = _seed_map(
+        [
+            {
+                "name": "Rollout",
+                "description": "The rollout of the thing.",
+                "aspects": [
+                    {
+                        "key": "0:delivery",
+                        "name": "delivery status",
+                        "description": "Where delivery stands.",
+                        "pages": [
+                            {"doc_id": a, "need_name": "delivery status"},
+                            {"doc_id": b, "need_name": "delivery progress"},
+                        ],
+                    },
+                    {
+                        "key": "0:architecture",
+                        "name": "architecture",
+                        "description": "How it is built.",
+                        "pages": [{"doc_id": c, "need_name": "architecture"}],
+                    },
+                ],
+            }
+        ]
+    )
+    return map_id
+
+
+def _aspect_ids(map_id: int) -> dict[str, int]:
+    record = need_map.get(map_id)
+    assert record is not None
+    return {a.name: a.aspect_id for t in record.topics for a in t.aspects}
+
+
+def test_single_page_aspect_is_mechanical_and_free(corpus, monkeypatch):
+    monkeypatch.setattr(
+        aspect_state.json_completion,
+        "complete_json",
+        lambda *a, **k: {"state": "unified", "conflict": False, "conflict_note": ""},
+    )
+    stats = aspect_state.run_generation(corpus)
+    assert stats is not None
+    ids = _aspect_ids(corpus)
+    stored = aspect_states.get(ids["architecture"])
+    assert stored is not None
+    assert stored.state == "attach-by-transplant; sessions stay the working copy"
+    assert stored.model == ""  # no model produced it
+    assert stored.conflict is False
+
+
+def test_fan_out_aspect_unifies_and_flags_conflict(corpus, monkeypatch):
+    calls: list[str] = []
+
+    def fake(system: str, user: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append(user)
+        return {
+            "state": "slice 3: merged per the engineering page, in review per the TODO",
+            "conflict": True,
+            "conflict_note": "eng/status.md says merged; notes/todo.md says in review",
+        }
+
+    monkeypatch.setattr(aspect_state.json_completion, "complete_json", fake)
+    stats = aspect_state.run_generation(corpus)
+    assert stats is not None
+    assert stats["conflicts"] == 1
+    assert len(calls) == 1  # exactly the one fan-out aspect
+    assert "eng/status.md" in calls[0] and "notes/todo.md" in calls[0]
+    ids = _aspect_ids(corpus)
+    stored = aspect_states.get(ids["delivery status"])
+    assert stored is not None
+    assert stored.conflict is True
+    assert "in review" in stored.conflict_note
+
+
+def test_fresh_states_are_skipped(corpus, monkeypatch):
+    monkeypatch.setattr(
+        aspect_state.json_completion,
+        "complete_json",
+        lambda *a, **k: {"state": "unified", "conflict": False, "conflict_note": ""},
+    )
+    first = aspect_state.run_generation(corpus)
+    assert first is not None and first["fresh"] == 0
+
+    def boom(*_a, **_k):
+        raise AssertionError("a fresh corpus must not reach the LLM")
+
+    monkeypatch.setattr(aspect_state.json_completion, "complete_json", boom)
+    second = aspect_state.run_generation(corpus)
+    assert second is not None
+    assert second["fresh"] == second["aspects"]
+    assert second["mechanical"] == 0 and second["unified"] == 0
+
+
+def test_failed_unification_is_counted_not_stored(corpus, monkeypatch):
+    monkeypatch.setattr(aspect_state.json_completion, "complete_json", lambda *a, **k: None)
+    stats = aspect_state.run_generation(corpus)
+    assert stats is not None
+    assert stats["failed"] == 1
+    ids = _aspect_ids(corpus)
+    assert aspect_states.get(ids["delivery status"]) is None  # nothing guessed
+    assert aspect_states.get(ids["architecture"]) is not None  # mechanical path unaffected
+
+
+def test_dangling_links_resolve_to_what_remains(corpus, monkeypatch):
+    # Re-extract one member page so its need name no longer matches the map's link.
+    ids = _aspect_ids(corpus)
+    record = need_map.get(corpus)
+    assert record is not None
+    b_doc = next(
+        n.doc_id
+        for t in record.topics
+        for a in t.aspects
+        if a.name == "delivery status"
+        for n in a.needs
+        if n.need_name == "delivery progress"
+    )
+    b_row = page_needs.get_by_doc_id(b_doc)
+    assert b_row is not None
+    page_needs.store(
+        b_row.path, body="changed body", needs=[_need("renamed need", "different now")], model="test-model"
+    )
+    monkeypatch.setattr(
+        aspect_state.json_completion,
+        "complete_json",
+        lambda *a, **k: {"state": "should not be called", "conflict": False, "conflict_note": ""},
+    )
+    stats = aspect_state.run_generation(corpus)
+    assert stats is not None
+    # The fan-out aspect degraded to one resolvable member -> mechanical path.
+    stored = aspect_states.get(ids["delivery status"])
+    assert stored is not None
+    assert stored.state == "slice 3 merged; watch until Friday"
+    assert stored.model == ""

--- a/backend/tests/test_rename_entity_type_taxonomies_migration.py
+++ b/backend/tests/test_rename_entity_type_taxonomies_migration.py
@@ -37,6 +37,7 @@ def _rewind_to_the_old_name(seed_row: bool = False) -> None:
         # that gains a foreign key to entity_type_taxonomies has to be listed here, or this rewind
         # stops reproducing a pre-rename database and the test fails on setup rather than on the
         # behaviour it is checking.
+        s.execute(sa.text("DROP TABLE IF EXISTS aspect_states"))
         s.execute(sa.text("DROP TABLE IF EXISTS aspect_pages"))
         s.execute(sa.text("DROP TABLE IF EXISTS topic_aspects"))
         s.execute(sa.text("DROP TABLE IF EXISTS aspects"))


### PR DESCRIPTION
## What

The state layer above need extraction: one row per aspect (`aspect_states`) holding what the aspect's member needs currently say, unified — the comparison target a future reconciler reads before touching any page, and the place two pages get caught disagreeing about the same facet.

## Design decisions 

- **Separate table, not columns on `aspects`** — `aspects` rows are a write-once snapshot per derivation (each derivation mints a new generation of rows); state is rewritten continually by a different process. One writer per table, and "no row" cleanly means "not generated yet". CASCADE from `aspects` scopes state to its map, so cross-derivation aspect identity never arises — a re-derivation starts stateless and regenerates.
- **No stored staleness fingerprint** — it would duplicate what timestamps already say. An aspect is skipped when its state's `updated_at` is newer than every member's `page_needs.updated_at`; a quiet corpus costs a pass zero calls and zero writes.
- **Split by fan-out**: a single-page aspect's state IS its needs' snapshots, copied mechanically (no LLM, `model=''`). Multi-page aspects get one completion that unifies the per-page snapshots and sets `conflict` + `conflict_note` when the pages make incompatible claims — different detail levels are explicitly *not* disagreement. On the current corpus that's ~234 mechanical to ~10 unified.
- **Failures are counted, never guessed**: a failed unification stores nothing — a wrong "the pages agree" is worse than no state.
- Dangling links (a need re-extracted/renamed since the map was derived) resolve to what remains rather than failing the aspect.

## Not in scope

No scheduling — generation is a queue task (`generate_aspect_states`) invoked explicitly, consistent with the decision to keep the ingestion auto-update filter authoritative for scheduled paths.

## Verified

5 tests through the generation entry point (mechanical path never touches the LLM seam, fan-out unification + conflict verdict, timestamp skip on a fresh corpus, failed-call-stores-nothing, dangling-link degradation to the mechanical path); migration chains on current head; full backend suite + pyright green. One existing test updated: the taxonomy-rename migration test's rewind helper gains `aspect_states` in its dependent-drop list, exactly as its comment instructs for new FK dependents.