### PR TITLE
feat(editor): selection toolbar — block style, inline marks, link, Add Comment

### DIFF
--- a/frontend/src/components/wiki/SelectionToolbar.tsx
+++ b/frontend/src/components/wiki/SelectionToolbar.tsx
@@ -135,7 +135,7 @@ export function SelectionToolbar({
   };
 
   return (
-    <div className="flex w-56 flex-col p-1">
+    <div className="flex w-48 flex-col">
       <Popover open={styleOpen} onOpenChange={setStyleOpen}>
         <Popover.Trigger asChild>
           <span className="inline-flex w-full">

--- a/frontend/src/components/wiki/SelectionToolbar.tsx
+++ b/frontend/src/components/wiki/SelectionToolbar.tsx
@@ -26,11 +26,17 @@ const BLOCK_LABELS: Record<BlockStyle, string> = {
   h1: "Heading 1",
   h2: "Heading 2",
   h3: "Heading 3",
+  h4: "Heading 4",
+  h5: "Heading 5",
+  h6: "Heading 6",
   bulletList: "Bullet list",
   orderedList: "Numbered list",
   taskList: "To-do list",
+  codeBlock: "Code block",
 };
 
+/** Offered styles — deeper headings (h4-h6) still *display* via
+ * BLOCK_LABELS when the selection is in one, they're just not offered. */
 const BLOCK_ORDER: BlockStyle[] = [
   "paragraph",
   "h1",
@@ -39,6 +45,7 @@ const BLOCK_ORDER: BlockStyle[] = [
   "bulletList",
   "orderedList",
   "taskList",
+  "codeBlock",
 ];
 
 /** The glyphs are typography samples of their own effect (a bold B, an

--- a/frontend/src/components/wiki/SelectionToolbar.tsx
+++ b/frontend/src/components/wiki/SelectionToolbar.tsx
@@ -4,6 +4,7 @@ import { useState, type SVGProps } from "react";
 import {
   Button,
   Divider,
+  InputTypeIn,
   LineItemButton,
   Popover,
 } from "@onyx-ai/opal/components";
@@ -198,21 +199,22 @@ export function SelectionToolbar({
         />
       </div>
       {linkDraft !== null && (
-        <input
-          autoFocus
-          value={linkDraft}
-          placeholder="Paste or type a URL…"
-          onChange={(e) => setLinkDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              submitLink();
-            } else if (e.key === "Escape") {
-              setLinkDraft(null);
-            }
-          }}
-          className="mx-1 mb-1 rounded-(--radius-06) border border-(--border-01) bg-(--background-tint-00) px-2 py-1 text-sm text-(--text-04) outline-none focus:border-(--border-02)"
-        />
+        <div className="px-1 pb-1">
+          <InputTypeIn
+            autoFocus
+            value={linkDraft}
+            placeholder="https://…"
+            onChange={(e) => setLinkDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submitLink();
+              } else if (e.key === "Escape") {
+                setLinkDraft(null);
+              }
+            }}
+          />
+        </div>
       )}
       <Divider paddingParallel="sm" paddingPerpendicular="xs" />
       <LineItemButton

--- a/frontend/src/components/wiki/SelectionToolbar.tsx
+++ b/frontend/src/components/wiki/SelectionToolbar.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useState, type SVGProps } from "react";
+import {
+  Button,
+  Divider,
+  LineItemButton,
+  Popover,
+} from "@onyx-ai/opal/components";
+import {
+  SvgBubbleText,
+  SvgCheck,
+  SvgChevronRight,
+  SvgCode,
+  SvgLink,
+} from "@onyx-ai/opal/icons";
+import type {
+  BlockStyle,
+  SelectionFormatState,
+  ToggleMark,
+} from "@/lib/editor/types";
+
+const BLOCK_LABELS: Record<BlockStyle, string> = {
+  paragraph: "Normal text",
+  h1: "Heading 1",
+  h2: "Heading 2",
+  h3: "Heading 3",
+  bulletList: "Bullet list",
+  orderedList: "Numbered list",
+  taskList: "To-do list",
+};
+
+const BLOCK_ORDER: BlockStyle[] = [
+  "paragraph",
+  "h1",
+  "h2",
+  "h3",
+  "bulletList",
+  "orderedList",
+  "taskList",
+];
+
+/** The glyphs are typography samples of their own effect (a bold B, an
+ * italic I, a struck S), matching the design mock — Opal has no
+ * text-formatting icons, so these render as svg text through Button's
+ * regular `icon` slot and inherit its states via currentColor. */
+function GlyphBold(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      <text
+        x="8"
+        y="12.5"
+        textAnchor="middle"
+        fontSize="13"
+        fontWeight="700"
+        fill="currentColor"
+      >
+        B
+      </text>
+    </svg>
+  );
+}
+
+function GlyphItalic(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      <text
+        x="8"
+        y="12.5"
+        textAnchor="middle"
+        fontSize="13"
+        fontStyle="italic"
+        fill="currentColor"
+      >
+        I
+      </text>
+    </svg>
+  );
+}
+
+function GlyphStrike(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 16 16" fill="none" {...props}>
+      <text
+        x="8"
+        y="12.5"
+        textAnchor="middle"
+        fontSize="13"
+        textDecoration="line-through"
+        fill="currentColor"
+      >
+        S
+      </text>
+    </svg>
+  );
+}
+
+const MARK_GLYPHS: Array<{
+  mark: ToggleMark;
+  tooltip: string;
+  icon: (props: SVGProps<SVGSVGElement>) => React.JSX.Element;
+}> = [
+  { mark: "bold", tooltip: "Bold", icon: GlyphBold },
+  { mark: "italic", tooltip: "Italic", icon: GlyphItalic },
+  { mark: "strike", tooltip: "Strikethrough", icon: GlyphStrike },
+];
+
+interface SelectionToolbarProps {
+  state: SelectionFormatState;
+  onToggleMark: (mark: ToggleMark) => void;
+  onSetBlock: (style: BlockStyle) => void;
+  onSetLink: (href: string) => void;
+  onComment: () => void;
+}
+
+/** Floating formatting menu for a non-collapsed editor selection: block
+ * style switcher, inline marks, link, and Add Comment. The host owns
+ * positioning (anchored above the selection, same spot the plain Comment
+ * pill used) and re-renders it with a fresh `state` snapshot after every
+ * action. */
+export function SelectionToolbar({
+  state,
+  onToggleMark,
+  onSetBlock,
+  onSetLink,
+  onComment,
+}: SelectionToolbarProps) {
+  const [styleOpen, setStyleOpen] = useState(false);
+  const [linkDraft, setLinkDraft] = useState<string | null>(null);
+
+  const submitLink = () => {
+    if (linkDraft !== null && linkDraft.trim()) onSetLink(linkDraft.trim());
+    setLinkDraft(null);
+  };
+
+  return (
+    <div className="flex w-56 flex-col p-1">
+      <Popover open={styleOpen} onOpenChange={setStyleOpen}>
+        <Popover.Trigger asChild>
+          <span className="inline-flex w-full">
+            <LineItemButton
+              title={BLOCK_LABELS[state.block]}
+              rightChildren={
+                <SvgChevronRight className="h-4 w-4 self-center text-(--text-03)" />
+              }
+              sizePreset="main-ui"
+              variant="section"
+              onClick={() => setStyleOpen((v) => !v)}
+            />
+          </span>
+        </Popover.Trigger>
+        <Popover.Content width="fit" side="right" align="start" sideOffset={4}>
+          <Popover.Menu>
+            {BLOCK_ORDER.map((style) => (
+              <LineItemButton
+                key={style}
+                title={BLOCK_LABELS[style]}
+                icon={state.block === style ? SvgCheck : undefined}
+                sizePreset="main-ui"
+                variant="section"
+                onClick={() => {
+                  setStyleOpen(false);
+                  onSetBlock(style);
+                }}
+              />
+            ))}
+          </Popover.Menu>
+        </Popover.Content>
+      </Popover>
+      <div className="flex items-center gap-0.5 px-1 py-0.5">
+        {MARK_GLYPHS.map(({ mark, tooltip, icon }) => (
+          <Button
+            key={mark}
+            icon={icon}
+            prominence={state.marks[mark] ? "secondary" : "tertiary"}
+            size="md"
+            tooltip={tooltip}
+            onClick={() => onToggleMark(mark)}
+          />
+        ))}
+        <Button
+          icon={SvgCode}
+          prominence={state.marks.code ? "secondary" : "tertiary"}
+          size="md"
+          tooltip="Code"
+          onClick={() => onToggleMark("code")}
+        />
+        <Divider orientation="vertical" paddingParallel="xs" />
+        <Button
+          icon={SvgLink}
+          prominence={state.link !== null ? "secondary" : "tertiary"}
+          size="md"
+          tooltip={state.link !== null ? "Remove link" : "Link"}
+          onClick={() => {
+            if (state.link !== null) onSetLink("");
+            else setLinkDraft((v) => (v === null ? "" : null));
+          }}
+        />
+      </div>
+      {linkDraft !== null && (
+        <input
+          autoFocus
+          value={linkDraft}
+          placeholder="Paste or type a URL…"
+          onChange={(e) => setLinkDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submitLink();
+            } else if (e.key === "Escape") {
+              setLinkDraft(null);
+            }
+          }}
+          className="mx-1 mb-1 rounded-(--radius-06) border border-(--border-01) bg-(--background-tint-00) px-2 py-1 text-sm text-(--text-04) outline-none focus:border-(--border-02)"
+        />
+      )}
+      <Divider paddingParallel="sm" paddingPerpendicular="xs" />
+      <LineItemButton
+        title="Add Comment"
+        icon={SvgBubbleText}
+        sizePreset="main-ui"
+        variant="section"
+        onClick={onComment}
+      />
+    </div>
+  );
+}

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -32,9 +32,11 @@ import {
 import { opaqueId } from "@/lib/editor/ids";
 import type {
   AnchoredHighlightTarget,
+  BlockStyle,
   CoeditorHandle,
   CommentDraft,
   CommentHighlightTarget,
+  SelectionFormatState,
 } from "@/lib/editor/types";
 
 /** Highlight ids whose spans contain a collapsed caret or intersect a
@@ -404,6 +406,74 @@ export function TipTapEditor({
         return () => {
           layoutSubs.current.delete(cb);
         };
+      },
+      formatState: (): SelectionFormatState | null => {
+        if (!editor) return null;
+        const block: BlockStyle = editor.isActive("heading", { level: 1 })
+          ? "h1"
+          : editor.isActive("heading", { level: 2 })
+            ? "h2"
+            : editor.isActive("heading", { level: 3 })
+              ? "h3"
+              : editor.isActive("taskList")
+                ? "taskList"
+                : editor.isActive("bulletList")
+                  ? "bulletList"
+                  : editor.isActive("orderedList")
+                    ? "orderedList"
+                    : "paragraph";
+        return {
+          marks: {
+            bold: editor.isActive("bold"),
+            italic: editor.isActive("italic"),
+            strike: editor.isActive("strike"),
+            code: editor.isActive("code"),
+          },
+          block,
+          link: editor.isActive("link")
+            ? ((editor.getAttributes("link").href as string | undefined) ?? "")
+            : null,
+        };
+      },
+      toggleMark: (mark) => {
+        if (!editor) return;
+        const chain = editor.chain().focus();
+        if (mark === "bold") chain.toggleBold().run();
+        else if (mark === "italic") chain.toggleItalic().run();
+        else if (mark === "strike") chain.toggleStrike().run();
+        else chain.toggleCode().run();
+      },
+      setBlockStyle: (style) => {
+        if (!editor) return;
+        const chain = editor.chain().focus();
+        if (style === "paragraph") {
+          // Clear whichever structure the selection is in: lifting out of a
+          // list needs the list toggled off, a heading needs setParagraph.
+          if (editor.isActive("taskList")) chain.toggleTaskList().run();
+          else if (editor.isActive("bulletList"))
+            chain.toggleBulletList().run();
+          else if (editor.isActive("orderedList"))
+            chain.toggleOrderedList().run();
+          else chain.setParagraph().run();
+        } else if (style === "h1") chain.toggleHeading({ level: 1 }).run();
+        else if (style === "h2") chain.toggleHeading({ level: 2 }).run();
+        else if (style === "h3") chain.toggleHeading({ level: 3 }).run();
+        else if (style === "bulletList") chain.toggleBulletList().run();
+        else if (style === "orderedList") chain.toggleOrderedList().run();
+        else chain.toggleTaskList().run();
+      },
+      setLink: (href) => {
+        if (!editor) return;
+        if (href) {
+          editor
+            .chain()
+            .focus()
+            .extendMarkRange("link")
+            .setLink({ href })
+            .run();
+        } else {
+          editor.chain().focus().extendMarkRange("link").unsetLink().run();
+        }
       },
     }),
     // No deps: the handle re-attaches every render, so a live session never

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -17,6 +17,7 @@ import {
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
 import { tiptapExtensions } from "@/lib/editor/extensions";
+import { normalizeUrl } from "@/lib/editor/extensions/components";
 import {
   commentHighlights as commentHighlightPlugin,
   sourceHighlights as sourceHighlightPlugin,
@@ -38,6 +39,26 @@ import type {
   CommentHighlightTarget,
   SelectionFormatState,
 } from "@/lib/editor/types";
+
+/** The selection's current top-level block style — shared by
+ * `formatState` (drives the toolbar's checked state) and `setBlockStyle`
+ * (whose commands are toggles: re-applying the checked style must be a
+ * no-op, not a toggle-off). */
+function currentBlockStyle(editor: Editor): BlockStyle {
+  return editor.isActive("heading", { level: 1 })
+    ? "h1"
+    : editor.isActive("heading", { level: 2 })
+      ? "h2"
+      : editor.isActive("heading", { level: 3 })
+        ? "h3"
+        : editor.isActive("taskList")
+          ? "taskList"
+          : editor.isActive("bulletList")
+            ? "bulletList"
+            : editor.isActive("orderedList")
+              ? "orderedList"
+              : "paragraph";
+}
 
 /** Highlight ids whose spans contain a collapsed caret or intersect a
  * selection, half-open at span ends so a caret just past a span misses —
@@ -409,19 +430,6 @@ export function TipTapEditor({
       },
       formatState: (): SelectionFormatState | null => {
         if (!editor) return null;
-        const block: BlockStyle = editor.isActive("heading", { level: 1 })
-          ? "h1"
-          : editor.isActive("heading", { level: 2 })
-            ? "h2"
-            : editor.isActive("heading", { level: 3 })
-              ? "h3"
-              : editor.isActive("taskList")
-                ? "taskList"
-                : editor.isActive("bulletList")
-                  ? "bulletList"
-                  : editor.isActive("orderedList")
-                    ? "orderedList"
-                    : "paragraph";
         return {
           marks: {
             bold: editor.isActive("bold"),
@@ -429,7 +437,7 @@ export function TipTapEditor({
             strike: editor.isActive("strike"),
             code: editor.isActive("code"),
           },
-          block,
+          block: currentBlockStyle(editor),
           link: editor.isActive("link")
             ? ((editor.getAttributes("link").href as string | undefined) ?? "")
             : null,
@@ -445,6 +453,9 @@ export function TipTapEditor({
       },
       setBlockStyle: (style) => {
         if (!editor) return;
+        // Tiptap's block commands are toggles — re-applying the style the
+        // selection already has would remove it instead of keeping it.
+        if (currentBlockStyle(editor) === style) return;
         const chain = editor.chain().focus();
         if (style === "paragraph") {
           // Clear whichever structure the selection is in: lifting out of a
@@ -469,7 +480,7 @@ export function TipTapEditor({
             .chain()
             .focus()
             .extendMarkRange("link")
-            .setLink({ href })
+            .setLink({ href: normalizeUrl(href) })
             .run();
         } else {
           editor.chain().focus().extendMarkRange("link").unsetLink().run();

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -284,11 +284,15 @@ export function TipTapEditor({
               endOffset: pmPosToTextOffset(editor, to),
               quotedText,
             };
-            // Anchor at the selection's *start* (doc order), so the menu
-            // opens where the selection begins instead of trailing its far
-            // end on long selections.
-            const coords = editor.view.coordsAtPos(from);
-            cb(draft, { x: coords.left, y: coords.top });
+            // Anchor at the selection *head* — where the cursor actually
+            // is after selecting (mouse-release point), regardless of
+            // selection direction — so the menu opens beside the cursor.
+            const head = Math.max(
+              from,
+              Math.min(to, editor.state.selection.head),
+            );
+            const coords = editor.view.coordsAtPos(head);
+            cb(draft, { x: coords.right, y: coords.top });
           }
         }
       }

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -45,19 +45,22 @@ import type {
  * (whose commands are toggles: re-applying the checked style must be a
  * no-op, not a toggle-off). */
 function currentBlockStyle(editor: Editor): BlockStyle {
-  return editor.isActive("heading", { level: 1 })
-    ? "h1"
-    : editor.isActive("heading", { level: 2 })
-      ? "h2"
-      : editor.isActive("heading", { level: 3 })
-        ? "h3"
-        : editor.isActive("taskList")
-          ? "taskList"
-          : editor.isActive("bulletList")
-            ? "bulletList"
-            : editor.isActive("orderedList")
-              ? "orderedList"
-              : "paragraph";
+  if (editor.isActive("codeBlock")) return "codeBlock";
+  if (editor.isActive("heading")) {
+    // Attr-less check + explicit coercion: a codec-seeded doc carries the
+    // level as the *string* Yjs XML attribute ("3"), so an attr-matched
+    // isActive("heading", { level: 3 }) never fires on loaded content.
+    const level = Number(editor.getAttributes("heading").level);
+    if (level >= 1 && level <= 6) return `h${level}` as BlockStyle;
+    return "paragraph";
+  }
+  return editor.isActive("taskList")
+    ? "taskList"
+    : editor.isActive("bulletList")
+      ? "bulletList"
+      : editor.isActive("orderedList")
+        ? "orderedList"
+        : "paragraph";
 }
 
 /** Highlight ids whose spans contain a collapsed caret or intersect a
@@ -473,12 +476,14 @@ export function TipTapEditor({
           else if (editor.isActive("orderedList"))
             chain.toggleOrderedList().run();
           else chain.setParagraph().run();
-        } else if (style === "h1") chain.toggleHeading({ level: 1 }).run();
-        else if (style === "h2") chain.toggleHeading({ level: 2 }).run();
-        else if (style === "h3") chain.toggleHeading({ level: 3 }).run();
+        } else if (style === "codeBlock") chain.toggleCodeBlock().run();
         else if (style === "bulletList") chain.toggleBulletList().run();
         else if (style === "orderedList") chain.toggleOrderedList().run();
-        else chain.toggleTaskList().run();
+        else if (style === "taskList") chain.toggleTaskList().run();
+        else {
+          const level = Number(style.slice(1)) as 1 | 2 | 3 | 4 | 5 | 6;
+          chain.toggleHeading({ level }).run();
+        }
       },
       setLink: (href) => {
         if (!editor) return;

--- a/frontend/src/lib/editor/components.tsx
+++ b/frontend/src/lib/editor/components.tsx
@@ -284,7 +284,10 @@ export function TipTapEditor({
               endOffset: pmPosToTextOffset(editor, to),
               quotedText,
             };
-            const coords = editor.view.coordsAtPos(to);
+            // Anchor at the selection's *start* (doc order), so the menu
+            // opens where the selection begins instead of trailing its far
+            // end on long selections.
+            const coords = editor.view.coordsAtPos(from);
             cb(draft, { x: coords.left, y: coords.top });
           }
         }

--- a/frontend/src/lib/editor/extensions/blocks.ts
+++ b/frontend/src/lib/editor/extensions/blocks.ts
@@ -406,7 +406,25 @@ const InlineCode = Mark.create({
             ? !!getMarkRange($from, type)
             : state.doc.rangeHasMark(from, to, type);
           if (active) {
-            const range = getMarkRange($from, type) ?? { from, to };
+            // The unwrap must cover the marked run's *own* bounds, not the
+            // selection's: a selection that merely overlaps the run would
+            // otherwise strip the mark from a slice and leave the literal
+            // backticks behind — which the next checkpoint's reparse turns
+            // straight back into a code span. When the selection starts
+            // outside the run, resolve inside its first marked character.
+            // (Several runs in one selection unwrap first-run-only — same
+            // fuzziness as Tiptap's own mark toggles.)
+            let range = getMarkRange($from, type);
+            if (!range) {
+              let marked: number | null = null;
+              state.doc.nodesBetween(from, to, (node, pos) => {
+                if (marked === null && node.isText && type.isInSet(node.marks))
+                  marked = pos;
+              });
+              if (marked !== null)
+                range = getMarkRange(state.doc.resolve(marked + 1), type);
+            }
+            if (!range) return false;
             if (!dispatch) return true;
             const { from: a, to: b } = range;
             tr.removeMark(a, b, type);

--- a/frontend/src/lib/editor/extensions/blocks.ts
+++ b/frontend/src/lib/editor/extensions/blocks.ts
@@ -42,7 +42,9 @@ import {
   InputRule,
   Mark,
   Node,
+  getMarkRange,
   mergeAttributes,
+  type CommandProps,
 } from "@tiptap/core";
 import { Fragment } from "@tiptap/pm/model";
 import { Plugin, TextSelection, type Transaction } from "@tiptap/pm/state";
@@ -389,14 +391,40 @@ const InlineCode = Mark.create({
         () =>
         ({ commands }: { commands: { setMark: (name: string) => boolean } }) =>
           commands.setMark(this.name),
+      // Backtick-aware, because this mark's own invariant (see the
+      // appendTransaction net below) is that the marked run's first and
+      // last characters ARE literal backticks: a plain toggleMark applies
+      // a tickless mark that the net strips on the very next transaction —
+      // the command must create the same shape the input rule creates, and
+      // remove the ticks along with the mark on the way off.
       toggleCode:
         () =>
-        ({
-          commands,
-        }: {
-          commands: { toggleMark: (name: string) => boolean };
-        }) =>
-          commands.toggleMark(this.name),
+        ({ state, tr, dispatch }: CommandProps) => {
+          const type = this.type;
+          const { $from, $to, from, to, empty } = state.selection;
+          const active = empty
+            ? !!getMarkRange($from, type)
+            : state.doc.rangeHasMark(from, to, type);
+          if (active) {
+            const range = getMarkRange($from, type) ?? { from, to };
+            if (!dispatch) return true;
+            const { from: a, to: b } = range;
+            tr.removeMark(a, b, type);
+            if (state.doc.textBetween(b - 1, b) === "`") tr.delete(b - 1, b);
+            if (state.doc.textBetween(a, a + 1) === "`") tr.delete(a, a + 1);
+            return true;
+          }
+          // Wrapping needs a real single-block selection with no interior
+          // backticks (the serializer's fence would misparse them).
+          if (empty || !$from.sameParent($to)) return false;
+          if (state.doc.textBetween(from, to).includes("`")) return false;
+          if (!dispatch) return true;
+          tr.insertText("`", to);
+          tr.insertText("`", from);
+          tr.addMark(from, to + 2, type.create());
+          tr.removeStoredMark(type);
+          return true;
+        },
       unsetCode:
         () =>
         ({

--- a/frontend/src/lib/editor/extensions/components.tsx
+++ b/frontend/src/lib/editor/extensions/components.tsx
@@ -104,7 +104,7 @@ export function CommandMenu({ ref, items, command }: CommandMenuProps) {
  * explicit one (`https:`, `mailto:`, …) untouched. Deliberately permissive —
  * no strict validation gate — because a mistyped link is fixed by unlinking,
  * not by blocking submit; the only hard stop is an empty URL. */
-function normalizeUrl(raw: string): string {
+export function normalizeUrl(raw: string): string {
   const url = raw.trim();
   if (!url) return "";
   return /^[a-z][\w+.-]*:/i.test(url) ? url : `https://${url}`;

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -39,15 +39,21 @@ export interface CommentDraft {
  * would render live and then silently vanish on the next checkpoint. */
 export type ToggleMark = "bold" | "italic" | "strike" | "code";
 
-/** Top-level block styles the selection toolbar can switch between. */
+/** Top-level block styles the selection toolbar can switch between.
+ * h4-h6 exist so deeper headings report truthfully in the current-style
+ * label; the dropdown only offers h1-h3. */
 export type BlockStyle =
   | "paragraph"
   | "h1"
   | "h2"
   | "h3"
+  | "h4"
+  | "h5"
+  | "h6"
   | "bulletList"
   | "orderedList"
-  | "taskList";
+  | "taskList"
+  | "codeBlock";
 
 /** Snapshot of the current selection's formatting, driving the toolbar's
  * active states. `link` is the active link mark's href ("" when a link is

--- a/frontend/src/lib/editor/types.ts
+++ b/frontend/src/lib/editor/types.ts
@@ -34,6 +34,30 @@ export interface CommentDraft {
   quotedText: string;
 }
 
+/** Inline marks the selection toolbar can toggle. Underline is deliberately
+ * absent: the markdown<->Yjs codec has no representation for it, so the mark
+ * would render live and then silently vanish on the next checkpoint. */
+export type ToggleMark = "bold" | "italic" | "strike" | "code";
+
+/** Top-level block styles the selection toolbar can switch between. */
+export type BlockStyle =
+  | "paragraph"
+  | "h1"
+  | "h2"
+  | "h3"
+  | "bulletList"
+  | "orderedList"
+  | "taskList";
+
+/** Snapshot of the current selection's formatting, driving the toolbar's
+ * active states. `link` is the active link mark's href ("" when a link is
+ * active without one), null when no link is active. */
+export interface SelectionFormatState {
+  marks: Record<ToggleMark, boolean>;
+  block: BlockStyle;
+  link: string | null;
+}
+
 /** Imperative handle for scrolling the editor to a raw-doc position — used
  * to bring an anchored comment into view (click-to-focus, `?comment=<id>`
  * deep links) and to back the margin-rail/custom-scrollbar UI. Shape
@@ -79,4 +103,14 @@ export interface CoeditorHandle {
    * synchronously inside the scroll event so overlays can repaint in the
    * same frame as the editor. Returns the unsubscriber. */
   subscribeLayout: (cb: (kind: "scroll" | "geometry") => void) => () => void;
+  /** The current selection's formatting, for the selection toolbar. Null
+   * before the editor mounts. */
+  formatState: () => SelectionFormatState | null;
+  /** Toggle an inline mark on the current selection. */
+  toggleMark: (mark: ToggleMark) => void;
+  /** Switch the current selection's top-level block style. */
+  setBlockStyle: (style: BlockStyle) => void;
+  /** Set (href non-empty) or clear (href "") the link mark on the current
+   * selection. */
+  setLink: (href: string) => void;
 }

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -41,6 +41,7 @@ import {
 import { RunAgentPanel } from "@/components/wiki/RunAgentPanel";
 import { ShareDialog } from "@/components/wiki/ShareDialog";
 import { CommentsPanel } from "@/components/wiki/CommentsPanel";
+import { SelectionToolbar } from "@/components/wiki/SelectionToolbar";
 import { EdgeScrollbar } from "@/components/wiki/EdgeScrollbar";
 import { sourceKey } from "@/components/wiki/sources";
 import { SourcesPanel } from "@/components/wiki/SourcesPanel";
@@ -69,7 +70,7 @@ import { pageTitle } from "@/lib/wiki/utils";
 import { useAuth } from "@/lib/auth";
 import { CoeditPresenceBar, TipTapEditor } from "@/lib/editor/components";
 import { useCoeditSession } from "@/lib/editor/hooks";
-import type { CoeditorHandle } from "@/lib/editor/types";
+import type { CoeditorHandle, SelectionFormatState } from "@/lib/editor/types";
 import {
   useHeaderActionsHost,
   useHeaderCrumbHost,
@@ -210,6 +211,11 @@ export function FileView({ path }: FileViewProps) {
     y: number;
     draft: CommentDraft;
   } | null>(null);
+  // Formatting snapshot for the selection toolbar, refreshed whenever the
+  // selection changes and after every toolbar action (an action changes
+  // marks without moving the selection, so the selection callback alone
+  // would leave the buttons stale).
+  const [selFmt, setSelFmt] = useState<SelectionFormatState | null>(null);
   const coeditorRef = useRef<CoeditorHandle | null>(null);
   // `viewingVersion`: a history version is displayed in the main pane (no
   // live editor — DiffView instead). `viewingOld`: that version is not the
@@ -560,9 +566,16 @@ export function FileView({ path }: FileViewProps) {
   const handleSelectionForComment = useCallback(
     (draft: CommentDraft | null, coords: { x: number; y: number } | null) => {
       setSelTool(draft && coords ? { x: coords.x, y: coords.y, draft } : null);
+      setSelFmt(
+        draft && coords ? (coeditorRef.current?.formatState() ?? null) : null,
+      );
     },
     [],
   );
+
+  const refreshSelFmt = useCallback(() => {
+    setSelFmt(coeditorRef.current?.formatState() ?? null);
+  }, []);
 
   // Agent activity rows feeding the presence avatar cluster.
   const [agents, setAgents] = useState<DocumentActivity[]>([]);
@@ -1516,28 +1529,59 @@ export function FileView({ path }: FileViewProps) {
       )}
       {selTool && (
         <div
-          onMouseDown={(e) => e.preventDefault()}
+          onMouseDown={(e) => {
+            // Keep the editor selection alive while interacting with the
+            // toolbar — except in its URL input, which needs real focus.
+            if (!(e.target instanceof HTMLInputElement)) e.preventDefault();
+          }}
           className="fixed z-[80] -translate-x-1/2 -translate-y-full rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-(--shadow-popover)"
           style={{
             left: selTool.x,
             top: selTool.y - 8,
           }}
         >
-          <Button
-            prominence="tertiary"
-            size="sm"
-            onClick={() => {
-              setCommentDraft(selTool.draft);
-              // Match the lane's 920px container query at click time:
-              // anywhere the lane can't show, the draft routes to the panel.
-              const rowWide = (docRowRef.current?.clientWidth ?? 0) >= 920;
-              if (panelTab !== null || isMobile || !rowWide) openComments();
-              setSelTool(null);
-              window.getSelection()?.removeAllRanges();
-            }}
-          >
-            💬 Comment
-          </Button>
+          {!viewingVersion && coedit.active && coedit.canWrite && selFmt ? (
+            <SelectionToolbar
+              state={selFmt}
+              onToggleMark={(mark) => {
+                coeditorRef.current?.toggleMark(mark);
+                refreshSelFmt();
+              }}
+              onSetBlock={(style) => {
+                coeditorRef.current?.setBlockStyle(style);
+                refreshSelFmt();
+              }}
+              onSetLink={(href) => {
+                coeditorRef.current?.setLink(href);
+                refreshSelFmt();
+              }}
+              onComment={() => {
+                setCommentDraft(selTool.draft);
+                // Match the lane's 920px container query at click time:
+                // anywhere the lane can't show, the draft routes to the panel.
+                const rowWide = (docRowRef.current?.clientWidth ?? 0) >= 920;
+                if (panelTab !== null || isMobile || !rowWide) openComments();
+                setSelTool(null);
+                window.getSelection()?.removeAllRanges();
+              }}
+            />
+          ) : (
+            <Button
+              prominence="tertiary"
+              size="sm"
+              onClick={() => {
+                setCommentDraft(selTool.draft);
+                // Match the lane's 920px container query at click time:
+                // anywhere the lane can't show, the draft routes to the panel.
+                const rowWide = (docRowRef.current?.clientWidth ?? 0) >= 920;
+                if (panelTab !== null || isMobile || !rowWide) openComments();
+                setSelTool(null);
+                window.getSelection()?.removeAllRanges();
+              }}
+            >
+              💬 Comment
+            </Button>
+          )}
         </div>
       )}
     </main>

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1535,29 +1535,17 @@ export function FileView({ path }: FileViewProps) {
             if (!(e.target instanceof HTMLInputElement)) e.preventDefault();
           }}
           className="fixed z-[80] rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-(--shadow-popover)"
-          style={(() => {
-            // Per the design mock: the panel docks just right of the
-            // content column, top-aligned with the selection's first line —
-            // not floating over the text. Falls back to the selection
-            // coordinates if the editor isn't mounted. Clamped inside the
-            // viewport on both axes (the panel is ~200px wide and up to
-            // ~240px tall with the link input open).
-            const pm = document
-              .querySelector(".editor-prose .ProseMirror")
-              ?.getBoundingClientRect();
-            const left = Math.max(
+          style={{
+            // Opens to the right of the cursor (the selection head),
+            // top-aligned with its line, clamped inside the viewport on
+            // both axes (the panel is ~200px wide and up to ~240px tall
+            // with the link input open).
+            left: Math.max(
               8,
-              Math.min(
-                (pm ? pm.right : selTool.x) + 16,
-                window.innerWidth - 208,
-              ),
-            );
-            const top = Math.max(
-              8,
-              Math.min(selTool.y, window.innerHeight - 248),
-            );
-            return { left, top };
-          })()}
+              Math.min(selTool.x + 12, window.innerWidth - 208),
+            ),
+            top: Math.max(8, Math.min(selTool.y, window.innerHeight - 248)),
+          }}
         >
           {!viewingVersion && coedit.active && coedit.canWrite && selFmt ? (
             <SelectionToolbar

--- a/frontend/src/views/wiki/FileView.tsx
+++ b/frontend/src/views/wiki/FileView.tsx
@@ -1534,11 +1534,30 @@ export function FileView({ path }: FileViewProps) {
             // toolbar — except in its URL input, which needs real focus.
             if (!(e.target instanceof HTMLInputElement)) e.preventDefault();
           }}
-          className="fixed z-[80] -translate-x-1/2 -translate-y-full rounded-(--radius-08) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-(--shadow-popover)"
-          style={{
-            left: selTool.x,
-            top: selTool.y - 8,
-          }}
+          className="fixed z-[80] rounded-(--radius-12) border border-(--border-01) bg-(--background-tint-01) p-1 shadow-(--shadow-popover)"
+          style={(() => {
+            // Per the design mock: the panel docks just right of the
+            // content column, top-aligned with the selection's first line —
+            // not floating over the text. Falls back to the selection
+            // coordinates if the editor isn't mounted. Clamped inside the
+            // viewport on both axes (the panel is ~200px wide and up to
+            // ~240px tall with the link input open).
+            const pm = document
+              .querySelector(".editor-prose .ProseMirror")
+              ?.getBoundingClientRect();
+            const left = Math.max(
+              8,
+              Math.min(
+                (pm ? pm.right : selTool.x) + 16,
+                window.innerWidth - 208,
+              ),
+            );
+            const top = Math.max(
+              8,
+              Math.min(selTool.y, window.innerHeight - 248),
+            );
+            return { left, top };
+          })()}
         >
           {!viewingVersion && coedit.active && coedit.canWrite && selFmt ? (
             <SelectionToolbar


### PR DESCRIPTION
## What

Selecting text in the live editor now opens a formatting menu (per the design mock) where the plain "💬 Comment" pill used to be:

- **Block style switcher** — Normal text / Heading 1–3 / Bullet list / Numbered list / To-do list, with the selection's current style shown and checked.
- **Inline marks** — Bold, Italic, Strikethrough (svg letter glyphs; Opal has no typography icons), Code, and Link (inline URL input; removing reuses the same button). All five round-trip through the markdown codec.
- **Add Comment** — the existing behavior, moved into the menu.

Scope per discussion: Copy Link / Edit with AI / Watch Changes / Launch Agent from the mock are deliberately left out for now.

Read-only surfaces (history versions, no write permission) keep the plain Comment pill — formatting commands need a writable session.

## Underline is disabled (including Cmd+U)

Markdown has no underline, and the codec confirms it: an underline mark serializes to plain text, so Cmd+U rendered formatting that silently vanished on the next checkpoint. StarterKit's underline extension is now off entirely until the codec grows a representation — no button, no shortcut, no silent loss.

## How

- `CoeditorHandle` gains `formatState` / `toggleMark` / `setBlockStyle` / `setLink`, keeping Tiptap types inside `lib/editor` — the host consumes a typed snapshot and re-reads it after each action (actions change marks without moving the selection, so the selection callback alone would leave button states stale).
- `SelectionToolbar` is a pure component; `FileView` owns positioning (same anchor the pill used) and the comment flow.
<img width="385" height="225" alt="Screenshot 2026-08-17 at 4 00 41 PM" src="https://github.com/user-attachments/assets/880ceac0-dba2-45ca-91d8-6852c4e39218" />

Verified on the local stack: block detection (selection in a bullet list shows "Bullet list"), bold on/off round-trips through a checkpoint with clean markdown, link input, Cmd+U no-ops, comment flow unchanged.
