### PR TITLE
feat(editor): Tab indents a plain line into the list above

### DIFF
--- a/frontend/src/lib/editor/extensions/index.ts
+++ b/frontend/src/lib/editor/extensions/index.ts
@@ -28,6 +28,7 @@ import { CommandMenu } from "@/lib/editor/extensions/commandMenu";
 import { AnchoredHighlights } from "@/lib/editor/extensions/highlights";
 import { imageSupport } from "@/lib/editor/extensions/images";
 import { LinkHover } from "@/lib/editor/extensions/linkHover";
+import { TabIndent } from "@/lib/editor/extensions/tabIndent";
 import { LinkInput } from "@/lib/editor/extensions/linkInput";
 import { presenceExtension } from "@/lib/editor/extensions/presence";
 
@@ -86,6 +87,7 @@ export function tiptapExtensions(
     JoinAdjacentLists,
     UniqueBlockIdentity,
     HeadingBackspace,
+    TabIndent,
     ThematicBreak,
     InlineCode,
     MarkdownLink,

--- a/frontend/src/lib/editor/extensions/tabIndent.test.ts
+++ b/frontend/src/lib/editor/extensions/tabIndent.test.ts
@@ -1,0 +1,150 @@
+/** `TabIndent` behaviors through a real headless Tiptap editor: a plain
+ * line below a list (blank-line blocks between are skipped) indents into
+ * it on Tab, everything else swallows Tab so the editor keeps focus. */
+import { Editor } from "@tiptap/core";
+import { StarterKit } from "@tiptap/starter-kit";
+import { TaskItem } from "@tiptap/extension-task-item";
+import { describe, expect, it } from "vitest";
+import {
+  BlockIdentity,
+  JoinAdjacentLists,
+  MixedTaskList,
+  UniqueBlockIdentity,
+} from "@/lib/editor/extensions/blocks";
+import { TabIndent } from "@/lib/editor/extensions/tabIndent";
+
+function makeEditor(): Editor {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({ undoRedo: false, trailingNode: false }),
+      MixedTaskList,
+      TaskItem.configure({ nested: true }),
+      BlockIdentity,
+      JoinAdjacentLists,
+      UniqueBlockIdentity,
+      TabIndent,
+    ],
+  });
+}
+
+type Json = Record<string, unknown>;
+
+function taskItem(text: string): Json {
+  return {
+    type: "taskItem",
+    attrs: { checked: false },
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+function listItem(text: string): Json {
+  return {
+    type: "listItem",
+    content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+  };
+}
+
+function para(text?: string): Json {
+  return text
+    ? { type: "paragraph", content: [{ type: "text", text }] }
+    : { type: "paragraph" };
+}
+
+function topLevelTypes(editor: Editor): string[] {
+  const out: string[] = [];
+  editor.state.doc.forEach((node) => out.push(node.type.name));
+  return out;
+}
+
+function pressTab(editor: Editor): boolean {
+  return editor.commands.keyboardShortcut("Tab");
+}
+
+function selectEndOfLastParagraph(editor: Editor) {
+  // Place the caret inside the trailing paragraph's text.
+  editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+}
+
+describe("TabIndent", () => {
+  it("indents a plain line directly below a bullet list into it", () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "bulletList", content: [listItem("a"), listItem("b")] },
+        para("target"),
+      ],
+    });
+    selectEndOfLastParagraph(editor);
+    expect(pressTab(editor)).toBe(true);
+    // Joined into the single preceding list.
+    expect(topLevelTypes(editor)).toEqual(["bulletList"]);
+    expect(editor.state.doc.child(0).childCount).toBe(3);
+  });
+
+  it("skips blank-line blocks when looking back for the list", () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "bulletList", content: [listItem("a")] },
+        para(),
+        para("target"),
+      ],
+    });
+    selectEndOfLastParagraph(editor);
+    expect(pressTab(editor)).toBe(true);
+    // The blank stays; the target became a (separate) bullet list that a
+    // markdown reparse reads as part of the same loose list.
+    expect(topLevelTypes(editor)).toEqual([
+      "bulletList",
+      "paragraph",
+      "bulletList",
+    ]);
+  });
+
+  it("indents a plain line below a task list into it", () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "taskList", content: [taskItem("a")] },
+        para(),
+        para("target"),
+      ],
+    });
+    selectEndOfLastParagraph(editor);
+    expect(pressTab(editor)).toBe(true);
+    expect(topLevelTypes(editor)).toEqual([
+      "taskList",
+      "paragraph",
+      "taskList",
+    ]);
+  });
+
+  it("swallows Tab on a plain line with no list above", () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [para("alpha"), para("target")],
+    });
+    selectEndOfLastParagraph(editor);
+    expect(pressTab(editor)).toBe(true); // handled (swallowed), not focus-out
+    expect(topLevelTypes(editor)).toEqual(["paragraph", "paragraph"]);
+  });
+
+  it("leaves Tab to the list handling inside a list", () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "bulletList", content: [listItem("a"), listItem("b")] },
+      ],
+    });
+    selectEndOfLastParagraph(editor);
+    pressTab(editor);
+    // The second item nested under the first — native sink behavior.
+    const first = editor.state.doc.child(0).child(0);
+    expect(first.lastChild?.type.name).toBe("bulletList");
+  });
+});

--- a/frontend/src/lib/editor/extensions/tabIndent.test.ts
+++ b/frontend/src/lib/editor/extensions/tabIndent.test.ts
@@ -133,6 +133,29 @@ describe("TabIndent", () => {
     expect(topLevelTypes(editor)).toEqual(["paragraph", "paragraph"]);
   });
 
+  it("swallows Tab when the selection spans multiple blocks", () => {
+    const editor = makeEditor();
+    editor.commands.setContent({
+      type: "doc",
+      content: [
+        { type: "bulletList", content: [listItem("a")] },
+        para("first"),
+        para("second"),
+      ],
+    });
+    // Select from inside "first" through "second".
+    editor.commands.setTextSelection({
+      from: editor.state.doc.content.size - 10,
+      to: editor.state.doc.content.size - 1,
+    });
+    expect(pressTab(editor)).toBe(true);
+    expect(topLevelTypes(editor)).toEqual([
+      "bulletList",
+      "paragraph",
+      "paragraph",
+    ]);
+  });
+
   it("leaves Tab to the list handling inside a list", () => {
     const editor = makeEditor();
     editor.commands.setContent({

--- a/frontend/src/lib/editor/extensions/tabIndent.ts
+++ b/frontend/src/lib/editor/extensions/tabIndent.ts
@@ -40,8 +40,15 @@ export const TabIndent = Extension.create({
         ) {
           return false; // the list/code handling owns Tab here
         }
-        const { $from } = editor.state.selection;
-        if ($from.depth === 1 && editor.isActive("paragraph")) {
+        const { $from, $to } = editor.state.selection;
+        // Single-line gesture only: a selection spanning several blocks
+        // would hand the list-toggle every selected block, converting them
+        // all — swallow instead.
+        if (
+          $from.depth === 1 &&
+          $from.sameParent($to) &&
+          editor.isActive("paragraph")
+        ) {
           // Walk back over blank-line blocks (every blank line is its own
           // empty paragraph in this editor) to the nearest real block — a
           // blank between a list and the line being indented still reads

--- a/frontend/src/lib/editor/extensions/tabIndent.ts
+++ b/frontend/src/lib/editor/extensions/tabIndent.ts
@@ -1,0 +1,82 @@
+import { Extension } from "@tiptap/core";
+
+/** List node types a plain line can indent into. */
+const LIST_TYPES = new Set(["bulletList", "orderedList", "taskList"]);
+
+const LIST_TOGGLE = {
+  bulletList: "toggleBulletList",
+  orderedList: "toggleOrderedList",
+  taskList: "toggleTaskList",
+} as const;
+
+/** Tab behavior for plain lines.
+ *
+ * Inside lists and code blocks, Tab already means something (sink the item /
+ * literal input) and this extension stays out of the way. On a top-level
+ * plain line, browsers' default Tab moves focus out of the editor entirely —
+ * never useful mid-writing. Instead:
+ *
+ * - A line sitting directly below a list indents *into* it: the line becomes
+ *   an item of the same list kind, and JoinAdjacentLists merges the two
+ *   lists into one (the merged node keeps the first list's identity, so no
+ *   duplicated block id is ever created — see its docstring). Further Tabs
+ *   nest it deeper through the list's own Tab handling. This is the only
+ *   indent markdown can express for a plain line — block-nesting outside a
+ *   list has no markdown form.
+ * - Anywhere else, Tab (and Shift-Tab) is swallowed so focus stays in the
+ *   editor.
+ */
+export const TabIndent = Extension.create({
+  name: "tabIndent",
+  addKeyboardShortcuts() {
+    return {
+      Tab: () => {
+        const { editor } = this;
+        if (
+          editor.isActive("bulletList") ||
+          editor.isActive("orderedList") ||
+          editor.isActive("taskList") ||
+          editor.isActive("codeBlock")
+        ) {
+          return false; // the list/code handling owns Tab here
+        }
+        const { $from } = editor.state.selection;
+        if ($from.depth === 1 && editor.isActive("paragraph")) {
+          // Walk back over blank-line blocks (every blank line is its own
+          // empty paragraph in this editor) to the nearest real block — a
+          // blank between a list and the line being indented still reads
+          // as one loose list in markdown, so it shouldn't break the join.
+          let index = $from.index(0) - 1;
+          while (index >= 0) {
+            const prev = editor.state.doc.child(index);
+            if (prev.type.name === "paragraph" && !prev.textContent.trim()) {
+              index -= 1;
+              continue;
+            }
+            const kind = prev.type.name;
+            if (LIST_TYPES.has(kind)) {
+              return editor
+                .chain()
+                [LIST_TOGGLE[kind as keyof typeof LIST_TOGGLE]]()
+                .run();
+            }
+            break;
+          }
+        }
+        return true; // swallow: never let Tab yank focus out of the editor
+      },
+      "Shift-Tab": () => {
+        const { editor } = this;
+        if (
+          editor.isActive("bulletList") ||
+          editor.isActive("orderedList") ||
+          editor.isActive("taskList") ||
+          editor.isActive("codeBlock")
+        ) {
+          return false;
+        }
+        return true;
+      },
+    };
+  },
+});


### PR DESCRIPTION
## What

Tab on a plain line used to fall through to the browser and throw focus out of the editor (the "can only tab to indent when it's a bullet / numbered list / checkbox" report). Now:

- **A plain line below a list indents into it**: the line becomes an item of the same list kind (bullet / numbered / to-do). Blank-line blocks between are skipped — a blank between bullets still reads as one loose list in markdown. The existing `JoinAdjacentLists` merges the result into the preceding list when directly adjacent, so no shared block ids are ever created. Further Tabs nest through the list's own handling; Shift-Tab lifts as before.
- **Tab anywhere else outside lists/code blocks is swallowed** so focus stays in the editor.
- Inside lists and code blocks, nothing changes — the native handling keeps owning Tab.

This is the only indent markdown can express for a plain line (block nesting outside a list has no markdown form), so it's pure list commands — no codec changes.

## Tests

Vitest through a real headless Tiptap editor with the production list extensions (`MixedTaskList`, `JoinAdjacentLists`, `UniqueBlockIdentity`): direct join, blank-skip join, task-list join, swallow with no list above, and native sink retained inside lists. Also verified live on the local stack: plain line + Tab → joins the list; Tab → nests; Shift-Tab → lifts; committed markdown stays clean.

## Note from live testing (pre-existing, not addressed here)

Keystrokes typed in the first moments after a page loads — before the coedit session finishes its write-ready handshake — are silently dropped (the editor is briefly read-only with no visual indication). Made this PR's verification interesting; filed here for visibility.