### PR TITLE
fix(coedit): lineage-generation guard — a reseed can no longer union old and new documents

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -248,6 +248,7 @@ def _ingest_yjs_frame(
     session_id: int,
     user: User,
     raw: bytes,
+    lineage: int,
 ) -> int | None:
     """Authorize, validate, durably log and refresh presence for one inbound
     frame — returning the ``ydoc_seq`` assigned, or ``None`` if nothing was
@@ -272,7 +273,21 @@ def _ingest_yjs_frame(
     update = _apply_yjs_frame(conn, session_id, user, raw)
     if update is None:
         return None
-    seq = coedit.apply_update(session_id, update_bytes=update, author_user_id=user.id)
+    try:
+        seq = coedit.apply_update(
+            session_id,
+            update_bytes=update,
+            author_user_id=user.id,
+            expected_lineage=lineage,
+        )
+    except coedit.StaleLineageError:
+        # This connection's document is a replaced lineage (the checkpoint
+        # engine reseeded the session after we joined). Logging its update
+        # would union the old document into the new one, so it's refused;
+        # tell this client to rebuild — a fresh join gets the current
+        # lineage and snapshot.
+        conn.post({"type": "resync_required", "reason": "stale_lineage"})
+        return None
     if seq is None:
         return None  # session closed underneath us
     coedit.touch(session_id, user.id, edited=True)
@@ -284,6 +299,7 @@ async def _recv_loop(
     conn: coedit_channel.Connection,
     session_id: int,
     user: User,
+    lineage: int,
 ) -> None:
     while True:
         # Low-level receive() (not receive_bytes()/receive_json()) so one
@@ -301,7 +317,7 @@ async def _recv_loop(
             # fetch what it missed. Relaying first would leave the gap
             # undetectable.
             seq = await asyncio.to_thread(
-                _ingest_yjs_frame, conn, session_id, user, data
+                _ingest_yjs_frame, conn, session_id, user, data, lineage
             )
             if seq is not None:
                 coedit_channel.broadcast_yjs(session_id, data, seq)
@@ -563,6 +579,7 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
                 session_id=sess.id,
                 base_sha=sess.base_sha,
                 can_write=can_write,
+                lineage=sess.ydoc_lineage,
                 participants=participants,
             ).model_dump()
         )
@@ -574,7 +591,9 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
             await asyncio.to_thread(coedit_live.initial_sync_message, sess.id)
         )
 
-        recv_task = asyncio.create_task(_recv_loop(websocket, conn, sess.id, user))
+        recv_task = asyncio.create_task(
+            _recv_loop(websocket, conn, sess.id, user, sess.ydoc_lineage)
+        )
         send_task = asyncio.create_task(_send_loop(websocket, conn, ready, sess.id, user))
         done, pending = await asyncio.wait(
             {recv_task, send_task}, return_when=asyncio.FIRST_COMPLETED

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -286,6 +286,24 @@ def _ingest_yjs_frame(
         # would union the old document into the new one, so it's refused;
         # tell this client to rebuild — a fresh join gets the current
         # lineage and snapshot.
+        #
+        # Deliberately NOT closed server-side. A client that honors
+        # ``resync_required`` closes and rebuilds itself; a client that
+        # predates the frame is *safer* left on this connection, where its
+        # updates keep being refused — force-closing it would make its
+        # reconnect loop rejoin at the current generation, and the sync
+        # handshake would then push its replaced-lineage content through a
+        # connection this guard has no reason to distrust. Refusal here is
+        # the corruption barrier; the frame is only the recovery signal.
+        # Each refusal costs the sender a keystroke's worth of edits, which
+        # the WARNING below makes visible to operators.
+        log.warning(
+            "coedit: session %s refused a stale-lineage update from user %s "
+            "(connection joined at lineage %d); resync_required sent",
+            session_id,
+            user.id,
+            lineage,
+        )
         conn.post({"type": "resync_required", "reason": "stale_lineage"})
         return None
     if seq is None:

--- a/backend/app/db/migrations/versions/a9c2e5f8b3d1_coedit_lineage.py
+++ b/backend/app/db/migrations/versions/a9c2e5f8b3d1_coedit_lineage.py
@@ -1,0 +1,62 @@
+"""coedit lineage generation columns
+
+Adds ``coedit_sessions.ydoc_lineage`` and ``coedit_updates.lineage``: the
+session's CRDT lineage generation, bumped when the checkpoint engine reseeds
+the document, and the generation each logged update was produced against.
+Rebuilds replay only current-generation rows, and the WS layer rejects
+updates from clients still on a replaced generation — an old-generation Yjs
+update merged into a reseeded document unions both documents' content
+(whole-page duplication) instead of conflicting.
+
+Column adds are guarded on the live inspector because ``0001_initial`` runs
+``Base.metadata.create_all`` against the current model registry — databases
+bootstrapped after these columns joined ``models.py`` already have them.
+
+Revision ID: a9c2e5f8b3d1
+Revises: d7e4b9a2c1f6
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a9c2e5f8b3d1"
+down_revision: str | None = "d7e4b9a2c1f6"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def _columns(inspector: sa.Inspector, table: str) -> set[str]:
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    if "ydoc_lineage" not in _columns(inspector, "coedit_sessions"):
+        op.add_column(
+            "coedit_sessions",
+            sa.Column(
+                "ydoc_lineage", sa.BigInteger(), nullable=False, server_default=sa.text("0")
+            ),
+        )
+    if "lineage" not in _columns(inspector, "coedit_updates"):
+        op.add_column(
+            "coedit_updates",
+            sa.Column(
+                "lineage", sa.BigInteger(), nullable=False, server_default=sa.text("0")
+            ),
+        )
+    if "ydoc_lineage" not in _columns(inspector, "wiki_documents"):
+        op.add_column(
+            "wiki_documents",
+            sa.Column(
+                "ydoc_lineage", sa.BigInteger(), nullable=False, server_default=sa.text("0")
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("wiki_documents", "ydoc_lineage")
+    op.drop_column("coedit_updates", "lineage")
+    op.drop_column("coedit_sessions", "ydoc_lineage")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1004,6 +1004,16 @@ class CoeditSession(Base):
     # row at open (never-read pages in tests/seed scripts), carry NULL until
     # the next open stamps them.
     doc_id: Mapped[str | None] = mapped_column(Text)
+    # The session's CRDT lineage generation. Bumped whenever the server
+    # replaces the document with a freshly seeded one (the checkpoint
+    # engine's reseed-on-divergence fallback) instead of splicing onto the
+    # existing lineage. Updates are only accepted from clients on the
+    # current generation: a Yjs update generated against a replaced lineage
+    # can never converge with the new one — merging the two unions both
+    # documents' content (whole-page duplication) rather than conflicting.
+    ydoc_lineage: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'active'"))
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
@@ -1102,6 +1112,13 @@ class CoeditUpdate(Base):
     # deliberately NOT unique — surviving rows from two sessions of one page
     # can share a seq.
     doc_id: Mapped[str | None] = mapped_column(Text)
+    # The session's ``ydoc_lineage`` when this update was logged. A rebuild
+    # replays only rows whose lineage matches the session's current one: a
+    # row stamped with a replaced lineage is unintegrable — applying it
+    # unions the old document's content into the new one.
+    lineage: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
     update_payload: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
@@ -1183,6 +1200,15 @@ class WikiDocument(Base):
     # Git HEAD the document was last seeded from / checkpointed against —
     # the merge base for the checkpoint 3-way merge.
     base_sha: Mapped[str | None] = mapped_column(Text)
+    # The document's CRDT lineage generation — the durable, page-scoped home
+    # of the counter ``coedit_sessions.ydoc_lineage`` serves per session.
+    # Mirrored from checkpoints (which bump it on a reseed) and inherited by
+    # every session that transplants this row, so the generation survives
+    # session turnover: a client holding a replaced lineage is refused even
+    # when the session it rejoins is a brand-new row.
+    ydoc_lineage: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
     # When the document last checkpointed to git — the overdue-detection
     # input once the checkpoint scan reads document state (cutover). NULL for
     # a document that has never checkpointed.

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -79,6 +79,11 @@ class JoinedFrame(BaseModel):
     session_id: int
     base_sha: str | None
     can_write: bool
+    # The session's CRDT lineage generation at join. A client that later
+    # receives ``resync_required`` (the server reseeded the document) must
+    # discard its local doc and rejoin — the fresh join carries the new
+    # generation.
+    lineage: int
     participants: list[ParticipantOut]
 
 

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -47,6 +47,14 @@ from app.wiki import doc_ids, wiki_documents
 log = logging.getLogger(__name__)
 
 
+class StaleLineageError(Exception):
+    """The update was produced against a lineage generation the session has
+    replaced (a checkpoint reseed bumped ``ydoc_lineage``). It must not be
+    logged: replaying it onto the current lineage would union the replaced
+    document's content into the page rather than converge. The sender needs a
+    resync — a fresh document built from the current snapshot."""
+
+
 # --------------------------------------------------------------------------- #
 # Time helpers (match agent_activity: ISO-8601 UTC text, second precision)    #
 # --------------------------------------------------------------------------- #
@@ -86,6 +94,7 @@ class SessionRow(BaseModel):
     ydoc_checkpointed_seq: int
     base_sha: str | None
     doc_id: str | None
+    ydoc_lineage: int
     status: str
     created_at: str
     updated_at: str
@@ -121,6 +130,7 @@ def _session_row(s: CoeditSession) -> SessionRow:
         ydoc_checkpointed_seq=s.ydoc_checkpointed_seq,
         base_sha=s.base_sha,
         doc_id=s.doc_id,
+        ydoc_lineage=s.ydoc_lineage,
         status=s.status,
         created_at=s.created_at,
         updated_at=s.updated_at,
@@ -235,6 +245,7 @@ class CheckpointSessionRow(BaseModel):
     status: str
     base_sha: str | None
     doc_id: str | None
+    ydoc_lineage: int
     ydoc_seq: int
     ydoc_checkpointed_seq: int
     ydoc_snapshot: bytes | None
@@ -257,6 +268,7 @@ def get_session_for_checkpoint(session_id: int) -> CheckpointSessionRow | None:
             status=row.status,
             base_sha=row.base_sha,
             doc_id=row.doc_id,
+            ydoc_lineage=row.ydoc_lineage,
             ydoc_seq=row.ydoc_seq,
             ydoc_checkpointed_seq=row.ydoc_checkpointed_seq,
             ydoc_snapshot=row.ydoc_snapshot,
@@ -419,6 +431,10 @@ def transplant_from_document(session_id: int, path: str) -> tuple[bool, str | No
                 ydoc_snapshot_seq=0,
                 ydoc_snapshot_body=doc_row.ydoc_snapshot_body,
                 base_sha=doc_row.base_sha,
+                # The generation travels with the lineage: a session serving a
+                # reseeded document must refuse the pre-reseed generation even
+                # though the session row itself is brand new.
+                ydoc_lineage=doc_row.ydoc_lineage,
             )
             .returning(CoeditSession.id)
         ).one_or_none()
@@ -433,6 +449,7 @@ class UpdateRow(BaseModel):
     seq: int
     author_user_id: str | None  # None for a server-produced update
     client_id: str | None
+    lineage: int  # the session's ydoc_lineage when this row was logged
     update_payload: bytes
     created_at: str
 
@@ -472,6 +489,7 @@ def apply_update(
     update_bytes: bytes,
     author_user_id: str | None,
     client_id: str | None = None,
+    expected_lineage: int | None = None,
 ) -> int | None:
     """Durably log a Yjs update, returning its assigned seq (or ``None`` if the
     session isn't active).
@@ -490,17 +508,46 @@ def apply_update(
 
     This just appends the row and advances the watermark, atomically via one
     ``RETURNING`` update.
+
+    ``expected_lineage`` is the lineage generation the update was produced
+    against (the value the caller learned when it built or joined the
+    document). When given and the session has since moved to a different
+    generation (a checkpoint reseed), the update is refused with
+    ``StaleLineageError`` instead of being logged: the lineage guard lives in
+    the same conditional UPDATE that assigns the seq, so a reseed committing
+    concurrently can't slip a stale row in between a check and the append.
+    ``None`` skips the guard — for callers that hold no document at all.
     """
     now = _iso(_now())
     with session() as s:
-        bumped = s.execute(
+        stmt = (
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.status == SessionStatus.ACTIVE.value)
             .values(ydoc_seq=CoeditSession.ydoc_seq + 1, updated_at=now)
-            .returning(CoeditSession.ydoc_seq, CoeditSession.doc_id)
+            .returning(
+                CoeditSession.ydoc_seq, CoeditSession.doc_id, CoeditSession.ydoc_lineage
+            )
             .execution_options(synchronize_session=False)
-        ).one_or_none()
+        )
+        if expected_lineage is not None:
+            stmt = stmt.where(CoeditSession.ydoc_lineage == expected_lineage)
+        bumped = s.execute(stmt).one_or_none()
         if bumped is None:
+            if expected_lineage is not None:
+                current = s.execute(
+                    select(CoeditSession.status, CoeditSession.ydoc_lineage).where(
+                        CoeditSession.id == session_id
+                    )
+                ).one_or_none()
+                if (
+                    current is not None
+                    and current.status == SessionStatus.ACTIVE.value
+                    and current.ydoc_lineage != expected_lineage
+                ):
+                    raise StaleLineageError(
+                        f"session {session_id}: update for lineage {expected_lineage}, "
+                        f"session is on {current.ydoc_lineage}"
+                    )
             return None
         s.add(
             CoeditUpdate(
@@ -512,6 +559,10 @@ def apply_update(
                 # own binding rather than re-resolved through the path (which
                 # can be transiently wrong mid-move).
                 doc_id=bumped.doc_id,
+                # Stamped from the row the guard just matched, so a replayer
+                # can tell current-generation rows from replaced-generation
+                # leftovers.
+                lineage=bumped.ydoc_lineage,
                 update_payload=update_bytes,
             )
         )
@@ -543,6 +594,7 @@ def updates_since(session_id: int, after_seq: int) -> UpdatesSince:
                     seq=u.seq,
                     author_user_id=u.author_user_id,
                     client_id=u.client_id,
+                    lineage=u.lineage,
                     update_payload=u.update_payload,
                     created_at=u.created_at,
                 )
@@ -578,7 +630,13 @@ def set_base_sha(session_id: int, base_sha: str) -> bool:
 
 
 def advance_checkpoint(
-    session_id: int, *, seq: int, snapshot: bytes, body: str, base_sha: str
+    session_id: int,
+    *,
+    seq: int,
+    snapshot: bytes,
+    body: str,
+    base_sha: str,
+    bump_lineage: bool = False,
 ) -> None:
     """Record a checkpoint's result — a real commit, or a no-op where the
     doc's content already matched HEAD — moving the snapshot, the
@@ -609,6 +667,13 @@ def advance_checkpoint(
     re-advances at the *same* seq — new snapshot, new ``base_sha``, no new
     local update — and a strictly-less guard would silently discard that
     fold.
+
+    ``bump_lineage`` marks a checkpoint that *reseeded* the document — the
+    snapshot being written is a fresh CRDT lineage, not a splice of the old
+    one. Bumping ``ydoc_lineage`` in the same UPDATE makes the swap and the
+    generation change atomic: from this statement on, updates produced
+    against the replaced lineage are refused (``apply_update``'s guard) and
+    skipped by rebuilds, instead of unioning the old document into the new.
     """
     now = _iso(_now())
     with session() as s:
@@ -617,22 +682,27 @@ def advance_checkpoint(
         # conditional-UPDATE call sites (e.g. close_if_clean), and sidesteps
         # a basedpyright strict-mode gap: SQLAlchemy's plain Result.rowcount
         # isn't typed on the generic Result[Any] this execute() returns.
-        updated_path = s.scalars(
+        values: dict[str, object] = dict(
+            ydoc_snapshot=snapshot,
+            ydoc_snapshot_seq=seq,
+            ydoc_snapshot_body=body,
+            ydoc_checkpointed_seq=seq,
+            base_sha=base_sha,
+            last_checkpoint_at=now,
+            updated_at=now,
+        )
+        if bump_lineage:
+            values["ydoc_lineage"] = CoeditSession.ydoc_lineage + 1
+        updated = s.execute(
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.ydoc_checkpointed_seq <= seq)
-            .values(
-                ydoc_snapshot=snapshot,
-                ydoc_snapshot_seq=seq,
-                ydoc_snapshot_body=body,
-                ydoc_checkpointed_seq=seq,
-                base_sha=base_sha,
-                last_checkpoint_at=now,
-                updated_at=now,
-            )
-            .returning(CoeditSession.path)
+            .values(**values)
+            # RETURNING yields the post-update row, so ydoc_lineage here is
+            # the possibly-bumped generation the mirror must record.
+            .returning(CoeditSession.path, CoeditSession.ydoc_lineage)
             .execution_options(synchronize_session=False)
         ).one_or_none()
-        if updated_path is not None:
+        if updated is not None:
             s.execute(
                 delete(CoeditUpdate).where(
                     CoeditUpdate.session_id == session_id, CoeditUpdate.seq <= seq
@@ -642,7 +712,13 @@ def advance_checkpoint(
             # ``wiki_documents`` row, in this same transaction so the two
             # stores can't disagree about which snapshot exists.
             wiki_documents.mirror_checkpoint(
-                s, updated_path, seq=seq, snapshot=snapshot, body=body, base_sha=base_sha
+                s,
+                updated.path,
+                seq=seq,
+                snapshot=snapshot,
+                body=body,
+                base_sha=base_sha,
+                lineage=updated.ydoc_lineage,
             )
 
 
@@ -818,6 +894,7 @@ def on_path_moved(moves: list[PathMove]) -> list[int]:
                             snapshot=newest.ydoc_snapshot,
                             body=newest.ydoc_snapshot_body,
                             base_sha=newest.base_sha,
+                            lineage=newest.ydoc_lineage,
                         )
             except IntegrityError:
                 # A racing open_session won the unique index between our check

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -354,6 +354,22 @@ def _rebuild_doc(sess: coedit.CheckpointSessionRow) -> tuple[Doc, str, TouchedTr
     tracker = TouchedTracker(doc)
     since = coedit.updates_since(sess.id, sess.ydoc_snapshot_seq)
     for u in since.updates:
+        if u.lineage != sess.ydoc_lineage:
+            # A leftover from a replaced lineage (logged in the window between
+            # a reseed's snapshot read and its lineage bump). Integrating it
+            # would union the old document's content into the new one — the
+            # whole-page-duplication failure the lineage guard exists to kill.
+            # Its content (at most one client's in-flight burst) is lost;
+            # losing it is strictly better than doubling the page.
+            log.warning(
+                "coedit checkpoint: session %s seq %d is from replaced lineage "
+                "%d (current %d); skipping",
+                sess.id,
+                u.seq,
+                u.lineage,
+                sess.ydoc_lineage,
+            )
+            continue
         try:
             doc.apply_update(u.update_payload)
         except Exception:
@@ -603,6 +619,17 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
             change_kind = ChangeKind.EDIT
             tracker.reset()
             for u in late.updates:
+                if u.lineage != sess.ydoc_lineage:
+                    # Same replaced-lineage guard as _rebuild_doc's replay.
+                    log.warning(
+                        "coedit checkpoint: session %s seq %d is from replaced "
+                        "lineage %d (current %d); skipping late fold",
+                        sess.id,
+                        u.seq,
+                        u.lineage,
+                        sess.ydoc_lineage,
+                    )
+                    continue
                 try:
                     doc.apply_update(u.update_payload)
                 except Exception:
@@ -696,17 +723,28 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
             snapshot=snapshot,
             body=new_body,
             base_sha=new_sha,
+            # A reseed writes a fresh CRDT lineage: bump the generation in the
+            # same UPDATE, so updates produced against the replaced lineage
+            # are refused from this statement on instead of unioning the old
+            # document into the new (whole-page duplication).
+            bump_lineage=reseeded,
         )
         if result is not None:
             wiki_drafts.clear_if_diverged(path, new_body)
         if diverged:
             if reseeded:
-                # A fresh lineage shares no history with what clients hold, so
-                # there is no delta to send: they converge on their next
-                # reconnect handshake, against the snapshot just written.
+                # A fresh lineage shares no history with what clients hold —
+                # there is no delta to send, and any update they produce
+                # against the replaced lineage is refused from here on
+                # (``apply_update``'s lineage guard). Tell every connection to
+                # rebuild from the new snapshot now, rather than waiting for a
+                # chance reconnect while their editors show pre-merge content.
+                coedit_channel.publish_control(
+                    session_id, {"type": "resync_required", "reason": "reseeded"}
+                )
                 log.warning(
-                    "coedit checkpoint: session %s reseeded on divergence; connected "
-                    "clients stay on pre-merge content until they reconnect",
+                    "coedit checkpoint: session %s reseeded on divergence; "
+                    "resync_required sent to connected clients",
                     session_id,
                 )
             else:

--- a/backend/app/wiki/coedit_rebase.py
+++ b/backend/app/wiki/coedit_rebase.py
@@ -94,7 +94,19 @@ def rebase_session(session_id: int, head_sha: str) -> RebaseOutcome:
         return RebaseOutcome.NOOP
 
     # author_user_id=None: the server produced this update, not a person.
-    seq = coedit.apply_update(session_id, update_bytes=update_bytes, author_user_id=None)
+    # expected_lineage: the delta was built from the document as of ``sess``;
+    # if a checkpoint reseeded the session in the meantime, folding it in
+    # would poison the new lineage — refuse and let the trigger re-run
+    # against the settled state.
+    try:
+        seq = coedit.apply_update(
+            session_id,
+            update_bytes=update_bytes,
+            author_user_id=None,
+            expected_lineage=sess.ydoc_lineage,
+        )
+    except coedit.StaleLineageError:
+        return RebaseOutcome.SKIP
     if seq is None:
         return RebaseOutcome.SKIP  # session closed underneath us
     coedit_channel.broadcast_yjs(session_id, create_update_message(update_bytes), seq)

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -84,24 +84,37 @@ def mirror_seed(
     seq 0. Overwrites an existing row — a fresh seed means the session layer
     just minted a new lineage for this page, and while sessions own document
     state the mirror's job is to record whichever lineage is live, not to
-    defend the old one.
+    defend the old one. A markdown seed is by definition generation 0: it
+    only happens when no document row existed to transplant.
     """
-    _upsert(s, path, snapshot=snapshot, seq=0, body=body, base_sha=base_sha)
+    _upsert(s, path, snapshot=snapshot, seq=0, body=body, base_sha=base_sha, lineage=0)
 
 
 def mirror_checkpoint(
-    s: Session, path: str, *, seq: int, snapshot: bytes, body: str, base_sha: str
+    s: Session, path: str, *, seq: int, snapshot: bytes, body: str, base_sha: str, lineage: int
 ) -> None:
     """Mirror a checkpoint's advanced snapshot state onto the page's document
     row. Upsert, not update: the row can be missing for a session that
     predates the table (opened before the migration ran), and the checkpoint
     state is complete in itself — snapshot, body, and base all move together.
+    ``lineage`` is the session's generation after the checkpoint (bumped by a
+    reseed); mirroring it here is what lets a later session inherit it on
+    transplant, so the generation survives session turnover.
     """
-    _upsert(s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha)
+    _upsert(
+        s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha, lineage=lineage
+    )
 
 
 def _upsert(
-    s: Session, path: str, *, snapshot: bytes, seq: int, body: str, base_sha: str | None
+    s: Session,
+    path: str,
+    *,
+    snapshot: bytes,
+    seq: int,
+    body: str,
+    base_sha: str | None,
+    lineage: int,
 ) -> None:
     doc_id = doc_ids.id_for_path_in(s, path)
     if doc_id is None:
@@ -118,6 +131,7 @@ def _upsert(
         ydoc_snapshot_body=body,
         ydoc_seq=seq,
         base_sha=base_sha,
+        ydoc_lineage=lineage,
         created_at=now,
         updated_at=now,
     )
@@ -130,6 +144,7 @@ def _upsert(
                 "ydoc_snapshot_body": stmt.excluded.ydoc_snapshot_body,
                 "ydoc_seq": stmt.excluded.ydoc_seq,
                 "base_sha": stmt.excluded.base_sha,
+                "ydoc_lineage": stmt.excluded.ydoc_lineage,
                 "updated_at": stmt.excluded.updated_at,
             },
         )
@@ -137,7 +152,14 @@ def _upsert(
 
 
 def mirror_session_state(
-    s: Session, path: str, *, seq: int, snapshot: bytes, body: str, base_sha: str | None
+    s: Session,
+    path: str,
+    *,
+    seq: int,
+    snapshot: bytes,
+    body: str,
+    base_sha: str | None,
+    lineage: int,
 ) -> None:
     """Re-mirror a session's snapshot state wholesale — the move re-key's
     repair for the window where a checkpoint resolved the page's old path,
@@ -145,7 +167,9 @@ def mirror_session_state(
     ``coedit.on_path_moved``). Runs after the registry re-key, so ``path``
     is the page's live location and resolves its real id.
     """
-    _upsert(s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha)
+    _upsert(
+        s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha, lineage=lineage
+    )
 
 
 def mirror_base_sha(s: Session, path: str, base_sha: str) -> None:

--- a/backend/tests/test_coedit_lineage.py
+++ b/backend/tests/test_coedit_lineage.py
@@ -1,0 +1,182 @@
+"""Lineage-generation guard (``coedit_sessions.ydoc_lineage``) — the reseed
+poison fix.
+
+When the checkpoint engine reseeds a session's document (the diverged branch's
+non-splice-safe fallback), the new snapshot is a fresh CRDT lineage. A Yjs
+update produced against the replaced lineage can never converge with it:
+merging the two unions both documents' content — whole-page duplication —
+rather than conflicting. The guard has three parts, each pinned here:
+
+- ``apply_update(expected_lineage=...)`` refuses a stale-generation update
+  with ``StaleLineageError`` instead of logging it.
+- the reseed bumps ``ydoc_lineage`` atomically with the snapshot swap and
+  broadcasts ``resync_required`` so connected clients rebuild.
+- a rebuild replays only current-generation rows, so a leftover stale row
+  (logged in the pre-bump window) is skipped, not unioned in.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pycrdt import Doc
+
+from app.auth import users as users_repo
+from app.wiki import coedit, coedit_channel, coedit_checkpoint, doc_ids, markdown_splice, markdown_yjs
+from app.wiki import git as wiki_git
+
+_PATH = "guides/lineage.md"
+_BODY = "alpha one\n\nbeta two\n"
+
+
+def _seed_page(body: str) -> str:
+    sha = wiki_git.commit_file(_PATH, body, "seed", author="Seed <seed@x.com>")
+    # Raw git seeding bypasses the lifecycle hooks, so mint the registry id
+    # they would have — the document-row mirror resolves paths through it.
+    doc_ids.mint_for_page(_PATH)
+    return sha
+
+
+def _open_with_client(body: str) -> tuple[coedit.SessionRow, Doc, str]:
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    sha = _seed_page(body)
+    sess = coedit.open_session(_PATH, base_sha=sha)
+    coedit.join(sess.id, uid)
+    doc = markdown_yjs.seed_doc_from_markdown(body)
+    coedit.set_initial_snapshot(sess.id, doc.get_update(), body)
+    return sess, doc, uid
+
+
+def _delta_edit(doc: Doc, prefix: str) -> bytes:
+    from app.wiki.markdown_yjs import ROOT_XML_KEY
+    from pycrdt import XmlFragment
+
+    before = doc.get_state()
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    with doc.transaction():
+        root.children[0].children[0].insert(0, prefix)
+    return doc.get_update(before)
+
+
+def test_apply_update_refuses_stale_lineage(tmp_repo):
+    sess, doc, uid = _open_with_client(_BODY)
+    update = _delta_edit(doc, "X ")
+
+    # Current generation: accepted.
+    seq = coedit.apply_update(
+        sess.id, update_bytes=update, author_user_id=uid, expected_lineage=0
+    )
+    assert seq is not None
+
+    # Bump the generation the way a reseed does (same snapshot content is
+    # fine — the guard is on the counter, not the bytes).
+    coedit.advance_checkpoint(
+        sess.id,
+        seq=seq,
+        snapshot=doc.get_update(),
+        body=_BODY,
+        base_sha=sess.base_sha or "",
+        bump_lineage=True,
+    )
+    refreshed = coedit.get_session(sess.id)
+    assert refreshed is not None and refreshed.ydoc_lineage == 1
+
+    # A stale-generation update is refused, not logged.
+    stale = _delta_edit(doc, "Y ")
+    with pytest.raises(coedit.StaleLineageError):
+        coedit.apply_update(
+            sess.id, update_bytes=stale, author_user_id=uid, expected_lineage=0
+        )
+    assert coedit.updates_since(sess.id, 0).updates == []  # pruned + nothing new
+
+    # The current generation still flows, and rows are stamped with it.
+    seq2 = coedit.apply_update(
+        sess.id, update_bytes=stale, author_user_id=uid, expected_lineage=1
+    )
+    assert seq2 is not None
+    rows = coedit.updates_since(sess.id, seq).updates
+    assert [r.lineage for r in rows] == [1]
+
+
+def test_reseed_bumps_lineage_and_broadcasts_resync(tmp_repo, monkeypatch):
+    sess, doc, uid = _open_with_client(_BODY)
+    # Local edit on paragraph 1...
+    coedit.apply_update(
+        sess.id, update_bytes=_delta_edit(doc, "EDIT "), author_user_id=uid
+    )
+    # ...and an out-of-band commit on paragraph 2, so the checkpoint's merge
+    # diverges from what the doc holds.
+    wiki_git.commit_file(_PATH, "alpha one\n\nbeta CHANGED\n", "oob", author="X <x@x.com>")
+
+    # Force the non-splice-safe fallback: the divergence must reseed.
+    monkeypatch.setattr(markdown_splice, "apply_markdown_diff", lambda *a, **k: False)
+    frames: list[tuple[int, dict[str, object]]] = []
+    monkeypatch.setattr(
+        coedit_channel, "publish_control", lambda sid, frame: frames.append((sid, frame))
+    )
+
+    outcome = coedit_checkpoint.checkpoint_session(sess.id)
+
+    assert outcome is not None and outcome.diverged
+    refreshed = coedit.get_session(sess.id)
+    assert refreshed is not None and refreshed.ydoc_lineage == 1
+    assert (sess.id, {"type": "resync_required", "reason": "reseeded"}) in frames
+    # The merge result itself is intact — both sides present exactly once.
+    committed = wiki_git.read_file(_PATH)
+    assert committed.count("EDIT alpha one") == 1
+    assert committed.count("beta CHANGED") == 1
+
+
+def test_new_session_inherits_document_lineage(tmp_repo, monkeypatch):
+    """The generation survives session turnover: a brand-new session serving a
+    reseeded document starts at the document's generation, not 0 — otherwise a
+    client that slept through the reseed would find its stale generation
+    "matching" the fresh session row and slip past the guard."""
+    sess, doc, uid = _open_with_client(_BODY)
+    coedit.apply_update(
+        sess.id, update_bytes=_delta_edit(doc, "EDIT "), author_user_id=uid
+    )
+    wiki_git.commit_file(_PATH, "alpha one\n\nbeta CHANGED\n", "oob", author="X <x@x.com>")
+    monkeypatch.setattr(markdown_splice, "apply_markdown_diff", lambda *a, **k: False)
+    assert coedit_checkpoint.checkpoint_session(sess.id) is not None
+    coedit.close_session(sess.id)
+
+    sess2 = coedit.open_session(_PATH, base_sha=wiki_git.head_sha_for_path(_PATH))
+    assert sess2.id != sess.id
+    attached, _base = coedit.transplant_from_document(sess2.id, _PATH)
+    assert attached
+    fresh = coedit.get_session(sess2.id)
+    assert fresh is not None and fresh.ydoc_lineage == 1
+
+
+def test_rebuild_skips_replaced_lineage_rows(tmp_repo):
+    sess, doc, uid = _open_with_client(_BODY)
+
+    # A whole-document state from an unrelated lineage — exactly what a
+    # stale client syncs after a reseed it never heard about.
+    foreign = markdown_yjs.seed_doc_from_markdown("POISON copy of the page\n")
+    seq = coedit.apply_update(
+        sess.id, update_bytes=foreign.get_update(), author_user_id=uid
+    )
+    assert seq is not None
+
+    # Reseed-style bump that does NOT prune the poison row (seq=0 keeps it),
+    # simulating a row that slipped into the pre-bump window.
+    coedit.advance_checkpoint(
+        sess.id,
+        seq=0,
+        snapshot=doc.get_update(),
+        body=_BODY,
+        base_sha=sess.base_sha or "",
+        bump_lineage=True,
+    )
+    # A current-generation edit so the session is dirty and commits.
+    coedit.apply_update(
+        sess.id, update_bytes=_delta_edit(doc, "OK "), author_user_id=uid, expected_lineage=1
+    )
+
+    outcome = coedit_checkpoint.checkpoint_session(sess.id)
+
+    assert outcome is not None
+    committed = wiki_git.read_file(_PATH)
+    assert "POISON" not in committed  # the stale row was skipped, not unioned
+    assert committed.startswith("OK alpha one")


### PR DESCRIPTION
## Problem

When a checkpoint's divergence can't be spliced onto the session document's existing CRDT lineage, the engine reseeds — replacing the document with a freshly seeded one. But connected clients keep their old-lineage docs, and the server kept logging their updates. Yjs merges two unrelated lineages by *union*, not conflict: replaying one old-lineage update onto the reseeded snapshot appends the entire old document after the new one. This doubled a real page last week (whole page duplicated, glued without a separator at the seam), traced commit-by-commit to exactly this sequence: agent rewrite → rebase conflict → AI merge → splice failure → reseed → still-connected client synced its old lineage back in.

## Fix

A **lineage generation counter**, scoped to the document so it survives session turnover:

- `coedit_sessions.ydoc_lineage` + `wiki_documents.ydoc_lineage` + `coedit_updates.lineage` (guarded migration).
- A reseed bumps the generation **in the same UPDATE** as the snapshot swap (`advance_checkpoint(bump_lineage=True)`), mirrors it to the document row, and broadcasts `resync_required` to every connection.
- `apply_update(expected_lineage=...)` refuses stale-generation updates with `StaleLineageError` — the guard lives in the same conditional UPDATE that assigns the seq, so a concurrent reseed can't slip a stale row between check and append. The WS route passes the connection's join-time generation and answers a refusal with `resync_required` to that client.
- Rebuilds and late-fold replays skip rows stamped with a replaced generation — a leftover from the pre-bump window is dropped (one client's in-flight burst) instead of doubling the page.
- New sessions inherit the document row's generation on transplant, so a client that slept through a reseed can't match a fresh session row's counter.
- Live-rebase folds pass their generation too, so a fold racing a reseed skips instead of poisoning.

The `joined` frame now carries `lineage`; the client half (rebuild-and-rejoin on `resync_required`) is stacked in the follow-up PR.

## Tests

`tests/test_coedit_lineage.py`: stale update refused + rows stamped; reseed bumps the generation and broadcasts `resync_required` while the merge result stays intact; a poisoned leftover row is skipped by the rebuild (page does not double); a new session inherits the document's generation. Full coedit + migration suite: 170 passed. ruff + basedpyright clean.