### PR TITLE
fix(coedit): refuse foreign-lineage sync payloads (stale-client backstop)

### DIFF
--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -46,7 +46,7 @@ from pycrdt import (
     YSyncMessageType,
     read_message,
 )
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from app.auth import User, require_can
 from app.auth.deps import require_user_ws
@@ -174,11 +174,29 @@ def _sync_update_frame(update: bytes) -> bytes:
     return create_update_message(update)
 
 
+class _ConnectionGuard(BaseModel):
+    """Mutable per-connection flags the recv loop threads through its hops.
+
+    ``foreign``: this connection's document proved to be a replaced lineage
+    (its SYNC_STEP1 state vector shares no client id with the session's
+    document — see ``coedit_live.sync_reply``). Set once, never cleared: the
+    only recovery is a rebuilt document on a fresh connection. While set,
+    every content frame from the connection is dropped — its content can only
+    union into the page as a duplicate — and no sync reply is returned, so
+    the stale document isn't fed more content to union locally either. This
+    is the backstop for clients that predate ``resync_required``; a current
+    client never reaches this state (it rebuilds before syncing).
+    """
+
+    foreign: bool = False
+
+
 def _apply_yjs_frame(
     conn: coedit_channel.Connection,
     session_id: int,
     user: User,
     raw: bytes,
+    guard: _ConnectionGuard,
 ) -> bytes | None:
     """Validate, then hand back the update bytes to durably log; ``None`` when
     nothing content-changing happened or the sender isn't allowed to send it.
@@ -205,6 +223,11 @@ def _apply_yjs_frame(
             return None
         sync_type = inner[0]
         is_content = sync_type in (YSyncMessageType.SYNC_STEP2, YSyncMessageType.SYNC_UPDATE)
+        if is_content and guard.foreign:
+            # A foreign-lineage doc's content can only union into the page as
+            # a duplicate. Dropped silently — the resync_required frame was
+            # sent when the guard tripped.
+            return None
         if is_content and not _authorize(session_id, user, "write"):
             return None
         if not is_content:
@@ -215,10 +238,21 @@ def _apply_yjs_frame(
             # Reply with whatever this client is missing, computed from a doc
             # built for this call and dropped with it.
             try:
-                reply = coedit_live.sync_reply(session_id, raw)
+                reply, foreign = coedit_live.sync_reply(session_id, raw)
             except coedit_live.SessionGone:
                 return None
-            if reply is not None:
+            if foreign and not guard.foreign:
+                guard.foreign = True
+                log.warning(
+                    "coedit: session %s connection from user %s presented a "
+                    "foreign state vector (no client-id overlap with the "
+                    "current lineage); refusing its content and requesting a "
+                    "resync",
+                    session_id,
+                    user.id,
+                )
+                conn.post({"type": "resync_required", "reason": "foreign_state"})
+            if reply is not None and not guard.foreign:
                 conn.post(coedit_channel.YjsBytes(payload=reply))
             return None
         update = read_message(inner[1:])
@@ -249,6 +283,7 @@ def _ingest_yjs_frame(
     user: User,
     raw: bytes,
     lineage: int,
+    guard: _ConnectionGuard,
 ) -> int | None:
     """Authorize, validate, durably log and refresh presence for one inbound
     frame — returning the ``ydoc_seq`` assigned, or ``None`` if nothing was
@@ -270,7 +305,7 @@ def _ingest_yjs_frame(
     identical two-transaction shape, so this is a narrower version of a race that
     is inherent to checking permission outside the write.
     """
-    update = _apply_yjs_frame(conn, session_id, user, raw)
+    update = _apply_yjs_frame(conn, session_id, user, raw, guard)
     if update is None:
         return None
     try:
@@ -318,6 +353,7 @@ async def _recv_loop(
     session_id: int,
     user: User,
     lineage: int,
+    guard: _ConnectionGuard,
 ) -> None:
     while True:
         # Low-level receive() (not receive_bytes()/receive_json()) so one
@@ -335,7 +371,7 @@ async def _recv_loop(
             # fetch what it missed. Relaying first would leave the gap
             # undetectable.
             seq = await asyncio.to_thread(
-                _ingest_yjs_frame, conn, session_id, user, data, lineage
+                _ingest_yjs_frame, conn, session_id, user, data, lineage, guard
             )
             if seq is not None:
                 coedit_channel.broadcast_yjs(session_id, data, seq)
@@ -610,7 +646,7 @@ async def ws(websocket: WebSocket, path: str, user: User = Depends(require_user_
         )
 
         recv_task = asyncio.create_task(
-            _recv_loop(websocket, conn, sess.id, user, sess.ydoc_lineage)
+            _recv_loop(websocket, conn, sess.id, user, sess.ydoc_lineage, _ConnectionGuard())
         )
         send_task = asyncio.create_task(_send_loop(websocket, conn, ready, sess.id, user))
         done, pending = await asyncio.wait(

--- a/backend/app/api/coedit.py
+++ b/backend/app/api/coedit.py
@@ -57,6 +57,7 @@ from app.models.coedit import (
     JoinedFrame,
     JoinErrorFrame,
     ParticipantOut,
+    ResyncRequiredFrame,
 )
 from app.tasks.coedit_checkpoint import checkpoint_coedit_session_task
 from app.tasks.coedit_rebase import rebase_coedit_session
@@ -178,14 +179,14 @@ class _ConnectionGuard(BaseModel):
     """Mutable per-connection flags the recv loop threads through its hops.
 
     ``foreign``: this connection's document proved to be a replaced lineage
-    (its SYNC_STEP1 state vector shares no client id with the session's
-    document — see ``coedit_live.sync_reply``). Set once, never cleared: the
-    only recovery is a rebuilt document on a fresh connection. While set,
-    every content frame from the connection is dropped — its content can only
-    union into the page as a duplicate — and no sync reply is returned, so
-    the stale document isn't fed more content to union locally either. This
-    is the backstop for clients that predate ``resync_required``; a current
-    client never reaches this state (it rebuilds before syncing).
+    (its SYNC_STEP1 state vector — see ``coedit_live.sync_reply``). Set once,
+    never cleared: the only recovery is a rebuilt document on a fresh
+    connection. While set, every binary frame from the connection is dropped
+    (content would union into the page as a duplicate), and nothing feeds the
+    stale document either: no sync reply, no ``get_updates_since`` replay,
+    and no relayed broadcasts (``coedit_channel.suppress_yjs``). This is the
+    backstop for clients that predate ``resync_required``; a current client
+    all but never reaches this state (it rebuilds before syncing).
     """
 
     foreign: bool = False
@@ -216,6 +217,13 @@ def _apply_yjs_frame(
     """
     if not raw:
         return None
+    if guard.foreign:
+        # Everything from a foreign-lineage connection is dropped — content
+        # would union into the page as a duplicate, awareness carets reference
+        # a document nobody else holds, and repeat handshakes would only
+        # recompute a reply the guard withholds. The resync_required frame was
+        # sent when the guard tripped; recovery is a fresh connection.
+        return None
     msg_type = raw[0]
     if msg_type == YMessageType.SYNC:
         inner = raw[1:]
@@ -223,11 +231,6 @@ def _apply_yjs_frame(
             return None
         sync_type = inner[0]
         is_content = sync_type in (YSyncMessageType.SYNC_STEP2, YSyncMessageType.SYNC_UPDATE)
-        if is_content and guard.foreign:
-            # A foreign-lineage doc's content can only union into the page as
-            # a duplicate. Dropped silently — the resync_required frame was
-            # sent when the guard tripped.
-            return None
         if is_content and not _authorize(session_id, user, "write"):
             return None
         if not is_content:
@@ -241,17 +244,19 @@ def _apply_yjs_frame(
                 reply, foreign = coedit_live.sync_reply(session_id, raw)
             except coedit_live.SessionGone:
                 return None
-            if foreign and not guard.foreign:
+            if foreign:
                 guard.foreign = True
+                # Also stop feeding it broadcasts: every relayed frame would
+                # grow the client-side union it must ultimately discard.
+                coedit_channel.suppress_yjs(conn.id)
                 log.warning(
                     "coedit: session %s connection from user %s presented a "
-                    "foreign state vector (no client-id overlap with the "
-                    "current lineage); refusing its content and requesting a "
-                    "resync",
+                    "foreign state vector (replaced-lineage content); "
+                    "refusing its frames and requesting a resync",
                     session_id,
                     user.id,
                 )
-                conn.post({"type": "resync_required", "reason": "foreign_state"})
+                conn.post(ResyncRequiredFrame(reason="foreign_state").model_dump())
             if reply is not None and not guard.foreign:
                 conn.post(coedit_channel.YjsBytes(payload=reply))
             return None
@@ -339,7 +344,7 @@ def _ingest_yjs_frame(
             user.id,
             lineage,
         )
-        conn.post({"type": "resync_required", "reason": "stale_lineage"})
+        conn.post(ResyncRequiredFrame(reason="stale_lineage").model_dump())
         return None
     if seq is None:
         return None  # session closed underneath us
@@ -393,6 +398,8 @@ async def _recv_loop(
             # A client that saw a gap in the relay stream asks for what it
             # missed. Room-less this is the whole recovery path for a dropped
             # relay — without it a client stays diverged until it reconnects.
+            if guard.foreign:
+                continue  # a replaced-lineage doc gets no more content to union
             if not await asyncio.to_thread(_authorize, session_id, user, "read"):
                 continue
             missed = await asyncio.to_thread(coedit.updates_since, session_id, since.since_seq)

--- a/backend/app/db/migrations/versions/b3d7f1a2c4e5_retired_client_ids.py
+++ b/backend/app/db/migrations/versions/b3d7f1a2c4e5_retired_client_ids.py
@@ -1,0 +1,51 @@
+"""retired client-id sets for replaced coedit lineages
+
+Adds ``coedit_sessions.retired_client_ids`` and
+``wiki_documents.retired_client_ids``: the Yjs client ids belonging to
+lineages a reseed replaced, accumulated from the discarded document's state
+vector. The foreign-state guard flags any connecting client whose state
+vector contains one — a mixed document (old content plus current-lineage
+broadcasts it kept integrating) shares ids with the current lineage, so an
+overlap test alone cannot catch it; holding a retired id can only mean
+retained replaced-lineage content.
+
+Column adds are guarded on the live inspector because ``0001_initial`` runs
+``Base.metadata.create_all`` against the current model registry.
+
+Revision ID: b3d7f1a2c4e5
+Revises: a9c2e5f8b3d1
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b3d7f1a2c4e5"
+down_revision: str | None = "a9c2e5f8b3d1"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def _columns(inspector: sa.Inspector, table: str) -> set[str]:
+    return {c["name"] for c in inspector.get_columns(table)}
+
+
+def upgrade() -> None:
+    inspector = sa.inspect(op.get_bind())
+    for table in ("coedit_sessions", "wiki_documents"):
+        if "retired_client_ids" not in _columns(inspector, table):
+            op.add_column(
+                table,
+                sa.Column(
+                    "retired_client_ids",
+                    sa.dialects.postgresql.JSONB(),
+                    nullable=False,
+                    server_default=sa.text("'[]'::jsonb"),
+                ),
+            )
+
+
+def downgrade() -> None:
+    op.drop_column("wiki_documents", "retired_client_ids")
+    op.drop_column("coedit_sessions", "retired_client_ids")

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -1014,6 +1014,15 @@ class CoeditSession(Base):
     ydoc_lineage: Mapped[int] = mapped_column(
         BigInteger, nullable=False, server_default=text("0")
     )
+    # Yjs client ids belonging to lineages this session has replaced,
+    # accumulated at each reseed from the discarded document's state vector.
+    # A connecting client whose state vector contains any of them still holds
+    # replaced-lineage content — even when it also holds current-lineage ids
+    # from broadcasts it kept integrating — and must resync, not sync. JSON
+    # array of ints.
+    retired_client_ids: Mapped[list[int]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'active'"))
     created_at: Mapped[str] = mapped_column(
         Text, nullable=False, server_default=_NOW_TEXT_DEFAULT
@@ -1208,6 +1217,13 @@ class WikiDocument(Base):
     # when the session it rejoins is a brand-new row.
     ydoc_lineage: Mapped[int] = mapped_column(
         BigInteger, nullable=False, server_default=text("0")
+    )
+    # The page-scoped home of ``coedit_sessions.retired_client_ids`` —
+    # mirrored from checkpoints and inherited on transplant, so a client
+    # holding replaced-lineage content is recognized even across session
+    # turnover. JSON array of ints.
+    retired_client_ids: Mapped[list[int]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
     )
     # When the document last checkpointed to git — the overdue-detection
     # input once the checkpoint scan reads document state (cutover). NULL for

--- a/backend/app/models/coedit.py
+++ b/backend/app/models/coedit.py
@@ -87,6 +87,18 @@ class JoinedFrame(BaseModel):
     participants: list[ParticipantOut]
 
 
+class ResyncRequiredFrame(BaseModel):
+    """Server -> client: the document this client holds can no longer sync
+    with the session — the server replaced the lineage (``reason:
+    "reseeded"``), refused a stale-generation update (``"stale_lineage"``),
+    or recognized a replaced-lineage state vector (``"foreign_state"``). The
+    client must discard its local doc and rejoin fresh; every further sync
+    frame from the old doc is refused server-side."""
+
+    type: str = "resync_required"
+    reason: str
+
+
 class PresenceFrame(BaseModel):
     """Server -> client, broadcast whenever the participant roster changes
     (join/leave) — distinct from Yjs Awareness (live cursor/color state);

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -246,6 +246,7 @@ class CheckpointSessionRow(BaseModel):
     base_sha: str | None
     doc_id: str | None
     ydoc_lineage: int
+    retired_client_ids: list[int]
     ydoc_seq: int
     ydoc_checkpointed_seq: int
     ydoc_snapshot: bytes | None
@@ -269,6 +270,7 @@ def get_session_for_checkpoint(session_id: int) -> CheckpointSessionRow | None:
             base_sha=row.base_sha,
             doc_id=row.doc_id,
             ydoc_lineage=row.ydoc_lineage,
+            retired_client_ids=row.retired_client_ids,
             ydoc_seq=row.ydoc_seq,
             ydoc_checkpointed_seq=row.ydoc_checkpointed_seq,
             ydoc_snapshot=row.ydoc_snapshot,
@@ -431,10 +433,12 @@ def transplant_from_document(session_id: int, path: str) -> tuple[bool, str | No
                 ydoc_snapshot_seq=0,
                 ydoc_snapshot_body=doc_row.ydoc_snapshot_body,
                 base_sha=doc_row.base_sha,
-                # The generation travels with the lineage: a session serving a
-                # reseeded document must refuse the pre-reseed generation even
-                # though the session row itself is brand new.
+                # The generation and the retired-id set travel with the
+                # lineage: a session serving a reseeded document must refuse
+                # replaced-lineage content even though the session row itself
+                # is brand new.
                 ydoc_lineage=doc_row.ydoc_lineage,
+                retired_client_ids=doc_row.retired_client_ids,
             )
             .returning(CoeditSession.id)
         ).one_or_none()
@@ -584,6 +588,16 @@ def updates_since(session_id: int, after_seq: int) -> UpdatesSince:
                 CoeditUpdate.session_id == session_id,
                 CoeditUpdate.seq > after_seq,
                 CoeditUpdate.seq <= seq,
+                # Replaced-generation leftovers (rows logged in a reseed's
+                # pre-bump window) are unintegrable poison for every
+                # consumer — rebuilds, late folds, and client catch-up
+                # relays alike: integrating one unions the replaced
+                # document's content into the current lineage. Filtered here
+                # once so no consumer can forget.
+                CoeditUpdate.lineage
+                == select(CoeditSession.ydoc_lineage)
+                .where(CoeditSession.id == session_id)
+                .scalar_subquery(),
             )
             .order_by(CoeditUpdate.seq.asc())
         ).all()
@@ -637,6 +651,7 @@ def advance_checkpoint(
     body: str,
     base_sha: str,
     bump_lineage: bool = False,
+    retired_client_ids: list[int] | None = None,
 ) -> None:
     """Record a checkpoint's result — a real commit, or a no-op where the
     doc's content already matched HEAD — moving the snapshot, the
@@ -693,13 +708,22 @@ def advance_checkpoint(
         )
         if bump_lineage:
             values["ydoc_lineage"] = CoeditSession.ydoc_lineage + 1
+        if retired_client_ids is not None:
+            # The caller (the reseed) supplies the complete merged set — the
+            # ids of every lineage this session has ever replaced.
+            values["retired_client_ids"] = retired_client_ids
         updated = s.execute(
             update(CoeditSession)
             .where(CoeditSession.id == session_id, CoeditSession.ydoc_checkpointed_seq <= seq)
             .values(**values)
-            # RETURNING yields the post-update row, so ydoc_lineage here is
-            # the possibly-bumped generation the mirror must record.
-            .returning(CoeditSession.path, CoeditSession.ydoc_lineage)
+            # RETURNING yields the post-update row, so ydoc_lineage /
+            # retired_client_ids here are the possibly-advanced values the
+            # mirror must record.
+            .returning(
+                CoeditSession.path,
+                CoeditSession.ydoc_lineage,
+                CoeditSession.retired_client_ids,
+            )
             .execution_options(synchronize_session=False)
         ).one_or_none()
         if updated is not None:
@@ -719,6 +743,7 @@ def advance_checkpoint(
                 body=body,
                 base_sha=base_sha,
                 lineage=updated.ydoc_lineage,
+                retired_client_ids=updated.retired_client_ids,
             )
 
 
@@ -895,6 +920,7 @@ def on_path_moved(moves: list[PathMove]) -> list[int]:
                             body=newest.ydoc_snapshot_body,
                             base_sha=newest.base_sha,
                             lineage=newest.ydoc_lineage,
+                            retired_client_ids=newest.retired_client_ids,
                         )
             except IntegrityError:
                 # A racing open_session won the unique index between our check

--- a/backend/app/wiki/coedit.py
+++ b/backend/app/wiki/coedit.py
@@ -616,6 +616,56 @@ def updates_since(session_id: int, after_seq: int) -> UpdatesSince:
             ],
         )
 
+
+def replaced_lineage_update_payloads(session_id: int) -> list[bytes]:
+    """Payloads of surviving log rows from replaced generations, oldest first.
+
+    Read by the reseed's second retirement pass: because ``apply_update``
+    refuses old-generation rows once the bump lands, a post-bump read sees
+    every row that slipped into the pre-bump window — there is no later
+    straggler to miss. These rows are never replayed (``updates_since``
+    filters them) and are pruned by whichever future checkpoint advances
+    past their seq.
+    """
+    with session() as s:
+        return list(
+            s.scalars(
+                select(CoeditUpdate.update_payload)
+                .where(
+                    CoeditUpdate.session_id == session_id,
+                    CoeditUpdate.lineage
+                    != select(CoeditSession.ydoc_lineage)
+                    .where(CoeditSession.id == session_id)
+                    .scalar_subquery(),
+                )
+                .order_by(CoeditUpdate.seq.asc())
+            ).all()
+        )
+
+
+def extend_retired_client_ids(session_id: int, ids: set[int]) -> None:
+    """Merge ``ids`` into the session's retired set and its document mirror.
+
+    Plain read-merge-write: the only caller is the checkpoint engine, which
+    holds the per-session checkpoint lock, so nothing races the merge.
+    """
+    if not ids:
+        return
+    with session() as s:
+        row = s.get(CoeditSession, session_id)
+        if row is None:
+            return
+        merged = sorted(set(row.retired_client_ids) | ids)
+        row.retired_client_ids = merged
+        doc_id = doc_ids.id_for_path_in(s, row.path)
+        if doc_id is not None:
+            s.execute(
+                update(WikiDocument)
+                .where(WikiDocument.doc_id == doc_id)
+                .values(retired_client_ids=merged, updated_at=_iso(_now()))
+            )
+
+
 def set_base_sha(session_id: int, base_sha: str) -> bool:
     """Point an active session's merge base at ``base_sha``. True if it moved.
 

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -104,6 +104,10 @@ _queues: dict[str, queue.Queue[QueueItem]] = {}
 _notifiers: dict[str, Callable[[], None]] = {}  # conn_id -> wake its send loop
 _session_of: dict[str, int] = {}  # conn_id -> coedit_session_id
 _conns_by_session: dict[int, set[str]] = {}  # coedit_session_id -> {conn_id}
+# Connections whose document proved to be a replaced lineage: binary Yjs
+# frames are withheld from them (control frames still flow). See
+# ``suppress_yjs``.
+_suppressed_yjs: set[str] = set()
 _lock = threading.Lock()
 
 
@@ -128,6 +132,7 @@ def disconnect(conn_id: str) -> None:
         sid = _session_of.pop(conn_id, None)
         _queues.pop(conn_id, None)
         _notifiers.pop(conn_id, None)
+        _suppressed_yjs.discard(conn_id)
         if sid is not None:
             conns = _conns_by_session.get(sid)
             if conns is not None:
@@ -188,6 +193,17 @@ def _deliver_local(coedit_session_id: int, frame: ControlFrame) -> None:
     )
 
 
+def suppress_yjs(conn_id: str) -> None:
+    """Stop delivering binary Yjs frames to one connection. Control frames
+    still flow — ``resync_required`` must reach it. For a connection whose
+    document proved to be a replaced lineage: feeding it more content only
+    grows the client-side union it would try to sync back. Lasts for the
+    connection's lifetime (cleared by ``disconnect``); recovery is a rebuilt
+    document on a fresh connection."""
+    with _lock:
+        _suppressed_yjs.add(conn_id)
+
+
 def _deliver_local_bytes(
     coedit_session_id: int, payload: bytes, seq: int | None = None
 ) -> None:
@@ -195,6 +211,7 @@ def _deliver_local_bytes(
         targets = [
             (_queues.get(cid), _notifiers.get(cid))
             for cid in _conns_by_session.get(coedit_session_id, ())
+            if cid not in _suppressed_yjs
         ]
     item = YjsBytes(payload=payload, seq=seq)
     for q, notify in targets:

--- a/backend/app/wiki/coedit_channel.py
+++ b/backend/app/wiki/coedit_channel.py
@@ -199,9 +199,29 @@ def suppress_yjs(conn_id: str) -> None:
     document proved to be a replaced lineage: feeding it more content only
     grows the client-side union it would try to sync back. Lasts for the
     connection's lifetime (cleared by ``disconnect``); recovery is a rebuilt
-    document on a fresh connection."""
+    document on a fresh connection.
+
+    Binary frames already sitting in the connection's queue are drained too —
+    a broadcast enqueued between registration and this call would otherwise
+    still be delivered. A frame the send loop dequeued *before* this call can
+    still go out; that residue is harmless (the doc is already condemned: its
+    retired/old-lineage ids flag it foreign at its next sync regardless of
+    what else it integrated)."""
     with _lock:
         _suppressed_yjs.add(conn_id)
+        q = _queues.get(conn_id)
+    if q is None:
+        return
+    kept: list[QueueItem] = []
+    try:
+        while True:
+            item = q.get_nowait()
+            if not isinstance(item, YjsBytes):
+                kept.append(item)
+    except queue.Empty:
+        pass
+    for item in kept:
+        q.put_nowait(item)
 
 
 def _deliver_local_bytes(

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -33,8 +33,9 @@ from pydantic import BaseModel, ConfigDict
 
 from app.auth import User, set_current_user
 from app.auth import users as users_repo
+from app.models.coedit import ResyncRequiredFrame
 from app.models.wiki import ChangeKind
-from app.wiki import coedit, coedit_channel, filesystem
+from app.wiki import coedit, coedit_channel, coedit_live, filesystem
 from app.wiki import drafts as wiki_drafts
 from app.wiki import git as wiki_git
 from app.wiki import markdown_blocks, markdown_splice, markdown_yjs
@@ -352,24 +353,12 @@ def _rebuild_doc(sess: coedit.CheckpointSessionRow) -> tuple[Doc, str, TouchedTr
     doc.apply_update(sess.ydoc_snapshot)
     base_body = sess.ydoc_snapshot_body
     tracker = TouchedTracker(doc)
+    # Replaced-generation rows never reach here: ``updates_since`` filters
+    # them for every consumer at the query (their content — at most one
+    # client's in-flight burst caught in a reseed's pre-bump window — is
+    # lost, which is strictly better than unioning it into a doubled page).
     since = coedit.updates_since(sess.id, sess.ydoc_snapshot_seq)
     for u in since.updates:
-        if u.lineage != sess.ydoc_lineage:
-            # A leftover from a replaced lineage (logged in the window between
-            # a reseed's snapshot read and its lineage bump). Integrating it
-            # would union the old document's content into the new one — the
-            # whole-page-duplication failure the lineage guard exists to kill.
-            # Its content (at most one client's in-flight burst) is lost;
-            # losing it is strictly better than doubling the page.
-            log.warning(
-                "coedit checkpoint: session %s seq %d is from replaced lineage "
-                "%d (current %d); skipping",
-                sess.id,
-                u.seq,
-                u.lineage,
-                sess.ydoc_lineage,
-            )
-            continue
         try:
             doc.apply_update(u.update_payload)
         except Exception:
@@ -618,18 +607,9 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
             base_body = result.new_body if result is not None else body
             change_kind = ChangeKind.EDIT
             tracker.reset()
+            # Replaced-generation rows never reach here — ``updates_since``
+            # filters them for every consumer at the query.
             for u in late.updates:
-                if u.lineage != sess.ydoc_lineage:
-                    # Same replaced-lineage guard as _rebuild_doc's replay.
-                    log.warning(
-                        "coedit checkpoint: session %s seq %d is from replaced "
-                        "lineage %d (current %d); skipping late fold",
-                        sess.id,
-                        u.seq,
-                        u.lineage,
-                        sess.ydoc_lineage,
-                    )
-                    continue
                 try:
                     doc.apply_update(u.update_payload)
                 except Exception:
@@ -697,7 +677,8 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         diverged = new_body != body
         # The state connected clients are on, captured before the finalizing
         # mutations below, so a divergence can be handed to them as a plain
-        # delta (see the broadcast after advance_checkpoint).
+        # delta (see the broadcast after advance_checkpoint) — and, on a
+        # reseed, so the replaced lineage's client ids can be retired.
         pre_finalize = doc.get_state()
         reseeded = False
         if diverged:
@@ -726,8 +707,20 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
             # A reseed writes a fresh CRDT lineage: bump the generation in the
             # same UPDATE, so updates produced against the replaced lineage
             # are refused from this statement on instead of unioning the old
-            # document into the new (whole-page duplication).
+            # document into the new (whole-page duplication). The replaced
+            # lineage's client ids are retired alongside, so a client still
+            # holding them — even mixed with current-lineage ids it went on
+            # integrating — is recognized as foreign at its next sync
+            # (``coedit_live.sync_reply``).
             bump_lineage=reseeded,
+            retired_client_ids=(
+                sorted(
+                    set(sess.retired_client_ids)
+                    | coedit_live.state_vector_client_ids(pre_finalize)
+                )
+                if reseeded
+                else None
+            ),
         )
         if result is not None:
             wiki_drafts.clear_if_diverged(path, new_body)
@@ -740,7 +733,7 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 # rebuild from the new snapshot now, rather than waiting for a
                 # chance reconnect while their editors show pre-merge content.
                 coedit_channel.publish_control(
-                    session_id, {"type": "resync_required", "reason": "reseeded"}
+                    session_id, ResyncRequiredFrame(reason="reseeded").model_dump()
                 )
                 log.warning(
                     "coedit checkpoint: session %s reseeded on divergence; "

--- a/backend/app/wiki/coedit_checkpoint.py
+++ b/backend/app/wiki/coedit_checkpoint.py
@@ -378,6 +378,44 @@ def _rebuild_doc(sess: coedit.CheckpointSessionRow) -> tuple[Doc, str, TouchedTr
     return doc, base_body, tracker, replayed_seq
 
 
+def _retire_straggler_ids(session_id: int, old_doc: Doc) -> None:
+    """Second retirement pass after a reseed's lineage bump.
+
+    The bump's initial retired set comes from the discarded doc's state
+    vector — which cannot contain the client id of an update logged *between*
+    the checkpoint's final log read and the bump (a client's first-ever
+    keystroke landing in that window). The bump is the fence: once it lands,
+    ``apply_update`` refuses old-generation rows, so the surviving
+    replaced-generation rows read here are ALL such stragglers. Folding them
+    into the discarded doc (their own lineage — they integrate; a fresh doc
+    would leave chained ones pending and invisible) surfaces every straggler
+    id for retirement. Runs under the caller's checkpoint lock.
+    """
+    stragglers = coedit.replaced_lineage_update_payloads(session_id)
+    if not stragglers:
+        return
+    for payload in stragglers:
+        try:
+            old_doc.apply_update(payload)
+        except Exception:
+            log.exception(
+                "coedit checkpoint: session %s straggler payload failed to apply "
+                "during retirement; skipping",
+                session_id,
+            )
+    sess = coedit.get_session_for_checkpoint(session_id)
+    already = set(sess.retired_client_ids) if sess is not None else set()
+    extra = coedit_live.state_vector_client_ids(old_doc.get_state()) - already
+    if extra:
+        coedit.extend_retired_client_ids(session_id, extra)
+        log.warning(
+            "coedit checkpoint: session %s retired %d straggler client id(s) "
+            "logged in the reseed's pre-bump window",
+            session_id,
+            len(extra),
+        )
+
+
 class CheckpointOutcome(BaseModel):
     """What a successful checkpoint produced, for the caller
     (``app/tasks/coedit_checkpoint.py``) to act on.
@@ -681,6 +719,7 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
         # reseed, so the replaced lineage's client ids can be retired.
         pre_finalize = doc.get_state()
         reseeded = False
+        old_doc: Doc | None = None
         if diverged:
             if not markdown_splice.apply_markdown_diff(doc, body, new_body):
                 # doc's children don't correspond 1:1 to a fresh parse of
@@ -690,6 +729,9 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 # pairing; fall back to the old, lineage-discarding
                 # behavior rather than risk misapplying the diff (no worse
                 # than before this fix for this rarer, compounding case).
+                # The discarded doc is kept for the post-bump retirement
+                # pass below.
+                old_doc = doc
                 doc = markdown_yjs.seed_doc_from_markdown(new_body)
                 reseeded = True
             else:
@@ -722,6 +764,8 @@ def checkpoint_session(session_id: int) -> CheckpointOutcome | None:
                 else None
             ),
         )
+        if reseeded and old_doc is not None:
+            _retire_straggler_ids(session_id, old_doc)
         if result is not None:
             wiki_drafts.clear_if_diverged(path, new_body)
         if diverged:

--- a/backend/app/wiki/coedit_live.py
+++ b/backend/app/wiki/coedit_live.py
@@ -30,7 +30,14 @@ from __future__ import annotations
 
 import logging
 
-from pycrdt import Doc, YMessageType, create_sync_message, handle_sync_message, read_message
+from pycrdt import (
+    Doc,
+    YMessageType,
+    YSyncMessageType,
+    create_sync_message,
+    handle_sync_message,
+    read_message,
+)
 
 from app.wiki import coedit
 from app.wiki.git import merge_content
@@ -57,6 +64,19 @@ def _load(session_id: int) -> tuple[Doc, int]:
     doc.apply_update(sess.ydoc_snapshot)
     since = coedit.updates_since(session_id, sess.ydoc_snapshot_seq)
     for u in since.updates:
+        if u.lineage != sess.ydoc_lineage:
+            # A leftover row from a replaced lineage — same guard as the
+            # checkpoint engine's replay: integrating it would union the old
+            # document's content into the current one.
+            log.warning(
+                "coedit live: session %s seq %d is from replaced lineage %d "
+                "(current %d); skipping",
+                session_id,
+                u.seq,
+                u.lineage,
+                sess.ydoc_lineage,
+            )
+            continue
         try:
             doc.apply_update(u.update_payload)
         except Exception:
@@ -85,15 +105,69 @@ def validate_update(payload: bytes) -> bool:
         return False
 
 
-def sync_reply(session_id: int, payload: bytes) -> bytes | None:
-    """Answer a client's sync message (the join handshake), or ``None``.
+def _read_var_uint(buf: bytes, pos: int) -> tuple[int, int]:
+    """Decode one lib0 variable-length unsigned int (7 bits per byte, high
+    bit = continuation) — the primitive a Yjs state vector is built from."""
+    value = 0
+    shift = 0
+    while True:
+        b = buf[pos]
+        pos += 1
+        value |= (b & 0x7F) << shift
+        if b < 0x80:
+            return value, pos
+        shift += 7
+
+
+def state_vector_client_ids(sv: bytes) -> set[int]:
+    """The client ids carrying a nonzero clock in an encoded Yjs state vector.
+
+    A state vector is the compact "what I have" summary a client sends in
+    SYNC_STEP1: a count, then ``(client_id, clock)`` varint pairs. The id set
+    is what makes lineages comparable without content: two documents that
+    ever exchanged updates share ids; two independently seeded documents
+    share none.
+    """
+    ids: set[int] = set()
+    count, pos = _read_var_uint(sv, 0)
+    for _ in range(count):
+        client, pos = _read_var_uint(sv, pos)
+        clock, pos = _read_var_uint(sv, pos)
+        if clock > 0:
+            ids.add(client)
+    return ids
+
+
+def sync_reply(session_id: int, payload: bytes) -> tuple[bytes | None, bool]:
+    """Answer a client's sync message (the join handshake); returns
+    ``(reply, foreign)``.
 
     Handles STEP1 (client sends its state vector, we reply with what it's
     missing) and STEP2/UPDATE the same way `pycrdt` does against a resident
     doc — the doc here is just built for the call.
+
+    ``foreign`` is True when a STEP1's state vector shares **no** client id
+    with the session's document while both are non-empty. That is the
+    signature of a replaced lineage: a document that ever synced with this
+    session shares most of its ids, while a doc retained across a server
+    reseed shares none — and letting it sync would union both documents'
+    content into a duplicated page. The lineage-generation guard cannot catch
+    this case when the sender reconnected *after* the reseed (its connection
+    joined at the current generation; the foreignness is in the payload),
+    which is exactly what a client that predates the ``resync_required``
+    protocol does. The one false positive — a client that joined, never
+    received server state, and typed before syncing — is refused too, which
+    costs those keystrokes but can't corrupt; only pre-``resync_required``
+    clients can reach that state.
     """
     doc, _seq = _load(session_id)
-    return handle_sync_message(payload[1:], doc)
+    sync = payload[1:]
+    foreign = False
+    if sync and sync[0] == YSyncMessageType.SYNC_STEP1:
+        client_ids = state_vector_client_ids(read_message(sync[1:]))
+        doc_ids = state_vector_client_ids(doc.get_state())
+        foreign = bool(client_ids) and bool(doc_ids) and not (client_ids & doc_ids)
+    return handle_sync_message(sync, doc), foreign
 
 
 def initial_sync_message(session_id: int) -> bytes:
@@ -162,6 +236,7 @@ __all__ = [
     "initial_sync_message",
     "read_body",
     "rebase_delta",
+    "state_vector_client_ids",
     "sync_reply",
     "validate_update",
     "YMessageType",

--- a/backend/app/wiki/coedit_live.py
+++ b/backend/app/wiki/coedit_live.py
@@ -51,8 +51,10 @@ class SessionGone(Exception):
     """The session isn't active, or has no snapshot to rebuild from."""
 
 
-def _load(session_id: int) -> tuple[Doc, int]:
-    """Rebuild a session's document; returns it with the seq it is current as of.
+def _load(session_id: int) -> tuple[Doc, int, coedit.CheckpointSessionRow]:
+    """Rebuild a session's document; returns it with the seq it is current as
+    of, plus the session row it was built from (already fetched — callers
+    that need lineage fields shouldn't re-read it).
 
     Private on purpose: the `Doc` must not leave the calling thread, so every
     caller in this module consumes it and drops it within its own function.
@@ -63,20 +65,9 @@ def _load(session_id: int) -> tuple[Doc, int]:
     doc = Doc()
     doc.apply_update(sess.ydoc_snapshot)
     since = coedit.updates_since(session_id, sess.ydoc_snapshot_seq)
+    # Replaced-generation rows never reach here: ``updates_since`` filters
+    # them for every consumer at the query.
     for u in since.updates:
-        if u.lineage != sess.ydoc_lineage:
-            # A leftover row from a replaced lineage — same guard as the
-            # checkpoint engine's replay: integrating it would union the old
-            # document's content into the current one.
-            log.warning(
-                "coedit live: session %s seq %d is from replaced lineage %d "
-                "(current %d); skipping",
-                session_id,
-                u.seq,
-                u.lineage,
-                sess.ydoc_lineage,
-            )
-            continue
         try:
             doc.apply_update(u.update_payload)
         except Exception:
@@ -88,7 +79,8 @@ def _load(session_id: int) -> tuple[Doc, int]:
                 session_id,
                 u.seq,
             )
-    return doc, since.head_seq if since.head_seq is not None else sess.ydoc_snapshot_seq
+    seq = since.head_seq if since.head_seq is not None else sess.ydoc_snapshot_seq
+    return doc, seq, sess
 
 
 def validate_update(payload: bytes) -> bool:
@@ -105,18 +97,30 @@ def validate_update(payload: bytes) -> bool:
         return False
 
 
+# A legitimate lib0 varint never exceeds 10 bytes (Yjs ids/clocks fit 64
+# bits). The cap keeps a crafted run of continuation bytes from turning the
+# decode into unbounded-bigint work on a shared threadpool worker.
+_VAR_UINT_MAX_SHIFT = 63
+
+
 def _read_var_uint(buf: bytes, pos: int) -> tuple[int, int]:
     """Decode one lib0 variable-length unsigned int (7 bits per byte, high
-    bit = continuation) — the primitive a Yjs state vector is built from."""
+    bit = continuation) — the primitive a Yjs state vector is built from.
+    Raises ``ValueError`` on truncated or over-long input; callers treat any
+    decode failure as "not a usable state vector"."""
     value = 0
     shift = 0
     while True:
+        if pos >= len(buf):
+            raise ValueError("truncated varint")
         b = buf[pos]
         pos += 1
         value |= (b & 0x7F) << shift
         if b < 0x80:
             return value, pos
         shift += 7
+        if shift > _VAR_UINT_MAX_SHIFT:
+            raise ValueError("varint exceeds 64 bits")
 
 
 def state_vector_client_ids(sv: bytes) -> set[int]:
@@ -126,10 +130,13 @@ def state_vector_client_ids(sv: bytes) -> set[int]:
     SYNC_STEP1: a count, then ``(client_id, clock)`` varint pairs. The id set
     is what makes lineages comparable without content: two documents that
     ever exchanged updates share ids; two independently seeded documents
-    share none.
+    share none. Raises ``ValueError`` on malformed input (each entry is at
+    least two bytes, so a count the buffer can't hold is rejected up front).
     """
     ids: set[int] = set()
     count, pos = _read_var_uint(sv, 0)
+    if count > (len(sv) - pos) // 2:
+        raise ValueError("state-vector count exceeds payload")
     for _ in range(count):
         client, pos = _read_var_uint(sv, pos)
         clock, pos = _read_var_uint(sv, pos)
@@ -146,33 +153,60 @@ def sync_reply(session_id: int, payload: bytes) -> tuple[bytes | None, bool]:
     missing) and STEP2/UPDATE the same way `pycrdt` does against a resident
     doc — the doc here is just built for the call.
 
-    ``foreign`` is True when a STEP1's state vector shares **no** client id
-    with the session's document while both are non-empty. That is the
-    signature of a replaced lineage: a document that ever synced with this
-    session shares most of its ids, while a doc retained across a server
-    reseed shares none — and letting it sync would union both documents'
-    content into a duplicated page. The lineage-generation guard cannot catch
-    this case when the sender reconnected *after* the reseed (its connection
+    ``foreign`` is True for a STEP1 whose state vector proves the client
+    holds replaced-lineage content — content that, if synced, would union
+    into the page as a duplicate. The lineage-generation guard cannot catch
+    this case when the sender reconnected *after* a reseed (its connection
     joined at the current generation; the foreignness is in the payload),
     which is exactly what a client that predates the ``resync_required``
-    protocol does. The one false positive — a client that joined, never
-    received server state, and typed before syncing — is refused too, which
-    costs those keystrokes but can't corrupt; only pre-``resync_required``
-    clients can reach that state.
+    protocol does. Two tests, either suffices:
+
+    - the state vector contains a **retired** client id (a lineage some
+      reseed replaced — recorded at reseed time). This is the precise test,
+      and the only one that catches a *mixed* document: a stale tab that
+      kept integrating current-lineage broadcasts holds both lineages' ids,
+      so overlap with the current document proves nothing.
+    - the state vector shares **no** client id with the session's document
+      while both are non-empty — the wholly-foreign case, kept as a backstop
+      for lineages replaced before retired ids were recorded. The
+      both-non-empty gate means this backstop self-disables against an empty
+      current document; that blind spot is covered by the retired-id test
+      for every reseed recorded since it exists, and an empty-doc STEP2
+      rescue (a client whose unsent edits are the page's only content) is
+      worth keeping.
+
+    False-positive scope: any client that joined, never exchanged a sync
+    frame, and typed before its next STEP1 trips the second test — including
+    a current client whose connection dropped in the joined-but-unsynced
+    window. The cost is bounded (those unsent keystrokes are discarded on
+    the resync; nothing corrupts) and the window is a few hundred
+    milliseconds on a healthy connection.
     """
-    doc, _seq = _load(session_id)
+    doc, _seq, sess = _load(session_id)
     sync = payload[1:]
-    foreign = False
     if sync and sync[0] == YSyncMessageType.SYNC_STEP1:
-        client_ids = state_vector_client_ids(read_message(sync[1:]))
+        try:
+            client_ids = state_vector_client_ids(read_message(sync[1:]))
+        except (ValueError, IndexError):
+            # Malformed state vector: no verdict possible from it. Fall
+            # through to pycrdt's own (Rust-side, bounded) handling, which
+            # rejects garbage in microseconds.
+            client_ids = set()
         doc_ids = state_vector_client_ids(doc.get_state())
-        foreign = bool(client_ids) and bool(doc_ids) and not (client_ids & doc_ids)
-    return handle_sync_message(sync, doc), foreign
+        foreign = bool(client_ids & set(sess.retired_client_ids)) or (
+            bool(client_ids) and bool(doc_ids) and not (client_ids & doc_ids)
+        )
+        if foreign:
+            # No reply for a foreign doc: STEP1's answer is essentially the
+            # whole document, which would only feed the client-side union —
+            # and computing it is dead work the route would discard anyway.
+            return None, True
+    return handle_sync_message(sync, doc), False
 
 
 def initial_sync_message(session_id: int) -> bytes:
     """The server's own STEP1, sent on connect so the client sends us its diff."""
-    doc, _seq = _load(session_id)
+    doc, _seq, _sess = _load(session_id)
     return create_sync_message(doc)
 
 
@@ -183,7 +217,7 @@ def read_body(session_id: int) -> str | None:
     that happens to live in one worker.
     """
     try:
-        doc, _seq = _load(session_id)
+        doc, _seq, _sess = _load(session_id)
     except SessionGone:
         return None
     return reconstruct_body(doc)
@@ -209,7 +243,7 @@ def rebase_delta(
     precisely what leaves concurrent edits unintegrable.
     """
     try:
-        doc, _seq = _load(session_id)
+        doc, _seq, _sess = _load(session_id)
     except SessionGone:
         return None
     ours = reconstruct_body(doc)

--- a/backend/app/wiki/wiki_documents.py
+++ b/backend/app/wiki/wiki_documents.py
@@ -87,11 +87,28 @@ def mirror_seed(
     defend the old one. A markdown seed is by definition generation 0: it
     only happens when no document row existed to transplant.
     """
-    _upsert(s, path, snapshot=snapshot, seq=0, body=body, base_sha=base_sha, lineage=0)
+    _upsert(
+        s,
+        path,
+        snapshot=snapshot,
+        seq=0,
+        body=body,
+        base_sha=base_sha,
+        lineage=0,
+        retired_client_ids=[],
+    )
 
 
 def mirror_checkpoint(
-    s: Session, path: str, *, seq: int, snapshot: bytes, body: str, base_sha: str, lineage: int
+    s: Session,
+    path: str,
+    *,
+    seq: int,
+    snapshot: bytes,
+    body: str,
+    base_sha: str,
+    lineage: int,
+    retired_client_ids: list[int],
 ) -> None:
     """Mirror a checkpoint's advanced snapshot state onto the page's document
     row. Upsert, not update: the row can be missing for a session that
@@ -102,7 +119,14 @@ def mirror_checkpoint(
     transplant, so the generation survives session turnover.
     """
     _upsert(
-        s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha, lineage=lineage
+        s,
+        path,
+        snapshot=snapshot,
+        seq=seq,
+        body=body,
+        base_sha=base_sha,
+        lineage=lineage,
+        retired_client_ids=retired_client_ids,
     )
 
 
@@ -115,6 +139,7 @@ def _upsert(
     body: str,
     base_sha: str | None,
     lineage: int,
+    retired_client_ids: list[int],
 ) -> None:
     doc_id = doc_ids.id_for_path_in(s, path)
     if doc_id is None:
@@ -132,6 +157,7 @@ def _upsert(
         ydoc_seq=seq,
         base_sha=base_sha,
         ydoc_lineage=lineage,
+        retired_client_ids=retired_client_ids,
         created_at=now,
         updated_at=now,
     )
@@ -145,6 +171,7 @@ def _upsert(
                 "ydoc_seq": stmt.excluded.ydoc_seq,
                 "base_sha": stmt.excluded.base_sha,
                 "ydoc_lineage": stmt.excluded.ydoc_lineage,
+                "retired_client_ids": stmt.excluded.retired_client_ids,
                 "updated_at": stmt.excluded.updated_at,
             },
         )
@@ -160,6 +187,7 @@ def mirror_session_state(
     body: str,
     base_sha: str | None,
     lineage: int,
+    retired_client_ids: list[int],
 ) -> None:
     """Re-mirror a session's snapshot state wholesale — the move re-key's
     repair for the window where a checkpoint resolved the page's old path,
@@ -168,7 +196,14 @@ def mirror_session_state(
     is the page's live location and resolves its real id.
     """
     _upsert(
-        s, path, snapshot=snapshot, seq=seq, body=body, base_sha=base_sha, lineage=lineage
+        s,
+        path,
+        snapshot=snapshot,
+        seq=seq,
+        body=body,
+        base_sha=base_sha,
+        lineage=lineage,
+        retired_client_ids=retired_client_ids,
     )
 
 

--- a/backend/tests/test_coedit_foreign_state.py
+++ b/backend/tests/test_coedit_foreign_state.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import contextlib
 import json
-import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -22,6 +21,7 @@ from pycrdt import Doc, YMessageType, create_sync_message, create_update_message
 
 from app.auth import users as users_repo
 from app.main import create_app
+from app.tasks.queues import coedit_queue
 from app.wiki import coedit, coedit_live, doc_ids, markdown_yjs
 from app.wiki import git as wiki_git
 from tests._auth import login_fastapi
@@ -32,7 +32,10 @@ _BODY = "alpha one\n\nbeta two\n"
 
 @pytest.fixture
 def client(tmp_db, tmp_repo):
-    return TestClient(create_app())
+    # Immediate mode makes the WS checkpoint request synchronous, so the
+    # end-to-end test's checkpoint-ack barrier resolves without a worker.
+    with coedit_queue.immediate_mode():
+        yield TestClient(create_app())
 
 
 def _seed_session(body: str) -> tuple[coedit.SessionRow, Doc]:
@@ -44,6 +47,37 @@ def _seed_session(body: str) -> tuple[coedit.SessionRow, Doc]:
     doc = markdown_yjs.seed_doc_from_markdown(body)
     coedit.set_initial_snapshot(sess.id, doc.get_update(), body)
     return sess, doc
+
+
+def _log_edit(sess: coedit.SessionRow, doc: Doc, prefix: str) -> None:
+    """Prepend ``prefix`` to the doc's first paragraph and log the delta —
+    a real local edit, so a checkpoint has something to commit."""
+    from pycrdt import XmlFragment
+
+    from app.wiki.markdown_yjs import ROOT_XML_KEY
+
+    before = doc.get_state()
+    root = doc.get(ROOT_XML_KEY, type=XmlFragment)
+    with doc.transaction():
+        root.children[0].children[0].insert(0, prefix)
+    coedit.apply_update(sess.id, update_bytes=doc.get_update(before), author_user_id=None)
+
+
+def _reseed(sess: coedit.SessionRow, doc: Doc, monkeypatch) -> None:
+    """Drive the checkpoint engine down its reseed-on-divergence branch: a
+    local edit plus an out-of-band commit diverge the merge, and a patched
+    splice forces the lineage-discarding fallback."""
+    import app.wiki.markdown_splice as markdown_splice
+    from app.wiki import coedit_checkpoint
+
+    _log_edit(sess, doc, "EDIT ")
+    wiki_git.commit_file(_PATH, "alpha one\n\nbeta CHANGED\n", "oob", author="X <x@x.com>")
+    # Restore the attribute explicitly — monkeypatch.undo() would also wipe
+    # the conftest's CONFIG patches, which share this monkeypatch instance.
+    orig = markdown_splice.apply_markdown_diff
+    monkeypatch.setattr(markdown_splice, "apply_markdown_diff", lambda *a, **k: False)
+    assert coedit_checkpoint.checkpoint_session(sess.id) is not None
+    monkeypatch.setattr(markdown_splice, "apply_markdown_diff", orig)
 
 
 def test_state_vector_client_ids_decodes_the_docs_own_ids():
@@ -66,13 +100,78 @@ def test_empty_client_step1_is_not_foreign(tmp_repo):
     assert not foreign
 
 
-def test_foreign_step1_is_flagged_and_reply_still_computed(tmp_repo):
+def test_mixed_lineage_client_is_flagged_via_retired_ids(tmp_repo, monkeypatch):
+    """The incident shape: a stale tab keeps integrating current-lineage
+    broadcasts after a reseed, so its state vector holds BOTH lineages' ids —
+    overlap with the current document proves nothing. The retired-id test is
+    what catches it."""
+    sess, old_doc = _seed_session(_BODY)
+    _reseed(sess, old_doc, monkeypatch)
+
+    refreshed = coedit.get_session_for_checkpoint(sess.id)
+    assert refreshed is not None and refreshed.ydoc_snapshot is not None
+    # The replaced lineage's ids were retired at the reseed.
+    assert old_doc.client_id in refreshed.retired_client_ids
+
+    # The stale tab: old doc that has ALSO integrated the current lineage.
+    stale = Doc()
+    stale.apply_update(old_doc.get_update())
+    stale.apply_update(refreshed.ydoc_snapshot)
+    # Sanity: it genuinely overlaps the current document's ids — the
+    # any-overlap rule alone would have waved it through.
+    server_now = Doc()
+    server_now.apply_update(refreshed.ydoc_snapshot)
+    stale_ids = coedit_live.state_vector_client_ids(stale.get_state())
+    assert stale_ids & coedit_live.state_vector_client_ids(server_now.get_state())
+    _reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(stale))
+    assert foreign, "mixed-lineage doc must be refused despite current-id overlap"
+
+    # A purely current client stays welcome.
+    current = Doc()
+    current.apply_update(refreshed.ydoc_snapshot)
+    _reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(current))
+    assert not foreign
+
+
+def test_new_session_inherits_retired_ids(tmp_repo, monkeypatch):
+    """Retired ids survive session turnover via the document-row mirror, so a
+    stale tab can't dodge the guard by rejoining a brand-new session."""
+    sess, old_doc = _seed_session(_BODY)
+    _reseed(sess, old_doc, monkeypatch)
+    coedit.close_session(sess.id)
+
+    sess2 = coedit.open_session(_PATH, base_sha=wiki_git.head_sha_for_path(_PATH))
+    assert sess2.id != sess.id
+    attached, _base = coedit.transplant_from_document(sess2.id, _PATH)
+    assert attached
+    row = coedit.get_session_for_checkpoint(sess2.id)
+    assert row is not None and old_doc.client_id in row.retired_client_ids
+
+    _reply, foreign = coedit_live.sync_reply(sess2.id, create_sync_message(old_doc))
+    assert foreign
+
+
+def test_foreign_step1_is_flagged_and_reply_withheld(tmp_repo):
     sess, _server_doc = _seed_session(_BODY)
     foreign_doc = markdown_yjs.seed_doc_from_markdown("POISON copy of the page\n")
     reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(foreign_doc))
     assert foreign
-    # sync_reply reports; withholding the reply is the route's decision.
-    assert reply is not None
+    # No reply for a foreign doc: STEP1's answer is essentially the whole
+    # document, which would only feed the client-side union.
+    assert reply is None
+
+
+def test_malformed_state_vector_is_not_a_dos(tmp_repo):
+    """A crafted varint run must fail fast (bounded decode), and a malformed
+    state vector must not crash the verdict — it falls through to pycrdt."""
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError):
+        coedit_live.state_vector_client_ids(b"\xff" * 64)  # over-long varint
+    with _pytest.raises(ValueError):
+        coedit_live.state_vector_client_ids(b"\x80")  # truncated
+    with _pytest.raises(ValueError):
+        coedit_live.state_vector_client_ids(b"\x7f")  # count exceeds payload
 
 
 def test_foreign_client_refused_end_to_end(client):
@@ -114,9 +213,24 @@ def test_foreign_client_refused_end_to_end(client):
         else:
             raise AssertionError("never received resync_required")
 
-        # Its content is dropped: nothing logged, nothing in the body.
+        # Its content is dropped: nothing logged, nothing in the body. The
+        # checkpoint request after it is the barrier — per-connection frames
+        # process in order, so its ack proves the poison frame was handled
+        # (a sleep would false-pass under CI load with the frame still
+        # queued).
         ws.send_bytes(create_update_message(foreign_doc.get_update()))
-        time.sleep(0.3)
+        ws.send_json({"type": "checkpoint", "request_id": "barrier-1"})
+        for _ in range(20):
+            msg = ws.receive()
+            text = msg.get("text")
+            if text is None:
+                continue
+            frame = json.loads(text)
+            if frame.get("type") == "checkpoint_result":
+                assert frame["request_id"] == "barrier-1"
+                break
+        else:
+            raise AssertionError("never received the checkpoint barrier ack")
         after = coedit.get_session(session_id)
         assert after is not None and after.ydoc_seq == before.ydoc_seq
         body = coedit_live.read_body(session_id)

--- a/backend/tests/test_coedit_foreign_state.py
+++ b/backend/tests/test_coedit_foreign_state.py
@@ -1,0 +1,127 @@
+"""Foreign-state guard — the backstop for clients that predate
+``resync_required``.
+
+The lineage-generation guard (``ydoc_lineage``) refuses stale updates from a
+connection that joined before a reseed. It cannot catch a stale client that
+*reconnects after* the reseed: the new connection joins at the current
+generation, and the poison is in the sync payload, not the counter. The
+foreign-state guard closes that: a SYNC_STEP1 whose state vector shares no
+client id with the session's document marks the connection foreign — its
+content frames are dropped and no sync reply feeds it more content to union.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+from pycrdt import Doc, YMessageType, create_sync_message, create_update_message, handle_sync_message
+
+from app.auth import users as users_repo
+from app.main import create_app
+from app.wiki import coedit, coedit_live, doc_ids, markdown_yjs
+from app.wiki import git as wiki_git
+from tests._auth import login_fastapi
+
+_PATH = "guides/foreign.md"
+_BODY = "alpha one\n\nbeta two\n"
+
+
+@pytest.fixture
+def client(tmp_db, tmp_repo):
+    return TestClient(create_app())
+
+
+def _seed_session(body: str) -> tuple[coedit.SessionRow, Doc]:
+    sha = wiki_git.commit_file(_PATH, body, "seed", author="Seed <seed@x.com>")
+    # Raw git seeding bypasses the lifecycle hooks; mint the registry id they
+    # would have, so the document-row mirror resolves the path.
+    doc_ids.mint_for_page(_PATH)
+    sess = coedit.open_session(_PATH, base_sha=sha)
+    doc = markdown_yjs.seed_doc_from_markdown(body)
+    coedit.set_initial_snapshot(sess.id, doc.get_update(), body)
+    return sess, doc
+
+
+def test_state_vector_client_ids_decodes_the_docs_own_ids():
+    doc = markdown_yjs.seed_doc_from_markdown("hi\n")
+    assert coedit_live.state_vector_client_ids(doc.get_state()) == {doc.client_id}
+    assert coedit_live.state_vector_client_ids(Doc().get_state()) == set()
+
+
+def test_same_lineage_step1_is_not_foreign(tmp_repo):
+    sess, server_doc = _seed_session(_BODY)
+    client = Doc()
+    client.apply_update(server_doc.get_update())  # synced: shares the lineage
+    _reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(client))
+    assert not foreign
+
+
+def test_empty_client_step1_is_not_foreign(tmp_repo):
+    sess, _server_doc = _seed_session(_BODY)
+    _reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(Doc()))
+    assert not foreign
+
+
+def test_foreign_step1_is_flagged_and_reply_still_computed(tmp_repo):
+    sess, _server_doc = _seed_session(_BODY)
+    foreign_doc = markdown_yjs.seed_doc_from_markdown("POISON copy of the page\n")
+    reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(foreign_doc))
+    assert foreign
+    # sync_reply reports; withholding the reply is the route's decision.
+    assert reply is not None
+
+
+def test_foreign_client_refused_end_to_end(client):
+    """A stale tab reconnecting after a reseed: joins cleanly at the current
+    generation, then offers a foreign state vector — the server must answer
+    with ``resync_required`` and drop its content, not union it in."""
+    uid = users_repo.create(email="ada@x.com", password="hunter2-x", name="Ada")
+    login_fastapi(client, uid)
+    wiki_git.commit_file(_PATH, _BODY, "seed", author="Seed <seed@x.com>")
+
+    with client.websocket_connect(f"/api/coedit/ws?path={_PATH}") as ws:
+        joined = ws.receive_json()
+        assert joined["type"] == "joined"
+        ws.receive_bytes()  # the server's own SYNC_STEP1 query
+        # Complete a normal empty-doc handshake first — proves a fresh client
+        # is untouched by the guard.
+        doc = Doc()
+        ws.send_bytes(create_sync_message(doc))
+        reply = ws.receive_bytes()
+        assert reply[0] == YMessageType.SYNC
+        handle_sync_message(reply[1:], doc)
+
+        session_id = joined["session_id"]
+        before = coedit.get_session(session_id)
+        assert before is not None
+
+        # Now the stale tab's offer: an independently seeded doc.
+        foreign_doc = markdown_yjs.seed_doc_from_markdown("POISON copy of the page\n")
+        ws.send_bytes(create_sync_message(foreign_doc))
+        for _ in range(10):
+            msg = ws.receive()
+            text = msg.get("text")
+            if text is None:
+                continue  # skip presence/binary noise
+            frame = json.loads(text)
+            if frame.get("type") == "resync_required":
+                assert frame["reason"] == "foreign_state"
+                break
+        else:
+            raise AssertionError("never received resync_required")
+
+        # Its content is dropped: nothing logged, nothing in the body.
+        ws.send_bytes(create_update_message(foreign_doc.get_update()))
+        time.sleep(0.3)
+        after = coedit.get_session(session_id)
+        assert after is not None and after.ydoc_seq == before.ydoc_seq
+        body = coedit_live.read_body(session_id)
+        assert body is not None and "POISON" not in body
+
+        # Suppress the teardown checkpoint noise on context exit.
+        with contextlib.suppress(Exception):
+            ws.close()

--- a/backend/tests/test_coedit_foreign_state.py
+++ b/backend/tests/test_coedit_foreign_state.py
@@ -200,6 +200,26 @@ def test_straggler_ids_are_retired_after_the_bump(tmp_repo, monkeypatch):
     assert foreign
 
 
+def test_suppress_yjs_drains_queued_binary_frames(tmp_repo):
+    """Suppression must cover frames enqueued BEFORE the guard tripped — a
+    broadcast racing the foreign STEP1 would otherwise still be delivered."""
+    from app.wiki import coedit_channel
+
+    sess, _doc = _seed_session(_BODY)
+    conn = coedit_channel.connect(sess.id, lambda: None)
+    try:
+        coedit_channel.broadcast_yjs(sess.id, b"\x00pre-suppression frame")
+        assert conn.queue.qsize() == 1
+        coedit_channel.suppress_yjs(conn.id)
+        assert conn.queue.qsize() == 0  # queued binary drained
+        coedit_channel.broadcast_yjs(sess.id, b"\x00post-suppression frame")
+        assert conn.queue.qsize() == 0  # new binary withheld
+        coedit_channel.publish_control(sess.id, {"type": "resync_required", "reason": "t"})
+        assert conn.queue.qsize() == 1  # control frames still flow
+    finally:
+        coedit_channel.disconnect(conn.id)
+
+
 def test_foreign_step1_is_flagged_and_reply_withheld(tmp_repo):
     sess, _server_doc = _seed_session(_BODY)
     foreign_doc = markdown_yjs.seed_doc_from_markdown("POISON copy of the page\n")

--- a/backend/tests/test_coedit_foreign_state.py
+++ b/backend/tests/test_coedit_foreign_state.py
@@ -151,6 +151,55 @@ def test_new_session_inherits_retired_ids(tmp_repo, monkeypatch):
     assert foreign
 
 
+def test_straggler_ids_are_retired_after_the_bump(tmp_repo, monkeypatch):
+    """A client's first-ever update logged in the reseed's pre-bump window
+    carries an id the discarded doc's state vector never saw. The post-bump
+    second pass must retire it, or that client's later mixed state vector
+    would slip past both foreign tests."""
+    from app.db.models import CoeditUpdate
+    from app.db.session import session as db_session
+    from app.wiki import coedit_checkpoint
+
+    sess, old_doc = _seed_session(_BODY)
+    _reseed(sess, old_doc, monkeypatch)
+
+    # Simulate the pre-bump straggler: an old-generation row (lineage 0) that
+    # survived the reseed's prune — exactly what a commit racing the bump
+    # leaves behind (apply_update would refuse it now, so insert directly).
+    straggler = markdown_yjs.seed_doc_from_markdown("STRAY typed blind\n")
+    row = coedit.get_session_for_checkpoint(sess.id)
+    assert row is not None
+    with db_session() as s:
+        s.add(
+            CoeditUpdate(
+                session_id=sess.id,
+                seq=row.ydoc_seq + 1000,
+                author_user_id=None,
+                client_id=None,
+                lineage=0,
+                update_payload=straggler.get_update(),
+            )
+        )
+    assert straggler.client_id not in row.retired_client_ids
+
+    # The second pass folds the straggler into the discarded doc and retires
+    # its id (old_doc's own state was already retired at the bump).
+    replay = Doc()
+    assert row.ydoc_snapshot is not None
+    replay.apply_update(old_doc.get_update())
+    coedit_checkpoint._retire_straggler_ids(sess.id, replay)
+
+    after = coedit.get_session_for_checkpoint(sess.id)
+    assert after is not None and straggler.client_id in after.retired_client_ids
+
+    # A mixed doc built from the straggler + current content is now foreign.
+    mixed = Doc()
+    mixed.apply_update(straggler.get_update())
+    mixed.apply_update(after.ydoc_snapshot or b"")
+    _reply, foreign = coedit_live.sync_reply(sess.id, create_sync_message(mixed))
+    assert foreign
+
+
 def test_foreign_step1_is_flagged_and_reply_withheld(tmp_repo):
     sess, _server_doc = _seed_session(_BODY)
     foreign_doc = markdown_yjs.seed_doc_from_markdown("POISON copy of the page\n")


### PR DESCRIPTION
Follow-up to #637/#638, closing the hole those can't reach.

## Problem

#637's generation counter refuses stale updates from a connection that joined *before* a reseed. But a stale client that **reconnects after** the reseed joins at the current generation — the poison is in its sync payload, not the counter. #638 prevents that client-side, but only for clients running the new bundle: a long-lived tab loaded before the deploy ignores `resync_required`, keeps unioning broadcasts into its old doc locally, and on its next reconnect pushes the whole unioned doc through the sync handshake. Observed live: a page re-doubled (and later re-tripled) minutes after being cleaned, via exactly this path, with the #637 guard active and firing correctly on the *standing* connection.

## Fix

Compare lineages by content identity, not just the counter: a `SYNC_STEP1` **state vector that shares no client id with the session's document** (both non-empty) marks the connection foreign — a document that ever synced with this session shares most of its ids; an independently seeded or replaced-lineage one shares none. A foreign connection:

- gets `resync_required` (`reason: foreign_state`) once, with an operator-visible WARNING,
- has every content frame dropped for the connection's lifetime (recovery is a rebuilt doc on a fresh connection),
- receives no sync reply, so its local doc isn't fed more content to union client-side.

Fresh clients are untouched: an empty state vector never matches the rule, and a synced client always overlaps. The one false positive — a client that joined, never received server state, and typed before syncing — is refused too; that costs those keystrokes but can't corrupt, and only pre-`resync_required` clients can reach that state.

Also brings `coedit_live`'s rebuild in line with the checkpoint engine: replaced-generation log rows are skipped during replay.

## Tests

State-vector decoding; same-lineage / empty / foreign verdicts; and an end-to-end WebSocket test: a foreign doc's `SYNC_STEP1` draws `resync_required` and its content never reaches the log or the body, while a normal empty-doc handshake on the same connection works untouched. Full co-edit + migration suite: 158 passed; ruff + basedpyright clean.