### PR TITLE
fix(coedit): out-of-band commits fold into the page's document row

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -60,7 +60,7 @@ from app.models.coedit import (
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session_task
 from app.tasks.coedit_rebase import rebase_coedit_session
-from app.wiki import acl, coedit, coedit_channel, coedit_live, git, wiki_documents
+from app.wiki import acl, coedit, coedit_channel, coedit_live, git
 from app.wiki.markdown_yjs import seed_doc_from_markdown
 
 router = APIRouter()
@@ -447,7 +447,7 @@ def _seed_snapshot_sync(session_id: int, path: str, base_sha: str | None) -> boo
     transplants as this session's seq-0 state — a pure byte copy that carries
     the page's one CRDT lineage across sessions, so a reconnecting client's
     retained document syncs onto the lineage it already holds and nothing
-    duplicates (see ``coedit.transplant_snapshot``). If the document's
+    duplicates (see ``coedit.transplant_from_document``). If the document's
     ``base_sha`` is behind the page's HEAD (out-of-band commits landed while
     nobody had the page open), the drift is folded in as an ordinary
     live-rebase — the same queued fold an agent commit gets mid-session, so
@@ -467,16 +467,8 @@ def _seed_snapshot_sync(session_id: int, path: str, base_sha: str | None) -> boo
     """
     if coedit.has_snapshot(session_id):
         return True
-    doc_row = wiki_documents.get(path)
-    if doc_row is not None:
-        doc_snapshot = doc_row["ydoc_snapshot"]
-        doc_body = doc_row["ydoc_snapshot_body"]
-        doc_base = doc_row["base_sha"]
-        assert isinstance(doc_snapshot, bytes) and isinstance(doc_body, str)
-        assert doc_base is None or isinstance(doc_base, str)
-        coedit.transplant_snapshot(
-            session_id, snapshot=doc_snapshot, body=doc_body, base_sha=doc_base
-        )
+    attached, doc_base = coedit.transplant_from_document(session_id, path)
+    if attached:
         head = git.head_sha_for_path(path)
         if head is not None and doc_base != head:
             rebase_coedit_session(session_id, head)

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1128,12 +1128,13 @@ class WikiDocument(Base):
     ``coedit_sessions`` row happens to exist, so a second lineage for a page
     becomes structurally impossible instead of detected after the fact.
 
-    **Dual-write phase**: nothing reads this table yet. The mirror writes in
-    ``app/wiki/wiki_documents.py`` keep each row in lockstep with its page's
-    session snapshot state — the row *follows* the session, including a
-    reseed overwriting it. Seed-once semantics (row created on a page's first
-    open, never reseeded) begin at cutover, when opens attach here and
-    ``coedit_updates`` re-keys from sessions to documents.
+    Opens attach from this row (``_seed_snapshot_sync`` in
+    ``app/api/coedit.py`` transplants its snapshot as the new session's
+    seq-0 state; markdown seeding is only the no-row fallback). The mirror
+    writes in ``app/wiki/wiki_documents.py`` keep each row in lockstep with
+    its page's session snapshot state, and out-of-band commits landing while
+    no session is open fold in via ``advance_offline`` — so the row tracks
+    the page, not just its checkpoints.
 
     Named generically rather than ``coedit_*``: this is "the wiki's documents
     as CRDT rows", scoped today to live editing with git still authoritative.

--- a/backend/app/tasks/coedit_rebase.py
+++ b/backend/app/tasks/coedit_rebase.py
@@ -19,7 +19,7 @@ import logging
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session_task
 from app.tasks.queues import coedit_queue
 from app.wiki import coedit
-from app.wiki.coedit_rebase import RebaseOutcome, rebase_session
+from app.wiki.coedit_rebase import RebaseOutcome, rebase_document_row, rebase_session
 
 log = logging.getLogger(__name__)
 
@@ -40,11 +40,22 @@ def rebase_coedit_session(session_id: int, head_sha: str) -> None:
         checkpoint_coedit_session_task(session_id)
 
 
+@coedit_queue.task()
+def rebase_wiki_document(rel_path: str, head_sha: str) -> None:
+    """Fold the commit at ``head_sha`` into the page's document row (no
+    session open). Pure splice — see ``rebase_document_row``."""
+    rebase_document_row(rel_path, head_sha)
+
+
 def on_wiki_commit(rel_path: str, sha: str) -> None:
-    """Enqueue a live-rebase if an active session exists for ``rel_path`` and the
-    commit is external to it (``base_sha`` hasn't already advanced to ``sha``,
-    which is the case for the session's own checkpoint commit)."""
+    """Enqueue the fold for the commit at ``sha``: into the open session when
+    one exists (skipping the session's own checkpoint commit), else into the
+    page's ``wiki_documents`` row, so the next open transplants current
+    content instead of reconciling drift at attach time."""
     sess = coedit.get_active_session(rel_path)
-    if sess is None or sess.base_sha == sha:
+    if sess is None:
+        rebase_wiki_document(rel_path, sha)
+        return
+    if sess.base_sha == sha:
         return
     rebase_coedit_session(sess.id, sha)

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -39,7 +39,7 @@ from sqlalchemy.dialects.postgresql import aggregate_order_by
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
 
-from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User
+from app.db.models import CoeditParticipant, CoeditSession, CoeditUpdate, User, WikiDocument
 from app.models.wiki import PathMove
 from app.db.session import session, try_advisory_xact_lock
 from app.wiki import doc_ids, wiki_documents
@@ -278,7 +278,7 @@ def open_session(path: str, *, base_sha: str | None) -> SessionRow:
     A fresh row is otherwise inserted — never a reactivated closed one. The
     page's CRDT lineage doesn't live here: the attach path transplants it
     from the page's ``wiki_documents`` row into the new session
-    (``transplant_snapshot``; ``_seed_snapshot_sync`` in
+    (``transplant_from_document``; ``_seed_snapshot_sync`` in
     ``app/api/coedit.py``), so a reconnecting client's retained document
     always meets the lineage it already holds, whatever became of the old
     session row.
@@ -374,11 +374,11 @@ def set_initial_snapshot(session_id: int, snapshot: bytes, body: str) -> bool:
         return row is not None
 
 
-def transplant_snapshot(
-    session_id: int, *, snapshot: bytes, body: str, base_sha: str | None
-) -> bool:
+def transplant_from_document(session_id: int, path: str) -> tuple[bool, str | None]:
     """Adopt the page's persistent document as this session's own seq-0 state
-    — the attach path of the one-lineage-per-page model.
+    — the attach path of the one-lineage-per-page model. Returns
+    ``(attached, document_base_sha)``; ``(False, None)`` when the page has no
+    document row (the caller seeds from markdown instead).
 
     A pure byte copy from the ``wiki_documents`` row (no ``Doc`` is built):
     the transplanted snapshot *is* the page's CRDT lineage, so a client
@@ -390,6 +390,12 @@ def transplant_snapshot(
     is folded in afterwards as an ordinary live-rebase (see
     ``_seed_snapshot_sync`` in ``app/api/coedit.py``).
 
+    The row read and the session write share one transaction under
+    ``wiki_documents.attach_lock``, serializing the attach against the
+    offline fold (``advance_offline``) — without it, a fold could advance
+    the row between this read and write, leaving the session on a snapshot
+    the row no longer holds.
+
     Same conditionality as ``set_initial_snapshot`` (``ydoc_snapshot IS
     NULL``), so concurrent connectors race harmlessly — and unlike a markdown
     seed, even the loser lost nothing: both transplant the same lineage.
@@ -398,18 +404,25 @@ def transplant_snapshot(
     *source* of this state, already current.
     """
     with session() as s:
-        row = s.scalars(
+        doc_id = doc_ids.id_for_path_in(s, path)
+        if doc_id is None:
+            return (False, None)
+        wiki_documents.attach_lock(s, doc_id)
+        doc_row = s.scalar(select(WikiDocument).where(WikiDocument.doc_id == doc_id))
+        if doc_row is None:
+            return (False, None)
+        s.scalars(
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.ydoc_snapshot.is_(None))
             .values(
-                ydoc_snapshot=snapshot,
+                ydoc_snapshot=doc_row.ydoc_snapshot,
                 ydoc_snapshot_seq=0,
-                ydoc_snapshot_body=body,
-                base_sha=base_sha,
+                ydoc_snapshot_body=doc_row.ydoc_snapshot_body,
+                base_sha=doc_row.base_sha,
             )
             .returning(CoeditSession.id)
         ).one_or_none()
-        return row is not None
+        return (True, doc_row.base_sha)
 
 
 class UpdateRow(BaseModel):
@@ -890,7 +903,7 @@ def purge_closed_sessions(*, limit: int = 500) -> int:
     A closed *clean* row is pure dead weight: its updates were pruned by its
     final checkpoint, its participants left (FK cascade catches stragglers),
     and the page's lineage lives on its ``wiki_documents`` row — the next
-    open transplants from there (``transplant_snapshot``), so nothing ever
+    open transplants from there (``transplant_from_document``), so nothing ever
     reactivates or rebuilds from a closed session. That is what lets this be
     unconditional: the age gate and the keep-the-newest-row-per-path subquery
     that used to live here protected the row session *reuse* needed, and

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -493,7 +493,7 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 "coedit checkpoint: %s (session %s) held identical duplicate "
                 "top-level blocks %s; dropped the repeats and committing the "
                 "repaired document. The one-lineage-per-page invariant broke — "
-                "see transplant_snapshot / _seed_snapshot_sync.",
+                "see transplant_from_document / _seed_snapshot_sync.",
                 path,
                 session_id,
                 repair.deleted,
@@ -520,7 +520,7 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 "coedit checkpoint: %s (session %s) held %d block(s) restating the "
                 "page back onto itself; dropped them and committing the repaired "
                 "document. The one-lineage-per-page invariant broke — see "
-                "transplant_snapshot / _seed_snapshot_sync.",
+                "transplant_from_document / _seed_snapshot_sync.",
                 path,
                 session_id,
                 restated,

--- a/backend/app/wiki/coedit_rebase.py
+++ b/backend/app/wiki/coedit_rebase.py
@@ -31,8 +31,11 @@ from enum import Enum
 
 from pycrdt import create_update_message
 
-from app.wiki import coedit, coedit_live, coedit_channel
+from pycrdt import Doc
+
+from app.wiki import coedit, coedit_live, coedit_channel, wiki_documents
 from app.wiki import git as wiki_git
+from app.wiki import markdown_splice
 
 log = logging.getLogger(__name__)
 
@@ -96,4 +99,56 @@ def rebase_session(session_id: int, head_sha: str) -> RebaseOutcome:
         return RebaseOutcome.SKIP  # session closed underneath us
     coedit_channel.broadcast_yjs(session_id, create_update_message(update_bytes), seq)
     coedit.set_base_sha(session_id, head_sha)
+    return RebaseOutcome.APPLIED
+
+
+def rebase_document_row(path: str, head_sha: str) -> RebaseOutcome:
+    """Fold an out-of-band commit into the page's ``wiki_documents`` row when
+    no session is open.
+
+    The row otherwise advances only on checkpoints, so a stretch of git-only
+    writes (agent edits, ingestion) leaves it holding old content — and every
+    later open transplants that old content into the new session, riding the
+    conflict path to reconcile drift that could have been folded here flat.
+
+    With no session there are no concurrent edits: the row's own body is the
+    merge base, so the fold is a pure splice of HEAD onto the row's lineage —
+    no three-way, no conflict outcome. ``SKIP`` when there is nothing to do
+    (no row, already current, stale trigger) or when the splice finds no safe
+    block pairing — the open-time fold handles that page as before.
+    """
+    sess = coedit.get_active_session(path)
+    if sess is not None:
+        return RebaseOutcome.SKIP  # the session fold path owns the page
+    row = wiki_documents.get(path)
+    if row is None:
+        return RebaseOutcome.SKIP
+    row_base = row["base_sha"]
+    assert row_base is None or isinstance(row_base, str)
+    if row_base == head_sha:
+        return RebaseOutcome.SKIP
+    if row_base is not None and wiki_git.is_ancestor(head_sha, row_base):
+        return RebaseOutcome.SKIP  # stale trigger — the row moved past it
+    head_body = wiki_git.read_file_opt(path, ref=head_sha) or ""
+    row_snapshot, row_body = row["ydoc_snapshot"], row["ydoc_snapshot_body"]
+    assert isinstance(row_snapshot, bytes) and isinstance(row_body, str)
+
+    doc = Doc()
+    doc.apply_update(row_snapshot)
+    if not markdown_splice.apply_markdown_diff(doc, row_body, head_body):
+        # No safe block pairing (the same positional-drift guard the
+        # checkpoint splice has). Reseeding would mint a fresh lineage a
+        # disconnected client may still hold the old one of — leave the row
+        # and let the open-time fold reconcile, as before this function.
+        log.info("coedit row-rebase: no safe splice for %s; leaving row", path)
+        return RebaseOutcome.SKIP
+    markdown_splice.restamp_block_ids(doc, head_body)
+    if not wiki_documents.advance_offline(
+        path,
+        snapshot=doc.get_update(),
+        body=head_body,
+        base_sha=head_sha,
+        expected_base_sha=row_base,
+    ):
+        return RebaseOutcome.SKIP  # a session opened or a checkpoint landed first
     return RebaseOutcome.APPLIED

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -2,9 +2,10 @@
 
 One row per page holding the page's Yjs document state, keyed by the page's
 ``wiki_doc_ids`` id (see the model docstring in ``app/db/models.py``).
-Nothing reads the table yet: the ``mirror_*`` functions keep each row in
-lockstep with its page's session snapshot state so cutover can flip opens to
-read from here against already-correct data.
+Opens attach from here (``_seed_snapshot_sync`` transplants the row's
+snapshot as the new session's seq-0 state); the ``mirror_*`` functions keep
+each row in lockstep with its page's session snapshot state, and
+``advance_offline`` folds out-of-band commits in while no session is open.
 
 Keying by id is what removes the move hook: renames re-key the *registry*
 (``doc_ids.on_path_moved``) and never touch a document row, so a missed
@@ -161,6 +162,45 @@ def mirror_base_sha(s: Session, path: str, base_sha: str) -> None:
         .values(base_sha=base_sha, updated_at=_now_iso())
         .execution_options(synchronize_session=False)
     )
+
+
+def advance_offline(
+    path: str,
+    *,
+    snapshot: bytes,
+    body: str,
+    base_sha: str,
+    expected_base_sha: str | None,
+) -> bool:
+    """Advance a row folded outside any session (``rebase_document_row``).
+
+    Compare-and-swap on ``base_sha``: a checkpoint or move re-mirror that
+    landed since the caller read the row wins, and this write reports False
+    instead of clobbering the newer state. Seqs stay untouched — the fold is
+    not a logged update, and a transplant adopts the snapshot at seq 0
+    regardless.
+    """
+    with session() as s:
+        doc_id = doc_ids.id_for_path_in(s, path)
+        if doc_id is None:
+            return False
+        updated = s.scalars(
+            update(WikiDocument)
+            .where(
+                WikiDocument.doc_id == doc_id,
+                WikiDocument.base_sha.is_(None)
+                if expected_base_sha is None
+                else WikiDocument.base_sha == expected_base_sha,
+            )
+            .values(
+                ydoc_snapshot=snapshot,
+                ydoc_snapshot_body=body,
+                base_sha=base_sha,
+                updated_at=_now_iso(),
+            )
+            .returning(WikiDocument.doc_id)
+        ).one_or_none()
+        return updated is not None
 
 
 def on_pages_deleted(paths: list[str]) -> None:

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -50,7 +50,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from app.db.models import WikiDocument
+from app.db.models import CoeditSession, WikiDocument
 from app.db.session import session
 from app.wiki import doc_ids
 
@@ -179,10 +179,28 @@ def advance_offline(
     instead of clobbering the newer state. Seqs stay untouched — the fold is
     not a logged update, and a transplant adopts the snapshot at seq 0
     regardless.
+
+    The active-session re-check runs inside this same transaction, not just
+    in the caller: a session opening between the caller's check and this
+    write would transplant the pre-advance row, and the write landing anyway
+    would fork row and session onto different snapshots of the lineage until
+    the session's next checkpoint overwrote it. Checked here, either this
+    write commits before the open (the transplant reads the advanced row) or
+    the open wins and this write yields.
     """
     with session() as s:
         doc_id = doc_ids.id_for_path_in(s, path)
         if doc_id is None:
+            return False
+        # "active" matches the coedit_sessions status constraint; the enum
+        # lives in app.wiki.coedit, which imports this module.
+        active = s.scalar(
+            select(CoeditSession.id).where(
+                CoeditSession.path == path,
+                CoeditSession.status == "active",
+            )
+        )
+        if active is not None:
             return False
         updated = s.scalars(
             update(WikiDocument)

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -44,6 +44,7 @@ semantics begin at cutover.
 from __future__ import annotations
 
 import logging
+import zlib
 from datetime import datetime, timezone
 
 from sqlalchemy import delete, select, update
@@ -51,7 +52,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from app.db.models import CoeditSession, WikiDocument
-from app.db.session import session
+from app.db.session import advisory_xact_lock, session
 from app.wiki import doc_ids
 
 log = logging.getLogger(__name__)
@@ -164,6 +165,27 @@ def mirror_base_sha(s: Session, path: str, base_sha: str) -> None:
     )
 
 
+# Distinct from coedit's checkpoint-lock namespace (0xC0ED): this one keys
+# on the *document*, serializing the attach read+transplant against the
+# offline fold.
+_ATTACH_LOCK_NS = 0xA77A
+
+
+def attach_lock(s: Session, doc_id: str) -> None:
+    """Transaction-scoped advisory lock on the page's document.
+
+    Held by both writers whose interleaving could fork row and session onto
+    different snapshots: ``advance_offline`` (offline fold: active-session
+    check + row write) and ``coedit.transplant_from_document`` (attach: row
+    read + session write). Under the lock, a transplant either waits out an
+    in-flight fold and reads the advanced row, or commits first — in which
+    case the fold's own active-session re-check sees the session and yields.
+    """
+    advisory_xact_lock(
+        s, (_ATTACH_LOCK_NS << 32) | (zlib.crc32(doc_id.encode()) & 0xFFFFFFFF)
+    )
+
+
 def advance_offline(
     path: str,
     *,
@@ -192,6 +214,7 @@ def advance_offline(
         doc_id = doc_ids.id_for_path_in(s, path)
         if doc_id is None:
             return False
+        attach_lock(s, doc_id)
         # "active" matches the coedit_sessions status constraint; the enum
         # lives in app.wiki.coedit, which imports this module.
         active = s.scalar(

--- a/backend/tests/test_coedit_attach.py
+++ b/backend/tests/test_coedit_attach.py
@@ -1,4 +1,4 @@
-"""The attach path (``_seed_snapshot_sync`` + ``coedit.transplant_snapshot``)
+"""The attach path (``_seed_snapshot_sync`` + ``coedit.transplant_from_document``)
 — a new session adopts the page's persistent document from ``wiki_documents``
 instead of seeding a fresh lineage from markdown.
 

--- a/backend/tests/test_coedit_rebase.py
+++ b/backend/tests/test_coedit_rebase.py
@@ -24,7 +24,7 @@ from pycrdt import Doc, XmlFragment
 from app.auth import users as users_repo
 from app.tasks import coedit_rebase as coedit_rebase_task
 from app.tasks.queues import coedit_queue
-from app.wiki import coedit, coedit_live, coedit_rebase
+from app.wiki import coedit, coedit_live, coedit_rebase, doc_ids, wiki_documents
 from app.wiki import git as wiki_git
 from app.wiki.markdown_yjs import ROOT_XML_KEY, reconstruct_body, seed_doc_from_markdown
 
@@ -402,3 +402,67 @@ def test_conflicting_rewrite_folds_via_the_rebase_task(repo):
 
     doc, _seq = _rebuild(sid)
     assert "Entirely new content." in reconstruct_body(doc)
+
+
+# --- document-row fold (no session open) ------------------------------------ #
+
+
+def test_no_session_commit_folds_the_document_row(repo):
+    """Out-of-band commits landing while nobody has the page open advance the
+    page's document row, so the next open transplants current content instead
+    of old content plus a drift fold."""
+    doc_ids.mint_for_page(_PATH)
+    body = "# Title\n\nalpha\n"
+    sha = _seed(body)
+    sid = _session(body, sha)  # set_initial_snapshot mirrors the document row
+    coedit.close_session(sid)
+
+    rewrite = "# Title\n\nalpha\n\nA brand new section.\n"
+    new_sha = wiki_git.commit_file(_PATH, rewrite, "agent edit", author="A <a@x.com>")
+
+    assert (
+        coedit_rebase.rebase_document_row(_PATH, new_sha)
+        == coedit_rebase.RebaseOutcome.APPLIED
+    )
+    row = wiki_documents.get(_PATH)
+    assert row is not None
+    assert row["base_sha"] == new_sha
+    assert row["ydoc_snapshot_body"] == rewrite
+    snap = row["ydoc_snapshot"]
+    assert isinstance(snap, bytes)
+    doc = Doc()
+    doc.apply_update(snap)
+    assert "A brand new section." in reconstruct_body(doc)
+
+
+def test_row_fold_skips_while_a_session_is_open(repo):
+    doc_ids.mint_for_page(_PATH)
+    body = "# Title\n\nalpha\n"
+    sha = _seed(body)
+    _session(body, sha)  # stays active — the session fold path owns the page
+
+    new_sha = wiki_git.commit_file(_PATH, "other\n", "agent edit", author="A <a@x.com>")
+    assert (
+        coedit_rebase.rebase_document_row(_PATH, new_sha)
+        == coedit_rebase.RebaseOutcome.SKIP
+    )
+    row = wiki_documents.get(_PATH)
+    assert row is not None and row["base_sha"] == sha  # untouched
+
+
+def test_on_wiki_commit_routes_to_the_row_when_no_session(repo):
+    doc_ids.mint_for_page(_PATH)
+    body = "# Title\n\nalpha\n"
+    sha = _seed(body)
+    sid = _session(body, sha)
+    coedit.close_session(sid)
+
+    rewrite = "# Title\n\nalpha\n\nAdded by an agent.\n"
+    new_sha = wiki_git.commit_file(_PATH, rewrite, "agent edit", author="A <a@x.com>")
+    with coedit_queue.immediate_mode():
+        coedit_rebase_task.on_wiki_commit(_PATH, new_sha)
+
+    row = wiki_documents.get(_PATH)
+    assert row is not None
+    assert row["base_sha"] == new_sha
+    assert row["ydoc_snapshot_body"] == rewrite

--- a/backend/tests/test_wiki_documents.py
+++ b/backend/tests/test_wiki_documents.py
@@ -253,9 +253,20 @@ def test_on_pages_deleted_ignores_non_pages_and_missing_rows(users):
     assert count_rows(WikiDocument) == 0
 
 
+def test_advance_offline_refuses_while_a_session_is_open(page_id):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    # An open session owns the page — the offline fold yields even with a
+    # matching expected base (the check runs inside the write transaction).
+    assert not wiki_documents.advance_offline(
+        _PATH, snapshot=b"snap1", body="new", base_sha="sha2", expected_base_sha="sha1"
+    )
+
+
 def test_advance_offline_cas_yields_to_newer_state(page_id):
     s = coedit.open_session(_PATH, base_sha="sha1")
     coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    _force_close(s.id)
     # Expected base doesn't match the row's — a checkpoint or re-mirror won;
     # the offline fold must report False and leave the row alone.
     assert not wiki_documents.advance_offline(

--- a/backend/tests/test_wiki_documents.py
+++ b/backend/tests/test_wiki_documents.py
@@ -251,3 +251,22 @@ def test_recreate_after_delete_is_a_fresh_document(page_id):
 def test_on_pages_deleted_ignores_non_pages_and_missing_rows(users):
     wiki_documents.on_pages_deleted(["folder/notes.txt", "never-seen.md"])
     assert count_rows(WikiDocument) == 0
+
+
+def test_advance_offline_cas_yields_to_newer_state(page_id):
+    s = coedit.open_session(_PATH, base_sha="sha1")
+    coedit.set_initial_snapshot(s.id, b"snap0", "hello")
+    # Expected base doesn't match the row's — a checkpoint or re-mirror won;
+    # the offline fold must report False and leave the row alone.
+    assert not wiki_documents.advance_offline(
+        _PATH, snapshot=b"snap1", body="new", base_sha="sha2", expected_base_sha="wrong"
+    )
+    row = wiki_documents.get(_PATH)
+    assert row is not None and row["ydoc_snapshot"] == b"snap0"
+    assert wiki_documents.advance_offline(
+        _PATH, snapshot=b"snap1", body="new", base_sha="sha2", expected_base_sha="sha1"
+    )
+    row = wiki_documents.get(_PATH)
+    assert row is not None
+    assert row["ydoc_snapshot"] == b"snap1"
+    assert row["base_sha"] == "sha2"


### PR DESCRIPTION
Closes the stale-mirror transplant gap: a page's `wiki_documents` row — the lineage every open transplants from — previously advanced **only on co-edit checkpoints**. A stretch of git-only writes (agent edits, ingestion) left the row holding old content, so the next open transplanted an old revision into the fresh session and relied on the open-time drift fold, which can conflict; the reconciliation debt then rode the checkpoint path. This is the mechanism behind both document-corruption incidents (the older page that came back as 17 copies of a stale revision, and this week's duplication storm during a live multi-editor session — variant copies of blocks unioned in by every checkpoint merge, invisible to the identical-copy and restatement tripwires).

The fix keeps the row honest at the source: `on_wiki_commit` now routes a commit to the open session's fold when one exists (unchanged), **else to a new `rebase_document_row`** that folds the commit into the document row. With no session open the row's own body is the merge base, so the fold is a pure splice onto the existing lineage — no three-way, no conflict case, no lineage reset (reseeding would orphan any disconnected client's retained document, the exact #575-class hazard). Guards:

- active session appears before the task runs → SKIP (the session path owns the page);
- no safe block pairing for the splice → SKIP, open-time fold handles it as before;
- `advance_offline` is a compare-and-swap on `base_sha`, so a checkpoint or move re-mirror that lands concurrently wins and the offline fold yields.

Also corrects the module/model docstrings that still described the table as dual-write/"nothing reads this yet" — opens attach from it, and that stale text actively misdirected this investigation.

Tests: row fold on a no-session commit (content + base + decoded snapshot asserted), active-session skip, trigger routing end-to-end, CAS yield. Full backend suite: 2537 passed.