### PR TITLE
fix(coedit): family block ids — never emit duplicate _blockId values to clients

### DIFF
--- a/backend/app/wiki/markdown_splice.py
+++ b/backend/app/wiki/markdown_splice.py
@@ -33,6 +33,8 @@ Two pieces:
 from __future__ import annotations
 
 import difflib
+import re
+from typing import overload
 
 from pycrdt import Doc, Subscription, XmlElement, XmlFragment
 
@@ -48,6 +50,44 @@ from app.wiki.markdown_yjs import (
 )
 
 _ROW_TAGS = ("tableRow", "tableSeparator")
+
+# Family form of a positional block id: ``b5.1``, ``b5.2``, ... — stamped by
+# restamp_block_ids when several doc children map onto one reparsed block
+# range (family base ``b5``). Ids on the wire stay unique per child: the
+# frontend's UniqueBlockIdentity extension (frontend/src/lib/editor/blocks.ts)
+# nulls the id of any top-level node that duplicates another's, and an
+# id-less child looks brand-new to checkpoint_body — which then serializes it
+# *in addition to* the verbatim base_body range that already contains its
+# text, compounding one copy per checkpoint (the Value Proposition storm).
+_FAMILY_ID_RE = re.compile(r"^(b\d+)\.\d+$")
+
+
+@overload
+def _family_base(block_id: str) -> str: ...
+@overload
+def _family_base(block_id: None) -> None: ...
+def _family_base(block_id: str | None) -> str | None:
+    """The base positional id a (possibly family-form) block id resolves to.
+
+    ``b5.1`` -> ``b5``; anything else (a plain ``b5``, a client-minted id, or
+    ``None``) passes through unchanged.
+    """
+    if block_id is None:
+        return None
+    m = _FAMILY_ID_RE.match(block_id)
+    return m.group(1) if m else block_id
+
+
+@overload
+def _family_row(row_id: str) -> str: ...
+@overload
+def _family_row(row_id: None) -> None: ...
+def _family_row(row_id: str | None) -> str | None:
+    """Row-id counterpart of ``_family_base``: ``b5.1:r0`` -> ``b5:r0``."""
+    if row_id is None or ":" not in row_id:
+        return row_id
+    prefix, rest = row_id.split(":", 1)
+    return f"{_family_base(prefix)}:{rest}"
 
 
 class TouchedTracker:
@@ -144,58 +184,54 @@ def checkpoint_body(base_body: str, doc: Doc, tracker: TouchedTracker) -> str:
 
     root = doc.get(ROOT_XML_KEY, type=XmlFragment)
     parts: list[str] = []
-    # Ids restamp_block_ids has already emitted an untouched, verbatim
-    # range for — restamp_block_ids can assign the *same* id to more than
-    # one doc child (when a fresh reparse of base_body merges what the doc
-    # still models as separate elements — e.g. two adjacent bullet lists;
-    # see its own docstring), and orig_by_id/leading_gap_start are keyed by
-    # id, not by child, so every child sharing an id resolves to the exact
-    # same base_body range in *this* (whole-range verbatim slice) branch.
-    # Emitting that range on more than one child duplicates it outright —
-    # and since the duplicated output becomes the *next* checkpoint's own
-    # base_body, still carrying the same shared id, it compounds on every
-    # subsequent untouched checkpoint rather than staying merely wrong once
-    # (confirmed in review — a real regression from restamp_block_ids' own
-    # id-sharing fix, not present before it).
+    # Every id-keyed structure here is keyed by *family base*
+    # (``_family_base``): restamp_block_ids stamps children that map onto
+    # one reparsed block range with per-child family ids (``b5``, ``b5.1``,
+    # ...), and orig_by_id/leading_gap_start come from base_body's own
+    # reparse, which only knows the base (``b5``). Touch-membership also
+    # resolves by base: touching any family member re-serializes them all —
+    # the shared range can only be replaced as a unit, and per-child
+    # serialization is concatenation, not duplication. (Legacy snapshots
+    # where several children carry the literal same id normalize to the
+    # same base too, so both generations behave identically here.)
+    touched_bases = {_family_base(i) for i in tracker.touched_block_ids}
+    touched_rows_by_base: dict[str, set[str]] = {}
+    for raw_block_id, raw_row_ids in tracker.touched_row_ids.items():
+        touched_rows_by_base.setdefault(_family_base(raw_block_id), set()).update(
+            _family_row(r) for r in raw_row_ids
+        )
+    # Family bases already emitted as an untouched, verbatim range — that
+    # one range covers every member's text, so emitting it once per member
+    # would duplicate it outright, and the duplicated output becomes the
+    # *next* checkpoint's own base_body, compounding every round.
     #
     # Deliberately NOT applied to the table branch just below: unlike this
     # branch (one shared base_body range covering everything, requiring
     # dedup to avoid duplicating it per sharing child), _splice_table
-    # already emits only *this specific child's own rows* — an id-sharing
-    # table child was already handled correctly per-child before this fix
-    # (confirmed in review: two identical adjacent tables were byte-exact
-    # stable across repeated checkpoints). Applying the same dedup there
-    # was a second, different regression this fix introduced: it drops a
-    # second table sharing an id entirely, not just its duplicate content.
-    #
-    # The *touched* path (below, for both branches) needs no such guard
-    # either way: touching any child sharing an id marks the whole shared
-    # id touched (the membership check there is by id, not by child), so
-    # every sharing child independently re-serializes its own actual
-    # content — concatenation, not duplication.
-    emitted_untouched_ids: set[str] = set()
+    # already emits only *this specific child's own rows* — dropping a
+    # second table of the family entirely would lose it, not dedup it.
+    emitted_untouched_bases: set[str] = set()
     for child in root.children:
         if not isinstance(child, XmlElement):
             raise NotImplementedError(f"unexpected top-level child: {type(child)!r}")
         block_id = dict(child.attributes).get(BLOCK_ID_ATTR)
-        orig = orig_by_id.get(block_id) if block_id else None
+        base_id = _family_base(block_id)
+        orig = orig_by_id.get(base_id) if base_id else None
 
-        if orig is not None and child.tag == "table" and block_id not in tracker.touched_block_ids:
-            gap = base_body[leading_gap_start[block_id] : orig.start]
-            parts.append(gap + _splice_table(base_body, orig, child, tracker.touched_row_ids.get(block_id, set())))
+        if base_id is not None and orig is not None and child.tag == "table" and base_id not in touched_bases:
+            gap = base_body[leading_gap_start[base_id] : orig.start]
+            parts.append(gap + _splice_table(base_body, orig, child, touched_rows_by_base.get(base_id, set())))
             continue
 
         touched = (
-            orig is None
-            or block_id in tracker.touched_block_ids
-            or block_id in tracker.touched_row_ids
+            orig is None or base_id in touched_bases or base_id in touched_rows_by_base
         )
         if not touched:
-            assert orig is not None and block_id is not None
-            if block_id in emitted_untouched_ids:
+            assert orig is not None and base_id is not None
+            if base_id in emitted_untouched_bases:
                 continue
-            emitted_untouched_ids.add(block_id)
-            parts.append(base_body[leading_gap_start[block_id] : orig.end])
+            emitted_untouched_bases.add(base_id)
+            parts.append(base_body[leading_gap_start[base_id] : orig.end])
             continue
 
         parts.append(serialize_block(child))
@@ -241,8 +277,19 @@ def restamp_block_ids(doc: Doc, body: str) -> None:
     fix. Handled here by diffing each child's own serialization against
     each reparsed block's raw text (``difflib``, not a bare index) — an
     "equal"/"replace" run of one-or-more children maps onto whichever
-    reparsed block(s) it actually corresponds to, so multiple children can
-    correctly collapse onto the same id instead of drifting apart.
+    reparsed block(s) it actually corresponds to.
+
+    Children that map onto the *same* reparsed block get **family ids**
+    (first child ``b5``, then ``b5.1``, ``b5.2``, ...), never the same
+    literal id: every consumer in this module resolves them through
+    ``_family_base``, while the ids each individual child carries stay
+    unique document-wide. That uniqueness is load-bearing for the round
+    trip through connected clients — the frontend's UniqueBlockIdentity
+    extension nulls the ``_blockId`` of any top-level node duplicating
+    another's, and once a family member's id is gone, ``checkpoint_body``
+    would re-serialize it as brand-new on top of the verbatim base range
+    that already contains its text: one extra copy committed per
+    checkpoint, compounding for as long as the session stays dirty.
     """
     root = doc.get(ROOT_XML_KEY, type=XmlFragment)
     children = [c for c in root.children if isinstance(c, XmlElement)]
@@ -250,12 +297,15 @@ def restamp_block_ids(doc: Doc, body: str) -> None:
     old_texts = [serialize_block(c) for c in children]
     new_texts = [body[b.start : b.end] for b in blocks]
     matcher = difflib.SequenceMatcher(a=old_texts, b=new_texts, autojunk=False)
+    family_counts: dict[int, int] = {}
     for tag, i1, i2, j1, j2 in matcher.get_opcodes():
         if tag == "insert":
             continue  # a reparsed block with no corresponding doc child — nothing to restamp
         for offset, child in enumerate(children[i1:i2]):
             j = min(j1 + offset, j2 - 1) if j2 > j1 else max(j1 - 1, 0)
-            block_id = f"b{j}"
+            n = family_counts.get(j, 0)
+            family_counts[j] = n + 1
+            block_id = f"b{j}" if n == 0 else f"b{j}.{n}"
             if dict(child.attributes).get(BLOCK_ID_ATTR) != block_id:
                 child.attributes[BLOCK_ID_ATTR] = block_id
             if child.tag == "table":
@@ -290,7 +340,11 @@ def _splice_table(
     orig_rows = {r.row_id: r for r in orig.rows}
     parts: list[str] = []
     for index, row_el in enumerate(table_el.children):
-        row_id = dict(row_el.attributes).get(ROW_ID_ATTR)
+        # Rows of a family-id table carry the child's family prefix
+        # (``b5.1:r0``); orig rows come from base_body's reparse, which
+        # only knows the base (``b5:r0``) — normalize before looking up.
+        # touched_row_ids arrives from checkpoint_body already normalized.
+        row_id = _family_row(dict(row_el.attributes).get(ROW_ID_ATTR))
         orig_row = orig_rows.get(row_id) if row_id else None
         if orig_row is None or row_id in touched_row_ids:
             touched = True

--- a/backend/app/wiki/markdown_splice.py
+++ b/backend/app/wiki/markdown_splice.py
@@ -53,12 +53,11 @@ _ROW_TAGS = ("tableRow", "tableSeparator")
 
 # Family form of a positional block id: ``b5.1``, ``b5.2``, ... — stamped by
 # restamp_block_ids when several doc children map onto one reparsed block
-# range (family base ``b5``). Ids on the wire stay unique per child: the
-# frontend's UniqueBlockIdentity extension (frontend/src/lib/editor/blocks.ts)
-# nulls the id of any top-level node that duplicates another's, and an
-# id-less child looks brand-new to checkpoint_body — which then serializes it
-# *in addition to* the verbatim base_body range that already contains its
-# text, compounding one copy per checkpoint (the Value Proposition storm).
+# range (family base ``b5``). Ids on the wire must stay unique per child:
+# the frontend's UniqueBlockIdentity extension (blocks.ts) nulls the id of
+# any top-level node duplicating another's, and an id-less child reads as
+# brand-new here — serialized on top of the verbatim base_body range that
+# already contains its text, one extra copy per checkpoint.
 _FAMILY_ID_RE = re.compile(r"^(b\d+)\.\d+$")
 
 
@@ -200,16 +199,25 @@ def checkpoint_body(base_body: str, doc: Doc, tracker: TouchedTracker) -> str:
         touched_rows_by_base.setdefault(_family_base(raw_block_id), set()).update(
             _family_row(r) for r in raw_row_ids
         )
-    # Family bases already emitted as an untouched, verbatim range — that
-    # one range covers every member's text, so emitting it once per member
-    # would duplicate it outright, and the duplicated output becomes the
-    # *next* checkpoint's own base_body, compounding every round.
-    #
-    # Deliberately NOT applied to the table branch just below: unlike this
-    # branch (one shared base_body range covering everything, requiring
-    # dedup to avoid duplicating it per sharing child), _splice_table
-    # already emits only *this specific child's own rows* — dropping a
-    # second table of the family entirely would lose it, not dedup it.
+    # An untouched family's content must reach the output exactly once, and
+    # the two emission styles cannot mix within one family: the generic
+    # branch emits the family's *whole* base_body range verbatim (every
+    # member's text at once, deduped via emitted_untouched_bases), while the
+    # table branch emits only *one child's own rows*. So the row-level
+    # branch is reserved for families made entirely of tables — there, no
+    # member ever emits the whole range, and each table must emit its own
+    # rows (skipping one would drop it, not dedup it). A family that mixes
+    # a table with anything else (reparse folds table lines into an
+    # adjacent block's range in either direction) routes every member —
+    # tables included — through the generic emit-once path, because the one
+    # verbatim range already carries the table bytes; re-emitting rows on
+    # top compounds one table copy into git per checkpoint.
+    family_tags: dict[str, set[str]] = {}
+    for child in root.children:
+        if isinstance(child, XmlElement):
+            base = _family_base(dict(child.attributes).get(BLOCK_ID_ATTR))
+            if base is not None:
+                family_tags.setdefault(base, set()).add(child.tag)
     emitted_untouched_bases: set[str] = set()
     for child in root.children:
         if not isinstance(child, XmlElement):
@@ -218,7 +226,13 @@ def checkpoint_body(base_body: str, doc: Doc, tracker: TouchedTracker) -> str:
         base_id = _family_base(block_id)
         orig = orig_by_id.get(base_id) if base_id else None
 
-        if base_id is not None and orig is not None and child.tag == "table" and base_id not in touched_bases:
+        if (
+            base_id is not None
+            and orig is not None
+            and child.tag == "table"
+            and base_id not in touched_bases
+            and family_tags.get(base_id) == {"table"}
+        ):
             gap = base_body[leading_gap_start[base_id] : orig.start]
             parts.append(gap + _splice_table(base_body, orig, child, touched_rows_by_base.get(base_id, set())))
             continue
@@ -284,12 +298,7 @@ def restamp_block_ids(doc: Doc, body: str) -> None:
     literal id: every consumer in this module resolves them through
     ``_family_base``, while the ids each individual child carries stay
     unique document-wide. That uniqueness is load-bearing for the round
-    trip through connected clients — the frontend's UniqueBlockIdentity
-    extension nulls the ``_blockId`` of any top-level node duplicating
-    another's, and once a family member's id is gone, ``checkpoint_body``
-    would re-serialize it as brand-new on top of the verbatim base range
-    that already contains its text: one extra copy committed per
-    checkpoint, compounding for as long as the session stays dirty.
+    trip through connected clients — see the note on ``_FAMILY_ID_RE``.
     """
     root = doc.get(ROOT_XML_KEY, type=XmlFragment)
     children = [c for c in root.children if isinstance(c, XmlElement)]

--- a/backend/tests/test_markdown_splice.py
+++ b/backend/tests/test_markdown_splice.py
@@ -368,15 +368,17 @@ def test_editing_inside_code_block_leaves_everything_before_it_untouched() -> No
 # --- restamp_block_ids / apply_markdown_diff --------------------------------- #
 
 
-def test_restamp_assigns_shared_id_when_reparse_merges_adjacent_lists() -> None:
-    """Regression test (review): two doc children that reparse into *one*
-    CommonMark block (adjacent same-kind containers with no blank line
-    between them — plain markdown text can't distinguish "two lists" from
-    "one list with more items") must both land on that one block's id, not
-    drift onto distinct positional ids (b0, b1) that no longer correspond
-    to anything in the next base_body's own reparse — the exact drift that
-    caused checkpoint_body to duplicate content (see the module docstring
-    on restamp_block_ids)."""
+def test_restamp_assigns_family_ids_when_reparse_merges_adjacent_lists() -> None:
+    """Two doc children that reparse into *one* CommonMark block (adjacent
+    same-kind containers with no blank line between them — plain markdown
+    text can't distinguish "two lists" from "one list with more items")
+    must land on that one block's id *family* (b0, b0.1): resolving to the
+    same base keeps checkpoint_body's range lookups correct, while the ids
+    each child carries stay unique document-wide — a literally-shared id
+    round-trips through a connected client's UniqueBlockIdentity extension
+    as a nulled ``_blockId``, which checkpoint_body then re-serializes as a
+    brand-new block on top of the verbatim range that already contains its
+    text (the compounding-duplication storm)."""
     from app.wiki.markdown_blocks import top_level_block_ranges
     from app.wiki.markdown_yjs import build_block_element
 
@@ -401,13 +403,13 @@ def test_restamp_assigns_shared_id_when_reparse_merges_adjacent_lists() -> None:
 
     restamp_block_ids(doc, cp1_body)
     ids = [dict(c.attributes).get(BLOCK_ID_ATTR) for c in root.children]
-    assert ids == ["b0", "b0"], ids
+    assert ids == ["b0", "b0.1"], ids
 
     # Editing only the second child must not duplicate the first — both
-    # children sharing "b0" means touching either marks the shared id
-    # touched, so checkpoint_body re-serializes both (harmless for the
-    # unedited one) instead of slicing child 0 verbatim from a stale range
-    # that (pre-fix) covered the *whole* former text.
+    # children resolving to base "b0" means touching either marks the whole
+    # family touched, so checkpoint_body re-serializes both (harmless for
+    # the unedited one) instead of slicing child 0 verbatim from a stale
+    # range that covered the *whole* former text.
     tracker = TouchedTracker(doc)
     old_item_text = root.children[1].children[0].children[0].children[0]
     with doc.transaction():
@@ -418,14 +420,12 @@ def test_restamp_assigns_shared_id_when_reparse_merges_adjacent_lists() -> None:
     assert cp2_body == "- new\n- EDITED\n", cp2_body
 
 
-def test_checkpoint_body_does_not_dedup_shared_id_tables() -> None:
-    """Regression test (review): the dedup guard added for the shared-id
-    duplication bug above must NOT apply to the table branch —
-    _splice_table already emits only its own child's rows (it was already
-    correct, per-child, for two identical adjacent tables sharing a
-    restamped id before that dedup guard existed), so applying the same
-    "emit once" guard there drops a second table sharing an id entirely
-    instead of just de-duplicating its content."""
+def test_checkpoint_body_does_not_dedup_family_id_tables() -> None:
+    """The emit-once guard for untouched family bases must NOT apply to the
+    table branch — _splice_table emits only its own child's rows, so two
+    family tables are already handled correctly per-child, and an "emit
+    once per base" guard there would drop the second table entirely
+    instead of de-duplicating anything."""
     from app.wiki.markdown_blocks import top_level_block_ranges
     from app.wiki.markdown_yjs import build_block_element
 
@@ -447,7 +447,7 @@ def test_checkpoint_body_does_not_dedup_shared_id_tables() -> None:
     assert len(top_level_block_ranges(cp0_body)) == 1
     restamp_block_ids(doc, cp0_body)
     ids = [dict(c.attributes).get(BLOCK_ID_ATTR) for c in root.children]
-    assert ids == ["b0", "b0"], ids
+    assert ids == ["b0", "b0.1"], ids
 
     cp1 = checkpoint_body(cp0_body, doc, TouchedTracker(doc))
     assert cp1 == cp0_body, cp1
@@ -457,6 +457,103 @@ def test_checkpoint_body_does_not_dedup_shared_id_tables() -> None:
     restamp_block_ids(doc, cp1)
     cp2 = checkpoint_body(cp1, doc, TouchedTracker(doc))
     assert cp2 == cp1, cp2
+
+
+def test_family_ids_survive_client_id_nulling_without_compounding() -> None:
+    """The duplication-storm regression test, from the live incident's git
+    forensics: an image paragraph moved to sit directly under a bullet whose
+    line ends in a markdown hard-break (trailing spaces), no blank line
+    between. The reparse folds the image line into the list block (lazy
+    continuation), so the two doc children form one id family. A connected
+    client's UniqueBlockIdentity nulls any *duplicated* ``_blockId`` it
+    sees; with family ids there is no duplicate to null, so repeated
+    checkpoints while the user types elsewhere must keep exactly one image
+    forever (pre-fix: the nulled child re-serialized as brand-new next to
+    the verbatim range that already contained it — plus one copy per
+    checkpoint, unbounded)."""
+    from app.wiki.markdown_blocks import top_level_block_ranges
+    from app.wiki.markdown_yjs import build_block_element, serialize_block
+
+    bullet = "- some bullet ending in a hard break   \n"
+    image = "![img.png](/api/wiki/media/abc123#w=236)\n"
+    para = "Unrelated paragraph below.\n"
+    seed = image + "\n" + bullet + "\n" + para
+    doc = seed_doc_from_markdown(seed)
+    root = _root(doc)
+
+    # The move: the image paragraph leaves its own safe spot and lands
+    # directly under the bullet, no blank-line block between them.
+    with doc.transaction():
+        img_idx = next(
+            i
+            for i, c in enumerate(root.children)
+            if isinstance(c, XmlElement) and "![img.png]" in serialize_block(c)
+        )
+        del root.children[img_idx]
+        list_idx = next(
+            i
+            for i, c in enumerate(root.children)
+            if isinstance(c, XmlElement) and c.tag == "bulletList"
+        )
+        el, finishers = build_block_element(image, top_level_block_ranges(image)[0])
+        root.children.insert(list_idx + 1, el)
+        for f in finishers:
+            f()
+
+    body = checkpoint_body(seed, doc, TouchedTracker(doc))
+    assert body.count("![img.png]") == 1, body
+    assert bullet + image in body, body
+    # Sanity: this is the incident's drift condition — the image line
+    # reparses as a continuation of the list, not its own block.
+    merged = next(
+        r for r in top_level_block_ranges(body) if body[r.start : r.end].startswith("- some")
+    )
+    assert image.strip() in body[merged.start : merged.end]
+
+    restamp_block_ids(doc, body)
+    ids = [dict(c.attributes).get(BLOCK_ID_ATTR) for c in root.children]
+    assert len([i for i in ids if i]) == len(set(i for i in ids if i)), (
+        f"restamp emitted a duplicated id — UniqueBlockIdentity would null it: {ids}"
+    )
+
+    # Two checkpoint rounds of typing in the unrelated paragraph.
+    for marker in ("X", "Y"):
+        tracker = TouchedTracker(doc)
+        target = next(
+            c for c in root.children if "Unrelated" in serialize_block(c)
+        )
+        with doc.transaction():
+            target.children[0].insert(0, marker)
+        new_body = checkpoint_body(body, doc, tracker)
+        assert new_body.count("![img.png]") == 1, new_body
+        restamp_block_ids(doc, new_body)
+        tracker.stop()
+        body = new_body
+
+
+def test_checkpoint_body_still_dedups_legacy_literally_shared_ids() -> None:
+    """Snapshots persisted before the family-id scheme can hold several
+    children carrying the literal same id. Those normalize to the same
+    family base, so the untouched path still emits their shared range
+    exactly once — neither duplicated nor dropped."""
+    from app.wiki.markdown_blocks import top_level_block_ranges
+    from app.wiki.markdown_yjs import build_block_element
+
+    doc = Doc()
+    root = _root(doc)
+    for text in ("- new\n", "- old\n"):
+        with doc.transaction():
+            el, finishers = build_block_element(text, top_level_block_ranges(text)[0])
+            root.children.append(el)
+            for f in finishers:
+                f()
+    body = "- new\n- old\n"
+    with doc.transaction():
+        for c in root.children:
+            c.attributes[BLOCK_ID_ATTR] = "b0"
+
+    cp = checkpoint_body(body, doc, TouchedTracker(doc))
+    assert cp == body, cp
 
 
 def test_apply_markdown_diff_preserves_lineage_of_untouched_blocks() -> None:

--- a/backend/tests/test_markdown_splice.py
+++ b/backend/tests/test_markdown_splice.py
@@ -15,11 +15,14 @@ from app.wiki.markdown_splice import (
     checkpoint_body,
     restamp_block_ids,
 )
+from app.wiki.markdown_blocks import top_level_block_ranges
 from app.wiki.markdown_yjs import (
     BLOCK_ID_ATTR,
     ROOT_XML_KEY,
+    build_block_element,
     reconstruct_body,
     seed_doc_from_markdown,
+    serialize_block,
 )
 
 _SAMPLE = """# Heading
@@ -376,9 +379,9 @@ def test_restamp_assigns_family_ids_when_reparse_merges_adjacent_lists() -> None
     same base keeps checkpoint_body's range lookups correct, while the ids
     each child carries stay unique document-wide — a literally-shared id
     round-trips through a connected client's UniqueBlockIdentity extension
-    as a nulled ``_blockId``, which checkpoint_body then re-serializes as a
-    brand-new block on top of the verbatim range that already contains its
-    text (the compounding-duplication storm)."""
+    as a nulled ``_blockId``, which checkpoint_body re-serializes as a
+    brand-new block on top of the verbatim range already containing its
+    text."""
     from app.wiki.markdown_blocks import top_level_block_ranges
     from app.wiki.markdown_yjs import build_block_element
 
@@ -460,20 +463,13 @@ def test_checkpoint_body_does_not_dedup_family_id_tables() -> None:
 
 
 def test_family_ids_survive_client_id_nulling_without_compounding() -> None:
-    """The duplication-storm regression test, from the live incident's git
-    forensics: an image paragraph moved to sit directly under a bullet whose
-    line ends in a markdown hard-break (trailing spaces), no blank line
-    between. The reparse folds the image line into the list block (lazy
-    continuation), so the two doc children form one id family. A connected
-    client's UniqueBlockIdentity nulls any *duplicated* ``_blockId`` it
-    sees; with family ids there is no duplicate to null, so repeated
-    checkpoints while the user types elsewhere must keep exactly one image
-    forever (pre-fix: the nulled child re-serialized as brand-new next to
-    the verbatim range that already contained it — plus one copy per
-    checkpoint, unbounded)."""
-    from app.wiki.markdown_blocks import top_level_block_ranges
-    from app.wiki.markdown_yjs import build_block_element, serialize_block
-
+    """An image paragraph moved directly under a bullet whose line ends in a
+    markdown hard-break (trailing spaces), no blank line between: the
+    reparse folds the image line into the list block (lazy continuation),
+    so the two doc children form one id family. A connected client's
+    UniqueBlockIdentity nulls any *duplicated* ``_blockId`` it sees; family
+    ids leave it nothing to null, so repeated checkpoints while the user
+    types elsewhere must keep exactly one image."""
     bullet = "- some bullet ending in a hard break   \n"
     image = "![img.png](/api/wiki/media/abc123#w=236)\n"
     para = "Unrelated paragraph below.\n"
@@ -531,14 +527,86 @@ def test_family_ids_survive_client_id_nulling_without_compounding() -> None:
         body = new_body
 
 
+def test_mixed_family_table_member_does_not_reemit_rows() -> None:
+    """A table as a *non-first* family member: text typed on the blank line
+    directly above a table makes the reparse fold the table lines into the
+    text's own block (a table can't interrupt a paragraph/quote), so the
+    first member's verbatim range already carries the table bytes. The
+    table branch must then skip — re-emitting its rows adds one whole table
+    per checkpoint. A family of adjacent *tables* keeps per-child row
+    emission (covered above); only a whole-range-already-emitted base
+    suppresses it."""
+    body = "> quote 3\n\n| a4 | b4 |\n| --- | --- |\n| 1 | 2 |\n"
+    doc = seed_doc_from_markdown(body)
+    root = _root(doc)
+    tracker = TouchedTracker(doc)
+
+    # Type on the blank line between the quote and the table.
+    blank = next(
+        c
+        for c in root.children
+        if isinstance(c, XmlElement)
+        and c.tag == "paragraph"
+        and not serialize_block(c).strip()
+    )
+    with doc.transaction():
+        if len(blank.children):
+            blank.children[0].insert(0, "q")  # type: ignore[union-attr]
+        else:
+            blank.children.append(XmlText("q"))
+
+    body1 = checkpoint_body(body, doc, tracker)
+    assert body1.count("| a4 | b4 |") == 1, body1
+    restamp_block_ids(doc, body1)
+    tracker.reset()
+
+    # Two untouched rounds must be byte-identical — the table member's
+    # rows are already inside the first member's verbatim range.
+    body2 = checkpoint_body(body1, doc, tracker)
+    assert body2 == body1, f"{len(body1)} -> {len(body2)}: {body2!r}"
+    restamp_block_ids(doc, body2)
+    tracker.reset()
+    body3 = checkpoint_body(body2, doc, tracker)
+    assert body3 == body2
+
+
+def test_mixed_family_with_leading_tables_stays_stable() -> None:
+    """The mirror order: table members *first*, the whole-range-emitting
+    member last (reparse folds a trailing text line into the table block's
+    range). The tables must route through the generic emit-once path — the
+    first member's verbatim range carries every member's bytes — rather
+    than each re-emitting rows the range already contains."""
+    table = "| a | b |\n| --- | --- |\n| 1 | 2 |\n"
+    doc = Doc()
+    root = _root(doc)
+    with doc.transaction():
+        for text in (table, table, "tail line\n"):
+            el, finishers = build_block_element(text, top_level_block_ranges(text)[0])
+            root.children.append(el)
+            for f in finishers:
+                f()
+
+    body = checkpoint_body("", doc, TouchedTracker(doc))
+    ranges = top_level_block_ranges(body)
+    # Only meaningful if the reparse actually folds everything into one
+    # block (the family condition this test exists for).
+    assert len(ranges) == 1, [body[r.start : r.end] for r in ranges]
+
+    restamp_block_ids(doc, body)
+    for _ in range(2):
+        tracker = TouchedTracker(doc)
+        body2 = checkpoint_body(body, doc, tracker)
+        assert body2 == body, f"{len(body)} -> {len(body2)}: {body2!r}"
+        restamp_block_ids(doc, body2)
+        tracker.stop()
+        body = body2
+
+
 def test_checkpoint_body_still_dedups_legacy_literally_shared_ids() -> None:
     """Snapshots persisted before the family-id scheme can hold several
     children carrying the literal same id. Those normalize to the same
     family base, so the untouched path still emits their shared range
     exactly once — neither duplicated nor dropped."""
-    from app.wiki.markdown_blocks import top_level_block_ranges
-    from app.wiki.markdown_yjs import build_block_element
-
     doc = Doc()
     root = _root(doc)
     for text in ("- new\n", "- old\n"):


### PR DESCRIPTION
## Problem — the compounding-duplication storm

Git forensics on the latest duplication incident (a page inflating ~35KB → 573KB in an hour, +1 copy of the same blocks per checkpoint, seconds apart, while the editor rendered clean) pinned the generator to a client/server invariant conflict:

1. A block move put an image paragraph directly under a bullet whose line ends in a markdown hard-break (trailing spaces), no blank line between. On reparse that image line is a lazy continuation of the list — `top_level_block_ranges` folds both doc children into **one** block range.
2. `restamp_block_ids` deliberately assigned both children the **same** positional id (the shared-id design), and `checkpoint_body`'s emit-once guard handled that server-side.
3. But the frontend's `UniqueBlockIdentity` extension enforces the opposite invariant: it **nulls** the `_blockId` of any top-level node duplicating another's. Once the shared id reached a connected client (divergence broadcast / reconnect), the client stripped it.
4. Every subsequent checkpoint then saw an id-less child → "brand-new block" → serialized it **in addition to** the verbatim base-body range that already contains its text. One extra copy committed per checkpoint, compounding for as long as the session stayed dirty — invisible in the editor, unbounded in git.

Reproduced exactly in a unit test (1 → 2 → 3 copies per checkpoint pre-fix).

## Fix

`restamp_block_ids` now stamps children that map onto one reparsed range with **family ids** — `b5`, `b5.1`, `b5.2`, … — so every id on the wire is unique and `UniqueBlockIdentity` never fires. All id-keyed lookups in `markdown_splice` resolve through the family base:

- `checkpoint_body`: range lookup, touch-membership, and the untouched emit-once guard all key on `_family_base` (touching any member re-serializes the whole family, same semantics as before).
- `_splice_table`: row lookups normalize `b5.1:r0` → `b5:r0`, preserving row-level verbatim slicing for family tables.
- Legacy snapshots holding literally-shared ids normalize to the same base and keep their previous (correct) behavior.

Family ids can't collide with parse-derived ids (`b<int>` only) or client-minted ids, and no consumer outside this module interprets the id format (audited backend + frontend). Server-only change — no frontend deploy ordering.

## Tests

- New: the storm scenario end-to-end (seed → move image under a hard-break bullet → checkpoint → restamp → type elsewhere → repeated checkpoints stay at exactly one image; asserts restamp emits no duplicated ids for a client to null).
- New: legacy literally-shared ids still dedup without dropping content.
- Updated: adjacent-lists and adjacent-tables sharing tests to the family scheme (same stability assertions).
- 194 tests across the codec/coedit suites pass; verified a live checkpoint on a local stack commits cleanly.