### PR TITLE
fix(editor): headings render cramped — fixed base line-height inherited into 2em text

### DIFF
--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -28,9 +28,7 @@
   color: var(--text-04);
   font-family: var(--font-hanken-grotesk), ui-sans-serif;
   font-size: 1rem;
-  /* Unitless, so larger text inherits a ratio, not a fixed length — a fixed
-     1.5rem gave 2em headings a 24px line box (0.75), overlapping wrapped
-     heading lines. Body text is unchanged: 1rem * 1.5 is the same 24px. */
+  /* Unitless so line boxes scale with descendant font sizes. */
   line-height: 1.5;
   font-weight: 450;
 }

--- a/frontend/src/app/css/editor.css
+++ b/frontend/src/app/css/editor.css
@@ -28,7 +28,10 @@
   color: var(--text-04);
   font-family: var(--font-hanken-grotesk), ui-sans-serif;
   font-size: 1rem;
-  line-height: 1.5rem;
+  /* Unitless, so larger text inherits a ratio, not a fixed length — a fixed
+     1.5rem gave 2em headings a 24px line box (0.75), overlapping wrapped
+     heading lines. Body text is unchanged: 1rem * 1.5 is the same 24px. */
+  line-height: 1.5;
   font-weight: 450;
 }
 
@@ -55,7 +58,16 @@
   padding-right: var(--cm-gutter, 0rem);
 }
 
-/* Headings — same size scale as the old CM6 WYSIWYG decorations. */
+/* Headings — same size scale as the old CM6 WYSIWYG decorations. Tighter
+   than the body's 1.5 ratio, the usual display-type treatment. */
+.editor-prose h1,
+.editor-prose h2,
+.editor-prose h3,
+.editor-prose h4,
+.editor-prose h5,
+.editor-prose h6 {
+  line-height: 1.2;
+}
 .editor-prose h1 {
   font-size: 2em;
   font-weight: bold;


### PR DESCRIPTION
## Problem

Reported by Duo (via Slack): heading lines in the live editor render crushed together — a wrapped heading overlaps itself.

`.editor-prose` sets `line-height: 1.5rem` — a fixed 24px, not a ratio. Every heading inherits that fixed length, so an h1 at 2em (32px) gets a 24px line box: an effective 0.75 line-height. Dates to the original Tiptap editor styling (#557).

## Fix

- Base line-height is now unitless `1.5`, so descendants inherit a ratio. Body text is unchanged (1rem × 1.5 = the same 24px).
- Headings get an explicit `line-height: 1.2`, the usual display-type treatment — h1 goes from a 24px line box to 38.4px.

Verified on the local stack: computed styles before h1 32px/24px → after 32px/38.4px; p and li unchanged at 16px/24px.