### PR TITLE
fix(coedit): rebuild the editor doc when the server reseeds (resync_required)

### DIFF
--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -290,6 +290,11 @@ export function useCoeditSession(opts: {
   // recovery is already running.
   const [reconnectAttempts, setReconnectAttempts] = useState(0);
   const [retryToken, setRetryToken] = useState(0);
+  // Bumped when the server replaces the session document's CRDT lineage (a
+  // checkpoint reseed): re-runs the whole session effect, so the doc pair,
+  // presence, timers, and status all reset through the one existing cleanup
+  // path instead of a second hand-rolled lifecycle inside the loop.
+  const [resyncToken, setResyncToken] = useState(0);
   const retryJoin = useCallback(() => {
     setJoinError(null);
     setJoinErrorRetryable(true);
@@ -499,6 +504,13 @@ export function useCoeditSession(opts: {
     // reconnect (so your own caret stays put) and lets anything typed while
     // disconnected merge on reconnect instead of being discarded.
     //
+    // The one exception is a server-signaled resync: the server *replaced* the
+    // document's CRDT lineage (a checkpoint divergence it couldn't splice), so
+    // this doc can never converge with the session again — syncing the two
+    // unions both documents' content into a duplicated page. That case bumps
+    // `resyncToken`, re-running this whole effect: the cleanup below tears the
+    // pair down and the next run builds a fresh one.
+    //
     // Still never the outer `doc`/`awareness` state: this effect re-runs on
     // every path change and React does not reset that state, so reusing it would
     // hand the previous path's populated doc to this path's session and risk it
@@ -528,6 +540,26 @@ export function useCoeditSession(opts: {
 
     void (async () => {
       let failedAttempts = 0;
+      // The lineage generation this run's pair has synced against, from the
+      // last successful join; null until the first one (a fresh doc belongs
+      // to no generation, so its first join can never mismatch). A reconnect
+      // that lands on a *different* generation means the server reseeded
+      // while we were away — the pair must be discarded before any further
+      // sync, same as an explicit resync frame. Both cases end this run via
+      // `resyncToken`; the effect re-run starts over with a fresh pair, which
+      // is also why a lineage disagreement can't loop: a fresh pair passes
+      // `null` and always joins cleanly.
+      let docLineage: number | null = null;
+      const resync = (why: string) => {
+        // Whatever this pair held beyond its last relayed update is
+        // unrecoverable by design — a replaced lineage can't be merged
+        // without duplicating the page — so leave a trace for support.
+        console.warn(
+          `[coedit] server replaced the document lineage (${why}); ` +
+            "rebuilding the editor — unsynced local edits are discarded",
+        );
+        setResyncToken((t) => t + 1);
+      };
       while (!cancelled) {
         let snap;
         try {
@@ -535,6 +567,7 @@ export function useCoeditSession(opts: {
             path,
             sessionDoc,
             sessionAwareness,
+            docLineage,
             (p) => {
               if (!cancelled) setParticipants(p);
             },
@@ -574,6 +607,15 @@ export function useCoeditSession(opts: {
           closeSession(snap.connectionId);
           return;
         }
+        if (snap.staleLineage) {
+          // The server reseeded the document while we were disconnected: this
+          // pair holds a replaced lineage (svc has already suppressed its
+          // sync). Drop the connection and start the effect over.
+          closeSession(snap.connectionId);
+          if (!cancelled) resync("reconnected onto a newer generation");
+          return;
+        }
+        docLineage = snap.lineage;
         failedAttempts = 0;
         setReconnectAttempts(0);
         setJoinError(null);
@@ -608,10 +650,15 @@ export function useCoeditSession(opts: {
           }, AUTOSAVE_IDLE_MS);
         }
 
-        const { expected } = await snap.closed;
+        const { expected, resync: resyncClose } = await snap.closed;
         if (ownedConnection.current === snap.connectionId)
           ownedConnection.current = null;
         if (cancelled || expected) return;
+        if (resyncClose) {
+          // The server reseeded this session's document mid-connection.
+          resync("resync_required");
+          return;
+        }
         // The connection dropped: the whole gap until the next successful
         // join renders as "Reconnecting…", not as a save failure — the save
         // machinery's rejections during this window are consequences of the
@@ -664,7 +711,7 @@ export function useCoeditSession(opts: {
       })();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, path, retryToken]);
+  }, [enabled, path, retryToken, resyncToken]);
 
   return {
     active,

--- a/frontend/src/lib/editor/hooks.ts
+++ b/frontend/src/lib/editor/hooks.ts
@@ -615,7 +615,11 @@ export function useCoeditSession(opts: {
           if (!cancelled) resync("reconnected onto a newer generation");
           return;
         }
-        docLineage = snap.lineage;
+        // `?? docLineage`: a join answered by a backend that predates the
+        // field (mid rolling deploy) must not erase a generation this pair
+        // already learned — nulling it would disarm the mismatch check on
+        // the next reconnect and let a reseeded lineage merge with this one.
+        docLineage = snap.lineage ?? docLineage;
         failedAttempts = 0;
         setReconnectAttempts(0);
         setJoinError(null);

--- a/frontend/src/lib/editor/svc.ts
+++ b/frontend/src/lib/editor/svc.ts
@@ -56,6 +56,12 @@ export interface CoeditSession {
   session_id: number;
   base_sha: string | null;
   can_write: boolean;
+  /** The session's CRDT lineage generation at join, or null when the server
+   * predates the field (mid rolling deploy). Changes only when the server
+   * reseeds the document (a checkpoint divergence it couldn't splice); a doc
+   * built against a different generation can never converge with the session
+   * again and must be discarded, not synced. */
+  lineage: number | null;
   participants: CoeditParticipant[];
 }
 
@@ -64,7 +70,12 @@ export interface CoeditSession {
  * settles at *join*, not at connection-end; `closed` is the separate handle
  * the reconnect loop awaits for the connection's whole lifetime. */
 export interface CoeditConnection extends CoeditSession {
-  closed: Promise<{ code: number; expected: boolean }>;
+  /** True when this join landed on a different lineage generation than the
+   * caller's doc was built against (`expectedLineage`). The connection has
+   * already suppressed every sync exchange; the caller must close it,
+   * rebuild the doc, and rejoin. */
+  staleLineage: boolean;
+  closed: Promise<{ code: number; expected: boolean; resync: boolean }>;
   /** Handle for `closeSession`/`checkpointSession` — identifies this socket,
    * not the session, so a reconnect can't be mistaken for it. */
   connectionId: number;
@@ -103,16 +114,26 @@ let nextConnectionId = 1;
  *
  * `onPresence` fires with the full roster on every membership change.
  *
- * There is no "the server replaced the document" signal to handle. A
- * checkpoint's merge or an out-of-band commit folded into the session arrives
- * as an ordinary Yjs update on this same connection, which Yjs integrates
- * against whatever this client has — so the caret stays put and pending local
- * edits rebase over it, instead of the connection being torn down.
+ * A checkpoint's merge or an out-of-band commit folded into the session
+ * normally arrives as an ordinary Yjs update on this same connection, which
+ * Yjs integrates against whatever this client has — the caret stays put and
+ * pending local edits rebase over it. The one exception is `resync_required`:
+ * the server *replaced* the document's CRDT lineage (a divergence it couldn't
+ * splice), so this doc can never converge again — the connection closes with
+ * `resync: true` and the caller must rebuild the doc and rejoin.
  */
 export function connectSession(
   path: string,
   doc: Y.Doc,
   awareness: Awareness,
+  // The lineage generation `doc` last synced against, or null for a fresh
+  // doc. If the `joined` frame reports a different generation, every sync
+  // exchange on this connection is suppressed immediately: the server's
+  // sync request arrives right behind `joined`, and answering it would push
+  // this replaced-lineage doc's content onto the reseeded session — on a
+  // connection the server has no reason to distrust. The caller still gets
+  // the resolved connection and does the visible handling (close + rebuild).
+  expectedLineage: number | null,
   onPresence: (participants: CoeditParticipant[]) => void,
 ): Promise<CoeditConnection> {
   return new Promise((resolve, reject) => {
@@ -127,18 +148,36 @@ export function connectSession(
     // overwrite that specific rejection with its own generic message.
     let failedWithDetail = false;
     let expectedClose = false;
+    // Set by a `resync_required` frame: the server replaced the document's
+    // CRDT lineage (a checkpoint reseed), so this doc must be discarded and
+    // the session rejoined fresh — syncing it further would union old and
+    // new content. Carried out through `closed` for the reconnect loop.
+    let resyncRequested = false;
     let sessionId: number | null = null;
     let resolveClosed:
-      | ((info: { code: number; expected: boolean }) => void)
+      | ((info: { code: number; expected: boolean; resync: boolean }) => void)
       | null = null;
-    const closed = new Promise<{ code: number; expected: boolean }>((res) => {
+    const closed = new Promise<{
+      code: number;
+      expected: boolean;
+      resync: boolean;
+    }>((res) => {
       resolveClosed = res;
     });
 
     // Local Yjs changes -> outbound binary frames. `origin === "remote"`
     // filters out re-broadcasting what handleMessage just applied *from*
     // the server — only genuine local edits/presence changes go back out.
+    // Nothing outbound before `joined` (and its lineage verdict), and nothing
+    // after the verdict goes stale: an edit typed in the open->joined window
+    // would otherwise be sent from a doc whose lineage the server hasn't
+    // vouched for yet — on a reconnect after a reseed, that's
+    // replaced-lineage content entering the log through a connection the
+    // server's own guard has no reason to distrust. Nothing is lost by
+    // waiting: the post-join sync exchange carries any local state the
+    // server is missing.
     const onDocUpdate = (update: Uint8Array, origin: unknown) => {
+      if (!joined || resyncRequested) return;
       if (origin === "remote" || ws.readyState !== WebSocket.OPEN) return;
       ws.send(encodeUpdateMessage(update));
     };
@@ -146,6 +185,7 @@ export function connectSession(
       changes: { added: number[]; updated: number[]; removed: number[] },
       origin: unknown,
     ) => {
+      if (!joined || resyncRequested) return;
       if (origin === "remote" || ws.readyState !== WebSocket.OPEN) return;
       const changed = changes.added.concat(changes.updated, changes.removed);
       if (changed.length === 0) return;
@@ -167,6 +207,10 @@ export function connectSession(
 
     ws.onmessage = (event) => {
       if (event.data instanceof ArrayBuffer) {
+        // Once a resync is known to be needed, this doc must neither absorb
+        // the session's frames nor answer the server's sync request — its
+        // reply would carry replaced-lineage content.
+        if (resyncRequested) return;
         const reply = handleMessage(new Uint8Array(event.data), doc, awareness);
         if (reply && ws.readyState === WebSocket.OPEN) ws.send(reply);
         return;
@@ -192,6 +236,18 @@ export function connectSession(
         case "joined": {
           joined = true;
           sessionId = msg.session_id as number;
+          // Absent/malformed lineage (a backend without the field, mid
+          // rolling deploy) is null — never compared, so a mixed-version
+          // window can't fire a spurious resync that discards local edits.
+          const lineage = typeof msg.lineage === "number" ? msg.lineage : null;
+          // Mismatched generation: suppress sync from this instant (see
+          // `expectedLineage`); the caller closes and rebuilds on seeing
+          // `staleLineage` on the resolved connection.
+          const staleLineage =
+            expectedLineage !== null &&
+            lineage !== null &&
+            lineage !== expectedLineage;
+          if (staleLineage) resyncRequested = true;
           sockets.set(connectionId, {
             ws,
             pendingCheckpoints,
@@ -203,10 +259,20 @@ export function connectSession(
             session_id: sessionId,
             base_sha: msg.base_sha as string | null,
             can_write: msg.can_write as boolean,
+            lineage,
+            staleLineage,
             participants: msg.participants as CoeditParticipant[],
             closed,
             connectionId,
           });
+          return;
+        }
+        case "resync_required": {
+          // The server reseeded the session's document; our doc is a replaced
+          // lineage and every further sync frame would only union the two.
+          // Close and let the reconnect loop rebuild the doc and rejoin.
+          resyncRequested = true;
+          ws.close();
           return;
         }
         case "ping":
@@ -259,7 +325,11 @@ export function connectSession(
         reject(new ApiError(0, "Failed to join the editing session."));
         return;
       }
-      resolveClosed?.({ code: event.code, expected: expectedClose });
+      resolveClosed?.({
+        code: event.code,
+        expected: expectedClose,
+        resync: resyncRequested,
+      });
     };
 
     // A no-op: onclose (which always follows an error per the WebSocket


### PR DESCRIPTION
Stacked on #637 (backend lineage guard) — merge that first, then retarget this to main.

## Problem

The reconnect loop deliberately reuses one Y.Doc/Awareness pair across reconnects (caret identity, offline-edit merging). After a server-side reseed that reuse is exactly wrong: the local doc holds a **replaced CRDT lineage**, and syncing it with the reseeded session unions old and new content into a duplicated page — on either side of the wire.

## Fix

- `connectSession` takes the generation the doc last synced against; if the `joined` frame reports a different one, **all sync I/O on the connection is suppressed from that instant** — the server's sync request arrives right behind `joined`, and answering it would push stale content through a connection the server-side guard has no reason to distrust. Nothing outbound is sent before `joined` at all (the post-join sync exchange carries anything the server is missing).
- The verdict is computed once, in svc, and surfaced as `staleLineage` on the resolved connection — no second copy of the predicate in the hook.
- Both resync paths (`staleLineage` at join, `resync_required` mid-connection) bump a `resyncToken` that **re-runs the session effect**: the existing cleanup tears down the pair, presence, and timers, and the next run builds a fresh doc — one lifecycle instead of a second hand-rolled one inside the loop. A fresh doc passes `null` as its expected generation, so a rebuild always joins cleanly and a generation disagreement cannot loop.
- Discarded edits are unrecoverable by design (merging a replaced lineage is the duplication bug); a `console.warn` leaves a trace for support.
- `lineage` is validated (`typeof === "number"`, else null), so a mixed-version window during a rolling deploy can't fire a spurious resync that throws away offline edits.

Known follow-up (pre-existing, narrowed by this change): the template-gallery arm generation in FileView assumes the next `connectionId` bump is the template's own; a reseed landing inside that sub-second window can strand the arm.

## Tests

tsc + vitest clean; reviewed with a multi-angle verified pass (the effect-re-run design and the join-window suppression both came out of confirmed findings).