### PR TITLE
fix(coedit): fold a conflicting out-of-band commit into a clean session

### DIFF
--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -113,7 +113,12 @@ def scan_coedit_checkpoints() -> None:
     for sess in coedit.list_active_sessions():
         if sess.ydoc_seq != sess.ydoc_checkpointed_seq:
             continue  # dirty — the seq-based scan owns it
-        if sess.base_sha != wiki_git.head_sha_for_path(sess.path):
+        # None means no commit touches the path (or the git call itself
+        # failed — head_sha_for_path runs check=False): nothing to fold,
+        # and the engine's own gate would no-op, so enqueueing would just
+        # re-run every scan pass forever.
+        head = wiki_git.head_sha_for_path(sess.path)
+        if head is not None and sess.base_sha != head:
             checkpoint_coedit_session_task(sess.id)
             stranded += 1
     if stranded:

--- a/backend/app/tasks/coedit_checkpoint.py
+++ b/backend/app/tasks/coedit_checkpoint.py
@@ -22,6 +22,7 @@ from app.models.coedit import CheckpointResultFrame
 from app.tasks.queue import crontab
 from app.tasks.queues import coedit_queue
 from app.wiki import coedit, coedit_channel
+from app.wiki import git as wiki_git
 from app.wiki.coedit_checkpoint import checkpoint_session
 
 log = logging.getLogger(__name__)
@@ -103,6 +104,23 @@ def scan_coedit_checkpoints() -> None:
         checkpoint_coedit_session_task(sess.id)
     if due:
         log.info("coedit checkpoint scan: enqueued %d session(s)", len(due))
+    # A clean session can still be stranded behind git: a conflicting
+    # out-of-band fold hands off to the checkpoint engine, and if that
+    # enqueue is lost (crash, deploy) nothing else retries — the seq-based
+    # query above never sees a session with no local edits. One page-scoped
+    # git lookup per active session; the active set is small.
+    stranded = 0
+    for sess in coedit.list_active_sessions():
+        if sess.ydoc_seq != sess.ydoc_checkpointed_seq:
+            continue  # dirty — the seq-based scan owns it
+        if sess.base_sha != wiki_git.head_sha_for_path(sess.path):
+            checkpoint_coedit_session_task(sess.id)
+            stranded += 1
+    if stranded:
+        log.info(
+            "coedit checkpoint scan: enqueued %d clean-but-diverged session(s)",
+            stranded,
+        )
     abandoned = coedit.close_abandoned_sessions()
     if abandoned:
         log.info("coedit presence scan: closed %d abandoned session(s)", len(abandoned))

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -588,13 +588,14 @@ def advance_checkpoint(
     impossible: there is no code path that prunes without also advancing
     the snapshot to the same seq.
 
-    Conditional on ``ydoc_checkpointed_seq < seq`` so a slow in-flight
+    Conditional on ``ydoc_checkpointed_seq <= seq`` so a slow in-flight
     checkpoint can't clobber a faster concurrent one's more-advanced state
     — belt-and-suspenders alongside ``coedit.checkpoint_lock``'s own
-    per-session serialization, not a substitute for it (matches the old
-    ``mark_checkpointed``'s regression guard, which this replaces —
-    snapshot advancement was never optional here, so there's no longer a
-    narrower "just advance the watermark" operation to keep around).
+    per-session serialization, not a substitute for it. Equality is
+    allowed on purpose: a clean session folding an out-of-band commit
+    re-advances at the *same* seq — new snapshot, new ``base_sha``, no new
+    local update — and a strictly-less guard would silently discard that
+    fold.
     """
     now = _iso(_now())
     with session() as s:
@@ -605,7 +606,7 @@ def advance_checkpoint(
         # isn't typed on the generic Result[Any] this execute() returns.
         updated_path = s.scalars(
             update(CoeditSession)
-            .where(CoeditSession.id == session_id, CoeditSession.ydoc_checkpointed_seq < seq)
+            .where(CoeditSession.id == session_id, CoeditSession.ydoc_checkpointed_seq <= seq)
             .values(
                 ydoc_snapshot=snapshot,
                 ydoc_snapshot_seq=seq,
@@ -630,6 +631,18 @@ def advance_checkpoint(
             wiki_documents.mirror_checkpoint(
                 s, updated_path, seq=seq, snapshot=snapshot, body=body, base_sha=base_sha
             )
+
+
+def list_active_sessions() -> list[SessionRow]:
+    """Every ACTIVE session — the periodic scan's working set for checks
+    that aren't expressible as a SQL predicate (git divergence)."""
+    with session() as s:
+        rows = s.scalars(
+            select(CoeditSession).where(
+                CoeditSession.status == SessionStatus.ACTIVE.value
+            )
+        ).all()
+        return [_session_row(r) for r in rows]
 
 
 def sessions_due_for_checkpoint(

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -635,6 +635,22 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 )
                 return None
             new_body = wiki_git.read_file_opt(path, ref=new_sha) or ""
+            # This HEAD read races other writers: the merge's no-op proved the
+            # doc collapses cleanly into the HEAD *it* saw, not necessarily
+            # into whatever is HEAD now. Folding an unmerged revision would
+            # bypass the three-way path entirely, so re-verify against the
+            # revision actually being folded; on any doubt, finalize nothing —
+            # the newer commit's own rebase trigger (and the scan's diverged
+            # check) re-runs this checkpoint against the settled HEAD.
+            recheck = wiki_git.merge_content(base_body, new_body, body)
+            if not recheck.clean or recheck.merged != new_body:
+                log.info(
+                    "coedit checkpoint: HEAD of %s moved past the no-op merge "
+                    "(session %s); deferring to the next trigger",
+                    path,
+                    session_id,
+                )
+                return None
 
         # If the merge produced content beyond what this doc held (a
         # concurrent external commit folded in — whether or not a new

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -431,7 +431,16 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 )
             return None
         if sess.ydoc_seq == sess.ydoc_checkpointed_seq:
-            return None  # nothing new to commit
+            # Clean by seq — but an out-of-band commit may still have moved
+            # the page past ``base_sha``. That is exactly the state a
+            # conflicting live-rebase hands off here (``rebase_session``
+            # leaves the document alone on overlap), and with no local edit
+            # pending nothing else would ever fold the commit in: the page
+            # would stay on the old content in the editor indefinitely.
+            # Skip only when git agrees there is nothing to reconcile.
+            head = wiki_git.head_sha_for_path(sess.path)
+            if head is None or head == sess.base_sha:
+                return None  # nothing new to commit, nothing to fold
         if sess.ydoc_snapshot is None:
             # This session's very first connection hasn't finished
             # set_initial_snapshot yet — momentary, the next trigger retries.
@@ -605,14 +614,18 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                     )
             replayed_seq = late.head_seq if late.head_seq is not None else replayed_seq
 
-        if result is None:
-            # The merge produced exactly the current HEAD (doc already
-            # matches committed content). Still advance the snapshot/watermark
-            # against current HEAD so we don't re-attempt this seq forever —
-            # the rebuilt doc's own state (post-replay) is the new snapshot,
-            # even though nothing was actually committed.
-            head = wiki_git.head_sha_for_path(path)
-            if head is None:
+        if result is not None:
+            new_body, new_sha = result.new_body, result.sha
+        else:
+            # The merge collapsed to the current HEAD — nothing was
+            # committed. HEAD's content still becomes the snapshot state:
+            # when an out-of-band commit is what the merge collapsed to
+            # (this document had nothing of its own to add), that content
+            # differs from what the document holds, and advancing the
+            # watermark without folding it in would stamp the session
+            # synced while editors keep reading the old content.
+            new_sha = wiki_git.head_sha_for_path(path)
+            if new_sha is None:
                 # Shouldn't happen — a no-op merge implies HEAD exists. Surface
                 # it rather than silently leaving the session dirty forever.
                 log.warning(
@@ -621,21 +634,12 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                     session_id,
                 )
                 return None
-            # Restamp before snapshotting: this doc is kept as-is (not
-            # reseeded from markdown text), so its block/row ids would
-            # otherwise drift out of sync with base_body's own numbering
-            # the moment a future checkpoint re-parses a base_body whose
-            # block count/order has since changed — see
-            # restamp_block_ids's own docstring.
-            markdown_splice.restamp_block_ids(doc, body)
-            coedit.advance_checkpoint(
-                session_id, seq=replayed_seq, snapshot=doc.get_update(), body=body, base_sha=head
-            )
-            return None
+            new_body = wiki_git.read_file_opt(path, ref=new_sha) or ""
 
-        # If the AI/3-way merge changed the content beyond what this doc
-        # held (a concurrent external commit folded in), the *committed*
-        # result must become the new snapshot's content. Splice it onto
+        # If the merge produced content beyond what this doc held (a
+        # concurrent external commit folded in — whether or not a new
+        # commit was made for it), that result must become the new
+        # snapshot's content. Splice it onto
         # this doc's own lineage (apply_markdown_diff) rather than
         # discarding that lineage for a fresh seed_doc_from_markdown parse
         # — any edit logged *up to* replayed_seq is already folded into
@@ -647,14 +651,14 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         # either way (confirmed in review — silent, total loss, not an
         # error) — preserving lineage here is strictly better regardless.
         # See apply_markdown_diff's own docstring.
-        diverged = result.new_body != body
+        diverged = new_body != body
         # The state connected clients are on, captured before the finalizing
         # mutations below, so a divergence can be handed to them as a plain
         # delta (see the broadcast after advance_checkpoint).
         pre_finalize = doc.get_state()
         reseeded = False
         if diverged:
-            if not markdown_splice.apply_markdown_diff(doc, body, result.new_body):
+            if not markdown_splice.apply_markdown_diff(doc, body, new_body):
                 # doc's children don't correspond 1:1 to a fresh parse of
                 # their own body — the same positional drift
                 # restamp_block_ids guards against, just discovered here
@@ -662,10 +666,10 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 # pairing; fall back to the old, lineage-discarding
                 # behavior rather than risk misapplying the diff (no worse
                 # than before this fix for this rarer, compounding case).
-                doc = markdown_yjs.seed_doc_from_markdown(result.new_body)
+                doc = markdown_yjs.seed_doc_from_markdown(new_body)
                 reseeded = True
             else:
-                markdown_splice.restamp_block_ids(doc, result.new_body)
+                markdown_splice.restamp_block_ids(doc, new_body)
         else:
             markdown_splice.restamp_block_ids(doc, body)
         snapshot = doc.get_update()
@@ -674,10 +678,11 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
             session_id,
             seq=replayed_seq,
             snapshot=snapshot,
-            body=result.new_body,
-            base_sha=result.sha,
+            body=new_body,
+            base_sha=new_sha,
         )
-        wiki_drafts.clear_if_diverged(path, result.new_body)
+        if result is not None:
+            wiki_drafts.clear_if_diverged(path, new_body)
         if diverged:
             if reseeded:
                 # A fresh lineage shares no history with what clients hold, so
@@ -698,9 +703,13 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 coedit_channel.broadcast_yjs(
                     session_id, create_update_message(doc.get_update(pre_finalize))
                 )
+        if result is None:
+            # No commit was made; None keeps the "nothing committed"
+            # contract for callers even though the session state advanced.
+            return None
         return CheckpointOutcome(
             session_id=session_id,
-            sha=result.sha,
-            body=result.new_body,
+            sha=new_sha,
+            body=new_body,
             diverged=diverged,
         )

--- a/backend/tests/test_coedit_checkpoint.py
+++ b/backend/tests/test_coedit_checkpoint.py
@@ -928,3 +928,28 @@ def test_drop_restated_blocks_leaves_a_few_repeated_lines_alone() -> None:
     doc = seed_doc_from_markdown(base + "\nalpha\n")
     assert drop_restated_blocks(doc, base) == 0
     assert reconstruct_body(doc) == base + "\nalpha\n"
+
+
+def test_scan_heals_a_clean_session_stranded_behind_git(repo):
+    """A conflicting fold's checkpoint handoff can be lost (worker crash or
+    deploy between the rebase task and the checkpoint task). The seq-based
+    scan query can never see the result — the session has no local edits —
+    so the scan checks git divergence for clean sessions and enqueues those."""
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    body = "1. one\n1. two\n1. three\n"
+    sha = _seed_page(body)
+    sess = coedit.open_session(_PATH, base_sha=sha)
+    coedit.join(sess.id, uid)
+    _client(sess, body)  # seeds the initial snapshot; no edits follow
+
+    rewrite = "# Rewritten\n\nEntirely new content.\n"
+    wiki_git.commit_file(_PATH, rewrite, "agent rewrite", author="A <a@x.com>")
+
+    with coedit_queue.immediate_mode():
+        coedit_checkpoint_task.scan_coedit_checkpoints()
+
+    st = coedit.get_active_session(_PATH)
+    assert st is not None  # participant present — session stays open
+    assert st.base_sha == wiki_git.head_sha_for_path(_PATH)
+    live = coedit_live.read_body(st.id)
+    assert live is not None and "Entirely new content." in live

--- a/backend/tests/test_coedit_rebase.py
+++ b/backend/tests/test_coedit_rebase.py
@@ -353,3 +353,52 @@ def test_live_read_reflects_a_folded_commit(repo):
     coedit_rebase.rebase_session(sid, new_sha)
 
     assert coedit_live.read_body(sid) == "EDIT-one\ntwo\nTHREE\n"
+
+
+# --- clean session + conflicting rewrite (the stranded-page case) ----------- #
+
+
+# All-"1." ordered list on purpose: the codec's serializer renumbers it
+# (1./2./3.) and writes it loose, so the document's own text *rewrites* the
+# git base's lines — and a full out-of-band rewrite overlaps that phantom
+# delta. A deterministic CONFLICT with zero local edits pending.
+_TIGHT_LIST = "1. one\n1. two\n1. three\n"
+_REWRITE = "# Rewritten\n\nEntirely new content.\n"
+
+
+def test_conflicting_rewrite_reaches_a_clean_session(repo):
+    """A conflicting fold on a session with no local edits defers to the
+    checkpoint engine — which must fold HEAD into the document rather than
+    no-op on its clean-by-seq gate. Left unfolded, the editor serves the old
+    snapshot indefinitely while git already has the rewrite."""
+    from app.wiki.coedit_checkpoint import checkpoint_session
+
+    sha = _seed(_TIGHT_LIST)
+    sid = _session(_TIGHT_LIST, sha)
+    new_sha = wiki_git.commit_file(_PATH, _REWRITE, "agent rewrite", author="A <a@x.com>")
+
+    assert coedit_rebase.rebase_session(sid, new_sha) == coedit_rebase.RebaseOutcome.CONFLICT
+
+    outcome = checkpoint_session(sid)
+    assert outcome is None  # fold only — no commit was made
+
+    doc, _seq = _rebuild(sid)
+    assert "Entirely new content." in reconstruct_body(doc)
+    st = coedit.get_session(sid)
+    assert st is not None and st.base_sha == new_sha
+    # Git untouched: the rewrite is already HEAD; the fold must not re-commit.
+    assert wiki_git.read_file_opt(_PATH) == _REWRITE
+
+
+def test_conflicting_rewrite_folds_via_the_rebase_task(repo):
+    """End to end through the trigger: the rebase task's conflict fallback
+    enqueues the checkpoint, and the session ends up on the rewrite."""
+    sha = _seed(_TIGHT_LIST)
+    sid = _session(_TIGHT_LIST, sha)
+    new_sha = wiki_git.commit_file(_PATH, _REWRITE, "agent rewrite", author="A <a@x.com>")
+
+    with coedit_queue.immediate_mode():
+        coedit_rebase_task.rebase_coedit_session(sid, new_sha)
+
+    doc, _seq = _rebuild(sid)
+    assert "Entirely new content." in reconstruct_body(doc)


### PR DESCRIPTION
Agent/MCP writes land in git but never reach the editor when the write is a substantial rewrite of a previously co-edited page. The editor renders from the session's stored Yjs snapshot; a large out-of-band rewrite makes the live-rebase fold conflict (by design — the codec-normalized reconstruction differs bytewise from the git base, so a big rewrite overlaps the phantom delta), and the conflict fallback hands off to the checkpoint engine — which no-oped. The page then serves stale content indefinitely. Small edits fold silently, which is why this went unnoticed.

Three defects, three fixes:

1. **`checkpoint_session`'s clean gate** returned early whenever `ydoc_seq == ydoc_checkpointed_seq`, so a session with no local edits — exactly the state a conflicting fold hands off — never reached the merge. The gate now skips only when git agrees: clean *and* `base_sha` is still the page's HEAD.
2. **The no-commit tail** assumed the doc already matched HEAD and advanced the watermark with the stale body — which would have stamped the session synced while editors kept old content. The tail now folds HEAD's content into the doc (same splice/reseed/broadcast path as the diverged-commit case) and advances `base_sha`/snapshot to HEAD.
3. **`advance_checkpoint`'s regression guard** (`ydoc_checkpointed_seq < seq`) silently discarded the equal-seq write a clean fold produces — new snapshot, same watermark. Relaxed to `<=`; a stale checkpoint still can't overwrite a more-advanced one.

Plus a heal path: the periodic scan now also enqueues **clean-but-diverged** sessions (one page-scoped git lookup per active session), so a fold handoff lost to a crash/deploy — including any session already stranded in production today — recovers within a scan interval instead of never.

Tests: end-to-end repro (conflicting rewrite on a clean session, engine + task paths, pinned to a deterministically-conflicting fixture: an all-`1.` ordered list the serializer renumbers), scan-heal case, and the full backend suite (2533 passed).