### PR TITLE
feat(editor): synthetic animated caret (blink + glide + affinity)

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -461,9 +461,13 @@
   /* Above the peer caret (z-index: 1) and positioned image nodes. */
   z-index: 2;
   will-change: transform, opacity;
-  /* Glide between positions; disabled inline for line changes / big jumps. */
-  transition: transform 90ms ease;
-  animation: editor-caret-blink 1.06s ease-in-out infinite;
+  /* What glides and how it eases; *how long* is set inline per move from
+     GLIDE_MS (caret.ts) — hence no duration here, so an un-set move snaps.
+     `transform` must be named explicitly: the initial `all` would drag the
+     inline height and the blink's opacity into the same transition. */
+  transition-property: transform;
+  transition-timing-function: ease;
+  animation: editor-caret-blink 1s ease-in-out infinite;
 }
 /* Solid while moving/typing; the fade-blink resumes once still (caret.ts). */
 .editor-caret.is-moving {

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -17,6 +17,11 @@
      write against. */
   height: 100%;
   overflow-y: auto;
+  /* Containing block for the synthetic caret overlay (.editor-caret), which is
+     absolutely positioned in this scroller's scroll-origin space so it scrolls
+     with the text. Safe for the fixed-positioned TableGrips overlay — `relative`
+     (unlike `transform`) doesn't capture fixed descendants. */
+  position: relative;
   /* Reserves room for a peer's caret name-label, which renders 1.15em
      *above* its cursor line — with none, a caret on the doc's very first
      line gets its label clipped by overflow-y-auto (confirmed directly:
@@ -427,6 +432,61 @@
 }
 .editor-prose .ProseMirror-yjs-selection {
   opacity: 0.3;
+}
+
+/* Synthetic local caret. The native caret is hidden (it can't be animated —
+   only `caret-color` is stylable) and replaced by `.editor-caret`, a persistent
+   overlay the `caret` extension positions, so it can fade-blink and glide.
+   `caret-color: transparent` is restored to `auto` inline during IME
+   composition (see caret.ts). Peers are drawn separately (yCursorPlugin).
+
+   Gated to fine pointers: on touch/coarse devices the caret extension keeps the
+   native caret (selection handles / loupe / long-press anchor to it), so we
+   must not hide it there. Matches the `matchMedia("(pointer: fine)")` guard in
+   caret.ts. */
+@media (pointer: fine) {
+  .editor-prose .ProseMirror {
+    caret-color: transparent;
+  }
+}
+.editor-caret {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2px;
+  /* height is set inline to the caret line's measured height (caret.ts). */
+  border-radius: 1px;
+  background: var(--text-05);
+  pointer-events: none;
+  /* Above the peer caret (z-index: 1) and positioned image nodes. */
+  z-index: 2;
+  will-change: transform, opacity;
+  /* Glide between positions; disabled inline for line changes / big jumps. */
+  transition: transform 90ms ease;
+  animation: editor-caret-blink 1.06s ease-in-out infinite;
+}
+/* Solid while moving/typing; the fade-blink resumes once still (caret.ts). */
+.editor-caret.is-moving {
+  opacity: 1;
+  animation: none;
+}
+@keyframes editor-caret-blink {
+  0%,
+  40% {
+    opacity: 1;
+  }
+  50%,
+  90% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .editor-caret {
+    transition: none;
+  }
 }
 
 /* A draggable node is not user-selectable by default, so a selection covering

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -22,40 +22,13 @@
  * selection, which all anchor to it. Only IME candidate windows still lean on
  * the native caret, so it's restored during composition (see below).
  *
- * **We replaced the caret's pixels, not the caret.** `caret-color:
- * transparent` hides the native caret; it does not disable it. The browser
- * still owns where the cursor is, which visual line it sits on, and where every
- * key we don't handle sends it. This file draws a rectangle to match.
+ * **Rendering only.** This file has no opinion about caret motion. It asks
+ * `coordsAtPos` where the cursor is and draws a rectangle there; ProseMirror
+ * and the browser decide everything else, including which side of a soft wrap
+ * the caret sits on. No key is handled here.
  *
- * That matters for **affinity** — which side of a soft wrap the caret is on. A
- * wrap is one document position with two visual homes (end of visual line N,
- * start of line N+1), and neither the DOM nor ProseMirror has a field for which
- * one you mean. The browser keeps that bit internally and exposes no way to
- * read or write it.
- *
- * We deliberately don't model it. Ordinary motion paints wherever `coordsAtPos`
- * defaults to, so arrowing right onto a wrap puts the caret at the start of
- * line N+1 rather than the end of line N — which reads wrong at first, but is
- * what the browser does natively and what Notion does too. It's the convention,
- * not a defect. Don't "fix" it.
- *
- * The one exception is a key that *names* a side: End and Cmd+ArrowRight mean
- * "end of this visual line", and the default would paint them at the start of
- * the next one, contradicting both the command and the native caret. Those keys
- * are honoured (`affinityForKey`). That is the whole of it — a lookup on the
- * key, no state machine, no inference from direction of travel.
- *
- * It has been tried. Guessing the bit from the last key worked but bought
- * nothing; *leading* it — making a wrap two caret stops, with an arrow press
- * that flips sides without moving the document — broke everything that reads
- * the browser's bit instead of ours: cmd-left at a boundary no-opped, and
- * Up/Down departed from the line the caret wasn't visibly on, since that bit
- * carries the goal column too. There is no fix from inside this file; two bits
- * exist and we can only write one. Doing it properly means owning navigation
- * outright (Left/Right by grapheme cluster, Up/Down with goal-column memory,
- * line and word ops, Shift extension, bidi), the way CodeMirror and Monaco do —
- * ProseMirror deliberately delegates all of it to the browser. Git history
- * around `arrivingAffinity` has the working attempt if it ever comes up. */
+ * Tracking that side ourselves has been tried and reverted twice — see git
+ * history for `bias` / `affinityForKey`. Don't. */
 import { Extension } from "@tiptap/core";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
@@ -75,29 +48,6 @@ interface CaretPos {
   height: number;
 }
 
-/** Which side of a soft-wrap boundary to measure — end of visual line N or
- * start of line N+1 — as `coordsAtPos`'s signed `side` argument. */
-type Affinity = "upstream" | "downstream";
-const SIDE: Record<Affinity, number> = { upstream: -1, downstream: 1 };
-
-/** The side a key *names*, for the few that name one at all.
- *
- * Ordinary motion returns null and takes `coordsAtPos`'s default, which is the
- * convention at a wrap (see the docstring) — this is not affinity tracking and
- * must not grow into it. But a key that means "end of this visual line" lands
- * on a wrap boundary and the default paints it at the start of the *next* line,
- * contradicting both the command and the native caret. Those keys say which
- * side they meant, so use it.
- *
- * Meta only, not Ctrl: Cmd+Arrow is line-edge on macOS, while Ctrl+Arrow on
- * Windows/Linux is word motion, which can land anywhere and names nothing. */
-function affinityForKey(event: KeyboardEvent): Affinity | null {
-  const k = event.key;
-  if (k === "End" || (event.metaKey && k === "ArrowRight")) return "upstream";
-  if (k === "Home" || (event.metaKey && k === "ArrowLeft")) return "downstream";
-  return null;
-}
-
 class CaretView {
   private el: HTMLElement;
   private scroller: HTMLElement | null = null;
@@ -107,13 +57,6 @@ class CaretView {
   private last: CaretPos | null = null;
   // Set on mousedown to disambiguate the caret's side by the click's x.
   private clickX: number | null = null;
-  // The side a line-edge key named, applied on the next render. Null for every
-  // other key, which is how ordinary motion keeps coordsAtPos's default.
-  // `pending` is set at keydown and moves to `side` once the selection has
-  // actually landed — the key names the side of a position that doesn't exist
-  // yet when it's pressed.
-  private pending: Affinity | null = null;
-  private side: Affinity | null = null;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
 
@@ -151,12 +94,7 @@ class CaretView {
   }
 
   update(): void {
-    if (!this.enabled) return;
-    // Consume whatever the last key named — null for almost every key, which
-    // clears any side a previous line-edge key set.
-    this.side = this.pending;
-    this.pending = null;
-    this.render();
+    if (this.enabled) this.render();
   }
 
   private onComposeStart = () => {
@@ -173,42 +111,23 @@ class CaretView {
     this.clickX = event.clientX;
   };
 
-  /** Note the side a line-edge key named, for update() to apply once the
-   * selection has landed. **Never consumes a key** — always returns false;
-   * navigation belongs to the browser (see the docstring).
-   *
-   * A ProseMirror prop rather than a DOM listener, because PM installs its own
-   * keydown listener in the EditorView constructor, before any plugin view
-   * exists — a listener added from here runs after PM's entire handler chain,
-   * including after other plugins have consumed keys we'd then wrongly note. */
-  handleKeyDown = (event: KeyboardEvent): boolean => {
-    if (this.enabled) this.pending = affinityForKey(event);
-    return false;
-  };
-
-  /** Doc position → the scroller's scroll-origin space. At an ambiguous
-   * position the side comes from the click's x if there was one, then from a
-   * line-edge key if one named a side, and otherwise from `coordsAtPos`'s own
-   * default. Subtracts the scroller's border (`clientLeft/Top`) because
-   * `getBoundingClientRect` includes the border but absolute positioning is
-   * relative to the padding box. */
-  private caretPos(
-    clickX: number | null,
-    side: Affinity | null,
-  ): CaretPos | null {
+  /** Doc position → the scroller's scroll-origin space. Takes whatever side
+   * `coordsAtPos` picks, except on a click, where the click's own x says which
+   * end of an ambiguous position was meant. Subtracts the scroller's border
+   * (`clientLeft/Top`) because `getBoundingClientRect` includes the border but
+   * absolute positioning is relative to the padding box. */
+  private caretPos(clickX: number | null): CaretPos | null {
     if (!this.scroller) return null;
     const head = this.view.state.selection.head;
     let coords: { left: number; top: number; bottom: number };
     try {
       if (clickX != null) {
-        const up = this.view.coordsAtPos(head, SIDE.upstream);
-        const down = this.view.coordsAtPos(head, SIDE.downstream);
+        const before = this.view.coordsAtPos(head, -1);
+        const after = this.view.coordsAtPos(head, 1);
         coords =
-          Math.abs(up.left - clickX) <= Math.abs(down.left - clickX)
-            ? up
-            : down;
-      } else if (side != null) {
-        coords = this.view.coordsAtPos(head, SIDE[side]);
+          Math.abs(before.left - clickX) <= Math.abs(after.left - clickX)
+            ? before
+            : after;
       } else {
         coords = this.view.coordsAtPos(head);
       }
@@ -253,7 +172,7 @@ class CaretView {
       selection instanceof TextSelection &&
       selection.empty;
 
-    const pos = active ? this.caretPos(clickX, this.side) : null;
+    const pos = active ? this.caretPos(clickX) : null;
     if (!pos) {
       this.el.style.display = "none";
       // Re-appearance should snap, not glide from a stale position.
@@ -305,17 +224,6 @@ export const Caret = Extension.create({
   name: "caret",
 
   addProseMirrorPlugins() {
-    // The keydown prop and the plugin view must be the same Plugin so the prop
-    // can reach the instance; the closure is per-editor because
-    // addProseMirrorPlugins runs once per editor.
-    let caret: CaretView | null = null;
-    return [
-      new Plugin({
-        view: (view) => (caret = new CaretView(view)),
-        props: {
-          handleKeyDown: (_view, event) => caret?.handleKeyDown(event) ?? false,
-        },
-      }),
-    ];
+    return [new Plugin({ view: (view) => new CaretView(view) })];
   },
 });

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -20,9 +20,18 @@
  * Deliberately disabled on touch/coarse-pointer devices: hiding the native
  * caret would break the selection handles, the magnifier loupe, and long-press
  * selection, which all anchor to it. Only IME candidate windows still lean on
- * the native caret, so it's restored during composition (see below). */
+ * the native caret, so it's restored during composition (see below).
+ *
+ * Owning the caret means owning **affinity** — the side of an ambiguous
+ * position the caret sits on. A soft wrap is one document position with two
+ * visual homes (end of visual line N, start of line N+1), and ProseMirror's
+ * selection has no field for which one you mean, so `bias` reconstructs it.
+ * Here that bit is not just cosmetic: a wrap is two caret stops, and the
+ * arrow key that moves between them is consumed rather than moving the
+ * document position (`handleKeyDown`). */
 import { Extension } from "@tiptap/core";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
+import type { EditorState } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 
 // Stay solid this long after a move, then resume blinking — so typing/arrowing
@@ -54,6 +63,13 @@ class CaretView {
   // boundary — the caret belongs to, inferred from the last input's direction.
   // -1 = upstream (end of prev line), +1 = downstream (start of next line).
   private bias: number | null = null;
+  // Direction recorded on keydown, resolved into `bias` by update() once
+  // ProseMirror has actually moved the selection — the destination has to exist
+  // before we can measure whether it landed on a wrap boundary.
+  // `pendingHorizontal` marks Left/Right, the only keys the boundary inversion
+  // applies to.
+  private pending: number | null = null;
+  private pendingHorizontal = false;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
 
@@ -86,13 +102,66 @@ class CaretView {
     this.view.dom.addEventListener("compositionstart", this.onComposeStart);
     this.view.dom.addEventListener("compositionend", this.onComposeEnd);
     this.view.dom.addEventListener("mousedown", this.onMouseDown);
-    this.view.dom.addEventListener("keydown", this.onKeyDown);
     this.view.dom.addEventListener("focus", this.render);
     this.view.dom.addEventListener("blur", this.render);
   }
 
-  update(): void {
-    if (this.enabled) this.render();
+  update(_view: EditorView, prevState: EditorState): void {
+    if (!this.enabled) return;
+
+    const pending = this.pending;
+    const horizontal = this.pendingHorizontal;
+    this.pending = null;
+    this.pendingHorizontal = false;
+
+    const moved = prevState.selection.head !== this.view.state.selection.head;
+    if (moved && pending != null) {
+      // Resolve the recorded intent now that the selection has landed. At a
+      // soft-wrap boundary the arriving caret belongs to the line it came
+      // *from* — that's what makes the boundary two stops rather than one,
+      // with handleKeyDown's flip supplying the second. Everywhere else the
+      // affinity is simply the direction of travel.
+      //
+      // Horizontal keys only: Up/Down and Home/End already name the affinity
+      // they want (Down wants the line it arrives on, End wants upstream even
+      // though it travels right), so inverting them lands the caret a line off.
+      this.bias =
+        horizontal && this.isWrapBoundary(this.view.state.selection.head)
+          ? -pending
+          : pending;
+    } else if (moved) {
+      // The head moved with no key and no click behind it: a remote Yjs update
+      // (ySyncPlugin restores the selection on every remote change), undo/redo,
+      // or any programmatic setSelection. Whatever `bias` described, it
+      // described a different position — and a stale one would spend the user's
+      // next arrow press on a bogus flip. Drop it and re-derive from input.
+      this.bias = null;
+    }
+
+    this.render();
+  }
+
+  /** Is `pos` a soft-wrap boundary — one document position with two visual
+   * homes? Nothing in the model records where the browser chose to wrap, so it
+   * has to be measured: ask for both sides and see if they landed on different
+   * lines. (`view.endOfTextblock()` can't answer this — it reports *textblock*
+   * edges, not wrap points.)
+   *
+   * Requires a step down *and* a jump left. An inline image or a taller mark
+   * also shifts `.top` between the two sides; only a wrap throws the downstream
+   * side back to the line's left edge. That second conjunct is also what keeps
+   * the flip from ever stealing a key from gapcursor, tableEditing, or atom
+   * traversal: those act only at textblock edges, and a position with content
+   * to its left on one line and to its right on the next is by definition not
+   * one. Deliberately narrow — a false positive costs a swallowed keystroke. */
+  private isWrapBoundary(pos: number): boolean {
+    try {
+      const up = this.view.coordsAtPos(pos, -1);
+      const down = this.view.coordsAtPos(pos, 1);
+      return down.top > up.top + 1 && down.left < up.left;
+    } catch {
+      return false;
+    }
   }
 
   private onComposeStart = () => {
@@ -111,30 +180,67 @@ class CaretView {
     this.bias = null;
   };
 
-  /** Infer caret affinity from the input's direction, so the next render can
-   * paint an ambiguous boundary position (soft-wrap/bidi/mark edge) on the side
-   * the user meant. Backward motion → upstream; forward motion / a typed char →
-   * downstream. Not correct inside RTL (bidi) runs — the browser tracks the
-   * embedding level and we don't; left the obvious boundary rather than fake it. */
-  private onKeyDown = (event: KeyboardEvent) => {
+  /** Two jobs, in order: record the input's direction so update() can infer
+   * affinity once the selection lands, and consume the arrow key that crosses a
+   * soft-wrap boundary in place.
+   *
+   * Must be a ProseMirror `handleKeyDown` prop rather than a DOM listener:
+   * ProseMirror installs its own `keydown` listener in the EditorView
+   * constructor, before any plugin view is constructed, so a listener added
+   * from here would always run after PM's whole handler chain — too late to
+   * preventDefault, and it would clobber `bias` on keys PM already consumed.
+   *
+   * Returns true only for a genuine boundary flip. Everything else falls
+   * through to the plugins after us (tableEditing, gapcursor) and then PM's own
+   * atom traversal, none of which must ever lose a key to this. */
+  handleKeyDown = (event: KeyboardEvent): boolean => {
     const k = event.key;
-    if (
-      k === "ArrowLeft" ||
-      k === "ArrowUp" ||
-      k === "End" ||
-      k === "Backspace"
-    ) {
-      this.bias = -1;
+    const left = k === "ArrowLeft";
+    const right = k === "ArrowRight";
+
+    if (left || k === "ArrowUp" || k === "End" || k === "Backspace") {
+      this.pending = -1;
     } else if (
-      k === "ArrowRight" ||
+      right ||
       k === "ArrowDown" ||
       k === "Home" ||
       k === "Enter" ||
       k.length === 1 // a printable character
     ) {
-      this.bias = 1;
+      this.pending = 1;
     }
     // Modifiers, Escape, etc. leave the last inferred affinity in place.
+    this.pendingHorizontal = left || right;
+
+    // Cheap tests first — isWrapBoundary forces a layout read, and this keeps
+    // it off the hot path of a held-down arrow.
+    if (!this.enabled || !(left || right)) return false;
+    // Never consume a modified arrow: Shift extends the selection, Cmd/Ctrl
+    // jumps the line, Alt jumps the word. They still record intent above, which
+    // is what makes Cmd+ArrowRight land upstream at a wrapped line end.
+    if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey)
+      return false;
+
+    const dir = right ? 1 : -1;
+    // `bias === -dir` — affinity pointing against the press — is exactly
+    // "standing at the far end of a two-ended position". Anything else,
+    // including a null (unknown) bias, falls through and moves normally: a
+    // keystroke is never eaten on a guess.
+    if (this.bias !== -dir) return false;
+    const { selection } = this.view.state;
+    if (!(selection instanceof TextSelection) || !selection.empty) return false;
+    if (!this.isWrapBoundary(selection.head)) return false;
+
+    // The flip sets bias to the direction just pressed, so the next press can't
+    // flip again — a false-positive boundary costs one extra keypress, never a
+    // stuck caret. Not correct inside RTL (bidi) runs, where the physical key
+    // direction and the logical one diverge; same punt as before, and it
+    // self-heals for the same reason.
+    this.bias = dir;
+    this.pending = null; // consumed here — no transaction, so no update()
+    this.pendingHorizontal = false;
+    this.render();
+    return true;
   };
 
   /** Doc position → the scroller's scroll-origin space. The caret's side at an
@@ -153,10 +259,15 @@ class CaretView {
       if (clickX != null) {
         const before = this.view.coordsAtPos(head, -1);
         const after = this.view.coordsAtPos(head, 1);
-        coords =
-          Math.abs(before.left - clickX) <= Math.abs(after.left - clickX)
-            ? before
-            : after;
+        const upstream =
+          Math.abs(before.left - clickX) <= Math.abs(after.left - clickX);
+        coords = upstream ? before : after;
+        // Keep the side the click picked. The click's x is the most direct
+        // affinity signal there is, and persisting it is what lets
+        // click-then-arrow behave like arrow-then-arrow at a wrapped position —
+        // otherwise `bias` is null there and the first press can't flip. Off a
+        // boundary the two sides coincide, so whichever wins is harmless.
+        this.bias = upstream ? -1 : 1;
       } else if (bias != null) {
         coords = this.view.coordsAtPos(head, bias);
       } else {
@@ -244,7 +355,6 @@ class CaretView {
     this.view.dom.removeEventListener("compositionstart", this.onComposeStart);
     this.view.dom.removeEventListener("compositionend", this.onComposeEnd);
     this.view.dom.removeEventListener("mousedown", this.onMouseDown);
-    this.view.dom.removeEventListener("keydown", this.onKeyDown);
     this.view.dom.removeEventListener("focus", this.render);
     this.view.dom.removeEventListener("blur", this.render);
     if (this.idleTimer) clearTimeout(this.idleTimer);
@@ -258,6 +368,17 @@ export const Caret = Extension.create({
   name: "caret",
 
   addProseMirrorPlugins() {
-    return [new Plugin({ view: (view) => new CaretView(view) })];
+    // The keydown prop and the plugin view have to be the same Plugin so the
+    // prop can reach the instance; the closure is per-editor because
+    // addProseMirrorPlugins runs once per editor.
+    let caret: CaretView | null = null;
+    return [
+      new Plugin({
+        view: (view) => (caret = new CaretView(view)),
+        props: {
+          handleKeyDown: (_view, event) => caret?.handleKeyDown(event) ?? false,
+        },
+      }),
+    ];
   },
 });

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -1,0 +1,222 @@
+"use client";
+
+/** Synthetic local text caret — a single overlay element we position ourselves,
+ * so the caret can fade-blink and glide. The native caret exposes only
+ * `caret-color` (no shape/blink/transition control), so we hide it
+ * (`.ProseMirror { caret-color: transparent }`, gated to fine pointers in
+ * editor.css) and draw this replacement.
+ *
+ * Local-only by construction: `yCursorPlugin` (presence.ts) renders *peers'*
+ * carets and filters out the local client, so nothing else draws this one.
+ *
+ * A **persistent** DOM element, repositioned each update — NOT a
+ * `Decoration.widget`: a widget's DOM is torn down and rebuilt whenever its
+ * position changes, which would reset the CSS glide transition every move. The
+ * element lives inside the `.editor-prose` scroller and is positioned in that
+ * scroller's scroll-origin coordinate space (the `docSpaceRect` recipe in
+ * `components.tsx`), so it scrolls natively with the text and the glide
+ * transition fires only on real caret moves, never on scroll.
+ *
+ * Deliberately disabled on touch/coarse-pointer devices: hiding the native
+ * caret would break the selection handles, the magnifier loupe, and long-press
+ * selection, which all anchor to it. Only IME candidate windows still lean on
+ * the native caret, so it's restored during composition (see below). */
+import { Extension } from "@tiptap/core";
+import { Plugin, TextSelection } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
+
+// Stay solid this long after a move, then resume blinking — so typing/arrowing
+// doesn't strobe.
+const IDLE_BLINK_MS = 500;
+// A vertical jump past this fraction of the caret's own height is a line change,
+// which should snap rather than glide diagonally across the page.
+const LINE_JUMP_RATIO = 0.6;
+
+interface CaretPos {
+  x: number;
+  y: number;
+  height: number;
+}
+
+class CaretView {
+  private el: HTMLElement;
+  private scroller: HTMLElement | null = null;
+  private resize: ResizeObserver | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private composing = false;
+  private last: CaretPos | null = null;
+  // Set on mousedown so the render triggered by the click snaps (a click never
+  // glides) and can disambiguate the caret's side by the click's x.
+  private clickX: number | null = null;
+  // Touch/coarse pointer: keep the native caret, render nothing.
+  private readonly enabled: boolean;
+
+  constructor(private view: EditorView) {
+    this.el = document.createElement("div");
+    this.el.className = "editor-caret";
+    this.el.setAttribute("aria-hidden", "true");
+
+    this.enabled =
+      typeof window !== "undefined" &&
+      window.matchMedia("(pointer: fine)").matches;
+    if (!this.enabled) return;
+
+    // `view.dom` isn't inside `.editor-prose` yet at construction time — same
+    // deferred-lookup reason as the image plugin (images.ts).
+    setTimeout(() => {
+      this.scroller = this.view.dom.closest<HTMLElement>(".editor-prose");
+      if (!this.scroller) return;
+      this.scroller.appendChild(this.el);
+      // Reflow/rewrap moves the caret without a transaction — snap (clear
+      // `last`) rather than gliding.
+      this.resize = new ResizeObserver(() => {
+        this.last = null;
+        this.render();
+      });
+      this.resize.observe(this.scroller);
+      this.render();
+    }, 0);
+
+    this.view.dom.addEventListener("compositionstart", this.onComposeStart);
+    this.view.dom.addEventListener("compositionend", this.onComposeEnd);
+    this.view.dom.addEventListener("mousedown", this.onMouseDown);
+    this.view.dom.addEventListener("focus", this.render);
+    this.view.dom.addEventListener("blur", this.render);
+  }
+
+  update(): void {
+    if (this.enabled) this.render();
+  }
+
+  private onComposeStart = () => {
+    this.composing = true;
+    this.render();
+  };
+
+  private onComposeEnd = () => {
+    this.composing = false;
+    this.render();
+  };
+
+  private onMouseDown = (event: MouseEvent) => {
+    this.clickX = event.clientX;
+  };
+
+  /** Doc position → the scroller's scroll-origin space. `clickX`, when a click
+   * just happened, picks the caret side (`coordsAtPos` bias -1 vs +1) whose x is
+   * nearer the click — the fix for a wrapped line's end/start rendering at the
+   * same doc position. Subtracts the scroller's border (`clientLeft/Top`) because
+   * `getBoundingClientRect` includes the border but absolute positioning is
+   * relative to the padding box. */
+  private caretPos(clickX: number | null): CaretPos | null {
+    if (!this.scroller) return null;
+    const head = this.view.state.selection.head;
+    let coords: { left: number; top: number; bottom: number };
+    try {
+      if (clickX != null) {
+        const before = this.view.coordsAtPos(head, -1);
+        const after = this.view.coordsAtPos(head, 1);
+        coords =
+          Math.abs(before.left - clickX) <= Math.abs(after.left - clickX)
+            ? before
+            : after;
+      } else {
+        coords = this.view.coordsAtPos(head);
+      }
+    } catch {
+      // The head can briefly fall out of range mid-edit, or sit against a
+      // custom node view that can't be measured — hide rather than misplace.
+      return null;
+    }
+    const wrap = this.scroller.getBoundingClientRect();
+    return {
+      x:
+        coords.left -
+        wrap.left -
+        this.scroller.clientLeft +
+        this.scroller.scrollLeft,
+      y:
+        coords.top -
+        wrap.top -
+        this.scroller.clientTop +
+        this.scroller.scrollTop,
+      height: coords.bottom - coords.top,
+    };
+  }
+
+  private render = () => {
+    // During IME composition the native caret must lead (candidate window
+    // anchors to it) — show it, hide ours.
+    this.view.dom.style.caretColor = this.composing ? "auto" : "";
+
+    const clickX = this.clickX;
+    this.clickX = null;
+
+    const { selection } = this.view.state;
+    // Only a plain collapsed text cursor gets a caret. A range selection shows
+    // the native band; NodeSelection/GapCursor have their own rendering and
+    // `coordsAtPos(head)` isn't meaningful for them.
+    const active =
+      this.view.hasFocus() &&
+      this.view.editable &&
+      !this.composing &&
+      !!this.scroller &&
+      selection instanceof TextSelection &&
+      selection.empty;
+
+    const pos = active ? this.caretPos(clickX) : null;
+    if (!pos) {
+      this.el.style.display = "none";
+      // Re-appearance should snap, not glide from a stale position.
+      this.last = null;
+      return;
+    }
+
+    this.el.style.display = "";
+    this.el.style.height = `${pos.height}px`;
+
+    // Snap (no glide) on first show, a click, or a line change.
+    const snap =
+      !this.last ||
+      clickX != null ||
+      Math.abs(pos.y - this.last.y) > pos.height * LINE_JUMP_RATIO;
+    if (snap) {
+      this.el.style.transition = "none";
+      this.el.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
+      void this.el.offsetWidth; // commit the un-transitioned move
+      this.el.style.transition = "";
+    } else {
+      this.el.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
+    }
+    this.last = pos;
+
+    // Solid while moving; resume the fade-blink after a beat of stillness.
+    this.el.classList.add("is-moving");
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(
+      () => this.el.classList.remove("is-moving"),
+      IDLE_BLINK_MS,
+    );
+  };
+
+  destroy(): void {
+    if (!this.enabled) return;
+    this.view.dom.removeEventListener("compositionstart", this.onComposeStart);
+    this.view.dom.removeEventListener("compositionend", this.onComposeEnd);
+    this.view.dom.removeEventListener("mousedown", this.onMouseDown);
+    this.view.dom.removeEventListener("focus", this.render);
+    this.view.dom.removeEventListener("blur", this.render);
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.resize?.disconnect();
+    this.view.dom.style.caretColor = "";
+    this.el.remove();
+  }
+}
+
+export const Caret = Extension.create({
+  name: "caret",
+
+  addProseMirrorPlugins() {
+    return [new Plugin({ view: (view) => new CaretView(view) })];
+  },
+});

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -28,9 +28,12 @@ import type { EditorView } from "@tiptap/pm/view";
 // Stay solid this long after a move, then resume blinking — so typing/arrowing
 // doesn't strobe.
 const IDLE_BLINK_MS = 500;
-// A vertical jump past this fraction of the caret's own height is a line change,
-// which should snap rather than glide diagonally across the page.
-const LINE_JUMP_RATIO = 0.6;
+// Glide duration scales with distance so every move animates *visibly*: a small
+// step stays snappy, a page jump is a longer (still quick) glide rather than an
+// imperceptible zip. Clamped at both ends.
+const GLIDE_MS_PER_PX = 0.5;
+const GLIDE_MIN_MS = 70;
+const GLIDE_MAX_MS = 240;
 
 interface CaretPos {
   x: number;
@@ -45,9 +48,13 @@ class CaretView {
   private idleTimer: ReturnType<typeof setTimeout> | null = null;
   private composing = false;
   private last: CaretPos | null = null;
-  // Set on mousedown so the render triggered by the click snaps (a click never
-  // glides) and can disambiguate the caret's side by the click's x.
+  // Set on mousedown to disambiguate the caret's side by the click's x.
   private clickX: number | null = null;
+  // Reconstructed caret affinity (the bit the browser keeps but hides from the
+  // DOM API): which side of an ambiguous position — a soft-wrap/bidi/mark
+  // boundary — the caret belongs to, inferred from the last input's direction.
+  // -1 = upstream (end of prev line), +1 = downstream (start of next line).
+  private bias: number | null = null;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
 
@@ -80,6 +87,7 @@ class CaretView {
     this.view.dom.addEventListener("compositionstart", this.onComposeStart);
     this.view.dom.addEventListener("compositionend", this.onComposeEnd);
     this.view.dom.addEventListener("mousedown", this.onMouseDown);
+    this.view.dom.addEventListener("keydown", this.onKeyDown);
     this.view.dom.addEventListener("focus", this.render);
     this.view.dom.addEventListener("blur", this.render);
   }
@@ -100,15 +108,45 @@ class CaretView {
 
   private onMouseDown = (event: MouseEvent) => {
     this.clickX = event.clientX;
+    // The click's x is a more direct side signal than the last keyed direction.
+    this.bias = null;
   };
 
-  /** Doc position → the scroller's scroll-origin space. `clickX`, when a click
-   * just happened, picks the caret side (`coordsAtPos` bias -1 vs +1) whose x is
-   * nearer the click — the fix for a wrapped line's end/start rendering at the
-   * same doc position. Subtracts the scroller's border (`clientLeft/Top`) because
-   * `getBoundingClientRect` includes the border but absolute positioning is
-   * relative to the padding box. */
-  private caretPos(clickX: number | null): CaretPos | null {
+  /** Infer caret affinity from the input's direction, so the next render can
+   * paint an ambiguous boundary position (soft-wrap/bidi/mark edge) on the side
+   * the user meant. Backward motion → upstream; forward motion / a typed char →
+   * downstream. Not correct inside RTL (bidi) runs — the browser tracks the
+   * embedding level and we don't; left the obvious boundary rather than fake it. */
+  private onKeyDown = (event: KeyboardEvent) => {
+    const k = event.key;
+    if (
+      k === "ArrowLeft" ||
+      k === "ArrowUp" ||
+      k === "End" ||
+      k === "Backspace"
+    ) {
+      this.bias = -1;
+    } else if (
+      k === "ArrowRight" ||
+      k === "ArrowDown" ||
+      k === "Home" ||
+      k === "Enter" ||
+      k.length === 1 // a printable character
+    ) {
+      this.bias = 1;
+    }
+    // Modifiers, Escape, etc. leave the last inferred affinity in place.
+  };
+
+  /** Doc position → the scroller's scroll-origin space. The caret's side at an
+   * ambiguous boundary is chosen by, in order: the click x (most direct), then
+   * the reconstructed affinity `bias`, then `coordsAtPos`'s default. Subtracts
+   * the scroller's border (`clientLeft/Top`) because `getBoundingClientRect`
+   * includes the border but absolute positioning is relative to the padding box. */
+  private caretPos(
+    clickX: number | null,
+    bias: number | null,
+  ): CaretPos | null {
     if (!this.scroller) return null;
     const head = this.view.state.selection.head;
     let coords: { left: number; top: number; bottom: number };
@@ -120,6 +158,8 @@ class CaretView {
           Math.abs(before.left - clickX) <= Math.abs(after.left - clickX)
             ? before
             : after;
+      } else if (bias != null) {
+        coords = this.view.coordsAtPos(head, bias);
       } else {
         coords = this.view.coordsAtPos(head);
       }
@@ -153,6 +193,8 @@ class CaretView {
     this.clickX = null;
 
     const { selection } = this.view.state;
+    // `bias` persists across renders (it's the last known intent); `clickX` is
+    // one-shot, consumed above.
     // Only a plain collapsed text cursor gets a caret. A range selection shows
     // the native band; NodeSelection/GapCursor have their own rendering and
     // `coordsAtPos(head)` isn't meaningful for them.
@@ -164,7 +206,7 @@ class CaretView {
       selection instanceof TextSelection &&
       selection.empty;
 
-    const pos = active ? this.caretPos(clickX) : null;
+    const pos = active ? this.caretPos(clickX, this.bias) : null;
     if (!pos) {
       this.el.style.display = "none";
       // Re-appearance should snap, not glide from a stale position.
@@ -175,17 +217,21 @@ class CaretView {
     this.el.style.display = "";
     this.el.style.height = `${pos.height}px`;
 
-    // Snap (no glide) on first show, a click, or a line change.
-    const snap =
-      !this.last ||
-      clickX != null ||
-      Math.abs(pos.y - this.last.y) > pos.height * LINE_JUMP_RATIO;
-    if (snap) {
+    if (!this.last) {
+      // First appearance — snap in rather than glide from nowhere. Every actual
+      // move glides (below), regardless of distance. Reduced-motion is handled
+      // in CSS (transition-property: none), which no-ops the glide there.
       this.el.style.transition = "none";
       this.el.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
       void this.el.offsetWidth; // commit the un-transitioned move
       this.el.style.transition = "";
     } else {
+      const dist = Math.hypot(pos.x - this.last.x, pos.y - this.last.y);
+      const dur = Math.min(
+        GLIDE_MAX_MS,
+        Math.max(GLIDE_MIN_MS, dist * GLIDE_MS_PER_PX),
+      );
+      this.el.style.transitionDuration = `${dur}ms`;
       this.el.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
     }
     this.last = pos;
@@ -204,6 +250,7 @@ class CaretView {
     this.view.dom.removeEventListener("compositionstart", this.onComposeStart);
     this.view.dom.removeEventListener("compositionend", this.onComposeEnd);
     this.view.dom.removeEventListener("mousedown", this.onMouseDown);
+    this.view.dom.removeEventListener("keydown", this.onKeyDown);
     this.view.dom.removeEventListener("focus", this.render);
     this.view.dom.removeEventListener("blur", this.render);
     if (this.idleTimer) clearTimeout(this.idleTimer);

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -32,7 +32,7 @@ const IDLE_BLINK_MS = 500;
 // knob. Lower = quicker; a large jump covers more ground in this same time, so
 // it reads as a faster streak rather than a longer glide (fixed duration, not
 // distance-scaled). Reduced-motion no-ops the glide in CSS regardless.
-const GLIDE_MS = 70;
+const GLIDE_MS = 60;
 
 interface CaretPos {
   x: number;

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -28,12 +28,11 @@ import type { EditorView } from "@tiptap/pm/view";
 // Stay solid this long after a move, then resume blinking — so typing/arrowing
 // doesn't strobe.
 const IDLE_BLINK_MS = 500;
-// Glide duration scales with distance so every move animates *visibly*: a small
-// step stays snappy, a page jump is a longer (still quick) glide rather than an
-// imperceptible zip. Clamped at both ends.
-const GLIDE_MS_PER_PX = 0.5;
-const GLIDE_MIN_MS = 70;
-const GLIDE_MAX_MS = 240;
+// How long every caret move animates, small or large — the single glide-speed
+// knob. Lower = quicker; a large jump covers more ground in this same time, so
+// it reads as a faster streak rather than a longer glide (fixed duration, not
+// distance-scaled). Reduced-motion no-ops the glide in CSS regardless.
+const GLIDE_MS = 70;
 
 interface CaretPos {
   x: number;
@@ -226,12 +225,7 @@ class CaretView {
       void this.el.offsetWidth; // commit the un-transitioned move
       this.el.style.transition = "";
     } else {
-      const dist = Math.hypot(pos.x - this.last.x, pos.y - this.last.y);
-      const dur = Math.min(
-        GLIDE_MAX_MS,
-        Math.max(GLIDE_MIN_MS, dist * GLIDE_MS_PER_PX),
-      );
-      this.el.style.transitionDuration = `${dur}ms`;
+      this.el.style.transitionDuration = `${GLIDE_MS}ms`;
       this.el.style.transform = `translate(${pos.x}px, ${pos.y}px)`;
     }
     this.last = pos;

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -22,13 +22,29 @@
  * selection, which all anchor to it. Only IME candidate windows still lean on
  * the native caret, so it's restored during composition (see below).
  *
- * Owning the caret means owning **affinity** — the side of an ambiguous
- * position the caret sits on. A soft wrap is one document position with two
- * visual homes (end of visual line N, start of line N+1), and ProseMirror's
- * selection has no field for which one you mean, so `bias` reconstructs it.
- * Here that bit is not just cosmetic: a wrap is two caret stops, and the
- * arrow key that moves between them is consumed rather than moving the
- * document position (`handleKeyDown`). */
+ * **We replaced the caret's pixels, not the caret.** `caret-color:
+ * transparent` hides the native caret; it does not disable it. The browser
+ * still owns where the cursor is, which visual line it sits on, and where every
+ * key we don't handle sends it. This file draws a rectangle to match.
+ *
+ * That matters for **affinity** — which side of a soft wrap the caret is on. A
+ * wrap is one document position with two visual homes (end of visual line N,
+ * start of line N+1), and neither the DOM nor ProseMirror has a field for which
+ * one you mean. The browser keeps that bit internally and exposes no way to
+ * read or write it, so `bias` here is a *guess at* the browser's bit, inferred
+ * from the key that caused the move, used only to pick which side to paint.
+ *
+ * The guess must **mirror** the browser, never lead it. An earlier version made
+ * a wrap two caret stops — arriving painted the side you came from, and a
+ * second arrow press flipped sides without moving the document. It worked, and
+ * it broke everything that reads the browser's bit instead of ours: cmd-left at
+ * a boundary no-opped, and Up/Down departed from the line the caret wasn't
+ * visibly on (it also carries the goal column). There is no fix from inside
+ * this file — two bits exist and we can only write one. Making a wrap two stops
+ * requires owning navigation outright (Left/Right by grapheme cluster, Up/Down
+ * with goal-column memory, line and word ops, Shift extension, bidi), the way
+ * CodeMirror and Monaco do. ProseMirror deliberately delegates all of it to the
+ * browser. See git history around `arrivingAffinity` for the working attempt. */
 import { Extension } from "@tiptap/core";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
 import type { EditorState } from "@tiptap/pm/state";
@@ -49,30 +65,37 @@ interface CaretPos {
   height: number;
 }
 
-/** Which side of a soft-wrap boundary the caret sits on — the affinity bit the
- * browser keeps and hides from the DOM API. A wrap is one document position
- * with two visual homes, and this says which one to paint. */
+/** Which side of a soft-wrap boundary the caret sits on — end of visual line N
+ * or start of line N+1. */
 type Affinity = "upstream" | "downstream";
 
-/** Which way the last input travelled through the document. Not an `Affinity`:
- * at a wrap the caret lands on the side it came *from*, so the two are
- * opposites there and identical everywhere else. */
-type Direction = "backward" | "forward";
-
 /** `coordsAtPos`'s `side` argument, which is a signed number. The only place
- * either type above touches one. */
+ * this type touches one. */
 const SIDE: Record<Affinity, number> = { upstream: -1, downstream: 1 };
 
-/** Which side of the fence a move lands on, given the way it travelled.
+/** Guess the affinity the browser is about to pick, from the key causing the
+ * move. Mirrors it; see the docstring for why leading it doesn't work.
  *
- * Horizontal travel lands on the side it came *from* — you stay on the line you
- * were already on, and the arrow that crosses to the other side is the fence's
- * second stop (handleKeyDown's flip). Every other key names its own
- * destination: ArrowDown wants the line it arrives on, End wants the end of the
- * line even though it travels forward. Those map straight across. */
-function arrivingAffinity(from: Direction, horizontal: boolean): Affinity {
-  if (horizontal) return from === "forward" ? "upstream" : "downstream";
-  return from === "forward" ? "downstream" : "upstream";
+ * Most keys are just their direction of travel. The exceptions are the ones
+ * that name a line *edge* rather than a direction: End and Cmd/Ctrl+ArrowRight
+ * travel forward but mean "end of this visual line" (upstream), and Home and
+ * Cmd/Ctrl+ArrowLeft mean the start of it (downstream). Returns null for keys
+ * that don't move the caret, which leaves the last guess in place. */
+function affinityForKey(event: KeyboardEvent): Affinity | null {
+  const k = event.key;
+  const lineOp = event.metaKey || event.ctrlKey;
+  if (k === "End" || (lineOp && k === "ArrowRight")) return "upstream";
+  if (k === "Home" || (lineOp && k === "ArrowLeft")) return "downstream";
+  if (k === "ArrowLeft" || k === "ArrowUp" || k === "Backspace")
+    return "upstream";
+  if (
+    k === "ArrowRight" ||
+    k === "ArrowDown" ||
+    k === "Enter" ||
+    k.length === 1 // a printable character
+  )
+    return "downstream";
+  return null;
 }
 
 class CaretView {
@@ -84,20 +107,15 @@ class CaretView {
   private last: CaretPos | null = null;
   // Set on mousedown to disambiguate the caret's side by the click's x.
   private clickX: number | null = null;
-  // INVARIANT: non-null *only* while the caret is a collapsed cursor standing
-  // at a wrap boundary. Enter the fence, set it; leave, clear it. Everywhere
-  // else there is one place to paint and no side to record. That invariant is
-  // what lets handleKeyDown decide the flip from this bit alone without
-  // measuring — so it is re-derived on every move (update()) and dropped
-  // whenever a reflow moves the wrap points (the ResizeObserver above).
+  // Our guess at the browser's affinity, used only to pick which side of an
+  // ambiguous position to paint. Null means "no idea" — paint coordsAtPos's
+  // default. Only meaningful at a soft wrap; anywhere else both sides resolve
+  // to the same point, so a stale value is harmless.
   private bias: Affinity | null = null;
-  // Direction recorded on keydown, resolved into `bias` by update() once
-  // ProseMirror has actually moved the selection — the destination has to exist
-  // before we can measure whether it landed on a wrap boundary.
-  // `pendingHorizontal` marks Left/Right, the only keys that land on the side
-  // they came from rather than the side they point at.
-  private pending: Direction | null = null;
-  private pendingHorizontal = false;
+  // Set on keydown, applied by update() once ProseMirror has actually moved the
+  // selection. Two moments, because the key names the affinity of a position
+  // that doesn't exist yet when the key is pressed.
+  private pending: Affinity | null = null;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
 
@@ -118,13 +136,9 @@ class CaretView {
       if (!this.scroller) return;
       this.scroller.appendChild(this.el);
       // Reflow/rewrap moves the caret without a transaction — snap (clear
-      // `last`) rather than gliding. It also moves the wrap points themselves,
-      // so the fence the caret was standing in may not be there any more: drop
-      // `bias` too, or the invariant ("non-null ⇒ at a boundary") quietly stops
-      // holding and the next arrow press spends itself on a flip that isn't.
+      // `last`) rather than gliding.
       this.resize = new ResizeObserver(() => {
         this.last = null;
-        this.bias = null;
         this.render();
       });
       this.resize.observe(this.scroller);
@@ -142,62 +156,23 @@ class CaretView {
     if (!this.enabled) return;
 
     const pending = this.pending;
-    const horizontal = this.pendingHorizontal;
     this.pending = null;
-    this.pendingHorizontal = false;
 
     const sel = this.view.state.selection;
-    const collapsed = sel instanceof TextSelection && sel.empty;
     const moved = prevState.selection.head !== sel.head;
-    if (moved || !collapsed) {
-      // Enter the fence, set the bit; leave it, clear the bit. `bias` is
-      // re-derived from scratch here on every move and never carried, which is
-      // what makes the invariant true and lets handleKeyDown trust it without
-      // measuring anything.
-      //
-      // It stays null unless all three hold: the caret actually moved (a
-      // stationary head can't have entered anywhere), it's a collapsed cursor
-      // (a range has no affinity), and there's a `pending` direction behind the
-      // move. A null `pending` means no key and no click caused it — a remote
-      // Yjs update, undo/redo, a programmatic setSelection — so there's nothing
-      // to infer from and guessing would cost the user a keystroke.
-      //
-      // Which side of the fence you land on is the side you came *from*: that's
-      // what makes the boundary two stops rather than one, with handleKeyDown's
-      // flip supplying the second. Horizontal keys only — Up/Down and Home/End
-      // already name the affinity they want (Down wants the line it arrives on,
-      // End wants upstream even though it travels right), so inverting those
-      // lands the caret a line off.
-      this.bias =
-        moved && collapsed && pending != null && this.isWrapBoundary(sel.head)
-          ? arrivingAffinity(pending, horizontal)
-          : null;
+    if (!(sel instanceof TextSelection) || !sel.empty) {
+      // A range has no affinity, and no caret is painted for one.
+      this.bias = null;
+    } else if (moved) {
+      // Apply the guess recorded at keydown. A null `pending` means no key
+      // caused this move — a remote Yjs update (ySyncPlugin restores the
+      // selection on every remote change), undo/redo, a programmatic
+      // setSelection — so there's nothing to mirror and coordsAtPos's default
+      // is as good as anything we'd invent.
+      this.bias = pending;
     }
 
     this.render();
-  }
-
-  /** Is `pos` inside the fence — a soft-wrap boundary, one document position
-   * with two visual homes? Nothing in the model records where the browser chose
-   * to wrap, so it has to be measured: ask for both sides and see where they
-   * landed. (`view.endOfTextblock()` can't answer this — it reports *textblock*
-   * edges, not wrap points.)
-   *
-   * Requires a step down *and* a jump left. A taller mark or an inline image
-   * also shifts `.top` between the two sides; only a wrap throws the downstream
-   * side back to the line's left edge. That second conjunct is also what keeps
-   * the flip from stealing a key from gapcursor, tableEditing, or atom
-   * traversal: those act only at textblock edges, and a position with content
-   * to its left on one line and to its right on the next is by definition not
-   * one. */
-  private isWrapBoundary(pos: number): boolean {
-    try {
-      const up = this.view.coordsAtPos(pos, SIDE.upstream);
-      const down = this.view.coordsAtPos(pos, SIDE.downstream);
-      return down.top > up.top + 1 && down.left < up.left;
-    } catch {
-      return false;
-    }
   }
 
   private onComposeStart = () => {
@@ -216,63 +191,23 @@ class CaretView {
     this.bias = null;
   };
 
-  /** Two jobs, in order: record the input's direction so update() can infer
-   * affinity once the selection lands, and consume the arrow key that crosses a
-   * soft-wrap boundary in place.
+  /** Record which side the browser is about to put the caret on, for update()
+   * to apply once the selection has actually moved. **Never consumes a key** —
+   * always returns false. Navigation belongs to the browser (see the docstring);
+   * this only watches it go by.
    *
-   * Must be a ProseMirror `handleKeyDown` prop rather than a DOM listener:
-   * ProseMirror installs its own `keydown` listener in the EditorView
-   * constructor, before any plugin view is constructed, so a listener added
-   * from here would always run after PM's whole handler chain — too late to
-   * preventDefault, and it would clobber `bias` on keys PM already consumed.
+   * Must be a ProseMirror prop rather than a DOM listener even so. PM installs
+   * its own keydown listener in the EditorView constructor, before any plugin
+   * view exists, so a listener added from here runs after PM's entire handler
+   * chain — including after other plugins have consumed keys we would then
+   * wrongly record, like the command menu's ArrowDown or a table's ArrowRight.
    *
-   * Returns true only for a genuine boundary flip. Everything else falls
-   * through to the plugins after us (tableEditing, gapcursor) and then PM's own
-   * atom traversal, none of which must ever lose a key to this. */
+   * Not correct inside RTL (bidi) runs, where the physical key direction and
+   * the logical one diverge; the browser tracks embedding levels and we don't.
+   * Cosmetic only — the caret paints a line off at a wrapped bidi boundary. */
   handleKeyDown = (event: KeyboardEvent): boolean => {
-    const k = event.key;
-    const left = k === "ArrowLeft";
-    const right = k === "ArrowRight";
-
-    if (left || k === "ArrowUp" || k === "End" || k === "Backspace") {
-      this.pending = "backward";
-    } else if (
-      right ||
-      k === "ArrowDown" ||
-      k === "Home" ||
-      k === "Enter" ||
-      k.length === 1 // a printable character
-    ) {
-      this.pending = "forward";
-    }
-    // Modifiers, Escape, etc. leave the last recorded direction in place.
-    this.pendingHorizontal = left || right;
-
-    if (!this.enabled || !(left || right)) return false;
-    // Never consume a modified arrow: Shift extends the selection, Cmd/Ctrl
-    // jumps the line, Alt jumps the word. They still record direction above,
-    // which is what makes Cmd+ArrowRight land upstream at a wrapped line end.
-    if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey)
-      return false;
-
-    // Crossing the fence. `bias` is non-null only while the caret stands at a
-    // wrap boundary (see update()), so the bit alone answers both questions:
-    // are we in a fence, and are we at the end of it this press points away
-    // from. Nothing to re-measure. A null bias falls through and moves the
-    // document normally — a keystroke is never eaten on a guess.
-    //
-    // Not correct inside RTL (bidi) runs, where the physical key direction and
-    // the logical one diverge. Same punt as the rest of the file; the cost is
-    // one extra press, since the flip lands on the far side and the next press
-    // finds `bias` no longer pointing against it.
-    const from: Affinity = right ? "upstream" : "downstream";
-    if (this.bias !== from) return false;
-
-    this.bias = right ? "downstream" : "upstream";
-    this.pending = null; // consumed here — no transaction, so no update()
-    this.pendingHorizontal = false;
-    this.render();
-    return true;
+    if (this.enabled) this.pending = affinityForKey(event) ?? this.pending;
+    return false;
   };
 
   /** Doc position → the scroller's scroll-origin space. The caret's side at an
@@ -296,14 +231,10 @@ class CaretView {
             ? "upstream"
             : "downstream";
         coords = picked === "upstream" ? up : down;
-        // Keep the side the click picked, but only if the click landed in a
-        // fence — the same invariant update() maintains, checked against the
-        // rects already in hand rather than a second layout read. Persisting it
-        // is what lets click-then-arrow behave like arrow-then-arrow at a
-        // wrapped position; off a boundary the two sides coincide and recording
-        // a side would plant exactly the stale bit the invariant forbids.
-        this.bias =
-          down.top > up.top + 1 && down.left < up.left ? picked : null;
+        // Keep the side the click picked, so a later render without a fresh
+        // click still paints it. Off a wrap the two sides coincide and the
+        // choice is between identical points, so recording one is harmless.
+        this.bias = picked;
       } else if (bias != null) {
         coords = this.view.coordsAtPos(head, SIDE[bias]);
       } else {
@@ -339,8 +270,8 @@ class CaretView {
     this.clickX = null;
 
     const { selection } = this.view.state;
-    // `bias` is whatever the last move left behind — non-null only if that move
-    // ended inside a fence; `clickX` is one-shot, consumed above.
+    // `bias` is whatever the last move left behind; `clickX` is one-shot,
+    // consumed above.
     // Only a plain collapsed text cursor gets a caret. A range selection shows
     // the native band; NodeSelection/GapCursor have their own rendering and
     // `coordsAtPos(head)` isn't meaningful for them.

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -31,23 +31,27 @@
  * wrap is one document position with two visual homes (end of visual line N,
  * start of line N+1), and neither the DOM nor ProseMirror has a field for which
  * one you mean. The browser keeps that bit internally and exposes no way to
- * read or write it, so `bias` here is a *guess at* the browser's bit, inferred
- * from the key that caused the move, used only to pick which side to paint.
+ * read or write it.
  *
- * The guess must **mirror** the browser, never lead it. An earlier version made
- * a wrap two caret stops — arriving painted the side you came from, and a
- * second arrow press flipped sides without moving the document. It worked, and
- * it broke everything that reads the browser's bit instead of ours: cmd-left at
- * a boundary no-opped, and Up/Down departed from the line the caret wasn't
- * visibly on (it also carries the goal column). There is no fix from inside
- * this file — two bits exist and we can only write one. Making a wrap two stops
- * requires owning navigation outright (Left/Right by grapheme cluster, Up/Down
- * with goal-column memory, line and word ops, Shift extension, bidi), the way
- * CodeMirror and Monaco do. ProseMirror deliberately delegates all of it to the
- * browser. See git history around `arrivingAffinity` for the working attempt. */
+ * We deliberately don't model it: keyboard motion paints wherever
+ * `coordsAtPos` defaults to. So arrowing right onto a wrap puts the caret at
+ * the start of line N+1 rather than the end of line N — which reads wrong at
+ * first, but is what the browser does natively and what Notion does too. It's
+ * the convention, not a defect. Don't "fix" it.
+ *
+ * It has been tried. Guessing the bit from the last key worked but bought
+ * nothing; *leading* it — making a wrap two caret stops, with an arrow press
+ * that flips sides without moving the document — broke everything that reads
+ * the browser's bit instead of ours: cmd-left at a boundary no-opped, and
+ * Up/Down departed from the line the caret wasn't visibly on, since that bit
+ * carries the goal column too. There is no fix from inside this file; two bits
+ * exist and we can only write one. Doing it properly means owning navigation
+ * outright (Left/Right by grapheme cluster, Up/Down with goal-column memory,
+ * line and word ops, Shift extension, bidi), the way CodeMirror and Monaco do —
+ * ProseMirror deliberately delegates all of it to the browser. Git history
+ * around `arrivingAffinity` has the working attempt if it ever comes up. */
 import { Extension } from "@tiptap/core";
 import { Plugin, TextSelection } from "@tiptap/pm/state";
-import type { EditorState } from "@tiptap/pm/state";
 import type { EditorView } from "@tiptap/pm/view";
 
 // Stay solid this long after a move, then resume blinking — so typing/arrowing
@@ -65,38 +69,10 @@ interface CaretPos {
   height: number;
 }
 
-/** Which side of a soft-wrap boundary the caret sits on — end of visual line N
- * or start of line N+1. */
-type Affinity = "upstream" | "downstream";
-
-/** `coordsAtPos`'s `side` argument, which is a signed number. The only place
- * this type touches one. */
-const SIDE: Record<Affinity, number> = { upstream: -1, downstream: 1 };
-
-/** Guess the affinity the browser is about to pick, from the key causing the
- * move. Mirrors it; see the docstring for why leading it doesn't work.
- *
- * Most keys are just their direction of travel. The exceptions are the ones
- * that name a line *edge* rather than a direction: End and Cmd/Ctrl+ArrowRight
- * travel forward but mean "end of this visual line" (upstream), and Home and
- * Cmd/Ctrl+ArrowLeft mean the start of it (downstream). Returns null for keys
- * that don't move the caret, which leaves the last guess in place. */
-function affinityForKey(event: KeyboardEvent): Affinity | null {
-  const k = event.key;
-  const lineOp = event.metaKey || event.ctrlKey;
-  if (k === "End" || (lineOp && k === "ArrowRight")) return "upstream";
-  if (k === "Home" || (lineOp && k === "ArrowLeft")) return "downstream";
-  if (k === "ArrowLeft" || k === "ArrowUp" || k === "Backspace")
-    return "upstream";
-  if (
-    k === "ArrowRight" ||
-    k === "ArrowDown" ||
-    k === "Enter" ||
-    k.length === 1 // a printable character
-  )
-    return "downstream";
-  return null;
-}
+/** Which side of a soft-wrap boundary to measure — end of visual line N or
+ * start of line N+1 — as `coordsAtPos`'s signed `side` argument. Only the click
+ * path picks between them now; keyboard motion takes the default. */
+const SIDE = { upstream: -1, downstream: 1 };
 
 class CaretView {
   private el: HTMLElement;
@@ -107,15 +83,6 @@ class CaretView {
   private last: CaretPos | null = null;
   // Set on mousedown to disambiguate the caret's side by the click's x.
   private clickX: number | null = null;
-  // Our guess at the browser's affinity, used only to pick which side of an
-  // ambiguous position to paint. Null means "no idea" — paint coordsAtPos's
-  // default. Only meaningful at a soft wrap; anywhere else both sides resolve
-  // to the same point, so a stale value is harmless.
-  private bias: Affinity | null = null;
-  // Set on keydown, applied by update() once ProseMirror has actually moved the
-  // selection. Two moments, because the key names the affinity of a position
-  // that doesn't exist yet when the key is pressed.
-  private pending: Affinity | null = null;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
 
@@ -152,27 +119,8 @@ class CaretView {
     this.view.dom.addEventListener("blur", this.render);
   }
 
-  update(_view: EditorView, prevState: EditorState): void {
-    if (!this.enabled) return;
-
-    const pending = this.pending;
-    this.pending = null;
-
-    const sel = this.view.state.selection;
-    const moved = prevState.selection.head !== sel.head;
-    if (!(sel instanceof TextSelection) || !sel.empty) {
-      // A range has no affinity, and no caret is painted for one.
-      this.bias = null;
-    } else if (moved) {
-      // Apply the guess recorded at keydown. A null `pending` means no key
-      // caused this move — a remote Yjs update (ySyncPlugin restores the
-      // selection on every remote change), undo/redo, a programmatic
-      // setSelection — so there's nothing to mirror and coordsAtPos's default
-      // is as good as anything we'd invent.
-      this.bias = pending;
-    }
-
-    this.render();
+  update(): void {
+    if (this.enabled) this.render();
   }
 
   private onComposeStart = () => {
@@ -187,38 +135,15 @@ class CaretView {
 
   private onMouseDown = (event: MouseEvent) => {
     this.clickX = event.clientX;
-    // The click's x is a more direct side signal than the last keyed direction.
-    this.bias = null;
   };
 
-  /** Record which side the browser is about to put the caret on, for update()
-   * to apply once the selection has actually moved. **Never consumes a key** —
-   * always returns false. Navigation belongs to the browser (see the docstring);
-   * this only watches it go by.
-   *
-   * Must be a ProseMirror prop rather than a DOM listener even so. PM installs
-   * its own keydown listener in the EditorView constructor, before any plugin
-   * view exists, so a listener added from here runs after PM's entire handler
-   * chain — including after other plugins have consumed keys we would then
-   * wrongly record, like the command menu's ArrowDown or a table's ArrowRight.
-   *
-   * Not correct inside RTL (bidi) runs, where the physical key direction and
-   * the logical one diverge; the browser tracks embedding levels and we don't.
-   * Cosmetic only — the caret paints a line off at a wrapped bidi boundary. */
-  handleKeyDown = (event: KeyboardEvent): boolean => {
-    if (this.enabled) this.pending = affinityForKey(event) ?? this.pending;
-    return false;
-  };
-
-  /** Doc position → the scroller's scroll-origin space. The caret's side at an
-   * ambiguous boundary is chosen by, in order: the click x (most direct), then
-   * the reconstructed affinity `bias`, then `coordsAtPos`'s default. Subtracts
-   * the scroller's border (`clientLeft/Top`) because `getBoundingClientRect`
-   * includes the border but absolute positioning is relative to the padding box. */
-  private caretPos(
-    clickX: number | null,
-    bias: Affinity | null,
-  ): CaretPos | null {
+  /** Doc position → the scroller's scroll-origin space. At an ambiguous
+   * position the side comes from the click's x if there was one, and otherwise
+   * from `coordsAtPos`'s own default — keyboard motion contributes nothing.
+   * Subtracts the scroller's border (`clientLeft/Top`) because
+   * `getBoundingClientRect` includes the border but absolute positioning is
+   * relative to the padding box. */
+  private caretPos(clickX: number | null): CaretPos | null {
     if (!this.scroller) return null;
     const head = this.view.state.selection.head;
     let coords: { left: number; top: number; bottom: number };
@@ -226,17 +151,10 @@ class CaretView {
       if (clickX != null) {
         const up = this.view.coordsAtPos(head, SIDE.upstream);
         const down = this.view.coordsAtPos(head, SIDE.downstream);
-        const picked: Affinity =
+        coords =
           Math.abs(up.left - clickX) <= Math.abs(down.left - clickX)
-            ? "upstream"
-            : "downstream";
-        coords = picked === "upstream" ? up : down;
-        // Keep the side the click picked, so a later render without a fresh
-        // click still paints it. Off a wrap the two sides coincide and the
-        // choice is between identical points, so recording one is harmless.
-        this.bias = picked;
-      } else if (bias != null) {
-        coords = this.view.coordsAtPos(head, SIDE[bias]);
+            ? up
+            : down;
       } else {
         coords = this.view.coordsAtPos(head);
       }
@@ -270,8 +188,6 @@ class CaretView {
     this.clickX = null;
 
     const { selection } = this.view.state;
-    // `bias` is whatever the last move left behind; `clickX` is one-shot,
-    // consumed above.
     // Only a plain collapsed text cursor gets a caret. A range selection shows
     // the native band; NodeSelection/GapCursor have their own rendering and
     // `coordsAtPos(head)` isn't meaningful for them.
@@ -283,7 +199,7 @@ class CaretView {
       selection instanceof TextSelection &&
       selection.empty;
 
-    const pos = active ? this.caretPos(clickX, this.bias) : null;
+    const pos = active ? this.caretPos(clickX) : null;
     if (!pos) {
       this.el.style.display = "none";
       // Re-appearance should snap, not glide from a stale position.
@@ -335,17 +251,6 @@ export const Caret = Extension.create({
   name: "caret",
 
   addProseMirrorPlugins() {
-    // The keydown prop and the plugin view have to be the same Plugin so the
-    // prop can reach the instance; the closure is per-editor because
-    // addProseMirrorPlugins runs once per editor.
-    let caret: CaretView | null = null;
-    return [
-      new Plugin({
-        view: (view) => (caret = new CaretView(view)),
-        props: {
-          handleKeyDown: (_view, event) => caret?.handleKeyDown(event) ?? false,
-        },
-      }),
-    ];
+    return [new Plugin({ view: (view) => new CaretView(view) })];
   },
 });

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -33,11 +33,17 @@
  * one you mean. The browser keeps that bit internally and exposes no way to
  * read or write it.
  *
- * We deliberately don't model it: keyboard motion paints wherever
- * `coordsAtPos` defaults to. So arrowing right onto a wrap puts the caret at
- * the start of line N+1 rather than the end of line N — which reads wrong at
- * first, but is what the browser does natively and what Notion does too. It's
- * the convention, not a defect. Don't "fix" it.
+ * We deliberately don't model it. Ordinary motion paints wherever `coordsAtPos`
+ * defaults to, so arrowing right onto a wrap puts the caret at the start of
+ * line N+1 rather than the end of line N — which reads wrong at first, but is
+ * what the browser does natively and what Notion does too. It's the convention,
+ * not a defect. Don't "fix" it.
+ *
+ * The one exception is a key that *names* a side: End and Cmd+ArrowRight mean
+ * "end of this visual line", and the default would paint them at the start of
+ * the next one, contradicting both the command and the native caret. Those keys
+ * are honoured (`affinityForKey`). That is the whole of it — a lookup on the
+ * key, no state machine, no inference from direction of travel.
  *
  * It has been tried. Guessing the bit from the last key worked but bought
  * nothing; *leading* it — making a wrap two caret stops, with an arrow press
@@ -70,9 +76,27 @@ interface CaretPos {
 }
 
 /** Which side of a soft-wrap boundary to measure — end of visual line N or
- * start of line N+1 — as `coordsAtPos`'s signed `side` argument. Only the click
- * path picks between them now; keyboard motion takes the default. */
-const SIDE = { upstream: -1, downstream: 1 };
+ * start of line N+1 — as `coordsAtPos`'s signed `side` argument. */
+type Affinity = "upstream" | "downstream";
+const SIDE: Record<Affinity, number> = { upstream: -1, downstream: 1 };
+
+/** The side a key *names*, for the few that name one at all.
+ *
+ * Ordinary motion returns null and takes `coordsAtPos`'s default, which is the
+ * convention at a wrap (see the docstring) — this is not affinity tracking and
+ * must not grow into it. But a key that means "end of this visual line" lands
+ * on a wrap boundary and the default paints it at the start of the *next* line,
+ * contradicting both the command and the native caret. Those keys say which
+ * side they meant, so use it.
+ *
+ * Meta only, not Ctrl: Cmd+Arrow is line-edge on macOS, while Ctrl+Arrow on
+ * Windows/Linux is word motion, which can land anywhere and names nothing. */
+function affinityForKey(event: KeyboardEvent): Affinity | null {
+  const k = event.key;
+  if (k === "End" || (event.metaKey && k === "ArrowRight")) return "upstream";
+  if (k === "Home" || (event.metaKey && k === "ArrowLeft")) return "downstream";
+  return null;
+}
 
 class CaretView {
   private el: HTMLElement;
@@ -83,6 +107,13 @@ class CaretView {
   private last: CaretPos | null = null;
   // Set on mousedown to disambiguate the caret's side by the click's x.
   private clickX: number | null = null;
+  // The side a line-edge key named, applied on the next render. Null for every
+  // other key, which is how ordinary motion keeps coordsAtPos's default.
+  // `pending` is set at keydown and moves to `side` once the selection has
+  // actually landed — the key names the side of a position that doesn't exist
+  // yet when it's pressed.
+  private pending: Affinity | null = null;
+  private side: Affinity | null = null;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
 
@@ -120,7 +151,12 @@ class CaretView {
   }
 
   update(): void {
-    if (this.enabled) this.render();
+    if (!this.enabled) return;
+    // Consume whatever the last key named — null for almost every key, which
+    // clears any side a previous line-edge key set.
+    this.side = this.pending;
+    this.pending = null;
+    this.render();
   }
 
   private onComposeStart = () => {
@@ -137,13 +173,29 @@ class CaretView {
     this.clickX = event.clientX;
   };
 
+  /** Note the side a line-edge key named, for update() to apply once the
+   * selection has landed. **Never consumes a key** — always returns false;
+   * navigation belongs to the browser (see the docstring).
+   *
+   * A ProseMirror prop rather than a DOM listener, because PM installs its own
+   * keydown listener in the EditorView constructor, before any plugin view
+   * exists — a listener added from here runs after PM's entire handler chain,
+   * including after other plugins have consumed keys we'd then wrongly note. */
+  handleKeyDown = (event: KeyboardEvent): boolean => {
+    if (this.enabled) this.pending = affinityForKey(event);
+    return false;
+  };
+
   /** Doc position → the scroller's scroll-origin space. At an ambiguous
-   * position the side comes from the click's x if there was one, and otherwise
-   * from `coordsAtPos`'s own default — keyboard motion contributes nothing.
-   * Subtracts the scroller's border (`clientLeft/Top`) because
+   * position the side comes from the click's x if there was one, then from a
+   * line-edge key if one named a side, and otherwise from `coordsAtPos`'s own
+   * default. Subtracts the scroller's border (`clientLeft/Top`) because
    * `getBoundingClientRect` includes the border but absolute positioning is
    * relative to the padding box. */
-  private caretPos(clickX: number | null): CaretPos | null {
+  private caretPos(
+    clickX: number | null,
+    side: Affinity | null,
+  ): CaretPos | null {
     if (!this.scroller) return null;
     const head = this.view.state.selection.head;
     let coords: { left: number; top: number; bottom: number };
@@ -155,6 +207,8 @@ class CaretView {
           Math.abs(up.left - clickX) <= Math.abs(down.left - clickX)
             ? up
             : down;
+      } else if (side != null) {
+        coords = this.view.coordsAtPos(head, SIDE[side]);
       } else {
         coords = this.view.coordsAtPos(head);
       }
@@ -199,7 +253,7 @@ class CaretView {
       selection instanceof TextSelection &&
       selection.empty;
 
-    const pos = active ? this.caretPos(clickX) : null;
+    const pos = active ? this.caretPos(clickX, this.side) : null;
     if (!pos) {
       this.el.style.display = "none";
       // Re-appearance should snap, not glide from a stale position.
@@ -251,6 +305,17 @@ export const Caret = Extension.create({
   name: "caret",
 
   addProseMirrorPlugins() {
-    return [new Plugin({ view: (view) => new CaretView(view) })];
+    // The keydown prop and the plugin view must be the same Plugin so the prop
+    // can reach the instance; the closure is per-editor because
+    // addProseMirrorPlugins runs once per editor.
+    let caret: CaretView | null = null;
+    return [
+      new Plugin({
+        view: (view) => (caret = new CaretView(view)),
+        props: {
+          handleKeyDown: (_view, event) => caret?.handleKeyDown(event) ?? false,
+        },
+      }),
+    ];
   },
 });

--- a/frontend/src/lib/editor/extensions/caret.ts
+++ b/frontend/src/lib/editor/extensions/caret.ts
@@ -49,6 +49,32 @@ interface CaretPos {
   height: number;
 }
 
+/** Which side of a soft-wrap boundary the caret sits on — the affinity bit the
+ * browser keeps and hides from the DOM API. A wrap is one document position
+ * with two visual homes, and this says which one to paint. */
+type Affinity = "upstream" | "downstream";
+
+/** Which way the last input travelled through the document. Not an `Affinity`:
+ * at a wrap the caret lands on the side it came *from*, so the two are
+ * opposites there and identical everywhere else. */
+type Direction = "backward" | "forward";
+
+/** `coordsAtPos`'s `side` argument, which is a signed number. The only place
+ * either type above touches one. */
+const SIDE: Record<Affinity, number> = { upstream: -1, downstream: 1 };
+
+/** Which side of the fence a move lands on, given the way it travelled.
+ *
+ * Horizontal travel lands on the side it came *from* — you stay on the line you
+ * were already on, and the arrow that crosses to the other side is the fence's
+ * second stop (handleKeyDown's flip). Every other key names its own
+ * destination: ArrowDown wants the line it arrives on, End wants the end of the
+ * line even though it travels forward. Those map straight across. */
+function arrivingAffinity(from: Direction, horizontal: boolean): Affinity {
+  if (horizontal) return from === "forward" ? "upstream" : "downstream";
+  return from === "forward" ? "downstream" : "upstream";
+}
+
 class CaretView {
   private el: HTMLElement;
   private scroller: HTMLElement | null = null;
@@ -58,17 +84,19 @@ class CaretView {
   private last: CaretPos | null = null;
   // Set on mousedown to disambiguate the caret's side by the click's x.
   private clickX: number | null = null;
-  // Reconstructed caret affinity (the bit the browser keeps but hides from the
-  // DOM API): which side of an ambiguous position — a soft-wrap/bidi/mark
-  // boundary — the caret belongs to, inferred from the last input's direction.
-  // -1 = upstream (end of prev line), +1 = downstream (start of next line).
-  private bias: number | null = null;
+  // INVARIANT: non-null *only* while the caret is a collapsed cursor standing
+  // at a wrap boundary. Enter the fence, set it; leave, clear it. Everywhere
+  // else there is one place to paint and no side to record. That invariant is
+  // what lets handleKeyDown decide the flip from this bit alone without
+  // measuring — so it is re-derived on every move (update()) and dropped
+  // whenever a reflow moves the wrap points (the ResizeObserver above).
+  private bias: Affinity | null = null;
   // Direction recorded on keydown, resolved into `bias` by update() once
   // ProseMirror has actually moved the selection — the destination has to exist
   // before we can measure whether it landed on a wrap boundary.
-  // `pendingHorizontal` marks Left/Right, the only keys the boundary inversion
-  // applies to.
-  private pending: number | null = null;
+  // `pendingHorizontal` marks Left/Right, the only keys that land on the side
+  // they came from rather than the side they point at.
+  private pending: Direction | null = null;
   private pendingHorizontal = false;
   // Touch/coarse pointer: keep the native caret, render nothing.
   private readonly enabled: boolean;
@@ -90,9 +118,13 @@ class CaretView {
       if (!this.scroller) return;
       this.scroller.appendChild(this.el);
       // Reflow/rewrap moves the caret without a transaction — snap (clear
-      // `last`) rather than gliding.
+      // `last`) rather than gliding. It also moves the wrap points themselves,
+      // so the fence the caret was standing in may not be there any more: drop
+      // `bias` too, or the invariant ("non-null ⇒ at a boundary") quietly stops
+      // holding and the next arrow press spends itself on a flip that isn't.
       this.resize = new ResizeObserver(() => {
         this.last = null;
+        this.bias = null;
         this.render();
       });
       this.resize.observe(this.scroller);
@@ -114,50 +146,54 @@ class CaretView {
     this.pending = null;
     this.pendingHorizontal = false;
 
-    const moved = prevState.selection.head !== this.view.state.selection.head;
-    if (moved && pending != null) {
-      // Resolve the recorded intent now that the selection has landed. At a
-      // soft-wrap boundary the arriving caret belongs to the line it came
-      // *from* — that's what makes the boundary two stops rather than one,
-      // with handleKeyDown's flip supplying the second. Everywhere else the
-      // affinity is simply the direction of travel.
+    const sel = this.view.state.selection;
+    const collapsed = sel instanceof TextSelection && sel.empty;
+    const moved = prevState.selection.head !== sel.head;
+    if (moved || !collapsed) {
+      // Enter the fence, set the bit; leave it, clear the bit. `bias` is
+      // re-derived from scratch here on every move and never carried, which is
+      // what makes the invariant true and lets handleKeyDown trust it without
+      // measuring anything.
       //
-      // Horizontal keys only: Up/Down and Home/End already name the affinity
-      // they want (Down wants the line it arrives on, End wants upstream even
-      // though it travels right), so inverting them lands the caret a line off.
+      // It stays null unless all three hold: the caret actually moved (a
+      // stationary head can't have entered anywhere), it's a collapsed cursor
+      // (a range has no affinity), and there's a `pending` direction behind the
+      // move. A null `pending` means no key and no click caused it — a remote
+      // Yjs update, undo/redo, a programmatic setSelection — so there's nothing
+      // to infer from and guessing would cost the user a keystroke.
+      //
+      // Which side of the fence you land on is the side you came *from*: that's
+      // what makes the boundary two stops rather than one, with handleKeyDown's
+      // flip supplying the second. Horizontal keys only — Up/Down and Home/End
+      // already name the affinity they want (Down wants the line it arrives on,
+      // End wants upstream even though it travels right), so inverting those
+      // lands the caret a line off.
       this.bias =
-        horizontal && this.isWrapBoundary(this.view.state.selection.head)
-          ? -pending
-          : pending;
-    } else if (moved) {
-      // The head moved with no key and no click behind it: a remote Yjs update
-      // (ySyncPlugin restores the selection on every remote change), undo/redo,
-      // or any programmatic setSelection. Whatever `bias` described, it
-      // described a different position — and a stale one would spend the user's
-      // next arrow press on a bogus flip. Drop it and re-derive from input.
-      this.bias = null;
+        moved && collapsed && pending != null && this.isWrapBoundary(sel.head)
+          ? arrivingAffinity(pending, horizontal)
+          : null;
     }
 
     this.render();
   }
 
-  /** Is `pos` a soft-wrap boundary — one document position with two visual
-   * homes? Nothing in the model records where the browser chose to wrap, so it
-   * has to be measured: ask for both sides and see if they landed on different
-   * lines. (`view.endOfTextblock()` can't answer this — it reports *textblock*
+  /** Is `pos` inside the fence — a soft-wrap boundary, one document position
+   * with two visual homes? Nothing in the model records where the browser chose
+   * to wrap, so it has to be measured: ask for both sides and see where they
+   * landed. (`view.endOfTextblock()` can't answer this — it reports *textblock*
    * edges, not wrap points.)
    *
-   * Requires a step down *and* a jump left. An inline image or a taller mark
+   * Requires a step down *and* a jump left. A taller mark or an inline image
    * also shifts `.top` between the two sides; only a wrap throws the downstream
    * side back to the line's left edge. That second conjunct is also what keeps
-   * the flip from ever stealing a key from gapcursor, tableEditing, or atom
+   * the flip from stealing a key from gapcursor, tableEditing, or atom
    * traversal: those act only at textblock edges, and a position with content
    * to its left on one line and to its right on the next is by definition not
-   * one. Deliberately narrow — a false positive costs a swallowed keystroke. */
+   * one. */
   private isWrapBoundary(pos: number): boolean {
     try {
-      const up = this.view.coordsAtPos(pos, -1);
-      const down = this.view.coordsAtPos(pos, 1);
+      const up = this.view.coordsAtPos(pos, SIDE.upstream);
+      const down = this.view.coordsAtPos(pos, SIDE.downstream);
       return down.top > up.top + 1 && down.left < up.left;
     } catch {
       return false;
@@ -199,7 +235,7 @@ class CaretView {
     const right = k === "ArrowRight";
 
     if (left || k === "ArrowUp" || k === "End" || k === "Backspace") {
-      this.pending = -1;
+      this.pending = "backward";
     } else if (
       right ||
       k === "ArrowDown" ||
@@ -207,36 +243,32 @@ class CaretView {
       k === "Enter" ||
       k.length === 1 // a printable character
     ) {
-      this.pending = 1;
+      this.pending = "forward";
     }
-    // Modifiers, Escape, etc. leave the last inferred affinity in place.
+    // Modifiers, Escape, etc. leave the last recorded direction in place.
     this.pendingHorizontal = left || right;
 
-    // Cheap tests first — isWrapBoundary forces a layout read, and this keeps
-    // it off the hot path of a held-down arrow.
     if (!this.enabled || !(left || right)) return false;
     // Never consume a modified arrow: Shift extends the selection, Cmd/Ctrl
-    // jumps the line, Alt jumps the word. They still record intent above, which
-    // is what makes Cmd+ArrowRight land upstream at a wrapped line end.
+    // jumps the line, Alt jumps the word. They still record direction above,
+    // which is what makes Cmd+ArrowRight land upstream at a wrapped line end.
     if (event.shiftKey || event.ctrlKey || event.metaKey || event.altKey)
       return false;
 
-    const dir = right ? 1 : -1;
-    // `bias === -dir` — affinity pointing against the press — is exactly
-    // "standing at the far end of a two-ended position". Anything else,
-    // including a null (unknown) bias, falls through and moves normally: a
-    // keystroke is never eaten on a guess.
-    if (this.bias !== -dir) return false;
-    const { selection } = this.view.state;
-    if (!(selection instanceof TextSelection) || !selection.empty) return false;
-    if (!this.isWrapBoundary(selection.head)) return false;
+    // Crossing the fence. `bias` is non-null only while the caret stands at a
+    // wrap boundary (see update()), so the bit alone answers both questions:
+    // are we in a fence, and are we at the end of it this press points away
+    // from. Nothing to re-measure. A null bias falls through and moves the
+    // document normally — a keystroke is never eaten on a guess.
+    //
+    // Not correct inside RTL (bidi) runs, where the physical key direction and
+    // the logical one diverge. Same punt as the rest of the file; the cost is
+    // one extra press, since the flip lands on the far side and the next press
+    // finds `bias` no longer pointing against it.
+    const from: Affinity = right ? "upstream" : "downstream";
+    if (this.bias !== from) return false;
 
-    // The flip sets bias to the direction just pressed, so the next press can't
-    // flip again — a false-positive boundary costs one extra keypress, never a
-    // stuck caret. Not correct inside RTL (bidi) runs, where the physical key
-    // direction and the logical one diverge; same punt as before, and it
-    // self-heals for the same reason.
-    this.bias = dir;
+    this.bias = right ? "downstream" : "upstream";
     this.pending = null; // consumed here — no transaction, so no update()
     this.pendingHorizontal = false;
     this.render();
@@ -250,26 +282,30 @@ class CaretView {
    * includes the border but absolute positioning is relative to the padding box. */
   private caretPos(
     clickX: number | null,
-    bias: number | null,
+    bias: Affinity | null,
   ): CaretPos | null {
     if (!this.scroller) return null;
     const head = this.view.state.selection.head;
     let coords: { left: number; top: number; bottom: number };
     try {
       if (clickX != null) {
-        const before = this.view.coordsAtPos(head, -1);
-        const after = this.view.coordsAtPos(head, 1);
-        const upstream =
-          Math.abs(before.left - clickX) <= Math.abs(after.left - clickX);
-        coords = upstream ? before : after;
-        // Keep the side the click picked. The click's x is the most direct
-        // affinity signal there is, and persisting it is what lets
-        // click-then-arrow behave like arrow-then-arrow at a wrapped position —
-        // otherwise `bias` is null there and the first press can't flip. Off a
-        // boundary the two sides coincide, so whichever wins is harmless.
-        this.bias = upstream ? -1 : 1;
+        const up = this.view.coordsAtPos(head, SIDE.upstream);
+        const down = this.view.coordsAtPos(head, SIDE.downstream);
+        const picked: Affinity =
+          Math.abs(up.left - clickX) <= Math.abs(down.left - clickX)
+            ? "upstream"
+            : "downstream";
+        coords = picked === "upstream" ? up : down;
+        // Keep the side the click picked, but only if the click landed in a
+        // fence — the same invariant update() maintains, checked against the
+        // rects already in hand rather than a second layout read. Persisting it
+        // is what lets click-then-arrow behave like arrow-then-arrow at a
+        // wrapped position; off a boundary the two sides coincide and recording
+        // a side would plant exactly the stale bit the invariant forbids.
+        this.bias =
+          down.top > up.top + 1 && down.left < up.left ? picked : null;
       } else if (bias != null) {
-        coords = this.view.coordsAtPos(head, bias);
+        coords = this.view.coordsAtPos(head, SIDE[bias]);
       } else {
         coords = this.view.coordsAtPos(head);
       }
@@ -303,8 +339,8 @@ class CaretView {
     this.clickX = null;
 
     const { selection } = this.view.state;
-    // `bias` persists across renders (it's the last known intent); `clickX` is
-    // one-shot, consumed above.
+    // `bias` is whatever the last move left behind — non-null only if that move
+    // ended inside a fence; `clickX` is one-shot, consumed above.
     // Only a plain collapsed text cursor gets a caret. A range selection shows
     // the native band; NodeSelection/GapCursor have their own rendering and
     // `coordsAtPos(head)` isn't meaningful for them.

--- a/frontend/src/lib/editor/extensions/index.ts
+++ b/frontend/src/lib/editor/extensions/index.ts
@@ -24,6 +24,7 @@ import {
   ThematicBreak,
   UniqueBlockIdentity,
 } from "@/lib/editor/extensions/blocks";
+import { Caret } from "@/lib/editor/extensions/caret";
 import { CommandMenu } from "@/lib/editor/extensions/commandMenu";
 import { AnchoredHighlights } from "@/lib/editor/extensions/highlights";
 import { imageSupport } from "@/lib/editor/extensions/images";
@@ -130,6 +131,7 @@ export function tiptapExtensions(
     MarkdownLink,
     AnchoredHighlights,
     presenceExtension(awareness),
+    Caret,
     CommandMenu,
     LinkInput,
     LinkHover,


### PR DESCRIPTION
## Summary

The native text caret can't be animated — the platform exposes only `caret-color`. So this hides it (on fine pointers) and draws a synthetic replacement (`extensions/caret.ts`) that can **fade-blink** and **glide** on movement.

- **Persistent overlay**, not a `Decoration.widget` (a widget's DOM rebuilds on every reposition, resetting the transition). Lives inside the `.editor-prose` scroller in scroll-origin coordinates, so it scrolls natively and the glide fires only on real caret moves, never on scroll.
- **Blink** is an opacity keyframe (a fade, not hard on/off); solid while moving, resumes blinking when idle.
- **Glide** is a `transform` transition — every move animates, tunable via a single `GLIDE_MS` constant.
- **Affinity bit**: a keydown listener reconstructs the caret affinity the DOM API hides (backward keys → upstream, forward keys / typed char → downstream) and feeds `coordsAtPos(head, side)`, so an ambiguous boundary (soft-wrap / mark edge) paints on the side the user meant. Clicks win via the click x.

Local-only — peers still render via `yCursorPlugin`.

### Edge handling
- Native caret restored during **IME composition** (candidate windows anchor to it).
- **Disabled on touch/coarse pointers** — selection handles, the loupe, and long-press depend on the native caret.
- Renders only for a **collapsed `TextSelection`** (NodeSelection / GapCursor fall through).
- Padding-box border offset subtracted; `prefers-reduced-motion` no-ops the glide.

### Known limitations (documented in code)
- **RTL/bidi affinity** is not handled — the direction→side mapping inverts inside RTL runs, and the browser's embedding-level info isn't exposed to us.
- Positions against a custom node view that can't be measured **hide** the caret rather than misplace it (graceful; deeper `domAtPos` + `Range` fallback deferred).

Sets up a later PR: driving the caret's color from mark context (the "inside a link" signal) hangs off the same `update()`.

## Test plan

- Fine-pointer device: native caret hidden, synthetic caret shows at a collapsed cursor when focused.
- Blink fades; solid while typing/arrowing, resumes when idle.
- Every move glides — typing, arrows, up/down, and large jumps.
- Arrow to a soft-wrap boundary lands the caret on the intended side.
- Range selection → no caret; blur → no caret; scroll → caret stays glued.
- Touch device / `prefers-reduced-motion`: native caret / no glide.
- Peers still render their carets.
- Tune `GLIDE_MS` (`caret.ts`) to change glide speed.
